### PR TITLE
Add bounded SQLite connection pools

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = "1.0"
 axum = "0.8.9"
 blake3 = "1.8"
 clap = { version = "4.6.6", features = ["derive", "env"] }
-rusqlite = { version = "0.39.0", features = ["bundled"] }
+rusqlite = { version = "0.39.0", features = ["bundled", "hooks"] }
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.53.1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ minimum supported Rust version (MSRV) and the latest stable toolchain.
 
 - Stable BLAKE3 routing from a caller-provided shard key
 - A protocol-neutral async engine with per-request HTTP sessions
+- Bounded, lazy per-shard SQLite connection pools with explicit backpressure
 - Protocol-neutral typed values, ordered columns, positional rows, and results
 - A fixed shard count recorded in `manifest.sqlite`
 - One WAL-enabled SQLite database per shard
@@ -59,6 +60,13 @@ cargo run -- --data-dir ./briskdb-data --shards 4
 
 The default listener is `127.0.0.1:7654`. Configuration can also be supplied
 with `BRISKDB_LISTEN`, `BRISKDB_DATA_DIR`, and `BRISKDB_SHARDS`.
+
+Rust embedders can customize pool sizing through the public `EngineOptions`
+type. Existing engine constructors and server startup keep the defaults of four
+active connections and 32 queued operations per shard. Server deployments can
+override them with `--connections-per-shard` /
+`BRISKDB_CONNECTIONS_PER_SHARD` and `--queue-capacity-per-shard` /
+`BRISKDB_QUEUE_CAPACITY_PER_SHARD`.
 
 Create a table on every shard:
 
@@ -111,14 +119,38 @@ selected shard depends on the routing key; an example response is:
 This is an initial scaffold, not a production database yet. The current API
 accepts SQL and should only be exposed on a trusted network. The HTTP adapter
 creates an ephemeral session for each data request, so session state and
-transactions cannot span HTTP requests. Each SQL operation currently opens one
-or more SQLite connections on Tokio's blocking workers; bounded workers,
-connection pools, backpressure, cancellation, and deadlines remain roadmap
-work. Broadcast changes and future scatter operations are not atomic across
-shard files. The shard count is immutable after database creation, so
-resharding will require an explicit migration workflow.
+transactions cannot span HTTP requests. Each shard has its own bounded pool, so
+routed work queued for one shard does not consume another shard's capacity.
+Pool admission happens before blocking SQLite work: once a shard's active slots
+and queue are full, the engine returns retryable `Busy` (HTTP 503) instead of
+growing work without bound. Connections are opened lazily and reused. Broadcast
+is the deliberate cross-shard exception: it reserves one slot from every shard
+before dispatch and can therefore occupy capacity in several pools at once.
 
-Near-term work includes authentication, connection pools, schema migrations,
+`EngineOptions` permits 1–16 active connections and 1–1,024 queued operations
+per shard, with at most 512 active connections across all shards.
+SQLite statements that can leave connection-local state remain uncontracted
+pass-through behavior. Such connections, and connections left in a transaction,
+are retired rather than reused by another session. Clean read handles can be
+shared for ordinary SQL, but a deny-only authorizer probe moves connection-local
+SQL such as `PRAGMA data_version`, plus any cross-owner write, to a fresh
+disposable handle before execution.
+A handle that performed an ordinary write may return to the same session,
+preserving SQLite write counters, but is replaced before a different session can
+observe `last_insert_rowid()`, `changes()`, or `total_changes()`. Those functions
+remain uncontracted across calls until sessions gain connection pinning.
+Dropping queued work skips it before SQLite starts; dropping in-flight work does
+not yet cancel it, and it may still commit.
+Cancellation, deadlines, limits, and graceful shutdown remain roadmap work.
+Broadcast changes and future scatter operations are not atomic across shard
+files. The shard count is immutable after database creation, so resharding will
+require an explicit migration workflow. Pooling does not change the manifest
+schema, shard files, or stored-data format. Until graceful pool draining lands
+in issue #11, dropping the final `Engine` may close idle SQLite handles
+synchronously on the dropping thread; server operation dispatch itself remains
+behind the bounded worker boundary.
+
+Near-term work includes authentication, cancellation, schema migrations,
 scatter/gather reads, observability, backup tooling, and failure-injection
 tests for multi-shard operations.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -171,7 +171,7 @@ Status: **in progress**
   MySQL.
 - [x] Introduce a `Session` state machine and an async `Engine` interface used
   by every frontend.
-- [ ] Move blocking SQLite work behind a bounded worker/pool abstraction; add
+- [x] Move blocking SQLite work behind a bounded worker/pool abstraction; add
   per-shard connection pools and backpressure.
 - [ ] Add cancellation, request deadlines, result row/byte limits, and graceful
   shutdown hooks to the core interface.

--- a/benches/storage.rs
+++ b/benches/storage.rs
@@ -3,7 +3,9 @@ mod support;
 use std::{hint::black_box, time::Duration};
 
 use criterion::{Criterion, SamplingMode, Throughput, criterion_group, criterion_main};
-use support::{BENCHMARK_SHARDS, BenchmarkFixture};
+use support::{
+    BENCHMARK_SHARDS, BenchmarkFixture, EngineBenchmarkFixture, engine_benchmark_runtime,
+};
 
 fn storage_benchmarks(criterion: &mut Criterion) {
     let read_fixture = BenchmarkFixture::new().expect("initialize point-read benchmark");
@@ -84,5 +86,101 @@ fn storage_benchmarks(criterion: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, storage_benchmarks);
+fn engine_benchmarks(criterion: &mut Criterion) {
+    let runtime = engine_benchmark_runtime().expect("initialize engine benchmark runtime");
+
+    let read_fixture =
+        EngineBenchmarkFixture::new(&runtime).expect("initialize engine point-read benchmark");
+    assert_eq!(
+        runtime
+            .block_on(read_fixture.point_read())
+            .expect("preflight engine point read")
+            .len(),
+        1
+    );
+    assert_eq!(
+        runtime
+            .block_on(read_fixture.write_count(0))
+            .expect("preflight engine read row"),
+        0
+    );
+    for (shard, key) in read_fixture.keys_by_shard().iter().enumerate() {
+        assert_eq!(usize::from(read_fixture.shard_for_key(key)), shard);
+    }
+
+    let write_fixture =
+        EngineBenchmarkFixture::new(&runtime).expect("initialize engine point-write benchmark");
+    assert_eq!(
+        runtime
+            .block_on(write_fixture.point_write())
+            .expect("preflight engine point write"),
+        1
+    );
+    assert_eq!(
+        runtime
+            .block_on(write_fixture.write_count(0))
+            .expect("preflight engine written row"),
+        1
+    );
+
+    let concurrent_fixture = EngineBenchmarkFixture::new(&runtime)
+        .expect("initialize engine concurrent-write benchmark");
+    assert_eq!(
+        runtime
+            .block_on(concurrent_fixture.four_shard_concurrent_write_wave())
+            .expect("preflight engine concurrent writes"),
+        [1; BENCHMARK_SHARDS as usize]
+    );
+    for shard in 0..BENCHMARK_SHARDS as usize {
+        assert_eq!(
+            runtime
+                .block_on(concurrent_fixture.write_count(shard))
+                .expect("preflight engine concurrent row"),
+            1
+        );
+    }
+
+    let mut group = criterion.benchmark_group("engine");
+    group.sample_size(20);
+    group.sampling_mode(SamplingMode::Flat);
+    group.warm_up_time(Duration::from_secs(2));
+    group.measurement_time(Duration::from_secs(5));
+
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("point_read", |bencher| {
+        bencher.iter(|| {
+            let rows = runtime
+                .block_on(read_fixture.point_read())
+                .expect("benchmark engine point read");
+            assert_eq!(rows.len(), 1);
+            black_box(rows)
+        });
+    });
+
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("point_write", |bencher| {
+        bencher.iter(|| {
+            let affected = runtime
+                .block_on(write_fixture.point_write())
+                .expect("benchmark engine point write");
+            assert_eq!(affected, 1);
+            black_box(affected)
+        });
+    });
+
+    group.throughput(Throughput::Elements(u64::from(BENCHMARK_SHARDS)));
+    group.bench_function("four_shard_concurrent_writes", |bencher| {
+        bencher.iter(|| {
+            let affected = runtime
+                .block_on(concurrent_fixture.four_shard_concurrent_write_wave())
+                .expect("benchmark engine concurrent writes");
+            assert_eq!(affected, [1; BENCHMARK_SHARDS as usize]);
+            black_box(affected)
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, storage_benchmarks, engine_benchmarks);
 criterion_main!(benches);

--- a/benches/support/mod.rs
+++ b/benches/support/mod.rs
@@ -6,16 +6,215 @@ use std::{
 
 use anyhow::{Context, anyhow, bail};
 use briskdb::{
-    core::{ResultSet, Value},
+    core::{Engine, ResultSet, Session, Statement, Value},
     storage::Database,
 };
+use tokio::{runtime::Runtime, task::JoinSet};
 
 pub const BENCHMARK_SHARDS: u16 = 4;
+const BENCHMARK_KEY_PREFIX: &str = "benchmark-key";
+
+const CREATE_BENCHMARK_TABLE: &str = "CREATE TABLE benchmark_items (
+    id TEXT PRIMARY KEY,
+    writes INTEGER NOT NULL,
+    payload TEXT NOT NULL
+);";
+
+const INSERT_BENCHMARK_ITEM: &str =
+    "INSERT INTO benchmark_items (id, writes, payload) VALUES (?1, ?2, ?3)";
+
+const READ_BENCHMARK_ITEM: &str = "SELECT id, writes, payload FROM benchmark_items WHERE id = ?1";
+
+const UPDATE_BENCHMARK_ITEM: &str = "UPDATE benchmark_items SET writes = writes + 1 WHERE id = ?1";
+
+const READ_WRITE_COUNT: &str = "SELECT writes FROM benchmark_items WHERE id = ?1";
+
+pub fn engine_benchmark_runtime() -> anyhow::Result<Runtime> {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .context("create engine benchmark runtime")
+}
 
 pub struct BenchmarkFixture {
     _directory: tempfile::TempDir,
     database: Arc<Database>,
     keys_by_shard: [String; BENCHMARK_SHARDS as usize],
+}
+
+pub struct EngineBenchmarkFixture {
+    _directory: tempfile::TempDir,
+    engine: Engine,
+    keys_by_shard: [String; BENCHMARK_SHARDS as usize],
+    sessions_by_shard: [Arc<Session>; BENCHMARK_SHARDS as usize],
+}
+
+impl EngineBenchmarkFixture {
+    pub fn new(runtime: &Runtime) -> anyhow::Result<Self> {
+        let directory = tempfile::tempdir().context("create engine benchmark directory")?;
+        let engine = runtime.block_on(Engine::open(directory.path(), BENCHMARK_SHARDS))?;
+        let keys_by_shard = find_engine_key_for_each_shard()?;
+
+        let sessions_by_shard = runtime.block_on(async {
+            let session = engine.session();
+            let completed = engine
+                .broadcast(&session, CREATE_BENCHMARK_TABLE.to_owned())
+                .await?;
+            if completed != (0..BENCHMARK_SHARDS).collect::<Vec<_>>() {
+                bail!("engine benchmark schema broadcast returned unexpected shards")
+            }
+
+            for (expected_shard, key) in keys_by_shard.iter().enumerate() {
+                let session = engine.session();
+                session.set_routing_key(key).await?;
+                let inserted = engine
+                    .execute(
+                        &session,
+                        Statement::new(
+                            INSERT_BENCHMARK_ITEM,
+                            vec![
+                                Value::from(key.clone()),
+                                Value::from(0_i64),
+                                Value::from("baseline payload"),
+                            ],
+                        ),
+                    )
+                    .await?;
+                if inserted.shard != expected_shard as u16 || inserted.value != 1 {
+                    bail!("engine benchmark seed insert returned an unexpected result")
+                }
+            }
+
+            let mut sessions = Vec::with_capacity(BENCHMARK_SHARDS as usize);
+            for key in &keys_by_shard {
+                let session = Arc::new(engine.session());
+                session.set_routing_key(key).await?;
+                sessions.push(session);
+            }
+            sessions.try_into().map_err(|_| {
+                anyhow!("engine benchmark created the wrong number of persistent sessions")
+            })
+        })?;
+
+        Ok(Self {
+            _directory: directory,
+            engine,
+            keys_by_shard,
+            sessions_by_shard,
+        })
+    }
+
+    pub fn keys_by_shard(&self) -> &[String; BENCHMARK_SHARDS as usize] {
+        &self.keys_by_shard
+    }
+
+    pub fn shard_for_key(&self, key: &str) -> u16 {
+        engine_shard_for_key(key)
+    }
+
+    pub async fn point_read(&self) -> anyhow::Result<ResultSet> {
+        let key = &self.keys_by_shard[0];
+        let result = self
+            .engine
+            .query(
+                &self.sessions_by_shard[0],
+                Statement::new(READ_BENCHMARK_ITEM, vec![Value::from(key.clone())]),
+            )
+            .await?;
+        if result.shard != 0 {
+            bail!(
+                "engine point read routed to unexpected shard {}",
+                result.shard
+            )
+        }
+        Ok(result.value)
+    }
+
+    pub async fn point_write(&self) -> anyhow::Result<usize> {
+        self.update_key(0).await
+    }
+
+    pub async fn four_shard_concurrent_write_wave(
+        &self,
+    ) -> anyhow::Result<[usize; BENCHMARK_SHARDS as usize]> {
+        let mut tasks = JoinSet::new();
+
+        for (expected_shard, key) in self.keys_by_shard.iter().cloned().enumerate() {
+            let engine = self.engine.clone();
+            let session = Arc::clone(&self.sessions_by_shard[expected_shard]);
+            tasks.spawn(async move {
+                let result = engine
+                    .execute(
+                        &session,
+                        Statement::new(UPDATE_BENCHMARK_ITEM, vec![Value::from(key)]),
+                    )
+                    .await?;
+                if result.shard != expected_shard as u16 {
+                    bail!(
+                        "engine concurrent write routed to unexpected shard {}",
+                        result.shard
+                    )
+                }
+                Ok::<_, anyhow::Error>(result.value)
+            });
+        }
+
+        let mut affected = Vec::with_capacity(BENCHMARK_SHARDS as usize);
+        while let Some(result) = tasks.join_next().await {
+            affected.push(
+                result.map_err(|error| anyhow!("engine benchmark worker failed: {error}"))??,
+            );
+        }
+
+        affected
+            .try_into()
+            .map_err(|_| anyhow!("engine concurrent benchmark returned the wrong result count"))
+    }
+
+    pub async fn write_count(&self, shard: usize) -> anyhow::Result<i64> {
+        let key = self
+            .keys_by_shard
+            .get(shard)
+            .context("engine benchmark shard index is out of range")?;
+        let result = self
+            .engine
+            .query(
+                &self.sessions_by_shard[shard],
+                Statement::new(READ_WRITE_COUNT, vec![Value::from(key.clone())]),
+            )
+            .await?;
+        if usize::from(result.shard) != shard {
+            bail!(
+                "engine write-count query routed to unexpected shard {}",
+                result.shard
+            )
+        }
+        result
+            .value
+            .rows()
+            .first()
+            .and_then(|row| row.get(0))
+            .and_then(Value::as_i64)
+            .context("engine benchmark row did not contain an integer write count")
+    }
+
+    async fn update_key(&self, shard: usize) -> anyhow::Result<usize> {
+        let key = self.keys_by_shard[shard].clone();
+        let result = self
+            .engine
+            .execute(
+                &self.sessions_by_shard[shard],
+                Statement::new(UPDATE_BENCHMARK_ITEM, vec![Value::from(key)]),
+            )
+            .await?;
+        if usize::from(result.shard) != shard {
+            bail!(
+                "engine point write routed to unexpected shard {}",
+                result.shard
+            )
+        }
+        Ok(result.value)
+    }
 }
 
 impl BenchmarkFixture {
@@ -139,7 +338,7 @@ fn find_key_for_each_shard(
     let mut keys: [Option<String>; BENCHMARK_SHARDS as usize] = array::from_fn(|_| None);
 
     for candidate in 0..SEARCH_LIMIT {
-        let key = format!("benchmark-key-{candidate}");
+        let key = format!("{BENCHMARK_KEY_PREFIX}-{candidate}");
         let shard = usize::from(database.shard_for_key(key.as_bytes()));
         if keys[shard].is_none() {
             keys[shard] = Some(key);
@@ -150,4 +349,30 @@ fn find_key_for_each_shard(
     }
 
     bail!("could not find a benchmark key for every shard in {SEARCH_LIMIT} candidates")
+}
+
+fn find_engine_key_for_each_shard() -> anyhow::Result<[String; BENCHMARK_SHARDS as usize]> {
+    const SEARCH_LIMIT: usize = 10_000;
+    let mut keys: [Option<String>; BENCHMARK_SHARDS as usize] = array::from_fn(|_| None);
+
+    for candidate in 0..SEARCH_LIMIT {
+        let key = format!("{BENCHMARK_KEY_PREFIX}-{candidate}");
+        let shard = usize::from(engine_shard_for_key(&key));
+        if keys[shard].is_none() {
+            keys[shard] = Some(key);
+            if keys.iter().all(Option::is_some) {
+                return Ok(keys.map(|key| key.expect("every engine shard key was populated")));
+            }
+        }
+    }
+
+    bail!("could not find an engine benchmark key for every shard in {SEARCH_LIMIT} candidates")
+}
+
+fn engine_shard_for_key(key: &str) -> u16 {
+    let digest = blake3::hash(key.as_bytes());
+    let prefix: [u8; 8] = digest.as_bytes()[..8]
+        .try_into()
+        .expect("BLAKE3 digest always contains eight bytes");
+    (u64::from_le_bytes(prefix) % u64::from(BENCHMARK_SHARDS)) as u16
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,7 +21,7 @@ server ---------> protocol::http
 
 | Module | Responsibility | Must not own |
 | --- | --- | --- |
-| `core` | Protocol-neutral `Engine`, `Session`, statements, values, results, and errors; stable key routing; routed execute/query and schema broadcast | JSON/HTTP types, listeners, or Axum handlers |
+| `core` | Protocol-neutral `Engine`, `Session`, statements, values, results, and errors; stable key routing; bounded per-shard admission and connection pools; routed execute/query and schema broadcast | JSON/HTTP types, listeners, or Axum handlers |
 | `storage` | Manifest and shard layout, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
 | `sql` | SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, routing, filesystem layout, or protocol responses |
 | `protocol::http` | HTTP request extraction plus JSON/BriskDB value and RFC 9457 problem-detail encoding | BLAKE3 routing, shard files, or rusqlite calls |
@@ -67,9 +67,10 @@ routing, storage, SQL conversion, CLI, and server assembly.
 
 The module names are stable boundaries, not a claim that later roadmap work is
 already complete. The async engine and initial session lifecycle are now in
-place; connection pools, cancellation, and limits are separate issues. The
-synchronous `Database` API remains available as a Rust compatibility surface
-and is the implementation used behind the asynchronous boundary.
+place, including bounded per-shard connection pools. Cancellation, deadlines,
+limits, and graceful shutdown are separate work. The synchronous `Database` API
+remains available as a Rust compatibility surface; existing engine and server
+entry points retain their signatures and default behavior.
 
 ## Session and asynchronous engine boundary
 
@@ -95,24 +96,84 @@ Consequently, session settings and transactions cannot span HTTP requests.
 Schema broadcast and status calls also go through the shared engine, but do not
 perform a routing decision in the adapter.
 
-The local engine currently uses Tokio blocking workers around the existing
-synchronous `Database` operations. Those workers are not BriskDB's planned
-bounded execution pool, and each SQL operation still opens one or more shard
-connections. Bounded per-shard pools and backpressure are issue #10;
-cancellation, deadlines, limits, and graceful shutdown are issue #11. Real
-`BEGIN`/`COMMIT`/`ROLLBACK`,
-failed-transaction state, and single-shard pinning are deliberately deferred to
-the PostgreSQL and MySQL transaction work in issues #34 and #47. `Ready` and
-`Closed` therefore describe session lifecycle, not SQL transaction state.
+### Bounded worker and connection-pool boundary
 
-Dropping an engine future does not cancel SQLite work in this phase. The
-blocking worker retains the session lock until that work ends, so another call
-cannot overlap it on the same session; an operation may still commit after its
-frontend disconnects. Issue #11 owns interruption and cancellation semantics.
+The local engine owns one independent pool per physical shard. `EngineOptions`
+defaults each pool to four active connections and a queue of 32 admitted
+operations. Connections are created lazily, up to the active limit, and are
+reused after successful cleanup. Admission occurs on the asynchronous side
+before work is handed to a Tokio blocking worker, so waiting for a shard slot
+does not occupy an unbounded set of blocking threads.
 
-This boundary changes Rust orchestration only. It does not change command-line
-or environment configuration, HTTP routes or JSON shapes, shard routing,
-manifest schema, SQLite files, WAL or synchronous settings, or any stored data.
+Custom options allow 1–16 active connections and 1–1,024 queued operations per
+shard. Construction also enforces an aggregate limit of 512
+active connections (`shard_count * connections_per_shard`). Existing
+constructors and server assembly use the defaults, so their APIs and behavior
+remain compatible. Server configuration exposes
+`--connections-per-shard` / `BRISKDB_CONNECTIONS_PER_SHARD` and
+`--queue-capacity-per-shard` / `BRISKDB_QUEUE_CAPACITY_PER_SHARD`.
+
+When a shard has no active slot and its admission queue is full, a new operation
+fails immediately with retryable `Busy`, which the HTTP adapter maps to 503.
+Capacity for routed work belongs to its selected shard: saturation on shard A
+neither consumes shard B's slots nor delays work already admitted there. Schema
+broadcast is the deliberate cross-shard exception. It reserves one slot from
+every shard in ascending order before dispatch, so it can occupy capacity in
+several pools while waiting; it then checks out each connection only when that
+shard's turn arrives. The deterministic reservation order prevents concurrent
+broadcasts from deadlocking each other.
+
+Pool checkout also establishes a connection-hygiene boundary. SQLite authorizer
+events identify operations that can persist connection-local state, including
+transaction and savepoint control, `PRAGMA`, `ATTACH`/`DETACH`, and temporary
+objects. The operation is allowed under the current one-call SQLite
+pass-through behavior, but that behavior remains uncontracted. Clean read
+handles may cross sessions for ordinary statements. The pool retains the first
+session associated with each physical handle; an ordinary foreign read does not
+relabel that history. Before a routed statement uses such a foreign handle, the
+engine prepares it under a deny-only authorizer probe. The first
+connection-local or write action is rejected before it can run—even for PRAGMAs
+with prepare-time effects—and the real statement is then executed once on a
+fresh handle. This also gives every cross-owner write clean SQLite counter state.
+The expected probe error is never exposed to the caller. Any other probe error
+also fails closed to a fresh handle. Opening that replacement can surface its own
+storage error; otherwise only the real execution determines the caller-visible
+SQL result. Broadcast batches are not preflighted because later statements can
+depend on earlier schema changes; instead, a foreign handle is replaced before
+the batch begins.
+
+A connection marked tainted by real execution is closed after the call instead
+of returning to the pool. If a call leaves a transaction open, rollback is
+attempted for cleanup and the connection is likewise retired; cleanup failures
+also prevent reuse. Thus connection-local state and observer metadata such as
+`PRAGMA data_version` cannot leak from one ephemeral HTTP `Session` to another.
+
+Ordinary writes require a narrower rule because SQLite exposes per-connection
+`last_insert_rowid()`, `changes()`, and `total_changes()` state. The pool records
+the owning BriskDB session after any authorizer-observed insert, update, or
+delete. That physical handle remains reusable by the same session, preserving
+its SQLite semantics, but a checkout for any other session retires and replaces
+it before SQL runs. Handles used only for reads remain reusable across sessions.
+This ownership is a leakage-prevention rule, not connection pinning: a competing
+session can replace an idle write-bearing handle, so write-counter functions
+remain uncontracted across calls until transaction/session pinning is added.
+
+Dropping an engine future while it is still queued removes that work before it
+starts. Once work is running on a blocking worker, dropping the future does not
+interrupt SQLite; the operation may still commit after its frontend disconnects.
+Issue #11 owns in-flight cancellation, deadlines, result limits, and graceful
+shutdown. In particular, implicit Rust destruction is not yet an asynchronous
+shutdown operation: dropping the final `Engine` may close idle SQLite handles
+synchronously on the dropping thread. Issue #11 will add an explicit bounded
+drain path. Real multi-call `BEGIN`/`COMMIT`/`ROLLBACK`, failed-transaction
+state, and single-shard pinning remain deferred to the PostgreSQL and MySQL
+transaction work in issues #34 and #47. `Ready` and `Closed` therefore describe
+session lifecycle, not SQL transaction state.
+
+This boundary changes Rust orchestration and adds opt-in `EngineOptions` plus
+pool-sizing CLI/environment configuration. It does not change existing option
+defaults, HTTP routes or JSON shapes, shard routing, manifest schema, SQLite
+files, WAL or synchronous settings, or any stored data.
 
 ## Error boundary
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,14 +1,19 @@
 # Benchmark baseline
 
-BriskDB's Criterion suite establishes a repeatable performance baseline for
-the current sharded storage prototype. It is a measurement tool, not a claim
-about production capacity or a timing threshold for shared CI runners.
+BriskDB's Criterion suite establishes repeatable controls for the synchronous
+storage path and the bounded asynchronous engine. It is a measurement tool, not
+a claim about production capacity or a timing threshold for shared CI runners.
 
 ## Workload contract
 
 Every benchmark creates a fresh temporary BriskDB database with exactly four
 shards, broadcasts the same table definition to each shard, and seeds one
-primary-key row per shard. Timed operations use the public
+primary-key row per shard. Point updates keep the database size constant,
+preventing ever-growing insert cost from distorting later samples. Concurrent
+workloads deterministically find and verify one key for every physical shard.
+
+The original `storage/*` group is retained unchanged as the synchronous,
+unpooled control. Timed operations use the public
 `briskdb::storage::Database` interface.
 
 | Benchmark | One timed iteration | Reported throughput |
@@ -17,17 +22,29 @@ primary-key row per shard. Timed operations use the public
 | `storage/point_write` | Route a fixed key and increment one row by primary key | rows written per second |
 | `storage/four_shard_concurrent_writes` | Release four threads together; each routes and updates one key on a different shard, then join them | total rows written per second; four per iteration |
 
-Point updates keep the database size constant, preventing ever-growing insert
-cost from distorting later samples. The concurrent workload deterministically
-finds and verifies one key for each physical shard. Its timing intentionally
-includes thread creation, barrier synchronization, and joins because the
-prototype does not yet have a persistent worker pool.
+The concurrent storage control intentionally includes thread creation, barrier
+synchronization, and joins. Keeping that cost and the benchmark names stable
+allows results to remain comparable with the initial issue #3 snapshot.
 
-These are steady-state, warm-cache workloads after Criterion's warm-up period.
-They do not measure first access after process start or a cold operating-system
-page cache.
+The `engine/*` group exercises the same logical operations through the public
+asynchronous `Engine` and routed `Session` interface, using the default four
+active connections and queue capacity of 32 per shard.
 
-The measurements include:
+| Benchmark | One timed iteration | Reported throughput |
+| --- | --- | --- |
+| `engine/point_read` | Route through the engine and select one fixed primary-key row | rows read per second |
+| `engine/point_write` | Route through the engine and increment one fixed primary-key row | rows written per second |
+| `engine/four_shard_concurrent_writes` | Submit one routed update to each of four shards concurrently and await all four | total rows written per second; four per iteration |
+
+Engine fixtures perform successful untimed preflight operations before
+measurement. Criterion warm-up therefore establishes the lazily opened pooled
+connections needed by each workload. Engine samples measure steady-state
+connection reuse, not startup or first-checkout cost. Each key has one
+long-lived routed `Session` established during fixture setup. This models a
+connection-oriented frontend and lets write-bearing handles remain with their
+owning session; it is not a model of separate ephemeral HTTP requests.
+
+The `storage/*` measurements include:
 
 - BLAKE3 routing;
 - opening and configuring a SQLite connection for each operation;
@@ -37,15 +54,22 @@ The measurements include:
   timeout.
 
 They exclude HTTP parsing, networking, Tokio scheduling, server startup,
-database creation, schema broadcast, key discovery, and seed inserts. Future
-pooling or engine work should keep these benchmark names stable or document a
-deliberate workload-contract change.
+database creation, schema broadcast, key discovery, and seed inserts.
+
+The `engine/*` measurements include routing, session serialization, asynchronous
+admission, blocking-worker dispatch, pooled connection checkout and return,
+parameter/result conversion, and SQLite/filesystem work. They exclude HTTP and
+networking, engine/database construction, schema and seed setup, key discovery,
+session creation, routing-context setup, and pool warm-up. Both groups use warm
+operating-system caches after Criterion's warm-up period; neither measures first
+process access or a cold page cache. A deliberate change to either workload
+contract must be documented before comparing it with an older result.
 
 ## Run and compare
 
-First verify the workloads. The dedicated tests assert exact read results,
-single-row write counts, distinct routing to all four shards, and the final
-state after concurrent writes:
+First verify the workloads. Dedicated tests assert exact read results,
+single-row write counts, distinct routing to all four shards, and final state
+after concurrent writes for both paths:
 
 ```bash
 cargo test --locked --test benchmark_workloads
@@ -55,7 +79,7 @@ cargo test --locked --bench storage
 The second command runs Criterion's one-iteration test mode. It is also covered
 by CI's `cargo test --locked --all-targets --all-features` command.
 
-Collect the complete baseline in the optimized benchmark profile:
+Collect both benchmark groups in the optimized benchmark profile:
 
 ```bash
 cargo bench --locked --bench storage
@@ -73,7 +97,9 @@ Use a quiet machine, the same Rust toolchain and locked dependency graph, the
 same power mode, and the same local filesystem. Virtualized CI storage,
 antivirus/indexing activity, thermal throttling, and filesystem cache state can
 change these numbers substantially. Compare distributions, not a single run,
-and investigate correctness separately from performance.
+and investigate correctness separately from performance. Record the exact
+branch or commit and `EngineOptions` for engine comparisons; the canonical
+warm-pool control uses four connections and 32 queued operations per shard.
 
 ## Initial snapshot
 
@@ -94,3 +120,25 @@ window, flat sampling, and 20 samples per workload.
 
 These values are a hardware-specific reference point. They must not be used as
 cross-machine guarantees or CI pass/fail limits.
+
+## Issue #10 pooled-engine comparison
+
+The issue #10 implementation was measured against unpooled main commit
+`1c0f9ab` on the same host and stable Rust 1.94.1 described above. The new
+`engine/*` harness was copied byte-for-byte into the detached base worktree so
+both revisions executed the same SQL, session setup, Tokio runtime strategy,
+Criterion settings, dependency lockfile, and temporary-filesystem workload.
+The pooled revision used default `EngineOptions` (four active connections and
+32 queued operations per shard). Criterion saved the unpooled result as a named
+baseline and performed its statistical comparison in the same target directory.
+
+| Benchmark | Unpooled main | Default pooled engine | Median elapsed-time change |
+| --- | ---: | ---: | ---: |
+| `engine/point_read` | 386.00 µs; 2.591 K rows/s | 10.516 µs; 95.09 K rows/s | −97.28% |
+| `engine/point_write` | 629.56 µs; 1.588 K rows/s | 43.860 µs; 22.80 K rows/s | −93.03% |
+| `engine/four_shard_concurrent_writes` | 1.5817 ms; 2.529 K rows/s | 106.03 µs; 37.72 K rows/s | −93.30% |
+
+Criterion classified all three changes as statistically significant
+improvements (`p < 0.05`). These local results primarily quantify removal of
+per-operation SQLite connection opening and configuration; they remain a
+hardware-specific engineering comparison, not a production capacity promise.

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -43,6 +43,23 @@ implies retryability in BriskDB; notably, `OutOfMemory` and
 contract. Storage-open and I/O failures can be permanent, so BriskDB does not
 guess that a later attempt will recover.
 
+Bounded-pool admission uses the existing `Busy` kind; it does not add a separate
+overload error. An operation receives `Busy` when its target shard has all
+configured connection slots active and its per-shard admission queue is full.
+The HTTP response is therefore the fixed 503 problem detail above. Admission
+accounting is per shard, so one shard returning `Busy` does not by itself imply
+that another shard is saturated. Routed single-shard requests consume only
+their selected pool; broadcast is the intentional exception and reserves one
+slot in every pool. Clients that retry should use the same bounded exponential
+backoff and jitter as for SQLite-originated `Busy` failures.
+
+If a caller drops a future while its operation is queued, the engine skips the
+operation and there is no error response to serialize. Once blocking SQLite
+execution has started, dropping the future does not cancel the operation; it may
+still commit. Issue #11 defines future in-flight cancellation and deadline
+behavior. Queue depth, pool internals, SQL text, and connection-cleanup details
+remain diagnostic data and must not be added to the fixed public problem detail.
+
 MySQL has separate foreign-key errors for the parent and child directions.
 `ForeignKeyViolation` does not retain that direction, so BriskDB deliberately
 uses the general 1105/`HY000` mapping instead of guessing a more specific MySQL

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -55,19 +55,57 @@ Every HTTP operation now calls the same protocol-neutral async engine intended
 for future PostgreSQL and MySQL adapters. Execute and query requests create a
 fresh `Ready` session, put the request's `shard_key` in its routing context, and
 submit an owned statement. The engine, rather than the HTTP adapter, selects the
-shard and opens the SQLite connection. The session is discarded when that HTTP
-request finishes, so a transaction cannot span requests.
+shard and acquires a pooled SQLite connection. The session is discarded when
+that HTTP request finishes, so a transaction cannot span requests.
 
-The asynchronous boundary currently delegates each operation to Tokio's
-blocking workers, and each SQL operation still opens one or more SQLite
-connections. It does not yet provide the bounded per-shard pools and
-backpressure planned in issue #10, or the cancellation and deadline behavior
-planned in issue #11. Dropping a request future does not interrupt an in-flight
-SQLite operation; the operation may still commit after the client disconnects.
-Broadcast execution remains non-atomic: its parameterless SQL batch is not
-wrapped in a transaction on each shard, and shards are processed sequentially.
-A failure can therefore leave earlier statements committed on the failing shard
-as well as leave earlier shards fully or partially updated.
+The asynchronous boundary admits work to an independent bounded pool for each
+shard before dispatching blocking SQLite work. The default pool permits four
+active connections and 32 queued operations per shard. Public `EngineOptions`
+accepts 1–16 active connections and 1–1,024 queued operations per shard,
+provided the configured shard count and per-shard active limit do not exceed
+512 total active connections. Connections are opened lazily and reused. A full
+queue returns the retryable `Busy` error (HTTP 503), while single-shard routed
+work waiting on one shard does not consume another shard's capacity. Broadcast
+intentionally reserves one slot in every shard pool before it dispatches.
+
+SQLite forms that can leave connection-local state remain allowed by the
+current one-call pass-through, but they are uncontracted. The pool observes
+transaction and savepoint control, `PRAGMA`, `ATTACH`/`DETACH`, and temporary
+objects and marks the connection tainted. A clean read handle can be reused by
+another session for ordinary SQL without transferring the handle's recorded
+first-owner history. Before connection-local routed SQL executes on such a
+foreign handle, a deny-only authorizer probe identifies it without permitting
+prepare-time effects. The probe also identifies writes, so a cross-owner write
+starts with fresh SQLite counter state. The real statement then runs once on the
+fresh handle. Any other probe error also fails closed to a fresh handle, after
+which replacement acquisition can return a storage error; otherwise the normal
+statement boundary produces the public SQL result or error. Broadcast batches
+instead receive a fresh handle up front when ownership changes, avoiding any
+multi-statement preflight. After the call, a tainted connection is closed instead
+of being reused. A connection left in a transaction is also retired after
+rollback cleanup is attempted. This preserves existing one-call SQLite behavior
+without allowing connection-local state or observer metadata such as
+`PRAGMA data_version` to leak into another ephemeral HTTP session; it does not
+add multi-request transactions or promise compatibility for those statements.
+
+SQLite also retains `last_insert_rowid()`, `changes()`, and `total_changes()` on
+the physical connection after ordinary writes. A write-bearing handle may be
+reused by its owning BriskDB `Session`, but the pool closes and replaces it
+before checkout by a different session. Read-only handles can cross sessions.
+This preserves same-session write metadata without exposing one HTTP request's
+connection-local counters to the next request when the owned handle remains
+available. It does not pin that handle, so these observer functions remain
+uncontracted across calls in the current SQL surface.
+
+Dropping a request future before its queued operation starts causes that work to
+be skipped. Dropping it after blocking execution begins does not interrupt
+SQLite, and the operation may still commit after the client disconnects.
+Cancellation and deadline behavior remain planned in issue #11. Broadcast
+execution remains non-atomic: its parameterless SQL batch is not wrapped in a
+transaction on each shard, and shards are processed sequentially. A failure can
+therefore leave earlier statements committed on the failing shard as well as
+leave earlier shards fully or partially updated. Pooling does not change the
+manifest schema, shard files, or stored-data format.
 
 ### Current parameter and result conversion
 

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -11,8 +11,12 @@ use std::{
 use tokio::sync::OwnedMutexGuard;
 
 use super::{
-    Database, EngineError, EngineErrorKind, EngineResult, ResultSet, Routed, Session, SessionInner,
-    Value,
+    BlockingPool, Database, EngineError, EngineErrorKind, EngineOptions, EngineResult, ResultSet,
+    Routed, Session, SessionInner, Value,
+};
+use crate::{
+    sql,
+    storage::{ConnectionOwner, ConnectionPools, PooledConnection},
 };
 
 static NEXT_ENGINE_ID: AtomicU64 = AtomicU64::new(1);
@@ -53,6 +57,9 @@ impl Statement {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EngineStatus {
     shard_count: u16,
+    max_blocking_workers: usize,
+    connections_per_shard: usize,
+    queue_capacity_per_shard: usize,
 }
 
 impl EngineStatus {
@@ -60,19 +67,38 @@ impl EngineStatus {
     pub const fn shard_count(&self) -> u16 {
         self.shard_count
     }
+
+    /// Return the maximum number of BriskDB SQLite tasks admitted to Tokio's
+    /// blocking workers at once.
+    pub const fn max_blocking_workers(&self) -> usize {
+        self.max_blocking_workers
+    }
+
+    /// Return the maximum active SQLite connections for each shard.
+    pub const fn connections_per_shard(&self) -> usize {
+        self.connections_per_shard
+    }
+
+    /// Return the maximum number of additional queued requests for each shard.
+    pub const fn queue_capacity_per_shard(&self) -> usize {
+        self.queue_capacity_per_shard
+    }
 }
 
 #[derive(Debug)]
 struct EngineInner {
     id: u64,
     database: Arc<Database>,
+    options: EngineOptions,
+    workers: BlockingPool,
+    connections: ConnectionPools,
 }
 
 /// Shared asynchronous entry point used by every network frontend.
 ///
 /// Clones refer to the same engine identity and database. SQLite remains
-/// blocking internally, so operations hand owned work to Tokio blocking
-/// workers until the bounded pool abstraction is introduced.
+/// blocking internally, so operations acquire bounded per-shard admission and
+/// connection capacity before handing owned work to Tokio blocking workers.
 #[derive(Debug, Clone)]
 pub struct Engine {
     inner: Arc<EngineInner>,
@@ -81,19 +107,59 @@ pub struct Engine {
 impl Engine {
     /// Open a database without blocking the async runtime executor.
     pub async fn open(root: impl AsRef<Path>, requested_shards: u16) -> EngineResult<Self> {
+        Self::open_with_options(root, requested_shards, EngineOptions::default()).await
+    }
+
+    /// Open a database with explicit worker and per-shard pool limits.
+    pub async fn open_with_options(
+        root: impl AsRef<Path>,
+        requested_shards: u16,
+        options: EngineOptions,
+    ) -> EngineResult<Self> {
+        crate::storage::validate_shard_count(requested_shards)?;
         let root = PathBuf::from(root.as_ref());
-        let database = run_blocking(move || Database::open(root, requested_shards)).await?;
-        Ok(Self::from_database(Arc::new(database)))
+        let worker_limit = options.worker_limit(requested_shards)?;
+        let workers = BlockingPool::new(worker_limit);
+        let database = workers
+            .run(move || Database::open(root, requested_shards))
+            .await?;
+        Self::from_parts(Arc::new(database), options, workers)
     }
 
     /// Wrap the synchronous compatibility API in the shared async boundary.
     pub fn from_database(database: Arc<Database>) -> Self {
-        Self {
+        Self::from_database_with_options(database, EngineOptions::default())
+            .expect("default engine options are valid for every supported database")
+    }
+
+    /// Wrap the synchronous compatibility API with explicit pool limits.
+    pub fn from_database_with_options(
+        database: Arc<Database>,
+        options: EngineOptions,
+    ) -> EngineResult<Self> {
+        let workers = BlockingPool::new(options.worker_limit(database.shard_count())?);
+        Self::from_parts(database, options, workers)
+    }
+
+    fn from_parts(
+        database: Arc<Database>,
+        options: EngineOptions,
+        workers: BlockingPool,
+    ) -> EngineResult<Self> {
+        let connections = ConnectionPools::new(
+            database.storage.clone(),
+            options.connections_per_shard(),
+            options.queue_capacity_per_shard(),
+        )?;
+        Ok(Self {
             inner: Arc::new(EngineInner {
                 id: NEXT_ENGINE_ID.fetch_add(1, Ordering::Relaxed),
                 database,
+                options,
+                workers,
+                connections,
             }),
-        }
+        })
     }
 
     /// Create a new frontend-owned session.
@@ -106,11 +172,19 @@ impl Engine {
         self.inner.database.shard_count()
     }
 
+    /// Return the engine's immutable pool and admission options.
+    pub fn options(&self) -> EngineOptions {
+        self.inner.options
+    }
+
     /// Return engine status after validating the calling session.
     pub async fn status(&self, session: &Session) -> EngineResult<EngineStatus> {
         let _guard = self.ready_session(session).await?;
         Ok(EngineStatus {
             shard_count: self.shard_count(),
+            max_blocking_workers: self.inner.workers.limit(),
+            connections_per_shard: self.inner.options.connections_per_shard(),
+            queue_capacity_per_shard: self.inner.options.queue_capacity_per_shard(),
         })
     }
 
@@ -121,15 +195,18 @@ impl Engine {
         statement: Statement,
     ) -> EngineResult<Routed<usize>> {
         let guard = self.ready_session(session).await?;
+        let owner = ConnectionOwner::new(session.id().get());
         let routing_key = required_routing_key(&guard)?.to_owned();
-        let database = Arc::clone(&self.inner.database);
+        let shard = self.inner.database.shard_for_key(routing_key.as_bytes());
         let (sql, params) = statement.into_parts();
 
-        run_blocking(move || {
-            let _guard = guard;
-            database.execute_routed(&routing_key, &sql, &params)
-        })
-        .await
+        let value = self
+            .run_on_shard(shard, owner, guard, move |connection| {
+                connection.isolate_foreign_sql(&sql)?;
+                sql::execute(connection, &sql, &params)
+            })
+            .await?;
+        Ok(Routed { shard, value })
     }
 
     /// Query a routed statement and return its selected shard and rows.
@@ -139,27 +216,76 @@ impl Engine {
         statement: Statement,
     ) -> EngineResult<Routed<ResultSet>> {
         let guard = self.ready_session(session).await?;
+        let owner = ConnectionOwner::new(session.id().get());
         let routing_key = required_routing_key(&guard)?.to_owned();
-        let database = Arc::clone(&self.inner.database);
+        let shard = self.inner.database.shard_for_key(routing_key.as_bytes());
         let (sql, params) = statement.into_parts();
 
-        run_blocking(move || {
-            let _guard = guard;
-            database.query_routed(&routing_key, &sql, &params)
-        })
-        .await
+        let value = self
+            .run_on_shard(shard, owner, guard, move |connection| {
+                connection.isolate_foreign_sql(&sql)?;
+                sql::query(connection, &sql, &params)
+            })
+            .await?;
+        Ok(Routed { shard, value })
     }
 
     /// Execute a parameterless SQL batch sequentially on every shard.
     pub async fn broadcast(&self, session: &Session, sql: String) -> EngineResult<Vec<u16>> {
         let guard = self.ready_session(session).await?;
-        let database = Arc::clone(&self.inner.database);
+        let owner = ConnectionOwner::new(session.id().get());
+        let permits = self.inner.connections.acquire_all_for_owner(owner).await?;
+        let workers = self.inner.workers.clone();
 
-        run_blocking(move || {
-            let _guard = guard;
-            database.broadcast(&sql)
-        })
-        .await
+        workers
+            .run(move || {
+                let _guard = guard;
+                let mut completed = Vec::with_capacity(permits.len());
+                for (shard, permit) in permits {
+                    let mut connection = permit.checkout().map_err(|error| {
+                        error.context(format!("broadcast failed to open shard {shard}"))
+                    })?;
+                    connection.ensure_owner_local().map_err(|error| {
+                        error.context(format!("broadcast failed to isolate shard {shard}"))
+                    })?;
+                    let result = sql::execute_batch(&connection, &sql);
+                    retire_if_broken(&mut connection, &result);
+                    result.map_err(|error| {
+                        error.context(format!("broadcast failed on shard {shard}"))
+                    })?;
+                    completed.push(shard);
+                }
+                Ok(completed)
+            })
+            .await
+    }
+
+    async fn run_on_shard<T, F>(
+        &self,
+        shard: u16,
+        owner: ConnectionOwner,
+        session: OwnedMutexGuard<SessionInner>,
+        work: F,
+    ) -> EngineResult<T>
+    where
+        T: Send + 'static,
+        F: FnOnce(&mut PooledConnection) -> EngineResult<T> + Send + 'static,
+    {
+        let permit = self
+            .inner
+            .connections
+            .acquire_for_owner(shard, owner)
+            .await?;
+        self.inner
+            .workers
+            .run(move || {
+                let _session = session;
+                let mut connection = permit.checkout()?;
+                let result = work(&mut connection);
+                retire_if_broken(&mut connection, &result);
+                result
+            })
+            .await
     }
 
     async fn ready_session(
@@ -182,12 +308,13 @@ impl Engine {
     async fn hold_session_for_test(
         &self,
         session: &Session,
+        shard: u16,
         started: tokio::sync::oneshot::Sender<()>,
         release: std::sync::mpsc::Receiver<()>,
     ) -> EngineResult<()> {
         let guard = self.ready_session(session).await?;
-        run_blocking(move || {
-            let _guard = guard;
+        let owner = ConnectionOwner::new(session.id().get());
+        self.run_on_shard(shard, owner, guard, move |_| {
             let _ = started.send(());
             release.recv().expect("test releases the blocking worker");
             Ok(())
@@ -196,11 +323,21 @@ impl Engine {
     }
 
     #[cfg(test)]
-    async fn panic_worker_for_test(&self, session: &Session) -> EngineResult<()> {
+    async fn panic_worker_for_test(&self, session: &Session, shard: u16) -> EngineResult<()> {
         let guard = self.ready_session(session).await?;
-        run_blocking(move || {
-            let _guard = guard;
+        let owner = ConnectionOwner::new(session.id().get());
+        self.run_on_shard(shard, owner, guard, move |_| {
             panic!("intentional blocking worker panic")
+        })
+        .await
+    }
+
+    #[cfg(test)]
+    async fn connection_id_for_test(&self, session: &Session, shard: u16) -> EngineResult<u64> {
+        let guard = self.ready_session(session).await?;
+        let owner = ConnectionOwner::new(session.id().get());
+        self.run_on_shard(shard, owner, guard, move |connection| {
+            Ok(connection.connection_id())
         })
         .await
     }
@@ -215,18 +352,18 @@ fn required_routing_key(session: &SessionInner) -> EngineResult<&str> {
     })
 }
 
-async fn run_blocking<T, F>(work: F) -> EngineResult<T>
-where
-    T: Send + 'static,
-    F: FnOnce() -> EngineResult<T> + Send + 'static,
-{
-    tokio::task::spawn_blocking(work).await.map_err(|error| {
-        EngineError::from_source(
-            EngineErrorKind::Internal,
-            "blocking engine task failed",
-            error,
+fn retire_if_broken<T>(connection: &mut PooledConnection, result: &EngineResult<T>) {
+    if result.as_ref().is_err_and(|error| {
+        matches!(
+            error.kind(),
+            EngineErrorKind::StorageUnavailable
+                | EngineErrorKind::DataCorruption
+                | EngineErrorKind::OutOfMemory
+                | EngineErrorKind::Internal
         )
-    })?
+    }) {
+        connection.mark_broken();
+    }
 }
 
 #[cfg(test)]
@@ -242,6 +379,33 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let database = Arc::new(Database::open(temp.path(), 4).unwrap());
         (temp, Engine::from_database(database))
+    }
+
+    fn engine_with_options(
+        shards: u16,
+        connections_per_shard: usize,
+        queue_capacity_per_shard: usize,
+    ) -> (tempfile::TempDir, Engine) {
+        let temp = tempfile::tempdir().unwrap();
+        let database = Arc::new(Database::open(temp.path(), shards).unwrap());
+        let options = EngineOptions::new(connections_per_shard, queue_capacity_per_shard).unwrap();
+        let engine = Engine::from_database_with_options(database, options).unwrap();
+        (temp, engine)
+    }
+
+    async fn wait_for_pool_occupancy(engine: &Engine, shard: u16, active: usize, queued: usize) {
+        timeout(Duration::from_secs(2), async {
+            loop {
+                let snapshot = engine.inner.connections.snapshot().unwrap();
+                let shard = snapshot.shards[usize::from(shard)];
+                if shard.active == active && shard.queued == queued {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("pool occupancy should reach the expected state");
     }
 
     fn assert_send_sync<T: Send + Sync>() {}
@@ -274,8 +438,26 @@ mod tests {
         assert_send(engine.status(&session));
         assert_send(engine.query(&session, Statement::new("SELECT 1", vec![])));
         assert_eq!(engine.shard_count(), 4);
-        assert_eq!(engine.status(&session).await.unwrap().shard_count(), 4);
+        assert_eq!(engine.options(), EngineOptions::default());
+        let status = engine.status(&session).await.unwrap();
+        assert_eq!(status.shard_count(), 4);
+        assert_eq!(status.max_blocking_workers(), 16);
+        assert_eq!(status.connections_per_shard(), 4);
+        assert_eq!(status.queue_capacity_per_shard(), 32);
         assert_eq!(session.state().await, SessionState::Ready);
+    }
+
+    #[tokio::test]
+    async fn async_open_preserves_shard_validation_before_pool_construction() {
+        let temp = tempfile::tempdir().unwrap();
+
+        for requested_shards in [0, 1, 65, u16::MAX] {
+            let data_dir = temp.path().join(requested_shards.to_string());
+            let error = Engine::open(&data_dir, requested_shards).await.unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::InvalidArgument);
+            assert_eq!(error.to_string(), "shard count must be between 2 and 64");
+            assert!(!data_dir.exists());
+        }
     }
 
     #[tokio::test]
@@ -332,6 +514,24 @@ mod tests {
             .unwrap()
         );
         assert_eq!(session.state().await, SessionState::Ready);
+
+        let pools = engine.inner.connections.snapshot().unwrap();
+        assert_eq!(pools.pool_size, 4);
+        assert_eq!(pools.queue_capacity, 32);
+        for shard in &pools.shards {
+            assert_eq!(shard.active, 0);
+            assert_eq!(shard.queued, 0);
+            assert_eq!(shard.opened, 1);
+            assert_eq!(shard.idle, 1);
+            if shard.shard == write.shard {
+                assert_eq!(shard.checkouts, 3);
+                assert_eq!(shard.reused, 2);
+            } else {
+                assert_eq!(shard.checkouts, 1);
+                assert_eq!(shard.reused, 0);
+            }
+            assert_eq!(shard.retired, 0);
+        }
     }
 
     #[tokio::test]
@@ -366,6 +566,13 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(recovered.value.rows()[0].get(0), Some(&Value::from(42_i64)));
+
+        let shard = engine.inner.database.shard_for_key(b"widget-1");
+        let snapshot = engine.inner.connections.snapshot().unwrap().shards[usize::from(shard)];
+        assert_eq!(snapshot.opened, 1);
+        assert_eq!(snapshot.checkouts, 2);
+        assert_eq!(snapshot.reused, 1);
+        assert_eq!(snapshot.retired, 0);
     }
 
     #[tokio::test]
@@ -417,6 +624,17 @@ mod tests {
                 .kind(),
             EngineErrorKind::FailedPrecondition
         );
+
+        for engine in [&first, &second] {
+            let pools = engine.inner.connections.snapshot().unwrap();
+            assert!(pools.shards.iter().all(|shard| {
+                shard.active == 0 && shard.queued == 0 && shard.opened == 0 && shard.checkouts == 0
+            }));
+            assert_eq!(
+                engine.inner.workers.available_permits(),
+                engine.inner.workers.limit()
+            );
+        }
     }
 
     #[tokio::test]
@@ -449,21 +667,694 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_worker_panic_is_internal_and_releases_the_session() {
-        let (_temp, engine) = engine();
-        let session = engine.session();
+    async fn concurrent_broadcasts_use_ordered_pool_acquisition_without_deadlock() {
+        let (_temp, engine) = engine_with_options(2, 1, 1);
+        let holder_session = Arc::new(engine.session());
+        let (holder_started_tx, holder_started_rx) = oneshot::channel();
+        let (holder_release_tx, holder_release_rx) = mpsc::channel();
+        let holder_engine = engine.clone();
+        let holder_session_for_task = Arc::clone(&holder_session);
+        let holder = tokio::spawn(async move {
+            holder_engine
+                .hold_session_for_test(
+                    &holder_session_for_task,
+                    1,
+                    holder_started_tx,
+                    holder_release_rx,
+                )
+                .await
+        });
+        timeout(Duration::from_secs(2), holder_started_rx)
+            .await
+            .unwrap()
+            .unwrap();
 
-        let error = engine.panic_worker_for_test(&session).await.unwrap_err();
+        let first_session = Arc::new(engine.session());
+        let first_engine = engine.clone();
+        let first_session_for_task = Arc::clone(&first_session);
+        let first = tokio::spawn(async move {
+            first_engine
+                .broadcast(
+                    &first_session_for_task,
+                    "CREATE TABLE IF NOT EXISTS broadcast_marker (id INTEGER)".to_owned(),
+                )
+                .await
+        });
+        wait_for_pool_occupancy(&engine, 0, 1, 0).await;
+        wait_for_pool_occupancy(&engine, 1, 1, 1).await;
+
+        let second_session = Arc::new(engine.session());
+        let second_engine = engine.clone();
+        let second_session_for_task = Arc::clone(&second_session);
+        let second = tokio::spawn(async move {
+            second_engine
+                .broadcast(
+                    &second_session_for_task,
+                    "CREATE TABLE IF NOT EXISTS broadcast_marker (id INTEGER)".to_owned(),
+                )
+                .await
+        });
+        wait_for_pool_occupancy(&engine, 0, 1, 1).await;
+        assert_eq!(engine.inner.workers.available_permits(), 1);
+
+        holder_release_tx.send(()).unwrap();
+        holder.await.unwrap().unwrap();
+        assert_eq!(
+            timeout(Duration::from_secs(2), first)
+                .await
+                .expect("first ordered broadcast should complete")
+                .unwrap()
+                .unwrap(),
+            [0, 1]
+        );
+        assert_eq!(
+            timeout(Duration::from_secs(2), second)
+                .await
+                .expect("second ordered broadcast should complete")
+                .unwrap()
+                .unwrap(),
+            [0, 1]
+        );
+
+        for shard in 0..2 {
+            wait_for_pool_occupancy(&engine, shard, 0, 0).await;
+        }
+        assert_eq!(engine.inner.workers.available_permits(), 2);
+    }
+
+    #[tokio::test]
+    async fn aborting_a_dispatched_broadcast_does_not_stop_later_shards() {
+        let (_temp, engine) = engine_with_options(2, 1, 1);
+        let blocker = engine.inner.database.storage.open_shard(1).unwrap();
+        blocker.execute_batch("BEGIN EXCLUSIVE").unwrap();
+
+        let session = Arc::new(engine.session());
+        let broadcast_engine = engine.clone();
+        let broadcast_session = Arc::clone(&session);
+        let broadcast = tokio::spawn(async move {
+            broadcast_engine
+                .broadcast(
+                    &broadcast_session,
+                    "CREATE TABLE abort_marker (id INTEGER)".to_owned(),
+                )
+                .await
+        });
+
+        let shard_zero = engine.inner.database.storage.open_shard(0).unwrap();
+        timeout(Duration::from_secs(2), async {
+            loop {
+                let exists = shard_zero
+                    .query_row(
+                        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE name = 'abort_marker')",
+                        [],
+                        |row| row.get::<_, bool>(0),
+                    )
+                    .unwrap();
+                if exists {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("broadcast should complete shard zero before blocking on shard one");
+
+        broadcast.abort();
+        assert!(broadcast.await.unwrap_err().is_cancelled());
+        assert_eq!(
+            engine.inner.connections.snapshot().unwrap().shards[1].active,
+            1
+        );
+        assert_eq!(engine.inner.workers.available_permits(), 1);
+
+        blocker.execute_batch("COMMIT").unwrap();
+        let status = timeout(Duration::from_secs(2), engine.status(&session))
+            .await
+            .expect("detached broadcast should release its session")
+            .unwrap();
+        assert_eq!(status.shard_count(), 2);
+        assert!(
+            blocker
+                .query_row(
+                    "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE name = 'abort_marker')",
+                    [],
+                    |row| row.get::<_, bool>(0),
+                )
+                .unwrap()
+        );
+        for shard in 0..2 {
+            wait_for_pool_occupancy(&engine, shard, 0, 0).await;
+        }
+        assert_eq!(engine.inner.workers.available_permits(), 2);
+    }
+
+    #[tokio::test]
+    async fn connection_local_sql_is_allowed_then_retired_without_session_leakage() {
+        let (_temp, engine) = engine_with_options(2, 1, 1);
+        let first = engine.session();
+        first.set_routing_key("tenant-state").await.unwrap();
+        let shard = engine.inner.database.shard_for_key(b"tenant-state");
+
+        let created = engine
+            .execute(
+                &first,
+                Statement::new("CREATE TEMP TABLE session_temp (id INTEGER)", vec![]),
+            )
+            .await
+            .unwrap();
+        assert_eq!(created.value, 0);
+        let after_stateful =
+            engine.inner.connections.snapshot().unwrap().shards[usize::from(shard)];
+        assert_eq!(after_stateful.opened, 1);
+        assert_eq!(after_stateful.retired, 1);
+        assert_eq!(after_stateful.idle, 0);
+
+        let second = engine.session();
+        second.set_routing_key("tenant-state").await.unwrap();
+        let temp_objects = engine
+            .query(
+                &second,
+                Statement::new(
+                    "SELECT name FROM sqlite_temp_master WHERE name = 'session_temp'",
+                    vec![],
+                ),
+            )
+            .await
+            .unwrap();
+        assert!(temp_objects.value.rows().is_empty());
+
+        let after_replacement =
+            engine.inner.connections.snapshot().unwrap().shards[usize::from(shard)];
+        assert_eq!(after_replacement.opened, 2);
+        assert_eq!(after_replacement.checkouts, 2);
+        assert_eq!(after_replacement.retired, 1);
+        assert_eq!(after_replacement.idle, 1);
+    }
+
+    #[tokio::test]
+    async fn pragma_data_version_never_exposes_a_foreign_pooled_handles_history() {
+        let (_temp, engine) = engine_with_options(2, 2, 1);
+        let shard = 0;
+        let routing_key = (0_u32..10_000)
+            .map(|candidate| format!("data-version-{candidate}"))
+            .find(|candidate| engine.inner.database.shard_for_key(candidate.as_bytes()) == shard)
+            .expect("a deterministic key should route to shard zero");
+
+        let holder_session = Arc::new(engine.session());
+        let (holder_started_tx, holder_started_rx) = oneshot::channel();
+        let (holder_release_tx, holder_release_rx) = mpsc::channel();
+        let holder_engine = engine.clone();
+        let holder_session_for_task = Arc::clone(&holder_session);
+        let holder = tokio::spawn(async move {
+            holder_engine
+                .hold_session_for_test(
+                    &holder_session_for_task,
+                    shard,
+                    holder_started_tx,
+                    holder_release_rx,
+                )
+                .await
+        });
+        timeout(Duration::from_secs(2), holder_started_rx)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let writer = engine.session();
+        writer.set_routing_key(routing_key.clone()).await.unwrap();
+        engine
+            .execute(
+                &writer,
+                Statement::new(
+                    "CREATE TABLE data_version_marker (id INTEGER PRIMARY KEY)",
+                    vec![],
+                ),
+            )
+            .await
+            .unwrap();
+
+        let fresh_control = engine.inner.database.storage.open_shard(shard).unwrap();
+        let fresh_data_version = fresh_control
+            .query_row("PRAGMA data_version", [], |row| row.get::<_, i64>(0))
+            .unwrap();
+
+        holder_release_tx.send(()).unwrap();
+        holder.await.unwrap().unwrap();
+
+        let observer = engine.session();
+        observer.set_routing_key(routing_key).await.unwrap();
+        engine
+            .query(&observer, Statement::new("SELECT 1", vec![]))
+            .await
+            .unwrap();
+        let result = engine
+            .query(&observer, Statement::new("PRAGMA data_version", vec![]))
+            .await
+            .unwrap();
+        assert_eq!(
+            result.value.rows()[0].get(0),
+            Some(&Value::from(fresh_data_version))
+        );
+
+        let snapshot = engine.inner.connections.snapshot().unwrap().shards[usize::from(shard)];
+        assert_eq!(snapshot.opened, 3);
+        assert_eq!(snapshot.checkouts, 4);
+        assert_eq!(snapshot.reused, 2);
+        assert_eq!(snapshot.retired, 2);
+        assert_eq!(snapshot.idle, 1);
+    }
+
+    #[tokio::test]
+    async fn cross_owner_probe_never_replaces_public_statement_errors() {
+        let (_temp, engine) = engine_with_options(2, 1, 1);
+        let routing_key = "probe-error-key";
+        let first = engine.session();
+        first.set_routing_key(routing_key).await.unwrap();
+        engine
+            .query(&first, Statement::new("SELECT 1", vec![]))
+            .await
+            .unwrap();
+
+        let missing_table = engine.session();
+        missing_table.set_routing_key(routing_key).await.unwrap();
+        assert_eq!(
+            engine
+                .query(
+                    &missing_table,
+                    Statement::new("SELECT * FROM missing_table", vec![]),
+                )
+                .await
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::InvalidQuery
+        );
+
+        let wrong_parameters = engine.session();
+        wrong_parameters.set_routing_key(routing_key).await.unwrap();
+        assert_eq!(
+            engine
+                .query(&wrong_parameters, Statement::new("SELECT ?1", vec![]),)
+                .await
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::InvalidArgument
+        );
+
+        let multiple_statements = engine.session();
+        multiple_statements
+            .set_routing_key(routing_key)
+            .await
+            .unwrap();
+        assert_eq!(
+            engine
+                .query(
+                    &multiple_statements,
+                    Statement::new("SELECT 1; SELECT 2", vec![]),
+                )
+                .await
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::InvalidQuery
+        );
+    }
+
+    #[tokio::test]
+    async fn foreign_owner_broadcast_batches_execute_once_without_statement_preflight() {
+        let (_temp, engine) = engine_with_options(2, 1, 1);
+        let first = engine.session();
+        assert_eq!(
+            engine
+                .broadcast(&first, "SELECT 1".to_owned())
+                .await
+                .unwrap(),
+            [0, 1]
+        );
+
+        let second = engine.session();
+        assert_eq!(
+            engine
+                .broadcast(
+                    &second,
+                    "CREATE TABLE batch_marker (id INTEGER PRIMARY KEY); \
+                     INSERT INTO batch_marker (id) VALUES (1);"
+                        .to_owned(),
+                )
+                .await
+                .unwrap(),
+            [0, 1]
+        );
+
+        for shard in 0..2 {
+            let connection = engine.inner.database.storage.open_shard(shard).unwrap();
+            assert_eq!(
+                connection
+                    .query_row("SELECT COUNT(*) FROM batch_marker", [], |row| {
+                        row.get::<_, i64>(0)
+                    })
+                    .unwrap(),
+                1
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn write_counters_remain_visible_to_the_writer_but_never_cross_sessions() {
+        let (_temp, engine) = engine_with_options(2, 1, 1);
+        let schema = engine.session();
+        engine
+            .broadcast(
+                &schema,
+                "CREATE TABLE write_state (id INTEGER PRIMARY KEY)".to_owned(),
+            )
+            .await
+            .unwrap();
+
+        let writer = engine.session();
+        writer.set_routing_key("write-state-key").await.unwrap();
+        let shard = engine
+            .execute(
+                &writer,
+                Statement::new("INSERT INTO write_state (id) VALUES (1)", vec![]),
+            )
+            .await
+            .unwrap()
+            .shard;
+        let writer_state = engine
+            .query(
+                &writer,
+                Statement::new(
+                    "SELECT last_insert_rowid(), changes(), total_changes()",
+                    vec![],
+                ),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            writer_state.value.rows()[0].values(),
+            [Value::from(1_i64), Value::from(1_i64), Value::from(1_i64)]
+        );
+
+        let observer = engine.session();
+        observer.set_routing_key("write-state-key").await.unwrap();
+        let observer_state = engine
+            .query(
+                &observer,
+                Statement::new(
+                    "SELECT last_insert_rowid(), changes(), total_changes(), \
+                     (SELECT COUNT(*) FROM write_state)",
+                    vec![],
+                ),
+            )
+            .await
+            .unwrap();
+        assert_eq!(observer_state.shard, shard);
+        assert_eq!(
+            observer_state.value.rows()[0].values(),
+            [
+                Value::from(0_i64),
+                Value::from(0_i64),
+                Value::from(0_i64),
+                Value::from(1_i64),
+            ]
+        );
+
+        let snapshot = engine.inner.connections.snapshot().unwrap().shards[usize::from(shard)];
+        assert_eq!(snapshot.opened, 3);
+        assert_eq!(snapshot.retired, 2);
+        assert_eq!(snapshot.idle, 1);
+    }
+
+    #[tokio::test]
+    async fn exact_per_shard_active_and_queue_limits_return_retryable_busy_and_recover() {
+        let (_temp, engine) = engine_with_options(2, 1, 1);
+        let first_session = Arc::new(engine.session());
+        let second_session = Arc::new(engine.session());
+
+        let (first_started_tx, first_started_rx) = oneshot::channel();
+        let (first_release_tx, first_release_rx) = mpsc::channel();
+        let first_engine = engine.clone();
+        let first_session_for_task = Arc::clone(&first_session);
+        let first = tokio::spawn(async move {
+            first_engine
+                .hold_session_for_test(
+                    &first_session_for_task,
+                    0,
+                    first_started_tx,
+                    first_release_rx,
+                )
+                .await
+        });
+        timeout(Duration::from_secs(2), first_started_rx)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let (second_started_tx, mut second_started_rx) = oneshot::channel();
+        let (second_release_tx, second_release_rx) = mpsc::channel();
+        let second_engine = engine.clone();
+        let second_session_for_task = Arc::clone(&second_session);
+        let second = tokio::spawn(async move {
+            second_engine
+                .hold_session_for_test(
+                    &second_session_for_task,
+                    0,
+                    second_started_tx,
+                    second_release_rx,
+                )
+                .await
+        });
+        wait_for_pool_occupancy(&engine, 0, 1, 1).await;
+        assert!(
+            timeout(Duration::from_millis(50), &mut second_started_rx)
+                .await
+                .is_err()
+        );
+
+        let overflow_session = engine.session();
+        let (overflow_started_tx, overflow_started_rx) = oneshot::channel();
+        let (_overflow_release_tx, overflow_release_rx) = mpsc::channel();
+        let overflow = timeout(
+            Duration::from_secs(2),
+            engine.hold_session_for_test(
+                &overflow_session,
+                0,
+                overflow_started_tx,
+                overflow_release_rx,
+            ),
+        )
+        .await
+        .unwrap()
+        .unwrap_err();
+        assert_eq!(overflow.kind(), EngineErrorKind::Busy);
+        assert!(overflow.is_retryable());
+        assert!(overflow_started_rx.await.is_err());
+
+        first_release_tx.send(()).unwrap();
+        timeout(Duration::from_secs(2), &mut second_started_rx)
+            .await
+            .unwrap()
+            .unwrap();
+        second_release_tx.send(()).unwrap();
+        first.await.unwrap().unwrap();
+        second.await.unwrap().unwrap();
+        wait_for_pool_occupancy(&engine, 0, 0, 0).await;
+
+        let shard = engine.inner.connections.snapshot().unwrap().shards[0];
+        assert_eq!(shard.opened, 1);
+        assert_eq!(shard.checkouts, 2);
+        assert_eq!(shard.reused, 1);
+    }
+
+    #[tokio::test]
+    async fn aborting_queued_engine_work_removes_it_before_sqlite_and_restores_capacity() {
+        let (_temp, engine) = engine_with_options(2, 1, 1);
+        let first_session = Arc::new(engine.session());
+        let queued_session = Arc::new(engine.session());
+        let (first_started_tx, first_started_rx) = oneshot::channel();
+        let (first_release_tx, first_release_rx) = mpsc::channel();
+        let first_engine = engine.clone();
+        let first_session_for_task = Arc::clone(&first_session);
+        let first = tokio::spawn(async move {
+            first_engine
+                .hold_session_for_test(
+                    &first_session_for_task,
+                    0,
+                    first_started_tx,
+                    first_release_rx,
+                )
+                .await
+        });
+        timeout(Duration::from_secs(2), first_started_rx)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let (queued_started_tx, queued_started_rx) = oneshot::channel();
+        let (_queued_release_tx, queued_release_rx) = mpsc::channel();
+        let queued_engine = engine.clone();
+        let queued_session_for_task = Arc::clone(&queued_session);
+        let queued = tokio::spawn(async move {
+            queued_engine
+                .hold_session_for_test(
+                    &queued_session_for_task,
+                    0,
+                    queued_started_tx,
+                    queued_release_rx,
+                )
+                .await
+        });
+        wait_for_pool_occupancy(&engine, 0, 1, 1).await;
+        queued.abort();
+        assert!(queued.await.unwrap_err().is_cancelled());
+        assert!(queued_started_rx.await.is_err());
+        wait_for_pool_occupancy(&engine, 0, 1, 0).await;
+
+        let replacement_session = Arc::new(engine.session());
+        let (replacement_started_tx, replacement_started_rx) = oneshot::channel();
+        let (replacement_release_tx, replacement_release_rx) = mpsc::channel();
+        let replacement_engine = engine.clone();
+        let replacement_session_for_task = Arc::clone(&replacement_session);
+        let replacement = tokio::spawn(async move {
+            replacement_engine
+                .hold_session_for_test(
+                    &replacement_session_for_task,
+                    0,
+                    replacement_started_tx,
+                    replacement_release_rx,
+                )
+                .await
+        });
+        wait_for_pool_occupancy(&engine, 0, 1, 1).await;
+
+        first_release_tx.send(()).unwrap();
+        timeout(Duration::from_secs(2), replacement_started_rx)
+            .await
+            .unwrap()
+            .unwrap();
+        replacement_release_tx.send(()).unwrap();
+        first.await.unwrap().unwrap();
+        replacement.await.unwrap().unwrap();
+
+        let shard = engine.inner.connections.snapshot().unwrap().shards[0];
+        assert_eq!(shard.active, 0);
+        assert_eq!(shard.queued, 0);
+        assert_eq!(shard.checkouts, 2);
+        assert_eq!(shard.opened, 1);
+        assert_eq!(shard.reused, 1);
+    }
+
+    #[tokio::test]
+    async fn a_hot_shard_queue_does_not_consume_workers_or_capacity_from_another_shard() {
+        let (_temp, engine) = engine_with_options(2, 1, 1);
+        let first_session = Arc::new(engine.session());
+        let queued_session = Arc::new(engine.session());
+        let free_session = Arc::new(engine.session());
+
+        let (first_started_tx, first_started_rx) = oneshot::channel();
+        let (first_release_tx, first_release_rx) = mpsc::channel();
+        let first_engine = engine.clone();
+        let first_session_for_task = Arc::clone(&first_session);
+        let first = tokio::spawn(async move {
+            first_engine
+                .hold_session_for_test(
+                    &first_session_for_task,
+                    0,
+                    first_started_tx,
+                    first_release_rx,
+                )
+                .await
+        });
+        timeout(Duration::from_secs(2), first_started_rx)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let (queued_started_tx, mut queued_started_rx) = oneshot::channel();
+        let (queued_release_tx, queued_release_rx) = mpsc::channel();
+        let queued_engine = engine.clone();
+        let queued_session_for_task = Arc::clone(&queued_session);
+        let queued = tokio::spawn(async move {
+            queued_engine
+                .hold_session_for_test(
+                    &queued_session_for_task,
+                    0,
+                    queued_started_tx,
+                    queued_release_rx,
+                )
+                .await
+        });
+        wait_for_pool_occupancy(&engine, 0, 1, 1).await;
+        assert_eq!(engine.inner.workers.available_permits(), 1);
+
+        let (free_started_tx, free_started_rx) = oneshot::channel();
+        let (free_release_tx, free_release_rx) = mpsc::channel();
+        let free_engine = engine.clone();
+        let free_session_for_task = Arc::clone(&free_session);
+        let free = tokio::spawn(async move {
+            free_engine
+                .hold_session_for_test(&free_session_for_task, 1, free_started_tx, free_release_rx)
+                .await
+        });
+        timeout(Duration::from_secs(2), free_started_rx)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(engine.inner.workers.available_permits(), 0);
+        assert!(
+            timeout(Duration::from_millis(50), &mut queued_started_rx)
+                .await
+                .is_err()
+        );
+
+        free_release_tx.send(()).unwrap();
+        free.await.unwrap().unwrap();
+        first_release_tx.send(()).unwrap();
+        timeout(Duration::from_secs(2), &mut queued_started_rx)
+            .await
+            .unwrap()
+            .unwrap();
+        queued_release_tx.send(()).unwrap();
+        first.await.unwrap().unwrap();
+        queued.await.unwrap().unwrap();
+
+        let snapshot = engine.inner.connections.snapshot().unwrap();
+        assert_eq!(snapshot.shards[0].opened, 1);
+        assert_eq!(snapshot.shards[0].checkouts, 2);
+        assert_eq!(snapshot.shards[1].opened, 1);
+        assert_eq!(snapshot.shards[1].checkouts, 1);
+        assert_eq!(engine.inner.workers.available_permits(), 2);
+    }
+
+    #[tokio::test]
+    async fn a_worker_panic_is_internal_and_releases_the_session() {
+        let (_temp, engine) = engine_with_options(2, 1, 1);
+        let session = engine.session();
+        let original_id = engine.connection_id_for_test(&session, 0).await.unwrap();
+
+        let error = engine.panic_worker_for_test(&session, 0).await.unwrap_err();
         assert_eq!(error.kind(), EngineErrorKind::Internal);
         assert_eq!(error.to_string(), "blocking engine task failed");
         assert!(error.source().is_some());
-        assert_eq!(engine.status(&session).await.unwrap().shard_count(), 4);
+        let after_panic = engine.inner.connections.snapshot().unwrap().shards[0];
+        assert_eq!(after_panic.opened, 1);
+        assert_eq!(after_panic.checkouts, 2);
+        assert_eq!(after_panic.reused, 1);
+        assert_eq!(after_panic.retired, 1);
+        assert_eq!(after_panic.idle, 0);
+
+        let replacement_id = engine.connection_id_for_test(&session, 0).await.unwrap();
+        assert_ne!(replacement_id, original_id);
+        let after_replacement = engine.inner.connections.snapshot().unwrap().shards[0];
+        assert_eq!(after_replacement.opened, 2);
+        assert_eq!(after_replacement.retired, 1);
+        assert_eq!(after_replacement.idle, 1);
+        assert_eq!(engine.status(&session).await.unwrap().shard_count(), 2);
         assert_eq!(session.state().await, SessionState::Ready);
     }
 
     #[tokio::test]
     async fn same_session_calls_wait_without_starting_another_blocking_worker() {
-        let (_temp, engine) = engine();
+        let (_temp, engine) = engine_with_options(2, 1, 1);
         let session = Arc::new(engine.session());
         let (first_started_tx, first_started_rx) = oneshot::channel();
         let (first_release_tx, first_release_rx) = mpsc::channel();
@@ -471,7 +1362,7 @@ mod tests {
         let first_session = Arc::clone(&session);
         let first = tokio::spawn(async move {
             first_engine
-                .hold_session_for_test(&first_session, first_started_tx, first_release_rx)
+                .hold_session_for_test(&first_session, 0, first_started_tx, first_release_rx)
                 .await
         });
         timeout(Duration::from_secs(2), first_started_rx)
@@ -485,7 +1376,7 @@ mod tests {
         let second_session = Arc::clone(&session);
         let second = tokio::spawn(async move {
             second_engine
-                .hold_session_for_test(&second_session, second_started_tx, second_release_rx)
+                .hold_session_for_test(&second_session, 0, second_started_tx, second_release_rx)
                 .await
         });
 
@@ -494,6 +1385,10 @@ mod tests {
                 .await
                 .is_err()
         );
+        let waiting = engine.inner.connections.snapshot().unwrap().shards[0];
+        assert_eq!(waiting.active, 1);
+        assert_eq!(waiting.queued, 0);
+        assert_eq!(engine.inner.workers.available_permits(), 1);
         first_release_tx.send(()).unwrap();
         timeout(Duration::from_secs(2), &mut second_started_rx)
             .await
@@ -503,11 +1398,15 @@ mod tests {
 
         first.await.unwrap().unwrap();
         second.await.unwrap().unwrap();
+        let completed = engine.inner.connections.snapshot().unwrap().shards[0];
+        assert_eq!(completed.checkouts, 2);
+        assert_eq!(completed.opened, 1);
+        assert_eq!(completed.reused, 1);
     }
 
     #[tokio::test]
     async fn aborting_an_outer_future_does_not_release_an_in_flight_session() {
-        let (_temp, engine) = engine();
+        let (_temp, engine) = engine_with_options(2, 1, 1);
         let session = Arc::new(engine.session());
         let (started_tx, started_rx) = oneshot::channel();
         let (release_tx, release_rx) = mpsc::channel();
@@ -515,7 +1414,7 @@ mod tests {
         let worker_session = Arc::clone(&session);
         let worker = tokio::spawn(async move {
             worker_engine
-                .hold_session_for_test(&worker_session, started_tx, release_rx)
+                .hold_session_for_test(&worker_session, 0, started_tx, release_rx)
                 .await
         });
         timeout(Duration::from_secs(2), started_rx)
@@ -524,6 +1423,10 @@ mod tests {
             .unwrap();
         worker.abort();
         assert!(worker.await.unwrap_err().is_cancelled());
+        let detached = engine.inner.connections.snapshot().unwrap().shards[0];
+        assert_eq!(detached.active, 1);
+        assert_eq!(detached.queued, 0);
+        assert_eq!(engine.inner.workers.available_permits(), 1);
 
         let status_engine = engine.clone();
         let status_session = Arc::clone(&session);
@@ -542,8 +1445,10 @@ mod tests {
                 .unwrap()
                 .unwrap()
                 .shard_count(),
-            4
+            2
         );
+        wait_for_pool_occupancy(&engine, 0, 0, 0).await;
+        assert_eq!(engine.inner.workers.available_permits(), 2);
     }
 
     #[tokio::test]
@@ -560,7 +1465,12 @@ mod tests {
         let first_session_for_task = Arc::clone(&first_session);
         let first = tokio::spawn(async move {
             first_engine
-                .hold_session_for_test(&first_session_for_task, first_started_tx, first_release_rx)
+                .hold_session_for_test(
+                    &first_session_for_task,
+                    0,
+                    first_started_tx,
+                    first_release_rx,
+                )
                 .await
         });
         let second_engine = engine.clone();
@@ -569,6 +1479,7 @@ mod tests {
             second_engine
                 .hold_session_for_test(
                     &second_session_for_task,
+                    0,
                     second_started_tx,
                     second_release_rx,
                 )

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -5,15 +5,22 @@
 
 mod engine;
 mod error;
+mod options;
 mod session;
 mod types;
+pub(crate) mod worker;
 
 pub use engine::{Engine, EngineStatus, Statement};
 pub use error::{EngineError, EngineErrorKind, EngineResult};
+pub use options::{
+    DEFAULT_CONNECTIONS_PER_SHARD, DEFAULT_QUEUE_CAPACITY_PER_SHARD, EngineOptions,
+    MAX_CONNECTIONS_PER_SHARD, MAX_QUEUE_CAPACITY_PER_SHARD,
+};
 pub use session::{Session, SessionId, SessionState};
 pub use types::{
     Column, DataType, Decimal, ParseDecimalError, ResultSet, ResultSetShapeError, Row, Value,
 };
+pub(crate) use worker::BlockingPool;
 
 use session::SessionInner;
 

--- a/src/core/options.rs
+++ b/src/core/options.rs
@@ -1,0 +1,163 @@
+//! Configuration for the asynchronous engine execution boundary.
+
+use super::{EngineError, EngineErrorKind, EngineResult};
+
+/// Default number of concurrently leased SQLite connections per shard.
+pub const DEFAULT_CONNECTIONS_PER_SHARD: usize = 4;
+
+/// Default number of operations admitted to each shard's pending queue.
+pub const DEFAULT_QUEUE_CAPACITY_PER_SHARD: usize = 32;
+
+/// Maximum configurable connections per shard.
+pub const MAX_CONNECTIONS_PER_SHARD: usize = 16;
+
+/// Maximum configurable pending operations per shard.
+pub const MAX_QUEUE_CAPACITY_PER_SHARD: usize = 1_024;
+
+const MAX_TOTAL_ACTIVE_CONNECTIONS: usize = 512;
+
+/// Resource limits for the asynchronous engine.
+///
+/// These limits bound active SQLite connections and the amount of work that
+/// can be admitted ahead of each shard. They do not configure request
+/// deadlines or cancellation, which are separate engine policies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EngineOptions {
+    connections_per_shard: usize,
+    queue_capacity_per_shard: usize,
+}
+
+impl EngineOptions {
+    /// Construct validated engine resource limits.
+    pub fn new(
+        connections_per_shard: usize,
+        queue_capacity_per_shard: usize,
+    ) -> EngineResult<Self> {
+        if !(1..=MAX_CONNECTIONS_PER_SHARD).contains(&connections_per_shard) {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                format!("connections per shard must be between 1 and {MAX_CONNECTIONS_PER_SHARD}"),
+            ));
+        }
+        if !(1..=MAX_QUEUE_CAPACITY_PER_SHARD).contains(&queue_capacity_per_shard) {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                format!(
+                    "queue capacity per shard must be between 1 and {MAX_QUEUE_CAPACITY_PER_SHARD}"
+                ),
+            ));
+        }
+
+        Ok(Self {
+            connections_per_shard,
+            queue_capacity_per_shard,
+        })
+    }
+
+    /// Return the maximum number of concurrently leased connections per shard.
+    pub const fn connections_per_shard(&self) -> usize {
+        self.connections_per_shard
+    }
+
+    /// Return the number of pending operations admitted per shard.
+    pub const fn queue_capacity_per_shard(&self) -> usize {
+        self.queue_capacity_per_shard
+    }
+
+    /// Validate limits that depend on the database's physical shard count.
+    ///
+    /// The returned value is the maximum number of active SQLite connections
+    /// across all shards and is also the blocking-worker concurrency bound.
+    pub(crate) fn worker_limit(self, shard_count: u16) -> EngineResult<usize> {
+        let total_active_connections = self
+            .connections_per_shard
+            .checked_mul(usize::from(shard_count))
+            .ok_or_else(|| invalid_total_connections(shard_count))?;
+
+        if total_active_connections == 0 || total_active_connections > MAX_TOTAL_ACTIVE_CONNECTIONS
+        {
+            return Err(invalid_total_connections(shard_count));
+        }
+
+        Ok(total_active_connections)
+    }
+}
+
+impl Default for EngineOptions {
+    fn default() -> Self {
+        Self {
+            connections_per_shard: DEFAULT_CONNECTIONS_PER_SHARD,
+            queue_capacity_per_shard: DEFAULT_QUEUE_CAPACITY_PER_SHARD,
+        }
+    }
+}
+
+fn invalid_total_connections(shard_count: u16) -> EngineError {
+    EngineError::new(
+        EngineErrorKind::InvalidArgument,
+        format!(
+            "configured connection pools for {shard_count} shards must contain between 1 and \
+             {MAX_TOTAL_ACTIVE_CONNECTIONS} total active connections"
+        ),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_are_explicit_and_valid_for_the_supported_shard_range() {
+        let options = EngineOptions::default();
+
+        assert_eq!(options.connections_per_shard(), 4);
+        assert_eq!(options.queue_capacity_per_shard(), 32);
+        assert_eq!(options.worker_limit(2).unwrap(), 8);
+        assert_eq!(options.worker_limit(64).unwrap(), 256);
+    }
+
+    #[test]
+    fn constructor_rejects_zero_and_values_above_each_limit() {
+        for (connections, queue_capacity) in [
+            (0, 1),
+            (MAX_CONNECTIONS_PER_SHARD + 1, 1),
+            (1, 0),
+            (1, MAX_QUEUE_CAPACITY_PER_SHARD + 1),
+        ] {
+            assert_eq!(
+                EngineOptions::new(connections, queue_capacity)
+                    .unwrap_err()
+                    .kind(),
+                EngineErrorKind::InvalidArgument
+            );
+        }
+    }
+
+    #[test]
+    fn constructor_preserves_boundary_values_and_accessors() {
+        let minimum = EngineOptions::new(1, 1).unwrap();
+        assert_eq!(minimum.connections_per_shard(), 1);
+        assert_eq!(minimum.queue_capacity_per_shard(), 1);
+
+        let maximum =
+            EngineOptions::new(MAX_CONNECTIONS_PER_SHARD, MAX_QUEUE_CAPACITY_PER_SHARD).unwrap();
+        assert_eq!(maximum.connections_per_shard(), 16);
+        assert_eq!(maximum.queue_capacity_per_shard(), 1_024);
+    }
+
+    #[test]
+    fn shard_validation_uses_checked_total_active_connection_limit() {
+        let at_limit = EngineOptions::new(8, 1).unwrap();
+        assert_eq!(at_limit.worker_limit(64).unwrap(), 512);
+
+        let over_limit = EngineOptions::new(16, 1).unwrap();
+        assert_eq!(
+            over_limit.worker_limit(64).unwrap_err().kind(),
+            EngineErrorKind::InvalidArgument
+        );
+        assert_eq!(
+            EngineOptions::default().worker_limit(0).unwrap_err().kind(),
+            EngineErrorKind::InvalidArgument
+        );
+    }
+}

--- a/src/core/worker.rs
+++ b/src/core/worker.rs
@@ -1,0 +1,215 @@
+//! Bounded admission for blocking engine work.
+
+use std::sync::Arc;
+
+use tokio::sync::Semaphore;
+
+use super::{EngineError, EngineErrorKind, EngineResult};
+
+/// A cloneable concurrency bound around Tokio's blocking workers.
+#[derive(Debug, Clone)]
+pub(crate) struct BlockingPool {
+    limit: usize,
+    permits: Arc<Semaphore>,
+}
+
+impl BlockingPool {
+    /// Construct a blocking pool with an already-validated concurrency bound.
+    pub(crate) fn new(max_active: usize) -> Self {
+        assert!(max_active > 0, "blocking pool must have active capacity");
+        Self {
+            limit: max_active,
+            permits: Arc::new(Semaphore::new(max_active)),
+        }
+    }
+
+    /// Return the configured maximum number of active blocking tasks.
+    pub(crate) const fn limit(&self) -> usize {
+        self.limit
+    }
+
+    /// Return the number of permits not currently held by admitted work.
+    #[cfg(test)]
+    pub(crate) fn available_permits(&self) -> usize {
+        self.permits.available_permits()
+    }
+
+    /// Wait for capacity, then execute blocking work without exceeding the
+    /// configured concurrency bound.
+    pub(crate) async fn run<T, F>(&self, work: F) -> EngineResult<T>
+    where
+        T: Send + 'static,
+        F: FnOnce() -> EngineResult<T> + Send + 'static,
+    {
+        let permit = Arc::clone(&self.permits)
+            .acquire_owned()
+            .await
+            .map_err(|error| {
+                EngineError::from_source(
+                    EngineErrorKind::Internal,
+                    "blocking engine pool closed unexpectedly",
+                    error,
+                )
+            })?;
+
+        tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            work()
+        })
+        .await
+        .map_err(|error| {
+            EngineError::from_source(
+                EngineErrorKind::Internal,
+                "blocking engine task failed",
+                error,
+            )
+        })?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::mpsc, time::Duration};
+
+    use tokio::{sync::oneshot, time::timeout};
+
+    use super::*;
+
+    fn assert_send_sync<T: Send + Sync>() {}
+
+    fn assert_send<T: Send>(_: T) {}
+
+    async fn wait_for_started(started: oneshot::Receiver<()>) {
+        timeout(Duration::from_secs(2), started)
+            .await
+            .expect("blocking work should start")
+            .expect("blocking worker should report that it started");
+    }
+
+    fn held_work(
+        started: oneshot::Sender<()>,
+        release: mpsc::Receiver<()>,
+    ) -> impl FnOnce() -> EngineResult<()> + Send + 'static {
+        move || {
+            let _ = started.send(());
+            release.recv().expect("test releases the blocking work");
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn public_future_and_pool_are_send_and_pool_is_sync() {
+        assert_send_sync::<BlockingPool>();
+        let pool = BlockingPool::new(1);
+        assert_eq!(pool.limit(), 1);
+        assert_eq!(pool.available_permits(), 1);
+        assert_send(pool.run(|| Ok::<_, EngineError>(())))
+    }
+
+    #[tokio::test]
+    async fn active_blocking_work_never_exceeds_the_exact_bound() {
+        let pool = BlockingPool::new(2);
+        let (first_started_tx, first_started_rx) = oneshot::channel();
+        let (second_started_tx, second_started_rx) = oneshot::channel();
+        let (third_started_tx, mut third_started_rx) = oneshot::channel();
+        let (first_release_tx, first_release_rx) = mpsc::channel();
+        let (second_release_tx, second_release_rx) = mpsc::channel();
+        let (third_release_tx, third_release_rx) = mpsc::channel();
+
+        let first_pool = pool.clone();
+        let first = tokio::spawn(async move {
+            first_pool
+                .run(held_work(first_started_tx, first_release_rx))
+                .await
+        });
+        let second_pool = pool.clone();
+        let second = tokio::spawn(async move {
+            second_pool
+                .run(held_work(second_started_tx, second_release_rx))
+                .await
+        });
+        wait_for_started(first_started_rx).await;
+        wait_for_started(second_started_rx).await;
+        assert_eq!(pool.available_permits(), 0);
+
+        let third_pool = pool.clone();
+        let third = tokio::spawn(async move {
+            third_pool
+                .run(held_work(third_started_tx, third_release_rx))
+                .await
+        });
+        assert!(
+            timeout(Duration::from_millis(50), &mut third_started_rx)
+                .await
+                .is_err(),
+            "third worker started while both permits were held"
+        );
+
+        first_release_tx.send(()).unwrap();
+        wait_for_started(third_started_rx).await;
+        assert_eq!(pool.available_permits(), 0);
+        second_release_tx.send(()).unwrap();
+        third_release_tx.send(()).unwrap();
+
+        first.await.unwrap().unwrap();
+        second.await.unwrap().unwrap();
+        third.await.unwrap().unwrap();
+        assert_eq!(pool.available_permits(), 2);
+    }
+
+    #[tokio::test]
+    async fn a_worker_panic_is_internal_and_returns_its_permit() {
+        let pool = BlockingPool::new(1);
+        let error = pool
+            .run(|| -> EngineResult<()> { panic!("intentional worker panic") })
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.kind(), EngineErrorKind::Internal);
+        assert_eq!(error.to_string(), "blocking engine task failed");
+        timeout(Duration::from_secs(2), pool.run(|| Ok(())))
+            .await
+            .expect("panic must release the blocking permit")
+            .unwrap();
+        assert_eq!(pool.available_permits(), 1);
+    }
+
+    #[tokio::test]
+    async fn aborting_the_outer_future_keeps_the_permit_until_work_finishes() {
+        let pool = BlockingPool::new(1);
+        let (first_started_tx, first_started_rx) = oneshot::channel();
+        let (first_release_tx, first_release_rx) = mpsc::channel();
+        let first_pool = pool.clone();
+        let first = tokio::spawn(async move {
+            first_pool
+                .run(held_work(first_started_tx, first_release_rx))
+                .await
+        });
+        wait_for_started(first_started_rx).await;
+        assert_eq!(pool.available_permits(), 0);
+        first.abort();
+        assert!(first.await.unwrap_err().is_cancelled());
+
+        let (second_started_tx, mut second_started_rx) = oneshot::channel();
+        let (second_release_tx, second_release_rx) = mpsc::channel();
+        let second_pool = pool.clone();
+        let second = tokio::spawn(async move {
+            second_pool
+                .run(held_work(second_started_tx, second_release_rx))
+                .await
+        });
+        assert!(
+            timeout(Duration::from_millis(50), &mut second_started_rx)
+                .await
+                .is_err(),
+            "detached blocking work released its permit before finishing"
+        );
+
+        first_release_tx.send(()).unwrap();
+        wait_for_started(second_started_rx).await;
+        assert_eq!(pool.available_permits(), 0);
+        second_release_tx.send(()).unwrap();
+        second.await.unwrap().unwrap();
+        assert_eq!(pool.available_permits(), 1);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,12 @@
 use std::{net::SocketAddr, path::PathBuf};
 
-use briskdb::server::{self, Config};
+use briskdb::{
+    core::{
+        DEFAULT_CONNECTIONS_PER_SHARD, DEFAULT_QUEUE_CAPACITY_PER_SHARD, EngineOptions,
+        EngineResult,
+    },
+    server::{self, Config},
+};
 use clap::Parser;
 use tracing_subscriber::EnvFilter;
 
@@ -18,6 +24,39 @@ struct Args {
     /// Fixed shard count for a new database (2-64).
     #[arg(long, env = "BRISKDB_SHARDS", default_value_t = 4)]
     shards: u16,
+
+    /// Maximum active SQLite connections for each shard (1-16).
+    #[arg(
+        long,
+        env = "BRISKDB_CONNECTIONS_PER_SHARD",
+        default_value_t = DEFAULT_CONNECTIONS_PER_SHARD
+    )]
+    connections_per_shard: usize,
+
+    /// Maximum queued operations waiting for each shard (1-1024).
+    #[arg(
+        long,
+        env = "BRISKDB_QUEUE_CAPACITY_PER_SHARD",
+        default_value_t = DEFAULT_QUEUE_CAPACITY_PER_SHARD
+    )]
+    queue_capacity_per_shard: usize,
+}
+
+impl Args {
+    /// Convert command-line input into validated server startup configuration.
+    ///
+    /// Keeping this conversion ahead of `server::run_with_engine_options`
+    /// ensures invalid limits cannot bind a listener or create database files.
+    fn into_server_parts(self) -> EngineResult<(Config, EngineOptions)> {
+        let options =
+            EngineOptions::new(self.connections_per_shard, self.queue_capacity_per_shard)?;
+        let config = Config {
+            listen: self.listen,
+            data_dir: self.data_dir,
+            shards: self.shards,
+        };
+        Ok((config, options))
+    }
 }
 
 #[tokio::main]
@@ -28,17 +67,16 @@ async fn main() -> anyhow::Result<()> {
         )
         .init();
 
-    let args = Args::parse();
-    server::run(Config {
-        listen: args.listen,
-        data_dir: args.data_dir,
-        shards: args.shards,
-    })
-    .await
+    let (config, options) = Args::parse().into_server_parts()?;
+    server::run_with_engine_options(config, options).await
 }
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::OsStr;
+
+    use clap::CommandFactory;
+
     use super::*;
 
     #[test]
@@ -48,6 +86,11 @@ mod tests {
         assert_eq!(args.listen, "127.0.0.1:7654".parse().unwrap());
         assert_eq!(args.data_dir, PathBuf::from("./briskdb-data"));
         assert_eq!(args.shards, 4);
+        assert_eq!(args.connections_per_shard, DEFAULT_CONNECTIONS_PER_SHARD);
+        assert_eq!(
+            args.queue_capacity_per_shard,
+            DEFAULT_QUEUE_CAPACITY_PER_SHARD
+        );
     }
 
     #[test]
@@ -60,11 +103,126 @@ mod tests {
             "/tmp/briskdb-test-data",
             "--shards",
             "8",
+            "--connections-per-shard",
+            "3",
+            "--queue-capacity-per-shard",
+            "17",
         ])
         .unwrap();
 
         assert_eq!(args.listen, "127.0.0.1:9000".parse().unwrap());
         assert_eq!(args.data_dir, PathBuf::from("/tmp/briskdb-test-data"));
         assert_eq!(args.shards, 8);
+        assert_eq!(args.connections_per_shard, 3);
+        assert_eq!(args.queue_capacity_per_shard, 17);
+    }
+
+    #[test]
+    fn cli_values_convert_to_server_config_and_validated_options() {
+        let args = Args::try_parse_from([
+            "briskdb",
+            "--listen",
+            "127.0.0.1:9000",
+            "--data-dir",
+            "/tmp/briskdb-test-data",
+            "--shards",
+            "8",
+            "--connections-per-shard",
+            "3",
+            "--queue-capacity-per-shard",
+            "17",
+        ])
+        .unwrap();
+
+        let (config, options) = args.into_server_parts().unwrap();
+        assert_eq!(
+            config,
+            Config {
+                listen: "127.0.0.1:9000".parse().unwrap(),
+                data_dir: PathBuf::from("/tmp/briskdb-test-data"),
+                shards: 8,
+            }
+        );
+        assert_eq!(options.connections_per_shard(), 3);
+        assert_eq!(options.queue_capacity_per_shard(), 17);
+    }
+
+    #[test]
+    fn invalid_cli_limits_fail_during_startup_conversion() {
+        for arguments in [
+            [
+                "briskdb",
+                "--connections-per-shard",
+                "0",
+                "--queue-capacity-per-shard",
+                "1",
+            ],
+            [
+                "briskdb",
+                "--connections-per-shard",
+                "1",
+                "--queue-capacity-per-shard",
+                "1025",
+            ],
+        ] {
+            let error = Args::try_parse_from(arguments)
+                .unwrap()
+                .into_server_parts()
+                .unwrap_err();
+            assert_eq!(
+                error.kind(),
+                briskdb::core::EngineErrorKind::InvalidArgument
+            );
+        }
+    }
+
+    #[test]
+    fn pool_flags_are_bound_to_the_documented_environment_variables() {
+        let command = Args::command();
+        let connections = command
+            .get_arguments()
+            .find(|argument| argument.get_id() == "connections_per_shard")
+            .unwrap();
+        let queue = command
+            .get_arguments()
+            .find(|argument| argument.get_id() == "queue_capacity_per_shard")
+            .unwrap();
+
+        assert_eq!(
+            connections.get_env(),
+            Some(OsStr::new("BRISKDB_CONNECTIONS_PER_SHARD"))
+        );
+        assert_eq!(
+            queue.get_env(),
+            Some(OsStr::new("BRISKDB_QUEUE_CAPACITY_PER_SHARD"))
+        );
+    }
+
+    #[test]
+    fn pool_limits_parse_from_environment_in_an_isolated_process() {
+        const CHILD_MARKER: &str = "BRISKDB_POOL_ENV_TEST_CHILD";
+
+        if std::env::var_os(CHILD_MARKER).is_some() {
+            let args = Args::try_parse_from(["briskdb"]).unwrap();
+            assert_eq!(args.connections_per_shard, 6);
+            assert_eq!(args.queue_capacity_per_shard, 41);
+            return;
+        }
+
+        let status = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "tests::pool_limits_parse_from_environment_in_an_isolated_process",
+            ])
+            .env(CHILD_MARKER, "1")
+            .env("BRISKDB_LISTEN", "127.0.0.1:7654")
+            .env("BRISKDB_DATA_DIR", "./briskdb-env-test-data")
+            .env("BRISKDB_SHARDS", "4")
+            .env("BRISKDB_CONNECTIONS_PER_SHARD", "6")
+            .env("BRISKDB_QUEUE_CAPACITY_PER_SHARD", "41")
+            .status()
+            .unwrap();
+
+        assert!(status.success());
     }
 }

--- a/src/protocol/http.rs
+++ b/src/protocol/http.rs
@@ -818,6 +818,11 @@ mod tests {
             "crate::storage",
             "blake3",
             "rusqlite",
+            "ConnectionPools",
+            "PooledConnection",
+            "BlockingPool",
+            "EngineOptions",
+            "Semaphore",
         ] {
             assert!(
                 !production_source.contains(forbidden),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -5,7 +5,10 @@ use std::{net::SocketAddr, path::PathBuf};
 use anyhow::Context;
 use tracing::info;
 
-use crate::{core::Engine, protocol::http};
+use crate::{
+    core::{Engine, EngineOptions},
+    protocol::http,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Config {
@@ -15,7 +18,16 @@ pub struct Config {
 }
 
 pub async fn run(config: Config) -> anyhow::Result<()> {
-    let engine = Engine::open(&config.data_dir, config.shards).await?;
+    run_with_engine_options(config, EngineOptions::default()).await
+}
+
+/// Start the server with explicit bounded-worker and per-shard pool limits.
+///
+/// `options` is validated before any database files or listener are created.
+/// [`run`] remains the compatibility entry point and delegates here with
+/// [`EngineOptions::default`].
+pub async fn run_with_engine_options(config: Config, options: EngineOptions) -> anyhow::Result<()> {
+    let engine = Engine::open_with_options(&config.data_dir, config.shards, options).await?;
     let listener = tokio::net::TcpListener::bind(config.listen)
         .await
         .with_context(|| format!("failed to bind {}", config.listen))?;
@@ -24,6 +36,10 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
         listen = %config.listen,
         data_dir = %config.data_dir.display(),
         shards = engine.shard_count(),
+        max_blocking_workers = engine.options().connections_per_shard()
+            * usize::from(engine.shard_count()),
+        connections_per_shard = engine.options().connections_per_shard(),
+        queue_capacity_per_shard = engine.options().queue_capacity_per_shard(),
         "BriskDB is ready"
     );
 
@@ -35,17 +51,51 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
 mod tests {
     use super::*;
 
+    fn unavailable_address() -> (std::net::TcpListener, SocketAddr) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        (listener, address)
+    }
+
     #[tokio::test]
-    async fn invalid_shard_count_fails_before_listener_startup() {
+    async fn default_entry_point_validates_before_database_or_listener_startup() {
         let temp = tempfile::tempdir().unwrap();
+        let data_dir = temp.path().join("database");
+        let (_occupied_listener, listen) = unavailable_address();
         let error = run(Config {
-            listen: "127.0.0.1:0".parse().unwrap(),
-            data_dir: temp.path().to_path_buf(),
+            listen,
+            data_dir: data_dir.clone(),
             shards: 1,
         })
         .await
         .unwrap_err();
 
         assert_eq!(error.to_string(), "shard count must be between 2 and 64");
+        assert!(!data_dir.exists());
+    }
+
+    #[tokio::test]
+    async fn aggregate_pool_limit_fails_before_database_or_listener_startup() {
+        let temp = tempfile::tempdir().unwrap();
+        let data_dir = temp.path().join("database");
+        let (_occupied_listener, listen) = unavailable_address();
+        let options = EngineOptions::new(16, 1).unwrap();
+        let error = run_with_engine_options(
+            Config {
+                listen,
+                data_dir: data_dir.clone(),
+                shards: 64,
+            },
+            options,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("must contain between 1 and 512 total active connections")
+        );
+        assert!(!data_dir.exists());
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,11 +1,21 @@
 //! SQLite file layout, manifest initialization, and connection configuration.
 
+pub(crate) mod pool;
+pub(crate) use pool::{ConnectionOwner, ConnectionPools, PooledConnection};
+
 use std::{
     fs,
     path::{Path, PathBuf},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
-use rusqlite::{Connection, OptionalExtension};
+use rusqlite::{
+    Connection, OptionalExtension,
+    hooks::{AuthAction, AuthContext, Authorization},
+};
 
 pub use crate::core::Database;
 use crate::{
@@ -15,7 +25,7 @@ use crate::{
 
 const SCHEMA_VERSION: &str = "1";
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct Storage {
     root: PathBuf,
     shard_count: u16,
@@ -23,12 +33,7 @@ pub(crate) struct Storage {
 
 impl Storage {
     pub(crate) fn open(root: impl AsRef<Path>, requested_shards: u16) -> EngineResult<Self> {
-        if !(2..=64).contains(&requested_shards) {
-            return Err(EngineError::new(
-                EngineErrorKind::InvalidArgument,
-                "shard count must be between 2 and 64",
-            ));
-        }
+        validate_shard_count(requested_shards)?;
 
         let root = root.as_ref().to_path_buf();
         let shards_dir = root.join("shards");
@@ -131,6 +136,131 @@ impl Storage {
         configure_connection(&connection)?;
         Ok(connection)
     }
+
+    pub(crate) fn open_pooled_shard(
+        &self,
+        shard: u16,
+    ) -> EngineResult<(Connection, ConnectionHygiene)> {
+        let connection = self.open_shard(shard)?;
+        let tainted = Arc::new(AtomicBool::new(false));
+        let wrote = Arc::new(AtomicBool::new(false));
+        let probing = Arc::new(AtomicBool::new(false));
+        let probe_tainted = Arc::new(AtomicBool::new(false));
+        let probe_wrote = Arc::new(AtomicBool::new(false));
+        let authorizer_taint = Arc::clone(&tainted);
+        let authorizer_wrote = Arc::clone(&wrote);
+        let authorizer_probing = Arc::clone(&probing);
+        let authorizer_probe_tainted = Arc::clone(&probe_tainted);
+        let authorizer_probe_wrote = Arc::clone(&probe_wrote);
+        connection
+            .authorizer(Some(move |context: AuthContext<'_>| {
+                if action_taints_connection(context.action) {
+                    if authorizer_probing.load(Ordering::Relaxed) {
+                        authorizer_probe_tainted.store(true, Ordering::Relaxed);
+                        return Authorization::Deny;
+                    }
+                    authorizer_taint.store(true, Ordering::Relaxed);
+                }
+                if action_writes_connection(context.action) {
+                    if authorizer_probing.load(Ordering::Relaxed) {
+                        authorizer_probe_wrote.store(true, Ordering::Relaxed);
+                        return Authorization::Deny;
+                    }
+                    authorizer_wrote.store(true, Ordering::Relaxed);
+                }
+                Authorization::Allow
+            }))
+            .map_err(sqlite_error::storage)?;
+        Ok((
+            connection,
+            ConnectionHygiene {
+                tainted,
+                wrote,
+                probing,
+                probe_tainted,
+                probe_wrote,
+            },
+        ))
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ConnectionHygiene {
+    pub(crate) tainted: Arc<AtomicBool>,
+    pub(crate) wrote: Arc<AtomicBool>,
+    probing: Arc<AtomicBool>,
+    probe_tainted: Arc<AtomicBool>,
+    probe_wrote: Arc<AtomicBool>,
+}
+
+impl ConnectionHygiene {
+    /// Enter a non-executing authorizer probe. Tainting and write actions are
+    /// denied at prepare time so they cannot affect a foreign physical handle.
+    pub(crate) fn begin_probe(&self) -> ConnectionProbe<'_> {
+        self.probe_tainted.store(false, Ordering::Relaxed);
+        self.probe_wrote.store(false, Ordering::Relaxed);
+        let was_probing = self.probing.swap(true, Ordering::Relaxed);
+        debug_assert!(!was_probing, "connection hygiene probes cannot be nested");
+        ConnectionProbe { hygiene: self }
+    }
+}
+
+/// Restores the normal authorizer mode even if statement preparation unwinds.
+pub(crate) struct ConnectionProbe<'a> {
+    hygiene: &'a ConnectionHygiene,
+}
+
+impl ConnectionProbe<'_> {
+    pub(crate) fn requires_fresh_connection(&self) -> bool {
+        self.hygiene.probe_tainted.load(Ordering::Relaxed)
+            || self.hygiene.probe_wrote.load(Ordering::Relaxed)
+    }
+}
+
+impl Drop for ConnectionProbe<'_> {
+    fn drop(&mut self) {
+        self.hygiene.probing.store(false, Ordering::Relaxed);
+    }
+}
+
+pub(crate) fn validate_shard_count(requested_shards: u16) -> EngineResult<()> {
+    if (2..=64).contains(&requested_shards) {
+        Ok(())
+    } else {
+        Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            "shard count must be between 2 and 64",
+        ))
+    }
+}
+
+fn action_taints_connection(action: AuthAction<'_>) -> bool {
+    matches!(
+        action,
+        AuthAction::Unknown { .. }
+            | AuthAction::CreateTempIndex { .. }
+            | AuthAction::CreateTempTable { .. }
+            | AuthAction::CreateTempTrigger { .. }
+            | AuthAction::CreateTempView { .. }
+            | AuthAction::DropTempIndex { .. }
+            | AuthAction::DropTempTable { .. }
+            | AuthAction::DropTempTrigger { .. }
+            | AuthAction::DropTempView { .. }
+            | AuthAction::Pragma { .. }
+            | AuthAction::Transaction { .. }
+            | AuthAction::Attach { .. }
+            | AuthAction::Detach { .. }
+            | AuthAction::CreateVtable { .. }
+            | AuthAction::DropVtable { .. }
+            | AuthAction::Savepoint { .. }
+    )
+}
+
+fn action_writes_connection(action: AuthAction<'_>) -> bool {
+    matches!(
+        action,
+        AuthAction::Insert { .. } | AuthAction::Update { .. } | AuthAction::Delete { .. }
+    )
 }
 
 fn configure_connection(connection: &Connection) -> EngineResult<()> {

--- a/src/storage/pool.rs
+++ b/src/storage/pool.rs
@@ -1,0 +1,1375 @@
+//! Bounded per-shard SQLite connection pools.
+
+use std::{
+    ops::Deref,
+    sync::{Arc, Mutex, MutexGuard, atomic::Ordering},
+};
+
+#[cfg(test)]
+use std::sync::atomic::AtomicU64;
+
+use rusqlite::Connection;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore, TryAcquireError};
+
+use crate::core::{EngineError, EngineErrorKind, EngineResult};
+
+use super::{ConnectionHygiene, Storage};
+
+/// Identity of the engine session allowed to observe a connection's write-local state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ConnectionOwner(u64);
+
+impl ConnectionOwner {
+    pub(crate) const fn new(session_id: u64) -> Self {
+        Self(session_id)
+    }
+}
+
+/// The bounded pools for every physical shard.
+#[derive(Debug, Clone)]
+pub(crate) struct ConnectionPools {
+    shards: Vec<ShardPool>,
+    #[cfg(test)]
+    pool_size: usize,
+    #[cfg(test)]
+    queue_capacity: usize,
+}
+
+impl ConnectionPools {
+    pub(crate) fn new(
+        storage: Storage,
+        pool_size: usize,
+        queue_capacity: usize,
+    ) -> EngineResult<Self> {
+        if pool_size == 0 {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "connections per shard must be at least 1",
+            ));
+        }
+        let admission_capacity = pool_size
+            .checked_add(queue_capacity)
+            .filter(|&capacity| capacity <= Semaphore::MAX_PERMITS)
+            .ok_or_else(|| {
+                EngineError::new(
+                    EngineErrorKind::InvalidArgument,
+                    "connection and queue capacity exceeds the semaphore limit",
+                )
+            })?;
+
+        let shards = (0..storage.shard_count())
+            .map(|shard| {
+                ShardPool::new(
+                    storage.clone(),
+                    shard,
+                    pool_size,
+                    queue_capacity,
+                    admission_capacity,
+                )
+            })
+            .collect();
+        Ok(Self {
+            shards,
+            #[cfg(test)]
+            pool_size,
+            #[cfg(test)]
+            queue_capacity,
+        })
+    }
+
+    /// Reserve bounded admission and one active connection slot for a shard.
+    ///
+    /// Admission is attempted before waiting for a connection. Once the active
+    /// and queued capacity is exhausted, this returns `Busy` immediately.
+    pub(crate) async fn acquire_for_owner(
+        &self,
+        shard: u16,
+        owner: ConnectionOwner,
+    ) -> EngineResult<PoolPermit> {
+        self.shard(shard)?.acquire(owner).await
+    }
+
+    /// Reserve one slot on every shard in deterministic shard order.
+    pub(crate) async fn acquire_all_for_owner(
+        &self,
+        owner: ConnectionOwner,
+    ) -> EngineResult<Vec<(u16, PoolPermit)>> {
+        let mut permits = Vec::with_capacity(self.shards.len());
+        for shard in 0..self.shards.len() {
+            let shard = u16::try_from(shard).expect("the storage shard count fits in u16");
+            permits.push((shard, self.acquire_for_owner(shard, owner).await?));
+        }
+        Ok(permits)
+    }
+
+    #[cfg(test)]
+    async fn acquire(&self, shard: u16) -> EngineResult<PoolPermit> {
+        self.acquire_for_owner(shard, ConnectionOwner::new(1)).await
+    }
+
+    #[cfg(test)]
+    async fn acquire_all(&self) -> EngineResult<Vec<(u16, PoolPermit)>> {
+        self.acquire_all_for_owner(ConnectionOwner::new(1)).await
+    }
+
+    #[cfg(test)]
+    pub(crate) fn snapshot(&self) -> EngineResult<PoolSnapshot> {
+        Ok(PoolSnapshot {
+            pool_size: self.pool_size,
+            queue_capacity: self.queue_capacity,
+            shards: self
+                .shards
+                .iter()
+                .map(ShardPool::snapshot)
+                .collect::<EngineResult<_>>()?,
+        })
+    }
+
+    fn shard(&self, shard: u16) -> EngineResult<&ShardPool> {
+        self.shards.get(usize::from(shard)).ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::Internal,
+                format!("shard {shard} is outside the configured pool range"),
+            )
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ShardPool {
+    inner: Arc<ShardPoolInner>,
+}
+
+impl ShardPool {
+    fn new(
+        storage: Storage,
+        shard: u16,
+        pool_size: usize,
+        _queue_capacity: usize,
+        admission_capacity: usize,
+    ) -> Self {
+        Self {
+            inner: Arc::new(ShardPoolInner {
+                storage,
+                shard,
+                #[cfg(test)]
+                pool_size,
+                #[cfg(test)]
+                queue_capacity: _queue_capacity,
+                admission: Arc::new(Semaphore::new(admission_capacity)),
+                connections: Arc::new(Semaphore::new(pool_size)),
+                idle: Mutex::new(Vec::with_capacity(pool_size)),
+                #[cfg(test)]
+                next_connection_id: AtomicU64::new(1),
+                #[cfg(test)]
+                opened: AtomicU64::new(0),
+                #[cfg(test)]
+                checkouts: AtomicU64::new(0),
+                #[cfg(test)]
+                reused: AtomicU64::new(0),
+                #[cfg(test)]
+                retired: AtomicU64::new(0),
+            }),
+        }
+    }
+
+    async fn acquire(&self, owner: ConnectionOwner) -> EngineResult<PoolPermit> {
+        let admission = match Arc::clone(&self.inner.admission).try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(TryAcquireError::NoPermits) => {
+                return Err(EngineError::new(
+                    EngineErrorKind::Busy,
+                    format!("shard {} connection queue is full", self.inner.shard),
+                ));
+            }
+            Err(TryAcquireError::Closed) => {
+                return Err(EngineError::new(
+                    EngineErrorKind::Internal,
+                    format!("shard {} admission semaphore is closed", self.inner.shard),
+                ));
+            }
+        };
+        let connection = Arc::clone(&self.inner.connections)
+            .acquire_owned()
+            .await
+            .map_err(|error| {
+                EngineError::from_source(
+                    EngineErrorKind::Internal,
+                    format!("shard {} connection semaphore is closed", self.inner.shard),
+                    error,
+                )
+            })?;
+
+        Ok(PoolPermit {
+            pool: self.clone(),
+            owner,
+            admission,
+            connection,
+        })
+    }
+
+    #[cfg(test)]
+    fn snapshot(&self) -> EngineResult<ShardPoolSnapshot> {
+        let admitted = self
+            .inner
+            .pool_size
+            .saturating_add(self.inner.queue_capacity)
+            .saturating_sub(self.inner.admission.available_permits());
+        let active = self
+            .inner
+            .pool_size
+            .saturating_sub(self.inner.connections.available_permits());
+        let idle = self.inner.lock_idle()?.len();
+
+        Ok(ShardPoolSnapshot {
+            shard: self.inner.shard,
+            active,
+            queued: admitted.saturating_sub(active),
+            idle,
+            opened: self.inner.opened.load(Ordering::Relaxed),
+            checkouts: self.inner.checkouts.load(Ordering::Relaxed),
+            reused: self.inner.reused.load(Ordering::Relaxed),
+            retired: self.inner.retired.load(Ordering::Relaxed),
+        })
+    }
+}
+
+#[derive(Debug)]
+struct ShardPoolInner {
+    storage: Storage,
+    shard: u16,
+    #[cfg(test)]
+    pool_size: usize,
+    #[cfg(test)]
+    queue_capacity: usize,
+    admission: Arc<Semaphore>,
+    connections: Arc<Semaphore>,
+    idle: Mutex<Vec<ManagedConnection>>,
+    #[cfg(test)]
+    next_connection_id: AtomicU64,
+    #[cfg(test)]
+    opened: AtomicU64,
+    #[cfg(test)]
+    checkouts: AtomicU64,
+    #[cfg(test)]
+    reused: AtomicU64,
+    #[cfg(test)]
+    retired: AtomicU64,
+}
+
+impl ShardPoolInner {
+    fn lock_idle(&self) -> EngineResult<MutexGuard<'_, Vec<ManagedConnection>>> {
+        self.idle.lock().map_err(|error| {
+            EngineError::new(
+                EngineErrorKind::Internal,
+                format!(
+                    "shard {} idle connection pool is poisoned: {error}",
+                    self.shard
+                ),
+            )
+        })
+    }
+
+    fn checkout(&self, owner: ConnectionOwner) -> EngineResult<ManagedConnection> {
+        let (reusable, foreign_write_connection) = {
+            let mut idle = self.lock_idle()?;
+            let reusable_index = idle
+                .iter()
+                .position(|connection| connection.write_owner == Some(owner))
+                .or_else(|| {
+                    idle.iter().position(|connection| {
+                        connection.write_owner.is_none() && connection.origin_owner == Some(owner)
+                    })
+                })
+                .or_else(|| {
+                    idle.iter()
+                        .position(|connection| connection.write_owner.is_none())
+                });
+            match reusable_index {
+                Some(index) => (Some(idle.swap_remove(index)), None),
+                None => (None, idle.pop()),
+            }
+        };
+
+        if let Some(connection) = foreign_write_connection {
+            self.retire(connection);
+        }
+
+        if let Some(connection) = reusable {
+            connection.hygiene.wrote.store(false, Ordering::Relaxed);
+            #[cfg(test)]
+            self.reused.fetch_add(1, Ordering::Relaxed);
+            return Ok(connection);
+        }
+
+        self.open_connection()
+    }
+
+    fn open_connection(&self) -> EngineResult<ManagedConnection> {
+        let (connection, hygiene) = self.storage.open_pooled_shard(self.shard)?;
+        #[cfg(test)]
+        let id = self.next_connection_id.fetch_add(1, Ordering::Relaxed);
+        #[cfg(test)]
+        self.opened.fetch_add(1, Ordering::Relaxed);
+        Ok(ManagedConnection {
+            #[cfg(test)]
+            id,
+            connection,
+            hygiene,
+            write_owner: None,
+            origin_owner: None,
+        })
+    }
+
+    fn retire(&self, connection: ManagedConnection) {
+        #[cfg(test)]
+        self.retired.fetch_add(1, Ordering::Relaxed);
+        drop(connection);
+    }
+
+    fn check_in(&self, mut connection: ManagedConnection, owner: ConnectionOwner, broken: bool) {
+        let panicking = std::thread::panicking();
+        let was_in_transaction = !connection.connection.is_autocommit();
+        let mut cleanup_failed = false;
+        if was_in_transaction && connection.connection.execute_batch("ROLLBACK").is_err() {
+            cleanup_failed = true;
+        }
+        let tainted = connection.hygiene.tainted.load(Ordering::Relaxed);
+
+        if broken || panicking || was_in_transaction || cleanup_failed || tainted {
+            self.retire(connection);
+            return;
+        }
+
+        if connection.hygiene.wrote.load(Ordering::Relaxed) {
+            connection.write_owner = Some(owner);
+        }
+        if connection.origin_owner.is_none() {
+            connection.origin_owner = Some(owner);
+        }
+
+        match self.idle.lock() {
+            Ok(mut idle) => idle.push(connection),
+            Err(_) => self.retire(connection),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ManagedConnection {
+    #[cfg(test)]
+    id: u64,
+    connection: Connection,
+    hygiene: ConnectionHygiene,
+    write_owner: Option<ConnectionOwner>,
+    origin_owner: Option<ConnectionOwner>,
+}
+
+/// Admission plus an active connection slot reserved outside a blocking task.
+#[derive(Debug)]
+pub(crate) struct PoolPermit {
+    pool: ShardPool,
+    owner: ConnectionOwner,
+    admission: OwnedSemaphorePermit,
+    connection: OwnedSemaphorePermit,
+}
+
+impl PoolPermit {
+    /// Checkout or lazily open a connection. Call this on the blocking worker.
+    pub(crate) fn checkout(self) -> EngineResult<PooledConnection> {
+        let PoolPermit {
+            pool,
+            owner,
+            admission,
+            connection,
+        } = self;
+        let managed = pool.inner.checkout(owner)?;
+        let borrowed_from_other_owner = managed
+            .origin_owner
+            .is_some_and(|origin_owner| origin_owner != owner);
+        #[cfg(test)]
+        pool.inner.checkouts.fetch_add(1, Ordering::Relaxed);
+        Ok(PooledConnection {
+            pool,
+            owner,
+            managed: Some(managed),
+            broken: false,
+            borrowed_from_other_owner,
+            _admission: admission,
+            _connection: connection,
+        })
+    }
+}
+
+/// A checked-out SQLite connection that returns clean state to its shard pool.
+#[derive(Debug)]
+pub(crate) struct PooledConnection {
+    pool: ShardPool,
+    owner: ConnectionOwner,
+    managed: Option<ManagedConnection>,
+    broken: bool,
+    borrowed_from_other_owner: bool,
+    _admission: OwnedSemaphorePermit,
+    _connection: OwnedSemaphorePermit,
+}
+
+impl PooledConnection {
+    #[cfg(test)]
+    pub(crate) fn connection_id(&self) -> u64 {
+        self.managed
+            .as_ref()
+            .expect("a live pooled connection owns its SQLite handle")
+            .id
+    }
+
+    /// Retire this physical connection instead of returning it to the pool.
+    pub(crate) fn mark_broken(&mut self) {
+        self.broken = true;
+    }
+
+    /// Ensure foreign SQL cannot inherit connection-local history or write on a
+    /// handle whose physical history began under another session.
+    ///
+    /// SQLite reports authorizer actions while preparing a statement. For a
+    /// clean handle borrowed from another owner, probe once in an authorizer
+    /// mode that denies the first connection-local or write action before it can
+    /// have a prepare-time effect. If the probe finds either, replace the handle
+    /// before the real execution. Any probe error also fails closed to a fresh
+    /// handle. The probe error itself is never exposed; opening the replacement
+    /// can return a storage error, and otherwise the real statement boundary is
+    /// authoritative for the SQL result.
+    pub(crate) fn isolate_foreign_sql(&mut self, sql: &str) -> EngineResult<()> {
+        if !self.borrowed_from_other_owner {
+            return Ok(());
+        }
+
+        let requires_fresh = {
+            let managed = self
+                .managed
+                .as_ref()
+                .expect("a live pooled connection owns its SQLite handle");
+            let probe = managed.hygiene.begin_probe();
+            let prepared = managed.connection.prepare(sql);
+            let preparation_failed = prepared.is_err();
+            drop(prepared);
+            preparation_failed || probe.requires_fresh_connection()
+        };
+        if requires_fresh {
+            self.replace_with_fresh()?;
+        }
+        Ok(())
+    }
+
+    /// Give a multi-statement operation a fresh handle when the checked-out
+    /// connection was last used by another session.
+    pub(crate) fn ensure_owner_local(&mut self) -> EngineResult<()> {
+        if self.borrowed_from_other_owner {
+            self.replace_with_fresh()?;
+        }
+        Ok(())
+    }
+
+    fn replace_with_fresh(&mut self) -> EngineResult<()> {
+        let previous = self
+            .managed
+            .take()
+            .expect("a live pooled connection owns its SQLite handle");
+        self.pool.inner.retire(previous);
+        self.managed = Some(self.pool.inner.open_connection()?);
+        self.borrowed_from_other_owner = false;
+        Ok(())
+    }
+}
+
+impl Deref for PooledConnection {
+    type Target = Connection;
+
+    fn deref(&self) -> &Self::Target {
+        &self
+            .managed
+            .as_ref()
+            .expect("a live pooled connection owns its SQLite handle")
+            .connection
+    }
+}
+
+impl Drop for PooledConnection {
+    fn drop(&mut self) {
+        if let Some(connection) = self.managed.take() {
+            self.pool
+                .inner
+                .check_in(connection, self.owner, self.broken);
+        }
+    }
+}
+
+/// A deterministic snapshot of configured pool capacity and shard counters.
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PoolSnapshot {
+    pub(crate) pool_size: usize,
+    pub(crate) queue_capacity: usize,
+    pub(crate) shards: Vec<ShardPoolSnapshot>,
+}
+
+/// Counters and current occupancy for one shard pool.
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ShardPoolSnapshot {
+    pub(crate) shard: u16,
+    pub(crate) active: usize,
+    pub(crate) queued: usize,
+    pub(crate) idle: usize,
+    pub(crate) opened: u64,
+    pub(crate) checkouts: u64,
+    pub(crate) reused: u64,
+    pub(crate) retired: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs,
+        panic::{AssertUnwindSafe, catch_unwind},
+        sync::Arc,
+        time::Duration,
+    };
+
+    use rusqlite::hooks::{AuthAction, TransactionOperation};
+    use tokio::time::timeout;
+
+    use super::*;
+    use crate::storage::{action_taints_connection, action_writes_connection};
+
+    fn pools(pool_size: usize, queue_capacity: usize) -> (tempfile::TempDir, ConnectionPools) {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = Storage::open(temp.path(), 2).unwrap();
+        let pools = ConnectionPools::new(storage, pool_size, queue_capacity).unwrap();
+        (temp, pools)
+    }
+
+    async fn wait_for_occupancy(pools: &ConnectionPools, shard: u16, active: usize, queued: usize) {
+        timeout(Duration::from_secs(2), async {
+            loop {
+                let snapshot = pools.snapshot().unwrap().shards[usize::from(shard)];
+                if snapshot.active == active && snapshot.queued == queued {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+    }
+
+    #[test]
+    fn validates_capacity_before_constructing_semaphores() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = Storage::open(temp.path(), 2).unwrap();
+
+        let zero = ConnectionPools::new(storage.clone(), 0, 1).unwrap_err();
+        assert_eq!(zero.kind(), EngineErrorKind::InvalidArgument);
+        let excessive = ConnectionPools::new(storage, Semaphore::MAX_PERMITS, 1).unwrap_err();
+        assert_eq!(excessive.kind(), EngineErrorKind::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn rejects_a_shard_outside_the_pool_layout() {
+        let (_temp, pools) = pools(1, 0);
+        let error = pools.acquire(2).await.unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Internal);
+        assert_eq!(
+            error.to_string(),
+            "shard 2 is outside the configured pool range"
+        );
+    }
+
+    #[tokio::test]
+    async fn exact_active_and_queue_capacity_apply_backpressure_and_recover() {
+        let (_temp, pools) = pools(1, 1);
+        let first = pools.acquire(0).await.unwrap().checkout().unwrap();
+
+        let queued_pools = pools.clone();
+        let queued = tokio::spawn(async move { queued_pools.acquire(0).await });
+        wait_for_occupancy(&pools, 0, 1, 1).await;
+
+        let overflow = pools.acquire(0).await.unwrap_err();
+        assert_eq!(overflow.kind(), EngineErrorKind::Busy);
+        assert!(overflow.is_retryable());
+
+        drop(first);
+        let queued = queued.await.unwrap().unwrap().checkout().unwrap();
+        drop(queued);
+        wait_for_occupancy(&pools, 0, 0, 0).await;
+
+        let snapshot = pools.snapshot().unwrap();
+        assert_eq!(snapshot.pool_size, 1);
+        assert_eq!(snapshot.queue_capacity, 1);
+        assert_eq!(snapshot.shards[0].opened, 1);
+        assert_eq!(snapshot.shards[0].checkouts, 2);
+        assert_eq!(snapshot.shards[0].reused, 1);
+    }
+
+    #[tokio::test]
+    async fn cancelling_a_queued_acquire_releases_its_admission_slot() {
+        let (_temp, pools) = pools(1, 1);
+        let first = pools.acquire(0).await.unwrap().checkout().unwrap();
+
+        let queued_pools = pools.clone();
+        let queued = tokio::spawn(async move { queued_pools.acquire(0).await });
+        wait_for_occupancy(&pools, 0, 1, 1).await;
+        queued.abort();
+        assert!(queued.await.unwrap_err().is_cancelled());
+        wait_for_occupancy(&pools, 0, 1, 0).await;
+
+        let replacement_pools = pools.clone();
+        let replacement = tokio::spawn(async move { replacement_pools.acquire(0).await });
+        wait_for_occupancy(&pools, 0, 1, 1).await;
+        drop(first);
+        drop(replacement.await.unwrap().unwrap().checkout().unwrap());
+        wait_for_occupancy(&pools, 0, 0, 0).await;
+    }
+
+    #[tokio::test]
+    async fn connections_open_lazily_and_keep_stable_ids_when_reused() {
+        let (_temp, pools) = pools(2, 0);
+        assert_eq!(pools.snapshot().unwrap().shards[0].opened, 0);
+
+        let first = pools.acquire(0).await.unwrap().checkout().unwrap();
+        let first_id = first.connection_id();
+        drop(first);
+        let second = pools.acquire(0).await.unwrap().checkout().unwrap();
+        assert_eq!(second.connection_id(), first_id);
+        drop(second);
+
+        let snapshot = pools.snapshot().unwrap().shards[0];
+        assert_eq!(snapshot.opened, 1);
+        assert_eq!(snapshot.idle, 1);
+        assert_eq!(snapshot.checkouts, 2);
+        assert_eq!(snapshot.reused, 1);
+        assert_eq!(snapshot.retired, 0);
+    }
+
+    #[tokio::test]
+    async fn lazy_open_preserves_storage_error_classification() {
+        let (temp, pools) = pools(1, 0);
+        fs::write(
+            temp.path().join("shards/0000.sqlite"),
+            b"this is not a SQLite database",
+        )
+        .unwrap();
+
+        let error = pools.acquire(0).await.unwrap().checkout().unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+        let snapshot = pools.snapshot().unwrap().shards[0];
+        assert_eq!(snapshot.active, 0);
+        assert_eq!(snapshot.opened, 0);
+        assert_eq!(snapshot.checkouts, 0);
+    }
+
+    #[tokio::test]
+    async fn ordinary_implicit_dml_can_reuse_a_connection_within_one_owner() {
+        let (_temp, pools) = pools(1, 0);
+        let mut expected_id = None;
+        for sql in [
+            "CREATE TABLE widgets (id INTEGER PRIMARY KEY, value INTEGER)",
+            "INSERT INTO widgets (id, value) VALUES (1, 10)",
+            "UPDATE widgets SET value = 20 WHERE id = 1",
+            "DELETE FROM widgets WHERE id = 1",
+        ] {
+            let connection = pools.acquire(0).await.unwrap().checkout().unwrap();
+            let id = connection.connection_id();
+            assert_eq!(*expected_id.get_or_insert(id), id);
+            connection.execute_batch(sql).unwrap();
+            drop(connection);
+        }
+
+        let snapshot = pools.snapshot().unwrap().shards[0];
+        assert_eq!(snapshot.opened, 1);
+        assert_eq!(snapshot.reused, 3);
+        assert_eq!(snapshot.retired, 0);
+        assert_eq!(snapshot.idle, 1);
+    }
+
+    #[tokio::test]
+    async fn write_local_sqlite_state_never_crosses_connection_owners() {
+        let (_temp, pools) = pools(1, 0);
+        let first_owner = ConnectionOwner::new(11);
+        let second_owner = ConnectionOwner::new(22);
+        let third_owner = ConnectionOwner::new(33);
+
+        let first = pools
+            .acquire_for_owner(0, first_owner)
+            .await
+            .unwrap()
+            .checkout()
+            .unwrap();
+        first
+            .execute_batch(
+                "CREATE TABLE widgets (id INTEGER PRIMARY KEY);
+                 INSERT INTO widgets (id) VALUES (1);",
+            )
+            .unwrap();
+        let first_id = first.connection_id();
+        assert_eq!(
+            first
+                .query_row(
+                    "SELECT last_insert_rowid(), changes(), total_changes()",
+                    [],
+                    |row| Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, i64>(2)?
+                    )),
+                )
+                .unwrap(),
+            (1, 1, 1)
+        );
+        drop(first);
+
+        let second = pools
+            .acquire_for_owner(0, second_owner)
+            .await
+            .unwrap()
+            .checkout()
+            .unwrap();
+        let second_id = second.connection_id();
+        assert_ne!(second_id, first_id);
+        assert_eq!(
+            second
+                .query_row(
+                    "SELECT last_insert_rowid(), changes(), total_changes()",
+                    [],
+                    |row| Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, i64>(2)?
+                    )),
+                )
+                .unwrap(),
+            (0, 0, 0)
+        );
+        assert_eq!(
+            second
+                .query_row("SELECT COUNT(*) FROM widgets", [], |row| row
+                    .get::<_, i64>(0))
+                .unwrap(),
+            1
+        );
+        drop(second);
+
+        let third = pools
+            .acquire_for_owner(0, third_owner)
+            .await
+            .unwrap()
+            .checkout()
+            .unwrap();
+        assert_eq!(third.connection_id(), second_id);
+        drop(third);
+
+        let snapshot = pools.snapshot().unwrap().shards[0];
+        assert_eq!(snapshot.opened, 2);
+        assert_eq!(snapshot.checkouts, 3);
+        assert_eq!(snapshot.reused, 1);
+        assert_eq!(snapshot.retired, 1);
+        assert_eq!(snapshot.idle, 1);
+    }
+
+    #[tokio::test]
+    async fn a_foreign_write_moves_to_a_fresh_handle_and_keeps_its_own_counters() {
+        let (_temp, pools) = pools(1, 0);
+        let setup = pools.shards[0].inner.storage.open_shard(0).unwrap();
+        setup
+            .execute_batch("CREATE TABLE widgets (id INTEGER PRIMARY KEY)")
+            .unwrap();
+        drop(setup);
+
+        let first_owner = ConnectionOwner::new(11);
+        let writer = ConnectionOwner::new(22);
+        let first = pools
+            .acquire_for_owner(0, first_owner)
+            .await
+            .unwrap()
+            .checkout()
+            .unwrap();
+        first.query_row("SELECT 1", [], |_| Ok(())).unwrap();
+        let first_id = first.connection_id();
+        drop(first);
+
+        let mut write = pools
+            .acquire_for_owner(0, writer)
+            .await
+            .unwrap()
+            .checkout()
+            .unwrap();
+        assert_eq!(write.connection_id(), first_id);
+        write
+            .isolate_foreign_sql("INSERT INTO widgets (id) VALUES (1)")
+            .unwrap();
+        let writer_id = write.connection_id();
+        assert_ne!(writer_id, first_id);
+        assert_eq!(
+            write
+                .execute("INSERT INTO widgets (id) VALUES (1)", [])
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            write
+                .query_row(
+                    "SELECT last_insert_rowid(), changes(), total_changes()",
+                    [],
+                    |row| Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, i64>(2)?
+                    )),
+                )
+                .unwrap(),
+            (1, 1, 1)
+        );
+        drop(write);
+
+        let writer_again = pools
+            .acquire_for_owner(0, writer)
+            .await
+            .unwrap()
+            .checkout()
+            .unwrap();
+        assert_eq!(writer_again.connection_id(), writer_id);
+        assert!(!writer_again.borrowed_from_other_owner);
+        assert_eq!(
+            writer_again
+                .query_row(
+                    "SELECT last_insert_rowid(), changes(), total_changes()",
+                    [],
+                    |row| Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, i64>(2)?
+                    )),
+                )
+                .unwrap(),
+            (1, 1, 1)
+        );
+        drop(writer_again);
+
+        let snapshot = pools.snapshot().unwrap().shards[0];
+        assert_eq!(snapshot.opened, 2);
+        assert_eq!(snapshot.checkouts, 3);
+        assert_eq!(snapshot.reused, 2);
+        assert_eq!(snapshot.retired, 1);
+        assert_eq!(snapshot.idle, 1);
+    }
+
+    #[tokio::test]
+    async fn connection_local_sql_on_a_foreign_read_handle_moves_to_a_fresh_connection() {
+        let (_temp, pools) = pools(2, 0);
+        let first_owner = ConnectionOwner::new(11);
+        let writer = ConnectionOwner::new(22);
+        let observer = ConnectionOwner::new(33);
+
+        let first = pools
+            .acquire_for_owner(0, first_owner)
+            .await
+            .unwrap()
+            .checkout()
+            .unwrap();
+        first.query_row("SELECT 1", [], |_| Ok(())).unwrap();
+        let first_id = first.connection_id();
+
+        let writer_connection = pools
+            .acquire_for_owner(0, writer)
+            .await
+            .unwrap()
+            .checkout()
+            .unwrap();
+        writer_connection
+            .execute_batch("CREATE TABLE data_version_marker (id INTEGER PRIMARY KEY)")
+            .unwrap();
+        drop(writer_connection);
+        drop(first);
+
+        let fresh_control = pools.shards[0].inner.storage.open_shard(0).unwrap();
+        let fresh_data_version = fresh_control
+            .query_row("PRAGMA data_version", [], |row| row.get::<_, i64>(0))
+            .unwrap();
+
+        let mut observed = pools
+            .acquire_for_owner(0, observer)
+            .await
+            .unwrap()
+            .checkout()
+            .unwrap();
+        assert_eq!(observed.connection_id(), first_id);
+        assert!(observed.borrowed_from_other_owner);
+
+        observed.isolate_foreign_sql("PRAGMA data_version").unwrap();
+        assert_ne!(observed.connection_id(), first_id);
+        assert!(!observed.borrowed_from_other_owner);
+        let data_version = observed
+            .query_row("PRAGMA data_version", [], |row| row.get::<_, i64>(0))
+            .unwrap();
+        assert_eq!(data_version, fresh_data_version);
+        drop(observed);
+
+        let snapshot = pools.snapshot().unwrap().shards[0];
+        assert_eq!(snapshot.opened, 3);
+        assert_eq!(snapshot.checkouts, 3);
+        assert_eq!(snapshot.reused, 1);
+        assert_eq!(snapshot.retired, 2);
+        assert_eq!(snapshot.idle, 1);
+    }
+
+    #[tokio::test]
+    async fn an_ordinary_foreign_read_never_claims_the_handles_local_history() {
+        let (_temp, pools) = pools(1, 0);
+        let first_owner = ConnectionOwner::new(11);
+        let second_owner = ConnectionOwner::new(22);
+
+        let first = pools
+            .acquire_for_owner(0, first_owner)
+            .await
+            .unwrap()
+            .checkout()
+            .unwrap();
+        first.query_row("SELECT 1", [], |_| Ok(())).unwrap();
+        let original_id = first.connection_id();
+        drop(first);
+
+        let mut ordinary_read = pools
+            .acquire_for_owner(0, second_owner)
+            .await
+            .unwrap()
+            .checkout()
+            .unwrap();
+        assert_eq!(ordinary_read.connection_id(), original_id);
+        assert!(ordinary_read.borrowed_from_other_owner);
+        ordinary_read.isolate_foreign_sql("SELECT 1").unwrap();
+        ordinary_read.query_row("SELECT 1", [], |_| Ok(())).unwrap();
+        drop(ordinary_read);
+
+        let mut local_observer = pools
+            .acquire_for_owner(0, second_owner)
+            .await
+            .unwrap()
+            .checkout()
+            .unwrap();
+        assert_eq!(local_observer.connection_id(), original_id);
+        assert!(local_observer.borrowed_from_other_owner);
+        local_observer
+            .isolate_foreign_sql("PRAGMA data_version")
+            .unwrap();
+        assert_ne!(local_observer.connection_id(), original_id);
+        local_observer
+            .query_row("PRAGMA data_version", [], |_| Ok(()))
+            .unwrap();
+        drop(local_observer);
+
+        let snapshot = pools.snapshot().unwrap().shards[0];
+        assert_eq!(snapshot.opened, 2);
+        assert_eq!(snapshot.checkouts, 3);
+        assert_eq!(snapshot.reused, 2);
+        assert_eq!(snapshot.retired, 2);
+        assert_eq!(snapshot.idle, 0);
+    }
+
+    #[tokio::test]
+    async fn authorizer_probe_denies_prepare_time_pragma_effects_until_real_execution() {
+        let (temp, pools) = pools(1, 0);
+        let first_owner = ConnectionOwner::new(11);
+        let second_owner = ConnectionOwner::new(22);
+
+        let first = pools
+            .acquire_for_owner(0, first_owner)
+            .await
+            .unwrap()
+            .checkout()
+            .unwrap();
+        first.query_row("SELECT 1", [], |_| Ok(())).unwrap();
+        drop(first);
+
+        let control = Connection::open(temp.path().join("shards/0000.sqlite")).unwrap();
+        assert_eq!(
+            control
+                .query_row("PRAGMA user_version", [], |row| row.get::<_, i64>(0))
+                .unwrap(),
+            0
+        );
+
+        let mut second = pools
+            .acquire_for_owner(0, second_owner)
+            .await
+            .unwrap()
+            .checkout()
+            .unwrap();
+        second
+            .isolate_foreign_sql("PRAGMA user_version = 7")
+            .unwrap();
+        assert_eq!(
+            control
+                .query_row("PRAGMA user_version", [], |row| row.get::<_, i64>(0))
+                .unwrap(),
+            0,
+            "the authorizer probe must deny the PRAGMA before any prepare-time effect"
+        );
+
+        second.execute_batch("PRAGMA user_version = 7").unwrap();
+        assert_eq!(
+            control
+                .query_row("PRAGMA user_version", [], |row| row.get::<_, i64>(0))
+                .unwrap(),
+            7
+        );
+        drop(second);
+
+        let snapshot = pools.snapshot().unwrap().shards[0];
+        assert_eq!(snapshot.opened, 2);
+        assert_eq!(snapshot.retired, 2);
+        assert_eq!(snapshot.idle, 0);
+    }
+
+    #[tokio::test]
+    async fn every_probe_error_fails_closed_to_a_fresh_handle() {
+        let (_temp, pools) = pools(1, 0);
+        let first_owner = ConnectionOwner::new(11);
+        let second_owner = ConnectionOwner::new(22);
+
+        let first = pools
+            .acquire_for_owner(0, first_owner)
+            .await
+            .unwrap()
+            .checkout()
+            .unwrap();
+        first.query_row("SELECT 1", [], |_| Ok(())).unwrap();
+        let first_id = first.connection_id();
+        drop(first);
+
+        let mut second = pools
+            .acquire_for_owner(0, second_owner)
+            .await
+            .unwrap()
+            .checkout()
+            .unwrap();
+        assert_eq!(second.connection_id(), first_id);
+        second.isolate_foreign_sql("this is not valid SQL").unwrap();
+        assert_ne!(second.connection_id(), first_id);
+        assert!(second.prepare("this is not valid SQL").is_err());
+        drop(second);
+
+        let snapshot = pools.snapshot().unwrap().shards[0];
+        assert_eq!(snapshot.opened, 2);
+        assert_eq!(snapshot.reused, 1);
+        assert_eq!(snapshot.retired, 1);
+        assert_eq!(snapshot.idle, 1);
+    }
+
+    #[tokio::test]
+    async fn failed_fresh_replacement_preserves_storage_error_and_recovers_capacity() {
+        let (temp, pools) = pools(1, 0);
+        let first_owner = ConnectionOwner::new(11);
+        let second_owner = ConnectionOwner::new(22);
+
+        let first = pools
+            .acquire_for_owner(0, first_owner)
+            .await
+            .unwrap()
+            .checkout()
+            .unwrap();
+        first.query_row("SELECT 1", [], |_| Ok(())).unwrap();
+        drop(first);
+
+        let shard_path = temp.path().join("shards/0000.sqlite");
+        let backup_path = temp.path().join("shards/0000.sqlite.backup");
+        fs::rename(&shard_path, &backup_path).unwrap();
+        fs::create_dir(&shard_path).unwrap();
+
+        let mut second = pools
+            .acquire_for_owner(0, second_owner)
+            .await
+            .unwrap()
+            .checkout()
+            .unwrap();
+        let error = second
+            .isolate_foreign_sql("PRAGMA data_version")
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::StorageUnavailable);
+        drop(second);
+
+        let failed = pools.snapshot().unwrap().shards[0];
+        assert_eq!(failed.active, 0);
+        assert_eq!(failed.queued, 0);
+        assert_eq!(failed.idle, 0);
+        assert_eq!(failed.opened, 1);
+        assert_eq!(failed.retired, 1);
+
+        fs::remove_dir(&shard_path).unwrap();
+        fs::rename(&backup_path, &shard_path).unwrap();
+
+        let recovered = pools
+            .acquire_for_owner(0, second_owner)
+            .await
+            .unwrap()
+            .checkout()
+            .unwrap();
+        recovered.query_row("SELECT 1", [], |_| Ok(())).unwrap();
+        drop(recovered);
+
+        let recovered = pools.snapshot().unwrap().shards[0];
+        assert_eq!(recovered.active, 0);
+        assert_eq!(recovered.queued, 0);
+        assert_eq!(recovered.idle, 1);
+        assert_eq!(recovered.opened, 2);
+        assert_eq!(recovered.retired, 1);
+    }
+
+    #[tokio::test]
+    async fn ordinary_sql_errors_return_a_clean_connection_to_the_pool() {
+        let (_temp, pools) = pools(1, 0);
+        let connection = pools.acquire(0).await.unwrap().checkout().unwrap();
+        connection
+            .execute_batch("CREATE TABLE widgets (id INTEGER PRIMARY KEY)")
+            .unwrap();
+        connection
+            .execute("INSERT INTO widgets (id) VALUES (1)", [])
+            .unwrap();
+        let original_id = connection.connection_id();
+        let error = connection
+            .execute("INSERT INTO widgets (id) VALUES (1)", [])
+            .unwrap_err();
+        assert_eq!(
+            error.sqlite_error_code(),
+            Some(rusqlite::ErrorCode::ConstraintViolation)
+        );
+        drop(connection);
+
+        let replacement = pools.acquire(0).await.unwrap().checkout().unwrap();
+        assert_eq!(replacement.connection_id(), original_id);
+        drop(replacement);
+        let snapshot = pools.snapshot().unwrap().shards[0];
+        assert_eq!(snapshot.opened, 1);
+        assert_eq!(snapshot.reused, 1);
+        assert_eq!(snapshot.retired, 0);
+    }
+
+    #[tokio::test]
+    async fn non_autocommit_state_is_rolled_back_before_a_tainted_connection_retires() {
+        let (_temp, pools) = pools(1, 0);
+        let connection = pools.acquire(0).await.unwrap().checkout().unwrap();
+        connection
+            .execute_batch("CREATE TABLE widgets (id INTEGER PRIMARY KEY)")
+            .unwrap();
+        let original_id = connection.connection_id();
+        drop(connection);
+
+        let connection = pools.acquire(0).await.unwrap().checkout().unwrap();
+        assert_eq!(connection.connection_id(), original_id);
+        connection
+            .execute_batch("BEGIN; INSERT INTO widgets (id) VALUES (1)")
+            .unwrap();
+        assert!(!connection.is_autocommit());
+        drop(connection);
+
+        let replacement = pools.acquire(0).await.unwrap().checkout().unwrap();
+        assert_ne!(replacement.connection_id(), original_id);
+        assert_eq!(
+            replacement
+                .query_row("SELECT COUNT(*) FROM widgets", [], |row| row
+                    .get::<_, i64>(0))
+                .unwrap(),
+            0
+        );
+        drop(replacement);
+        let snapshot = pools.snapshot().unwrap().shards[0];
+        assert_eq!(snapshot.opened, 2);
+        assert_eq!(snapshot.retired, 1);
+    }
+
+    #[test]
+    fn authorizer_taints_every_connection_local_or_unknown_action() {
+        let actions = [
+            AuthAction::Unknown {
+                code: -1,
+                arg1: None,
+                arg2: None,
+            },
+            AuthAction::CreateTempIndex {
+                index_name: "i",
+                table_name: "t",
+            },
+            AuthAction::CreateTempTable { table_name: "t" },
+            AuthAction::CreateTempTrigger {
+                trigger_name: "tr",
+                table_name: "t",
+            },
+            AuthAction::CreateTempView { view_name: "v" },
+            AuthAction::DropTempIndex {
+                index_name: "i",
+                table_name: "t",
+            },
+            AuthAction::DropTempTable { table_name: "t" },
+            AuthAction::DropTempTrigger {
+                trigger_name: "tr",
+                table_name: "t",
+            },
+            AuthAction::DropTempView { view_name: "v" },
+            AuthAction::Pragma {
+                pragma_name: "cache_size",
+                pragma_value: None,
+            },
+            AuthAction::Transaction {
+                operation: TransactionOperation::Begin,
+            },
+            AuthAction::Attach {
+                filename: "other.sqlite",
+            },
+            AuthAction::Detach {
+                database_name: "other",
+            },
+            AuthAction::CreateVtable {
+                table_name: "vt",
+                module_name: "module",
+            },
+            AuthAction::DropVtable {
+                table_name: "vt",
+                module_name: "module",
+            },
+            AuthAction::Savepoint {
+                operation: TransactionOperation::Begin,
+                savepoint_name: "s",
+            },
+        ];
+
+        assert!(actions.into_iter().all(action_taints_connection));
+        assert!(!action_taints_connection(AuthAction::Select));
+        assert!(!action_taints_connection(AuthAction::Insert {
+            table_name: "widgets"
+        }));
+        assert!(action_writes_connection(AuthAction::Insert {
+            table_name: "widgets"
+        }));
+        assert!(action_writes_connection(AuthAction::Update {
+            table_name: "widgets",
+            column_name: "value",
+        }));
+        assert!(action_writes_connection(AuthAction::Delete {
+            table_name: "widgets"
+        }));
+        assert!(!action_writes_connection(AuthAction::Select));
+    }
+
+    #[tokio::test]
+    async fn table_valued_data_version_uses_the_same_connection_local_authorizer_boundary() {
+        let (_temp, pools) = pools(1, 0);
+        let connection = pools.acquire(0).await.unwrap().checkout().unwrap();
+        connection
+            .query_row("SELECT * FROM pragma_data_version", [], |row| {
+                row.get::<_, i64>(0)
+            })
+            .unwrap();
+        assert!(
+            connection
+                .managed
+                .as_ref()
+                .unwrap()
+                .hygiene
+                .tainted
+                .load(Ordering::Relaxed)
+        );
+    }
+
+    #[tokio::test]
+    async fn stateful_sql_runs_normally_for_one_lease_then_retires_the_connection() {
+        let (_temp, pools) = pools(1, 0);
+        let connection = pools.acquire(0).await.unwrap().checkout().unwrap();
+        let id = connection.connection_id();
+        assert_eq!(
+            connection
+                .query_row("PRAGMA busy_timeout", [], |row| row.get::<_, i64>(0))
+                .unwrap(),
+            5_000
+        );
+        drop(connection);
+
+        let replacement = pools.acquire(0).await.unwrap().checkout().unwrap();
+        assert_ne!(replacement.connection_id(), id);
+        drop(replacement);
+        assert_eq!(pools.snapshot().unwrap().shards[0].retired, 1);
+    }
+
+    #[tokio::test]
+    async fn every_new_pooled_connection_has_the_storage_pragmas() {
+        let (_temp, pools) = pools(1, 0);
+        let connection = pools.acquire(0).await.unwrap().checkout().unwrap();
+
+        assert_eq!(
+            connection
+                .query_row("PRAGMA journal_mode", [], |row| row.get::<_, String>(0))
+                .unwrap(),
+            "wal"
+        );
+        assert_eq!(
+            connection
+                .query_row("PRAGMA synchronous", [], |row| row.get::<_, i64>(0))
+                .unwrap(),
+            2
+        );
+        assert_eq!(
+            connection
+                .query_row("PRAGMA foreign_keys", [], |row| row.get::<_, i64>(0))
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            connection
+                .query_row("PRAGMA busy_timeout", [], |row| row.get::<_, i64>(0))
+                .unwrap(),
+            5_000
+        );
+    }
+
+    #[tokio::test]
+    async fn explicit_broken_and_panicking_connections_are_discarded() {
+        let (_temp, pools) = pools(1, 0);
+        let mut broken = pools.acquire(0).await.unwrap().checkout().unwrap();
+        let broken_id = broken.connection_id();
+        broken.mark_broken();
+        drop(broken);
+
+        let permit = pools.acquire(0).await.unwrap();
+        let panicking_id = Arc::new(AtomicU64::new(0));
+        let observed_id = Arc::clone(&panicking_id);
+        let panic = catch_unwind(AssertUnwindSafe(|| {
+            let connection = permit.checkout().unwrap();
+            observed_id.store(connection.connection_id(), Ordering::Relaxed);
+            panic!("intentional pooled worker panic");
+        }));
+        assert!(panic.is_err());
+
+        let replacement = pools.acquire(0).await.unwrap().checkout().unwrap();
+        assert_ne!(replacement.connection_id(), broken_id);
+        assert_ne!(
+            replacement.connection_id(),
+            panicking_id.load(Ordering::Relaxed)
+        );
+        drop(replacement);
+        let snapshot = pools.snapshot().unwrap().shards[0];
+        assert_eq!(snapshot.retired, 2);
+        assert_eq!(snapshot.opened, 3);
+    }
+
+    #[tokio::test]
+    async fn acquire_all_reserves_one_permit_for_each_shard() {
+        let (_temp, pools) = pools(1, 0);
+        let permits = pools.acquire_all().await.unwrap();
+        assert_eq!(
+            permits.iter().map(|(shard, _)| *shard).collect::<Vec<_>>(),
+            [0, 1]
+        );
+        assert_eq!(pools.snapshot().unwrap().shards[0].active, 1);
+        assert_eq!(pools.snapshot().unwrap().shards[1].active, 1);
+        drop(permits);
+        wait_for_occupancy(&pools, 0, 0, 0).await;
+        wait_for_occupancy(&pools, 1, 0, 0).await;
+    }
+}

--- a/tests/benchmark_workloads.rs
+++ b/tests/benchmark_workloads.rs
@@ -2,7 +2,9 @@
 mod support;
 
 use briskdb::core::{Column, DataType, Row, Value};
-use support::{BENCHMARK_SHARDS, BenchmarkFixture};
+use support::{
+    BENCHMARK_SHARDS, BenchmarkFixture, EngineBenchmarkFixture, engine_benchmark_runtime,
+};
 
 #[test]
 fn point_read_returns_the_seeded_row() {
@@ -56,5 +58,69 @@ fn concurrent_write_wave_updates_one_key_on_every_shard() {
 
     for shard in 0..BENCHMARK_SHARDS as usize {
         assert_eq!(fixture.write_count(shard).unwrap(), 2);
+    }
+}
+
+#[test]
+fn engine_point_read_returns_the_seeded_row_through_the_default_pool() {
+    let runtime = engine_benchmark_runtime().unwrap();
+    let fixture = EngineBenchmarkFixture::new(&runtime).unwrap();
+    let storage_fixture = BenchmarkFixture::new().unwrap();
+
+    assert_eq!(fixture.keys_by_shard(), storage_fixture.keys_by_shard());
+    let result = runtime.block_on(fixture.point_read()).unwrap();
+
+    assert_eq!(
+        result.columns(),
+        vec![
+            Column::new("id", DataType::Unknown),
+            Column::new("writes", DataType::Unknown),
+            Column::new("payload", DataType::Unknown),
+        ]
+    );
+    assert_eq!(
+        result.rows(),
+        vec![Row::new(vec![
+            Value::from(fixture.keys_by_shard()[0].clone()),
+            Value::from(0_i64),
+            Value::from("baseline payload"),
+        ])]
+    );
+}
+
+#[test]
+fn engine_point_write_reuses_the_fixture_and_updates_exactly_one_row() {
+    let runtime = engine_benchmark_runtime().unwrap();
+    let fixture = EngineBenchmarkFixture::new(&runtime).unwrap();
+
+    assert_eq!(runtime.block_on(fixture.point_write()).unwrap(), 1);
+    assert_eq!(runtime.block_on(fixture.point_write()).unwrap(), 1);
+
+    assert_eq!(runtime.block_on(fixture.write_count(0)).unwrap(), 2);
+}
+
+#[test]
+fn engine_concurrent_write_wave_updates_one_key_on_every_shard() {
+    let runtime = engine_benchmark_runtime().unwrap();
+    let fixture = EngineBenchmarkFixture::new(&runtime).unwrap();
+    for (shard, key) in fixture.keys_by_shard().iter().enumerate() {
+        assert_eq!(usize::from(fixture.shard_for_key(key)), shard);
+    }
+
+    assert_eq!(
+        runtime
+            .block_on(fixture.four_shard_concurrent_write_wave())
+            .unwrap(),
+        [1; BENCHMARK_SHARDS as usize]
+    );
+    assert_eq!(
+        runtime
+            .block_on(fixture.four_shard_concurrent_write_wave())
+            .unwrap(),
+        [1; BENCHMARK_SHARDS as usize]
+    );
+
+    for shard in 0..BENCHMARK_SHARDS as usize {
+        assert_eq!(runtime.block_on(fixture.write_count(shard)).unwrap(), 2);
     }
 }

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -4,7 +4,7 @@ use axum::Router;
 use briskdb::{
     api, core,
     protocol::{error, http},
-    storage,
+    server, storage,
 };
 
 #[test]
@@ -13,6 +13,7 @@ fn legacy_and_explicit_module_paths_are_both_available() {
     let _core_database: Option<core::Database> = None;
     let _engine: Option<core::Engine> = None;
     let _engine_status: Option<core::EngineStatus> = None;
+    let _engine_options: core::EngineOptions = core::EngineOptions::default();
     let _session: Option<core::Session> = None;
     let _ready = core::SessionState::Ready;
     let _closed = core::SessionState::Closed;
@@ -20,6 +21,8 @@ fn legacy_and_explicit_module_paths_are_both_available() {
     let _legacy_router: fn(Arc<storage::Database>) -> Router = api::router;
     let _http_router: fn(Arc<core::Database>) -> Router = http::router;
     let _engine_router: fn(core::Engine) -> Router = http::router_with_engine;
+    let _default_server_entry_point = server::run;
+    let _configured_server_entry_point = server::run_with_engine_options;
 
     let result = core::ResultSet::new(
         vec![core::Column::new("value", core::DataType::Int64)],
@@ -49,13 +52,85 @@ fn legacy_and_explicit_module_paths_are_both_available() {
     );
 }
 
+#[test]
+fn engine_options_are_public_validated_and_have_stable_defaults() {
+    let defaults = core::EngineOptions::default();
+    assert_eq!(
+        defaults.connections_per_shard(),
+        core::DEFAULT_CONNECTIONS_PER_SHARD
+    );
+    assert_eq!(
+        defaults.queue_capacity_per_shard(),
+        core::DEFAULT_QUEUE_CAPACITY_PER_SHARD
+    );
+
+    let minimum = core::EngineOptions::new(1, 1).unwrap();
+    assert_eq!(minimum.connections_per_shard(), 1);
+    assert_eq!(minimum.queue_capacity_per_shard(), 1);
+
+    let maximum = core::EngineOptions::new(
+        core::MAX_CONNECTIONS_PER_SHARD,
+        core::MAX_QUEUE_CAPACITY_PER_SHARD,
+    )
+    .unwrap();
+    assert_eq!(
+        maximum.connections_per_shard(),
+        core::MAX_CONNECTIONS_PER_SHARD
+    );
+    assert_eq!(
+        maximum.queue_capacity_per_shard(),
+        core::MAX_QUEUE_CAPACITY_PER_SHARD
+    );
+
+    for (connections, queue_capacity) in [
+        (0, 1),
+        (core::MAX_CONNECTIONS_PER_SHARD + 1, 1),
+        (1, 0),
+        (1, core::MAX_QUEUE_CAPACITY_PER_SHARD + 1),
+    ] {
+        assert_eq!(
+            core::EngineOptions::new(connections, queue_capacity)
+                .unwrap_err()
+                .kind(),
+            core::EngineErrorKind::InvalidArgument
+        );
+    }
+}
+
 #[tokio::test]
 async fn protocol_neutral_async_engine_surface_is_available() {
     let temp = tempfile::tempdir().unwrap();
-    let engine = core::Engine::open(temp.path(), 4).await.unwrap();
+    let options = core::EngineOptions::new(2, 7).unwrap();
+    let engine = core::Engine::open_with_options(temp.path(), 4, options)
+        .await
+        .unwrap();
     let session: core::Session = engine.session();
 
     assert_eq!(session.state().await, core::SessionState::Ready);
+    assert_eq!(engine.options(), options);
     let status: core::EngineStatus = engine.status(&session).await.unwrap();
     assert_eq!(status.shard_count(), 4);
+    assert_eq!(status.max_blocking_workers(), 8);
+    assert_eq!(status.connections_per_shard(), 2);
+    assert_eq!(status.queue_capacity_per_shard(), 7);
+}
+
+#[tokio::test]
+async fn default_and_wrapped_database_engine_constructors_remain_available() {
+    let default_temp = tempfile::tempdir().unwrap();
+    let default_engine = core::Engine::open(default_temp.path(), 2).await.unwrap();
+    assert_eq!(default_engine.options(), core::EngineOptions::default());
+
+    let wrapped_temp = tempfile::tempdir().unwrap();
+    let database = Arc::new(core::Database::open(wrapped_temp.path(), 4).unwrap());
+    let options = core::EngineOptions::new(3, 11).unwrap();
+    let wrapped = core::Engine::from_database_with_options(database, options).unwrap();
+    let session = wrapped.session();
+    let status = wrapped.status(&session).await.unwrap();
+
+    assert_eq!(wrapped.options(), options);
+    assert_eq!(status.shard_count(), 4);
+    assert_eq!(status.max_blocking_workers(), 12);
+    assert_eq!(status.connections_per_shard(), 3);
+    assert_eq!(status.queue_capacity_per_shard(), 11);
 }


### PR DESCRIPTION
## Summary

- move all async-engine SQLite work behind a bounded blocking-worker boundary
- add lazy independent per-shard connection pools with exact active/queue limits, retryable backpressure, deterministic broadcast admission, and public `EngineOptions`
- preserve cross-session isolation for SQLite-local state through authorizer hygiene, immutable physical-handle provenance, deny-only fail-closed probes, fresh cross-owner writes, and broken/tainted connection retirement
- expose validated CLI/environment pool limits without changing existing constructors, HTTP routes, JSON shapes, routing, or storage format
- extend the storage benchmark controls with equivalent pooled-engine read, write, and four-shard concurrent-write workloads

## Safety and recovery coverage

- exact active and queue boundaries, hot-shard isolation, cancellation before dispatch, in-flight abort behavior, worker panics, queue recovery, and permit recovery
- ordered concurrent broadcasts, broadcast abort after dispatch, partial broadcast failure, and multi-statement broadcast execution exactly once
- transaction rollback/retirement, stateful SQL retirement, storage-open failure recovery, broken connections, and replacement-open failure recovery
- cross-session tests for temporary state, write counters, `PRAGMA data_version`, table-valued PRAGMAs, ordinary-read handoff, fail-closed probe errors, and fresh cross-owner writes
- protocol-boundary guard proving the HTTP adapter has no pool, worker, routing, or SQLite escape hatch

## Validation

- `cargo +stable fmt --all -- --check`
- `cargo +stable test --locked --all-targets --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo +stable doc --locked --no-deps --document-private-items --all-features`
- `cargo +stable clippy --locked --all-targets --all-features -- -D warnings`
- the same complete gate on Rust 1.85.0
- 122 library tests, 6 CLI tests, 6 benchmark-workload tests, 4 public API tests, and all 6 Criterion smoke workloads
- strengthened isolation/concurrency regressions stress-run 20 times each
- three independent final reviews: storage, concurrency, and public API/documentation

## Benchmark comparison

The final benchmark harness was run byte-for-byte against unpooled main `1c0f9ab` on the same host and toolchain. Default pooled-engine median elapsed time improved by 97.28% for point reads, 93.03% for point writes, and 93.30% for four-shard concurrent writes; all three Criterion comparisons were statistically significant (`p < 0.05`). Full methodology and hardware-specific results are documented in `docs/BENCHMARKS.md`.

Closes #10
