### PR TITLE
Add the async session engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ minimum supported Rust version (MSRV) and the latest stable toolchain.
 ## Current foundation
 
 - Stable BLAKE3 routing from a caller-provided shard key
+- A protocol-neutral async engine with per-request HTTP sessions
 - Protocol-neutral typed values, ordered columns, positional rows, and results
 - A fixed shard count recorded in `manifest.sqlite`
 - One WAL-enabled SQLite database per shard
@@ -108,11 +109,14 @@ selected shard depends on the routing key; an example response is:
 ## Deliberate boundaries
 
 This is an initial scaffold, not a production database yet. The current API
-accepts SQL and should only be exposed on a trusted network. Each request opens
-a SQLite connection; pooling is the next performance step. Broadcast changes
-and future scatter operations are not atomic across shard files. The shard
-count is immutable after database creation, so resharding will require an
-explicit migration workflow.
+accepts SQL and should only be exposed on a trusted network. The HTTP adapter
+creates an ephemeral session for each data request, so session state and
+transactions cannot span HTTP requests. Each SQL operation currently opens one
+or more SQLite connections on Tokio's blocking workers; bounded workers,
+connection pools, backpressure, cancellation, and deadlines remain roadmap
+work. Broadcast changes and future scatter operations are not atomic across
+shard files. The shard count is immutable after database creation, so
+resharding will require an explicit migration workflow.
 
 Near-term work includes authentication, connection pools, schema migrations,
 scatter/gather reads, observability, backup tooling, and failure-injection

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -169,7 +169,7 @@ Status: **in progress**
 - [x] Preserve column order and duplicate column names.
 - [x] Add a structured error taxonomy and mappings for HTTP, PostgreSQL, and
   MySQL.
-- [ ] Introduce a `Session` state machine and an async `Engine` interface used
+- [x] Introduce a `Session` state machine and an async `Engine` interface used
   by every frontend.
 - [ ] Move blocking SQLite work behind a bounded worker/pool abstraction; add
   per-shard connection pools and backpressure.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,18 +21,20 @@ server ---------> protocol::http
 
 | Module | Responsibility | Must not own |
 | --- | --- | --- |
-| `core` | Protocol-neutral values, results, and `EngineError`; stable key routing; routed execute/query and schema broadcast | JSON/HTTP types, listeners, or Axum handlers |
+| `core` | Protocol-neutral `Engine`, `Session`, statements, values, results, and errors; stable key routing; routed execute/query and schema broadcast | JSON/HTTP types, listeners, or Axum handlers |
 | `storage` | Manifest and shard layout, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
 | `sql` | SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, routing, filesystem layout, or protocol responses |
 | `protocol::http` | HTTP request extraction plus JSON/BriskDB value and RFC 9457 problem-detail encoding | BLAKE3 routing, shard files, or rusqlite calls |
 | `protocol::error` | Exhaustive HTTP, PostgreSQL, and MySQL mappings from stable engine error kinds | SQLite errors, routing decisions, or wire-protocol session state |
 | `server` | Process configuration, database assembly, listener binding, and Axum lifecycle | SQL parsing or storage implementation details |
 
-Implementation dependencies flow one way: adapters call `core`; `core`
-coordinates `storage` and `sql`. The HTTP adapter receives the selected shard
-together with the operation result, so it does not make a second routing
-decision. The only reverse-facing name is `storage::Database`, a compatibility
-re-export of `core::Database`; the storage implementation does not call core.
+Implementation dependencies flow one way: adapters call the async `Engine` in
+`core`; the engine coordinates routing, `storage`, and `sql`. An adapter supplies
+protocol-neutral session routing context and an owned statement, then receives
+the selected shard together with the operation result. It neither computes a
+shard nor opens a SQLite connection. The only reverse-facing name is
+`storage::Database`, a compatibility re-export of `core::Database`; the storage
+implementation does not call core.
 
 ## Compatibility during the split
 
@@ -59,13 +61,58 @@ of `anyhow::Result<T>`; this intentional pre-1.0 source migration gives callers
 stable error identity while retaining automatic `?` conversion into `anyhow`.
 
 Automated HTTP contract tests cover health, schema broadcast, routed writes,
-routed reads, and structured problem-detail serialization. Unit tests remain
-colocated with routing, storage, SQL conversion, CLI, and server assembly.
+routed reads, and structured problem-detail serialization through the shared
+engine. Unit tests remain colocated with sessions, engine orchestration,
+routing, storage, SQL conversion, CLI, and server assembly.
 
 The module names are stable boundaries, not a claim that later roadmap work is
-already complete. Session state, the async `Engine` interface, connection
-pools, cancellation, and limits are separate issues. Until those land, the
-core intentionally retains the current synchronous execution interface.
+already complete. The async engine and initial session lifecycle are now in
+place; connection pools, cancellation, and limits are separate issues. The
+synchronous `Database` API remains available as a Rust compatibility surface
+and is the implementation used behind the asynchronous boundary.
+
+## Session and asynchronous engine boundary
+
+`Session` is protocol-neutral mutable state owned by one frontend connection or
+request. A new session is `Ready`; closing it is a terminal transition to
+`Closed`, and engine operations reject a closed session with
+`FailedPrecondition`. Ordinary statement failures do not close or poison a
+session, so a frontend may correct a request and continue. Sessions are not
+clonable. Frontends may issue concurrent calls against one borrowed session,
+but the engine serializes them; the HTTP adapter instead creates an independent
+session for every request.
+
+The current routing context is an optional caller-supplied shard key. Routed
+execute and query operations require that context, and the engine alone hashes
+it and reports the selected shard in `Routed<T>`. `Statement` owns its SQL text
+and typed parameters so an adapter can hand work across the asynchronous
+boundary without borrowing protocol buffers. `EngineStatus` exposes the shard
+count needed by health reporting without exposing the storage implementation.
+
+HTTP is stateless at this stage: each execute or query request creates a fresh
+session and initializes its routing context from the request's `shard_key`.
+Consequently, session settings and transactions cannot span HTTP requests.
+Schema broadcast and status calls also go through the shared engine, but do not
+perform a routing decision in the adapter.
+
+The local engine currently uses Tokio blocking workers around the existing
+synchronous `Database` operations. Those workers are not BriskDB's planned
+bounded execution pool, and each SQL operation still opens one or more shard
+connections. Bounded per-shard pools and backpressure are issue #10;
+cancellation, deadlines, limits, and graceful shutdown are issue #11. Real
+`BEGIN`/`COMMIT`/`ROLLBACK`,
+failed-transaction state, and single-shard pinning are deliberately deferred to
+the PostgreSQL and MySQL transaction work in issues #34 and #47. `Ready` and
+`Closed` therefore describe session lifecycle, not SQL transaction state.
+
+Dropping an engine future does not cancel SQLite work in this phase. The
+blocking worker retains the session lock until that work ends, so another call
+cannot overlap it on the same session; an operation may still commit after its
+frontend disconnects. Issue #11 owns interruption and cancellation semantics.
+
+This boundary changes Rust orchestration only. It does not change command-line
+or environment configuration, HTTP routes or JSON shapes, shard routing,
+manifest schema, SQLite files, WAL or synchronous settings, or any stored data.
 
 ## Error boundary
 

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -51,11 +51,23 @@ translation layer. HTTP requests send SQLite SQL directly to `rusqlite`.
 | PostgreSQL wire protocol | Planned | Common subset plus documented PostgreSQL normalization | SQL/bound-parameter inference with explicit session fallback |
 | MySQL wire protocol | Planned | Common subset plus documented MySQL normalization | SQL/bound-parameter inference with explicit session fallback |
 
-The current HTTP calls open a SQLite connection per request. A transaction
-cannot span requests. Broadcast execution is not atomic: its parameterless SQL
-batch is not wrapped in a transaction on each shard, and shards are processed
-sequentially. A failure can therefore leave earlier statements committed on the
-failing shard as well as leave earlier shards fully or partially updated.
+Every HTTP operation now calls the same protocol-neutral async engine intended
+for future PostgreSQL and MySQL adapters. Execute and query requests create a
+fresh `Ready` session, put the request's `shard_key` in its routing context, and
+submit an owned statement. The engine, rather than the HTTP adapter, selects the
+shard and opens the SQLite connection. The session is discarded when that HTTP
+request finishes, so a transaction cannot span requests.
+
+The asynchronous boundary currently delegates each operation to Tokio's
+blocking workers, and each SQL operation still opens one or more SQLite
+connections. It does not yet provide the bounded per-shard pools and
+backpressure planned in issue #10, or the cancellation and deadline behavior
+planned in issue #11. Dropping a request future does not interrupt an in-flight
+SQLite operation; the operation may still commit after the client disconnects.
+Broadcast execution remains non-atomic: its parameterless SQL batch is not
+wrapped in a transaction on each shard, and shards are processed sequentially.
+A failure can therefore leave earlier statements committed on the failing shard
+as well as leave earlier shards fully or partially updated.
 
 ### Current parameter and result conversion
 
@@ -160,6 +172,15 @@ multiple statements outside the broadcast endpoint, and attached-database
 operations are uncontracted public API behavior today. The experimental raw
 HTTP path might accept some of them; clients must not rely on acceptance,
 rejection, or unchanged semantics.
+
+The current `Session` `Ready`/`Closed` lifecycle is not a transaction state
+machine. Real `BEGIN`/`COMMIT`/`ROLLBACK`, failed-transaction behavior, and
+single-shard pinning remain planned for the PostgreSQL and MySQL transaction
+work in issues #34 and #47.
+
+The synchronous public Rust `Database` methods remain available for source
+compatibility. Network frontends use `Engine`; retaining `Database` does not
+authorize an adapter to bypass the shared asynchronous boundary.
 
 ### Planned common subset
 

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -1,0 +1,634 @@
+//! Asynchronous protocol-neutral engine boundary.
+
+use std::{
+    path::{Path, PathBuf},
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+
+use tokio::sync::OwnedMutexGuard;
+
+use super::{
+    Database, EngineError, EngineErrorKind, EngineResult, ResultSet, Routed, Session, SessionInner,
+    Value,
+};
+
+static NEXT_ENGINE_ID: AtomicU64 = AtomicU64::new(1);
+
+/// An owned SQL statement and its protocol-neutral parameters.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Statement {
+    sql: String,
+    params: Vec<Value>,
+}
+
+impl Statement {
+    /// Construct an owned statement suitable for asynchronous execution.
+    pub fn new(sql: impl Into<String>, params: Vec<Value>) -> Self {
+        Self {
+            sql: sql.into(),
+            params,
+        }
+    }
+
+    /// Return the SQL text.
+    pub fn sql(&self) -> &str {
+        &self.sql
+    }
+
+    /// Return the ordered bound parameters.
+    pub fn params(&self) -> &[Value] {
+        &self.params
+    }
+
+    /// Consume the statement into its SQL text and parameters.
+    pub fn into_parts(self) -> (String, Vec<Value>) {
+        (self.sql, self.params)
+    }
+}
+
+/// Read-only engine information returned through the async boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EngineStatus {
+    shard_count: u16,
+}
+
+impl EngineStatus {
+    /// Return the number of physical shards opened by the engine.
+    pub const fn shard_count(&self) -> u16 {
+        self.shard_count
+    }
+}
+
+#[derive(Debug)]
+struct EngineInner {
+    id: u64,
+    database: Arc<Database>,
+}
+
+/// Shared asynchronous entry point used by every network frontend.
+///
+/// Clones refer to the same engine identity and database. SQLite remains
+/// blocking internally, so operations hand owned work to Tokio blocking
+/// workers until the bounded pool abstraction is introduced.
+#[derive(Debug, Clone)]
+pub struct Engine {
+    inner: Arc<EngineInner>,
+}
+
+impl Engine {
+    /// Open a database without blocking the async runtime executor.
+    pub async fn open(root: impl AsRef<Path>, requested_shards: u16) -> EngineResult<Self> {
+        let root = PathBuf::from(root.as_ref());
+        let database = run_blocking(move || Database::open(root, requested_shards)).await?;
+        Ok(Self::from_database(Arc::new(database)))
+    }
+
+    /// Wrap the synchronous compatibility API in the shared async boundary.
+    pub fn from_database(database: Arc<Database>) -> Self {
+        Self {
+            inner: Arc::new(EngineInner {
+                id: NEXT_ENGINE_ID.fetch_add(1, Ordering::Relaxed),
+                database,
+            }),
+        }
+    }
+
+    /// Create a new frontend-owned session.
+    pub fn session(&self) -> Session {
+        Session::new(self.inner.id)
+    }
+
+    /// Return the configured physical shard count.
+    pub fn shard_count(&self) -> u16 {
+        self.inner.database.shard_count()
+    }
+
+    /// Return engine status after validating the calling session.
+    pub async fn status(&self, session: &Session) -> EngineResult<EngineStatus> {
+        let _guard = self.ready_session(session).await?;
+        Ok(EngineStatus {
+            shard_count: self.shard_count(),
+        })
+    }
+
+    /// Execute a routed statement and return its selected shard.
+    pub async fn execute(
+        &self,
+        session: &Session,
+        statement: Statement,
+    ) -> EngineResult<Routed<usize>> {
+        let guard = self.ready_session(session).await?;
+        let routing_key = required_routing_key(&guard)?.to_owned();
+        let database = Arc::clone(&self.inner.database);
+        let (sql, params) = statement.into_parts();
+
+        run_blocking(move || {
+            let _guard = guard;
+            database.execute_routed(&routing_key, &sql, &params)
+        })
+        .await
+    }
+
+    /// Query a routed statement and return its selected shard and rows.
+    pub async fn query(
+        &self,
+        session: &Session,
+        statement: Statement,
+    ) -> EngineResult<Routed<ResultSet>> {
+        let guard = self.ready_session(session).await?;
+        let routing_key = required_routing_key(&guard)?.to_owned();
+        let database = Arc::clone(&self.inner.database);
+        let (sql, params) = statement.into_parts();
+
+        run_blocking(move || {
+            let _guard = guard;
+            database.query_routed(&routing_key, &sql, &params)
+        })
+        .await
+    }
+
+    /// Execute a parameterless SQL batch sequentially on every shard.
+    pub async fn broadcast(&self, session: &Session, sql: String) -> EngineResult<Vec<u16>> {
+        let guard = self.ready_session(session).await?;
+        let database = Arc::clone(&self.inner.database);
+
+        run_blocking(move || {
+            let _guard = guard;
+            database.broadcast(&sql)
+        })
+        .await
+    }
+
+    async fn ready_session(
+        &self,
+        session: &Session,
+    ) -> EngineResult<OwnedMutexGuard<SessionInner>> {
+        if session.owner != self.inner.id {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "the session belongs to a different engine",
+            ));
+        }
+
+        let guard = Arc::clone(&session.inner).lock_owned().await;
+        guard.ensure_ready()?;
+        Ok(guard)
+    }
+
+    #[cfg(test)]
+    async fn hold_session_for_test(
+        &self,
+        session: &Session,
+        started: tokio::sync::oneshot::Sender<()>,
+        release: std::sync::mpsc::Receiver<()>,
+    ) -> EngineResult<()> {
+        let guard = self.ready_session(session).await?;
+        run_blocking(move || {
+            let _guard = guard;
+            let _ = started.send(());
+            release.recv().expect("test releases the blocking worker");
+            Ok(())
+        })
+        .await
+    }
+
+    #[cfg(test)]
+    async fn panic_worker_for_test(&self, session: &Session) -> EngineResult<()> {
+        let guard = self.ready_session(session).await?;
+        run_blocking(move || {
+            let _guard = guard;
+            panic!("intentional blocking worker panic")
+        })
+        .await
+    }
+}
+
+fn required_routing_key(session: &SessionInner) -> EngineResult<&str> {
+    session.routing_key().ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            "the session has no routing key",
+        )
+    })
+}
+
+async fn run_blocking<T, F>(work: F) -> EngineResult<T>
+where
+    T: Send + 'static,
+    F: FnOnce() -> EngineResult<T> + Send + 'static,
+{
+    tokio::task::spawn_blocking(work).await.map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::Internal,
+            "blocking engine task failed",
+            error,
+        )
+    })?
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{error::Error as _, sync::mpsc, time::Duration};
+
+    use tokio::{sync::oneshot, time::timeout};
+
+    use super::*;
+    use crate::core::{Column, DataType, Row, SessionState};
+
+    fn engine() -> (tempfile::TempDir, Engine) {
+        let temp = tempfile::tempdir().unwrap();
+        let database = Arc::new(Database::open(temp.path(), 4).unwrap());
+        (temp, Engine::from_database(database))
+    }
+
+    fn assert_send_sync<T: Send + Sync>() {}
+
+    fn assert_send<T: Send>(_: T) {}
+
+    fn assert_send_static<T: Send + 'static>(_: T) {}
+
+    #[test]
+    fn owned_public_types_have_expected_thread_safety_and_accessors() {
+        assert_send_sync::<Engine>();
+        assert_send_sync::<Session>();
+
+        let statement = Statement::new("SELECT ?1", vec![Value::from(42_i64)]);
+        assert_eq!(statement.sql(), "SELECT ?1");
+        assert_eq!(statement.params(), [Value::from(42_i64)]);
+        assert_send_static(statement.clone());
+        assert_eq!(
+            statement.into_parts(),
+            ("SELECT ?1".to_owned(), vec![Value::from(42_i64)])
+        );
+    }
+
+    #[tokio::test]
+    async fn open_and_status_cross_the_async_engine_boundary() {
+        let temp = tempfile::tempdir().unwrap();
+        let engine = Engine::open(temp.path(), 4).await.unwrap();
+        let session = engine.session();
+
+        assert_send(engine.status(&session));
+        assert_send(engine.query(&session, Statement::new("SELECT 1", vec![])));
+        assert_eq!(engine.shard_count(), 4);
+        assert_eq!(engine.status(&session).await.unwrap().shard_count(), 4);
+        assert_eq!(session.state().await, SessionState::Ready);
+    }
+
+    #[tokio::test]
+    async fn broadcast_execute_and_query_share_one_session_and_typed_results() {
+        let (_temp, engine) = engine();
+        let session = engine.session();
+        assert_eq!(
+            engine
+                .broadcast(
+                    &session,
+                    "CREATE TABLE widgets (id TEXT PRIMARY KEY, name TEXT NOT NULL)".to_owned(),
+                )
+                .await
+                .unwrap(),
+            [0, 1, 2, 3]
+        );
+        session.set_routing_key("widget-1").await.unwrap();
+
+        let write = engine
+            .execute(
+                &session,
+                Statement::new(
+                    "INSERT INTO widgets (id, name) VALUES (?1, ?2)",
+                    vec![Value::from("widget-1"), Value::from("First widget")],
+                ),
+            )
+            .await
+            .unwrap();
+        let read = engine
+            .query(
+                &session,
+                Statement::new(
+                    "SELECT id, name FROM widgets WHERE id = ?1",
+                    vec![Value::from("widget-1")],
+                ),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(write.shard, read.shard);
+        assert_eq!(write.value, 1);
+        assert_eq!(
+            read.value,
+            ResultSet::new(
+                vec![
+                    Column::new("id", DataType::Unknown),
+                    Column::new("name", DataType::Unknown),
+                ],
+                vec![Row::new(vec![
+                    Value::from("widget-1"),
+                    Value::from("First widget"),
+                ])],
+            )
+            .unwrap()
+        );
+        assert_eq!(session.state().await, SessionState::Ready);
+    }
+
+    #[tokio::test]
+    async fn missing_routing_context_and_query_errors_leave_session_reusable() {
+        let (_temp, engine) = engine();
+        let session = engine.session();
+
+        assert_eq!(
+            engine
+                .query(&session, Statement::new("SELECT 1", vec![]))
+                .await
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::InvalidArgument
+        );
+        assert_eq!(session.state().await, SessionState::Ready);
+
+        session.set_routing_key("widget-1").await.unwrap();
+        let invalid = engine
+            .query(
+                &session,
+                Statement::new("SELECT * FROM missing_table", vec![]),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(invalid.kind(), EngineErrorKind::InvalidQuery);
+        assert!(invalid.source().is_some());
+        assert_eq!(session.state().await, SessionState::Ready);
+
+        let recovered = engine
+            .query(&session, Statement::new("SELECT 42", vec![]))
+            .await
+            .unwrap();
+        assert_eq!(recovered.value.rows()[0].get(0), Some(&Value::from(42_i64)));
+    }
+
+    #[tokio::test]
+    async fn foreign_and_closed_sessions_are_rejected_before_work() {
+        let (_first_temp, first) = engine();
+        let (_second_temp, second) = engine();
+        let foreign = first.session();
+
+        assert_eq!(
+            second.status(&foreign).await.unwrap_err().kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+        foreign.set_routing_key("widget-1").await.unwrap();
+        assert_eq!(
+            second
+                .query(&foreign, Statement::new("SELECT 1", vec![]))
+                .await
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+
+        foreign.close().await.unwrap();
+        assert_eq!(
+            first.status(&foreign).await.unwrap_err().kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+        assert_eq!(
+            first
+                .broadcast(&foreign, "SELECT 1".to_owned())
+                .await
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+        assert_eq!(
+            first
+                .execute(&foreign, Statement::new("SELECT 1", vec![]))
+                .await
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+        assert_eq!(
+            first
+                .query(&foreign, Statement::new("SELECT 1", vec![]))
+                .await
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+    }
+
+    #[tokio::test]
+    async fn partial_broadcast_failure_can_recover_through_the_engine() {
+        let temp = tempfile::tempdir().unwrap();
+        let database = Arc::new(Database::open(temp.path(), 4).unwrap());
+        let shard_one = database.storage.open_shard(1).unwrap();
+        crate::sql::execute_batch(&shard_one, "CREATE TABLE marker (id INTEGER)").unwrap();
+        let engine = Engine::from_database(database);
+        let session = engine.session();
+
+        let error = engine
+            .broadcast(&session, "CREATE TABLE marker (id INTEGER)".to_owned())
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::InvalidQuery);
+        assert!(error.source().is_some());
+        assert_eq!(session.state().await, SessionState::Ready);
+
+        assert_eq!(
+            engine
+                .broadcast(
+                    &session,
+                    "CREATE TABLE IF NOT EXISTS marker (id INTEGER)".to_owned(),
+                )
+                .await
+                .unwrap(),
+            [0, 1, 2, 3]
+        );
+    }
+
+    #[tokio::test]
+    async fn a_worker_panic_is_internal_and_releases_the_session() {
+        let (_temp, engine) = engine();
+        let session = engine.session();
+
+        let error = engine.panic_worker_for_test(&session).await.unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Internal);
+        assert_eq!(error.to_string(), "blocking engine task failed");
+        assert!(error.source().is_some());
+        assert_eq!(engine.status(&session).await.unwrap().shard_count(), 4);
+        assert_eq!(session.state().await, SessionState::Ready);
+    }
+
+    #[tokio::test]
+    async fn same_session_calls_wait_without_starting_another_blocking_worker() {
+        let (_temp, engine) = engine();
+        let session = Arc::new(engine.session());
+        let (first_started_tx, first_started_rx) = oneshot::channel();
+        let (first_release_tx, first_release_rx) = mpsc::channel();
+        let first_engine = engine.clone();
+        let first_session = Arc::clone(&session);
+        let first = tokio::spawn(async move {
+            first_engine
+                .hold_session_for_test(&first_session, first_started_tx, first_release_rx)
+                .await
+        });
+        timeout(Duration::from_secs(2), first_started_rx)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let (second_started_tx, mut second_started_rx) = oneshot::channel();
+        let (second_release_tx, second_release_rx) = mpsc::channel();
+        let second_engine = engine.clone();
+        let second_session = Arc::clone(&session);
+        let second = tokio::spawn(async move {
+            second_engine
+                .hold_session_for_test(&second_session, second_started_tx, second_release_rx)
+                .await
+        });
+
+        assert!(
+            timeout(Duration::from_millis(50), &mut second_started_rx)
+                .await
+                .is_err()
+        );
+        first_release_tx.send(()).unwrap();
+        timeout(Duration::from_secs(2), &mut second_started_rx)
+            .await
+            .unwrap()
+            .unwrap();
+        second_release_tx.send(()).unwrap();
+
+        first.await.unwrap().unwrap();
+        second.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn aborting_an_outer_future_does_not_release_an_in_flight_session() {
+        let (_temp, engine) = engine();
+        let session = Arc::new(engine.session());
+        let (started_tx, started_rx) = oneshot::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let worker_engine = engine.clone();
+        let worker_session = Arc::clone(&session);
+        let worker = tokio::spawn(async move {
+            worker_engine
+                .hold_session_for_test(&worker_session, started_tx, release_rx)
+                .await
+        });
+        timeout(Duration::from_secs(2), started_rx)
+            .await
+            .unwrap()
+            .unwrap();
+        worker.abort();
+        assert!(worker.await.unwrap_err().is_cancelled());
+
+        let status_engine = engine.clone();
+        let status_session = Arc::clone(&session);
+        let mut status = tokio::spawn(async move { status_engine.status(&status_session).await });
+        assert!(
+            timeout(Duration::from_millis(50), &mut status)
+                .await
+                .is_err()
+        );
+
+        release_tx.send(()).unwrap();
+        assert_eq!(
+            timeout(Duration::from_secs(2), status)
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap()
+                .shard_count(),
+            4
+        );
+    }
+
+    #[tokio::test]
+    async fn independent_sessions_can_enter_blocking_workers_concurrently() {
+        let (_temp, engine) = engine();
+        let first_session = Arc::new(engine.session());
+        let second_session = Arc::new(engine.session());
+        let (first_started_tx, first_started_rx) = oneshot::channel();
+        let (second_started_tx, second_started_rx) = oneshot::channel();
+        let (first_release_tx, first_release_rx) = mpsc::channel();
+        let (second_release_tx, second_release_rx) = mpsc::channel();
+
+        let first_engine = engine.clone();
+        let first_session_for_task = Arc::clone(&first_session);
+        let first = tokio::spawn(async move {
+            first_engine
+                .hold_session_for_test(&first_session_for_task, first_started_tx, first_release_rx)
+                .await
+        });
+        let second_engine = engine.clone();
+        let second_session_for_task = Arc::clone(&second_session);
+        let second = tokio::spawn(async move {
+            second_engine
+                .hold_session_for_test(
+                    &second_session_for_task,
+                    second_started_tx,
+                    second_release_rx,
+                )
+                .await
+        });
+
+        timeout(Duration::from_secs(2), first_started_rx)
+            .await
+            .unwrap()
+            .unwrap();
+        timeout(Duration::from_secs(2), second_started_rx)
+            .await
+            .unwrap()
+            .unwrap();
+        first_release_tx.send(()).unwrap();
+        second_release_tx.send(()).unwrap();
+        first.await.unwrap().unwrap();
+        second.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn independent_sessions_keep_routing_and_values_isolated() {
+        let (_temp, engine) = engine();
+        let first = Arc::new(engine.session());
+        let second = Arc::new(engine.session());
+        first.set_routing_key("tenant-a").await.unwrap();
+        second.set_routing_key("tenant-b").await.unwrap();
+
+        let first_engine = engine.clone();
+        let first_session = Arc::clone(&first);
+        let first_query = tokio::spawn(async move {
+            first_engine
+                .query(
+                    &first_session,
+                    Statement::new("SELECT ?1", vec![Value::from("first")]),
+                )
+                .await
+        });
+        let second_engine = engine.clone();
+        let second_session = Arc::clone(&second);
+        let second_query = tokio::spawn(async move {
+            second_engine
+                .query(
+                    &second_session,
+                    Statement::new("SELECT ?1", vec![Value::from("second")]),
+                )
+                .await
+        });
+
+        let first_result = first_query.await.unwrap().unwrap();
+        let second_result = second_query.await.unwrap().unwrap();
+        assert_eq!(
+            first_result.value.rows()[0].get(0),
+            Some(&Value::from("first"))
+        );
+        assert_eq!(
+            second_result.value.rows()[0].get(0),
+            Some(&Value::from("second"))
+        );
+        assert_eq!(first.routing_key().await.as_deref(), Some("tenant-a"));
+        assert_eq!(second.routing_key().await.as_deref(), Some("tenant-b"));
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,13 +3,19 @@
 //! This module owns routing and coordinates storage and SQL execution. It does
 //! not depend on a network protocol.
 
+mod engine;
 mod error;
+mod session;
 mod types;
 
+pub use engine::{Engine, EngineStatus, Statement};
 pub use error::{EngineError, EngineErrorKind, EngineResult};
+pub use session::{Session, SessionId, SessionState};
 pub use types::{
     Column, DataType, Decimal, ParseDecimalError, ResultSet, ResultSetShapeError, Row, Value,
 };
+
+use session::SessionInner;
 
 use std::path::Path;
 

--- a/src/core/session.rs
+++ b/src/core/session.rs
@@ -1,0 +1,198 @@
+//! Protocol-neutral frontend session state.
+
+use std::{
+    fmt,
+    sync::Arc,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use tokio::sync::Mutex;
+
+use super::{EngineError, EngineErrorKind, EngineResult};
+
+static NEXT_SESSION_ID: AtomicU64 = AtomicU64::new(1);
+
+/// A process-unique identifier for a frontend session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct SessionId(u64);
+
+impl SessionId {
+    /// Return the numeric session identifier.
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+impl fmt::Display for SessionId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+/// The lifecycle state of a protocol-neutral session.
+///
+/// Transaction state will be added with the wire-protocol transaction work;
+/// these variants currently describe only whether the session can accept
+/// requests.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SessionState {
+    /// The session can accept requests.
+    Ready,
+    /// The session was closed and cannot be reopened.
+    Closed,
+}
+
+#[derive(Debug)]
+pub(crate) struct SessionInner {
+    state: SessionState,
+    routing_key: Option<String>,
+}
+
+impl SessionInner {
+    pub(crate) fn ensure_ready(&self) -> EngineResult<()> {
+        if self.state == SessionState::Ready {
+            Ok(())
+        } else {
+            Err(closed_session_error())
+        }
+    }
+
+    pub(crate) fn routing_key(&self) -> Option<&str> {
+        self.routing_key.as_deref()
+    }
+}
+
+/// Mutable state owned by one protocol frontend connection or request.
+///
+/// A `Session` deliberately does not implement [`Clone`]. Multiple operations
+/// may borrow the same session concurrently, but the engine serializes them.
+#[must_use = "a session must be passed to engine operations"]
+pub struct Session {
+    id: SessionId,
+    pub(crate) owner: u64,
+    pub(crate) inner: Arc<Mutex<SessionInner>>,
+}
+
+impl Session {
+    pub(crate) fn new(owner: u64) -> Self {
+        Self {
+            id: SessionId(NEXT_SESSION_ID.fetch_add(1, Ordering::Relaxed)),
+            owner,
+            inner: Arc::new(Mutex::new(SessionInner {
+                state: SessionState::Ready,
+                routing_key: None,
+            })),
+        }
+    }
+
+    /// Return this session's process-unique identifier.
+    pub const fn id(&self) -> SessionId {
+        self.id
+    }
+
+    /// Return the current lifecycle state.
+    pub async fn state(&self) -> SessionState {
+        self.inner.lock().await.state
+    }
+
+    /// Return a copy of the current explicit routing key, if one is set.
+    pub async fn routing_key(&self) -> Option<String> {
+        self.inner.lock().await.routing_key.clone()
+    }
+
+    /// Set the explicit routing key used by subsequent routed operations.
+    pub async fn set_routing_key(&self, routing_key: impl Into<String>) -> EngineResult<()> {
+        let routing_key = routing_key.into();
+        let mut inner = self.inner.lock().await;
+        inner.ensure_ready()?;
+        inner.routing_key = Some(routing_key);
+        Ok(())
+    }
+
+    /// Clear the explicit routing key used by routed operations.
+    pub async fn clear_routing_key(&self) -> EngineResult<()> {
+        let mut inner = self.inner.lock().await;
+        inner.ensure_ready()?;
+        inner.routing_key = None;
+        Ok(())
+    }
+
+    /// Close the session.
+    ///
+    /// Closing is terminal and idempotent. It also clears routing context.
+    pub async fn close(&self) -> EngineResult<()> {
+        let mut inner = self.inner.lock().await;
+        inner.state = SessionState::Closed;
+        inner.routing_key = None;
+        Ok(())
+    }
+}
+
+impl fmt::Debug for Session {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("Session")
+            .field("id", &self.id)
+            .finish_non_exhaustive()
+    }
+}
+
+fn closed_session_error() -> EngineError {
+    EngineError::new(EngineErrorKind::FailedPrecondition, "the session is closed")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn sessions_have_unique_ids_and_start_ready_without_routing_context() {
+        let first = Session::new(7);
+        let second = Session::new(7);
+
+        assert_ne!(first.id(), second.id());
+        assert!(first.id().get() > 0);
+        assert_eq!(first.id().to_string(), first.id().get().to_string());
+        assert_eq!(first.state().await, SessionState::Ready);
+        assert_eq!(first.routing_key().await, None);
+    }
+
+    #[tokio::test]
+    async fn routing_context_can_be_set_replaced_and_cleared() {
+        let session = Session::new(7);
+
+        session.set_routing_key("tenant-a").await.unwrap();
+        assert_eq!(session.routing_key().await.as_deref(), Some("tenant-a"));
+        session.set_routing_key("tenant-b").await.unwrap();
+        assert_eq!(session.routing_key().await.as_deref(), Some("tenant-b"));
+        session.clear_routing_key().await.unwrap();
+        assert_eq!(session.routing_key().await, None);
+        assert_eq!(session.state().await, SessionState::Ready);
+    }
+
+    #[tokio::test]
+    async fn close_is_idempotent_terminal_and_clears_routing_context() {
+        let session = Session::new(7);
+        session.set_routing_key("tenant-a").await.unwrap();
+
+        session.close().await.unwrap();
+        session.close().await.unwrap();
+
+        assert_eq!(session.state().await, SessionState::Closed);
+        assert_eq!(session.routing_key().await, None);
+        assert_eq!(
+            session
+                .set_routing_key("tenant-b")
+                .await
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+        assert_eq!(
+            session.clear_routing_key().await.unwrap_err().kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+        assert_eq!(session.state().await, SessionState::Closed);
+    }
+}

--- a/src/protocol/http.rs
+++ b/src/protocol/http.rs
@@ -13,24 +13,37 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value as JsonValue, json};
 
 use crate::{
-    core::{DataType, Database, EngineError, EngineErrorKind, ResultSet, Routed, Value},
+    core::{DataType, Database, Engine, EngineError, ResultSet, Routed, Statement, Value},
     protocol::error::http_error,
 };
 
+/// Build an HTTP router from the legacy synchronous database handle.
+///
+/// New callers should construct one shared [`Engine`] and use
+/// [`router_with_engine`]. This wrapper preserves the pre-engine Rust API while
+/// still sending every request through the shared asynchronous engine.
 pub fn router(database: Arc<Database>) -> Router {
+    router_with_engine(Engine::from_database(database))
+}
+
+/// Build an HTTP router backed by the protocol-neutral asynchronous engine.
+pub fn router_with_engine(engine: Engine) -> Router {
     Router::new()
         .route("/health", get(health))
         .route("/v1/execute", post(execute))
         .route("/v1/query", post(query))
         .route("/v1/admin/broadcast", post(broadcast))
-        .with_state(database)
+        .with_state(engine)
 }
 
-async fn health(State(database): State<Arc<Database>>) -> Json<JsonValue> {
-    Json(json!({
+async fn health(State(engine): State<Engine>) -> Result<Json<JsonValue>, ApiError> {
+    let session = engine.session();
+    let status = engine.status(&session).await?;
+
+    Ok(Json(json!({
         "status": "ok",
-        "shards": database.shard_count(),
-    }))
+        "shards": status.shard_count(),
+    })))
 }
 
 #[derive(Debug, Deserialize)]
@@ -66,21 +79,22 @@ struct QueryColumn {
 }
 
 async fn execute(
-    State(database): State<Arc<Database>>,
+    State(engine): State<Engine>,
     Json(request): Json<RoutedSqlRequest>,
 ) -> Result<Json<ExecuteResponse>, ApiError> {
+    let params = request
+        .params
+        .into_iter()
+        .map(json_to_value)
+        .collect::<Vec<_>>();
+    let session = engine.session();
+    session.set_routing_key(request.shard_key).await?;
     let Routed {
         shard,
         value: rows_affected,
-    } = tokio::task::spawn_blocking(move || {
-        let params = request
-            .params
-            .into_iter()
-            .map(json_to_value)
-            .collect::<Vec<_>>();
-        database.execute_routed(&request.shard_key, &request.sql, &params)
-    })
-    .await??;
+    } = engine
+        .execute(&session, Statement::new(request.sql, params))
+        .await?;
 
     Ok(Json(ExecuteResponse {
         shard,
@@ -89,31 +103,33 @@ async fn execute(
 }
 
 async fn query(
-    State(database): State<Arc<Database>>,
+    State(engine): State<Engine>,
     Json(request): Json<RoutedSqlRequest>,
 ) -> Result<Json<QueryResponse>, ApiError> {
-    let response = tokio::task::spawn_blocking(move || {
-        let params = request
-            .params
-            .into_iter()
-            .map(json_to_value)
-            .collect::<Vec<_>>();
-        let Routed {
-            shard,
-            value: result,
-        } = database.query_routed(&request.shard_key, &request.sql, &params)?;
-        Ok::<_, EngineError>(result_set_to_query_response(shard, result))
-    })
-    .await??;
+    let params = request
+        .params
+        .into_iter()
+        .map(json_to_value)
+        .collect::<Vec<_>>();
+    let session = engine.session();
+    session.set_routing_key(request.shard_key).await?;
+    let Routed {
+        shard,
+        value: result,
+    } = engine
+        .query(&session, Statement::new(request.sql, params))
+        .await?;
+    let response = result_set_to_query_response(shard, result);
 
     Ok(Json(response))
 }
 
 async fn broadcast(
-    State(database): State<Arc<Database>>,
+    State(engine): State<Engine>,
     Json(request): Json<BroadcastRequest>,
 ) -> Result<Json<JsonValue>, ApiError> {
-    let shards = tokio::task::spawn_blocking(move || database.broadcast(&request.sql)).await??;
+    let session = engine.session();
+    let shards = engine.broadcast(&session, request.sql).await?;
     Ok(Json(json!({"completed_shards": shards})))
 }
 
@@ -200,16 +216,6 @@ impl From<EngineError> for ApiError {
     }
 }
 
-impl From<tokio::task::JoinError> for ApiError {
-    fn from(error: tokio::task::JoinError) -> Self {
-        Self(EngineError::from_source(
-            EngineErrorKind::Internal,
-            "blocking engine task failed",
-            error,
-        ))
-    }
-}
-
 #[derive(Debug, Serialize)]
 struct ProblemDetails {
     #[serde(rename = "type")]
@@ -260,7 +266,11 @@ mod tests {
     use tower::ServiceExt;
 
     use super::*;
-    use crate::core::{Column, DataType, Row};
+    use crate::core::{Column, DataType, EngineErrorKind, Row};
+
+    fn engine_router(database: Arc<Database>) -> Router {
+        router_with_engine(Engine::from_database(database))
+    }
 
     async fn send_json(
         router: &Router,
@@ -299,11 +309,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn all_http_endpoints_follow_the_current_contract() {
+    async fn all_http_endpoints_follow_the_current_contract_through_the_engine() {
         let temp = tempfile::tempdir().unwrap();
         let database = Arc::new(Database::open(temp.path(), 4).unwrap());
         let expected_shard = database.shard_for_key(b"widget-1");
-        let application = router(database);
+        let application = engine_router(database);
 
         assert_eq!(
             request_json(&application, Method::GET, "/health", None).await,
@@ -365,9 +375,121 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn invalid_queries_use_safe_problem_details() {
+    async fn legacy_database_router_is_a_behavior_preserving_engine_wrapper() {
         let temp = tempfile::tempdir().unwrap();
         let application = router(Arc::new(Database::open(temp.path(), 4).unwrap()));
+
+        assert_eq!(
+            request_json(&application, Method::GET, "/health", None).await,
+            (StatusCode::OK, json!({"status": "ok", "shards": 4}))
+        );
+        let (status, body) = request_json(
+            &application,
+            Method::POST,
+            "/v1/query",
+            Some(json!({
+                "shard_key": "compatibility-request",
+                "sql": "SELECT 42 AS answer"
+            })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body["columns"],
+            json!([{"name": "answer", "data_type": "unknown"}])
+        );
+        assert_eq!(body["rows"], json!([[42]]));
+    }
+
+    #[tokio::test]
+    async fn a_failed_http_request_does_not_poison_the_next_session() {
+        let temp = tempfile::tempdir().unwrap();
+        let database = Arc::new(Database::open(temp.path(), 4).unwrap());
+        let expected_shard = database.shard_for_key(b"recovery-request");
+        let application = engine_router(database);
+
+        assert_eq!(
+            request_json(
+                &application,
+                Method::POST,
+                "/v1/query",
+                Some(json!({
+                    "shard_key": "recovery-request",
+                    "sql": "SELECT * FROM missing_table"
+                })),
+            )
+            .await
+            .0,
+            StatusCode::UNPROCESSABLE_ENTITY
+        );
+        assert_eq!(
+            request_json(
+                &application,
+                Method::POST,
+                "/v1/query",
+                Some(json!({
+                    "shard_key": "recovery-request",
+                    "sql": "SELECT 'recovered' AS state"
+                })),
+            )
+            .await,
+            (
+                StatusCode::OK,
+                json!({
+                    "shard": expected_shard,
+                    "columns": [{"name": "state", "data_type": "unknown"}],
+                    "rows": [["recovered"]]
+                })
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_http_requests_use_the_shared_engine_without_value_leakage() {
+        let temp = tempfile::tempdir().unwrap();
+        let database = Arc::new(Database::open(temp.path(), 4).unwrap());
+        let application = engine_router(Arc::clone(&database));
+        let mut requests = tokio::task::JoinSet::new();
+
+        for value in 0_i64..16 {
+            let application = application.clone();
+            let shard_key = format!("concurrent-{value}");
+            let expected_shard = database.shard_for_key(shard_key.as_bytes());
+            requests.spawn(async move {
+                let response = request_json(
+                    &application,
+                    Method::POST,
+                    "/v1/query",
+                    Some(json!({
+                        "shard_key": shard_key,
+                        "sql": "SELECT ?1 AS value",
+                        "params": [value]
+                    })),
+                )
+                .await;
+                (value, expected_shard, response)
+            });
+        }
+
+        let mut completed = 0;
+        while let Some(request) = requests.join_next().await {
+            let (value, expected_shard, (status, body)) = request.unwrap();
+            assert_eq!(status, StatusCode::OK, "request {value}: {body}");
+            assert_eq!(body["shard"], json!(expected_shard));
+            assert_eq!(
+                body["columns"],
+                json!([{"name": "value", "data_type": "unknown"}])
+            );
+            assert_eq!(body["rows"], json!([[value]]));
+            completed += 1;
+        }
+        assert_eq!(completed, 16);
+    }
+
+    #[tokio::test]
+    async fn invalid_queries_use_safe_problem_details() {
+        let temp = tempfile::tempdir().unwrap();
+        let application = engine_router(Arc::new(Database::open(temp.path(), 4).unwrap()));
 
         let response = send_json(
             &application,
@@ -402,7 +524,7 @@ mod tests {
     #[tokio::test]
     async fn unsigned_parameters_outside_sqlite_range_fail_instead_of_rounding() {
         let temp = tempfile::tempdir().unwrap();
-        let application = router(Arc::new(Database::open(temp.path(), 4).unwrap()));
+        let application = engine_router(Arc::new(Database::open(temp.path(), 4).unwrap()));
         let too_large = u64::try_from(i64::MAX).unwrap() + 1;
 
         let (status, body) = request_json(
@@ -434,7 +556,7 @@ mod tests {
     #[tokio::test]
     async fn constraint_failures_keep_their_precise_safe_kind() {
         let temp = tempfile::tempdir().unwrap();
-        let application = router(Arc::new(Database::open(temp.path(), 4).unwrap()));
+        let application = engine_router(Arc::new(Database::open(temp.path(), 4).unwrap()));
         assert_eq!(
             request_json(
                 &application,
@@ -511,13 +633,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn blocking_task_panics_become_redacted_internal_problems() {
-        let join_error = tokio::spawn(async {
-            panic!("password=hunter2 /private/customer.sqlite SELECT secret_value")
-        })
-        .await
-        .unwrap_err();
-        let response = ApiError::from(join_error).into_response();
+    async fn internal_engine_errors_become_redacted_internal_problems() {
+        let secret = "password=hunter2 /private/customer.sqlite SELECT secret_value";
+        let response = ApiError(EngineError::from_source(
+            EngineErrorKind::Internal,
+            secret,
+            io::Error::other(secret),
+        ))
+        .into_response();
 
         assert_eq!(
             response_json(response).await,
@@ -537,7 +660,7 @@ mod tests {
     #[tokio::test]
     async fn non_finite_sqlite_reals_keep_the_legacy_json_null_encoding() {
         let temp = tempfile::tempdir().unwrap();
-        let application = router(Arc::new(Database::open(temp.path(), 4).unwrap()));
+        let application = engine_router(Arc::new(Database::open(temp.path(), 4).unwrap()));
 
         let (status, body) = request_json(
             &application,
@@ -566,7 +689,7 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let database = Arc::new(Database::open(temp.path(), 4).unwrap());
         let expected_shard = database.shard_for_key(b"typed-row");
-        let application = router(database);
+        let application = engine_router(database);
 
         let (status, body) = request_json(
             &application,
@@ -601,7 +724,7 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let database = Arc::new(Database::open(temp.path(), 4).unwrap());
         let expected_shard = database.shard_for_key(b"duplicate-row");
-        let application = router(database);
+        let application = engine_router(database);
 
         let (status, body) = request_json(
             &application,
@@ -635,7 +758,7 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let database = Arc::new(Database::open(temp.path(), 4).unwrap());
         let expected_shard = database.shard_for_key(b"empty-row");
-        let application = router(database);
+        let application = engine_router(database);
 
         let (status, body) = request_json(
             &application,
@@ -665,6 +788,42 @@ mod tests {
     #[test]
     fn legacy_api_module_reexports_the_router() {
         let _legacy_router: fn(Arc<Database>) -> Router = crate::api::router;
+        let _engine_router: fn(Engine) -> Router = crate::api::router_with_engine;
+    }
+
+    #[test]
+    fn production_http_adapter_has_no_blocking_or_shard_routing_escape_hatches() {
+        let test_module_marker = ["#[cfg", "(test)]\nmod tests {"].concat();
+        let (production_source, _) = include_str!("http.rs")
+            .split_once(&test_module_marker)
+            .expect("the HTTP unit-test module has a cfg(test) boundary");
+
+        assert_eq!(
+            production_source.matches("Database").count(),
+            2,
+            "Database may appear only in the compatibility import and router signature"
+        );
+
+        for forbidden in [
+            "spawn_blocking",
+            "block_in_place",
+            "execute_routed(",
+            "query_routed(",
+            "shard_for_key(",
+            "database.execute(",
+            "database.query(",
+            "database.broadcast(",
+            "open_shard(",
+            "crate::sql",
+            "crate::storage",
+            "blake3",
+            "rusqlite",
+        ] {
+            assert!(
+                !production_source.contains(forbidden),
+                "HTTP production code contains forbidden backend escape hatch {forbidden}"
+            );
+        }
     }
 
     #[test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,11 +1,11 @@
 //! Server process assembly and listener lifecycle.
 
-use std::{net::SocketAddr, path::PathBuf, sync::Arc};
+use std::{net::SocketAddr, path::PathBuf};
 
 use anyhow::Context;
 use tracing::info;
 
-use crate::{core::Database, protocol::http};
+use crate::{core::Engine, protocol::http};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Config {
@@ -15,7 +15,7 @@ pub struct Config {
 }
 
 pub async fn run(config: Config) -> anyhow::Result<()> {
-    let database = Arc::new(Database::open(&config.data_dir, config.shards)?);
+    let engine = Engine::open(&config.data_dir, config.shards).await?;
     let listener = tokio::net::TcpListener::bind(config.listen)
         .await
         .with_context(|| format!("failed to bind {}", config.listen))?;
@@ -23,11 +23,11 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     info!(
         listen = %config.listen,
         data_dir = %config.data_dir.display(),
-        shards = database.shard_count(),
+        shards = engine.shard_count(),
         "BriskDB is ready"
     );
 
-    axum::serve(listener, http::router(database)).await?;
+    axum::serve(listener, http::router_with_engine(engine)).await?;
     Ok(())
 }
 

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -11,8 +11,15 @@ use briskdb::{
 fn legacy_and_explicit_module_paths_are_both_available() {
     let _legacy_database: Option<storage::Database> = None;
     let _core_database: Option<core::Database> = None;
+    let _engine: Option<core::Engine> = None;
+    let _engine_status: Option<core::EngineStatus> = None;
+    let _session: Option<core::Session> = None;
+    let _ready = core::SessionState::Ready;
+    let _closed = core::SessionState::Closed;
+    let _statement = core::Statement::new("SELECT ?1", vec![core::Value::from(42_i64)]);
     let _legacy_router: fn(Arc<storage::Database>) -> Router = api::router;
     let _http_router: fn(Arc<core::Database>) -> Router = http::router;
+    let _engine_router: fn(core::Engine) -> Router = http::router_with_engine;
 
     let result = core::ResultSet::new(
         vec![core::Column::new("value", core::DataType::Int64)],
@@ -40,4 +47,15 @@ fn legacy_and_explicit_module_paths_are_both_available() {
         error::mysql_error(core::EngineErrorKind::UniqueViolation).error_number,
         1062
     );
+}
+
+#[tokio::test]
+async fn protocol_neutral_async_engine_surface_is_available() {
+    let temp = tempfile::tempdir().unwrap();
+    let engine = core::Engine::open(temp.path(), 4).await.unwrap();
+    let session: core::Session = engine.session();
+
+    assert_eq!(session.state().await, core::SessionState::Ready);
+    let status: core::EngineStatus = engine.status(&session).await.unwrap();
+    assert_eq!(status.shard_count(), 4);
 }


### PR DESCRIPTION
## Summary

- add a protocol-neutral async `Engine`, owned `Statement` requests, status reporting, and non-clonable `Session` identities with a tested `Ready` to `Closed` lifecycle
- keep routing context in each session, serialize same-session work before dispatch, retain the session lock while blocking SQLite work finishes, and map blocking-worker failures into structured engine errors
- route health, execute, query, and broadcast HTTP handlers through one shared engine while preserving the legacy `router(Arc<Database>)` Rust API
- document current HTTP session lifetime and explicitly defer bounded pools, cancellation, and real transaction state to their dedicated roadmap issues

## Tests

- [x] Unit tests were added or updated for behavior-changing code.
- [x] Boundary/integration tests were added where the change crosses SQLite,
      HTTP, protocol, filesystem, or process boundaries.
- [ ] A regression test accompanies each bug fix. (No bug fix is included.)
- [ ] No automated test is applicable; the explanation is included above.
- [x] `cargo fmt --check` passes.
- [x] `cargo test` passes.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes.

Exact verification:

- `rustup run stable cargo fmt --all --check`
- `rustup run stable cargo clippy --locked --all-targets --all-features -- -D warnings`
- `rustup run stable cargo test --locked --all-targets --all-features`
- `rustup run stable cargo test --locked --doc --all-features`
- `RUSTDOCFLAGS='-D warnings' rustup run stable cargo doc --locked --no-deps --all-features`
- `rustup run 1.85.0 cargo clippy --locked --all-targets --all-features -- -D warnings`
- `rustup run 1.85.0 cargo test --locked --all-targets --all-features`
- `rustup run 1.85.0 cargo test --locked --doc --all-features`

The suite covers lifecycle transitions, routing context, wrong-engine and closed-session rejection, SQL and partial-broadcast recovery, worker panic mapping, same-session serialization, distinct-session concurrency, outer-future cancellation, full HTTP contracts, legacy router behavior, request recovery, concurrent value/routing isolation, and public API compatibility. Three independent review passes are clean.

## Compatibility and operations

- [x] Public behavior and compatibility documentation were updated where needed.
- [x] Storage-format, migration, security, and recovery effects were considered.

HTTP routes, JSON shapes, CLI configuration, routing output, manifest schema, shard files, and stored data are unchanged. The synchronous `Database` surface and its existing benchmark workloads remain available; network frontends use the new engine boundary.

Closes #9
