### PR TITLE
Add structured engine error mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ boundaries and dependency direction.
 
 The [SQL compatibility contract](docs/SQL_COMPATIBILITY.md) distinguishes the
 current SQLite pass-through API from planned PostgreSQL and MySQL compatibility.
+The [error contract](docs/ERRORS.md) defines stable engine error kinds, safe
+HTTP problem details, and the mappings reserved for future PostgreSQL and MySQL
+adapters.
 Contributions follow the repository's [test-first completion policy](CONTRIBUTING.md).
 The [benchmark baseline](docs/BENCHMARKS.md) defines the reproducible storage
 workloads used to measure the current prototype.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -167,7 +167,7 @@ Status: **in progress**
 - [x] Replace `serde_json::Value` in storage with BriskDB `Value`, `DataType`,
   `Column`, `Row`, and `ResultSet` types.
 - [x] Preserve column order and duplicate column names.
-- [ ] Add a structured error taxonomy and mappings for HTTP, PostgreSQL, and
+- [x] Add a structured error taxonomy and mappings for HTTP, PostgreSQL, and
   MySQL.
 - [ ] Introduce a `Session` state machine and an async `Engine` interface used
   by every frontend.

--- a/benches/support/mod.rs
+++ b/benches/support/mod.rs
@@ -63,11 +63,11 @@ impl BenchmarkFixture {
 
     pub fn point_read(&self) -> anyhow::Result<ResultSet> {
         let key = &self.keys_by_shard[0];
-        self.database.query(
+        Ok(self.database.query(
             key,
             "SELECT id, writes, payload FROM benchmark_items WHERE id = ?1",
             &[Value::from(key.clone())],
-        )
+        )?)
     }
 
     pub fn point_write(&self) -> anyhow::Result<usize> {
@@ -125,11 +125,11 @@ impl BenchmarkFixture {
 }
 
 fn update_key(database: &Database, key: &str) -> anyhow::Result<usize> {
-    database.execute(
+    Ok(database.execute(
         key,
         "UPDATE benchmark_items SET writes = writes + 1 WHERE id = ?1",
         &[Value::from(key)],
-    )
+    )?)
 }
 
 fn find_key_for_each_shard(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,10 +21,11 @@ server ---------> protocol::http
 
 | Module | Responsibility | Must not own |
 | --- | --- | --- |
-| `core` | Protocol-neutral `Value`, `DataType`, `Column`, `Row`, and `ResultSet`; stable key routing; routed execute/query and schema broadcast | JSON/HTTP types, listeners, or Axum handlers |
+| `core` | Protocol-neutral values, results, and `EngineError`; stable key routing; routed execute/query and schema broadcast | JSON/HTTP types, listeners, or Axum handlers |
 | `storage` | Manifest and shard layout, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
 | `sql` | SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, routing, filesystem layout, or protocol responses |
-| `protocol::http` | HTTP request extraction plus JSON/BriskDB value and response/error encoding | BLAKE3 routing, shard files, or rusqlite calls |
+| `protocol::http` | HTTP request extraction plus JSON/BriskDB value and RFC 9457 problem-detail encoding | BLAKE3 routing, shard files, or rusqlite calls |
+| `protocol::error` | Exhaustive HTTP, PostgreSQL, and MySQL mappings from stable engine error kinds | SQLite errors, routing decisions, or wire-protocol session state |
 | `server` | Process configuration, database assembly, listener binding, and Axum lifecycle | SQL parsing or storage implementation details |
 
 Implementation dependencies flow one way: adapters call `core`; `core`
@@ -50,15 +51,41 @@ response from name-keyed row objects to ordered column metadata and positional
 row arrays. This is a pre-1.0 response-contract break needed to keep duplicate
 and empty column names representable.
 
+The structured-error follow-up likewise replaces the experimental blanket 500
+response and `error`-member JSON body with kind-specific status codes and RFC
+9457 problem details. Routes, request fields, routing, and persistence are
+unchanged. Public Rust `Database` methods now return `EngineResult<T>` instead
+of `anyhow::Result<T>`; this intentional pre-1.0 source migration gives callers
+stable error identity while retaining automatic `?` conversion into `anyhow`.
+
 Automated HTTP contract tests cover health, schema broadcast, routed writes,
-routed reads, and SQLite error serialization. Unit tests remain colocated with
-routing, storage, SQL conversion, CLI, and server assembly.
+routed reads, and structured problem-detail serialization. Unit tests remain
+colocated with routing, storage, SQL conversion, CLI, and server assembly.
 
 The module names are stable boundaries, not a claim that later roadmap work is
-already complete. The structured error taxonomy, session state, the async
-`Engine` interface, connection pools, cancellation, and limits are separate
-issues. Until those land, the core intentionally retains the current
-synchronous execution interface.
+already complete. Session state, the async `Engine` interface, connection
+pools, cancellation, and limits are separate issues. Until those land, the
+core intentionally retains the current synchronous execution interface.
+
+## Error boundary
+
+The core exposes a stable `EngineErrorKind` without importing any protocol
+response type. SQL and storage classify SQLite failures from primary and
+extended result codes plus operation context; they never parse SQLite error
+messages. Protocol-owned tables map each kind to an HTTP status and safe RFC
+9457 problem, a PostgreSQL SQLSTATE, and a MySQL error number/SQLSTATE pair.
+The PostgreSQL and MySQL entries are mapping contracts for future adapters, not
+implemented listeners.
+
+Client responses use fixed, safe text for the error kind. Diagnostic display
+text and source chains stay available internally but are never serialized, so
+SQLite messages, SQL text, and filesystem paths do not leak through an adapter.
+Only `Busy` advertises that retrying may succeed; a 5xx status alone is not a
+retry signal. The complete taxonomy and mapping table are in the
+[error contract](ERRORS.md).
+
+This boundary changes reporting, not persistence: the manifest schema, shard
+files, stored values, routing, and configuration formats are unchanged.
 
 ## Typed result boundary
 

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -1,0 +1,108 @@
+# Error contract
+
+BriskDB classifies failures once, at the protocol-neutral engine boundary. An
+`EngineErrorKind` is stable error identity; protocol adapters translate that
+identity without inspecting an error message. The HTTP adapter uses the mapping
+today. The PostgreSQL and MySQL columns below are contracts for their planned
+adapters, not a claim that either wire-protocol listener is implemented.
+
+## Taxonomy and protocol mappings
+
+The stable code is suitable for programmatic comparisons. Clients must not use
+the human-readable text to identify an error.
+
+| Engine kind | Stable code | HTTP | HTTP title | Fixed public detail | PostgreSQL SQLSTATE | MySQL error | MySQL SQLSTATE | Retryable |
+| --- | --- | ---: | --- | --- | --- | ---: | --- | --- |
+| <a id="invalid-argument"></a>`InvalidArgument` | `invalid_argument` | 400 | Invalid argument | The request contains an invalid argument. | `22023` | 1210 | `HY000` | No |
+| <a id="numeric-out-of-range"></a>`NumericOutOfRange` | `numeric_out_of_range` | 422 | Numeric value out of range | A numeric value is outside the supported range. | `22003` | 1690 | `22003` | No |
+| <a id="invalid-text-encoding"></a>`InvalidTextEncoding` | `invalid_text_encoding` | 422 | Invalid text encoding | A text value has an unsupported encoding. | `22021` | 1366 | `HY000` | No |
+| <a id="invalid-query"></a>`InvalidQuery` | `invalid_query` | 422 | Invalid query | The query could not be processed. | `42000` | 1105 | `HY000` | No |
+| <a id="unsupported"></a>`Unsupported` | `unsupported` | 501 | Unsupported operation | The requested operation is not supported. | `0A000` | 1235 | `42000` | No |
+| <a id="failed-precondition"></a>`FailedPrecondition` | `failed_precondition` | 409 | Failed precondition | The operation cannot run in the current state. | `55000` | 1105 | `HY000` | No |
+| <a id="type-mismatch"></a>`TypeMismatch` | `type_mismatch` | 422 | Type mismatch | A value has an incompatible type. | `42804` | 1366 | `HY000` | No |
+| <a id="constraint-violation"></a>`ConstraintViolation` | `constraint_violation` | 409 | Constraint violation | A database constraint was violated. | `23000` | 1105 | `HY000` | No |
+| <a id="unique-violation"></a>`UniqueViolation` | `unique_violation` | 409 | Unique constraint violation | A unique constraint was violated. | `23505` | 1062 | `23000` | No |
+| <a id="not-null-violation"></a>`NotNullViolation` | `not_null_violation` | 409 | Not-null constraint violation | A not-null constraint was violated. | `23502` | 1048 | `23000` | No |
+| <a id="foreign-key-violation"></a>`ForeignKeyViolation` | `foreign_key_violation` | 409 | Foreign-key constraint violation | A foreign-key constraint was violated. | `23503` | 1105 | `HY000` | No |
+| <a id="check-violation"></a>`CheckViolation` | `check_violation` | 409 | Check constraint violation | A check constraint was violated. | `23514` | 3819 | `HY000` | No |
+| <a id="permission-denied"></a>`PermissionDenied` | `permission_denied` | 403 | Permission denied | The operation is not permitted. | `42501` | 1227 | `42000` | No |
+| <a id="read-only"></a>`ReadOnly` | `read_only` | 403 | Read-only storage | The storage is read-only. | `25006` | 1290 | `HY000` | No |
+| <a id="busy"></a>`Busy` | `busy` | 503 | Database busy | The database is busy; retry the operation later. | `55P03` | 1205 | `HY000` | Yes |
+| <a id="cancelled"></a>`Cancelled` | `cancelled` | 500 | Request cancelled | The operation was cancelled. | `57014` | 1317 | `70100` | No |
+| <a id="limit-exceeded"></a>`LimitExceeded` | `limit_exceeded` | 422 | Limit exceeded | The request exceeds an engine limit. | `54000` | 1105 | `HY000` | No |
+| <a id="storage-full"></a>`StorageFull` | `storage_full` | 507 | Storage full | The storage has no available space. | `53100` | 1114 | `HY000` | No |
+| <a id="out-of-memory"></a>`OutOfMemory` | `out_of_memory` | 503 | Out of memory | The engine does not have enough memory. | `53200` | 1037 | `HY001` | No |
+| <a id="storage-unavailable"></a>`StorageUnavailable` | `storage_unavailable` | 503 | Storage unavailable | The storage is unavailable. | `58030` | 1105 | `HY000` | No |
+| <a id="data-corruption"></a>`DataCorruption` | `data_corruption` | 500 | Data corruption | Stored data failed an integrity check. | `XX001` | 1105 | `HY000` | No |
+| <a id="internal"></a>`Internal` | `internal` | 500 | Internal error | An internal engine error occurred. | `XX000` | 1105 | `HY000` | No |
+
+Only `Busy` is retryable. A caller should retry it with bounded exponential
+backoff and jitter. No other HTTP status, SQLSTATE, or MySQL error number
+implies retryability in BriskDB; notably, `OutOfMemory` and
+`StorageUnavailable` also use HTTP 503 but are not retryable under this
+contract. Storage-open and I/O failures can be permanent, so BriskDB does not
+guess that a later attempt will recover.
+
+MySQL has separate foreign-key errors for the parent and child directions.
+`ForeignKeyViolation` does not retain that direction, so BriskDB deliberately
+uses the general 1105/`HY000` mapping instead of guessing a more specific MySQL
+error number.
+
+The MySQL table targets the MySQL 8.0 server-error catalog at version 8.0.16 or
+newer; 8.0.16 is the first release in that line with error 3819 for enforced
+check constraints. Exact supported client and server versions remain a wire
+adapter decision.
+
+## HTTP problem details
+
+Engine failures returned by HTTP use
+[RFC 9457 Problem Details](https://www.rfc-editor.org/rfc/rfc9457.html) and the
+`application/problem+json` media type. The response has `type`, `title`,
+`status`, `detail`, and the BriskDB extension member `code`. `type`, `title`,
+`status`, `detail`, and `code` are selected from the adapter's fixed table for
+the error kind. In particular, `detail` is safe, fixed text rather than the
+underlying SQLite message, SQL text, filesystem path, or error source.
+
+Each `type` is this document's URL followed by the stable code with underscores
+changed to hyphens. For example, `invalid_argument` uses
+`https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#invalid-argument`.
+The anchors in the mapping table are therefore both identifiers and
+human-readable documentation for the problem types.
+
+`EngineError` display text and its source chain are diagnostic data for logs
+and tests. An adapter must never serialize either one to a client. This keeps
+the public response stable while preserving the original cause for operators.
+Malformed JSON can still be rejected by the HTTP framework before a request
+reaches the engine; that decoding rejection is outside this taxonomy.
+
+## Classification boundary
+
+The SQL and storage layers classify SQLite failures from primary and extended
+[SQLite result codes](https://www.sqlite.org/rescode.html), plus the operation
+context where SQLite uses one broad code. They never parse SQLite's
+human-readable message to distinguish error kinds. Constraint subtypes use
+extended result codes; an unrecognized constraint remains
+`ConstraintViolation` rather than being guessed from text.
+
+The core contains no HTTP, PostgreSQL, or MySQL response types. Conversely,
+protocol adapters do not inspect SQLite errors. This lets every frontend share
+one error identity while retaining its own response encoding.
+
+Adding the taxonomy changes error reporting only. It does not change the
+manifest schema, shard files, stored values, routing, configuration, or any
+other on-disk format.
+
+This is a pre-1.0 Rust API migration: public `Database` operations now return
+`EngineResult<T>` instead of `anyhow::Result<T>`. The `?` operator still
+converts `EngineError` into `anyhow::Error`, but callers with explicit result
+types, direct returns, or function-pointer signatures must update them.
+
+## Authoritative references
+
+- [RFC 9457: Problem Details for HTTP APIs](https://www.rfc-editor.org/rfc/rfc9457.html)
+- [RFC 9110: HTTP Semantics](https://www.rfc-editor.org/rfc/rfc9110.html#name-status-codes)
+- [RFC 4918: HTTP 507 Insufficient Storage](https://www.rfc-editor.org/rfc/rfc4918.html#section-11.5)
+- [PostgreSQL error codes](https://www.postgresql.org/docs/current/errcodes-appendix.html)
+- [MySQL server error reference](https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html)
+- [MySQL error message elements](https://dev.mysql.com/doc/refman/8.4/en/error-message-elements.html)
+- [SQLite result and extended result codes](https://www.sqlite.org/rescode.html)

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -125,6 +125,19 @@ object-per-row shape, which collapsed duplicate names. It changes only HTTP
 query serialization; request fields, routing, configuration, the manifest,
 shard files, and stored data are unchanged.
 
+### Current error contract
+
+The engine exposes stable protocol-neutral error kinds. The HTTP adapter maps
+them to safe RFC 9457 problem details without serializing SQLite messages, SQL
+text, filesystem paths, or internal source chains. SQL and storage classify
+SQLite result codes and operation context; error-message text is never parsed
+to choose an error kind.
+
+The same kinds already have defined PostgreSQL SQLSTATE and MySQL error
+number/SQLSTATE mappings, but those are contracts for the planned adapters.
+They do not make either wire-protocol listener available. See the complete
+[error taxonomy and mapping table](ERRORS.md).
+
 ## SQL surface
 
 ### Implemented pass-through surface
@@ -183,7 +196,7 @@ not implemented unless listed as implemented in this document.
 | `ON CONFLICT` | PostgreSQL upsert syntax | Supported only after a tested translation contract is defined |
 | Functions/operators | PostgreSQL catalog | SQLite functions/operators unless an explicit shim is documented |
 | System catalogs | `pg_catalog`, `information_schema` | Only queries required by named, tested clients will be emulated |
-| Error behavior | SQLSTATE and failed transaction state | Planned stable SQLSTATE mapping and `I`/`T`/`E` transaction states |
+| Error behavior | SQLSTATE and failed transaction state | Stable error-kind-to-SQLSTATE mapping defined; wire encoding and `I`/`T`/`E` transaction states planned |
 | `COPY`, replication, `LISTEN/NOTIFY` | PostgreSQL subprotocols/features | Deferred and unsupported initially |
 
 PostgreSQL's static result metadata does not always have an exact equivalent in
@@ -211,7 +224,7 @@ engine used by PostgreSQL and HTTP.
 | Engines, character sets, collations | Per-table/column options | Engine clauses unsupported; charset/collation behavior must be explicitly mapped |
 | Session probes | `SET NAMES`, `SHOW VARIABLES`, `SELECT @@...` | Only the subset required by named, tested clients will be emulated |
 | Metadata | `information_schema` and MySQL metadata commands | Minimal tested compatibility only |
-| Errors | MySQL error number plus SQLSTATE | Planned mapping from stable BriskDB error kinds |
+| Errors | MySQL error number plus SQLSTATE | Stable error-kind mapping defined; listener and wire encoding planned |
 | Stored programs, binlog, `LOAD DATA` | MySQL-specific facilities | Deferred and unsupported initially |
 
 ## SQLite semantic differences
@@ -304,5 +317,7 @@ stable release and follows the project's eventual versioning policy afterward.
 
 - [PostgreSQL SQL syntax](https://www.postgresql.org/docs/current/sql-syntax.html)
 - [PostgreSQL frontend/backend protocol](https://www.postgresql.org/docs/current/protocol.html)
+- [PostgreSQL error codes](https://www.postgresql.org/docs/current/errcodes-appendix.html)
 - [MySQL SQL statements](https://dev.mysql.com/doc/refman/en/sql-statements.html)
 - [MySQL client/server protocol](https://dev.mysql.com/doc/dev/mysql-server/latest/PAGE_PROTOCOL.html)
+- [MySQL server error reference](https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html)

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -1,0 +1,240 @@
+//! Protocol-neutral engine errors.
+
+use std::{error::Error, fmt};
+
+/// The stable category of an engine failure.
+///
+/// Protocol adapters map these categories to their own error representations.
+/// The variants deliberately contain no HTTP, PostgreSQL, MySQL, or SQLite
+/// types.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum EngineErrorKind {
+    InvalidArgument,
+    NumericOutOfRange,
+    InvalidTextEncoding,
+    InvalidQuery,
+    Unsupported,
+    FailedPrecondition,
+    TypeMismatch,
+    ConstraintViolation,
+    UniqueViolation,
+    NotNullViolation,
+    ForeignKeyViolation,
+    CheckViolation,
+    PermissionDenied,
+    ReadOnly,
+    Busy,
+    Cancelled,
+    LimitExceeded,
+    StorageFull,
+    OutOfMemory,
+    StorageUnavailable,
+    DataCorruption,
+    Internal,
+}
+
+impl EngineErrorKind {
+    /// Every currently defined kind, in compatibility-table order.
+    pub const ALL: &'static [Self] = &[
+        Self::InvalidArgument,
+        Self::NumericOutOfRange,
+        Self::InvalidTextEncoding,
+        Self::InvalidQuery,
+        Self::Unsupported,
+        Self::FailedPrecondition,
+        Self::TypeMismatch,
+        Self::ConstraintViolation,
+        Self::UniqueViolation,
+        Self::NotNullViolation,
+        Self::ForeignKeyViolation,
+        Self::CheckViolation,
+        Self::PermissionDenied,
+        Self::ReadOnly,
+        Self::Busy,
+        Self::Cancelled,
+        Self::LimitExceeded,
+        Self::StorageFull,
+        Self::OutOfMemory,
+        Self::StorageUnavailable,
+        Self::DataCorruption,
+        Self::Internal,
+    ];
+
+    /// Stable machine-readable identifier used by every protocol adapter.
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::InvalidArgument => "invalid_argument",
+            Self::NumericOutOfRange => "numeric_out_of_range",
+            Self::InvalidTextEncoding => "invalid_text_encoding",
+            Self::InvalidQuery => "invalid_query",
+            Self::Unsupported => "unsupported",
+            Self::FailedPrecondition => "failed_precondition",
+            Self::TypeMismatch => "type_mismatch",
+            Self::ConstraintViolation => "constraint_violation",
+            Self::UniqueViolation => "unique_violation",
+            Self::NotNullViolation => "not_null_violation",
+            Self::ForeignKeyViolation => "foreign_key_violation",
+            Self::CheckViolation => "check_violation",
+            Self::PermissionDenied => "permission_denied",
+            Self::ReadOnly => "read_only",
+            Self::Busy => "busy",
+            Self::Cancelled => "cancelled",
+            Self::LimitExceeded => "limit_exceeded",
+            Self::StorageFull => "storage_full",
+            Self::OutOfMemory => "out_of_memory",
+            Self::StorageUnavailable => "storage_unavailable",
+            Self::DataCorruption => "data_corruption",
+            Self::Internal => "internal",
+        }
+    }
+
+    /// Whether BriskDB recommends automatic retry without external remediation.
+    pub const fn is_retryable(self) -> bool {
+        matches!(self, Self::Busy)
+    }
+}
+
+/// A classified engine failure with a diagnostic cause chain.
+///
+/// `Display` and [`EngineError::diagnostic`] are intended for logs and trusted
+/// Rust callers. Protocol adapters must serialize their fixed, safe mapping for
+/// [`EngineError::kind`] rather than this diagnostic text.
+#[derive(Debug)]
+pub struct EngineError {
+    kind: EngineErrorKind,
+    diagnostic: String,
+    source: Option<Box<dyn Error + Send + Sync + 'static>>,
+}
+
+impl EngineError {
+    /// Construct an error without an underlying cause.
+    pub fn new(kind: EngineErrorKind, diagnostic: impl Into<String>) -> Self {
+        Self {
+            kind,
+            diagnostic: diagnostic.into(),
+            source: None,
+        }
+    }
+
+    pub(crate) fn from_source<E>(
+        kind: EngineErrorKind,
+        diagnostic: impl Into<String>,
+        source: E,
+    ) -> Self
+    where
+        E: Error + Send + Sync + 'static,
+    {
+        Self {
+            kind,
+            diagnostic: diagnostic.into(),
+            source: Some(Box::new(source)),
+        }
+    }
+
+    pub(crate) fn context(self, diagnostic: impl Into<String>) -> Self {
+        Self::from_source(self.kind, diagnostic, self)
+    }
+
+    /// Return the stable error category.
+    pub const fn kind(&self) -> EngineErrorKind {
+        self.kind
+    }
+
+    /// Return the stable machine-readable identifier.
+    pub const fn code(&self) -> &'static str {
+        self.kind.code()
+    }
+
+    /// Return diagnostic text for logs and trusted Rust callers.
+    pub fn diagnostic(&self) -> &str {
+        &self.diagnostic
+    }
+
+    /// Whether BriskDB recommends automatic retry without external remediation.
+    pub const fn is_retryable(&self) -> bool {
+        self.kind.is_retryable()
+    }
+}
+
+impl fmt::Display for EngineError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.diagnostic)
+    }
+}
+
+impl Error for EngineError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.source
+            .as_deref()
+            .map(|source| source as &(dyn Error + 'static))
+    }
+}
+
+/// The result type returned by protocol-neutral engine operations.
+pub type EngineResult<T> = Result<T, EngineError>;
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashSet, io};
+
+    use super::*;
+
+    #[test]
+    fn every_kind_has_a_unique_stable_code() {
+        let codes = EngineErrorKind::ALL
+            .iter()
+            .copied()
+            .map(EngineErrorKind::code)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            codes.iter().copied().collect::<HashSet<_>>().len(),
+            codes.len()
+        );
+        assert!(codes.iter().all(|code| {
+            !code.is_empty()
+                && code
+                    .bytes()
+                    .all(|byte| byte.is_ascii_lowercase() || byte == b'_')
+        }));
+    }
+
+    #[test]
+    fn retryability_is_explicit_and_conservative() {
+        let retryable = EngineErrorKind::ALL
+            .iter()
+            .copied()
+            .filter(|kind| kind.is_retryable())
+            .collect::<Vec<_>>();
+        assert_eq!(retryable, [EngineErrorKind::Busy]);
+    }
+
+    #[test]
+    fn source_and_context_preserve_the_kind_and_cause_chain() {
+        let error = EngineError::from_source(
+            EngineErrorKind::StorageUnavailable,
+            "could not open storage",
+            io::Error::new(io::ErrorKind::NotFound, "private path"),
+        )
+        .context("broadcast failed on shard 2");
+
+        assert_eq!(error.kind(), EngineErrorKind::StorageUnavailable);
+        assert_eq!(error.code(), "storage_unavailable");
+        assert!(!error.is_retryable());
+        assert_eq!(error.to_string(), "broadcast failed on shard 2");
+
+        let first = error.source().unwrap();
+        assert_eq!(first.to_string(), "could not open storage");
+        let root = first.source().unwrap();
+        assert_eq!(
+            root.downcast_ref::<io::Error>().unwrap().kind(),
+            io::ErrorKind::NotFound
+        );
+    }
+
+    #[test]
+    fn engine_errors_are_thread_safe_standard_errors() {
+        fn assert_error<T: Error + Send + Sync + 'static>() {}
+        assert_error::<EngineError>();
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,15 +3,15 @@
 //! This module owns routing and coordinates storage and SQL execution. It does
 //! not depend on a network protocol.
 
+mod error;
 mod types;
 
+pub use error::{EngineError, EngineErrorKind, EngineResult};
 pub use types::{
     Column, DataType, Decimal, ParseDecimalError, ResultSet, ResultSetShapeError, Row, Value,
 };
 
 use std::path::Path;
-
-use anyhow::Context;
 
 use crate::{sql, storage::Storage};
 
@@ -27,7 +27,7 @@ pub struct Routed<T> {
 }
 
 impl Database {
-    pub fn open(root: impl AsRef<Path>, requested_shards: u16) -> anyhow::Result<Self> {
+    pub fn open(root: impl AsRef<Path>, requested_shards: u16) -> EngineResult<Self> {
         Ok(Self {
             storage: Storage::open(root, requested_shards)?,
         })
@@ -50,7 +50,7 @@ impl Database {
         shard_key: &str,
         statement: &str,
         params: &[Value],
-    ) -> anyhow::Result<Routed<usize>> {
+    ) -> EngineResult<Routed<usize>> {
         let shard = self.shard_for_key(shard_key.as_bytes());
         let connection = self.storage.open_shard(shard)?;
         let value = sql::execute(&connection, statement, params)?;
@@ -62,7 +62,7 @@ impl Database {
         shard_key: &str,
         statement: &str,
         params: &[Value],
-    ) -> anyhow::Result<Routed<ResultSet>> {
+    ) -> EngineResult<Routed<ResultSet>> {
         let shard = self.shard_for_key(shard_key.as_bytes());
         let connection = self.storage.open_shard(shard)?;
         let value = sql::query(&connection, statement, params)?;
@@ -74,7 +74,7 @@ impl Database {
         shard_key: &str,
         statement: &str,
         params: &[Value],
-    ) -> anyhow::Result<usize> {
+    ) -> EngineResult<usize> {
         Ok(self.execute_routed(shard_key, statement, params)?.value)
     }
 
@@ -83,16 +83,18 @@ impl Database {
         shard_key: &str,
         statement: &str,
         params: &[Value],
-    ) -> anyhow::Result<ResultSet> {
+    ) -> EngineResult<ResultSet> {
         Ok(self.query_routed(shard_key, statement, params)?.value)
     }
 
-    pub fn broadcast(&self, statement: &str) -> anyhow::Result<Vec<u16>> {
+    pub fn broadcast(&self, statement: &str) -> EngineResult<Vec<u16>> {
         let mut completed = Vec::with_capacity(usize::from(self.shard_count()));
         for shard in 0..self.shard_count() {
-            let connection = self.storage.open_shard(shard)?;
+            let connection = self.storage.open_shard(shard).map_err(|error| {
+                error.context(format!("broadcast failed to open shard {shard}"))
+            })?;
             sql::execute_batch(&connection, statement)
-                .with_context(|| format!("broadcast failed on shard {shard}"))?;
+                .map_err(|error| error.context(format!("broadcast failed on shard {shard}")))?;
             completed.push(shard);
         }
         Ok(completed)
@@ -101,6 +103,8 @@ impl Database {
 
 #[cfg(test)]
 mod tests {
+    use std::error::Error as _;
+
     use super::*;
 
     #[test]
@@ -202,5 +206,63 @@ mod tests {
             )
             .unwrap()
         );
+    }
+
+    #[test]
+    fn database_preserves_error_kinds_across_the_engine_boundary() {
+        let temp = tempfile::tempdir().unwrap();
+        let database = Database::open(temp.path(), 4).unwrap();
+
+        assert_eq!(
+            database
+                .query("widget-1", "SELECT * FROM missing_table", &[])
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::InvalidQuery
+        );
+        assert_eq!(
+            Database::open(temp.path(), 1).unwrap_err().kind(),
+            EngineErrorKind::InvalidArgument
+        );
+    }
+
+    #[test]
+    fn broadcast_failure_preserves_kind_and_can_recover_remaining_shards() {
+        let temp = tempfile::tempdir().unwrap();
+        let database = Database::open(temp.path(), 4).unwrap();
+        let shard_one = database.storage.open_shard(1).unwrap();
+        sql::execute_batch(&shard_one, "CREATE TABLE recovery_marker (id INTEGER);").unwrap();
+
+        let error = database
+            .broadcast("CREATE TABLE recovery_marker (id INTEGER);")
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::InvalidQuery);
+        assert_eq!(error.to_string(), "broadcast failed on shard 1");
+        assert!(error.source().is_some());
+
+        let shard_zero = database.storage.open_shard(0).unwrap();
+        let shard_two = database.storage.open_shard(2).unwrap();
+        let table_exists = |connection: &rusqlite::Connection| {
+            connection
+                .query_row(
+                    "SELECT EXISTS (
+                        SELECT 1 FROM sqlite_schema
+                        WHERE type = 'table' AND name = 'recovery_marker'
+                    )",
+                    [],
+                    |row| row.get::<_, bool>(0),
+                )
+                .unwrap()
+        };
+        assert!(table_exists(&shard_zero));
+        assert!(!table_exists(&shard_two));
+
+        assert_eq!(
+            database
+                .broadcast("CREATE TABLE IF NOT EXISTS recovery_marker (id INTEGER);")
+                .unwrap(),
+            [0, 1, 2, 3]
+        );
+        assert!(table_exists(&shard_two));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@ pub mod server;
 pub mod sql;
 pub mod storage;
 
+mod sqlite_error;
+
 // Preserve the original public module path while frontends migrate to the
 // explicit protocol namespace.
 pub use protocol::http as api;

--- a/src/protocol/error.rs
+++ b/src/protocol/error.rs
@@ -1,0 +1,426 @@
+//! Safe protocol representations of protocol-neutral engine errors.
+//!
+//! PostgreSQL and MySQL listeners are not implemented yet. Their records here
+//! are the tested compatibility contract those adapters will consume.
+
+use crate::core::EngineErrorKind;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct HttpErrorMapping {
+    pub status: u16,
+    pub problem_type: &'static str,
+    pub title: &'static str,
+    pub detail: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct PostgresErrorMapping {
+    pub sqlstate: &'static str,
+    pub message: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct MysqlErrorMapping {
+    pub error_number: u16,
+    pub sqlstate: &'static str,
+    pub message: &'static str,
+}
+
+/// Return the RFC 9457 representation for an engine error kind.
+pub const fn http_error(kind: EngineErrorKind) -> HttpErrorMapping {
+    let status = match kind {
+        EngineErrorKind::InvalidArgument => 400,
+        EngineErrorKind::NumericOutOfRange
+        | EngineErrorKind::InvalidTextEncoding
+        | EngineErrorKind::InvalidQuery
+        | EngineErrorKind::TypeMismatch => 422,
+        EngineErrorKind::Unsupported => 501,
+        EngineErrorKind::FailedPrecondition
+        | EngineErrorKind::ConstraintViolation
+        | EngineErrorKind::UniqueViolation
+        | EngineErrorKind::NotNullViolation
+        | EngineErrorKind::ForeignKeyViolation
+        | EngineErrorKind::CheckViolation => 409,
+        EngineErrorKind::PermissionDenied | EngineErrorKind::ReadOnly => 403,
+        EngineErrorKind::Busy
+        | EngineErrorKind::OutOfMemory
+        | EngineErrorKind::StorageUnavailable => 503,
+        EngineErrorKind::Cancelled => 500,
+        EngineErrorKind::LimitExceeded => 422,
+        EngineErrorKind::StorageFull => 507,
+        EngineErrorKind::DataCorruption | EngineErrorKind::Internal => 500,
+    };
+
+    HttpErrorMapping {
+        status,
+        problem_type: problem_type(kind),
+        title: title(kind),
+        detail: detail(kind),
+    }
+}
+
+/// Return the PostgreSQL SQLSTATE and safe message for an engine error kind.
+pub const fn postgres_error(kind: EngineErrorKind) -> PostgresErrorMapping {
+    let sqlstate = match kind {
+        EngineErrorKind::InvalidArgument => "22023",
+        EngineErrorKind::NumericOutOfRange => "22003",
+        EngineErrorKind::InvalidTextEncoding => "22021",
+        EngineErrorKind::InvalidQuery => "42000",
+        EngineErrorKind::Unsupported => "0A000",
+        EngineErrorKind::FailedPrecondition => "55000",
+        EngineErrorKind::TypeMismatch => "42804",
+        EngineErrorKind::ConstraintViolation => "23000",
+        EngineErrorKind::UniqueViolation => "23505",
+        EngineErrorKind::NotNullViolation => "23502",
+        EngineErrorKind::ForeignKeyViolation => "23503",
+        EngineErrorKind::CheckViolation => "23514",
+        EngineErrorKind::PermissionDenied => "42501",
+        EngineErrorKind::ReadOnly => "25006",
+        EngineErrorKind::Busy => "55P03",
+        EngineErrorKind::Cancelled => "57014",
+        EngineErrorKind::LimitExceeded => "54000",
+        EngineErrorKind::StorageFull => "53100",
+        EngineErrorKind::OutOfMemory => "53200",
+        EngineErrorKind::StorageUnavailable => "58030",
+        EngineErrorKind::DataCorruption => "XX001",
+        EngineErrorKind::Internal => "XX000",
+    };
+
+    PostgresErrorMapping {
+        sqlstate,
+        message: detail(kind),
+    }
+}
+
+/// Return the MySQL error number, SQLSTATE, and safe message for a kind.
+pub const fn mysql_error(kind: EngineErrorKind) -> MysqlErrorMapping {
+    let (error_number, sqlstate) = match kind {
+        EngineErrorKind::InvalidArgument => (1210, "HY000"),
+        EngineErrorKind::NumericOutOfRange => (1690, "22003"),
+        EngineErrorKind::InvalidTextEncoding => (1366, "HY000"),
+        EngineErrorKind::InvalidQuery => (1105, "HY000"),
+        EngineErrorKind::Unsupported => (1235, "42000"),
+        EngineErrorKind::FailedPrecondition => (1105, "HY000"),
+        EngineErrorKind::TypeMismatch => (1366, "HY000"),
+        EngineErrorKind::ConstraintViolation => (1105, "HY000"),
+        EngineErrorKind::UniqueViolation => (1062, "23000"),
+        EngineErrorKind::NotNullViolation => (1048, "23000"),
+        // SQLite does not report whether a foreign-key failure was caused by
+        // the parent or child side, so using MySQL 1451 or 1452 would lie.
+        EngineErrorKind::ForeignKeyViolation => (1105, "HY000"),
+        EngineErrorKind::CheckViolation => (3819, "HY000"),
+        EngineErrorKind::PermissionDenied => (1227, "42000"),
+        EngineErrorKind::ReadOnly => (1290, "HY000"),
+        EngineErrorKind::Busy => (1205, "HY000"),
+        EngineErrorKind::Cancelled => (1317, "70100"),
+        EngineErrorKind::LimitExceeded => (1105, "HY000"),
+        EngineErrorKind::StorageFull => (1114, "HY000"),
+        EngineErrorKind::OutOfMemory => (1037, "HY001"),
+        EngineErrorKind::StorageUnavailable
+        | EngineErrorKind::DataCorruption
+        | EngineErrorKind::Internal => (1105, "HY000"),
+    };
+
+    MysqlErrorMapping {
+        error_number,
+        sqlstate,
+        message: detail(kind),
+    }
+}
+
+const fn problem_type(kind: EngineErrorKind) -> &'static str {
+    match kind {
+        EngineErrorKind::InvalidArgument => {
+            "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#invalid-argument"
+        }
+        EngineErrorKind::NumericOutOfRange => {
+            "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#numeric-out-of-range"
+        }
+        EngineErrorKind::InvalidTextEncoding => {
+            "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#invalid-text-encoding"
+        }
+        EngineErrorKind::InvalidQuery => {
+            "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#invalid-query"
+        }
+        EngineErrorKind::Unsupported => {
+            "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#unsupported"
+        }
+        EngineErrorKind::FailedPrecondition => {
+            "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#failed-precondition"
+        }
+        EngineErrorKind::TypeMismatch => {
+            "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#type-mismatch"
+        }
+        EngineErrorKind::ConstraintViolation => {
+            "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#constraint-violation"
+        }
+        EngineErrorKind::UniqueViolation => {
+            "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#unique-violation"
+        }
+        EngineErrorKind::NotNullViolation => {
+            "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#not-null-violation"
+        }
+        EngineErrorKind::ForeignKeyViolation => {
+            "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#foreign-key-violation"
+        }
+        EngineErrorKind::CheckViolation => {
+            "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#check-violation"
+        }
+        EngineErrorKind::PermissionDenied => {
+            "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#permission-denied"
+        }
+        EngineErrorKind::ReadOnly => {
+            "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#read-only"
+        }
+        EngineErrorKind::Busy => {
+            "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#busy"
+        }
+        EngineErrorKind::Cancelled => {
+            "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#cancelled"
+        }
+        EngineErrorKind::LimitExceeded => {
+            "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#limit-exceeded"
+        }
+        EngineErrorKind::StorageFull => {
+            "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#storage-full"
+        }
+        EngineErrorKind::OutOfMemory => {
+            "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#out-of-memory"
+        }
+        EngineErrorKind::StorageUnavailable => {
+            "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#storage-unavailable"
+        }
+        EngineErrorKind::DataCorruption => {
+            "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#data-corruption"
+        }
+        EngineErrorKind::Internal => {
+            "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#internal"
+        }
+    }
+}
+
+const fn title(kind: EngineErrorKind) -> &'static str {
+    match kind {
+        EngineErrorKind::InvalidArgument => "Invalid argument",
+        EngineErrorKind::NumericOutOfRange => "Numeric value out of range",
+        EngineErrorKind::InvalidTextEncoding => "Invalid text encoding",
+        EngineErrorKind::InvalidQuery => "Invalid query",
+        EngineErrorKind::Unsupported => "Unsupported operation",
+        EngineErrorKind::FailedPrecondition => "Failed precondition",
+        EngineErrorKind::TypeMismatch => "Type mismatch",
+        EngineErrorKind::ConstraintViolation => "Constraint violation",
+        EngineErrorKind::UniqueViolation => "Unique constraint violation",
+        EngineErrorKind::NotNullViolation => "Not-null constraint violation",
+        EngineErrorKind::ForeignKeyViolation => "Foreign-key constraint violation",
+        EngineErrorKind::CheckViolation => "Check constraint violation",
+        EngineErrorKind::PermissionDenied => "Permission denied",
+        EngineErrorKind::ReadOnly => "Read-only storage",
+        EngineErrorKind::Busy => "Database busy",
+        EngineErrorKind::Cancelled => "Request cancelled",
+        EngineErrorKind::LimitExceeded => "Limit exceeded",
+        EngineErrorKind::StorageFull => "Storage full",
+        EngineErrorKind::OutOfMemory => "Out of memory",
+        EngineErrorKind::StorageUnavailable => "Storage unavailable",
+        EngineErrorKind::DataCorruption => "Data corruption",
+        EngineErrorKind::Internal => "Internal error",
+    }
+}
+
+const fn detail(kind: EngineErrorKind) -> &'static str {
+    match kind {
+        EngineErrorKind::InvalidArgument => "The request contains an invalid argument.",
+        EngineErrorKind::NumericOutOfRange => "A numeric value is outside the supported range.",
+        EngineErrorKind::InvalidTextEncoding => "A text value has an unsupported encoding.",
+        EngineErrorKind::InvalidQuery => "The query could not be processed.",
+        EngineErrorKind::Unsupported => "The requested operation is not supported.",
+        EngineErrorKind::FailedPrecondition => "The operation cannot run in the current state.",
+        EngineErrorKind::TypeMismatch => "A value has an incompatible type.",
+        EngineErrorKind::ConstraintViolation => "A database constraint was violated.",
+        EngineErrorKind::UniqueViolation => "A unique constraint was violated.",
+        EngineErrorKind::NotNullViolation => "A not-null constraint was violated.",
+        EngineErrorKind::ForeignKeyViolation => "A foreign-key constraint was violated.",
+        EngineErrorKind::CheckViolation => "A check constraint was violated.",
+        EngineErrorKind::PermissionDenied => "The operation is not permitted.",
+        EngineErrorKind::ReadOnly => "The storage is read-only.",
+        EngineErrorKind::Busy => "The database is busy; retry the operation later.",
+        EngineErrorKind::Cancelled => "The operation was cancelled.",
+        EngineErrorKind::LimitExceeded => "The request exceeds an engine limit.",
+        EngineErrorKind::StorageFull => "The storage has no available space.",
+        EngineErrorKind::OutOfMemory => "The engine does not have enough memory.",
+        EngineErrorKind::StorageUnavailable => "The storage is unavailable.",
+        EngineErrorKind::DataCorruption => "Stored data failed an integrity check.",
+        EngineErrorKind::Internal => "An internal engine error occurred.",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    #[test]
+    fn every_engine_kind_has_the_exact_cross_protocol_contract() {
+        let expected = [
+            (
+                EngineErrorKind::InvalidArgument,
+                400,
+                "22023",
+                1210,
+                "HY000",
+            ),
+            (
+                EngineErrorKind::NumericOutOfRange,
+                422,
+                "22003",
+                1690,
+                "22003",
+            ),
+            (
+                EngineErrorKind::InvalidTextEncoding,
+                422,
+                "22021",
+                1366,
+                "HY000",
+            ),
+            (EngineErrorKind::InvalidQuery, 422, "42000", 1105, "HY000"),
+            (EngineErrorKind::Unsupported, 501, "0A000", 1235, "42000"),
+            (
+                EngineErrorKind::FailedPrecondition,
+                409,
+                "55000",
+                1105,
+                "HY000",
+            ),
+            (EngineErrorKind::TypeMismatch, 422, "42804", 1366, "HY000"),
+            (
+                EngineErrorKind::ConstraintViolation,
+                409,
+                "23000",
+                1105,
+                "HY000",
+            ),
+            (
+                EngineErrorKind::UniqueViolation,
+                409,
+                "23505",
+                1062,
+                "23000",
+            ),
+            (
+                EngineErrorKind::NotNullViolation,
+                409,
+                "23502",
+                1048,
+                "23000",
+            ),
+            (
+                EngineErrorKind::ForeignKeyViolation,
+                409,
+                "23503",
+                1105,
+                "HY000",
+            ),
+            (EngineErrorKind::CheckViolation, 409, "23514", 3819, "HY000"),
+            (
+                EngineErrorKind::PermissionDenied,
+                403,
+                "42501",
+                1227,
+                "42000",
+            ),
+            (EngineErrorKind::ReadOnly, 403, "25006", 1290, "HY000"),
+            (EngineErrorKind::Busy, 503, "55P03", 1205, "HY000"),
+            (EngineErrorKind::Cancelled, 500, "57014", 1317, "70100"),
+            (EngineErrorKind::LimitExceeded, 422, "54000", 1105, "HY000"),
+            (EngineErrorKind::StorageFull, 507, "53100", 1114, "HY000"),
+            (EngineErrorKind::OutOfMemory, 503, "53200", 1037, "HY001"),
+            (
+                EngineErrorKind::StorageUnavailable,
+                503,
+                "58030",
+                1105,
+                "HY000",
+            ),
+            (EngineErrorKind::DataCorruption, 500, "XX001", 1105, "HY000"),
+            (EngineErrorKind::Internal, 500, "XX000", 1105, "HY000"),
+        ];
+
+        assert_eq!(expected.map(|row| row.0).as_slice(), EngineErrorKind::ALL);
+        for (kind, status, postgres, mysql_number, mysql_state) in expected {
+            let http = http_error(kind);
+            let pg = postgres_error(kind);
+            let mysql = mysql_error(kind);
+
+            assert_eq!(http.status, status, "{} HTTP status", kind.code());
+            assert_eq!(pg.sqlstate, postgres, "{} PostgreSQL SQLSTATE", kind.code());
+            assert_eq!(
+                mysql.error_number,
+                mysql_number,
+                "{} MySQL errno",
+                kind.code()
+            );
+            assert_eq!(
+                mysql.sqlstate,
+                mysql_state,
+                "{} MySQL SQLSTATE",
+                kind.code()
+            );
+            assert_eq!(pg.message, http.detail);
+            assert_eq!(mysql.message, http.detail);
+            assert_eq!(pg.sqlstate.len(), 5);
+            assert_eq!(mysql.sqlstate.len(), 5);
+            assert!(!http.title.is_empty());
+            assert!(!http.detail.is_empty());
+            assert!(
+                http.problem_type
+                    .starts_with("https://github.com/schapman1974/briskdb/")
+            );
+            assert!(http.problem_type.ends_with(&kind.code().replace('_', "-")));
+        }
+    }
+
+    #[test]
+    fn every_problem_type_is_unique() {
+        let problem_types = EngineErrorKind::ALL
+            .iter()
+            .copied()
+            .map(|kind| http_error(kind).problem_type)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            problem_types.iter().copied().collect::<HashSet<_>>().len(),
+            problem_types.len()
+        );
+    }
+
+    #[test]
+    fn public_error_documentation_matches_the_executable_mapping_table() {
+        let documentation = include_str!("../../docs/ERRORS.md");
+
+        for &kind in EngineErrorKind::ALL {
+            let http = http_error(kind);
+            let postgres = postgres_error(kind);
+            let mysql = mysql_error(kind);
+            let anchor = kind.code().replace('_', "-");
+            let expected_row = format!(
+                "| <a id=\"{anchor}\"></a>`{kind:?}` | `{}` | {} | {} | {} | `{}` | {} | `{}` | {} |",
+                kind.code(),
+                http.status,
+                http.title,
+                http.detail,
+                postgres.sqlstate,
+                mysql.error_number,
+                mysql.sqlstate,
+                if kind.is_retryable() { "Yes" } else { "No" },
+            );
+            assert!(
+                documentation.lines().any(|line| line == expected_row),
+                "missing or stale documentation row for {}",
+                kind.code()
+            );
+        }
+    }
+}

--- a/src/protocol/http.rs
+++ b/src/protocol/http.rs
@@ -5,14 +5,17 @@ use std::sync::Arc;
 use axum::{
     Json, Router,
     extract::State,
-    http::StatusCode,
+    http::{HeaderValue, StatusCode, header::CONTENT_TYPE},
     response::{IntoResponse, Response},
     routing::{get, post},
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Value as JsonValue, json};
 
-use crate::core::{DataType, Database, ResultSet, Routed, Value};
+use crate::{
+    core::{DataType, Database, EngineError, EngineErrorKind, ResultSet, Routed, Value},
+    protocol::error::http_error,
+};
 
 pub fn router(database: Arc<Database>) -> Router {
     Router::new()
@@ -99,7 +102,7 @@ async fn query(
             shard,
             value: result,
         } = database.query_routed(&request.shard_key, &request.sql, &params)?;
-        Ok::<_, anyhow::Error>(result_set_to_query_response(shard, result))
+        Ok::<_, EngineError>(result_set_to_query_response(shard, result))
     })
     .await??;
 
@@ -188,29 +191,68 @@ const fn data_type_name(data_type: DataType) -> &'static str {
     }
 }
 
-struct ApiError(anyhow::Error);
+#[derive(Debug)]
+struct ApiError(EngineError);
 
-impl<E> From<E> for ApiError
-where
-    E: Into<anyhow::Error>,
-{
-    fn from(error: E) -> Self {
-        Self(error.into())
+impl From<EngineError> for ApiError {
+    fn from(error: EngineError) -> Self {
+        Self(error)
     }
+}
+
+impl From<tokio::task::JoinError> for ApiError {
+    fn from(error: tokio::task::JoinError) -> Self {
+        Self(EngineError::from_source(
+            EngineErrorKind::Internal,
+            "blocking engine task failed",
+            error,
+        ))
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct ProblemDetails {
+    #[serde(rename = "type")]
+    problem_type: &'static str,
+    title: &'static str,
+    status: u16,
+    detail: &'static str,
+    code: &'static str,
 }
 
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": self.0.to_string()})),
+        let mapping = http_error(self.0.kind());
+        tracing::error!(
+            error = ?self.0,
+            error_code = self.0.code(),
+            "engine request failed"
+        );
+        let status = StatusCode::from_u16(mapping.status)
+            .expect("the exhaustive HTTP error mapping contains valid status codes");
+        let mut response = (
+            status,
+            Json(ProblemDetails {
+                problem_type: mapping.problem_type,
+                title: mapping.title,
+                status: mapping.status,
+                detail: mapping.detail,
+                code: self.0.code(),
+            }),
         )
-            .into_response()
+            .into_response();
+        response.headers_mut().insert(
+            CONTENT_TYPE,
+            HeaderValue::from_static("application/problem+json"),
+        );
+        response
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::io;
+
     use axum::{
         body::{Body, to_bytes},
         http::{Method, Request},
@@ -220,12 +262,12 @@ mod tests {
     use super::*;
     use crate::core::{Column, DataType, Row};
 
-    async fn request_json(
+    async fn send_json(
         router: &Router,
         method: Method,
         uri: &str,
         body: Option<JsonValue>,
-    ) -> (StatusCode, JsonValue) {
+    ) -> Response {
         let mut request = Request::builder().method(method).uri(uri);
         let body = match body {
             Some(value) => {
@@ -234,14 +276,26 @@ mod tests {
             }
             None => Body::empty(),
         };
-        let response = router
+        router
             .clone()
             .oneshot(request.body(body).unwrap())
             .await
-            .unwrap();
+            .unwrap()
+    }
+
+    async fn response_json(response: Response) -> (StatusCode, JsonValue) {
         let status = response.status();
         let bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
         (status, serde_json::from_slice(&bytes).unwrap())
+    }
+
+    async fn request_json(
+        router: &Router,
+        method: Method,
+        uri: &str,
+        body: Option<JsonValue>,
+    ) -> (StatusCode, JsonValue) {
+        response_json(send_json(router, method, uri, body).await).await
     }
 
     #[tokio::test]
@@ -311,11 +365,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn sqlite_errors_keep_the_json_500_contract() {
+    async fn invalid_queries_use_safe_problem_details() {
         let temp = tempfile::tempdir().unwrap();
         let application = router(Arc::new(Database::open(temp.path(), 4).unwrap()));
 
-        let (status, body) = request_json(
+        let response = send_json(
             &application,
             Method::POST,
             "/v1/query",
@@ -325,9 +379,24 @@ mod tests {
             })),
         )
         .await;
+        assert_eq!(
+            response.headers().get(CONTENT_TYPE).unwrap(),
+            "application/problem+json"
+        );
+        let (status, body) = response_json(response).await;
 
-        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
-        assert!(body["error"].as_str().unwrap().contains("no such table"));
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(
+            body,
+            json!({
+                "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#invalid-query",
+                "title": "Invalid query",
+                "status": 422,
+                "detail": "The query could not be processed.",
+                "code": "invalid_query"
+            })
+        );
+        assert!(!body.to_string().contains("missing_table"));
     }
 
     #[tokio::test]
@@ -348,10 +417,120 @@ mod tests {
         )
         .await;
 
-        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
         assert_eq!(
-            body["error"],
-            format!("unsigned integer {too_large} exceeds SQLite INTEGER range")
+            body,
+            json!({
+                "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#numeric-out-of-range",
+                "title": "Numeric value out of range",
+                "status": 422,
+                "detail": "A numeric value is outside the supported range.",
+                "code": "numeric_out_of_range"
+            })
+        );
+        assert!(!body.to_string().contains(&too_large.to_string()));
+    }
+
+    #[tokio::test]
+    async fn constraint_failures_keep_their_precise_safe_kind() {
+        let temp = tempfile::tempdir().unwrap();
+        let application = router(Arc::new(Database::open(temp.path(), 4).unwrap()));
+        assert_eq!(
+            request_json(
+                &application,
+                Method::POST,
+                "/v1/admin/broadcast",
+                Some(json!({"sql": "CREATE TABLE widgets (id TEXT PRIMARY KEY)"})),
+            )
+            .await
+            .0,
+            StatusCode::OK
+        );
+        let insert = || {
+            send_json(
+                &application,
+                Method::POST,
+                "/v1/execute",
+                Some(json!({
+                    "shard_key": "widget-1",
+                    "sql": "INSERT INTO widgets (id) VALUES (?1)",
+                    "params": ["private-value"]
+                })),
+            )
+        };
+        assert_eq!(response_json(insert().await).await.0, StatusCode::OK);
+
+        let response = insert().await;
+        assert_eq!(
+            response.headers().get(CONTENT_TYPE).unwrap(),
+            "application/problem+json"
+        );
+        assert_eq!(
+            response_json(response).await,
+            (
+                StatusCode::CONFLICT,
+                json!({
+                    "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#unique-violation",
+                    "title": "Unique constraint violation",
+                    "status": 409,
+                    "detail": "A unique constraint was violated.",
+                    "code": "unique_violation"
+                })
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn every_problem_kind_uses_its_exact_mapping_and_redacts_sources() {
+        let secret = "password=hunter2 /private/customer.sqlite SELECT secret_value";
+        for &kind in EngineErrorKind::ALL {
+            let mapping = http_error(kind);
+            let error = EngineError::from_source(kind, secret, io::Error::other(secret));
+            let response = ApiError(error).into_response();
+
+            assert_eq!(
+                response.headers().get(CONTENT_TYPE).unwrap(),
+                "application/problem+json"
+            );
+            let (status, body) = response_json(response).await;
+            assert_eq!(status.as_u16(), mapping.status, "{} status", kind.code());
+            assert_eq!(
+                body,
+                json!({
+                    "type": mapping.problem_type,
+                    "title": mapping.title,
+                    "status": mapping.status,
+                    "detail": mapping.detail,
+                    "code": kind.code()
+                }),
+                "{} body",
+                kind.code()
+            );
+            assert!(!body.to_string().contains(secret));
+        }
+    }
+
+    #[tokio::test]
+    async fn blocking_task_panics_become_redacted_internal_problems() {
+        let join_error = tokio::spawn(async {
+            panic!("password=hunter2 /private/customer.sqlite SELECT secret_value")
+        })
+        .await
+        .unwrap_err();
+        let response = ApiError::from(join_error).into_response();
+
+        assert_eq!(
+            response_json(response).await,
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                json!({
+                    "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#internal",
+                    "title": "Internal error",
+                    "status": 500,
+                    "detail": "An internal engine error occurred.",
+                    "code": "internal"
+                })
+            )
         );
     }
 

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,3 +1,4 @@
 //! Network protocol adapters.
 
+pub mod error;
 pub mod http;

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -8,71 +8,102 @@ use rusqlite::{
     types::{Value as SqlValue, ValueRef},
 };
 
-use crate::core::{Column, DataType, ResultSet, Row, Value};
+use crate::{
+    core::{Column, DataType, EngineError, EngineErrorKind, EngineResult, ResultSet, Row, Value},
+    sqlite_error,
+};
 
 pub(crate) fn execute(
     connection: &Connection,
     statement: &str,
     params: &[Value],
-) -> anyhow::Result<usize> {
+) -> EngineResult<usize> {
     let params = params
         .iter()
         .map(value_to_sql)
-        .collect::<anyhow::Result<Vec<_>>>()?;
-    Ok(connection.execute(statement, params_from_iter(params))?)
+        .collect::<EngineResult<Vec<_>>>()?;
+    connection
+        .execute(statement, params_from_iter(params))
+        .map_err(sqlite_error::statement)
 }
 
 pub(crate) fn query(
     connection: &Connection,
     statement: &str,
     params: &[Value],
-) -> anyhow::Result<ResultSet> {
+) -> EngineResult<ResultSet> {
     let params = params
         .iter()
         .map(value_to_sql)
-        .collect::<anyhow::Result<Vec<_>>>()?;
-    let mut statement = connection.prepare(statement)?;
+        .collect::<EngineResult<Vec<_>>>()?;
+    let mut statement = connection
+        .prepare(statement)
+        .map_err(sqlite_error::statement)?;
     let columns = statement
         .column_names()
         .into_iter()
         .map(|name| Column::new(name, DataType::Unknown))
         .collect::<Vec<_>>();
-    let mut sqlite_rows = statement.query(params_from_iter(params))?;
+    let mut sqlite_rows = statement
+        .query(params_from_iter(params))
+        .map_err(sqlite_error::statement)?;
     let mut rows = Vec::new();
 
-    while let Some(sqlite_row) = sqlite_rows.next()? {
+    while let Some(sqlite_row) = sqlite_rows.next().map_err(sqlite_error::statement)? {
         let mut values = Vec::with_capacity(columns.len());
         for index in 0..columns.len() {
-            values.push(sql_to_value(sqlite_row.get_ref(index)?));
+            values.push(sql_to_value(
+                sqlite_row.get_ref(index).map_err(sqlite_error::statement)?,
+            ));
         }
         rows.push(Row::new(values));
     }
-    Ok(ResultSet::new(columns, rows)?)
+    ResultSet::new(columns, rows).map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::Internal,
+            "SQLite returned rows that do not match their column metadata",
+            error,
+        )
+    })
 }
 
-pub(crate) fn execute_batch(connection: &Connection, statement: &str) -> anyhow::Result<()> {
-    connection.execute_batch(statement)?;
-    Ok(())
+pub(crate) fn execute_batch(connection: &Connection, statement: &str) -> EngineResult<()> {
+    connection
+        .execute_batch(statement)
+        .map_err(sqlite_error::statement)
 }
 
-fn value_to_sql(value: &Value) -> anyhow::Result<SqlValue> {
+fn value_to_sql(value: &Value) -> EngineResult<SqlValue> {
     Ok(match value {
         Value::Null => SqlValue::Null,
         Value::Boolean(value) => SqlValue::Integer(i64::from(*value)),
         Value::Int64(value) => SqlValue::Integer(*value),
-        Value::UInt64(value) => SqlValue::Integer(i64::try_from(*value).map_err(|_| {
-            anyhow::anyhow!("unsigned integer {value} exceeds SQLite INTEGER range")
+        Value::UInt64(value) => SqlValue::Integer(i64::try_from(*value).map_err(|error| {
+            EngineError::from_source(
+                EngineErrorKind::NumericOutOfRange,
+                format!("unsigned integer {value} exceeds SQLite INTEGER range"),
+                error,
+            )
         })?),
         Value::Float64(value) if value.is_nan() => {
-            anyhow::bail!("NaN has no lossless SQLite binding because SQLite converts it to NULL")
+            return Err(EngineError::new(
+                EngineErrorKind::Unsupported,
+                "NaN has no lossless SQLite binding because SQLite converts it to NULL",
+            ));
         }
         Value::Float64(value) => SqlValue::Real(*value),
         Value::Decimal(value) => {
-            anyhow::bail!("decimal value {value} has no lossless SQLite binding")
+            return Err(EngineError::new(
+                EngineErrorKind::Unsupported,
+                format!("decimal value {value} has no lossless SQLite binding"),
+            ));
         }
         Value::Text(value) => SqlValue::Text(value.clone()),
         Value::InvalidText(_) => {
-            anyhow::bail!("non-UTF-8 text has no lossless SQLite binding")
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidTextEncoding,
+                "non-UTF-8 text has no lossless SQLite binding",
+            ));
         }
         Value::Binary(value) => SqlValue::Blob(value.clone()),
     })
@@ -135,28 +166,31 @@ mod tests {
     #[test]
     fn values_without_lossless_sqlite_bindings_are_rejected() {
         let too_large = u64::try_from(i64::MAX).unwrap() + 1;
+        let error = value_to_sql(&Value::from(too_large)).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::NumericOutOfRange);
         assert_eq!(
-            value_to_sql(&Value::from(too_large))
-                .unwrap_err()
-                .to_string(),
+            error.to_string(),
             format!("unsigned integer {too_large} exceeds SQLite INTEGER range")
         );
+
+        let error = value_to_sql(&Value::decimal("12.3400").unwrap()).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Unsupported);
         assert_eq!(
-            value_to_sql(&Value::decimal("12.3400").unwrap())
-                .unwrap_err()
-                .to_string(),
+            error.to_string(),
             "decimal value 12.3400 has no lossless SQLite binding"
         );
+
+        let error = value_to_sql(&Value::InvalidText(vec![0x80])).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::InvalidTextEncoding);
         assert_eq!(
-            value_to_sql(&Value::InvalidText(vec![0x80]))
-                .unwrap_err()
-                .to_string(),
+            error.to_string(),
             "non-UTF-8 text has no lossless SQLite binding"
         );
+
+        let error = value_to_sql(&Value::from(f64::NAN)).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Unsupported);
         assert_eq!(
-            value_to_sql(&Value::from(f64::NAN))
-                .unwrap_err()
-                .to_string(),
+            error.to_string(),
             "NaN has no lossless SQLite binding because SQLite converts it to NULL"
         );
     }
@@ -197,9 +231,114 @@ mod tests {
         let connection = Connection::open_in_memory().unwrap();
         let error = query(&connection, "SELECT ?1 AS value", &[Value::from(f64::NAN)]).unwrap_err();
 
+        assert_eq!(error.kind(), EngineErrorKind::Unsupported);
         assert_eq!(
             error.to_string(),
             "NaN has no lossless SQLite binding because SQLite converts it to NULL"
+        );
+    }
+
+    #[test]
+    fn caller_sql_and_parameter_errors_are_classified_without_message_parsing() {
+        let connection = Connection::open_in_memory().unwrap();
+
+        assert_eq!(
+            query(&connection, "SELECT * FROM missing_table", &[])
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::InvalidQuery
+        );
+        assert_eq!(
+            query(&connection, "SELECT ?1", &[]).unwrap_err().kind(),
+            EngineErrorKind::InvalidArgument
+        );
+        assert_eq!(
+            execute(&connection, "SELECT 1", &[]).unwrap_err().kind(),
+            EngineErrorKind::InvalidQuery
+        );
+    }
+
+    #[test]
+    fn real_sqlite_constraint_failures_keep_their_precise_kinds() {
+        let connection = Connection::open_in_memory().unwrap();
+        connection
+            .pragma_update(None, "foreign_keys", "ON")
+            .unwrap();
+        execute_batch(
+            &connection,
+            "CREATE TABLE parents (id INTEGER PRIMARY KEY);
+             CREATE TABLE children (
+                 id INTEGER PRIMARY KEY,
+                 unique_value TEXT UNIQUE,
+                 required_value TEXT NOT NULL,
+                 checked_value INTEGER CHECK (checked_value > 0),
+                 parent_id INTEGER REFERENCES parents(id)
+             );",
+        )
+        .unwrap();
+        execute(
+            &connection,
+            "INSERT INTO children
+             (id, unique_value, required_value, checked_value, parent_id)
+             VALUES (1, 'duplicate', 'present', 1, NULL)",
+            &[],
+        )
+        .unwrap();
+
+        let cases = [
+            (
+                "INSERT INTO children
+                 (id, unique_value, required_value, checked_value, parent_id)
+                 VALUES (2, 'duplicate', 'present', 1, NULL)",
+                EngineErrorKind::UniqueViolation,
+            ),
+            (
+                "INSERT INTO children
+                 (id, unique_value, required_value, checked_value, parent_id)
+                 VALUES (2, 'other', NULL, 1, NULL)",
+                EngineErrorKind::NotNullViolation,
+            ),
+            (
+                "INSERT INTO children
+                 (id, unique_value, required_value, checked_value, parent_id)
+                 VALUES (2, 'other', 'present', 1, 999)",
+                EngineErrorKind::ForeignKeyViolation,
+            ),
+            (
+                "INSERT INTO children
+                 (id, unique_value, required_value, checked_value, parent_id)
+                 VALUES (2, 'other', 'present', 0, NULL)",
+                EngineErrorKind::CheckViolation,
+            ),
+        ];
+
+        for (statement, expected) in cases {
+            assert_eq!(
+                execute(&connection, statement, &[]).unwrap_err().kind(),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn busy_writes_are_retryable_after_the_competing_transaction_releases() {
+        let temp = tempfile::NamedTempFile::new().unwrap();
+        let first = Connection::open(temp.path()).unwrap();
+        let second = Connection::open(temp.path()).unwrap();
+        first.busy_timeout(std::time::Duration::ZERO).unwrap();
+        second.busy_timeout(std::time::Duration::ZERO).unwrap();
+        execute_batch(&first, "CREATE TABLE locks (id INTEGER PRIMARY KEY);").unwrap();
+        execute_batch(&first, "BEGIN IMMEDIATE;").unwrap();
+        execute(&first, "INSERT INTO locks (id) VALUES (1)", &[]).unwrap();
+
+        let error = execute(&second, "INSERT INTO locks (id) VALUES (2)", &[]).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Busy);
+        assert!(error.is_retryable());
+
+        execute_batch(&first, "COMMIT;").unwrap();
+        assert_eq!(
+            execute(&second, "INSERT INTO locks (id) VALUES (2)", &[]).unwrap(),
+            1
         );
     }
 

--- a/src/sqlite_error.rs
+++ b/src/sqlite_error.rs
@@ -1,0 +1,303 @@
+//! Context-aware conversion from SQLite and filesystem failures.
+//!
+//! SQLite uses `SQLITE_ERROR` for several unrelated caller and engine failures,
+//! so classification must know whether a failing statement came from a client
+//! or from BriskDB's own storage implementation. Error messages are never
+//! parsed because they are not a stable API.
+
+use std::io;
+
+use rusqlite::{Error, ffi};
+
+use crate::core::{EngineError, EngineErrorKind};
+
+#[derive(Clone, Copy)]
+enum Context {
+    Statement,
+    Storage,
+}
+
+pub(crate) fn statement(error: Error) -> EngineError {
+    convert(error, Context::Statement)
+}
+
+pub(crate) fn storage(error: Error) -> EngineError {
+    convert(error, Context::Storage)
+}
+
+pub(crate) fn storage_io(error: io::Error, diagnostic: impl Into<String>) -> EngineError {
+    let kind = match error.kind() {
+        io::ErrorKind::PermissionDenied => EngineErrorKind::PermissionDenied,
+        io::ErrorKind::ReadOnlyFilesystem => EngineErrorKind::ReadOnly,
+        io::ErrorKind::StorageFull | io::ErrorKind::QuotaExceeded => EngineErrorKind::StorageFull,
+        io::ErrorKind::OutOfMemory => EngineErrorKind::OutOfMemory,
+        io::ErrorKind::FileTooLarge => EngineErrorKind::LimitExceeded,
+        io::ErrorKind::AlreadyExists
+        | io::ErrorKind::InvalidInput
+        | io::ErrorKind::InvalidData
+        | io::ErrorKind::NotADirectory
+        | io::ErrorKind::IsADirectory => EngineErrorKind::FailedPrecondition,
+        io::ErrorKind::Unsupported => EngineErrorKind::Unsupported,
+        _ => EngineErrorKind::StorageUnavailable,
+    };
+    EngineError::from_source(kind, diagnostic, error)
+}
+
+fn convert(error: Error, context: Context) -> EngineError {
+    let kind = classify(&error, context);
+    let diagnostic = error.to_string();
+    EngineError::from_source(kind, diagnostic, error)
+}
+
+fn classify(error: &Error, context: Context) -> EngineErrorKind {
+    match error {
+        Error::SqliteFailure(error, _) | Error::SqlInputError { error, .. } => {
+            classify_sqlite_failure(*error, context)
+        }
+        Error::InvalidParameterName(_) | Error::InvalidParameterCount(_, _)
+            if matches!(context, Context::Statement) =>
+        {
+            EngineErrorKind::InvalidArgument
+        }
+        Error::IntegralValueOutOfRange(_, _) if matches!(context, Context::Statement) => {
+            EngineErrorKind::NumericOutOfRange
+        }
+        Error::Utf8Error(_, _) if matches!(context, Context::Statement) => {
+            EngineErrorKind::InvalidTextEncoding
+        }
+        Error::IntegralValueOutOfRange(_, _) | Error::Utf8Error(_, _) => {
+            EngineErrorKind::DataCorruption
+        }
+        Error::FromSqlConversionFailure(_, _, _) | Error::InvalidColumnType(_, _, _) => {
+            match context {
+                Context::Statement => EngineErrorKind::TypeMismatch,
+                Context::Storage => EngineErrorKind::DataCorruption,
+            }
+        }
+        Error::ToSqlConversionFailure(_) if matches!(context, Context::Statement) => {
+            EngineErrorKind::InvalidArgument
+        }
+        Error::NulError(_)
+        | Error::ExecuteReturnedResults
+        | Error::InvalidQuery
+        | Error::MultipleStatement
+            if matches!(context, Context::Statement) =>
+        {
+            EngineErrorKind::InvalidQuery
+        }
+        Error::InvalidPath(_) => EngineErrorKind::FailedPrecondition,
+        _ => EngineErrorKind::Internal,
+    }
+}
+
+fn classify_sqlite_failure(error: ffi::Error, context: Context) -> EngineErrorKind {
+    use ffi::ErrorCode;
+
+    match error.code {
+        ErrorCode::ConstraintViolation if matches!(context, Context::Statement) => {
+            classify_constraint(error.extended_code)
+        }
+        ErrorCode::ConstraintViolation => EngineErrorKind::Internal,
+        ErrorCode::DatabaseBusy | ErrorCode::DatabaseLocked | ErrorCode::SchemaChanged => {
+            EngineErrorKind::Busy
+        }
+        ErrorCode::OperationAborted | ErrorCode::OperationInterrupted => EngineErrorKind::Cancelled,
+        ErrorCode::PermissionDenied | ErrorCode::AuthorizationForStatementDenied => {
+            EngineErrorKind::PermissionDenied
+        }
+        ErrorCode::ReadOnly => EngineErrorKind::ReadOnly,
+        ErrorCode::OutOfMemory => EngineErrorKind::OutOfMemory,
+        ErrorCode::DiskFull => EngineErrorKind::StorageFull,
+        ErrorCode::TooBig => EngineErrorKind::LimitExceeded,
+        ErrorCode::SystemIoFailure
+        | ErrorCode::CannotOpen
+        | ErrorCode::FileLockingProtocolFailed => EngineErrorKind::StorageUnavailable,
+        ErrorCode::NoLargeFileSupport => EngineErrorKind::Unsupported,
+        ErrorCode::NotFound => EngineErrorKind::Internal,
+        ErrorCode::DatabaseCorrupt | ErrorCode::NotADatabase => EngineErrorKind::DataCorruption,
+        ErrorCode::TypeMismatch if matches!(context, Context::Statement) => {
+            EngineErrorKind::TypeMismatch
+        }
+        ErrorCode::TypeMismatch => EngineErrorKind::DataCorruption,
+        ErrorCode::ParameterOutOfRange if matches!(context, Context::Statement) => {
+            EngineErrorKind::InvalidArgument
+        }
+        ErrorCode::ParameterOutOfRange => EngineErrorKind::Internal,
+        ErrorCode::Unknown if matches!(context, Context::Statement) => {
+            EngineErrorKind::InvalidQuery
+        }
+        ErrorCode::InternalMalfunction | ErrorCode::ApiMisuse | ErrorCode::Unknown => {
+            EngineErrorKind::Internal
+        }
+        _ => EngineErrorKind::Internal,
+    }
+}
+
+fn classify_constraint(extended_code: i32) -> EngineErrorKind {
+    match extended_code {
+        ffi::SQLITE_CONSTRAINT_UNIQUE
+        | ffi::SQLITE_CONSTRAINT_PRIMARYKEY
+        | ffi::SQLITE_CONSTRAINT_ROWID => EngineErrorKind::UniqueViolation,
+        ffi::SQLITE_CONSTRAINT_NOTNULL => EngineErrorKind::NotNullViolation,
+        ffi::SQLITE_CONSTRAINT_FOREIGNKEY => EngineErrorKind::ForeignKeyViolation,
+        ffi::SQLITE_CONSTRAINT_CHECK => EngineErrorKind::CheckViolation,
+        ffi::SQLITE_CONSTRAINT_DATATYPE => EngineErrorKind::TypeMismatch,
+        _ => EngineErrorKind::ConstraintViolation,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sqlite_failure(result_code: i32, message: &str) -> Error {
+        Error::SqliteFailure(ffi::Error::new(result_code), Some(message.to_owned()))
+    }
+
+    #[test]
+    fn constraint_extensions_have_precise_message_independent_kinds() {
+        let cases = [
+            (ffi::SQLITE_CONSTRAINT, EngineErrorKind::ConstraintViolation),
+            (
+                ffi::SQLITE_CONSTRAINT_UNIQUE,
+                EngineErrorKind::UniqueViolation,
+            ),
+            (
+                ffi::SQLITE_CONSTRAINT_PRIMARYKEY,
+                EngineErrorKind::UniqueViolation,
+            ),
+            (
+                ffi::SQLITE_CONSTRAINT_ROWID,
+                EngineErrorKind::UniqueViolation,
+            ),
+            (
+                ffi::SQLITE_CONSTRAINT_NOTNULL,
+                EngineErrorKind::NotNullViolation,
+            ),
+            (
+                ffi::SQLITE_CONSTRAINT_FOREIGNKEY,
+                EngineErrorKind::ForeignKeyViolation,
+            ),
+            (
+                ffi::SQLITE_CONSTRAINT_CHECK,
+                EngineErrorKind::CheckViolation,
+            ),
+            (
+                ffi::SQLITE_CONSTRAINT_DATATYPE,
+                EngineErrorKind::TypeMismatch,
+            ),
+        ];
+
+        for (code, expected) in cases {
+            let first = statement(sqlite_failure(code, "first localized message"));
+            let second = statement(sqlite_failure(code, "entirely different text"));
+            assert_eq!(first.kind(), expected);
+            assert_eq!(second.kind(), expected);
+        }
+    }
+
+    #[test]
+    fn sqlite_primary_codes_cover_operational_and_recovery_failures() {
+        let cases = [
+            (ffi::SQLITE_BUSY, EngineErrorKind::Busy),
+            (ffi::SQLITE_LOCKED, EngineErrorKind::Busy),
+            (ffi::SQLITE_SCHEMA, EngineErrorKind::Busy),
+            (ffi::SQLITE_INTERRUPT, EngineErrorKind::Cancelled),
+            (ffi::SQLITE_ABORT, EngineErrorKind::Cancelled),
+            (ffi::SQLITE_PERM, EngineErrorKind::PermissionDenied),
+            (ffi::SQLITE_AUTH, EngineErrorKind::PermissionDenied),
+            (ffi::SQLITE_READONLY, EngineErrorKind::ReadOnly),
+            (ffi::SQLITE_NOMEM, EngineErrorKind::OutOfMemory),
+            (ffi::SQLITE_FULL, EngineErrorKind::StorageFull),
+            (ffi::SQLITE_TOOBIG, EngineErrorKind::LimitExceeded),
+            (ffi::SQLITE_IOERR, EngineErrorKind::StorageUnavailable),
+            (ffi::SQLITE_CANTOPEN, EngineErrorKind::StorageUnavailable),
+            (ffi::SQLITE_PROTOCOL, EngineErrorKind::StorageUnavailable),
+            (ffi::SQLITE_NOLFS, EngineErrorKind::Unsupported),
+            (ffi::SQLITE_NOTFOUND, EngineErrorKind::Internal),
+            (ffi::SQLITE_CORRUPT, EngineErrorKind::DataCorruption),
+            (ffi::SQLITE_NOTADB, EngineErrorKind::DataCorruption),
+            (ffi::SQLITE_MISMATCH, EngineErrorKind::TypeMismatch),
+            (ffi::SQLITE_RANGE, EngineErrorKind::InvalidArgument),
+            (ffi::SQLITE_INTERNAL, EngineErrorKind::Internal),
+            (ffi::SQLITE_MISUSE, EngineErrorKind::Internal),
+        ];
+
+        for (code, expected) in cases {
+            for message in [
+                "contradictory unique constraint text",
+                "完全に異なるメッセージ",
+            ] {
+                assert_eq!(statement(sqlite_failure(code, message)).kind(), expected);
+            }
+        }
+    }
+
+    #[test]
+    fn generic_sqlite_error_depends_on_the_trusted_statement_boundary() {
+        for message in ["UNIQUE constraint failed", "構文とは無関係なメッセージ"] {
+            let user_error = statement(sqlite_failure(ffi::SQLITE_ERROR, message));
+            let storage_error = storage(sqlite_failure(ffi::SQLITE_ERROR, message));
+
+            assert_eq!(user_error.kind(), EngineErrorKind::InvalidQuery);
+            assert_eq!(storage_error.kind(), EngineErrorKind::Internal);
+        }
+    }
+
+    #[test]
+    fn client_constraint_codes_are_not_applied_to_internal_storage_sql() {
+        let user_error = statement(sqlite_failure(ffi::SQLITE_CONSTRAINT_UNIQUE, "not parsed"));
+        let storage_error = storage(sqlite_failure(ffi::SQLITE_CONSTRAINT_UNIQUE, "not parsed"));
+
+        assert_eq!(user_error.kind(), EngineErrorKind::UniqueViolation);
+        assert_eq!(storage_error.kind(), EngineErrorKind::Internal);
+    }
+
+    #[test]
+    fn filesystem_errors_use_their_precise_available_kinds() {
+        let cases = [
+            (
+                io::ErrorKind::PermissionDenied,
+                EngineErrorKind::PermissionDenied,
+            ),
+            (io::ErrorKind::ReadOnlyFilesystem, EngineErrorKind::ReadOnly),
+            (io::ErrorKind::StorageFull, EngineErrorKind::StorageFull),
+            (io::ErrorKind::QuotaExceeded, EngineErrorKind::StorageFull),
+            (io::ErrorKind::OutOfMemory, EngineErrorKind::OutOfMemory),
+            (io::ErrorKind::FileTooLarge, EngineErrorKind::LimitExceeded),
+            (
+                io::ErrorKind::AlreadyExists,
+                EngineErrorKind::FailedPrecondition,
+            ),
+            (
+                io::ErrorKind::InvalidInput,
+                EngineErrorKind::FailedPrecondition,
+            ),
+            (
+                io::ErrorKind::InvalidData,
+                EngineErrorKind::FailedPrecondition,
+            ),
+            (
+                io::ErrorKind::NotADirectory,
+                EngineErrorKind::FailedPrecondition,
+            ),
+            (
+                io::ErrorKind::IsADirectory,
+                EngineErrorKind::FailedPrecondition,
+            ),
+            (io::ErrorKind::Unsupported, EngineErrorKind::Unsupported),
+            (io::ErrorKind::NotFound, EngineErrorKind::StorageUnavailable),
+        ];
+
+        for (io_kind, expected) in cases {
+            let error = storage_io(io::Error::from(io_kind), "create directory");
+            assert_eq!(error.kind(), expected, "{io_kind:?}");
+        }
+    }
+
+    #[test]
+    fn invalid_sqlite_paths_are_failed_preconditions() {
+        let error = storage(Error::InvalidPath("invalid".into()));
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -5,10 +5,13 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{Context, bail};
 use rusqlite::{Connection, OptionalExtension};
 
 pub use crate::core::Database;
+use crate::{
+    core::{EngineError, EngineErrorKind, EngineResult},
+    sqlite_error,
+};
 
 const SCHEMA_VERSION: &str = "1";
 
@@ -19,26 +22,34 @@ pub(crate) struct Storage {
 }
 
 impl Storage {
-    pub(crate) fn open(root: impl AsRef<Path>, requested_shards: u16) -> anyhow::Result<Self> {
+    pub(crate) fn open(root: impl AsRef<Path>, requested_shards: u16) -> EngineResult<Self> {
         if !(2..=64).contains(&requested_shards) {
-            bail!("shard count must be between 2 and 64");
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "shard count must be between 2 and 64",
+            ));
         }
 
         let root = root.as_ref().to_path_buf();
         let shards_dir = root.join("shards");
-        fs::create_dir_all(&shards_dir)
-            .with_context(|| format!("failed to create {}", shards_dir.display()))?;
+        fs::create_dir_all(&shards_dir).map_err(|error| {
+            sqlite_error::storage_io(error, format!("failed to create {}", shards_dir.display()))
+        })?;
 
         let manifest_path = root.join("manifest.sqlite");
-        let mut manifest = Connection::open(&manifest_path)
-            .with_context(|| format!("failed to open {}", manifest_path.display()))?;
+        let mut manifest = Connection::open(&manifest_path).map_err(|error| {
+            sqlite_error::storage(error)
+                .context(format!("failed to open {}", manifest_path.display()))
+        })?;
         configure_connection(&manifest)?;
-        manifest.execute_batch(
-            "CREATE TABLE IF NOT EXISTS briskdb_metadata (
+        manifest
+            .execute_batch(
+                "CREATE TABLE IF NOT EXISTS briskdb_metadata (
                 key TEXT PRIMARY KEY,
                 value TEXT NOT NULL
             );",
-        )?;
+            )
+            .map_err(sqlite_error::storage)?;
 
         let existing: Option<String> = manifest
             .query_row(
@@ -46,28 +57,46 @@ impl Storage {
                 [],
                 |row| row.get(0),
             )
-            .optional()?;
+            .optional()
+            .map_err(sqlite_error::storage)?;
 
         if let Some(existing) = existing {
-            let existing: u16 = existing
-                .parse()
-                .context("manifest has an invalid shard count")?;
+            let existing: u16 = existing.parse().map_err(|error| {
+                EngineError::from_source(
+                    EngineErrorKind::DataCorruption,
+                    "manifest has an invalid shard count",
+                    error,
+                )
+            })?;
+            if !(2..=64).contains(&existing) {
+                return Err(EngineError::new(
+                    EngineErrorKind::DataCorruption,
+                    format!("manifest shard count {existing} is outside the supported range"),
+                ));
+            }
             if existing != requested_shards {
-                bail!(
-                    "database was created with {existing} shards, but {requested_shards} were requested"
-                );
+                return Err(EngineError::new(
+                    EngineErrorKind::FailedPrecondition,
+                    format!(
+                        "database was created with {existing} shards, but {requested_shards} were requested"
+                    ),
+                ));
             }
         } else {
-            let transaction = manifest.transaction()?;
-            transaction.execute(
-                "INSERT INTO briskdb_metadata (key, value) VALUES ('shard_count', ?1)",
-                [requested_shards.to_string()],
-            )?;
-            transaction.execute(
-                "INSERT INTO briskdb_metadata (key, value) VALUES ('schema_version', ?1)",
-                [SCHEMA_VERSION],
-            )?;
-            transaction.commit()?;
+            let transaction = manifest.transaction().map_err(sqlite_error::storage)?;
+            transaction
+                .execute(
+                    "INSERT INTO briskdb_metadata (key, value) VALUES ('shard_count', ?1)",
+                    [requested_shards.to_string()],
+                )
+                .map_err(sqlite_error::storage)?;
+            transaction
+                .execute(
+                    "INSERT INTO briskdb_metadata (key, value) VALUES ('schema_version', ?1)",
+                    [SCHEMA_VERSION],
+                )
+                .map_err(sqlite_error::storage)?;
+            transaction.commit().map_err(sqlite_error::storage)?;
         }
 
         let storage = Self {
@@ -88,28 +117,42 @@ impl Storage {
         self.root.join("shards").join(format!("{shard:04}.sqlite"))
     }
 
-    pub(crate) fn open_shard(&self, shard: u16) -> anyhow::Result<Connection> {
+    pub(crate) fn open_shard(&self, shard: u16) -> EngineResult<Connection> {
         if shard >= self.shard_count {
-            bail!("shard {shard} is outside the configured range");
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                format!("shard {shard} is outside the configured range"),
+            ));
         }
         let path = self.shard_path(shard);
-        let connection = Connection::open(&path)
-            .with_context(|| format!("failed to open shard {}", path.display()))?;
+        let connection = Connection::open(&path).map_err(|error| {
+            sqlite_error::storage(error).context(format!("failed to open shard {}", path.display()))
+        })?;
         configure_connection(&connection)?;
         Ok(connection)
     }
 }
 
-fn configure_connection(connection: &Connection) -> anyhow::Result<()> {
-    connection.busy_timeout(std::time::Duration::from_secs(5))?;
-    connection.pragma_update(None, "journal_mode", "WAL")?;
-    connection.pragma_update(None, "synchronous", "FULL")?;
-    connection.pragma_update(None, "foreign_keys", "ON")?;
+fn configure_connection(connection: &Connection) -> EngineResult<()> {
+    connection
+        .busy_timeout(std::time::Duration::from_secs(5))
+        .map_err(sqlite_error::storage)?;
+    connection
+        .pragma_update(None, "journal_mode", "WAL")
+        .map_err(sqlite_error::storage)?;
+    connection
+        .pragma_update(None, "synchronous", "FULL")
+        .map_err(sqlite_error::storage)?;
+    connection
+        .pragma_update(None, "foreign_keys", "ON")
+        .map_err(sqlite_error::storage)?;
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
+    use std::error::Error as _;
+
     use super::*;
 
     #[test]
@@ -138,18 +181,19 @@ mod tests {
     #[test]
     fn rejects_invalid_or_changed_shard_counts() {
         let temp = tempfile::tempdir().unwrap();
-        assert_eq!(
-            Storage::open(temp.path(), 1).unwrap_err().to_string(),
-            "shard count must be between 2 and 64"
-        );
-        assert_eq!(
-            Storage::open(temp.path(), 65).unwrap_err().to_string(),
-            "shard count must be between 2 and 64"
-        );
+        let too_few = Storage::open(temp.path(), 1).unwrap_err();
+        assert_eq!(too_few.kind(), EngineErrorKind::InvalidArgument);
+        assert_eq!(too_few.to_string(), "shard count must be between 2 and 64");
+
+        let too_many = Storage::open(temp.path(), 65).unwrap_err();
+        assert_eq!(too_many.kind(), EngineErrorKind::InvalidArgument);
+        assert_eq!(too_many.to_string(), "shard count must be between 2 and 64");
 
         Storage::open(temp.path(), 4).unwrap();
+        let changed = Storage::open(temp.path(), 8).unwrap_err();
+        assert_eq!(changed.kind(), EngineErrorKind::FailedPrecondition);
         assert_eq!(
-            Storage::open(temp.path(), 8).unwrap_err().to_string(),
+            changed.to_string(),
             "database was created with 4 shards, but 8 were requested"
         );
     }
@@ -159,10 +203,73 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let storage = Storage::open(temp.path(), 4).unwrap();
 
-        assert_eq!(
-            storage.open_shard(4).unwrap_err().to_string(),
-            "shard 4 is outside the configured range"
-        );
+        let error = storage.open_shard(4).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Internal);
+        assert_eq!(error.to_string(), "shard 4 is outside the configured range");
+    }
+
+    #[test]
+    fn rejects_malformed_manifest_metadata_as_data_corruption() {
+        let temp = tempfile::tempdir().unwrap();
+        Storage::open(temp.path(), 4).unwrap();
+        let manifest = Connection::open(temp.path().join("manifest.sqlite")).unwrap();
+        manifest
+            .execute(
+                "UPDATE briskdb_metadata SET value = 'not-a-number' WHERE key = 'shard_count'",
+                [],
+            )
+            .unwrap();
+
+        let error = Storage::open(temp.path(), 4).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+        assert_eq!(error.to_string(), "manifest has an invalid shard count");
+        assert!(error.source().is_some());
+    }
+
+    #[test]
+    fn rejects_impossible_numeric_manifest_counts_as_data_corruption() {
+        for invalid in ["0", "1", "65", "65535"] {
+            let temp = tempfile::tempdir().unwrap();
+            Storage::open(temp.path(), 4).unwrap();
+            let manifest = Connection::open(temp.path().join("manifest.sqlite")).unwrap();
+            manifest
+                .execute(
+                    "UPDATE briskdb_metadata SET value = ?1 WHERE key = 'shard_count'",
+                    [invalid],
+                )
+                .unwrap();
+
+            let error = Storage::open(temp.path(), 4).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+            assert_eq!(
+                error.to_string(),
+                format!("manifest shard count {invalid} is outside the supported range")
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_a_corrupt_manifest_database() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(
+            temp.path().join("manifest.sqlite"),
+            b"not a sqlite database",
+        )
+        .unwrap();
+
+        let error = Storage::open(temp.path(), 4).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+        assert!(error.source().is_some());
+    }
+
+    #[test]
+    fn classifies_invalid_storage_path_shape_as_a_failed_precondition() {
+        let root_file = tempfile::NamedTempFile::new().unwrap();
+        let error = Storage::open(root_file.path(), 4).unwrap_err();
+
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert!(!error.is_retryable());
+        assert!(error.source().is_some());
     }
 
     #[test]

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -1,7 +1,11 @@
 use std::sync::Arc;
 
 use axum::Router;
-use briskdb::{api, core, protocol::http, storage};
+use briskdb::{
+    api, core,
+    protocol::{error, http},
+    storage,
+};
 
 #[test]
 fn legacy_and_explicit_module_paths_are_both_available() {
@@ -21,4 +25,19 @@ fn legacy_and_explicit_module_paths_are_both_available() {
     assert_eq!(core::Value::from(decimal).as_decimal(), Some("12.3400"));
     let _invalid_decimal: core::ParseDecimalError =
         "not-a-number".parse::<core::Decimal>().unwrap_err();
+
+    let engine_error = core::EngineError::new(core::EngineErrorKind::InvalidArgument, "diagnostic");
+    let _engine_result: core::EngineResult<()> = Err(engine_error);
+    assert_eq!(
+        error::http_error(core::EngineErrorKind::InvalidArgument).status,
+        400
+    );
+    assert_eq!(
+        error::postgres_error(core::EngineErrorKind::UniqueViolation).sqlstate,
+        "23505"
+    );
+    assert_eq!(
+        error::mysql_error(core::EngineErrorKind::UniqueViolation).error_number,
+        1062
+    );
 }


### PR DESCRIPTION
Closes #8

## Summary

- add a 22-kind, protocol-neutral `EngineError` / `EngineErrorKind` contract with stable codes, source chains, and conservative retry metadata
- classify SQLite and filesystem failures from structured result codes plus trusted operation context, without parsing localized error messages
- add exhaustive HTTP, PostgreSQL SQLSTATE, and MySQL errno/SQLSTATE mapping records for future adapters
- replace raw HTTP 500 error leakage with RFC 9457 `application/problem+json` responses containing fixed safe text
- document the taxonomy, protocol mappings, retry policy, intentional pre-1.0 Rust/HTTP migrations, and unchanged storage format

## Test coverage

- exact golden mapping coverage for every engine kind, including code/documentation synchronization
- real SQLite UNIQUE, PRIMARY KEY, NOT NULL, foreign-key, CHECK, invalid-query, parameter, corruption, and manifest failures
- deterministic two-connection busy/recovery coverage and partial-broadcast recovery coverage
- exact HTTP status/header/body tests plus exhaustive secret/source redaction for every kind and blocking-task panics
- public API, benchmark workload, and existing endpoint regression suites

## Verification

- `cargo fmt --all -- --check`
- `cargo test --locked --all-targets --all-features`
- `cargo test --locked --doc --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- the same full gates with Rust 1.85.0
- three independent clean re-reviews
- same-host Criterion A/B against `main`: no point-write or four-shard concurrent-write change; no regression in point reads

PostgreSQL and MySQL entries are mapping contracts only; their listeners remain planned. This change does not alter the manifest, shard files, routing, configuration, or stored-value format.
