### PR TITLE
Add Rust CI matrix and MSRV gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: "1"
+
+jobs:
+  quality:
+    name: Format and Clippy (stable)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install stable Rust with quality components
+        run: rustup toolchain install stable --profile minimal --component rustfmt,clippy
+
+      - name: Select stable Rust
+        run: rustup default stable
+
+      - name: Restore Rust build cache
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          shared-key: stable-quality
+
+      - name: Check formatting
+        run: cargo fmt --all --check
+
+      - name: Run Clippy
+        run: cargo clippy --locked --all-targets --all-features -- -D warnings
+
+  test:
+    name: Tests (${{ matrix.rust }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rust:
+          - "1.85.0"
+          - stable
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Rust ${{ matrix.rust }}
+        run: rustup toolchain install "${{ matrix.rust }}" --profile minimal
+
+      - name: Select Rust ${{ matrix.rust }}
+        run: rustup default "${{ matrix.rust }}"
+
+      - name: Restore Rust build cache
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          shared-key: tests-${{ matrix.rust }}
+
+      - name: Run target tests
+        run: cargo test --locked --all-targets --all-features
+
+      - name: Run documentation tests
+        run: cargo test --locked --doc --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,12 @@ jobs:
   quality:
     name: Format and Clippy (stable)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Check out source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install stable Rust with quality components
         run: rustup toolchain install stable --profile minimal --component rustfmt,clippy
@@ -48,6 +51,7 @@ jobs:
   test:
     name: Tests (${{ matrix.rust }})
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -57,6 +61,8 @@ jobs:
     steps:
       - name: Check out source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust ${{ matrix.rust }}
         run: rustup toolchain install "${{ matrix.rust }}" --profile minimal

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,12 +32,24 @@ test must explain why the change cannot affect executable behavior.
 
 ## Required local checks
 
+The crate declares Rust 1.85 as its minimum supported Rust version (MSRV).
+Behavior-changing code must compile and pass tests on both the MSRV and current
+stable Rust. The MSRV may only be raised deliberately, with release notes and a
+CI update in the same pull request.
+
 Run these before publishing a branch:
 
 ```bash
 cargo fmt --check
 cargo test
 cargo clippy --all-targets --all-features -- -D warnings
+```
+
+When Rust 1.85 is installed through `rustup`, also run:
+
+```bash
+cargo +1.85.0 test --locked --all-targets --all-features
+cargo +1.85.0 test --locked --doc --all-features
 ```
 
 Run targeted integration, compatibility, benchmark, or failure suites when the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,9 +40,10 @@ CI update in the same pull request.
 Run these before publishing a branch:
 
 ```bash
-cargo fmt --check
-cargo test
-cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --all --check
+cargo test --locked --all-targets --all-features
+cargo test --locked --doc --all-features
+cargo clippy --locked --all-targets --all-features -- -D warnings
 ```
 
 When Rust 1.85 is installed through `rustup`, also run:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "briskdb"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.85"
 description = "A small, fast, sharded SQLite server"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # BriskDB
 
+[![CI](https://github.com/schapman1974/briskdb/actions/workflows/ci.yml/badge.svg)](https://github.com/schapman1974/briskdb/actions/workflows/ci.yml)
+
 BriskDB is an experimental Rust server that spreads keyed workloads across
 multiple SQLite databases. It takes the central sharding model proven in
 TinyMongo and makes it available as a small network service.
@@ -11,6 +13,9 @@ planner, APIs, and production-hardening milestones.
 The [SQL compatibility contract](docs/SQL_COMPATIBILITY.md) distinguishes the
 current SQLite pass-through API from planned PostgreSQL and MySQL compatibility.
 Contributions follow the repository's [test-first completion policy](CONTRIBUTING.md).
+
+BriskDB supports Rust 1.85 and newer stable releases. CI tests the declared
+minimum supported Rust version (MSRV) and the latest stable toolchain.
 
 ## Current foundation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -150,7 +150,7 @@ Status: **in progress**
 - [x] Add initial unit and end-to-end smoke tests.
 - [x] Write `docs/SQL_COMPATIBILITY.md` with supported syntax and explicit
   SQLite/PostgreSQL/MySQL differences.
-- [ ] Add CI for formatting, Clippy, tests, and supported Rust versions.
+- [x] Add CI for formatting, Clippy, tests, and supported Rust versions.
 - [ ] Add a benchmark baseline for point reads, writes, and four-shard
   concurrent writes.
 - [ ] Choose and document the project license and supported-platform policy.


### PR DESCRIPTION
## Summary

- add GitHub Actions gates for formatting and Clippy on stable Rust
- test all targets and documentation on Rust 1.85.0 and current stable
- declare Rust 1.85 as the crate MSRV and document the support policy
- pin external Actions to verified release commits and use read-only workflow permissions
- add a CI badge and mark the roadmap item complete

## Why

Every future behavior change needs an automated test gate before merge. Testing both the declared MSRV and current stable prevents accidental compiler-support regressions while keeping the project current.

## Validation

- `actionlint` 1.7.12 with a verified release checksum
- `cargo +1.85.0 test --locked --all-targets --all-features` (5 passed)
- `cargo +1.85.0 test --locked --doc --all-features`
- `cargo fmt --all --check`
- `cargo test --locked --all-targets --all-features` (5 passed)
- `cargo test --locked --doc --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- Cargo metadata assertion that `rust-version` is `1.85`

Closes #2
