### PR TITLE
Add storage benchmark baseline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,18 @@ cargo +1.85.0 test --locked --doc --all-features
 Run targeted integration, compatibility, benchmark, or failure suites when the
 change touches those areas. The pull request must list every check performed.
 
+Storage-path changes must also run the benchmark correctness tests and smoke
+mode before publishing:
+
+```bash
+cargo test --locked --test benchmark_workloads
+cargo test --locked --bench storage
+```
+
+Run `cargo bench --locked --bench storage` on a quiet machine when collecting
+timings. Performance comparisons are meaningful only on the same machine and
+filesystem; see [the benchmark contract](docs/BENCHMARKS.md).
+
 ## Pull request loop
 
 1. Confirm the issue scope and acceptance criteria.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,6 +90,12 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "axum"
@@ -165,6 +177,7 @@ dependencies = [
  "axum",
  "blake3",
  "clap",
+ "criterion",
  "rusqlite",
  "serde",
  "serde_json",
@@ -187,6 +200,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +220,33 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -262,6 +308,49 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "criterion"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "num-traits",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "either"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "errno"
@@ -354,6 +443,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -467,6 +567,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,6 +683,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,6 +702,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "parking_lot"
@@ -660,6 +784,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,6 +861,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -934,6 +1079,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,6 +1231,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1127,6 +1292,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1139,6 +1313,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,9 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 
 [dev-dependencies]
+criterion = { version = "0.7", default-features = false }
 tempfile = "3.23"
+
+[[bench]]
+name = "storage"
+harness = false

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ planner, APIs, and production-hardening milestones.
 The [SQL compatibility contract](docs/SQL_COMPATIBILITY.md) distinguishes the
 current SQLite pass-through API from planned PostgreSQL and MySQL compatibility.
 Contributions follow the repository's [test-first completion policy](CONTRIBUTING.md).
+The [benchmark baseline](docs/BENCHMARKS.md) defines the reproducible storage
+workloads used to measure the current prototype.
 
 BriskDB supports Rust 1.85 and newer stable releases. CI tests the declared
 minimum supported Rust version (MSRV) and the latest stable toolchain.
@@ -25,6 +27,7 @@ minimum supported Rust version (MSRV) and the latest stable toolchain.
 - Routed execute and query endpoints
 - A broadcast endpoint for initializing schema on every shard
 - Full SQLite synchronous durability and a five-second busy timeout
+- Reproducible point-read, point-write, and four-shard write benchmarks
 
 The on-disk layout is deliberately simple:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -151,7 +151,7 @@ Status: **in progress**
 - [x] Write `docs/SQL_COMPATIBILITY.md` with supported syntax and explicit
   SQLite/PostgreSQL/MySQL differences.
 - [x] Add CI for formatting, Clippy, tests, and supported Rust versions.
-- [ ] Add a benchmark baseline for point reads, writes, and four-shard
+- [x] Add a benchmark baseline for point reads, writes, and four-shard
   concurrent writes.
 - [ ] Choose and document the project license and supported-platform policy.
 

--- a/benches/storage.rs
+++ b/benches/storage.rs
@@ -1,0 +1,88 @@
+mod support;
+
+use std::{hint::black_box, time::Duration};
+
+use criterion::{Criterion, SamplingMode, Throughput, criterion_group, criterion_main};
+use support::{BENCHMARK_SHARDS, BenchmarkFixture};
+
+fn storage_benchmarks(criterion: &mut Criterion) {
+    let read_fixture = BenchmarkFixture::new().expect("initialize point-read benchmark");
+    assert_eq!(
+        read_fixture
+            .point_read()
+            .expect("preflight point read")
+            .len(),
+        1
+    );
+    assert_eq!(read_fixture.write_count(0).expect("preflight read row"), 0);
+    for (shard, key) in read_fixture.keys_by_shard().iter().enumerate() {
+        assert_eq!(usize::from(read_fixture.shard_for_key(key)), shard);
+    }
+
+    let write_fixture = BenchmarkFixture::new().expect("initialize point-write benchmark");
+    assert_eq!(
+        write_fixture.point_write().expect("preflight point write"),
+        1
+    );
+    assert_eq!(
+        write_fixture.write_count(0).expect("preflight written row"),
+        1
+    );
+
+    let concurrent_fixture =
+        BenchmarkFixture::new().expect("initialize concurrent-write benchmark");
+    assert_eq!(
+        concurrent_fixture
+            .four_shard_concurrent_write_wave()
+            .expect("preflight concurrent writes"),
+        [1; BENCHMARK_SHARDS as usize]
+    );
+    for shard in 0..BENCHMARK_SHARDS as usize {
+        assert_eq!(
+            concurrent_fixture
+                .write_count(shard)
+                .expect("preflight concurrent row"),
+            1
+        );
+    }
+
+    let mut group = criterion.benchmark_group("storage");
+    group.sample_size(20);
+    group.sampling_mode(SamplingMode::Flat);
+    group.warm_up_time(Duration::from_secs(2));
+    group.measurement_time(Duration::from_secs(5));
+
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("point_read", |bencher| {
+        bencher.iter(|| {
+            let rows = read_fixture.point_read().expect("benchmark point read");
+            assert_eq!(rows.len(), 1);
+            black_box(rows)
+        });
+    });
+
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("point_write", |bencher| {
+        bencher.iter(|| {
+            let affected = write_fixture.point_write().expect("benchmark point write");
+            assert_eq!(affected, 1);
+            black_box(affected)
+        });
+    });
+
+    group.throughput(Throughput::Elements(u64::from(BENCHMARK_SHARDS)));
+    group.bench_function("four_shard_concurrent_writes", |bencher| {
+        bencher.iter(|| {
+            let affected = concurrent_fixture
+                .four_shard_concurrent_write_wave()
+                .expect("benchmark concurrent writes");
+            assert_eq!(affected, [1; BENCHMARK_SHARDS as usize]);
+            black_box(affected)
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, storage_benchmarks);
+criterion_main!(benches);

--- a/benches/support/mod.rs
+++ b/benches/support/mod.rs
@@ -1,0 +1,145 @@
+use std::{
+    array,
+    sync::{Arc, Barrier},
+    thread,
+};
+
+use anyhow::{Context, anyhow, bail};
+use briskdb::storage::Database;
+use serde_json::{Value, json};
+
+pub const BENCHMARK_SHARDS: u16 = 4;
+
+pub struct BenchmarkFixture {
+    _directory: tempfile::TempDir,
+    database: Arc<Database>,
+    keys_by_shard: [String; BENCHMARK_SHARDS as usize],
+}
+
+impl BenchmarkFixture {
+    pub fn new() -> anyhow::Result<Self> {
+        let directory = tempfile::tempdir().context("create benchmark directory")?;
+        let database = Arc::new(Database::open(directory.path(), BENCHMARK_SHARDS)?);
+        database.broadcast(
+            "CREATE TABLE benchmark_items (
+                id TEXT PRIMARY KEY,
+                writes INTEGER NOT NULL,
+                payload TEXT NOT NULL
+            );",
+        )?;
+
+        let keys_by_shard = find_key_for_each_shard(&database)?;
+        for key in &keys_by_shard {
+            let affected = database.execute(
+                key,
+                "INSERT INTO benchmark_items (id, writes, payload) VALUES (?1, ?2, ?3)",
+                &[json!(key), json!(0), json!("baseline payload")],
+            )?;
+            if affected != 1 {
+                bail!("benchmark seed insert affected {affected} rows")
+            }
+        }
+
+        Ok(Self {
+            _directory: directory,
+            database,
+            keys_by_shard,
+        })
+    }
+
+    pub fn keys_by_shard(&self) -> &[String; BENCHMARK_SHARDS as usize] {
+        &self.keys_by_shard
+    }
+
+    pub fn shard_for_key(&self, key: &str) -> u16 {
+        self.database.shard_for_key(key.as_bytes())
+    }
+
+    pub fn point_read(&self) -> anyhow::Result<Vec<Value>> {
+        let key = &self.keys_by_shard[0];
+        self.database.query(
+            key,
+            "SELECT id, writes, payload FROM benchmark_items WHERE id = ?1",
+            &[json!(key)],
+        )
+    }
+
+    pub fn point_write(&self) -> anyhow::Result<usize> {
+        update_key(&self.database, &self.keys_by_shard[0])
+    }
+
+    pub fn four_shard_concurrent_write_wave(
+        &self,
+    ) -> anyhow::Result<[usize; BENCHMARK_SHARDS as usize]> {
+        let barrier = Arc::new(Barrier::new(BENCHMARK_SHARDS as usize + 1));
+
+        thread::scope(|scope| {
+            let mut handles = Vec::with_capacity(BENCHMARK_SHARDS as usize);
+            for key in &self.keys_by_shard {
+                let database = Arc::clone(&self.database);
+                let barrier = Arc::clone(&barrier);
+                handles.push(scope.spawn(move || {
+                    barrier.wait();
+                    update_key(&database, key)
+                }));
+            }
+
+            barrier.wait();
+            let mut affected = Vec::with_capacity(BENCHMARK_SHARDS as usize);
+            for handle in handles {
+                let result = handle
+                    .join()
+                    .map_err(|_| anyhow!("concurrent benchmark worker panicked"))??;
+                affected.push(result);
+            }
+
+            affected
+                .try_into()
+                .map_err(|_| anyhow!("concurrent benchmark returned the wrong result count"))
+        })
+    }
+
+    pub fn write_count(&self, shard: usize) -> anyhow::Result<i64> {
+        let key = self
+            .keys_by_shard
+            .get(shard)
+            .context("benchmark shard index is out of range")?;
+        let rows = self.database.query(
+            key,
+            "SELECT writes FROM benchmark_items WHERE id = ?1",
+            &[json!(key)],
+        )?;
+        rows.first()
+            .and_then(|row| row.get("writes"))
+            .and_then(Value::as_i64)
+            .context("benchmark row did not contain an integer write count")
+    }
+}
+
+fn update_key(database: &Database, key: &str) -> anyhow::Result<usize> {
+    database.execute(
+        key,
+        "UPDATE benchmark_items SET writes = writes + 1 WHERE id = ?1",
+        &[json!(key)],
+    )
+}
+
+fn find_key_for_each_shard(
+    database: &Database,
+) -> anyhow::Result<[String; BENCHMARK_SHARDS as usize]> {
+    const SEARCH_LIMIT: usize = 10_000;
+    let mut keys: [Option<String>; BENCHMARK_SHARDS as usize] = array::from_fn(|_| None);
+
+    for candidate in 0..SEARCH_LIMIT {
+        let key = format!("benchmark-key-{candidate}");
+        let shard = usize::from(database.shard_for_key(key.as_bytes()));
+        if keys[shard].is_none() {
+            keys[shard] = Some(key);
+            if keys.iter().all(Option::is_some) {
+                return Ok(keys.map(|key| key.expect("every shard key was populated")));
+            }
+        }
+    }
+
+    bail!("could not find a benchmark key for every shard in {SEARCH_LIMIT} candidates")
+}

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,0 +1,96 @@
+# Benchmark baseline
+
+BriskDB's Criterion suite establishes a repeatable performance baseline for
+the current sharded storage prototype. It is a measurement tool, not a claim
+about production capacity or a timing threshold for shared CI runners.
+
+## Workload contract
+
+Every benchmark creates a fresh temporary BriskDB database with exactly four
+shards, broadcasts the same table definition to each shard, and seeds one
+primary-key row per shard. Timed operations use the public
+`briskdb::storage::Database` interface.
+
+| Benchmark | One timed iteration | Reported throughput |
+| --- | --- | --- |
+| `storage/point_read` | Route a fixed key and select its row by primary key | rows read per second |
+| `storage/point_write` | Route a fixed key and increment one row by primary key | rows written per second |
+| `storage/four_shard_concurrent_writes` | Release four threads together; each routes and updates one key on a different shard, then join them | total rows written per second; four per iteration |
+
+Point updates keep the database size constant, preventing ever-growing insert
+cost from distorting later samples. The concurrent workload deterministically
+finds and verifies one key for each physical shard. Its timing intentionally
+includes thread creation, barrier synchronization, and joins because the
+prototype does not yet have a persistent worker pool.
+
+These are steady-state, warm-cache workloads after Criterion's warm-up period.
+They do not measure first access after process start or a cold operating-system
+page cache.
+
+The measurements include:
+
+- BLAKE3 routing;
+- opening and configuring a SQLite connection for each operation;
+- parameter and result conversion at the storage boundary;
+- SQLite query/update work and filesystem I/O; and
+- WAL mode, `synchronous=FULL`, foreign-key checks, and the configured busy
+  timeout.
+
+They exclude HTTP parsing, networking, Tokio scheduling, server startup,
+database creation, schema broadcast, key discovery, and seed inserts. Future
+pooling or engine work should keep these benchmark names stable or document a
+deliberate workload-contract change.
+
+## Run and compare
+
+First verify the workloads. The dedicated tests assert exact read results,
+single-row write counts, distinct routing to all four shards, and the final
+state after concurrent writes:
+
+```bash
+cargo test --locked --test benchmark_workloads
+cargo test --locked --bench storage
+```
+
+The second command runs Criterion's one-iteration test mode. It is also covered
+by CI's `cargo test --locked --all-targets --all-features` command.
+
+Collect the complete baseline in the optimized benchmark profile:
+
+```bash
+cargo bench --locked --bench storage
+```
+
+Criterion results are written below `target/criterion/`, which is intentionally
+untracked. To save and later compare a named local baseline on the same host:
+
+```bash
+cargo bench --locked --bench storage -- --save-baseline before-change
+cargo bench --locked --bench storage -- --baseline before-change
+```
+
+Use a quiet machine, the same Rust toolchain and locked dependency graph, the
+same power mode, and the same local filesystem. Virtualized CI storage,
+antivirus/indexing activity, thermal throttling, and filesystem cache state can
+change these numbers substantially. Compare distributions, not a single run,
+and investigate correctness separately from performance.
+
+## Initial snapshot
+
+The initial issue #3 branch was measured on 2026-08-07 with `cargo bench
+--locked --bench storage` and the suite's 2-second warm-up, 5-second measurement
+window, flat sampling, and 20 samples per workload.
+
+- Apple M1 Pro, 10 cores, 16 GiB RAM
+- macOS/Darwin 25.2.0 on an internal APFS solid-state volume
+- `aarch64-apple-darwin`, Rust 1.94.1, Cargo 1.94.1
+- Criterion 0.7.0 and the repository's committed `Cargo.lock`
+
+| Benchmark | Time per iteration | Throughput |
+| --- | ---: | ---: |
+| `storage/point_read` | 382.90 µs (369.62–397.56 µs) | 2.612 K rows/s |
+| `storage/point_write` | 616.74 µs (604.04–629.88 µs) | 1.621 K rows/s |
+| `storage/four_shard_concurrent_writes` | 1.5832 ms per four-write wave (1.5374–1.6352 ms) | 2.527 K rows/s total |
+
+These values are a hardware-specific reference point. They must not be used as
+cross-machine guarantees or CI pass/fail limits.

--- a/tests/benchmark_workloads.rs
+++ b/tests/benchmark_workloads.rs
@@ -1,0 +1,47 @@
+#[path = "../benches/support/mod.rs"]
+mod support;
+
+use support::{BENCHMARK_SHARDS, BenchmarkFixture};
+
+#[test]
+fn point_read_returns_the_seeded_row() {
+    let fixture = BenchmarkFixture::new().unwrap();
+
+    let rows = fixture.point_read().unwrap();
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["id"], fixture.keys_by_shard()[0]);
+    assert_eq!(rows[0]["writes"], 0);
+    assert_eq!(rows[0]["payload"], "baseline payload");
+}
+
+#[test]
+fn point_write_updates_exactly_one_row() {
+    let fixture = BenchmarkFixture::new().unwrap();
+
+    assert_eq!(fixture.point_write().unwrap(), 1);
+    assert_eq!(fixture.point_write().unwrap(), 1);
+
+    assert_eq!(fixture.write_count(0).unwrap(), 2);
+}
+
+#[test]
+fn concurrent_write_wave_updates_one_key_on_every_shard() {
+    let fixture = BenchmarkFixture::new().unwrap();
+    for (shard, key) in fixture.keys_by_shard().iter().enumerate() {
+        assert_eq!(usize::from(fixture.shard_for_key(key)), shard);
+    }
+
+    assert_eq!(
+        fixture.four_shard_concurrent_write_wave().unwrap(),
+        [1; BENCHMARK_SHARDS as usize]
+    );
+    assert_eq!(
+        fixture.four_shard_concurrent_write_wave().unwrap(),
+        [1; BENCHMARK_SHARDS as usize]
+    );
+
+    for shard in 0..BENCHMARK_SHARDS as usize {
+        assert_eq!(fixture.write_count(shard).unwrap(), 2);
+    }
+}


### PR DESCRIPTION
## Summary

- add stable Criterion benchmarks for routed point reads, durable point updates, and synchronized writes across four distinct shards
- add dedicated correctness tests for exact results, repeatable writes, deterministic per-shard routing, and concurrent final state
- document the benchmark contract, inclusions/exclusions, reproducible commands, comparison workflow, and an initial machine-specific snapshot
- keep the suite compatible with BriskDB's Rust 1.85 MSRV and mark roadmap issue #3 complete

## Test coverage

- `cargo fmt --all --check`
- `cargo test --locked --all-targets --all-features`
- `cargo test --locked --doc --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --test benchmark_workloads`
- `cargo test --locked --bench storage`
- `cargo +1.85.0 test --locked --all-targets --all-features`
- `cargo +1.85.0 test --locked --doc --all-features`
- `cargo +1.85.0 clippy --locked --all-targets --all-features -- -D warnings`
- `cargo bench --locked --bench storage`
- all local Markdown links resolve

The complete benchmark run measured the documented M1 Pro snapshot. It is retained as a hardware-specific reference, not a cross-machine CI threshold.

Closes #3
