### PR TITLE
Add protocol-neutral value and result types

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ minimum supported Rust version (MSRV) and the latest stable toolchain.
 ## Current foundation
 
 - Stable BLAKE3 routing from a caller-provided shard key
+- Protocol-neutral typed values, ordered columns, positional rows, and results
 - A fixed shard count recorded in `manifest.sqlite`
 - One WAL-enabled SQLite database per shard
 - Routed execute and query endpoints

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -164,7 +164,7 @@ Status: **in progress**
 
 - [x] Split the crate into `core`, `storage`, `sql`, `protocol/http`, and
   `server` modules without changing externally visible behavior.
-- [ ] Replace `serde_json::Value` in storage with BriskDB `Value`, `DataType`,
+- [x] Replace `serde_json::Value` in storage with BriskDB `Value`, `DataType`,
   `Column`, `Row`, and `ResultSet` types.
 - [ ] Preserve column order and duplicate column names.
 - [ ] Add a structured error taxonomy and mappings for HTTP, PostgreSQL, and

--- a/benches/support/mod.rs
+++ b/benches/support/mod.rs
@@ -5,8 +5,10 @@ use std::{
 };
 
 use anyhow::{Context, anyhow, bail};
-use briskdb::storage::Database;
-use serde_json::{Value, json};
+use briskdb::{
+    core::{ResultSet, Value},
+    storage::Database,
+};
 
 pub const BENCHMARK_SHARDS: u16 = 4;
 
@@ -33,7 +35,11 @@ impl BenchmarkFixture {
             let affected = database.execute(
                 key,
                 "INSERT INTO benchmark_items (id, writes, payload) VALUES (?1, ?2, ?3)",
-                &[json!(key), json!(0), json!("baseline payload")],
+                &[
+                    Value::from(key.clone()),
+                    Value::from(0_i64),
+                    Value::from("baseline payload"),
+                ],
             )?;
             if affected != 1 {
                 bail!("benchmark seed insert affected {affected} rows")
@@ -55,12 +61,12 @@ impl BenchmarkFixture {
         self.database.shard_for_key(key.as_bytes())
     }
 
-    pub fn point_read(&self) -> anyhow::Result<Vec<Value>> {
+    pub fn point_read(&self) -> anyhow::Result<ResultSet> {
         let key = &self.keys_by_shard[0];
         self.database.query(
             key,
             "SELECT id, writes, payload FROM benchmark_items WHERE id = ?1",
-            &[json!(key)],
+            &[Value::from(key.clone())],
         )
     }
 
@@ -104,13 +110,15 @@ impl BenchmarkFixture {
             .keys_by_shard
             .get(shard)
             .context("benchmark shard index is out of range")?;
-        let rows = self.database.query(
+        let result = self.database.query(
             key,
             "SELECT writes FROM benchmark_items WHERE id = ?1",
-            &[json!(key)],
+            &[Value::from(key.clone())],
         )?;
-        rows.first()
-            .and_then(|row| row.get("writes"))
+        result
+            .rows()
+            .first()
+            .and_then(|row| row.get(0))
             .and_then(Value::as_i64)
             .context("benchmark row did not contain an integer write count")
     }
@@ -120,7 +128,7 @@ fn update_key(database: &Database, key: &str) -> anyhow::Result<usize> {
     database.execute(
         key,
         "UPDATE benchmark_items SET writes = writes + 1 WHERE id = ?1",
-        &[json!(key)],
+        &[Value::from(key)],
     )
 }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,9 @@
 # Architecture
 
 BriskDB is organized so network protocols can share one routing and execution
-core. The first module split preserves the experimental HTTP and Rust APIs
-while making future PostgreSQL and MySQL adapters explicit peers.
+core. The module layout preserves the experimental HTTP contract and existing
+Rust module paths while making future PostgreSQL and MySQL adapters explicit
+peers.
 
 ```text
 binary (main)
@@ -20,10 +21,10 @@ server ---------> protocol::http
 
 | Module | Responsibility | Must not own |
 | --- | --- | --- |
-| `core` | Stable key routing and protocol-neutral coordination of routed execute/query and schema broadcast | HTTP types, listeners, or Axum handlers |
+| `core` | Protocol-neutral `Value`, `DataType`, `Column`, `Row`, and `ResultSet`; stable key routing; routed execute/query and schema broadcast | JSON/HTTP types, listeners, or Axum handlers |
 | `storage` | Manifest and shard layout, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
-| `sql` | SQLite statement execution and the current JSON/SQLite value conversion | Routing, filesystem layout, or protocol responses |
-| `protocol::http` | HTTP request extraction and response/error encoding | BLAKE3 routing, shard files, or rusqlite calls |
+| `sql` | SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, routing, filesystem layout, or protocol responses |
+| `protocol::http` | HTTP request extraction plus JSON/BriskDB value and response/error encoding | BLAKE3 routing, shard files, or rusqlite calls |
 | `server` | Process configuration, database assembly, listener binding, and Axum lifecycle | SQL parsing or storage implementation details |
 
 Implementation dependencies flow one way: adapters call `core`; `core`
@@ -39,7 +40,7 @@ This change deliberately preserves:
 - the CLI flags, environment variables, defaults, and listener behavior;
 - every HTTP route, request field, response shape, and current error status;
 - BLAKE3 routing, shard filenames, manifest schema, WAL and synchronous modes;
-- SQLite pass-through semantics and JSON value conversion; and
+- SQLite pass-through semantics and the legacy HTTP JSON response shape; and
 - the existing `briskdb::api::router` and `briskdb::storage::Database` Rust
   paths through compatibility re-exports.
 
@@ -48,8 +49,43 @@ routed reads, and SQLite error serialization. Unit tests remain colocated with
 routing, storage, SQL conversion, CLI, and server assembly.
 
 The module names are stable boundaries, not a claim that later roadmap work is
-already complete. In particular, BriskDB-specific value/result types, the
-structured error taxonomy, session state, the async `Engine` interface,
-connection pools, cancellation, and limits are separate issues. Until those
-land, the core intentionally retains the current synchronous SQLite and JSON
-interfaces.
+already complete. The structured error taxonomy, session state, the async
+`Engine` interface, connection pools, cancellation, and limits are separate
+issues. Until those land, the core intentionally retains the current
+synchronous execution interface.
+
+## Typed result boundary
+
+Core and SQL code do not use `serde_json::Value`. The protocol-neutral value
+model distinguishes signed and unsigned 64-bit integers, binary floating point,
+validated exact decimal text, valid UTF-8 text, text containing invalid UTF-8
+bytes, and binary data. Decimal construction validates SQL-style decimal syntax
+while preserving the caller's digits, scale, sign, and exponent text. This
+prevents an adapter from silently narrowing an unsigned
+integer, rounding a decimal, or replacing text bytes before it reaches the
+storage boundary. `ResultSet` keeps an ordered `Vec<Column>` and each `Row`
+keeps positional `Vec<Value>` data. SQLite cannot reliably provide one static
+type for every dynamic result column, so column metadata begins as
+`DataType::Unknown`; each value still reports its concrete type.
+
+Conversions into SQLite are checked against its five storage classes. Unsigned
+integers bind as `INTEGER` only when they fit in `i64`; larger unsigned values,
+exact decimals, invalid UTF-8 text, and `NaN` are rejected rather than coerced
+to another SQLite storage class. SQLite `TEXT` results preserve invalid bytes as
+`Value::InvalidText` inside the core.
+
+The experimental HTTP adapter is the only JSON conversion boundary. It renders
+exact decimals as JSON strings, converts `InvalidText` to a JSON string with
+invalid byte sequences replaced by U+FFFD, and maps non-finite floats to JSON
+`null`; these losses are explicit adapter policy rather than storage behavior.
+It keeps the original object-per-row
+response for compatibility, which means duplicate names are still overwritten
+there even though the core result is positional. The next roadmap item changes
+that duplicate-column behavior deliberately. HTTP parameters that cannot bind
+to SQLite without loss now fail instead of being rounded or rewritten.
+
+The pre-1.0 Rust `Database::execute` and `Database::query` signatures now use
+BriskDB `Value` and `ResultSet` directly instead of `serde_json::Value`. This is
+an intentional source-level migration to establish the protocol-neutral core;
+the legacy module paths remain available, but the old JSON-typed method
+signatures do not.

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -60,24 +60,44 @@ failing shard as well as leave earlier shards fully or partially updated.
 ### Current parameter and result conversion
 
 Use SQLite positional placeholders such as `?1` and `?2`. Values are never
-interpolated into SQL text.
+interpolated into SQL text. The HTTP adapter converts JSON parameters into
+protocol-neutral BriskDB values; the SQL layer binds only those typed values.
 
 | JSON input | SQLite binding |
 | --- | --- |
 | `null` | `NULL` |
 | `true` / `false` | `INTEGER` `1` / `0` |
 | Signed integer representable as `i64` | `INTEGER` |
-| Other accepted JSON number | `REAL` through `f64`; large integers can lose precision |
+| Unsigned integer no greater than `i64::MAX` | `INTEGER` after a checked conversion |
+| Unsigned integer greater than `i64::MAX` | Rejected; it is not rounded to `REAL` |
+| Accepted fractional or exponent-form JSON number | `REAL` through `f64` |
 | Number outside `serde_json`'s accepted range | Request decoding fails before SQLite binding |
 | String | `TEXT` |
 | Array or object | Compact JSON stored as `TEXT` |
 
-SQLite results currently map `NULL`, `INTEGER`, and `REAL` directly to their
-JSON counterparts. `TEXT` is decoded as UTF-8 with invalid byte sequences
-replaced by U+FFFD. A `BLOB` is returned as an array of byte-valued JSON
-integers. Query results are currently JSON objects keyed by column name, so a
-later duplicate column name overwrites an earlier one. The protocol-neutral
-row model will replace these lossy representations before the API is stable.
+SQLite results map to protocol-neutral BriskDB `Null`, `Int64`, `Float64`,
+`Text`, `InvalidText`, and `Binary` values. Valid `TEXT` becomes `Text`; invalid
+UTF-8 remains byte-for-byte intact in `InvalidText`. The wider value model also
+has `UInt64` and a validated, exact string-backed `Decimal` variant for protocol
+inputs. Decimal construction accepts SQL-style signed decimal and exponent
+syntax and preserves its original digits and scale.
+SQLite binding accepts `UInt64` only through a checked conversion to `i64` and
+rejects larger values, `Decimal`, `InvalidText`, and `Float64(NaN)` instead of
+rounding, rewriting, or allowing SQLite to turn `NaN` into `NULL`. Infinite
+`Float64` values remain SQLite `REAL` values. Ordered column metadata and
+positional rows are preserved inside `ResultSet`; SQLite result-column metadata
+is marked `Unknown` because dynamic SQLite values do not guarantee one static
+type.
+
+The experimental HTTP adapter still returns `NULL`, `INTEGER`, `REAL`, and
+`TEXT` as their JSON counterparts and a `BLOB` as an array of byte-valued JSON
+integers. It encodes exact `Decimal` values as JSON strings and renders
+`InvalidText` lossily, replacing invalid UTF-8 byte sequences with U+FFFD.
+Because JSON has no non-finite number syntax, it renders infinite or `NaN`
+`Float64` values as `null`. Its current rows are objects keyed by column name,
+so a later duplicate column name overwrites an earlier one. This remaining
+adapter loss is tracked separately; storage and core no longer collapse rows
+into JSON maps.
 
 ## SQL surface
 
@@ -154,7 +174,7 @@ engine used by PostgreSQL and HTTP.
 | --- | --- | --- |
 | Parameters | `?` in prepared statements | Planned normalization to bound SQLite parameters; no string interpolation |
 | Identifier quoting | Backticks by default | Planned normalization; double-quoted strict SQL remains available |
-| Type system | Static signed/unsigned column types | Planned loss-aware mapping; integers outside signed 64-bit range need an explicit policy |
+| Type system | Static signed/unsigned column types | BriskDB retains `UInt64` without narrowing; current SQLite binding rejects values above `i64::MAX` until an explicit storage mapping exists |
 | Boolean | Commonly `TINYINT(1)` | Stored as SQLite integer `0` or `1`; protocol adapter returns documented metadata |
 | `AUTO_INCREMENT` | Table column attribute | Unsupported until generated-key semantics are designed |
 | `UNSIGNED`, display widths | MySQL column attributes | No current SQLite equivalent; unsupported initially |

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,10 +3,15 @@
 //! This module owns routing and coordinates storage and SQL execution. It does
 //! not depend on a network protocol.
 
+mod types;
+
+pub use types::{
+    Column, DataType, Decimal, ParseDecimalError, ResultSet, ResultSetShapeError, Row, Value,
+};
+
 use std::path::Path;
 
 use anyhow::Context;
-use serde_json::Value;
 
 use crate::{sql, storage::Storage};
 
@@ -57,7 +62,7 @@ impl Database {
         shard_key: &str,
         statement: &str,
         params: &[Value],
-    ) -> anyhow::Result<Routed<Vec<Value>>> {
+    ) -> anyhow::Result<Routed<ResultSet>> {
         let shard = self.shard_for_key(shard_key.as_bytes());
         let connection = self.storage.open_shard(shard)?;
         let value = sql::query(&connection, statement, params)?;
@@ -78,7 +83,7 @@ impl Database {
         shard_key: &str,
         statement: &str,
         params: &[Value],
-    ) -> anyhow::Result<Vec<Value>> {
+    ) -> anyhow::Result<ResultSet> {
         Ok(self.query_routed(shard_key, statement, params)?.value)
     }
 
@@ -96,8 +101,6 @@ impl Database {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
-
     use super::*;
 
     #[test]
@@ -122,14 +125,14 @@ mod tests {
             .execute_routed(
                 "widget-1",
                 "INSERT INTO widgets (id, name) VALUES (?1, ?2)",
-                &[json!("widget-1"), json!("First widget")],
+                &[Value::from("widget-1"), Value::from("First widget")],
             )
             .unwrap();
         let read = database
             .query_routed(
                 "widget-1",
                 "SELECT id, name FROM widgets WHERE id = ?1",
-                &[json!("widget-1")],
+                &[Value::from("widget-1")],
             )
             .unwrap();
 
@@ -144,7 +147,17 @@ mod tests {
         assert_eq!(read.shard, expected_shard);
         assert_eq!(
             read.value,
-            vec![json!({"id": "widget-1", "name": "First widget"})]
+            ResultSet::new(
+                vec![
+                    Column::new("id", DataType::Unknown),
+                    Column::new("name", DataType::Unknown),
+                ],
+                vec![Row::new(vec![
+                    Value::from("widget-1"),
+                    Value::from("First widget"),
+                ])],
+            )
+            .unwrap()
         );
     }
 
@@ -164,7 +177,7 @@ mod tests {
                 .execute(
                     "widget-1",
                     "INSERT INTO widgets (id, name) VALUES (?1, ?2)",
-                    &[json!("widget-1"), json!("First widget")],
+                    &[Value::from("widget-1"), Value::from("First widget")],
                 )
                 .unwrap(),
             1
@@ -174,10 +187,20 @@ mod tests {
                 .query(
                     "widget-1",
                     "SELECT id, name FROM widgets WHERE id = ?1",
-                    &[json!("widget-1")],
+                    &[Value::from("widget-1")],
                 )
                 .unwrap(),
-            vec![json!({"id": "widget-1", "name": "First widget"})]
+            ResultSet::new(
+                vec![
+                    Column::new("id", DataType::Unknown),
+                    Column::new("name", DataType::Unknown),
+                ],
+                vec![Row::new(vec![
+                    Value::from("widget-1"),
+                    Value::from("First widget"),
+                ])],
+            )
+            .unwrap()
         );
     }
 }

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -1,0 +1,468 @@
+//! Protocol-neutral values and tabular query results.
+
+use std::{error::Error, fmt, str::FromStr};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DataType {
+    Unknown,
+    Null,
+    Boolean,
+    Int64,
+    UInt64,
+    Float64,
+    Decimal,
+    Text,
+    Binary,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Value {
+    Null,
+    Boolean(bool),
+    Int64(i64),
+    UInt64(u64),
+    Float64(f64),
+    Decimal(Decimal),
+    Text(String),
+    InvalidText(Vec<u8>),
+    Binary(Vec<u8>),
+}
+
+impl Value {
+    pub const fn data_type(&self) -> DataType {
+        match self {
+            Self::Null => DataType::Null,
+            Self::Boolean(_) => DataType::Boolean,
+            Self::Int64(_) => DataType::Int64,
+            Self::UInt64(_) => DataType::UInt64,
+            Self::Float64(_) => DataType::Float64,
+            Self::Decimal(_) => DataType::Decimal,
+            Self::Text(_) | Self::InvalidText(_) => DataType::Text,
+            Self::Binary(_) => DataType::Binary,
+        }
+    }
+
+    pub fn decimal(value: impl Into<String>) -> Result<Self, ParseDecimalError> {
+        Decimal::parse(value).map(Self::Decimal)
+    }
+
+    pub const fn as_i64(&self) -> Option<i64> {
+        match self {
+            Self::Int64(value) => Some(*value),
+            _ => None,
+        }
+    }
+
+    pub const fn as_u64(&self) -> Option<u64> {
+        match self {
+            Self::UInt64(value) => Some(*value),
+            _ => None,
+        }
+    }
+
+    pub fn as_decimal(&self) -> Option<&str> {
+        match self {
+            Self::Decimal(value) => Some(value.as_str()),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            Self::Text(value) => Some(value),
+            _ => None,
+        }
+    }
+
+    pub fn as_text_bytes(&self) -> Option<&[u8]> {
+        match self {
+            Self::Text(value) => Some(value.as_bytes()),
+            Self::InvalidText(value) => Some(value),
+            _ => None,
+        }
+    }
+
+    pub fn as_bytes(&self) -> Option<&[u8]> {
+        match self {
+            Self::Binary(value) => Some(value),
+            _ => None,
+        }
+    }
+}
+
+impl From<bool> for Value {
+    fn from(value: bool) -> Self {
+        Self::Boolean(value)
+    }
+}
+
+impl From<i64> for Value {
+    fn from(value: i64) -> Self {
+        Self::Int64(value)
+    }
+}
+
+impl From<u64> for Value {
+    fn from(value: u64) -> Self {
+        Self::UInt64(value)
+    }
+}
+
+impl From<f64> for Value {
+    fn from(value: f64) -> Self {
+        Self::Float64(value)
+    }
+}
+
+impl From<String> for Value {
+    fn from(value: String) -> Self {
+        Self::Text(value)
+    }
+}
+
+impl From<&str> for Value {
+    fn from(value: &str) -> Self {
+        Self::Text(value.to_owned())
+    }
+}
+
+impl From<Vec<u8>> for Value {
+    fn from(value: Vec<u8>) -> Self {
+        Self::Binary(value)
+    }
+}
+
+impl From<Decimal> for Value {
+    fn from(value: Decimal) -> Self {
+        Self::Decimal(value)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Decimal {
+    representation: String,
+}
+
+impl Decimal {
+    pub fn parse(value: impl Into<String>) -> Result<Self, ParseDecimalError> {
+        let representation = value.into();
+        if is_decimal_literal(&representation) {
+            Ok(Self { representation })
+        } else {
+            Err(ParseDecimalError)
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.representation
+    }
+
+    pub fn into_string(self) -> String {
+        self.representation
+    }
+}
+
+impl fmt::Display for Decimal {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl FromStr for Decimal {
+    type Err = ParseDecimalError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::parse(value)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParseDecimalError;
+
+impl fmt::Display for ParseDecimalError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("invalid decimal literal")
+    }
+}
+
+impl Error for ParseDecimalError {}
+
+fn is_decimal_literal(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    let mut index = 0;
+
+    if matches!(bytes.first(), Some(b'+' | b'-')) {
+        index += 1;
+    }
+
+    let mut mantissa_digits = 0;
+    while bytes.get(index).is_some_and(u8::is_ascii_digit) {
+        index += 1;
+        mantissa_digits += 1;
+    }
+
+    if bytes.get(index) == Some(&b'.') {
+        index += 1;
+        while bytes.get(index).is_some_and(u8::is_ascii_digit) {
+            index += 1;
+            mantissa_digits += 1;
+        }
+    }
+
+    if mantissa_digits == 0 {
+        return false;
+    }
+
+    if matches!(bytes.get(index), Some(b'e' | b'E')) {
+        index += 1;
+        if matches!(bytes.get(index), Some(b'+' | b'-')) {
+            index += 1;
+        }
+
+        let exponent_start = index;
+        while bytes.get(index).is_some_and(u8::is_ascii_digit) {
+            index += 1;
+        }
+        if index == exponent_start {
+            return false;
+        }
+    }
+
+    index == bytes.len()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Column {
+    pub name: String,
+    pub data_type: DataType,
+}
+
+impl Column {
+    pub fn new(name: impl Into<String>, data_type: DataType) -> Self {
+        Self {
+            name: name.into(),
+            data_type,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Row {
+    values: Vec<Value>,
+}
+
+impl Row {
+    pub fn new(values: Vec<Value>) -> Self {
+        Self { values }
+    }
+
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+
+    pub fn get(&self, index: usize) -> Option<&Value> {
+        self.values.get(index)
+    }
+
+    pub fn values(&self) -> &[Value] {
+        &self.values
+    }
+
+    pub fn into_values(self) -> Vec<Value> {
+        self.values
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResultSetShapeError {
+    row_index: usize,
+    expected: usize,
+    actual: usize,
+}
+
+impl ResultSetShapeError {
+    pub const fn row_index(&self) -> usize {
+        self.row_index
+    }
+
+    pub const fn expected(&self) -> usize {
+        self.expected
+    }
+
+    pub const fn actual(&self) -> usize {
+        self.actual
+    }
+}
+
+impl fmt::Display for ResultSetShapeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "row {} has {} values but the result set has {} columns",
+            self.row_index, self.actual, self.expected
+        )
+    }
+}
+
+impl Error for ResultSetShapeError {}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResultSet {
+    columns: Vec<Column>,
+    rows: Vec<Row>,
+}
+
+impl ResultSet {
+    pub fn new(columns: Vec<Column>, rows: Vec<Row>) -> Result<Self, ResultSetShapeError> {
+        if let Some((row_index, row)) = rows
+            .iter()
+            .enumerate()
+            .find(|(_, row)| row.len() != columns.len())
+        {
+            return Err(ResultSetShapeError {
+                row_index,
+                expected: columns.len(),
+                actual: row.len(),
+            });
+        }
+        Ok(Self { columns, rows })
+    }
+
+    pub fn columns(&self) -> &[Column] {
+        &self.columns
+    }
+
+    pub fn rows(&self) -> &[Row] {
+        &self.rows
+    }
+
+    pub fn into_parts(self) -> (Vec<Column>, Vec<Row>) {
+        (self.columns, self.rows)
+    }
+
+    pub fn len(&self) -> usize {
+        self.rows.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn values_report_their_exact_protocol_neutral_types() {
+        let cases = [
+            (Value::Null, DataType::Null),
+            (Value::from(true), DataType::Boolean),
+            (Value::from(42_i64), DataType::Int64),
+            (Value::from(42_u64), DataType::UInt64),
+            (Value::from(1.5_f64), DataType::Float64),
+            (Value::decimal("12.3400").unwrap(), DataType::Decimal),
+            (Value::from("text"), DataType::Text),
+            (Value::InvalidText(vec![0x80]), DataType::Text),
+            (Value::from(vec![0_u8, 255]), DataType::Binary),
+        ];
+
+        for (value, expected) in cases {
+            assert_eq!(value.data_type(), expected);
+        }
+    }
+
+    #[test]
+    fn typed_accessors_do_not_coerce_values() {
+        assert_eq!(Value::from(42_i64).as_i64(), Some(42));
+        assert_eq!(Value::from(42_u64).as_u64(), Some(42));
+        assert_eq!(Value::from(42.0_f64).as_i64(), None);
+        assert_eq!(
+            Value::decimal("12.3400").unwrap().as_decimal(),
+            Some("12.3400")
+        );
+        assert_eq!(Value::from("text").as_str(), Some("text"));
+        assert_eq!(Value::InvalidText(vec![0x80]).as_str(), None);
+        assert_eq!(
+            Value::InvalidText(vec![b'f', 0x80]).as_text_bytes(),
+            Some(&[b'f', 0x80][..])
+        );
+        assert_eq!(Value::from(true).as_str(), None);
+        assert_eq!(Value::from(vec![1_u8, 2]).as_bytes(), Some(&[1, 2][..]));
+        assert_eq!(Value::Null.as_bytes(), None);
+    }
+
+    #[test]
+    fn decimal_values_validate_and_preserve_exact_text() {
+        for valid in [
+            "0", "-0", "+12", "12.3400", "1.", ".5", "-.5", "1e3", "1.20E-4",
+        ] {
+            let decimal = Decimal::parse(valid).unwrap();
+            assert_eq!(decimal.as_str(), valid);
+            assert_eq!(decimal.to_string(), valid);
+        }
+
+        for invalid in [
+            "", "+", "-", ".", "e1", "1e", "1e+", "1.2.3", " 1", "1 ", "NaN", "Infinity", "1_000",
+        ] {
+            assert_eq!(
+                Decimal::parse(invalid).unwrap_err().to_string(),
+                "invalid decimal literal"
+            );
+        }
+
+        assert_eq!(
+            "12.3400".parse::<Decimal>().unwrap().into_string(),
+            "12.3400"
+        );
+    }
+
+    #[test]
+    fn result_sets_keep_ordered_columns_and_positional_rows() {
+        let result = ResultSet::new(
+            vec![
+                Column::new("first", DataType::Unknown),
+                Column::new("second", DataType::Unknown),
+            ],
+            vec![Row::new(vec![Value::from(1_i64), Value::from("two")])],
+        )
+        .unwrap();
+
+        assert_eq!(result.columns()[0].name, "first");
+        assert_eq!(result.columns()[1].name, "second");
+        assert_eq!(result.rows()[0].get(0), Some(&Value::from(1_i64)));
+        assert_eq!(result.rows()[0].get(1), Some(&Value::from("two")));
+        assert_eq!(result.len(), 1);
+        assert!(!result.is_empty());
+        assert!(!result.rows()[0].is_empty());
+    }
+
+    #[test]
+    fn result_sets_reject_short_and_long_rows() {
+        let columns = vec![
+            Column::new("first", DataType::Unknown),
+            Column::new("second", DataType::Unknown),
+        ];
+
+        let short = ResultSet::new(columns.clone(), vec![Row::new(vec![Value::Null])]).unwrap_err();
+        assert_eq!(short.row_index(), 0);
+        assert_eq!(short.expected(), 2);
+        assert_eq!(short.actual(), 1);
+        assert_eq!(
+            short.to_string(),
+            "row 0 has 1 values but the result set has 2 columns"
+        );
+
+        let long = ResultSet::new(
+            columns,
+            vec![Row::new(vec![Value::Null, Value::Null, Value::Null])],
+        )
+        .unwrap_err();
+        assert_eq!(long.expected(), 2);
+        assert_eq!(long.actual(), 3);
+    }
+}

--- a/src/protocol/http.rs
+++ b/src/protocol/http.rs
@@ -10,9 +10,9 @@ use axum::{
     routing::{get, post},
 };
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
+use serde_json::{Map, Value as JsonValue, json};
 
-use crate::core::{Database, Routed};
+use crate::core::{Database, ResultSet, Routed, Value};
 
 pub fn router(database: Arc<Database>) -> Router {
     Router::new()
@@ -23,7 +23,7 @@ pub fn router(database: Arc<Database>) -> Router {
         .with_state(database)
 }
 
-async fn health(State(database): State<Arc<Database>>) -> Json<Value> {
+async fn health(State(database): State<Arc<Database>>) -> Json<JsonValue> {
     Json(json!({
         "status": "ok",
         "shards": database.shard_count(),
@@ -35,7 +35,7 @@ struct RoutedSqlRequest {
     shard_key: String,
     sql: String,
     #[serde(default)]
-    params: Vec<Value>,
+    params: Vec<JsonValue>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -57,7 +57,12 @@ async fn execute(
         shard,
         value: rows_affected,
     } = tokio::task::spawn_blocking(move || {
-        database.execute_routed(&request.shard_key, &request.sql, &request.params)
+        let params = request
+            .params
+            .into_iter()
+            .map(json_to_value)
+            .collect::<Vec<_>>();
+        database.execute_routed(&request.shard_key, &request.sql, &params)
     })
     .await??;
 
@@ -70,9 +75,18 @@ async fn execute(
 async fn query(
     State(database): State<Arc<Database>>,
     Json(request): Json<RoutedSqlRequest>,
-) -> Result<Json<Value>, ApiError> {
-    let Routed { shard, value: rows } = tokio::task::spawn_blocking(move || {
-        database.query_routed(&request.shard_key, &request.sql, &request.params)
+) -> Result<Json<JsonValue>, ApiError> {
+    let (shard, rows) = tokio::task::spawn_blocking(move || {
+        let params = request
+            .params
+            .into_iter()
+            .map(json_to_value)
+            .collect::<Vec<_>>();
+        let Routed {
+            shard,
+            value: result,
+        } = database.query_routed(&request.shard_key, &request.sql, &params)?;
+        Ok::<_, anyhow::Error>((shard, result_set_to_json_rows(result)))
     })
     .await??;
 
@@ -82,9 +96,61 @@ async fn query(
 async fn broadcast(
     State(database): State<Arc<Database>>,
     Json(request): Json<BroadcastRequest>,
-) -> Result<Json<Value>, ApiError> {
+) -> Result<Json<JsonValue>, ApiError> {
     let shards = tokio::task::spawn_blocking(move || database.broadcast(&request.sql)).await??;
     Ok(Json(json!({"completed_shards": shards})))
+}
+
+fn json_to_value(value: JsonValue) -> Value {
+    match value {
+        JsonValue::Null => Value::Null,
+        JsonValue::Bool(value) => Value::Boolean(value),
+        JsonValue::Number(value) => value
+            .as_i64()
+            .map(Value::Int64)
+            .or_else(|| value.as_u64().map(Value::UInt64))
+            .or_else(|| value.as_f64().map(Value::Float64))
+            .unwrap_or_else(|| {
+                Value::decimal(value.to_string())
+                    .expect("a serde_json Number always has valid decimal syntax")
+            }),
+        JsonValue::String(value) => Value::Text(value),
+        JsonValue::Array(value) => Value::Text(JsonValue::Array(value).to_string()),
+        JsonValue::Object(value) => Value::Text(JsonValue::Object(value).to_string()),
+    }
+}
+
+fn value_to_json(value: Value) -> JsonValue {
+    match value {
+        Value::Null => JsonValue::Null,
+        Value::Boolean(value) => JsonValue::Bool(value),
+        Value::Int64(value) => json!(value),
+        Value::UInt64(value) => json!(value),
+        Value::Float64(value) => {
+            serde_json::Number::from_f64(value).map_or(JsonValue::Null, JsonValue::Number)
+        }
+        Value::Decimal(value) => JsonValue::String(value.into_string()),
+        Value::Text(value) => JsonValue::String(value),
+        Value::InvalidText(value) => {
+            JsonValue::String(String::from_utf8_lossy(&value).into_owned())
+        }
+        Value::Binary(value) => {
+            JsonValue::Array(value.into_iter().map(|byte| json!(byte)).collect())
+        }
+    }
+}
+
+fn result_set_to_json_rows(result: ResultSet) -> Vec<JsonValue> {
+    let (columns, rows) = result.into_parts();
+    rows.into_iter()
+        .map(|row| {
+            let mut object = Map::with_capacity(columns.len());
+            for (column, value) in columns.iter().zip(row.into_values()) {
+                object.insert(column.name.clone(), value_to_json(value));
+            }
+            JsonValue::Object(object)
+        })
+        .collect()
 }
 
 struct ApiError(anyhow::Error);
@@ -117,13 +183,14 @@ mod tests {
     use tower::ServiceExt;
 
     use super::*;
+    use crate::core::{Column, DataType, Row};
 
     async fn request_json(
         router: &Router,
         method: Method,
         uri: &str,
-        body: Option<Value>,
-    ) -> (StatusCode, Value) {
+        body: Option<JsonValue>,
+    ) -> (StatusCode, JsonValue) {
         let mut request = Request::builder().method(method).uri(uri);
         let body = match body {
             Some(value) => {
@@ -224,8 +291,151 @@ mod tests {
         assert!(body["error"].as_str().unwrap().contains("no such table"));
     }
 
+    #[tokio::test]
+    async fn unsigned_parameters_outside_sqlite_range_fail_instead_of_rounding() {
+        let temp = tempfile::tempdir().unwrap();
+        let application = router(Arc::new(Database::open(temp.path(), 4).unwrap()));
+        let too_large = u64::try_from(i64::MAX).unwrap() + 1;
+
+        let (status, body) = request_json(
+            &application,
+            Method::POST,
+            "/v1/query",
+            Some(json!({
+                "shard_key": "typed-row",
+                "sql": "SELECT ?1 AS value",
+                "params": [too_large]
+            })),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(
+            body["error"],
+            format!("unsigned integer {too_large} exceeds SQLite INTEGER range")
+        );
+    }
+
+    #[tokio::test]
+    async fn non_finite_sqlite_reals_keep_the_legacy_json_null_encoding() {
+        let temp = tempfile::tempdir().unwrap();
+        let application = router(Arc::new(Database::open(temp.path(), 4).unwrap()));
+
+        let (status, body) = request_json(
+            &application,
+            Method::POST,
+            "/v1/query",
+            Some(json!({
+                "shard_key": "typed-row",
+                "sql": "SELECT 1e999 AS positive_infinity, -1e999 AS negative_infinity"
+            })),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body["rows"],
+            json!([{"positive_infinity": null, "negative_infinity": null}])
+        );
+    }
+
+    #[tokio::test]
+    async fn typed_core_keeps_legacy_http_parameter_and_blob_shapes() {
+        let temp = tempfile::tempdir().unwrap();
+        let application = router(Arc::new(Database::open(temp.path(), 4).unwrap()));
+
+        let (status, body) = request_json(
+            &application,
+            Method::POST,
+            "/v1/query",
+            Some(json!({
+                "shard_key": "typed-row",
+                "sql": "SELECT ?1 AS enabled, ?2 AS object_text, ?3 AS array_text, X'00ff' AS data",
+                "params": [true, {"nested": true}, [1, "two"]]
+            })),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body["rows"],
+            json!([{
+                "enabled": 1,
+                "object_text": "{\"nested\":true}",
+                "array_text": "[1,\"two\"]",
+                "data": [0, 255]
+            }])
+        );
+    }
+
     #[test]
     fn legacy_api_module_reexports_the_router() {
         let _legacy_router: fn(Arc<Database>) -> Router = crate::api::router;
+    }
+
+    #[test]
+    fn json_parameters_keep_the_existing_binding_contract() {
+        assert_eq!(json_to_value(JsonValue::Null), Value::Null);
+        assert_eq!(json_to_value(json!(true)), Value::from(true));
+        assert_eq!(json_to_value(json!(42)), Value::from(42_i64));
+        assert_eq!(json_to_value(json!(1.5)), Value::from(1.5_f64));
+        assert_eq!(json_to_value(json!("text")), Value::from("text"));
+        assert_eq!(json_to_value(json!([1, "two"])), Value::from("[1,\"two\"]"));
+        assert_eq!(
+            json_to_value(json!({"nested": true})),
+            Value::from("{\"nested\":true}")
+        );
+
+        let above_signed_i64_range = json!(9_223_372_036_854_775_809_u64);
+        assert_eq!(
+            json_to_value(above_signed_i64_range),
+            Value::from(9_223_372_036_854_775_809_u64)
+        );
+    }
+
+    #[test]
+    fn typed_values_encode_to_explicit_legacy_json_shapes() {
+        assert_eq!(
+            value_to_json(Value::from(u64::MAX)),
+            json!(18_446_744_073_709_551_615_u64)
+        );
+        assert_eq!(
+            value_to_json(Value::decimal("12.3400").unwrap()),
+            json!("12.3400")
+        );
+        assert_eq!(value_to_json(Value::from(f64::INFINITY)), JsonValue::Null);
+        assert_eq!(value_to_json(Value::from(f64::NAN)), JsonValue::Null);
+        assert_eq!(
+            value_to_json(Value::InvalidText(vec![b'f', 0x80])),
+            JsonValue::String("f\u{fffd}".to_owned())
+        );
+    }
+
+    #[test]
+    fn legacy_result_encoding_keeps_json_shapes_and_duplicate_overwrite() {
+        let result = ResultSet::new(
+            vec![
+                Column::new("duplicate", DataType::Unknown),
+                Column::new("duplicate", DataType::Unknown),
+                Column::new("blob", DataType::Unknown),
+                Column::new("flag", DataType::Unknown),
+            ],
+            vec![Row::new(vec![
+                Value::from(1_i64),
+                Value::from("last value wins"),
+                Value::from(vec![0_u8, 255]),
+                Value::from(true),
+            ])],
+        )
+        .unwrap();
+
+        assert_eq!(
+            result_set_to_json_rows(result),
+            vec![json!({
+                "duplicate": "last value wins",
+                "blob": [0, 255],
+                "flag": true
+            })]
+        );
     }
 }

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -7,14 +7,18 @@ use rusqlite::{
     Connection, params_from_iter,
     types::{Value as SqlValue, ValueRef},
 };
-use serde_json::{Map, Value, json};
+
+use crate::core::{Column, DataType, ResultSet, Row, Value};
 
 pub(crate) fn execute(
     connection: &Connection,
     statement: &str,
     params: &[Value],
 ) -> anyhow::Result<usize> {
-    let params = params.iter().map(json_to_sql).collect::<Vec<_>>();
+    let params = params
+        .iter()
+        .map(value_to_sql)
+        .collect::<anyhow::Result<Vec<_>>>()?;
     Ok(connection.execute(statement, params_from_iter(params))?)
 }
 
@@ -22,25 +26,28 @@ pub(crate) fn query(
     connection: &Connection,
     statement: &str,
     params: &[Value],
-) -> anyhow::Result<Vec<Value>> {
-    let params = params.iter().map(json_to_sql).collect::<Vec<_>>();
+) -> anyhow::Result<ResultSet> {
+    let params = params
+        .iter()
+        .map(value_to_sql)
+        .collect::<anyhow::Result<Vec<_>>>()?;
     let mut statement = connection.prepare(statement)?;
-    let column_names = statement
+    let columns = statement
         .column_names()
         .into_iter()
-        .map(ToOwned::to_owned)
+        .map(|name| Column::new(name, DataType::Unknown))
         .collect::<Vec<_>>();
-    let mut rows = statement.query(params_from_iter(params))?;
-    let mut result = Vec::new();
+    let mut sqlite_rows = statement.query(params_from_iter(params))?;
+    let mut rows = Vec::new();
 
-    while let Some(row) = rows.next()? {
-        let mut object = Map::with_capacity(column_names.len());
-        for (index, name) in column_names.iter().enumerate() {
-            object.insert(name.clone(), sql_to_json(row.get_ref(index)?));
+    while let Some(sqlite_row) = sqlite_rows.next()? {
+        let mut values = Vec::with_capacity(columns.len());
+        for index in 0..columns.len() {
+            values.push(sql_to_value(sqlite_row.get_ref(index)?));
         }
-        result.push(Value::Object(object));
+        rows.push(Row::new(values));
     }
-    Ok(result)
+    Ok(ResultSet::new(columns, rows)?)
 }
 
 pub(crate) fn execute_batch(connection: &Connection, statement: &str) -> anyhow::Result<()> {
@@ -48,27 +55,39 @@ pub(crate) fn execute_batch(connection: &Connection, statement: &str) -> anyhow:
     Ok(())
 }
 
-fn json_to_sql(value: &Value) -> SqlValue {
-    match value {
+fn value_to_sql(value: &Value) -> anyhow::Result<SqlValue> {
+    Ok(match value {
         Value::Null => SqlValue::Null,
-        Value::Bool(value) => SqlValue::Integer(i64::from(*value)),
-        Value::Number(value) => value
-            .as_i64()
-            .map(SqlValue::Integer)
-            .or_else(|| value.as_f64().map(SqlValue::Real))
-            .unwrap_or_else(|| SqlValue::Text(value.to_string())),
-        Value::String(value) => SqlValue::Text(value.clone()),
-        Value::Array(_) | Value::Object(_) => SqlValue::Text(value.to_string()),
-    }
+        Value::Boolean(value) => SqlValue::Integer(i64::from(*value)),
+        Value::Int64(value) => SqlValue::Integer(*value),
+        Value::UInt64(value) => SqlValue::Integer(i64::try_from(*value).map_err(|_| {
+            anyhow::anyhow!("unsigned integer {value} exceeds SQLite INTEGER range")
+        })?),
+        Value::Float64(value) if value.is_nan() => {
+            anyhow::bail!("NaN has no lossless SQLite binding because SQLite converts it to NULL")
+        }
+        Value::Float64(value) => SqlValue::Real(*value),
+        Value::Decimal(value) => {
+            anyhow::bail!("decimal value {value} has no lossless SQLite binding")
+        }
+        Value::Text(value) => SqlValue::Text(value.clone()),
+        Value::InvalidText(_) => {
+            anyhow::bail!("non-UTF-8 text has no lossless SQLite binding")
+        }
+        Value::Binary(value) => SqlValue::Blob(value.clone()),
+    })
 }
 
-fn sql_to_json(value: ValueRef<'_>) -> Value {
+fn sql_to_value(value: ValueRef<'_>) -> Value {
     match value {
         ValueRef::Null => Value::Null,
-        ValueRef::Integer(value) => json!(value),
-        ValueRef::Real(value) => json!(value),
-        ValueRef::Text(value) => Value::String(String::from_utf8_lossy(value).into_owned()),
-        ValueRef::Blob(value) => Value::Array(value.iter().map(|byte| json!(byte)).collect()),
+        ValueRef::Integer(value) => Value::Int64(value),
+        ValueRef::Real(value) => Value::Float64(value),
+        ValueRef::Text(value) => match std::str::from_utf8(value) {
+            Ok(value) => Value::Text(value.to_owned()),
+            Err(_) => Value::InvalidText(value.to_vec()),
+        },
+        ValueRef::Blob(value) => Value::Binary(value.to_vec()),
     }
 }
 
@@ -77,52 +96,191 @@ mod tests {
     use super::*;
 
     #[test]
-    fn json_number_conversion_matches_the_http_compatibility_contract() {
-        assert_eq!(json_to_sql(&json!(42)), SqlValue::Integer(42));
-        assert_eq!(json_to_sql(&json!(1.5)), SqlValue::Real(1.5));
-
-        let above_signed_i64_range = json!(9_223_372_036_854_775_809_u64);
+    fn protocol_values_bind_to_the_expected_sqlite_storage_classes() {
+        assert_eq!(value_to_sql(&Value::Null).unwrap(), SqlValue::Null);
         assert_eq!(
-            json_to_sql(&above_signed_i64_range),
-            SqlValue::Real(9_223_372_036_854_775_808.0)
+            value_to_sql(&Value::from(true)).unwrap(),
+            SqlValue::Integer(1)
         );
-        assert!(serde_json::from_str::<Value>("1e400").is_err());
+        assert_eq!(
+            value_to_sql(&Value::from(false)).unwrap(),
+            SqlValue::Integer(0)
+        );
+        assert_eq!(
+            value_to_sql(&Value::from(42_i64)).unwrap(),
+            SqlValue::Integer(42)
+        );
+        assert_eq!(
+            value_to_sql(&Value::from(42_u64)).unwrap(),
+            SqlValue::Integer(42)
+        );
+        assert_eq!(
+            value_to_sql(&Value::from(1.5_f64)).unwrap(),
+            SqlValue::Real(1.5)
+        );
+        assert_eq!(
+            value_to_sql(&Value::from(f64::INFINITY)).unwrap(),
+            SqlValue::Real(f64::INFINITY)
+        );
+        assert_eq!(
+            value_to_sql(&Value::from("text")).unwrap(),
+            SqlValue::Text("text".to_owned())
+        );
+        assert_eq!(
+            value_to_sql(&Value::from(vec![0_u8, 255])).unwrap(),
+            SqlValue::Blob(vec![0, 255])
+        );
     }
 
     #[test]
-    fn sqlite_text_with_invalid_utf8_is_converted_lossily() {
+    fn values_without_lossless_sqlite_bindings_are_rejected() {
+        let too_large = u64::try_from(i64::MAX).unwrap() + 1;
         assert_eq!(
-            sql_to_json(ValueRef::Text(&[b'f', 0x80])),
-            Value::String("f\u{fffd}".to_owned())
+            value_to_sql(&Value::from(too_large))
+                .unwrap_err()
+                .to_string(),
+            format!("unsigned integer {too_large} exceeds SQLite INTEGER range")
+        );
+        assert_eq!(
+            value_to_sql(&Value::decimal("12.3400").unwrap())
+                .unwrap_err()
+                .to_string(),
+            "decimal value 12.3400 has no lossless SQLite binding"
+        );
+        assert_eq!(
+            value_to_sql(&Value::InvalidText(vec![0x80]))
+                .unwrap_err()
+                .to_string(),
+            "non-UTF-8 text has no lossless SQLite binding"
+        );
+        assert_eq!(
+            value_to_sql(&Value::from(f64::NAN))
+                .unwrap_err()
+                .to_string(),
+            "NaN has no lossless SQLite binding because SQLite converts it to NULL"
         );
     }
 
     #[test]
-    fn executes_and_queries_with_json_parameters() {
+    fn sqlite_storage_classes_convert_without_json_loss() {
+        assert_eq!(sql_to_value(ValueRef::Null), Value::Null);
+        assert_eq!(sql_to_value(ValueRef::Integer(42)), Value::from(42_i64));
+        assert_eq!(sql_to_value(ValueRef::Real(1.5)), Value::from(1.5_f64));
+        assert_eq!(sql_to_value(ValueRef::Text(b"text")), Value::from("text"));
+        assert_eq!(
+            sql_to_value(ValueRef::Blob(&[0, 255])),
+            Value::from(vec![0_u8, 255])
+        );
+    }
+
+    #[test]
+    fn sqlite_text_with_invalid_utf8_preserves_its_original_bytes() {
+        assert_eq!(
+            sql_to_value(ValueRef::Text(&[b'f', 0x80])),
+            Value::InvalidText(vec![b'f', 0x80])
+        );
+    }
+
+    #[test]
+    fn query_preserves_invalid_sqlite_text_bytes() {
+        let connection = Connection::open_in_memory().unwrap();
+        let result = query(&connection, "SELECT CAST(X'6680' AS TEXT) AS value", &[]).unwrap();
+
+        assert_eq!(
+            result.rows()[0].get(0),
+            Some(&Value::InvalidText(vec![b'f', 0x80]))
+        );
+    }
+
+    #[test]
+    fn query_rejects_nan_before_sqlite_can_convert_it_to_null() {
+        let connection = Connection::open_in_memory().unwrap();
+        let error = query(&connection, "SELECT ?1 AS value", &[Value::from(f64::NAN)]).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "NaN has no lossless SQLite binding because SQLite converts it to NULL"
+        );
+    }
+
+    #[test]
+    fn execute_and_query_return_ordered_typed_results() {
         let connection = Connection::open_in_memory().unwrap();
         execute_batch(
             &connection,
-            "CREATE TABLE values_table (id INTEGER PRIMARY KEY, value TEXT NOT NULL);",
+            "CREATE TABLE values_table (
+                id INTEGER PRIMARY KEY,
+                enabled INTEGER NOT NULL,
+                ratio REAL NOT NULL,
+                text_value TEXT NOT NULL,
+                blob_value BLOB NOT NULL,
+                optional_value TEXT
+            );",
         )
         .unwrap();
 
         assert_eq!(
             execute(
                 &connection,
-                "INSERT INTO values_table (id, value) VALUES (?1, ?2)",
-                &[json!(7), json!({"nested": true})],
+                "INSERT INTO values_table
+                 (id, enabled, ratio, text_value, blob_value, optional_value)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                &[
+                    Value::from(7_i64),
+                    Value::from(true),
+                    Value::from(1.5_f64),
+                    Value::from("text"),
+                    Value::from(vec![0_u8, 255]),
+                    Value::Null,
+                ],
             )
             .unwrap(),
             1
         );
+
+        let result = query(
+            &connection,
+            "SELECT id, enabled, ratio, text_value, blob_value, optional_value
+             FROM values_table WHERE id = ?1",
+            &[Value::from(7_i64)],
+        )
+        .unwrap();
         assert_eq!(
-            query(
-                &connection,
-                "SELECT id, value FROM values_table WHERE id = ?1",
-                &[json!(7)],
-            )
-            .unwrap(),
-            vec![json!({"id": 7, "value": "{\"nested\":true}"})]
+            result.columns(),
+            vec![
+                Column::new("id", DataType::Unknown),
+                Column::new("enabled", DataType::Unknown),
+                Column::new("ratio", DataType::Unknown),
+                Column::new("text_value", DataType::Unknown),
+                Column::new("blob_value", DataType::Unknown),
+                Column::new("optional_value", DataType::Unknown),
+            ]
         );
+        assert_eq!(
+            result.rows(),
+            vec![Row::new(vec![
+                Value::from(7_i64),
+                Value::from(1_i64),
+                Value::from(1.5_f64),
+                Value::from("text"),
+                Value::from(vec![0_u8, 255]),
+                Value::Null,
+            ])]
+        );
+    }
+
+    #[test]
+    fn empty_results_still_return_ordered_column_metadata() {
+        let connection = Connection::open_in_memory().unwrap();
+        let result = query(&connection, "SELECT 1 AS first, 2 AS second WHERE 0", &[]).unwrap();
+
+        assert_eq!(
+            result.columns(),
+            vec![
+                Column::new("first", DataType::Unknown),
+                Column::new("second", DataType::Unknown),
+            ]
+        );
+        assert!(result.is_empty());
     }
 }

--- a/tests/benchmark_workloads.rs
+++ b/tests/benchmark_workloads.rs
@@ -1,18 +1,31 @@
 #[path = "../benches/support/mod.rs"]
 mod support;
 
+use briskdb::core::{Column, DataType, Row, Value};
 use support::{BENCHMARK_SHARDS, BenchmarkFixture};
 
 #[test]
 fn point_read_returns_the_seeded_row() {
     let fixture = BenchmarkFixture::new().unwrap();
 
-    let rows = fixture.point_read().unwrap();
+    let result = fixture.point_read().unwrap();
 
-    assert_eq!(rows.len(), 1);
-    assert_eq!(rows[0]["id"], fixture.keys_by_shard()[0]);
-    assert_eq!(rows[0]["writes"], 0);
-    assert_eq!(rows[0]["payload"], "baseline payload");
+    assert_eq!(
+        result.columns(),
+        vec![
+            Column::new("id", DataType::Unknown),
+            Column::new("writes", DataType::Unknown),
+            Column::new("payload", DataType::Unknown),
+        ]
+    );
+    assert_eq!(
+        result.rows(),
+        vec![Row::new(vec![
+            Value::from(fixture.keys_by_shard()[0].clone()),
+            Value::from(0_i64),
+            Value::from("baseline payload"),
+        ])]
+    );
 }
 
 #[test]

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -9,4 +9,16 @@ fn legacy_and_explicit_module_paths_are_both_available() {
     let _core_database: Option<core::Database> = None;
     let _legacy_router: fn(Arc<storage::Database>) -> Router = api::router;
     let _http_router: fn(Arc<core::Database>) -> Router = http::router;
+
+    let result = core::ResultSet::new(
+        vec![core::Column::new("value", core::DataType::Int64)],
+        vec![core::Row::new(vec![core::Value::from(42_i64)])],
+    )
+    .unwrap();
+    assert_eq!(result.rows()[0].get(0), Some(&core::Value::from(42_i64)));
+
+    let decimal = "12.3400".parse::<core::Decimal>().unwrap();
+    assert_eq!(core::Value::from(decimal).as_decimal(), Some("12.3400"));
+    let _invalid_decimal: core::ParseDecimalError =
+        "not-a-number".parse::<core::Decimal>().unwrap_err();
 }


### PR DESCRIPTION
## Summary

- add protocol-neutral `Value`, `DataType`, validated `Decimal`, `Column`, `Row`, and `ResultSet` core types
- preserve ordered columns, positional row values, unsigned integers, exact decimal text, binary data, and invalid UTF-8 bytes across the core/SQLite boundary
- enforce result-set row widths and reject SQLite bindings that would silently narrow or rewrite values
- isolate `serde_json` conversion in the HTTP adapter while retaining its existing object-row, blob-array, duplicate-overwrite, and non-finite-number response behavior
- move request/result JSON materialization onto the blocking worker and migrate benchmark/public API callers to typed results
- document the pre-1.0 Rust API migration and checked conversion policy

## Intentional compatibility change

HTTP unsigned integer parameters above `i64::MAX` now return an error because SQLite cannot bind them losslessly. The previous implementation rounded them through `f64`.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features`
- `cargo test --locked --doc --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --no-deps --all-features`
- the same formatting, Clippy, test, doctest, and rustdoc gates on Rust 1.85.0
- optimized Criterion point-read, point-write, and four-shard concurrent-write benchmarks; no performance change detected
- two independent clean code-review passes after edge-case fixes

Closes #6
