### PR TITLE
Define license and supported-platform policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   quality:
     name: Format and Clippy (stable)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - name: Check out source
@@ -50,7 +50,7 @@ jobs:
 
   test:
     name: Tests (${{ matrix.rust }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     strategy:
       fail-fast: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2024"
 rust-version = "1.85"
 description = "A small, fast, sharded SQLite server"
+license = "MIT"
+repository = "https://github.com/schapman1974/briskdb"
 
 [dependencies]
 anyhow = "1.0"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Stephen Chapman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ current SQLite pass-through API from planned PostgreSQL and MySQL compatibility.
 Contributions follow the repository's [test-first completion policy](CONTRIBUTING.md).
 The [benchmark baseline](docs/BENCHMARKS.md) defines the reproducible storage
 workloads used to measure the current prototype.
+BriskDB is available under the [MIT License](LICENSE). The
+[supported-platform policy](docs/SUPPORTED_PLATFORMS.md) defines the tested
+operating-system, Rust, and filesystem boundaries.
 
 BriskDB supports Rust 1.85 and newer stable releases. CI tests the declared
 minimum supported Rust version (MSRV) and the latest stable toolchain.
@@ -94,3 +97,8 @@ explicit migration workflow.
 Near-term work includes authentication, connection pools, schema migrations,
 scatter/gather reads, observability, backup tooling, and failure-injection
 tests for multi-shard operations.
+
+## License
+
+Copyright (c) 2026 Stephen Chapman. BriskDB is distributed under the
+[MIT License](LICENSE).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -141,7 +141,7 @@ therefore required before calling the driver interfaces production-ready.
 ## Milestones
 ### 0. Baseline and compatibility contract
 
-Status: **in progress**
+Status: **complete**
 
 - [x] Create the Rust service and Git repository.
 - [x] Persist a fixed shard count in `manifest.sqlite`.
@@ -153,7 +153,7 @@ Status: **in progress**
 - [x] Add CI for formatting, Clippy, tests, and supported Rust versions.
 - [x] Add a benchmark baseline for point reads, writes, and four-shard
   concurrent writes.
-- [ ] Choose and document the project license and supported-platform policy.
+- [x] Choose and document the project license and supported-platform policy.
 
 Exit criterion: the current prototype is reproducible in CI and its promises
 and non-promises are written down.

--- a/docs/SUPPORTED_PLATFORMS.md
+++ b/docs/SUPPORTED_PLATFORMS.md
@@ -1,0 +1,56 @@
+# Supported platforms
+
+BriskDB is an experimental database server. “Supported” currently means that a
+target is continuously built and tested and that a regression blocks a pull
+request. It does not mean that BriskDB is production-ready or covered by a
+service-level agreement.
+
+## CI-supported target
+
+The current support contract is intentionally narrow:
+
+- `x86_64-unknown-linux-gnu` on Ubuntu 24.04;
+- Rust 1.85, the declared minimum supported Rust version (MSRV); and
+- the latest stable Rust release.
+
+Every pull request must pass formatting, Clippy, unit and integration tests,
+documentation tests, and benchmark correctness smoke tests on the pinned
+Ubuntu 24.04 GitHub-hosted runner. BriskDB uses rusqlite's bundled SQLite build,
+so the host's system SQLite version is not part of this contract.
+
+The MSRV may only be raised deliberately, with documentation and CI changed in
+the same pull request. A supported operating-system runner may be replaced
+before its upstream end of life, also through a tested pull request and policy
+update.
+
+## Development-tested targets
+
+Maintainers also develop and run the full suite on `aarch64-apple-darwin`.
+macOS is useful for development and benchmark comparisons, but it is
+best-effort until it has a required CI job. Linux ARM64, Intel macOS, Windows,
+the musl target, 32-bit targets, big-endian targets, mobile platforms, and
+WebAssembly are not currently tested or supported.
+
+Reports from unlisted targets are welcome. A target moves into the supported
+tier only after repeatable CI coverage exists for its compile, test, and
+storage behavior.
+
+## Filesystem and deployment boundary
+
+All BriskDB data files must reside on storage local to the server host with
+working file locks and durable synchronization semantics. The current engine
+enables SQLite WAL mode and `synchronous=FULL` for the manifest and every
+shard. Network filesystems such as NFS or SMB, cloud-synchronized folders,
+userspace filesystems with unverified locking, and sharing one data directory
+between hosts are unsupported.
+
+Only a single BriskDB server process per data directory is currently tested.
+Do not copy, move, edit, or separately open the manifest, shard, WAL, or shared
+memory files while the server is running. Backup, restore, multi-process
+access, filesystem-fault behavior, and crash-recovery guarantees will become
+supported only when their roadmap issues add the corresponding automated
+tests.
+
+When reporting a platform problem, include the BriskDB revision, `rustc -Vv`,
+operating-system and architecture details, filesystem type, mount options, and
+whether the data directory is local or remote.


### PR DESCRIPTION
## Summary

- license BriskDB under the canonical MIT license, matching TinyMongo's established project convention
- publish SPDX `MIT` and repository metadata in `Cargo.toml`
- define Ubuntu 24.04 x86_64 with Rust 1.85 and current stable as the CI-supported platform
- document best-effort and unsupported targets plus SQLite WAL filesystem/deployment boundaries
- pin CI to Ubuntu 24.04 without changing the protected check contexts and mark phase 0 complete

## Validation

- `cargo fmt --all --check`
- `cargo test --locked --all-targets --all-features`
- `cargo test --locked --doc --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo +1.85.0 test --locked --all-targets --all-features`
- `cargo +1.85.0 test --locked --doc --all-features`
- `cargo +1.85.0 clippy --locked --all-targets --all-features -- -D warnings`
- Actionlint 1.7.12 with verified release checksum
- Cargo metadata asserts the MIT SPDX identifier and repository URL
- `cargo package --locked --allow-dirty --no-verify --list` includes the license and platform policy
- workflow YAML parses and all local Markdown links resolve

No runtime code changed, so the existing suite and package/configuration checks are the applicable automated coverage; no artificial unit test was added.

Closes #4
