### PR TITLE
Preserve ordered duplicate query columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,20 @@ curl -X POST http://127.0.0.1:7654/v1/query \
   }'
 ```
 
+The response keeps column metadata and row values in matching index order. The
+selected shard depends on the routing key; an example response is:
+
+```json
+{
+  "shard": 0,
+  "columns": [
+    {"name": "id", "data_type": "unknown"},
+    {"name": "name", "data_type": "unknown"}
+  ],
+  "rows": [["widget-1", "First widget"]]
+}
+```
+
 ## Deliberate boundaries
 
 This is an initial scaffold, not a production database yet. The current API

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -166,7 +166,7 @@ Status: **in progress**
   `server` modules without changing externally visible behavior.
 - [x] Replace `serde_json::Value` in storage with BriskDB `Value`, `DataType`,
   `Column`, `Row`, and `ResultSet` types.
-- [ ] Preserve column order and duplicate column names.
+- [x] Preserve column order and duplicate column names.
 - [ ] Add a structured error taxonomy and mappings for HTTP, PostgreSQL, and
   MySQL.
 - [ ] Introduce a `Session` state machine and an async `Engine` interface used

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -35,14 +35,20 @@ re-export of `core::Database`; the storage implementation does not call core.
 
 ## Compatibility during the split
 
-This change deliberately preserves:
+The module split deliberately preserved:
 
 - the CLI flags, environment variables, defaults, and listener behavior;
-- every HTTP route, request field, response shape, and current error status;
+- every HTTP route and request field, the health, execute, and broadcast response
+  shapes, and current error statuses;
 - BLAKE3 routing, shard filenames, manifest schema, WAL and synchronous modes;
-- SQLite pass-through semantics and the legacy HTTP JSON response shape; and
+- SQLite pass-through semantics and cell-level HTTP JSON encoding behavior; and
 - the existing `briskdb::api::router` and `briskdb::storage::Database` Rust
   paths through compatibility re-exports.
+
+The ordered-result follow-up deliberately changes the experimental `/v1/query`
+response from name-keyed row objects to ordered column metadata and positional
+row arrays. This is a pre-1.0 response-contract break needed to keep duplicate
+and empty column names representable.
 
 Automated HTTP contract tests cover health, schema broadcast, routed writes,
 routed reads, and SQLite error serialization. Unit tests remain colocated with
@@ -74,15 +80,19 @@ exact decimals, invalid UTF-8 text, and `NaN` are rejected rather than coerced
 to another SQLite storage class. SQLite `TEXT` results preserve invalid bytes as
 `Value::InvalidText` inside the core.
 
-The experimental HTTP adapter is the only JSON conversion boundary. It renders
-exact decimals as JSON strings, converts `InvalidText` to a JSON string with
-invalid byte sequences replaced by U+FFFD, and maps non-finite floats to JSON
-`null`; these losses are explicit adapter policy rather than storage behavior.
-It keeps the original object-per-row
-response for compatibility, which means duplicate names are still overwritten
-there even though the core result is positional. The next roadmap item changes
-that duplicate-column behavior deliberately. HTTP parameters that cannot bind
-to SQLite without loss now fail instead of being rounded or rewritten.
+The experimental HTTP adapter is the only JSON conversion boundary.
+`/v1/query` returns `shard`, an ordered `columns` array of `name` and
+`data_type` metadata objects, and positional arrays in `rows`. Column and row
+indices correspond exactly. Duplicate and empty names are valid, and metadata
+is returned even when there are zero rows.
+
+The adapter renders exact decimals as JSON strings, converts `InvalidText` to a
+JSON string with invalid byte sequences replaced by U+FFFD, and maps non-finite
+floats to JSON `null`; these losses are explicit adapter policy rather than
+storage behavior. HTTP parameters that cannot bind to SQLite without loss fail
+instead of being rounded or rewritten. The ordered response change affects only
+HTTP query serialization: it does not change routing, configuration, the
+manifest, shard files, or any other on-disk data.
 
 The pre-1.0 Rust `Database::execute` and `Database::query` signatures now use
 BriskDB `Value` and `ResultSet` directly instead of `serde_json::Value`. This is

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -89,15 +89,41 @@ positional rows are preserved inside `ResultSet`; SQLite result-column metadata
 is marked `Unknown` because dynamic SQLite values do not guarantee one static
 type.
 
-The experimental HTTP adapter still returns `NULL`, `INTEGER`, `REAL`, and
-`TEXT` as their JSON counterparts and a `BLOB` as an array of byte-valued JSON
-integers. It encodes exact `Decimal` values as JSON strings and renders
-`InvalidText` lossily, replacing invalid UTF-8 byte sequences with U+FFFD.
-Because JSON has no non-finite number syntax, it renders infinite or `NaN`
-`Float64` values as `null`. Its current rows are objects keyed by column name,
-so a later duplicate column name overwrites an earlier one. This remaining
-adapter loss is tracked separately; storage and core no longer collapse rows
-into JSON maps.
+The experimental `/v1/query` response exposes the ordered result directly. For
+example:
+
+```json
+{
+  "shard": 0,
+  "columns": [
+    {"name": "value", "data_type": "unknown"},
+    {"name": "value", "data_type": "unknown"}
+  ],
+  "rows": [[1, 2]]
+}
+```
+
+For every row, `rows[row_index][column_index]` is described by
+`columns[column_index]`. Column names may be duplicated or empty and are never
+used as JSON object keys. A query that produces no rows still returns all of its
+ordered column metadata with `"rows": []`. The `data_type` label is one of
+`unknown`, `null`, `boolean`, `int64`, `uint64`, `float64`, `decimal`, `text`,
+or `binary`. SQLite result columns currently report `unknown` because SQLite
+does not guarantee one static result type.
+
+Cell encoding retains the existing HTTP policy: nulls, booleans, signed and
+unsigned integers, finite floats, and valid text use their direct JSON forms;
+binary data is an array of byte-valued JSON integers; and exact decimals are
+JSON strings. `InvalidText` is rendered lossily with invalid UTF-8 byte
+sequences replaced by U+FFFD. Because JSON has no non-finite number syntax,
+infinite or `NaN` `Float64` values become `null`. Consumers that decode every
+JSON number through binary floating point must also account for precision loss
+when reading large `uint64` cells.
+
+This ordered response intentionally replaces the earlier experimental
+object-per-row shape, which collapsed duplicate names. It changes only HTTP
+query serialization; request fields, routing, configuration, the manifest,
+shard files, and stored data are unchanged.
 
 ## SQL surface
 

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -442,6 +442,55 @@ mod tests {
     }
 
     #[test]
+    fn result_sets_keep_duplicate_names_in_their_original_positions() {
+        let result = ResultSet::new(
+            vec![
+                Column::new("duplicate", DataType::Int64),
+                Column::new("middle", DataType::Text),
+                Column::new("duplicate", DataType::Boolean),
+            ],
+            vec![Row::new(vec![
+                Value::from(1_i64),
+                Value::from("two"),
+                Value::from(true),
+            ])],
+        )
+        .unwrap();
+
+        assert_eq!(
+            result
+                .columns()
+                .iter()
+                .map(|column| column.name.as_str())
+                .collect::<Vec<_>>(),
+            ["duplicate", "middle", "duplicate"]
+        );
+        assert_eq!(
+            result.rows()[0].values(),
+            [Value::from(1_i64), Value::from("two"), Value::from(true)]
+        );
+    }
+
+    #[test]
+    fn result_sets_accept_all_valid_empty_shapes() {
+        let completely_empty = ResultSet::new(Vec::new(), Vec::new()).unwrap();
+        assert!(completely_empty.columns().is_empty());
+        assert!(completely_empty.rows().is_empty());
+
+        let empty_row = ResultSet::new(Vec::new(), vec![Row::new(Vec::new())]).unwrap();
+        assert!(empty_row.columns().is_empty());
+        assert_eq!(empty_row.rows(), [Row::new(Vec::new())]);
+
+        let metadata_only =
+            ResultSet::new(vec![Column::new("value", DataType::Unknown)], Vec::new()).unwrap();
+        assert_eq!(
+            metadata_only.columns(),
+            [Column::new("value", DataType::Unknown)]
+        );
+        assert!(metadata_only.rows().is_empty());
+    }
+
+    #[test]
     fn result_sets_reject_short_and_long_rows() {
         let columns = vec![
             Column::new("first", DataType::Unknown),

--- a/src/protocol/http.rs
+++ b/src/protocol/http.rs
@@ -10,9 +10,9 @@ use axum::{
     routing::{get, post},
 };
 use serde::{Deserialize, Serialize};
-use serde_json::{Map, Value as JsonValue, json};
+use serde_json::{Value as JsonValue, json};
 
-use crate::core::{Database, ResultSet, Routed, Value};
+use crate::core::{DataType, Database, ResultSet, Routed, Value};
 
 pub fn router(database: Arc<Database>) -> Router {
     Router::new()
@@ -49,6 +49,19 @@ struct ExecuteResponse {
     rows_affected: usize,
 }
 
+#[derive(Debug, Serialize)]
+struct QueryResponse {
+    shard: u16,
+    columns: Vec<QueryColumn>,
+    rows: Vec<Vec<JsonValue>>,
+}
+
+#[derive(Debug, Serialize)]
+struct QueryColumn {
+    name: String,
+    data_type: &'static str,
+}
+
 async fn execute(
     State(database): State<Arc<Database>>,
     Json(request): Json<RoutedSqlRequest>,
@@ -75,8 +88,8 @@ async fn execute(
 async fn query(
     State(database): State<Arc<Database>>,
     Json(request): Json<RoutedSqlRequest>,
-) -> Result<Json<JsonValue>, ApiError> {
-    let (shard, rows) = tokio::task::spawn_blocking(move || {
+) -> Result<Json<QueryResponse>, ApiError> {
+    let response = tokio::task::spawn_blocking(move || {
         let params = request
             .params
             .into_iter()
@@ -86,11 +99,11 @@ async fn query(
             shard,
             value: result,
         } = database.query_routed(&request.shard_key, &request.sql, &params)?;
-        Ok::<_, anyhow::Error>((shard, result_set_to_json_rows(result)))
+        Ok::<_, anyhow::Error>(result_set_to_query_response(shard, result))
     })
     .await??;
 
-    Ok(Json(json!({"shard": shard, "rows": rows})))
+    Ok(Json(response))
 }
 
 async fn broadcast(
@@ -140,17 +153,39 @@ fn value_to_json(value: Value) -> JsonValue {
     }
 }
 
-fn result_set_to_json_rows(result: ResultSet) -> Vec<JsonValue> {
+fn result_set_to_query_response(shard: u16, result: ResultSet) -> QueryResponse {
     let (columns, rows) = result.into_parts();
-    rows.into_iter()
-        .map(|row| {
-            let mut object = Map::with_capacity(columns.len());
-            for (column, value) in columns.iter().zip(row.into_values()) {
-                object.insert(column.name.clone(), value_to_json(value));
-            }
-            JsonValue::Object(object)
+    let columns = columns
+        .into_iter()
+        .map(|column| QueryColumn {
+            name: column.name,
+            data_type: data_type_name(column.data_type),
         })
-        .collect()
+        .collect();
+    let rows = rows
+        .into_iter()
+        .map(|row| row.into_values().into_iter().map(value_to_json).collect())
+        .collect();
+
+    QueryResponse {
+        shard,
+        columns,
+        rows,
+    }
+}
+
+const fn data_type_name(data_type: DataType) -> &'static str {
+    match data_type {
+        DataType::Unknown => "unknown",
+        DataType::Null => "null",
+        DataType::Boolean => "boolean",
+        DataType::Int64 => "int64",
+        DataType::UInt64 => "uint64",
+        DataType::Float64 => "float64",
+        DataType::Decimal => "decimal",
+        DataType::Text => "text",
+        DataType::Binary => "binary",
+    }
 }
 
 struct ApiError(anyhow::Error);
@@ -210,7 +245,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn http_contract_is_preserved_across_all_endpoints() {
+    async fn all_http_endpoints_follow_the_current_contract() {
         let temp = tempfile::tempdir().unwrap();
         let database = Arc::new(Database::open(temp.path(), 4).unwrap());
         let expected_shard = database.shard_for_key(b"widget-1");
@@ -265,7 +300,11 @@ mod tests {
                 StatusCode::OK,
                 json!({
                     "shard": expected_shard,
-                    "rows": [{"id": "widget-1", "name": "First widget"}]
+                    "columns": [
+                        {"name": "id", "data_type": "unknown"},
+                        {"name": "name", "data_type": "unknown"}
+                    ],
+                    "rows": [["widget-1", "First widget"]]
                 }),
             )
         );
@@ -334,15 +373,21 @@ mod tests {
 
         assert_eq!(status, StatusCode::OK);
         assert_eq!(
-            body["rows"],
-            json!([{"positive_infinity": null, "negative_infinity": null}])
+            body["columns"],
+            json!([
+                {"name": "positive_infinity", "data_type": "unknown"},
+                {"name": "negative_infinity", "data_type": "unknown"}
+            ])
         );
+        assert_eq!(body["rows"], json!([[null, null]]));
     }
 
     #[tokio::test]
     async fn typed_core_keeps_legacy_http_parameter_and_blob_shapes() {
         let temp = tempfile::tempdir().unwrap();
-        let application = router(Arc::new(Database::open(temp.path(), 4).unwrap()));
+        let database = Arc::new(Database::open(temp.path(), 4).unwrap());
+        let expected_shard = database.shard_for_key(b"typed-row");
+        let application = router(database);
 
         let (status, body) = request_json(
             &application,
@@ -358,13 +403,83 @@ mod tests {
 
         assert_eq!(status, StatusCode::OK);
         assert_eq!(
-            body["rows"],
-            json!([{
-                "enabled": 1,
-                "object_text": "{\"nested\":true}",
-                "array_text": "[1,\"two\"]",
-                "data": [0, 255]
-            }])
+            body,
+            json!({
+                "shard": expected_shard,
+                "columns": [
+                    {"name": "enabled", "data_type": "unknown"},
+                    {"name": "object_text", "data_type": "unknown"},
+                    {"name": "array_text", "data_type": "unknown"},
+                    {"name": "data", "data_type": "unknown"}
+                ],
+                "rows": [[1, "{\"nested\":true}", "[1,\"two\"]", [0, 255]]]
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn query_preserves_duplicate_column_names_and_positions() {
+        let temp = tempfile::tempdir().unwrap();
+        let database = Arc::new(Database::open(temp.path(), 4).unwrap());
+        let expected_shard = database.shard_for_key(b"duplicate-row");
+        let application = router(database);
+
+        let (status, body) = request_json(
+            &application,
+            Method::POST,
+            "/v1/query",
+            Some(json!({
+                "shard_key": "duplicate-row",
+                "sql": "SELECT 1 AS duplicate, 2 AS middle, 3 AS duplicate, 4 AS \"\""
+            })),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body,
+            json!({
+                "shard": expected_shard,
+                "columns": [
+                    {"name": "duplicate", "data_type": "unknown"},
+                    {"name": "middle", "data_type": "unknown"},
+                    {"name": "duplicate", "data_type": "unknown"},
+                    {"name": "", "data_type": "unknown"}
+                ],
+                "rows": [[1, 2, 3, 4]]
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_query_results_keep_duplicate_column_metadata() {
+        let temp = tempfile::tempdir().unwrap();
+        let database = Arc::new(Database::open(temp.path(), 4).unwrap());
+        let expected_shard = database.shard_for_key(b"empty-row");
+        let application = router(database);
+
+        let (status, body) = request_json(
+            &application,
+            Method::POST,
+            "/v1/query",
+            Some(json!({
+                "shard_key": "empty-row",
+                "sql": "SELECT 1 AS duplicate, 2 AS duplicate WHERE 0"
+            })),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body,
+            json!({
+                "shard": expected_shard,
+                "columns": [
+                    {"name": "duplicate", "data_type": "unknown"},
+                    {"name": "duplicate", "data_type": "unknown"}
+                ],
+                "rows": []
+            })
         );
     }
 
@@ -412,30 +527,87 @@ mod tests {
     }
 
     #[test]
-    fn legacy_result_encoding_keeps_json_shapes_and_duplicate_overwrite() {
+    fn every_data_type_has_a_stable_http_metadata_name() {
+        assert_eq!(
+            [
+                DataType::Unknown,
+                DataType::Null,
+                DataType::Boolean,
+                DataType::Int64,
+                DataType::UInt64,
+                DataType::Float64,
+                DataType::Decimal,
+                DataType::Text,
+                DataType::Binary,
+            ]
+            .map(data_type_name),
+            [
+                "unknown", "null", "boolean", "int64", "uint64", "float64", "decimal", "text",
+                "binary",
+            ]
+        );
+    }
+
+    #[test]
+    fn result_encoding_keeps_column_order_duplicate_names_and_row_positions() {
         let result = ResultSet::new(
             vec![
                 Column::new("duplicate", DataType::Unknown),
-                Column::new("duplicate", DataType::Unknown),
-                Column::new("blob", DataType::Unknown),
-                Column::new("flag", DataType::Unknown),
+                Column::new("duplicate", DataType::Text),
+                Column::new("blob", DataType::Binary),
+                Column::new("flag", DataType::Boolean),
+                Column::new("", DataType::Null),
             ],
-            vec![Row::new(vec![
-                Value::from(1_i64),
-                Value::from("last value wins"),
-                Value::from(vec![0_u8, 255]),
-                Value::from(true),
-            ])],
+            vec![
+                Row::new(vec![
+                    Value::from(1_i64),
+                    Value::from("second position"),
+                    Value::from(vec![0_u8, 255]),
+                    Value::from(true),
+                    Value::Null,
+                ]),
+                Row::new(vec![
+                    Value::from(2_i64),
+                    Value::from("still separate"),
+                    Value::from(vec![1_u8, 2]),
+                    Value::from(false),
+                    Value::Null,
+                ]),
+            ],
         )
         .unwrap();
 
         assert_eq!(
-            result_set_to_json_rows(result),
-            vec![json!({
-                "duplicate": "last value wins",
-                "blob": [0, 255],
-                "flag": true
-            })]
+            serde_json::to_value(result_set_to_query_response(3, result)).unwrap(),
+            json!({
+                "shard": 3,
+                "columns": [
+                    {"name": "duplicate", "data_type": "unknown"},
+                    {"name": "duplicate", "data_type": "text"},
+                    {"name": "blob", "data_type": "binary"},
+                    {"name": "flag", "data_type": "boolean"},
+                    {"name": "", "data_type": "null"}
+                ],
+                "rows": [
+                    [1, "second position", [0, 255], true, null],
+                    [2, "still separate", [1, 2], false, null]
+                ]
+            })
+        );
+    }
+
+    #[test]
+    fn result_encoding_keeps_valid_zero_column_shapes() {
+        let empty = ResultSet::new(Vec::new(), Vec::new()).unwrap();
+        assert_eq!(
+            serde_json::to_value(result_set_to_query_response(1, empty)).unwrap(),
+            json!({"shard": 1, "columns": [], "rows": []})
+        );
+
+        let empty_row = ResultSet::new(Vec::new(), vec![Row::new(Vec::new())]).unwrap();
+        assert_eq!(
+            serde_json::to_value(result_set_to_query_response(2, empty_row)).unwrap(),
+            json!({"shard": 2, "columns": [], "rows": [[]]})
         );
     }
 }

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -270,15 +270,50 @@ mod tests {
     }
 
     #[test]
-    fn empty_results_still_return_ordered_column_metadata() {
+    fn query_preserves_duplicate_column_names_and_positions() {
         let connection = Connection::open_in_memory().unwrap();
-        let result = query(&connection, "SELECT 1 AS first, 2 AS second WHERE 0", &[]).unwrap();
+        let result = query(
+            &connection,
+            "SELECT 1 AS duplicate, 2 AS middle, 3 AS duplicate, 4 AS \"\"",
+            &[],
+        )
+        .unwrap();
 
         assert_eq!(
             result.columns(),
-            vec![
-                Column::new("first", DataType::Unknown),
-                Column::new("second", DataType::Unknown),
+            [
+                Column::new("duplicate", DataType::Unknown),
+                Column::new("middle", DataType::Unknown),
+                Column::new("duplicate", DataType::Unknown),
+                Column::new("", DataType::Unknown),
+            ]
+        );
+        assert_eq!(
+            result.rows(),
+            [Row::new(vec![
+                Value::from(1_i64),
+                Value::from(2_i64),
+                Value::from(3_i64),
+                Value::from(4_i64),
+            ])]
+        );
+    }
+
+    #[test]
+    fn empty_results_still_return_ordered_duplicate_column_metadata() {
+        let connection = Connection::open_in_memory().unwrap();
+        let result = query(
+            &connection,
+            "SELECT 1 AS duplicate, 2 AS duplicate WHERE 0",
+            &[],
+        )
+        .unwrap();
+
+        assert_eq!(
+            result.columns(),
+            [
+                Column::new("duplicate", DataType::Unknown),
+                Column::new("duplicate", DataType::Unknown),
             ]
         );
         assert!(result.is_empty());


### PR DESCRIPTION
## Summary

- replace lossy name-keyed HTTP query rows with ordered column metadata and positional row arrays
- preserve duplicate and empty column names, row alignment, and metadata for zero-row results
- expose stable adapter-only names for every BriskDB `DataType` without adding serde coupling to core
- add core, SQLite, HTTP conversion, and end-to-end regression tests for duplicate names, empty names, multiple rows, and valid empty shapes
- document the exact response contract, cell encodings, intentional experimental API break, and lack of storage/configuration impact

## Response shape

```json
{
  "shard": 0,
  "columns": [
    {"name": "value", "data_type": "unknown"},
    {"name": "value", "data_type": "unknown"}
  ],
  "rows": [[1, 2]]
}
```

`columns[i]` describes `rows[*][i]`; names are never used as JSON object keys.

## Intentional compatibility change

The experimental `/v1/query` endpoint now returns `columns` plus row arrays instead of name-keyed row objects. Health, execute, broadcast, request, routing, cell-encoding, error, configuration, and on-disk behavior are unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features`
- `cargo test --locked --doc --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --no-deps --all-features`
- the same formatting, Clippy, test, doctest, and rustdoc gates on Rust 1.85.0
- controlled same-host Criterion A/B against clean `main`; no performance change detected for point reads, point writes, or four-shard concurrent writes
- two independent clean post-implementation reviews

Closes #7
