### PR TITLE
Add core request controls and graceful shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,6 +178,8 @@ dependencies = [
  "blake3",
  "clap",
  "criterion",
+ "hyper",
+ "hyper-util",
  "rusqlite",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,17 +12,19 @@ anyhow = "1.0"
 axum = "0.8.9"
 blake3 = "1.8"
 clap = { version = "4.6.6", features = ["derive", "env"] }
+hyper = { version = "1.11", features = ["http1", "server"] }
+hyper-util = { version = "0.1.20", features = ["service", "tokio"] }
 rusqlite = { version = "0.39.0", features = ["bundled", "hooks"] }
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.53.1", features = ["full"] }
+tower = { version = "0.5", features = ["util"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 
 [dev-dependencies]
 criterion = { version = "0.7", default-features = false }
 tempfile = "3.23"
-tower = { version = "0.5", features = ["util"] }
 
 [[bench]]
 name = "storage"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ current SQLite pass-through API from planned PostgreSQL and MySQL compatibility.
 The [error contract](docs/ERRORS.md) defines stable engine error kinds, safe
 HTTP problem details, and the mappings reserved for future PostgreSQL and MySQL
 adapters.
+The [request-control contract](docs/REQUEST_CONTROLS.md) defines cancellation,
+deadlines, materialized-result budgets, and graceful shutdown.
 Contributions follow the repository's [test-first completion policy](CONTRIBUTING.md).
 The [benchmark baseline](docs/BENCHMARKS.md) defines the reproducible storage
 workloads used to measure the current prototype.
@@ -32,6 +34,9 @@ minimum supported Rust version (MSRV) and the latest stable toolchain.
 - Stable BLAKE3 routing from a caller-provided shard key
 - A protocol-neutral async engine with per-request HTTP sessions
 - Bounded, lazy per-shard SQLite connection pools with explicit backpressure
+- Request cancellation and deadlines that interrupt SQLite and await cleanup
+- Finite per-query row/logical-byte budgets with no partial results
+- Explicit graceful drain, forced cancellation, and blocking handle cleanup
 - Protocol-neutral typed values, ordered columns, positional rows, and results
 - A fixed shard count recorded in `manifest.sqlite`
 - One WAL-enabled SQLite database per shard
@@ -67,6 +72,18 @@ active connections and 32 queued operations per shard. Server deployments can
 override them with `--connections-per-shard` /
 `BRISKDB_CONNECTIONS_PER_SHARD` and `--queue-capacity-per-shard` /
 `BRISKDB_QUEUE_CAPACITY_PER_SHARD`.
+
+Queries default to 10,000 rows and 16 MiB of protocol-neutral logical result
+data. Configure these with `--max-result-rows` / `BRISKDB_MAX_RESULT_ROWS` and
+`--max-result-bytes` / `BRISKDB_MAX_RESULT_BYTES`. Requests default to a
+30-second engine deadline; use `--request-timeout-ms` /
+`BRISKDB_REQUEST_TIMEOUT_MS`, where zero disables that default. Graceful
+shutdown allows 30 seconds before cancelling admitted work and is configured by
+`--shutdown-grace-ms` / `BRISKDB_SHUTDOWN_GRACE_MS`. Ctrl-C and, on Unix,
+SIGTERM stop new admissions, drain or cancel admitted SQLite work, close idle
+handles, and then stop the process. Accepted HTTP connections are tracked;
+connections that outlive the grace window are force-closed and joined before
+the server returns.
 
 Create a table on every shard:
 
@@ -139,18 +156,22 @@ A handle that performed an ordinary write may return to the same session,
 preserving SQLite write counters, but is replaced before a different session can
 observe `last_insert_rowid()`, `changes()`, or `total_changes()`. Those functions
 remain uncontracted across calls until sessions gain connection pinning.
-Dropping queued work skips it before SQLite starts; dropping in-flight work does
-not yet cancel it, and it may still commit.
-Cancellation, deadlines, limits, and graceful shutdown remain roadmap work.
+Dropping queued work skips it before SQLite starts. Dropping in-flight work
+interrupts its exact leased handle and retains lifecycle, worker, pool, and
+session permits until SQLite cleanup finishes. Explicit cancellation behaves
+the same way. A near-complete statement may still win the race and return
+success; BriskDB never reports cancellation while a known running write might
+still commit.
+Queries have finite row and logical-byte budgets, account values before cloning
+payloads, and return no partial result on `LimitExceeded`.
 Broadcast changes and future scatter operations are not atomic across shard
 files. The shard count is immutable after database creation, so resharding will
 require an explicit migration workflow. Pooling does not change the manifest
-schema, shard files, or stored-data format. Until graceful pool draining lands
-in issue #11, dropping the final `Engine` may close idle SQLite handles
-synchronously on the dropping thread; server operation dispatch itself remains
-behind the bounded worker boundary.
+schema, shard files, or stored-data format. Embedders should call
+`Engine::shutdown`; merely dropping the final `Engine` is not the explicit
+asynchronous cleanup contract.
 
-Near-term work includes authentication, cancellation, schema migrations,
+Near-term work includes authentication, schema migrations,
 scatter/gather reads, observability, backup tooling, and failure-injection
 tests for multi-shard operations.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -160,7 +160,7 @@ and non-promises are written down.
 
 ### 1. Protocol-neutral core
 
-Status: **in progress**
+Status: **complete**
 
 - [x] Split the crate into `core`, `storage`, `sql`, `protocol/http`, and
   `server` modules without changing externally visible behavior.
@@ -173,7 +173,7 @@ Status: **in progress**
   by every frontend.
 - [x] Move blocking SQLite work behind a bounded worker/pool abstraction; add
   per-shard connection pools and backpressure.
-- [ ] Add cancellation, request deadlines, result row/byte limits, and graceful
+- [x] Add cancellation, request deadlines, result row/byte limits, and graceful
   shutdown hooks to the core interface.
 
 Exit criterion: the HTTP adapter contains no routing or SQLite logic and all

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,7 +26,7 @@ server ---------> protocol::http
 | `sql` | SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, routing, filesystem layout, or protocol responses |
 | `protocol::http` | HTTP request extraction plus JSON/BriskDB value and RFC 9457 problem-detail encoding | BLAKE3 routing, shard files, or rusqlite calls |
 | `protocol::error` | Exhaustive HTTP, PostgreSQL, and MySQL mappings from stable engine error kinds | SQLite errors, routing decisions, or wire-protocol session state |
-| `server` | Process configuration, database assembly, listener binding, and Axum lifecycle | SQL parsing or storage implementation details |
+| `server` | Process configuration, database assembly, listener binding, and tracked Axum HTTP/1 connection lifecycle | SQL parsing or storage implementation details |
 
 Implementation dependencies flow one way: adapters call the async `Engine` in
 `core`; the engine coordinates routing, `storage`, and `sql`. An adapter supplies
@@ -66,11 +66,11 @@ engine. Unit tests remain colocated with sessions, engine orchestration,
 routing, storage, SQL conversion, CLI, and server assembly.
 
 The module names are stable boundaries, not a claim that later roadmap work is
-already complete. The async engine and initial session lifecycle are now in
-place, including bounded per-shard connection pools. Cancellation, deadlines,
-limits, and graceful shutdown are separate work. The synchronous `Database` API
-remains available as a Rust compatibility surface; existing engine and server
-entry points retain their signatures and default behavior.
+already complete. The async engine, session lifecycle, bounded per-shard pools,
+request controls, and explicit shutdown lifecycle are now in place. The
+synchronous `Database` API remains available as a Rust compatibility surface;
+existing engine and server entry points retain their signatures and delegate to
+the controlled defaults.
 
 ## Session and asynchronous engine boundary
 
@@ -112,6 +112,11 @@ constructors and server assembly use the defaults, so their APIs and behavior
 remain compatible. Server configuration exposes
 `--connections-per-shard` / `BRISKDB_CONNECTIONS_PER_SHARD` and
 `--queue-capacity-per-shard` / `BRISKDB_QUEUE_CAPACITY_PER_SHARD`.
+The same options boundary carries finite result rows/bytes, the optional
+engine-wide request timeout, and the shutdown grace period. The binary exposes
+them as `--max-result-rows`, `--max-result-bytes`,
+`--request-timeout-ms`, and `--shutdown-grace-ms` with corresponding
+`BRISKDB_*` environment variables.
 
 When a shard has no active slot and its admission queue is full, a new operation
 fails immediately with retryable `Busy`, which the HTTP adapter maps to 503.
@@ -158,17 +163,44 @@ This ownership is a leakage-prevention rule, not connection pinning: a competing
 session can replace an idle write-bearing handle, so write-counter functions
 remain uncontracted across calls until transaction/session pinning is added.
 
-Dropping an engine future while it is still queued removes that work before it
-starts. Once work is running on a blocking worker, dropping the future does not
-interrupt SQLite; the operation may still commit after its frontend disconnects.
-Issue #11 owns in-flight cancellation, deadlines, result limits, and graceful
-shutdown. In particular, implicit Rust destruction is not yet an asynchronous
-shutdown operation: dropping the final `Engine` may close idle SQLite handles
-synchronously on the dropping thread. Issue #11 will add an explicit bounded
-drain path. Real multi-call `BEGIN`/`COMMIT`/`ROLLBACK`, failed-transaction
-state, and single-shard pinning remain deferred to the PostgreSQL and MySQL
-transaction work in issues #34 and #47. `Ready` and `Closed` therefore describe
-session lifecycle, not SQL transaction state.
+Every operation acquires a lifecycle lease before its first await. Dropping a
+queued future removes the operation before SQLite starts. Once work is running,
+the future's drop guard interrupts the exact leased SQLite handle; the blocking
+closure retains lifecycle, worker, pool, and session permits until rollback and
+connection cleanup really finish. The lease-scoped progress callback and
+interrupt handle are removed before check-in, and interrupted connections are
+retired, preventing a late signal from affecting the next request.
+
+`RequestContext` supplies a sticky cancellation token, an optional absolute
+deadline, and optional narrower result limits. The engine default deadline and
+result budget are owned by `EngineOptions`, so protocol adapters contain no
+SQLite control policy. Queries account a stable logical result representation
+while stepping SQLite and before cloning payloads. A row or byte overflow
+returns no partial `ResultSet`; query statements must be read-only so early
+termination cannot hide DML `RETURNING` effects. The exact accounting contract
+is documented in [request controls](REQUEST_CONTROLS.md).
+
+All engine clones share one mutex-protected lifecycle. The mutex makes the
+`Running` admission check and active-operation increment atomic with
+`begin_shutdown()` changing the state to `Draining`. New work then receives
+`ShuttingDown`; admitted leases drain. After the grace period, shutdown cancels
+the admitted set and still waits for blocking cleanup before closing idle
+SQLite handles on a worker and marking `Stopped`. A timed-out cleanup remains
+`Draining` and can be resumed. Ordinary clone destruction does not initiate
+this explicit asynchronous path.
+
+The server owns accepted HTTP/1 connections in a tracked task set. It stops
+engine admission before dropping the listener, starts HTTP and core draining
+together, and aborts then joins any connection that exceeds the HTTP grace
+deadline. Signal receivers are installed before readiness is logged. Dropping
+the server future aborts its tracked connection set and synchronously enters
+`Draining`; a surviving embedder-owned `Engine` clone can resume asynchronous
+cleanup with `shutdown()`.
+
+Real multi-call `BEGIN`/`COMMIT`/`ROLLBACK`, failed-transaction state, and
+single-shard pinning remain deferred to the PostgreSQL and MySQL transaction
+work in issues #34 and #47. `Ready` and `Closed` therefore describe session
+lifecycle, not SQL transaction state.
 
 This boundary changes Rust orchestration and adds opt-in `EngineOptions` plus
 pool-sizing CLI/environment configuration. It does not change existing option

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -29,7 +29,9 @@ the human-readable text to identify an error.
 | <a id="read-only"></a>`ReadOnly` | `read_only` | 403 | Read-only storage | The storage is read-only. | `25006` | 1290 | `HY000` | No |
 | <a id="busy"></a>`Busy` | `busy` | 503 | Database busy | The database is busy; retry the operation later. | `55P03` | 1205 | `HY000` | Yes |
 | <a id="cancelled"></a>`Cancelled` | `cancelled` | 500 | Request cancelled | The operation was cancelled. | `57014` | 1317 | `70100` | No |
+| <a id="deadline-exceeded"></a>`DeadlineExceeded` | `deadline_exceeded` | 504 | Request deadline exceeded | The operation exceeded its request deadline. | `57014` | 3024 | `HY000` | No |
 | <a id="limit-exceeded"></a>`LimitExceeded` | `limit_exceeded` | 422 | Limit exceeded | The request exceeds an engine limit. | `54000` | 1105 | `HY000` | No |
+| <a id="shutting-down"></a>`ShuttingDown` | `shutting_down` | 503 | Server shutting down | The server is shutting down and cannot accept the operation. | `57P01` | 1053 | `08S01` | No |
 | <a id="storage-full"></a>`StorageFull` | `storage_full` | 507 | Storage full | The storage has no available space. | `53100` | 1114 | `HY000` | No |
 | <a id="out-of-memory"></a>`OutOfMemory` | `out_of_memory` | 503 | Out of memory | The engine does not have enough memory. | `53200` | 1037 | `HY001` | No |
 | <a id="storage-unavailable"></a>`StorageUnavailable` | `storage_unavailable` | 503 | Storage unavailable | The storage is unavailable. | `58030` | 1105 | `HY000` | No |
@@ -41,7 +43,9 @@ backoff and jitter. No other HTTP status, SQLSTATE, or MySQL error number
 implies retryability in BriskDB; notably, `OutOfMemory` and
 `StorageUnavailable` also use HTTP 503 but are not retryable under this
 contract. Storage-open and I/O failures can be permanent, so BriskDB does not
-guess that a later attempt will recover.
+guess that a later attempt will recover. `ShuttingDown` is also conservative:
+retrying the same draining process cannot make progress, although a caller may
+choose to reconnect to another server or wait for a replacement to start.
 
 Bounded-pool admission uses the existing `Busy` kind; it does not add a separate
 overload error. An operation receives `Busy` when its target shard has all
@@ -53,12 +57,14 @@ their selected pool; broadcast is the intentional exception and reserves one
 slot in every pool. Clients that retry should use the same bounded exponential
 backoff and jitter as for SQLite-originated `Busy` failures.
 
-If a caller drops a future while its operation is queued, the engine skips the
-operation and there is no error response to serialize. Once blocking SQLite
-execution has started, dropping the future does not cancel the operation; it may
-still commit. Issue #11 defines future in-flight cancellation and deadline
-behavior. Queue depth, pool internals, SQL text, and connection-cleanup details
-remain diagnostic data and must not be added to the fixed public problem detail.
+An explicit cancellation is `Cancelled`; expiration of an absolute request
+deadline is `DeadlineExceeded`, even though PostgreSQL represents both with
+SQLSTATE `57014`. MySQL distinguishes them with errors 1317 and 3024. If a
+caller drops an operation future, there is no client left to receive either
+error. Requests rejected after graceful shutdown begins use `ShuttingDown`.
+Queue depth, pool internals, SQL text, deadline values, and connection-cleanup
+details remain diagnostic data and must not be added to the fixed public
+problem detail.
 
 MySQL has separate foreign-key errors for the parent and child directions.
 `ForeignKeyViolation` does not retain that direction, so BriskDB deliberately

--- a/docs/REQUEST_CONTROLS.md
+++ b/docs/REQUEST_CONTROLS.md
@@ -1,0 +1,123 @@
+# Request controls and shutdown
+
+BriskDB applies cancellation, deadlines, result budgets, and shutdown at the
+protocol-neutral `Engine` boundary. HTTP and future PostgreSQL/MySQL adapters
+therefore share the same resource and cleanup semantics.
+
+## Per-request context
+
+The existing `Engine::execute`, `query`, `broadcast`, and `status` methods keep
+their signatures and use a default `RequestContext`. Frontends that have their
+own cancellation or deadline source can call the corresponding
+`*_with_context` method:
+
+```rust
+use std::time::Duration;
+use briskdb::core::{CancellationToken, RequestContext, ResultLimits};
+
+let cancellation = CancellationToken::new();
+let context = RequestContext::new()
+    .with_cancellation_token(cancellation.clone())
+    .with_timeout(Duration::from_secs(2))?
+    .with_result_limits(ResultLimits::new(500, 1024 * 1024)?);
+# Ok::<(), briskdb::core::EngineError>(())
+```
+
+`CancellationToken` is cloneable, sticky, and idempotent. All existing and
+future waiters observe cancellation after `cancel()` is called. Tokens belong
+to request contexts, not sessions, so cancelling request A cannot accidentally
+cancel a later request B on the same session.
+
+An operation still waiting for its session, shard connection, or blocking
+worker leaves the queue immediately when cancelled. It never starts SQL. Once
+SQLite is running, BriskDB arms an interrupt handle and progress callback only
+for the currently leased physical connection. Cancellation interrupts that
+handle, waits for the blocking task to finish rollback and pool cleanup, and
+only then returns `Cancelled`. The interrupted handle is retired before another
+request can use it. Dropping the public operation future follows the same
+interrupt path; lifecycle and pool permits remain held by the blocking closure
+until cleanup really completes.
+
+Lazy pooled-handle configuration and the authorizer probe used before a clean
+handle crosses session owners run under the same controls. Cancellation can
+therefore end SQLite lock waits or expensive preparation before the main SQL
+call starts. Opening the database file itself is an operating-system call and
+cannot be synchronously interrupted, but controls are checked before any
+SQLite configuration or statement work proceeds.
+
+Completion wins a very close race with cancellation. A statement that is known
+to have completed successfully returns success rather than a misleading
+cancellation error. A single SQLite write statement interrupted before
+completion retains SQLite's statement atomicity. Callers must still treat any
+transport-level disconnect without a BriskDB response as an unknown outcome.
+
+The engine default deadline is 30 seconds. `EngineOptions::with_request_timeout`
+can change it or use `None` to disable only that default. An explicit absolute
+deadline in `RequestContext` remains active, and the earlier of the engine and
+request deadlines wins. Deadline failures use the distinct
+`DeadlineExceeded` kind. The server flag `--request-timeout-ms 0` disables the
+engine default.
+
+## Materialized result budgets
+
+Every query has a finite row and logical-byte budget. Defaults are 10,000 rows
+and 16 MiB; the configurable hard caps are 1,000,000 rows and 1 GiB. A request
+context may narrow but never widen its engine's configured budget. Equality at
+the limit succeeds. Exceeding either limit returns `LimitExceeded` without a
+partial `ResultSet`.
+
+Logical bytes use a stable protocol-neutral model rather than JSON or future
+wire-protocol encoding:
+
+- 16 bytes for the result envelope;
+- for each column, one type byte, an eight-byte length, and the UTF-8 column
+  name bytes;
+- eight bytes for each row; and
+- for each value, one type byte, an eight-byte length, and its payload.
+
+Null has a zero-byte payload. Integer and floating payloads use eight bytes.
+Text and binary payloads use their exact byte length. All arithmetic is checked.
+BriskDB accounts borrowed SQLite values before cloning any text or blob into the
+result. Detecting a row overflow requires stepping one additional SQLite row,
+and SQLite can still allocate its current row internally. The logical limit is
+not an HTTP encoded-body limit; for example, the current JSON representation of
+a blob expands bytes into JSON integers.
+
+The query path accepts only SQLite statements reported as read-only. This
+prevents an early result-budget failure from accompanying a partially consumed
+DML `RETURNING` statement. Execute and broadcast do not materialize a
+`ResultSet` and are unaffected by query result budgets. A future scatter/gather
+implementation must apply one budget to the combined result, not a fresh budget
+for every shard.
+
+## Graceful shutdown
+
+All `Engine` clones share a monotonic lifecycle:
+
+```text
+Running -> Draining -> Stopped
+```
+
+`begin_shutdown()` atomically stops new admissions. New operations return
+`ShuttingDown`; operations admitted before the transition keep running.
+`shutdown()` waits for those operations for the configured grace period. If the
+period expires, it cancels admitted work and waits one additional grace period
+for SQLite cleanup. A completed report records whether forced cancellation was
+needed. Idle SQLite connections are closed on a bounded blocking worker before
+the engine reaches `Stopped`.
+
+If forced cleanup also exceeds its grace period, shutdown returns
+`DeadlineExceeded` and leaves the engine safely in `Draining`. A later
+`shutdown()` call resumes cleanup. Concurrent calls are serialized, completed
+shutdown is idempotent, and dropping one shutdown waiter does not strand the
+shared lifecycle. Dropping an ordinary `Engine` clone does not initiate
+shutdown; embedders should call the explicit asynchronous hook.
+
+The server constructs its SIGINT/SIGTERM receivers before logging readiness on
+supported Unix hosts. It transitions the engine to `Draining` before dropping
+the listener and signaling each tracked HTTP/1 connection. HTTP draining and
+core shutdown start together. A connection still active at the HTTP grace
+deadline is aborted and joined before server shutdown returns; core cleanup may
+continue through its separately documented forced-cleanup grace. Broadcast
+remains sequential and non-atomic across shard files: cancellation preserves
+the committed prefix and prevents later shards from starting.

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -97,15 +97,27 @@ connection-local counters to the next request when the owned handle remains
 available. It does not pin that handle, so these observer functions remain
 uncontracted across calls in the current SQL surface.
 
-Dropping a request future before its queued operation starts causes that work to
-be skipped. Dropping it after blocking execution begins does not interrupt
-SQLite, and the operation may still commit after the client disconnects.
-Cancellation and deadline behavior remain planned in issue #11. Broadcast
-execution remains non-atomic: its parameterless SQL batch is not wrapped in a
-transaction on each shard, and shards are processed sequentially. A failure can
-therefore leave earlier statements committed on the failing shard as well as
-leave earlier shards fully or partially updated. Pooling does not change the
-manifest schema, shard files, or stored-data format.
+Dropping or explicitly cancelling a request before its queued operation starts
+skips SQLite entirely. After execution begins, BriskDB interrupts the exact
+leased connection and does not return cancellation until blocking rollback and
+connection cleanup finish. A successfully completed statement wins a very
+close cancellation race. Request deadlines use the same cleanup path but retain
+the distinct `DeadlineExceeded` error kind.
+
+Queries are restricted to statements SQLite identifies as read-only and have
+finite row and protocol-neutral logical-byte budgets. BriskDB returns no partial
+result when a budget is exceeded. This deliberately rejects write-capable query
+forms such as DML `RETURNING`; callers must use the execute surface, whose
+result is rows affected rather than returned rows. Exact accounting and
+configuration semantics are in [request controls](REQUEST_CONTROLS.md).
+
+Broadcast execution remains non-atomic: its parameterless SQL batch is not
+wrapped in a transaction on each shard, and shards are processed sequentially.
+A failure can therefore leave earlier statements committed on the failing
+shard as well as leave earlier shards fully or partially updated. Cancellation
+preserves the completed shard prefix and stops before later shards. Pooling and
+request controls do not change the manifest schema, shard files, or stored-data
+format.
 
 ### Current parameter and result conversion
 
@@ -205,11 +217,12 @@ SQLite library and used through the matching HTTP endpoint:
 
 Other SQLite syntax may happen to pass through, but it is not a stable BriskDB
 contract until it appears in this table and has conformance tests. In
-particular, multi-request transactions, multi-shard writes, `RETURNING`,
-multiple statements outside the broadcast endpoint, and attached-database
-operations are uncontracted public API behavior today. The experimental raw
-HTTP path might accept some of them; clients must not rely on acceptance,
-rejection, or unchanged semantics.
+particular, multi-request transactions, multi-shard writes, multiple statements
+outside the broadcast endpoint, and attached-database operations are
+uncontracted public API behavior today. DML `RETURNING` is explicitly rejected
+from the query surface, and the execute surface exposes only a rows-affected
+count, never a returned rowset. The experimental raw HTTP path uses those same
+engine boundaries.
 
 The current `Session` `Ready`/`Closed` lifecycle is not a transaction state
 machine. Real `BEGIN`/`COMMIT`/`ROLLBACK`, failed-transaction behavior, and

--- a/docs/SUPPORTED_PLATFORMS.md
+++ b/docs/SUPPORTED_PLATFORMS.md
@@ -23,6 +23,13 @@ the same pull request. A supported operating-system runner may be replaced
 before its upstream end of life, also through a tested pull request and policy
 update.
 
+The server installs SIGINT and SIGTERM streams before reporting readiness on
+Unix. A Windows build installs its Ctrl-C stream at the same point, although
+Windows is not currently in the supported tier. Signal handling enters the same
+tested `Engine` drain/cancel/cleanup lifecycle; platform-specific
+service-manager integration beyond those signals is not yet part of the support
+contract.
+
 ## Development-tested targets
 
 Maintainers also develop and run the full suite on `aarch64-apple-darwin`.

--- a/src/core/control.rs
+++ b/src/core/control.rs
@@ -1,0 +1,459 @@
+//! Protocol-neutral request cancellation and deadline controls.
+
+use std::{
+    fmt,
+    future::Future,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+use tokio::sync::Notify;
+
+use super::{EngineError, EngineErrorKind, EngineResult, ResultLimits};
+
+/// A cloneable, sticky request-cancellation signal.
+///
+/// Cancellation is idempotent. Once cancelled, all current and future waiters
+/// observe the signal. A token controls only requests whose
+/// [`RequestContext`] contains that token; it is never stored on a session.
+#[derive(Clone, Default)]
+pub struct CancellationToken {
+    inner: Arc<CancellationInner>,
+}
+
+#[derive(Default)]
+struct CancellationInner {
+    cancelled: AtomicBool,
+    notify: Notify,
+}
+
+impl CancellationToken {
+    /// Create a token in the non-cancelled state.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Cancel every request currently observing this token.
+    ///
+    /// Returns `true` only for the call that changed the token's state.
+    pub fn cancel(&self) -> bool {
+        let changed = !self.inner.cancelled.swap(true, Ordering::AcqRel);
+        if changed {
+            self.inner.notify.notify_waiters();
+        }
+        changed
+    }
+
+    /// Return whether cancellation has already been requested.
+    pub fn is_cancelled(&self) -> bool {
+        self.inner.cancelled.load(Ordering::Acquire)
+    }
+
+    /// Wait until cancellation is requested.
+    pub async fn cancelled(&self) {
+        loop {
+            // Register before checking the sticky bit so cancellation cannot
+            // land in a lost-wakeup window between the two operations.
+            let notified = self.inner.notify.notified();
+            if self.is_cancelled() {
+                return;
+            }
+            notified.await;
+        }
+    }
+}
+
+impl fmt::Debug for CancellationToken {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CancellationToken")
+            .field("cancelled", &self.is_cancelled())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Per-request controls consumed by the protocol-neutral engine boundary.
+///
+/// A frontend can use the same context for one operation. Reusing a cancelled
+/// context intentionally cancels the later operation as well. Result limits in
+/// a context may narrow, but never widen, the engine-wide limits.
+#[derive(Debug, Clone, Default)]
+pub struct RequestContext {
+    cancellation: CancellationToken,
+    deadline: Option<Instant>,
+    result_limits: Option<ResultLimits>,
+}
+
+impl RequestContext {
+    /// Create a request with a fresh cancellation token and no explicit
+    /// deadline or result-limit override.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Replace the cancellation token observed by this request.
+    #[must_use]
+    pub fn with_cancellation_token(mut self, cancellation: CancellationToken) -> Self {
+        self.cancellation = cancellation;
+        self
+    }
+
+    /// Set an absolute monotonic deadline.
+    #[must_use]
+    pub fn with_deadline(mut self, deadline: Instant) -> Self {
+        self.deadline = Some(deadline);
+        self
+    }
+
+    /// Set a deadline relative to the current monotonic time.
+    pub fn with_timeout(mut self, timeout: Duration) -> EngineResult<Self> {
+        if timeout.is_zero() {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "request timeout must be greater than zero",
+            ));
+        }
+        self.deadline = Some(Instant::now().checked_add(timeout).ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "request timeout is too large for the monotonic clock",
+            )
+        })?);
+        Ok(self)
+    }
+
+    /// Narrow the configured query-result limits for this request.
+    #[must_use]
+    pub fn with_result_limits(mut self, result_limits: ResultLimits) -> Self {
+        self.result_limits = Some(result_limits);
+        self
+    }
+
+    /// Return a clone of the request cancellation token.
+    pub fn cancellation_token(&self) -> CancellationToken {
+        self.cancellation.clone()
+    }
+
+    /// Return the caller-supplied absolute deadline, if any.
+    pub fn deadline(&self) -> Option<Instant> {
+        self.deadline
+    }
+
+    /// Return the caller-supplied result-limit override, if any.
+    pub fn result_limits(&self) -> Option<ResultLimits> {
+        self.result_limits
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CancellationReason {
+    Cancelled,
+    DeadlineExceeded,
+}
+
+impl CancellationReason {
+    pub(crate) fn error(self) -> EngineError {
+        match self {
+            Self::Cancelled => EngineError::new(
+                EngineErrorKind::Cancelled,
+                "the request was cancelled before the operation completed",
+            ),
+            Self::DeadlineExceeded => {
+                EngineError::deadline_exceeded("the request deadline elapsed")
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OperationPhase {
+    Pending,
+    Running,
+    Finished,
+}
+
+struct OperationState {
+    phase: OperationPhase,
+    reason: Option<CancellationReason>,
+    interrupt: Option<Arc<dyn Fn() + Send + Sync + 'static>>,
+}
+
+/// Race-safe state shared by the async caller and one leased SQLite handle.
+///
+/// The mutex is the linearization point between cancellation and the start of
+/// SQLite execution. A pending cancellation prevents SQL from starting; a
+/// running cancellation interrupts the exact currently leased handle.
+pub(crate) struct OperationControl {
+    state: Mutex<OperationState>,
+    deadline: Option<Instant>,
+}
+
+impl OperationControl {
+    pub(crate) fn new(deadline: Option<Instant>) -> Arc<Self> {
+        Arc::new(Self {
+            state: Mutex::new(OperationState {
+                phase: OperationPhase::Pending,
+                reason: None,
+                interrupt: None,
+            }),
+            deadline,
+        })
+    }
+
+    pub(crate) fn request_cancel(&self, reason: CancellationReason) -> bool {
+        let interrupt = {
+            let mut state = self.lock_state();
+            if state.phase == OperationPhase::Finished || state.reason.is_some() {
+                return false;
+            }
+            state.reason = Some(reason);
+            state.interrupt.clone()
+        };
+        if let Some(interrupt) = interrupt {
+            interrupt();
+        }
+        true
+    }
+
+    pub(crate) fn arm(
+        &self,
+        interrupt: Arc<dyn Fn() + Send + Sync + 'static>,
+    ) -> Result<(), CancellationReason> {
+        self.expire_deadline();
+        let mut state = self.lock_state();
+        if let Some(reason) = state.reason {
+            return Err(reason);
+        }
+        debug_assert_eq!(state.phase, OperationPhase::Pending);
+        state.phase = OperationPhase::Running;
+        state.interrupt = Some(interrupt);
+        Ok(())
+    }
+
+    pub(crate) fn should_stop(&self) -> bool {
+        self.expire_deadline();
+        self.lock_state().reason.is_some()
+    }
+
+    pub(crate) fn disarm(&self) -> Option<CancellationReason> {
+        let mut state = self.lock_state();
+        state.interrupt = None;
+        if state.phase == OperationPhase::Running {
+            state.phase = OperationPhase::Pending;
+        }
+        state.reason
+    }
+
+    pub(crate) fn complete<T>(&self, result: EngineResult<T>) -> EngineResult<T> {
+        let reason = {
+            let mut state = self.lock_state();
+            state.phase = OperationPhase::Finished;
+            state.interrupt = None;
+            state.reason
+        };
+
+        // A completed SQLite operation wins a very close cancellation race.
+        // In particular, never report cancellation for a write known to have
+        // committed successfully. Interrupted failures use the first accepted
+        // cancellation reason so deadlines remain distinguishable.
+        match (result, reason) {
+            (Ok(value), _) => Ok(value),
+            (Err(_), Some(reason)) => Err(reason.error()),
+            (Err(error), None) => Err(error),
+        }
+    }
+
+    pub(crate) fn reason(&self) -> Option<CancellationReason> {
+        self.expire_deadline();
+        self.lock_state().reason
+    }
+
+    fn expire_deadline(&self) {
+        if self
+            .deadline
+            .is_some_and(|deadline| Instant::now() >= deadline)
+        {
+            self.request_cancel(CancellationReason::DeadlineExceeded);
+        }
+    }
+
+    fn lock_state(&self) -> std::sync::MutexGuard<'_, OperationState> {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+impl fmt::Debug for OperationControl {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let state = self.lock_state();
+        formatter
+            .debug_struct("OperationControl")
+            .field("phase", &state.phase)
+            .field("reason", &state.reason)
+            .field("interrupt_armed", &state.interrupt.is_some())
+            .field("deadline", &self.deadline)
+            .finish()
+    }
+}
+
+/// Cancel a started operation if its public future is dropped.
+pub(crate) struct CancelOnDrop {
+    control: Arc<OperationControl>,
+    armed: bool,
+}
+
+impl CancelOnDrop {
+    pub(crate) fn new(control: Arc<OperationControl>) -> Self {
+        Self {
+            control,
+            armed: true,
+        }
+    }
+
+    pub(crate) fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for CancelOnDrop {
+    fn drop(&mut self) {
+        if self.armed {
+            self.control.request_cancel(CancellationReason::Cancelled);
+        }
+    }
+}
+
+pub(crate) async fn wait_for_cancellation(
+    request: &CancellationToken,
+    shutdown: &CancellationToken,
+    deadline: Option<Instant>,
+) -> CancellationReason {
+    let deadline_wait = async move {
+        match deadline {
+            Some(deadline) => {
+                tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)).await
+            }
+            None => std::future::pending::<()>().await,
+        }
+    };
+    tokio::select! {
+        _ = request.cancelled() => CancellationReason::Cancelled,
+        _ = shutdown.cancelled() => CancellationReason::Cancelled,
+        _ = deadline_wait => CancellationReason::DeadlineExceeded,
+    }
+}
+
+pub(crate) async fn wait_pending<T, F>(
+    future: F,
+    request: &CancellationToken,
+    shutdown: &CancellationToken,
+    deadline: Option<Instant>,
+    control: &OperationControl,
+) -> EngineResult<T>
+where
+    F: Future<Output = EngineResult<T>>,
+{
+    tokio::pin!(future);
+    tokio::select! {
+        biased;
+        result = &mut future => result,
+        reason = wait_for_cancellation(request, shutdown, deadline) => {
+            control.request_cancel(reason);
+            Err(reason.error())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    fn assert_send_sync<T: Send + Sync>() {}
+
+    #[test]
+    fn public_control_types_are_send_sync_and_have_stable_accessors() {
+        assert_send_sync::<CancellationToken>();
+        assert_send_sync::<RequestContext>();
+
+        let token = CancellationToken::new();
+        let deadline = Instant::now() + Duration::from_secs(1);
+        let limits = ResultLimits::new(7, 512).unwrap();
+        let context = RequestContext::new()
+            .with_cancellation_token(token.clone())
+            .with_deadline(deadline)
+            .with_result_limits(limits);
+
+        assert!(!context.cancellation_token().is_cancelled());
+        assert_eq!(context.deadline(), Some(deadline));
+        assert_eq!(context.result_limits(), Some(limits));
+    }
+
+    #[tokio::test]
+    async fn cancellation_is_sticky_idempotent_and_wakes_every_waiter() {
+        let token = CancellationToken::new();
+        let observed = Arc::new(AtomicUsize::new(0));
+        let mut waiters = Vec::new();
+        for _ in 0..8 {
+            let token = token.clone();
+            let observed = Arc::clone(&observed);
+            waiters.push(tokio::spawn(async move {
+                token.cancelled().await;
+                observed.fetch_add(1, Ordering::SeqCst);
+            }));
+        }
+
+        assert!(token.cancel());
+        assert!(!token.cancel());
+        for waiter in waiters {
+            waiter.await.unwrap();
+        }
+        assert_eq!(observed.load(Ordering::SeqCst), 8);
+        tokio::time::timeout(Duration::from_millis(10), token.cancelled())
+            .await
+            .expect("late waiter must observe sticky cancellation");
+    }
+
+    #[tokio::test]
+    async fn already_elapsed_deadline_wins_a_pending_wait() {
+        let request = CancellationToken::new();
+        let shutdown = CancellationToken::new();
+        let deadline = Instant::now() - Duration::from_millis(1);
+        let control = OperationControl::new(Some(deadline));
+
+        let error = wait_pending(
+            std::future::pending::<EngineResult<()>>(),
+            &request,
+            &shutdown,
+            Some(deadline),
+            &control,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DeadlineExceeded);
+        assert_eq!(control.reason(), Some(CancellationReason::DeadlineExceeded));
+    }
+
+    #[test]
+    fn timeout_builder_rejects_zero_and_preserves_a_relative_deadline() {
+        assert_eq!(
+            RequestContext::new()
+                .with_timeout(Duration::ZERO)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::InvalidArgument
+        );
+
+        let before = Instant::now();
+        let context = RequestContext::new()
+            .with_timeout(Duration::from_millis(50))
+            .unwrap();
+        let deadline = context.deadline().unwrap();
+        assert!(deadline >= before + Duration::from_millis(50));
+    }
+}

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -6,13 +6,16 @@ use std::{
         Arc,
         atomic::{AtomicU64, Ordering},
     },
+    time::{Duration, Instant},
 };
 
-use tokio::sync::OwnedMutexGuard;
+use tokio::{sync::OwnedMutexGuard, task::JoinHandle};
 
 use super::{
-    BlockingPool, Database, EngineError, EngineErrorKind, EngineOptions, EngineResult, ResultSet,
-    Routed, Session, SessionInner, Value,
+    BlockingPool, CancelOnDrop, CancellationReason, CancellationToken, Database, EngineError,
+    EngineErrorKind, EngineOptions, EngineResult, EngineState, Lifecycle, OperationControl,
+    OperationLease, RequestContext, ResultLimits, ResultSet, Routed, Session, SessionInner,
+    ShutdownReport, Value, wait_for_cancellation, wait_pending,
 };
 use crate::{
     sql,
@@ -60,6 +63,10 @@ pub struct EngineStatus {
     max_blocking_workers: usize,
     connections_per_shard: usize,
     queue_capacity_per_shard: usize,
+    max_result_rows: u64,
+    max_result_bytes: u64,
+    request_timeout: Option<Duration>,
+    shutdown_grace: Duration,
 }
 
 impl EngineStatus {
@@ -83,6 +90,26 @@ impl EngineStatus {
     pub const fn queue_capacity_per_shard(&self) -> usize {
         self.queue_capacity_per_shard
     }
+
+    /// Return the maximum rows retained by one query.
+    pub const fn max_result_rows(&self) -> u64 {
+        self.max_result_rows
+    }
+
+    /// Return the maximum protocol-neutral logical bytes retained by one query.
+    pub const fn max_result_bytes(&self) -> u64 {
+        self.max_result_bytes
+    }
+
+    /// Return the engine-wide request timeout, if enabled.
+    pub const fn request_timeout(&self) -> Option<Duration> {
+        self.request_timeout
+    }
+
+    /// Return the graceful-shutdown drain period.
+    pub const fn shutdown_grace(&self) -> Duration {
+        self.shutdown_grace
+    }
 }
 
 #[derive(Debug)]
@@ -92,6 +119,88 @@ struct EngineInner {
     options: EngineOptions,
     workers: BlockingPool,
     connections: ConnectionPools,
+    lifecycle: Arc<Lifecycle>,
+    shutdown_cancel: CancellationToken,
+    shutdown_gate: Arc<tokio::sync::Mutex<()>>,
+}
+
+struct Operation {
+    lease: Option<OperationLease>,
+    control: Arc<OperationControl>,
+    cancellation: CancellationToken,
+    shutdown_cancel: CancellationToken,
+    deadline: Option<Instant>,
+    result_limits: ResultLimits,
+    cancel_on_drop: CancelOnDrop,
+}
+
+impl Operation {
+    async fn wait_pending<T, F>(&self, future: F) -> EngineResult<T>
+    where
+        F: std::future::Future<Output = EngineResult<T>>,
+    {
+        wait_pending(
+            future,
+            &self.cancellation,
+            &self.shutdown_cancel,
+            self.deadline,
+            &self.control,
+        )
+        .await
+    }
+
+    fn check_before_start(&self) -> EngineResult<()> {
+        let reason = if self.cancellation.is_cancelled() || self.shutdown_cancel.is_cancelled() {
+            Some(CancellationReason::Cancelled)
+        } else if self
+            .deadline
+            .is_some_and(|deadline| Instant::now() >= deadline)
+        {
+            Some(CancellationReason::DeadlineExceeded)
+        } else {
+            None
+        };
+        if let Some(reason) = reason {
+            self.control.request_cancel(reason);
+            return Err(reason.error());
+        }
+        Ok(())
+    }
+
+    fn take_lease(&mut self) -> OperationLease {
+        self.lease
+            .take()
+            .expect("an operation moves its lifecycle lease only once")
+    }
+
+    fn finish<T>(&mut self, result: EngineResult<T>) -> EngineResult<T> {
+        let result = self.control.complete(result);
+        self.cancel_on_drop.disarm();
+        result
+    }
+
+    fn finish_started<T>(&mut self, result: EngineResult<T>) -> EngineResult<T> {
+        self.cancel_on_drop.disarm();
+        result
+    }
+
+    async fn wait_started<T>(&self, mut join: JoinHandle<EngineResult<T>>) -> EngineResult<T>
+    where
+        T: Send + 'static,
+    {
+        tokio::select! {
+            biased;
+            result = &mut join => flatten_join(result),
+            reason = wait_for_cancellation(
+                &self.cancellation,
+                &self.shutdown_cancel,
+                self.deadline,
+            ) => {
+                self.control.request_cancel(reason);
+                flatten_join(join.await)
+            }
+        }
+    }
 }
 
 /// Shared asynchronous entry point used by every network frontend.
@@ -158,6 +267,9 @@ impl Engine {
                 options,
                 workers,
                 connections,
+                lifecycle: Lifecycle::new(),
+                shutdown_cancel: CancellationToken::new(),
+                shutdown_gate: Arc::new(tokio::sync::Mutex::new(())),
             }),
         })
     }
@@ -177,15 +289,157 @@ impl Engine {
         self.inner.options
     }
 
+    /// Return the lifecycle state shared by every engine clone.
+    pub fn state(&self) -> EngineState {
+        self.inner.lifecycle.state()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn active_operations_for_test(&self) -> usize {
+        self.inner.lifecycle.active()
+    }
+
+    /// Stop admitting new work while allowing already-admitted operations to drain.
+    ///
+    /// This transition is synchronous, monotonic, and idempotent. Call
+    /// [`Engine::shutdown`] to await cleanup of SQLite handles.
+    pub fn begin_shutdown(&self) -> EngineState {
+        self.inner.lifecycle.begin_shutdown()
+    }
+
+    /// Drain admitted operations and close idle SQLite handles.
+    ///
+    /// If the configured grace period elapses, admitted requests are cancelled
+    /// and given one additional grace period to finish SQLite cleanup. A second
+    /// timeout leaves the engine safely in `Draining`; a later call resumes the
+    /// shutdown attempt.
+    pub async fn shutdown(&self) -> EngineResult<ShutdownReport> {
+        self.shutdown_with_grace(self.inner.options.shutdown_grace())
+            .await
+    }
+
+    /// Perform shutdown with an explicit finite grace period.
+    pub async fn shutdown_with_grace(&self, grace: Duration) -> EngineResult<ShutdownReport> {
+        if grace.is_zero() {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "shutdown grace period must be greater than zero",
+            ));
+        }
+
+        let shutdown_guard = Arc::clone(&self.inner.shutdown_gate).lock_owned().await;
+        if let Some(report) = self.inner.lifecycle.report() {
+            return Ok(report);
+        }
+        self.begin_shutdown();
+
+        let forced_now = if tokio::time::timeout(grace, self.inner.lifecycle.wait_for_drain())
+            .await
+            .is_ok()
+        {
+            false
+        } else {
+            self.inner.lifecycle.mark_forced();
+            self.inner.shutdown_cancel.cancel();
+            tokio::time::timeout(grace, self.inner.lifecycle.wait_for_drain())
+                .await
+                .map_err(|_| {
+                    EngineError::deadline_exceeded(
+                        "engine shutdown timed out while cancelled operations were cleaning up",
+                    )
+                })?;
+            true
+        };
+
+        let report = if forced_now || self.inner.lifecycle.was_forced() {
+            ShutdownReport::forced_shutdown()
+        } else {
+            ShutdownReport::graceful()
+        };
+        let connections = self.inner.connections.clone();
+        let lifecycle = Arc::clone(&self.inner.lifecycle);
+        self.inner
+            .workers
+            .run(move || {
+                // Once this finalizer starts, the owned gate remains in the
+                // blocking closure even if its async caller is cancelled. A
+                // later shutdown therefore cannot report Stopped before every
+                // SQLite handle from this finalizer has actually closed.
+                let _shutdown_guard = shutdown_guard;
+                connections.close_idle()?;
+                lifecycle.mark_stopped(report);
+                Ok(())
+            })
+            .await?;
+        Ok(report)
+    }
+
+    fn operation(&self, context: RequestContext) -> EngineResult<Operation> {
+        let lease = self.inner.lifecycle.try_acquire()?;
+        let cancellation = context.cancellation_token();
+        let now = Instant::now();
+        let engine_deadline = self
+            .inner
+            .options
+            .request_timeout()
+            .and_then(|timeout| now.checked_add(timeout));
+        let deadline = match (context.deadline(), engine_deadline) {
+            (Some(request), Some(engine)) => Some(request.min(engine)),
+            (Some(request), None) => Some(request),
+            (None, engine) => engine,
+        };
+        let configured = self.inner.options.result_limits();
+        let requested = context.result_limits().unwrap_or(configured);
+        let result_limits = ResultLimits::new(
+            configured.max_rows().min(requested.max_rows()),
+            configured.max_bytes().min(requested.max_bytes()),
+        )
+        .expect("the minimum of validated result limits is valid");
+        let control = OperationControl::new(deadline);
+        let cancel_on_drop = CancelOnDrop::new(Arc::clone(&control));
+        let operation = Operation {
+            lease: Some(lease),
+            control,
+            cancellation,
+            shutdown_cancel: self.inner.shutdown_cancel.clone(),
+            deadline,
+            result_limits,
+            cancel_on_drop,
+        };
+        operation.check_before_start()?;
+        Ok(operation)
+    }
+
     /// Return engine status after validating the calling session.
     pub async fn status(&self, session: &Session) -> EngineResult<EngineStatus> {
-        let _guard = self.ready_session(session).await?;
-        Ok(EngineStatus {
-            shard_count: self.shard_count(),
-            max_blocking_workers: self.inner.workers.limit(),
-            connections_per_shard: self.inner.options.connections_per_shard(),
-            queue_capacity_per_shard: self.inner.options.queue_capacity_per_shard(),
-        })
+        self.status_with_context(session, RequestContext::new())
+            .await
+    }
+
+    /// Return engine status with explicit cancellation and deadline controls.
+    pub async fn status_with_context(
+        &self,
+        session: &Session,
+        context: RequestContext,
+    ) -> EngineResult<EngineStatus> {
+        let mut operation = self.operation(context)?;
+        let result = async {
+            let _guard = operation.wait_pending(self.ready_session(session)).await?;
+            operation.check_before_start()?;
+            let result_limits = self.inner.options.result_limits();
+            Ok(EngineStatus {
+                shard_count: self.shard_count(),
+                max_blocking_workers: self.inner.workers.limit(),
+                connections_per_shard: self.inner.options.connections_per_shard(),
+                queue_capacity_per_shard: self.inner.options.queue_capacity_per_shard(),
+                max_result_rows: result_limits.max_rows(),
+                max_result_bytes: result_limits.max_bytes(),
+                request_timeout: self.inner.options.request_timeout(),
+                shutdown_grace: self.inner.options.shutdown_grace(),
+            })
+        }
+        .await;
+        operation.finish(result)
     }
 
     /// Execute a routed statement and return its selected shard.
@@ -194,18 +448,45 @@ impl Engine {
         session: &Session,
         statement: Statement,
     ) -> EngineResult<Routed<usize>> {
-        let guard = self.ready_session(session).await?;
+        self.execute_with_context(session, statement, RequestContext::new())
+            .await
+    }
+
+    /// Execute a routed statement with explicit request controls.
+    pub async fn execute_with_context(
+        &self,
+        session: &Session,
+        statement: Statement,
+        context: RequestContext,
+    ) -> EngineResult<Routed<usize>> {
+        let mut operation = self.operation(context)?;
+        let guard = match operation.wait_pending(self.ready_session(session)).await {
+            Ok(guard) => guard,
+            Err(error) => return operation.finish(Err(error)),
+        };
         let owner = ConnectionOwner::new(session.id().get());
-        let routing_key = required_routing_key(&guard)?.to_owned();
+        let routing_key = match required_routing_key(&guard) {
+            Ok(key) => key.to_owned(),
+            Err(error) => return operation.finish(Err(error)),
+        };
         let shard = self.inner.database.shard_for_key(routing_key.as_bytes());
         let (sql, params) = statement.into_parts();
 
         let value = self
-            .run_on_shard(shard, owner, guard, move |connection| {
-                connection.isolate_foreign_sql(&sql)?;
-                sql::execute(connection, &sql, &params)
-            })
-            .await?;
+            .run_on_shard(
+                &mut operation,
+                shard,
+                owner,
+                guard,
+                move |connection, control| {
+                    connection.isolate_foreign_sql_controlled(Arc::clone(&control), &sql)?;
+                    connection.run_controlled(control, |connection| {
+                        sql::execute(connection, &sql, &params)
+                    })
+                },
+            )
+            .await;
+        let value = operation.finish_started(value)?;
         Ok(Routed { shard, value })
     }
 
@@ -215,53 +496,129 @@ impl Engine {
         session: &Session,
         statement: Statement,
     ) -> EngineResult<Routed<ResultSet>> {
-        let guard = self.ready_session(session).await?;
+        self.query_with_context(session, statement, RequestContext::new())
+            .await
+    }
+
+    /// Query a routed statement with explicit cancellation, deadline, and
+    /// result-budget controls.
+    pub async fn query_with_context(
+        &self,
+        session: &Session,
+        statement: Statement,
+        context: RequestContext,
+    ) -> EngineResult<Routed<ResultSet>> {
+        let mut operation = self.operation(context)?;
+        let guard = match operation.wait_pending(self.ready_session(session)).await {
+            Ok(guard) => guard,
+            Err(error) => return operation.finish(Err(error)),
+        };
         let owner = ConnectionOwner::new(session.id().get());
-        let routing_key = required_routing_key(&guard)?.to_owned();
+        let routing_key = match required_routing_key(&guard) {
+            Ok(key) => key.to_owned(),
+            Err(error) => return operation.finish(Err(error)),
+        };
         let shard = self.inner.database.shard_for_key(routing_key.as_bytes());
         let (sql, params) = statement.into_parts();
+        let limits = operation.result_limits;
 
         let value = self
-            .run_on_shard(shard, owner, guard, move |connection| {
-                connection.isolate_foreign_sql(&sql)?;
-                sql::query(connection, &sql, &params)
-            })
-            .await?;
+            .run_on_shard(
+                &mut operation,
+                shard,
+                owner,
+                guard,
+                move |connection, control| {
+                    connection.isolate_foreign_sql_controlled(Arc::clone(&control), &sql)?;
+                    connection.run_controlled(control, |connection| {
+                        sql::query_with_limits(connection, &sql, &params, limits)
+                    })
+                },
+            )
+            .await;
+        let value = operation.finish_started(value)?;
         Ok(Routed { shard, value })
     }
 
     /// Execute a parameterless SQL batch sequentially on every shard.
     pub async fn broadcast(&self, session: &Session, sql: String) -> EngineResult<Vec<u16>> {
-        let guard = self.ready_session(session).await?;
-        let owner = ConnectionOwner::new(session.id().get());
-        let permits = self.inner.connections.acquire_all_for_owner(owner).await?;
-        let workers = self.inner.workers.clone();
+        self.broadcast_with_context(session, sql, RequestContext::new())
+            .await
+    }
 
-        workers
-            .run(move || {
-                let _guard = guard;
+    /// Execute a parameterless SQL batch on every shard with explicit request controls.
+    ///
+    /// Shards are processed in order. Cancellation stops before the next shard,
+    /// but statements already committed on earlier shards remain committed.
+    pub async fn broadcast_with_context(
+        &self,
+        session: &Session,
+        sql: String,
+        context: RequestContext,
+    ) -> EngineResult<Vec<u16>> {
+        let mut operation = self.operation(context)?;
+        let guard = match operation.wait_pending(self.ready_session(session)).await {
+            Ok(guard) => guard,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let owner = ConnectionOwner::new(session.id().get());
+        let permits = match operation
+            .wait_pending(self.inner.connections.acquire_all_for_owner(owner))
+            .await
+        {
+            Ok(permits) => permits,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let worker = match operation.wait_pending(self.inner.workers.acquire()).await {
+            Ok(worker) => worker,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        if let Err(error) = operation.check_before_start() {
+            return operation.finish(Err(error));
+        }
+        let lease = operation.take_lease();
+        let control = Arc::clone(&operation.control);
+        let worker_control = Arc::clone(&control);
+        let join = worker.spawn(move || {
+            let _lease = lease;
+            let _session = guard;
+            let result = (|| {
                 let mut completed = Vec::with_capacity(permits.len());
                 for (shard, permit) in permits {
-                    let mut connection = permit.checkout().map_err(|error| {
-                        error.context(format!("broadcast failed to open shard {shard}"))
-                    })?;
-                    connection.ensure_owner_local().map_err(|error| {
-                        error.context(format!("broadcast failed to isolate shard {shard}"))
-                    })?;
-                    let result = sql::execute_batch(&connection, &sql);
+                    if let Some(reason) = worker_control.reason() {
+                        return Err(reason.error());
+                    }
+                    let mut connection = permit
+                        .checkout_controlled(Arc::clone(&worker_control))
+                        .map_err(|error| {
+                            error.context(format!("broadcast failed to open shard {shard}"))
+                        })?;
+                    connection
+                        .ensure_owner_local_controlled(Arc::clone(&worker_control))
+                        .map_err(|error| {
+                            error.context(format!("broadcast failed to isolate shard {shard}"))
+                        })?;
+                    let result = connection
+                        .run_controlled(Arc::clone(&worker_control), |connection| {
+                            sql::execute_batch(connection, &sql)
+                        });
                     retire_if_broken(&mut connection, &result);
-                    result.map_err(|error| {
-                        error.context(format!("broadcast failed on shard {shard}"))
-                    })?;
+                    if let Err(error) = result {
+                        return Err(error.context(format!("broadcast failed on shard {shard}")));
+                    }
                     completed.push(shard);
                 }
                 Ok(completed)
-            })
-            .await
+            })();
+            worker_control.complete(result)
+        });
+        let result = operation.wait_started(join).await;
+        operation.finish_started(result)
     }
 
     async fn run_on_shard<T, F>(
         &self,
+        operation: &mut Operation,
         shard: u16,
         owner: ConnectionOwner,
         session: OwnedMutexGuard<SessionInner>,
@@ -269,23 +626,38 @@ impl Engine {
     ) -> EngineResult<T>
     where
         T: Send + 'static,
-        F: FnOnce(&mut PooledConnection) -> EngineResult<T> + Send + 'static,
+        F: FnOnce(&mut PooledConnection, Arc<OperationControl>) -> EngineResult<T> + Send + 'static,
     {
-        let permit = self
-            .inner
-            .connections
-            .acquire_for_owner(shard, owner)
-            .await?;
-        self.inner
-            .workers
-            .run(move || {
-                let _session = session;
-                let mut connection = permit.checkout()?;
-                let result = work(&mut connection);
-                retire_if_broken(&mut connection, &result);
-                result
-            })
+        let permit = match operation
+            .wait_pending(self.inner.connections.acquire_for_owner(shard, owner))
             .await
+        {
+            Ok(permit) => permit,
+            Err(error) => return operation.control.complete(Err(error)),
+        };
+        let worker = match operation.wait_pending(self.inner.workers.acquire()).await {
+            Ok(worker) => worker,
+            Err(error) => return operation.control.complete(Err(error)),
+        };
+        if let Err(error) = operation.check_before_start() {
+            return operation.control.complete(Err(error));
+        }
+        let lease = operation.take_lease();
+        let control = Arc::clone(&operation.control);
+        let worker_control = Arc::clone(&control);
+        let join = worker.spawn(move || {
+            let _lease = lease;
+            let _session = session;
+            let result = permit
+                .checkout_controlled(Arc::clone(&worker_control))
+                .and_then(|mut connection| {
+                    let result = work(&mut connection, Arc::clone(&worker_control));
+                    retire_if_broken(&mut connection, &result);
+                    result
+                });
+            worker_control.complete(result)
+        });
+        operation.wait_started(join).await
     }
 
     async fn ready_session(
@@ -312,35 +684,102 @@ impl Engine {
         started: tokio::sync::oneshot::Sender<()>,
         release: std::sync::mpsc::Receiver<()>,
     ) -> EngineResult<()> {
-        let guard = self.ready_session(session).await?;
+        let mut operation = self.operation(RequestContext::new())?;
+        let guard = match operation.wait_pending(self.ready_session(session)).await {
+            Ok(guard) => guard,
+            Err(error) => return operation.finish(Err(error)),
+        };
         let owner = ConnectionOwner::new(session.id().get());
-        self.run_on_shard(shard, owner, guard, move |_| {
-            let _ = started.send(());
-            release.recv().expect("test releases the blocking worker");
-            Ok(())
-        })
-        .await
+        let result = self
+            .run_on_shard(&mut operation, shard, owner, guard, move |_, _| {
+                let _ = started.send(());
+                release.recv().expect("test releases the blocking worker");
+                Ok(())
+            })
+            .await;
+        operation.finish_started(result)
     }
 
     #[cfg(test)]
     async fn panic_worker_for_test(&self, session: &Session, shard: u16) -> EngineResult<()> {
-        let guard = self.ready_session(session).await?;
+        let mut operation = self.operation(RequestContext::new())?;
+        let guard = match operation.wait_pending(self.ready_session(session)).await {
+            Ok(guard) => guard,
+            Err(error) => return operation.finish(Err(error)),
+        };
         let owner = ConnectionOwner::new(session.id().get());
-        self.run_on_shard(shard, owner, guard, move |_| {
-            panic!("intentional blocking worker panic")
-        })
-        .await
+        let result = self
+            .run_on_shard(&mut operation, shard, owner, guard, move |_, _| {
+                panic!("intentional blocking worker panic")
+            })
+            .await;
+        operation.finish_started(result)
+    }
+
+    #[cfg(test)]
+    async fn panic_controlled_worker_for_test(
+        &self,
+        session: &Session,
+        shard: u16,
+    ) -> EngineResult<()> {
+        let mut operation = self.operation(RequestContext::new())?;
+        let guard = match operation.wait_pending(self.ready_session(session)).await {
+            Ok(guard) => guard,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let owner = ConnectionOwner::new(session.id().get());
+        let result = self
+            .run_on_shard(
+                &mut operation,
+                shard,
+                owner,
+                guard,
+                move |connection, control| {
+                    connection.run_controlled(control, |_connection| -> EngineResult<()> {
+                        panic!("intentional controlled SQLite worker panic")
+                    })
+                },
+            )
+            .await;
+        operation.finish_started(result)
     }
 
     #[cfg(test)]
     async fn connection_id_for_test(&self, session: &Session, shard: u16) -> EngineResult<u64> {
-        let guard = self.ready_session(session).await?;
-        let owner = ConnectionOwner::new(session.id().get());
-        self.run_on_shard(shard, owner, guard, move |connection| {
-            Ok(connection.connection_id())
-        })
-        .await
+        self.connection_id_with_context_for_test(session, shard, RequestContext::new())
+            .await
     }
+
+    #[cfg(test)]
+    async fn connection_id_with_context_for_test(
+        &self,
+        session: &Session,
+        shard: u16,
+        context: RequestContext,
+    ) -> EngineResult<u64> {
+        let mut operation = self.operation(context)?;
+        let guard = match operation.wait_pending(self.ready_session(session)).await {
+            Ok(guard) => guard,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let owner = ConnectionOwner::new(session.id().get());
+        let result = self
+            .run_on_shard(&mut operation, shard, owner, guard, move |connection, _| {
+                Ok(connection.connection_id())
+            })
+            .await;
+        operation.finish_started(result)
+    }
+}
+
+fn flatten_join<T>(result: Result<EngineResult<T>, tokio::task::JoinError>) -> EngineResult<T> {
+    result.map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::Internal,
+            "blocking engine task failed",
+            error,
+        )
+    })?
 }
 
 fn required_routing_key(session: &SessionInner) -> EngineResult<&str> {
@@ -386,11 +825,25 @@ mod tests {
         connections_per_shard: usize,
         queue_capacity_per_shard: usize,
     ) -> (tempfile::TempDir, Engine) {
+        let options = EngineOptions::new(connections_per_shard, queue_capacity_per_shard).unwrap();
+        engine_with_engine_options(shards, options)
+    }
+
+    fn engine_with_engine_options(
+        shards: u16,
+        options: EngineOptions,
+    ) -> (tempfile::TempDir, Engine) {
         let temp = tempfile::tempdir().unwrap();
         let database = Arc::new(Database::open(temp.path(), shards).unwrap());
-        let options = EngineOptions::new(connections_per_shard, queue_capacity_per_shard).unwrap();
         let engine = Engine::from_database_with_options(database, options).unwrap();
         (temp, engine)
+    }
+
+    fn routing_key_for_shard(engine: &Engine, expected: u16) -> String {
+        (0_u64..)
+            .map(|value| format!("shard-{value}"))
+            .find(|key| engine.inner.database.shard_for_key(key.as_bytes()) == expected)
+            .expect("the finite shard layout has a routing key")
     }
 
     async fn wait_for_pool_occupancy(engine: &Engine, shard: u16, active: usize, queued: usize) {
@@ -406,6 +859,26 @@ mod tests {
         })
         .await
         .expect("pool occupancy should reach the expected state");
+    }
+
+    async fn wait_for_blocking_signal(receiver: mpsc::Receiver<()>, message: &'static str) {
+        timeout(
+            Duration::from_secs(2),
+            tokio::task::spawn_blocking(move || receiver.recv().unwrap()),
+        )
+        .await
+        .expect(message)
+        .unwrap();
+    }
+
+    async fn wait_for_worker_capacity(engine: &Engine, expected: usize) {
+        timeout(Duration::from_secs(2), async {
+            while engine.inner.workers.available_permits() != expected {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("blocking-worker capacity should be restored");
     }
 
     fn assert_send_sync<T: Send + Sync>() {}
@@ -743,7 +1216,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn aborting_a_dispatched_broadcast_does_not_stop_later_shards() {
+    async fn aborting_a_dispatched_broadcast_stops_before_the_blocked_shard() {
         let (_temp, engine) = engine_with_options(2, 1, 1);
         let blocker = engine.inner.database.storage.open_shard(1).unwrap();
         blocker.execute_batch("BEGIN EXCLUSIVE").unwrap();
@@ -781,26 +1254,24 @@ mod tests {
 
         broadcast.abort();
         assert!(broadcast.await.unwrap_err().is_cancelled());
-        assert_eq!(
-            engine.inner.connections.snapshot().unwrap().shards[1].active,
-            1
-        );
-        assert_eq!(engine.inner.workers.available_permits(), 1);
+        wait_for_pool_occupancy(&engine, 1, 0, 0).await;
+        wait_for_worker_capacity(&engine, 2).await;
 
-        blocker.execute_batch("COMMIT").unwrap();
         let status = timeout(Duration::from_secs(2), engine.status(&session))
             .await
             .expect("detached broadcast should release its session")
             .unwrap();
         assert_eq!(status.shard_count(), 2);
+        blocker.execute_batch("COMMIT").unwrap();
         assert!(
-            blocker
+            !blocker
                 .query_row(
                     "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE name = 'abort_marker')",
                     [],
                     |row| row.get::<_, bool>(0),
                 )
-                .unwrap()
+                .unwrap(),
+            "the committed shard-zero prefix is retained, but cancellation must not execute shard one"
         );
         for shard in 0..2 {
             wait_for_pool_occupancy(&engine, shard, 0, 0).await;
@@ -1329,6 +1800,10 @@ mod tests {
     async fn a_worker_panic_is_internal_and_releases_the_session() {
         let (_temp, engine) = engine_with_options(2, 1, 1);
         let session = engine.session();
+        session
+            .set_routing_key(routing_key_for_shard(&engine, 0))
+            .await
+            .unwrap();
         let original_id = engine.connection_id_for_test(&session, 0).await.unwrap();
 
         let error = engine.panic_worker_for_test(&session, 0).await.unwrap_err();
@@ -1349,6 +1824,37 @@ mod tests {
         assert_eq!(after_replacement.retired, 1);
         assert_eq!(after_replacement.idle, 1);
         assert_eq!(engine.status(&session).await.unwrap().shard_count(), 2);
+        assert_eq!(session.state().await, SessionState::Ready);
+    }
+
+    #[tokio::test]
+    async fn panic_inside_controlled_sql_cleans_hooks_tls_and_retires_the_handle() {
+        let (_temp, engine) = engine_with_options(2, 1, 1);
+        let session = engine.session();
+        session
+            .set_routing_key(routing_key_for_shard(&engine, 0))
+            .await
+            .unwrap();
+        let original_id = engine.connection_id_for_test(&session, 0).await.unwrap();
+
+        let error = engine
+            .panic_controlled_worker_for_test(&session, 0)
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Internal);
+        let after_panic = engine.inner.connections.snapshot().unwrap().shards[0];
+        assert_eq!(after_panic.retired, 1);
+        assert_eq!(after_panic.idle, 0);
+        assert_eq!(after_panic.active, 0);
+
+        let replacement_id = engine.connection_id_for_test(&session, 0).await.unwrap();
+        assert_ne!(replacement_id, original_id);
+        let recovered = engine
+            .query(&session, Statement::new("SELECT 9", vec![]))
+            .await
+            .unwrap();
+        assert_eq!(recovered.value.rows()[0].get(0), Some(&Value::from(9_i64)));
+        assert_eq!(engine.inner.workers.available_permits(), 2);
         assert_eq!(session.state().await, SessionState::Ready);
     }
 
@@ -1541,5 +2047,941 @@ mod tests {
         );
         assert_eq!(first.routing_key().await.as_deref(), Some("tenant-a"));
         assert_eq!(second.routing_key().await.as_deref(), Some("tenant-b"));
+    }
+
+    #[tokio::test]
+    async fn explicit_cancellation_interrupts_running_sql_and_retires_only_that_handle() {
+        let options = EngineOptions::new(1, 1)
+            .unwrap()
+            .with_request_timeout(None)
+            .unwrap();
+        let (_temp, engine) = engine_with_engine_options(2, options);
+        let session = Arc::new(engine.session());
+        session.set_routing_key("cancel-query").await.unwrap();
+        let shard = engine.inner.database.shard_for_key(b"cancel-query");
+        let original_id = engine
+            .connection_id_for_test(&session, shard)
+            .await
+            .unwrap();
+        let token = CancellationToken::new();
+        let context = RequestContext::new().with_cancellation_token(token.clone());
+        let query_engine = engine.clone();
+        let query_session = Arc::clone(&session);
+        let query = tokio::spawn(async move {
+            query_engine
+                .query_with_context(
+                    &query_session,
+                    Statement::new(
+                        "WITH RECURSIVE numbers(value) AS (\
+                         VALUES(0) UNION ALL SELECT value + 1 FROM numbers \
+                         WHERE value < 1000000000) SELECT sum(value) FROM numbers",
+                        vec![],
+                    ),
+                    context,
+                )
+                .await
+        });
+        wait_for_pool_occupancy(&engine, shard, 1, 0).await;
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        assert!(token.cancel());
+
+        let error = timeout(Duration::from_secs(2), query)
+            .await
+            .expect("SQLite interrupt should bound cancellation cleanup")
+            .unwrap()
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Cancelled);
+        wait_for_pool_occupancy(&engine, shard, 0, 0).await;
+
+        let replacement_id = engine
+            .connection_id_for_test(&session, shard)
+            .await
+            .unwrap();
+        assert_ne!(replacement_id, original_id);
+        let recovered = engine
+            .query(&session, Statement::new("SELECT 42", vec![]))
+            .await
+            .unwrap();
+        assert_eq!(recovered.value.rows()[0].get(0), Some(&Value::from(42_i64)));
+        let snapshot = engine.inner.connections.snapshot().unwrap().shards[usize::from(shard)];
+        assert_eq!(snapshot.retired, 1);
+        assert_eq!(snapshot.active, 0);
+        assert_eq!(snapshot.queued, 0);
+    }
+
+    #[tokio::test]
+    async fn request_deadline_interrupts_running_sql_with_its_distinct_kind() {
+        let options = EngineOptions::new(1, 1)
+            .unwrap()
+            .with_request_timeout(None)
+            .unwrap();
+        let (_temp, engine) = engine_with_engine_options(2, options);
+        let session = engine.session();
+        session.set_routing_key("deadline-query").await.unwrap();
+        let context = RequestContext::new()
+            .with_timeout(Duration::from_millis(10))
+            .unwrap();
+
+        let error = timeout(
+            Duration::from_secs(2),
+            engine.query_with_context(
+                &session,
+                Statement::new(
+                    "WITH RECURSIVE numbers(value) AS (\
+                     VALUES(0) UNION ALL SELECT value + 1 FROM numbers \
+                     WHERE value < 1000000000) SELECT sum(value) FROM numbers",
+                    vec![],
+                ),
+                context,
+            ),
+        )
+        .await
+        .expect("deadline should interrupt SQLite")
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DeadlineExceeded);
+
+        let recovered = engine
+            .query(&session, Statement::new("SELECT 7", vec![]))
+            .await
+            .unwrap();
+        assert_eq!(recovered.value.rows()[0].get(0), Some(&Value::from(7_i64)));
+    }
+
+    #[tokio::test]
+    async fn cancelling_atomic_insert_select_returns_only_after_rollback() {
+        let options = EngineOptions::new(1, 1)
+            .unwrap()
+            .with_request_timeout(None)
+            .unwrap();
+        let (_temp, engine) = engine_with_engine_options(2, options);
+        let setup = engine.session();
+        engine
+            .broadcast(
+                &setup,
+                "CREATE TABLE cancellation_rows (id INTEGER PRIMARY KEY)".to_owned(),
+            )
+            .await
+            .unwrap();
+
+        let session = Arc::new(engine.session());
+        session.set_routing_key("cancel-write").await.unwrap();
+        let shard = engine.inner.database.shard_for_key(b"cancel-write");
+        let token = CancellationToken::new();
+        let context = RequestContext::new().with_cancellation_token(token.clone());
+        let write_engine = engine.clone();
+        let write_session = Arc::clone(&session);
+        let write = tokio::spawn(async move {
+            write_engine
+                .execute_with_context(
+                    &write_session,
+                    Statement::new(
+                        "WITH RECURSIVE numbers(value) AS (\
+                         VALUES(1) UNION ALL SELECT value + 1 FROM numbers \
+                         WHERE value < 100000000) \
+                         INSERT INTO cancellation_rows SELECT value FROM numbers",
+                        vec![],
+                    ),
+                    context,
+                )
+                .await
+        });
+        wait_for_pool_occupancy(&engine, shard, 1, 0).await;
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        token.cancel();
+        let error = timeout(Duration::from_secs(2), write)
+            .await
+            .expect("cancelled write should finish rollback")
+            .unwrap()
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Cancelled);
+
+        for _ in 0..2 {
+            let count = engine
+                .query(
+                    &session,
+                    Statement::new("SELECT COUNT(*) FROM cancellation_rows", vec![]),
+                )
+                .await
+                .unwrap();
+            assert_eq!(count.value.rows()[0].get(0), Some(&Value::from(0_i64)));
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn aborting_atomic_write_future_rolls_back_before_resources_are_reused() {
+        let options = EngineOptions::new(1, 1)
+            .unwrap()
+            .with_request_timeout(None)
+            .unwrap();
+        let (_temp, engine) = engine_with_engine_options(2, options);
+        let setup = engine.session();
+        engine
+            .broadcast(
+                &setup,
+                "CREATE TABLE aborted_rows (id INTEGER PRIMARY KEY)".to_owned(),
+            )
+            .await
+            .unwrap();
+
+        let session = Arc::new(engine.session());
+        session.set_routing_key("abort-write").await.unwrap();
+        let shard = engine.inner.database.shard_for_key(b"abort-write");
+        let write_engine = engine.clone();
+        let write_session = Arc::clone(&session);
+        let write = tokio::spawn(async move {
+            write_engine
+                .execute(
+                    &write_session,
+                    Statement::new(
+                        "WITH RECURSIVE numbers(value) AS (\
+                         VALUES(1) UNION ALL SELECT value + 1 FROM numbers \
+                         WHERE value < 100000000) \
+                         INSERT INTO aborted_rows SELECT value FROM numbers",
+                        vec![],
+                    ),
+                )
+                .await
+        });
+        wait_for_pool_occupancy(&engine, shard, 1, 0).await;
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        write.abort();
+        assert!(write.await.unwrap_err().is_cancelled());
+
+        timeout(
+            Duration::from_secs(2),
+            engine.inner.lifecycle.wait_for_drain(),
+        )
+        .await
+        .expect("the detached write should finish rollback");
+        wait_for_pool_occupancy(&engine, shard, 0, 0).await;
+        wait_for_worker_capacity(&engine, 2).await;
+        assert_eq!(engine.inner.lifecycle.active(), 0);
+
+        for _ in 0..2 {
+            let count = engine
+                .query(
+                    &session,
+                    Statement::new("SELECT COUNT(*) FROM aborted_rows", vec![]),
+                )
+                .await
+                .unwrap();
+            assert_eq!(count.value.rows()[0].get(0), Some(&Value::from(0_i64)));
+        }
+        assert_eq!(session.state().await, SessionState::Ready);
+    }
+
+    #[tokio::test]
+    async fn queued_token_cancellation_removes_admission_without_starting_sql() {
+        let (_temp, engine) = engine_with_options(2, 1, 1);
+        let holder_session = Arc::new(engine.session());
+        let (started_tx, started_rx) = oneshot::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let holder_engine = engine.clone();
+        let holder_session_for_task = Arc::clone(&holder_session);
+        let holder = tokio::spawn(async move {
+            holder_engine
+                .hold_session_for_test(&holder_session_for_task, 0, started_tx, release_rx)
+                .await
+        });
+        timeout(Duration::from_secs(2), started_rx)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let queued_session = Arc::new(engine.session());
+        queued_session
+            .set_routing_key(routing_key_for_shard(&engine, 0))
+            .await
+            .unwrap();
+        let token = CancellationToken::new();
+        let context = RequestContext::new().with_cancellation_token(token.clone());
+        let queued_engine = engine.clone();
+        let queued_session_for_task = Arc::clone(&queued_session);
+        let queued = tokio::spawn(async move {
+            queued_engine
+                .execute_with_context(
+                    &queued_session_for_task,
+                    Statement::new("CREATE TABLE must_not_start (id INTEGER)", vec![]),
+                    context,
+                )
+                .await
+        });
+        wait_for_pool_occupancy(&engine, 0, 1, 1).await;
+        token.cancel();
+        let error = timeout(Duration::from_secs(1), queued)
+            .await
+            .expect("queued cancellation must not wait for a connection")
+            .unwrap()
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Cancelled);
+        wait_for_pool_occupancy(&engine, 0, 1, 0).await;
+
+        release_tx.send(()).unwrap();
+        holder.await.unwrap().unwrap();
+        let shard = engine.inner.database.storage.open_shard(0).unwrap();
+        assert!(
+            !shard
+                .query_row(
+                    "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE name = 'must_not_start')",
+                    [],
+                    |row| row.get::<_, bool>(0),
+                )
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn queued_deadline_expires_without_waiting_for_a_connection_or_running_sql() {
+        let options = EngineOptions::new(1, 1)
+            .unwrap()
+            .with_request_timeout(None)
+            .unwrap();
+        let (_temp, engine) = engine_with_engine_options(2, options);
+        let holder_session = Arc::new(engine.session());
+        let (started_tx, started_rx) = oneshot::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let holder_engine = engine.clone();
+        let holder_session_for_task = Arc::clone(&holder_session);
+        let holder = tokio::spawn(async move {
+            holder_engine
+                .hold_session_for_test(&holder_session_for_task, 0, started_tx, release_rx)
+                .await
+        });
+        timeout(Duration::from_secs(2), started_rx)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let queued = engine.session();
+        queued
+            .set_routing_key(routing_key_for_shard(&engine, 0))
+            .await
+            .unwrap();
+        let context = RequestContext::new()
+            .with_timeout(Duration::from_millis(10))
+            .unwrap();
+        let error = timeout(
+            Duration::from_secs(1),
+            engine.execute_with_context(
+                &queued,
+                Statement::new("CREATE TABLE deadline_must_not_start (id INTEGER)", vec![]),
+                context,
+            ),
+        )
+        .await
+        .expect("queued deadline must expire independently of the held connection")
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DeadlineExceeded);
+        wait_for_pool_occupancy(&engine, 0, 1, 0).await;
+
+        release_tx.send(()).unwrap();
+        holder.await.unwrap().unwrap();
+        let shard = engine.inner.database.storage.open_shard(0).unwrap();
+        assert!(
+            !shard
+                .query_row(
+                    "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE name = \
+                 'deadline_must_not_start')",
+                    [],
+                    |row| row.get::<_, bool>(0),
+                )
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn late_cancellation_cannot_interrupt_a_reused_connection() {
+        let (_temp, engine) = engine_with_options(2, 1, 1);
+        let session = engine.session();
+        session.set_routing_key("late-cancel").await.unwrap();
+        let shard = engine.inner.database.shard_for_key(b"late-cancel");
+        let token = CancellationToken::new();
+        let first = engine
+            .query_with_context(
+                &session,
+                Statement::new("SELECT 1", vec![]),
+                RequestContext::new().with_cancellation_token(token.clone()),
+            )
+            .await
+            .unwrap();
+        assert_eq!(first.value.rows()[0].get(0), Some(&Value::from(1_i64)));
+        let first_id = engine
+            .connection_id_for_test(&session, shard)
+            .await
+            .unwrap();
+
+        token.cancel();
+        let second = engine
+            .query(&session, Statement::new("SELECT 2", vec![]))
+            .await
+            .unwrap();
+        assert_eq!(second.value.rows()[0].get(0), Some(&Value::from(2_i64)));
+        let second_id = engine
+            .connection_id_for_test(&session, shard)
+            .await
+            .unwrap();
+        assert_eq!(second_id, first_id);
+        assert_eq!(
+            engine.inner.connections.snapshot().unwrap().shards[usize::from(shard)].retired,
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn cancellation_during_hook_teardown_retires_before_immediate_reuse() {
+        let options = EngineOptions::new(1, 1)
+            .unwrap()
+            .with_request_timeout(None)
+            .unwrap();
+        let (_temp, engine) = engine_with_engine_options(2, options);
+        let session = Arc::new(engine.session());
+        session.set_routing_key("teardown-race").await.unwrap();
+        let shard = engine.inner.database.shard_for_key(b"teardown-race");
+        let original_id = engine
+            .connection_id_for_test(&session, shard)
+            .await
+            .unwrap();
+        let (started_tx, started_rx) = mpsc::channel();
+        let (_release_tx, release_rx) = mpsc::channel();
+        engine
+            .inner
+            .connections
+            .block_next_control_teardown(shard, started_tx, release_rx)
+            .unwrap();
+        let token = CancellationToken::new();
+        let request_engine = engine.clone();
+        let request_session = Arc::clone(&session);
+        let request_token = token.clone();
+        let request = tokio::spawn(async move {
+            request_engine
+                .query_with_context(
+                    &request_session,
+                    Statement::new("SELECT 1", vec![]),
+                    RequestContext::new().with_cancellation_token(request_token),
+                )
+                .await
+        });
+        wait_for_blocking_signal(started_rx, "hook teardown should reach its race barrier").await;
+        assert!(token.cancel());
+        let completed = timeout(Duration::from_secs(1), request)
+            .await
+            .expect("teardown cancellation should finish promptly")
+            .unwrap()
+            .unwrap();
+        assert_eq!(completed.value.rows()[0].get(0), Some(&Value::from(1_i64)));
+
+        let replacement_id = engine
+            .connection_id_for_test(&session, shard)
+            .await
+            .unwrap();
+        assert_ne!(replacement_id, original_id);
+        let recovered = engine
+            .query(&session, Statement::new("SELECT 2", vec![]))
+            .await
+            .unwrap();
+        assert_eq!(recovered.value.rows()[0].get(0), Some(&Value::from(2_i64)));
+        let snapshot = engine.inner.connections.snapshot().unwrap().shards[usize::from(shard)];
+        assert_eq!(snapshot.retired, 1);
+        assert_eq!(snapshot.active, 0);
+    }
+
+    #[tokio::test]
+    async fn deadline_interrupts_lazy_connection_setup_and_capacity_recovers() {
+        let options = EngineOptions::new(1, 1)
+            .unwrap()
+            .with_request_timeout(None)
+            .unwrap();
+        let (_temp, engine) = engine_with_engine_options(2, options);
+        let session = Arc::new(engine.session());
+        let key = routing_key_for_shard(&engine, 0);
+        session.set_routing_key(key).await.unwrap();
+        let (started_tx, started_rx) = mpsc::channel();
+        let (_release_tx, release_rx) = mpsc::channel();
+        engine
+            .inner
+            .connections
+            .block_next_connection_setup(0, started_tx, release_rx)
+            .unwrap();
+
+        let request_engine = engine.clone();
+        let request_session = Arc::clone(&session);
+        let request = tokio::spawn(async move {
+            request_engine
+                .query_with_context(
+                    &request_session,
+                    Statement::new("SELECT 1", vec![]),
+                    RequestContext::new()
+                        .with_timeout(Duration::from_millis(20))
+                        .unwrap(),
+                )
+                .await
+        });
+        wait_for_blocking_signal(started_rx, "connection setup should become active").await;
+        let error = timeout(Duration::from_secs(1), request)
+            .await
+            .expect("the deadline should interrupt connection setup")
+            .unwrap()
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DeadlineExceeded);
+        assert_eq!(engine.inner.lifecycle.active(), 0);
+        assert_eq!(engine.inner.workers.available_permits(), 2);
+        let failed = engine.inner.connections.snapshot().unwrap().shards[0];
+        assert_eq!(failed.active, 0);
+        assert_eq!(failed.opened, 0);
+
+        let recovered = engine
+            .query(&session, Statement::new("SELECT 2", vec![]))
+            .await
+            .unwrap();
+        assert_eq!(recovered.value.rows()[0].get(0), Some(&Value::from(2_i64)));
+    }
+
+    #[tokio::test]
+    async fn deadline_interrupts_a_real_lock_during_lazy_connection_configuration() {
+        let options = EngineOptions::new(1, 1)
+            .unwrap()
+            .with_request_timeout(None)
+            .unwrap();
+        let (_temp, engine) = engine_with_engine_options(2, options);
+        let blocker = engine.inner.database.storage.open_shard(0).unwrap();
+        blocker
+            .execute_batch("PRAGMA locking_mode = EXCLUSIVE; BEGIN EXCLUSIVE")
+            .unwrap();
+        let session = engine.session();
+        let context = RequestContext::new()
+            .with_timeout(Duration::from_millis(20))
+            .unwrap();
+
+        let started = std::time::Instant::now();
+        let error = timeout(
+            Duration::from_secs(1),
+            engine.connection_id_with_context_for_test(&session, 0, context),
+        )
+        .await
+        .expect("the request deadline must preempt SQLite's normal five-second busy wait")
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DeadlineExceeded);
+        assert!(started.elapsed() < Duration::from_secs(1));
+        assert_eq!(engine.inner.lifecycle.active(), 0);
+        wait_for_worker_capacity(&engine, 2).await;
+
+        blocker.execute_batch("COMMIT").unwrap();
+        drop(blocker);
+        assert!(engine.connection_id_for_test(&session, 0).await.unwrap() > 0);
+    }
+
+    #[tokio::test]
+    async fn cancellation_interrupts_foreign_owner_probe_and_retires_the_handle() {
+        let options = EngineOptions::new(1, 1)
+            .unwrap()
+            .with_request_timeout(None)
+            .unwrap();
+        let (_temp, engine) = engine_with_engine_options(2, options);
+        let key = routing_key_for_shard(&engine, 0);
+        let first = engine.session();
+        first.set_routing_key(key.clone()).await.unwrap();
+        engine
+            .query(&first, Statement::new("SELECT 1", vec![]))
+            .await
+            .unwrap();
+
+        let second = Arc::new(engine.session());
+        second.set_routing_key(key).await.unwrap();
+        let (started_tx, started_rx) = mpsc::channel();
+        let (_release_tx, release_rx) = mpsc::channel();
+        engine
+            .inner
+            .connections
+            .block_next_foreign_probe(0, started_tx, release_rx)
+            .unwrap();
+        let token = CancellationToken::new();
+        let request_engine = engine.clone();
+        let request_session = Arc::clone(&second);
+        let request_token = token.clone();
+        let request = tokio::spawn(async move {
+            request_engine
+                .query_with_context(
+                    &request_session,
+                    Statement::new("SELECT 2", vec![]),
+                    RequestContext::new().with_cancellation_token(request_token),
+                )
+                .await
+        });
+        wait_for_blocking_signal(started_rx, "foreign-owner probe should become active").await;
+        assert!(token.cancel());
+        let error = timeout(Duration::from_secs(1), request)
+            .await
+            .expect("cancellation should interrupt the foreign-owner probe")
+            .unwrap()
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Cancelled);
+        let cancelled = engine.inner.connections.snapshot().unwrap().shards[0];
+        assert_eq!(cancelled.active, 0);
+        assert_eq!(cancelled.retired, 1);
+        assert_eq!(engine.inner.workers.available_permits(), 2);
+
+        let recovered = engine
+            .query(&second, Statement::new("SELECT 3", vec![]))
+            .await
+            .unwrap();
+        assert_eq!(recovered.value.rows()[0].get(0), Some(&Value::from(3_i64)));
+    }
+
+    #[tokio::test]
+    async fn per_request_result_limits_can_narrow_but_never_widen_engine_limits() {
+        let engine_limits = ResultLimits::new(2, 1_024).unwrap();
+        let options = EngineOptions::new(1, 1)
+            .unwrap()
+            .with_result_limits(engine_limits);
+        let (_temp, engine) = engine_with_engine_options(2, options);
+        let session = engine.session();
+        session.set_routing_key("result-budget").await.unwrap();
+
+        let wider =
+            RequestContext::new().with_result_limits(ResultLimits::new(100, 1_000_000).unwrap());
+        let error = engine
+            .query_with_context(
+                &session,
+                Statement::new("SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3", vec![]),
+                wider,
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+
+        let narrower =
+            RequestContext::new().with_result_limits(ResultLimits::new(1, 1_024).unwrap());
+        let error = engine
+            .query_with_context(
+                &session,
+                Statement::new("SELECT 1 UNION ALL SELECT 2", vec![]),
+                narrower,
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+        let recovered = engine
+            .query(&session, Statement::new("SELECT 1", vec![]))
+            .await
+            .unwrap();
+        assert_eq!(recovered.value.rows().len(), 1);
+
+        let configured_bytes = ResultLimits::new(100, 50).unwrap();
+        let options = EngineOptions::new(1, 1)
+            .unwrap()
+            .with_result_limits(configured_bytes);
+        let (_byte_temp, byte_engine) = engine_with_engine_options(2, options);
+        let byte_session = byte_engine.session();
+        byte_session
+            .set_routing_key("configured-bytes")
+            .await
+            .unwrap();
+        let wider_bytes =
+            RequestContext::new().with_result_limits(ResultLimits::new(100, 100).unwrap());
+        let error = byte_engine
+            .query_with_context(
+                &byte_session,
+                Statement::new("SELECT 1 AS v", vec![]),
+                wider_bytes,
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+
+        let request_options = EngineOptions::new(1, 1)
+            .unwrap()
+            .with_result_limits(ResultLimits::new(100, 100).unwrap());
+        let (_request_temp, request_engine) = engine_with_engine_options(2, request_options);
+        let request_session = request_engine.session();
+        request_session
+            .set_routing_key("request-bytes")
+            .await
+            .unwrap();
+        let narrower_bytes =
+            RequestContext::new().with_result_limits(ResultLimits::new(100, 50).unwrap());
+        let error = request_engine
+            .query_with_context(
+                &request_session,
+                Statement::new("SELECT 1 AS v", vec![]),
+                narrower_bytes,
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+
+        let exact = RequestContext::new().with_result_limits(ResultLimits::new(100, 51).unwrap());
+        let exact_result = request_engine
+            .query_with_context(
+                &request_session,
+                Statement::new("SELECT 1 AS v", vec![]),
+                exact,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            exact_result.value.rows()[0].get(0),
+            Some(&Value::from(1_i64))
+        );
+    }
+
+    #[tokio::test]
+    async fn graceful_shutdown_drains_admitted_work_rejects_new_work_and_is_idempotent() {
+        let (_temp, engine) = engine_with_options(2, 1, 1);
+        let session = Arc::new(engine.session());
+        let (started_tx, started_rx) = oneshot::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let active_engine = engine.clone();
+        let active_session = Arc::clone(&session);
+        let active = tokio::spawn(async move {
+            active_engine
+                .hold_session_for_test(&active_session, 0, started_tx, release_rx)
+                .await
+        });
+        timeout(Duration::from_secs(2), started_rx)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(engine.begin_shutdown(), EngineState::Draining);
+        assert_eq!(engine.state(), EngineState::Draining);
+        let rejected = engine.status(&engine.session()).await.unwrap_err();
+        assert_eq!(rejected.kind(), EngineErrorKind::ShuttingDown);
+
+        let shutdown_engine = engine.clone();
+        let mut shutdown = tokio::spawn(async move { shutdown_engine.shutdown().await });
+        assert!(
+            timeout(Duration::from_millis(20), &mut shutdown)
+                .await
+                .is_err()
+        );
+        release_tx.send(()).unwrap();
+        active.await.unwrap().unwrap();
+        let report = shutdown.await.unwrap().unwrap();
+        assert!(!report.forced());
+        assert_eq!(engine.state(), EngineState::Stopped);
+        assert_eq!(engine.shutdown().await.unwrap(), report);
+        let snapshot = engine.inner.connections.snapshot().unwrap();
+        assert!(snapshot.shards.iter().all(|shard| shard.idle == 0));
+    }
+
+    #[tokio::test]
+    async fn shutdown_drains_work_already_waiting_on_the_same_session() {
+        let (_temp, engine) = engine_with_options(2, 1, 1);
+        let session = Arc::new(engine.session());
+        let (started_tx, started_rx) = oneshot::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let first_engine = engine.clone();
+        let first_session = Arc::clone(&session);
+        let first = tokio::spawn(async move {
+            first_engine
+                .hold_session_for_test(&first_session, 0, started_tx, release_rx)
+                .await
+        });
+        timeout(Duration::from_secs(2), started_rx)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let second_engine = engine.clone();
+        let second_session = Arc::clone(&session);
+        let second = tokio::spawn(async move { second_engine.status(&second_session).await });
+        timeout(Duration::from_secs(2), async {
+            while engine.inner.lifecycle.active() != 2 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        engine.begin_shutdown();
+        let shutdown_engine = engine.clone();
+        let shutdown = tokio::spawn(async move { shutdown_engine.shutdown().await });
+
+        release_tx.send(()).unwrap();
+        first.await.unwrap().unwrap();
+        assert_eq!(second.await.unwrap().unwrap().shard_count(), 2);
+        assert!(!shutdown.await.unwrap().unwrap().forced());
+        assert_eq!(engine.state(), EngineState::Stopped);
+    }
+
+    #[tokio::test]
+    async fn shutdown_force_cancels_running_sql_then_waits_for_cleanup() {
+        let options = EngineOptions::new(1, 1)
+            .unwrap()
+            .with_request_timeout(None)
+            .unwrap()
+            .with_shutdown_grace(Duration::from_millis(10))
+            .unwrap();
+        let (_temp, engine) = engine_with_engine_options(2, options);
+        let session = Arc::new(engine.session());
+        session.set_routing_key("shutdown-cancel").await.unwrap();
+        let shard = engine.inner.database.shard_for_key(b"shutdown-cancel");
+        let query_engine = engine.clone();
+        let query_session = Arc::clone(&session);
+        let query = tokio::spawn(async move {
+            query_engine
+                .query(
+                    &query_session,
+                    Statement::new(
+                        "WITH RECURSIVE numbers(value) AS (\
+                         VALUES(0) UNION ALL SELECT value + 1 FROM numbers \
+                         WHERE value < 1000000000) SELECT sum(value) FROM numbers",
+                        vec![],
+                    ),
+                )
+                .await
+        });
+        wait_for_pool_occupancy(&engine, shard, 1, 0).await;
+
+        let report = timeout(Duration::from_secs(2), engine.shutdown())
+            .await
+            .expect("forced shutdown should interrupt SQLite")
+            .unwrap();
+        assert!(report.forced());
+        assert_eq!(engine.state(), EngineState::Stopped);
+        let error = query.await.unwrap().unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Cancelled);
+        assert_eq!(engine.inner.lifecycle.active(), 0);
+        assert_eq!(engine.inner.workers.available_permits(), 2);
+    }
+
+    #[tokio::test]
+    async fn dropped_started_request_is_counted_until_cleanup_and_shutdown_can_resume() {
+        let options = EngineOptions::new(1, 1)
+            .unwrap()
+            .with_request_timeout(None)
+            .unwrap()
+            .with_shutdown_grace(Duration::from_millis(10))
+            .unwrap();
+        let (_temp, engine) = engine_with_engine_options(2, options);
+        let session = Arc::new(engine.session());
+        let (started_tx, started_rx) = oneshot::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let task_engine = engine.clone();
+        let task_session = Arc::clone(&session);
+        let task = tokio::spawn(async move {
+            task_engine
+                .hold_session_for_test(&task_session, 0, started_tx, release_rx)
+                .await
+        });
+        timeout(Duration::from_secs(2), started_rx)
+            .await
+            .unwrap()
+            .unwrap();
+        task.abort();
+        assert!(task.await.unwrap_err().is_cancelled());
+        assert_eq!(engine.inner.lifecycle.active(), 1);
+
+        let error = engine.shutdown().await.unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DeadlineExceeded);
+        assert_eq!(engine.state(), EngineState::Draining);
+        assert_eq!(engine.inner.lifecycle.active(), 1);
+
+        release_tx.send(()).unwrap();
+        timeout(
+            Duration::from_secs(2),
+            engine.inner.lifecycle.wait_for_drain(),
+        )
+        .await
+        .unwrap();
+        let report = engine.shutdown().await.unwrap();
+        assert!(report.forced());
+        assert_eq!(engine.state(), EngineState::Stopped);
+    }
+
+    #[tokio::test]
+    async fn cancelling_one_shutdown_waiter_does_not_strand_later_shutdown() {
+        let options = EngineOptions::new(1, 1)
+            .unwrap()
+            .with_request_timeout(None)
+            .unwrap()
+            .with_shutdown_grace(Duration::from_secs(1))
+            .unwrap();
+        let (_temp, engine) = engine_with_engine_options(2, options);
+        let session = Arc::new(engine.session());
+        let (started_tx, started_rx) = oneshot::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let active_engine = engine.clone();
+        let active_session = Arc::clone(&session);
+        let active = tokio::spawn(async move {
+            active_engine
+                .hold_session_for_test(&active_session, 0, started_tx, release_rx)
+                .await
+        });
+        timeout(Duration::from_secs(2), started_rx)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let first_engine = engine.clone();
+        let first = tokio::spawn(async move { first_engine.shutdown().await });
+        timeout(Duration::from_secs(1), async {
+            while engine.state() != EngineState::Draining {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        first.abort();
+        assert!(first.await.unwrap_err().is_cancelled());
+
+        release_tx.send(()).unwrap();
+        active.await.unwrap().unwrap();
+        let report = engine.shutdown().await.unwrap();
+        assert!(!report.forced());
+        assert_eq!(engine.state(), EngineState::Stopped);
+    }
+
+    #[tokio::test]
+    async fn cancelled_finalizer_keeps_shutdown_gate_until_handles_are_closed() {
+        let options = EngineOptions::new(1, 1)
+            .unwrap()
+            .with_request_timeout(None)
+            .unwrap()
+            .with_shutdown_grace(Duration::from_secs(1))
+            .unwrap();
+        let (_temp, engine) = engine_with_engine_options(2, options);
+        let session = engine.session();
+        session
+            .set_routing_key("open-an-idle-handle")
+            .await
+            .unwrap();
+        engine
+            .query(&session, Statement::new("SELECT 1", vec![]))
+            .await
+            .unwrap();
+
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        engine
+            .inner
+            .connections
+            .block_next_close_idle(started_tx, release_rx);
+
+        let first_engine = engine.clone();
+        let first = tokio::spawn(async move { first_engine.shutdown().await });
+        wait_for_blocking_signal(started_rx, "the first shutdown finalizer should start").await;
+        first.abort();
+        assert!(first.await.unwrap_err().is_cancelled());
+
+        let second_engine = engine.clone();
+        let mut second = tokio::spawn(async move { second_engine.shutdown().await });
+        assert!(
+            timeout(Duration::from_millis(20), &mut second)
+                .await
+                .is_err(),
+            "a later shutdown must wait for the detached finalizer"
+        );
+        assert_eq!(engine.state(), EngineState::Draining);
+
+        release_tx.send(()).unwrap();
+        let report = timeout(Duration::from_secs(2), second)
+            .await
+            .expect("the later shutdown should observe finalization")
+            .unwrap()
+            .unwrap();
+        assert!(!report.forced());
+        assert_eq!(engine.state(), EngineState::Stopped);
+        let snapshot = engine.inner.connections.snapshot().unwrap();
+        assert!(snapshot.shards.iter().all(|shard| shard.idle == 0));
     }
 }

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -26,7 +26,9 @@ pub enum EngineErrorKind {
     ReadOnly,
     Busy,
     Cancelled,
+    DeadlineExceeded,
     LimitExceeded,
+    ShuttingDown,
     StorageFull,
     OutOfMemory,
     StorageUnavailable,
@@ -53,7 +55,9 @@ impl EngineErrorKind {
         Self::ReadOnly,
         Self::Busy,
         Self::Cancelled,
+        Self::DeadlineExceeded,
         Self::LimitExceeded,
+        Self::ShuttingDown,
         Self::StorageFull,
         Self::OutOfMemory,
         Self::StorageUnavailable,
@@ -80,7 +84,9 @@ impl EngineErrorKind {
             Self::ReadOnly => "read_only",
             Self::Busy => "busy",
             Self::Cancelled => "cancelled",
+            Self::DeadlineExceeded => "deadline_exceeded",
             Self::LimitExceeded => "limit_exceeded",
+            Self::ShuttingDown => "shutting_down",
             Self::StorageFull => "storage_full",
             Self::OutOfMemory => "out_of_memory",
             Self::StorageUnavailable => "storage_unavailable",
@@ -115,6 +121,16 @@ impl EngineError {
             diagnostic: diagnostic.into(),
             source: None,
         }
+    }
+
+    /// Construct a request-deadline failure with trusted diagnostic context.
+    pub fn deadline_exceeded(diagnostic: impl Into<String>) -> Self {
+        Self::new(EngineErrorKind::DeadlineExceeded, diagnostic)
+    }
+
+    /// Construct a failure for work rejected while the engine is shutting down.
+    pub fn shutting_down(diagnostic: impl Into<String>) -> Self {
+        Self::new(EngineErrorKind::ShuttingDown, diagnostic)
     }
 
     pub(crate) fn from_source<E>(
@@ -207,6 +223,21 @@ mod tests {
             .filter(|kind| kind.is_retryable())
             .collect::<Vec<_>>();
         assert_eq!(retryable, [EngineErrorKind::Busy]);
+    }
+
+    #[test]
+    fn lifecycle_constructors_preserve_trusted_diagnostics() {
+        let deadline = EngineError::deadline_exceeded("query exceeded 25 ms");
+        assert_eq!(deadline.kind(), EngineErrorKind::DeadlineExceeded);
+        assert_eq!(deadline.code(), "deadline_exceeded");
+        assert_eq!(deadline.diagnostic(), "query exceeded 25 ms");
+        assert!(!deadline.is_retryable());
+
+        let shutdown = EngineError::shutting_down("engine is draining");
+        assert_eq!(shutdown.kind(), EngineErrorKind::ShuttingDown);
+        assert_eq!(shutdown.code(), "shutting_down");
+        assert_eq!(shutdown.diagnostic(), "engine is draining");
+        assert!(!shutdown.is_retryable());
     }
 
     #[test]

--- a/src/core/lifecycle.rs
+++ b/src/core/lifecycle.rs
@@ -1,0 +1,225 @@
+//! Shared engine admission and graceful-shutdown lifecycle.
+
+use std::{
+    fmt,
+    sync::{Arc, Mutex},
+};
+
+use tokio::sync::Notify;
+
+use super::{EngineError, EngineResult};
+
+/// The monotonic lifecycle state shared by every clone of an [`Engine`](super::Engine).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum EngineState {
+    /// New operations are admitted.
+    Running,
+    /// Shutdown has begun; admitted operations are draining and new work is rejected.
+    Draining,
+    /// Every admitted operation has finished and idle SQLite handles were closed.
+    Stopped,
+}
+
+/// Outcome of a completed graceful shutdown.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ShutdownReport {
+    forced: bool,
+}
+
+impl ShutdownReport {
+    pub(crate) const fn graceful() -> Self {
+        Self { forced: false }
+    }
+
+    pub(crate) const fn forced_shutdown() -> Self {
+        Self { forced: true }
+    }
+
+    /// Return whether the grace period expired and admitted work was cancelled.
+    pub const fn forced(self) -> bool {
+        self.forced
+    }
+}
+
+#[derive(Debug)]
+struct LifecycleState {
+    phase: EngineState,
+    active: usize,
+    forced: bool,
+    report: Option<ShutdownReport>,
+}
+
+/// One mutex protects both admission state and the active count. That makes
+/// admission atomic with respect to shutdown observing an empty engine.
+pub(crate) struct Lifecycle {
+    state: Mutex<LifecycleState>,
+    changed: Notify,
+}
+
+impl Lifecycle {
+    pub(crate) fn new() -> Arc<Self> {
+        Arc::new(Self {
+            state: Mutex::new(LifecycleState {
+                phase: EngineState::Running,
+                active: 0,
+                forced: false,
+                report: None,
+            }),
+            changed: Notify::new(),
+        })
+    }
+
+    pub(crate) fn state(&self) -> EngineState {
+        self.lock_state().phase
+    }
+
+    pub(crate) fn report(&self) -> Option<ShutdownReport> {
+        self.lock_state().report
+    }
+
+    pub(crate) fn mark_forced(&self) {
+        self.lock_state().forced = true;
+    }
+
+    pub(crate) fn was_forced(&self) -> bool {
+        self.lock_state().forced
+    }
+
+    pub(crate) fn try_acquire(self: &Arc<Self>) -> EngineResult<OperationLease> {
+        let mut state = self.lock_state();
+        if state.phase != EngineState::Running {
+            return Err(EngineError::shutting_down(
+                "the engine is draining and no longer accepts operations",
+            ));
+        }
+        state.active = state.active.checked_add(1).ok_or_else(|| {
+            EngineError::shutting_down("the engine operation counter is exhausted")
+        })?;
+        Ok(OperationLease {
+            lifecycle: Arc::clone(self),
+        })
+    }
+
+    pub(crate) fn begin_shutdown(&self) -> EngineState {
+        let mut state = self.lock_state();
+        if state.phase == EngineState::Running {
+            state.phase = EngineState::Draining;
+            self.changed.notify_waiters();
+        }
+        state.phase
+    }
+
+    pub(crate) async fn wait_for_drain(&self) {
+        loop {
+            // Register before inspecting the count to avoid losing the final
+            // lease's notification.
+            let changed = self.changed.notified();
+            if self.lock_state().active == 0 {
+                return;
+            }
+            changed.await;
+        }
+    }
+
+    pub(crate) fn mark_stopped(&self, report: ShutdownReport) {
+        let mut state = self.lock_state();
+        debug_assert_eq!(state.active, 0);
+        state.phase = EngineState::Stopped;
+        state.report = Some(report);
+        self.changed.notify_waiters();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn active(&self) -> usize {
+        self.lock_state().active
+    }
+
+    fn release(&self) {
+        let mut state = self.lock_state();
+        debug_assert!(state.active > 0);
+        state.active = state.active.saturating_sub(1);
+        if state.active == 0 {
+            self.changed.notify_waiters();
+        }
+    }
+
+    fn lock_state(&self) -> std::sync::MutexGuard<'_, LifecycleState> {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+impl fmt::Debug for Lifecycle {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("Lifecycle")
+            .field("state", &*self.lock_state())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Counts an admitted operation until all of its resources are cleaned up.
+#[derive(Debug)]
+pub(crate) struct OperationLease {
+    lifecycle: Arc<Lifecycle>,
+}
+
+impl Drop for OperationLease {
+    fn drop(&mut self) {
+        self.lifecycle.release();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+    use crate::core::EngineErrorKind;
+
+    #[tokio::test]
+    async fn admission_and_shutdown_are_one_atomic_monotonic_state_machine() {
+        let lifecycle = Lifecycle::new();
+        let first = lifecycle.try_acquire().unwrap();
+        let second = lifecycle.try_acquire().unwrap();
+        assert_eq!(lifecycle.active(), 2);
+
+        assert_eq!(lifecycle.begin_shutdown(), EngineState::Draining);
+        assert_eq!(
+            lifecycle.try_acquire().unwrap_err().kind(),
+            EngineErrorKind::ShuttingDown
+        );
+        assert_eq!(lifecycle.begin_shutdown(), EngineState::Draining);
+
+        let waiter = {
+            let lifecycle = Arc::clone(&lifecycle);
+            tokio::spawn(async move { lifecycle.wait_for_drain().await })
+        };
+        drop(first);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), waiter)
+                .await
+                .is_err()
+        );
+        drop(second);
+        tokio::time::timeout(Duration::from_secs(1), lifecycle.wait_for_drain())
+            .await
+            .unwrap();
+
+        lifecycle.mark_stopped(ShutdownReport::graceful());
+        assert_eq!(lifecycle.state(), EngineState::Stopped);
+        assert_eq!(lifecycle.report(), Some(ShutdownReport::graceful()));
+        assert_eq!(lifecycle.begin_shutdown(), EngineState::Stopped);
+    }
+
+    #[tokio::test]
+    async fn drain_wait_has_no_lost_wakeup_when_already_empty() {
+        let lifecycle = Lifecycle::new();
+        lifecycle.begin_shutdown();
+        tokio::time::timeout(Duration::from_millis(20), lifecycle.wait_for_drain())
+            .await
+            .expect("an empty lifecycle drains immediately");
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,18 +3,28 @@
 //! This module owns routing and coordinates storage and SQL execution. It does
 //! not depend on a network protocol.
 
+mod control;
 mod engine;
 mod error;
+mod lifecycle;
 mod options;
 mod session;
 mod types;
 pub(crate) mod worker;
 
+pub(crate) use control::{
+    CancelOnDrop, CancellationReason, OperationControl, wait_for_cancellation, wait_pending,
+};
+pub use control::{CancellationToken, RequestContext};
 pub use engine::{Engine, EngineStatus, Statement};
 pub use error::{EngineError, EngineErrorKind, EngineResult};
+pub use lifecycle::{EngineState, ShutdownReport};
+pub(crate) use lifecycle::{Lifecycle, OperationLease};
 pub use options::{
-    DEFAULT_CONNECTIONS_PER_SHARD, DEFAULT_QUEUE_CAPACITY_PER_SHARD, EngineOptions,
-    MAX_CONNECTIONS_PER_SHARD, MAX_QUEUE_CAPACITY_PER_SHARD,
+    DEFAULT_CONNECTIONS_PER_SHARD, DEFAULT_MAX_RESULT_BYTES, DEFAULT_MAX_RESULT_ROWS,
+    DEFAULT_QUEUE_CAPACITY_PER_SHARD, DEFAULT_REQUEST_TIMEOUT_MS, DEFAULT_SHUTDOWN_GRACE_MS,
+    EngineOptions, MAX_CONNECTIONS_PER_SHARD, MAX_QUEUE_CAPACITY_PER_SHARD, MAX_REQUEST_TIMEOUT_MS,
+    MAX_RESULT_BYTES, MAX_RESULT_ROWS, MAX_SHUTDOWN_GRACE_MS, ResultLimits,
 };
 pub use session::{Session, SessionId, SessionState};
 pub use types::{

--- a/src/core/options.rs
+++ b/src/core/options.rs
@@ -1,5 +1,7 @@
 //! Configuration for the asynchronous engine execution boundary.
 
+use std::time::Duration;
+
 use super::{EngineError, EngineErrorKind, EngineResult};
 
 /// Default number of concurrently leased SQLite connections per shard.
@@ -8,23 +10,106 @@ pub const DEFAULT_CONNECTIONS_PER_SHARD: usize = 4;
 /// Default number of operations admitted to each shard's pending queue.
 pub const DEFAULT_QUEUE_CAPACITY_PER_SHARD: usize = 32;
 
+/// Default maximum number of rows materialized by one query.
+pub const DEFAULT_MAX_RESULT_ROWS: u64 = 10_000;
+
+/// Default maximum logical size of one materialized query result (16 MiB).
+pub const DEFAULT_MAX_RESULT_BYTES: u64 = 16 * 1024 * 1024;
+
+/// Default engine-enforced request deadline in milliseconds.
+pub const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 30_000;
+
+/// Default graceful-shutdown drain period in milliseconds.
+pub const DEFAULT_SHUTDOWN_GRACE_MS: u64 = 30_000;
+
 /// Maximum configurable connections per shard.
 pub const MAX_CONNECTIONS_PER_SHARD: usize = 16;
 
 /// Maximum configurable pending operations per shard.
 pub const MAX_QUEUE_CAPACITY_PER_SHARD: usize = 1_024;
 
+/// Maximum configurable rows in one materialized query result.
+pub const MAX_RESULT_ROWS: u64 = 1_000_000;
+
+/// Maximum configurable logical size of one materialized query result (1 GiB).
+pub const MAX_RESULT_BYTES: u64 = 1024 * 1024 * 1024;
+
+/// Maximum configured request timeout (24 hours).
+pub const MAX_REQUEST_TIMEOUT_MS: u64 = 24 * 60 * 60 * 1_000;
+
+/// Maximum configured graceful-shutdown period (24 hours).
+pub const MAX_SHUTDOWN_GRACE_MS: u64 = 24 * 60 * 60 * 1_000;
+
 const MAX_TOTAL_ACTIVE_CONNECTIONS: usize = 512;
+
+/// Validated finite limits for a materialized query result.
+///
+/// BriskDB accounts a result independently of any wire protocol: 16 bytes for
+/// the result envelope, one type byte plus an eight-byte length and the UTF-8
+/// name for each column, eight bytes for each row, and one type byte plus an
+/// eight-byte length and the value payload for each value. Integer and floating
+/// payloads are eight bytes, null has no payload, and text/blob payloads use
+/// their byte length.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResultLimits {
+    max_rows: u64,
+    max_bytes: u64,
+}
+
+impl ResultLimits {
+    /// Construct validated finite result limits.
+    pub fn new(max_rows: u64, max_bytes: u64) -> EngineResult<Self> {
+        if !(1..=MAX_RESULT_ROWS).contains(&max_rows) {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                format!("maximum result rows must be between 1 and {MAX_RESULT_ROWS}"),
+            ));
+        }
+        if !(1..=MAX_RESULT_BYTES).contains(&max_bytes) {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                format!("maximum result bytes must be between 1 and {MAX_RESULT_BYTES}"),
+            ));
+        }
+
+        Ok(Self {
+            max_rows,
+            max_bytes,
+        })
+    }
+
+    /// Return the maximum number of rows materialized by one query.
+    pub const fn max_rows(self) -> u64 {
+        self.max_rows
+    }
+
+    /// Return the maximum protocol-neutral logical byte size of one result.
+    pub const fn max_bytes(self) -> u64 {
+        self.max_bytes
+    }
+}
+
+impl Default for ResultLimits {
+    fn default() -> Self {
+        Self {
+            max_rows: DEFAULT_MAX_RESULT_ROWS,
+            max_bytes: DEFAULT_MAX_RESULT_BYTES,
+        }
+    }
+}
 
 /// Resource limits for the asynchronous engine.
 ///
-/// These limits bound active SQLite connections and the amount of work that
-/// can be admitted ahead of each shard. They do not configure request
-/// deadlines or cancellation, which are separate engine policies.
+/// These limits bound active SQLite connections, admitted work, materialized
+/// results, request duration, and graceful-shutdown draining. A caller can
+/// narrow the result and time limits for one request through `RequestContext`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EngineOptions {
     connections_per_shard: usize,
     queue_capacity_per_shard: usize,
+    result_limits: ResultLimits,
+    request_timeout: Option<Duration>,
+    shutdown_grace: Duration,
 }
 
 impl EngineOptions {
@@ -51,6 +136,9 @@ impl EngineOptions {
         Ok(Self {
             connections_per_shard,
             queue_capacity_per_shard,
+            result_limits: ResultLimits::default(),
+            request_timeout: Some(Duration::from_millis(DEFAULT_REQUEST_TIMEOUT_MS)),
+            shutdown_grace: Duration::from_millis(DEFAULT_SHUTDOWN_GRACE_MS),
         })
     }
 
@@ -62,6 +150,48 @@ impl EngineOptions {
     /// Return the number of pending operations admitted per shard.
     pub const fn queue_capacity_per_shard(&self) -> usize {
         self.queue_capacity_per_shard
+    }
+
+    /// Return the finite limits applied to each materialized query result.
+    pub const fn result_limits(&self) -> ResultLimits {
+        self.result_limits
+    }
+
+    /// Replace the finite limits applied to each materialized query result.
+    #[must_use]
+    pub const fn with_result_limits(mut self, result_limits: ResultLimits) -> Self {
+        self.result_limits = result_limits;
+        self
+    }
+
+    /// Return the maximum duration of one operation, or `None` when the
+    /// engine-wide deadline is disabled.
+    pub const fn request_timeout(&self) -> Option<Duration> {
+        self.request_timeout
+    }
+
+    /// Set or disable the engine-wide request deadline.
+    ///
+    /// Passing `None` disables only the engine default; an explicit
+    /// `RequestContext` deadline is still enforced.
+    pub fn with_request_timeout(mut self, timeout: Option<Duration>) -> EngineResult<Self> {
+        if let Some(timeout) = timeout {
+            validate_duration(timeout, MAX_REQUEST_TIMEOUT_MS, "request timeout")?;
+        }
+        self.request_timeout = timeout;
+        Ok(self)
+    }
+
+    /// Return the grace period allowed before shutdown cancels admitted work.
+    pub const fn shutdown_grace(&self) -> Duration {
+        self.shutdown_grace
+    }
+
+    /// Set the finite graceful-shutdown drain period.
+    pub fn with_shutdown_grace(mut self, grace: Duration) -> EngineResult<Self> {
+        validate_duration(grace, MAX_SHUTDOWN_GRACE_MS, "shutdown grace period")?;
+        self.shutdown_grace = grace;
+        Ok(self)
     }
 
     /// Validate limits that depend on the database's physical shard count.
@@ -88,8 +218,24 @@ impl Default for EngineOptions {
         Self {
             connections_per_shard: DEFAULT_CONNECTIONS_PER_SHARD,
             queue_capacity_per_shard: DEFAULT_QUEUE_CAPACITY_PER_SHARD,
+            result_limits: ResultLimits {
+                max_rows: DEFAULT_MAX_RESULT_ROWS,
+                max_bytes: DEFAULT_MAX_RESULT_BYTES,
+            },
+            request_timeout: Some(Duration::from_millis(DEFAULT_REQUEST_TIMEOUT_MS)),
+            shutdown_grace: Duration::from_millis(DEFAULT_SHUTDOWN_GRACE_MS),
         }
     }
+}
+
+fn validate_duration(duration: Duration, maximum_ms: u64, name: &str) -> EngineResult<()> {
+    if duration < Duration::from_millis(1) || duration > Duration::from_millis(maximum_ms) {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            format!("{name} must be between 1 and {maximum_ms} milliseconds"),
+        ));
+    }
+    Ok(())
 }
 
 fn invalid_total_connections(shard_count: u16) -> EngineError {
@@ -112,6 +258,11 @@ mod tests {
 
         assert_eq!(options.connections_per_shard(), 4);
         assert_eq!(options.queue_capacity_per_shard(), 32);
+        assert_eq!(options.result_limits(), ResultLimits::default());
+        assert_eq!(options.result_limits().max_rows(), 10_000);
+        assert_eq!(options.result_limits().max_bytes(), 16 * 1024 * 1024);
+        assert_eq!(options.request_timeout(), Some(Duration::from_secs(30)));
+        assert_eq!(options.shutdown_grace(), Duration::from_secs(30));
         assert_eq!(options.worker_limit(2).unwrap(), 8);
         assert_eq!(options.worker_limit(64).unwrap(), 256);
     }
@@ -143,6 +294,99 @@ mod tests {
             EngineOptions::new(MAX_CONNECTIONS_PER_SHARD, MAX_QUEUE_CAPACITY_PER_SHARD).unwrap();
         assert_eq!(maximum.connections_per_shard(), 16);
         assert_eq!(maximum.queue_capacity_per_shard(), 1_024);
+        assert_eq!(minimum.result_limits(), ResultLimits::default());
+        assert_eq!(maximum.result_limits(), ResultLimits::default());
+    }
+
+    #[test]
+    fn result_limit_constructor_preserves_inclusive_boundaries() {
+        let minimum = ResultLimits::new(1, 1).unwrap();
+        assert_eq!(minimum.max_rows(), 1);
+        assert_eq!(minimum.max_bytes(), 1);
+
+        let maximum = ResultLimits::new(MAX_RESULT_ROWS, MAX_RESULT_BYTES).unwrap();
+        assert_eq!(maximum.max_rows(), 1_000_000);
+        assert_eq!(maximum.max_bytes(), 1024 * 1024 * 1024);
+    }
+
+    #[test]
+    fn result_limit_constructor_rejects_zero_and_values_above_each_cap() {
+        for (max_rows, max_bytes) in [
+            (0, 1),
+            (MAX_RESULT_ROWS + 1, 1),
+            (1, 0),
+            (1, MAX_RESULT_BYTES + 1),
+        ] {
+            let error = ResultLimits::new(max_rows, max_bytes).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::InvalidArgument);
+        }
+    }
+
+    #[test]
+    fn engine_options_builder_replaces_only_result_limits() {
+        let limits = ResultLimits::new(37, 4_096).unwrap();
+        let options = EngineOptions::new(2, 7).unwrap().with_result_limits(limits);
+
+        assert_eq!(options.connections_per_shard(), 2);
+        assert_eq!(options.queue_capacity_per_shard(), 7);
+        assert_eq!(options.result_limits(), limits);
+        assert_eq!(options.request_timeout(), Some(Duration::from_secs(30)));
+        assert_eq!(options.shutdown_grace(), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn timeout_and_shutdown_builders_validate_boundaries_and_disable_semantics() {
+        let minimum = EngineOptions::default()
+            .with_request_timeout(Some(Duration::from_millis(1)))
+            .unwrap()
+            .with_shutdown_grace(Duration::from_millis(1))
+            .unwrap();
+        assert_eq!(minimum.request_timeout(), Some(Duration::from_millis(1)));
+        assert_eq!(minimum.shutdown_grace(), Duration::from_millis(1));
+
+        let maximum = EngineOptions::default()
+            .with_request_timeout(Some(Duration::from_millis(MAX_REQUEST_TIMEOUT_MS)))
+            .unwrap()
+            .with_shutdown_grace(Duration::from_millis(MAX_SHUTDOWN_GRACE_MS))
+            .unwrap();
+        assert_eq!(
+            maximum.request_timeout(),
+            Some(Duration::from_millis(MAX_REQUEST_TIMEOUT_MS))
+        );
+        assert_eq!(
+            maximum.shutdown_grace(),
+            Duration::from_millis(MAX_SHUTDOWN_GRACE_MS)
+        );
+
+        assert_eq!(
+            EngineOptions::default()
+                .with_request_timeout(None)
+                .unwrap()
+                .request_timeout(),
+            None
+        );
+        for error in [
+            EngineOptions::default()
+                .with_request_timeout(Some(Duration::ZERO))
+                .unwrap_err(),
+            EngineOptions::default()
+                .with_request_timeout(Some(Duration::from_nanos(1)))
+                .unwrap_err(),
+            EngineOptions::default()
+                .with_request_timeout(Some(Duration::from_millis(MAX_REQUEST_TIMEOUT_MS + 1)))
+                .unwrap_err(),
+            EngineOptions::default()
+                .with_shutdown_grace(Duration::ZERO)
+                .unwrap_err(),
+            EngineOptions::default()
+                .with_shutdown_grace(Duration::from_nanos(1))
+                .unwrap_err(),
+            EngineOptions::default()
+                .with_shutdown_grace(Duration::from_millis(MAX_SHUTDOWN_GRACE_MS + 1))
+                .unwrap_err(),
+        ] {
+            assert_eq!(error.kind(), EngineErrorKind::InvalidArgument);
+        }
     }
 
     #[test]

--- a/src/core/worker.rs
+++ b/src/core/worker.rs
@@ -2,7 +2,10 @@
 
 use std::sync::Arc;
 
-use tokio::sync::Semaphore;
+use tokio::{
+    sync::{OwnedSemaphorePermit, Semaphore},
+    task::JoinHandle,
+};
 
 use super::{EngineError, EngineErrorKind, EngineResult};
 
@@ -41,6 +44,16 @@ impl BlockingPool {
         T: Send + 'static,
         F: FnOnce() -> EngineResult<T> + Send + 'static,
     {
+        join_blocking(self.acquire().await?.spawn(work)).await
+    }
+
+    /// Wait for one blocking-worker slot without starting any work.
+    ///
+    /// Separating admission from spawning lets request cancellation discard a
+    /// queued operation immediately. Once [`BlockingPermit::spawn`] is called,
+    /// the permit moves into the blocking closure and survives a dropped async
+    /// caller until cleanup really finishes.
+    pub(crate) async fn acquire(&self) -> EngineResult<BlockingPermit> {
         let permit = Arc::clone(&self.permits)
             .acquire_owned()
             .await
@@ -51,20 +64,40 @@ impl BlockingPool {
                     error,
                 )
             })?;
+        Ok(BlockingPermit { permit })
+    }
+}
 
+/// One reserved BriskDB blocking-worker slot.
+#[derive(Debug)]
+pub(crate) struct BlockingPermit {
+    permit: OwnedSemaphorePermit,
+}
+
+impl BlockingPermit {
+    pub(crate) fn spawn<T, F>(self, work: F) -> JoinHandle<EngineResult<T>>
+    where
+        T: Send + 'static,
+        F: FnOnce() -> EngineResult<T> + Send + 'static,
+    {
         tokio::task::spawn_blocking(move || {
-            let _permit = permit;
+            let _permit = self.permit;
             work()
         })
-        .await
-        .map_err(|error| {
-            EngineError::from_source(
-                EngineErrorKind::Internal,
-                "blocking engine task failed",
-                error,
-            )
-        })?
     }
+}
+
+pub(crate) async fn join_blocking<T>(join: JoinHandle<EngineResult<T>>) -> EngineResult<T>
+where
+    T: Send + 'static,
+{
+    join.await.map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::Internal,
+            "blocking engine task failed",
+            error,
+        )
+    })?
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,10 @@
-use std::{net::SocketAddr, path::PathBuf};
+use std::{net::SocketAddr, path::PathBuf, time::Duration};
 
 use briskdb::{
     core::{
-        DEFAULT_CONNECTIONS_PER_SHARD, DEFAULT_QUEUE_CAPACITY_PER_SHARD, EngineOptions,
-        EngineResult,
+        DEFAULT_CONNECTIONS_PER_SHARD, DEFAULT_MAX_RESULT_BYTES, DEFAULT_MAX_RESULT_ROWS,
+        DEFAULT_QUEUE_CAPACITY_PER_SHARD, DEFAULT_REQUEST_TIMEOUT_MS, DEFAULT_SHUTDOWN_GRACE_MS,
+        EngineOptions, EngineResult, ResultLimits,
     },
     server::{self, Config},
 };
@@ -40,6 +41,38 @@ struct Args {
         default_value_t = DEFAULT_QUEUE_CAPACITY_PER_SHARD
     )]
     queue_capacity_per_shard: usize,
+
+    /// Maximum rows materialized by one query (1-1000000).
+    #[arg(
+        long,
+        env = "BRISKDB_MAX_RESULT_ROWS",
+        default_value_t = DEFAULT_MAX_RESULT_ROWS
+    )]
+    max_result_rows: u64,
+
+    /// Maximum protocol-neutral logical bytes materialized by one query (1-1 GiB).
+    #[arg(
+        long,
+        env = "BRISKDB_MAX_RESULT_BYTES",
+        default_value_t = DEFAULT_MAX_RESULT_BYTES
+    )]
+    max_result_bytes: u64,
+
+    /// Engine request timeout in milliseconds; zero disables the default deadline.
+    #[arg(
+        long,
+        env = "BRISKDB_REQUEST_TIMEOUT_MS",
+        default_value_t = DEFAULT_REQUEST_TIMEOUT_MS
+    )]
+    request_timeout_ms: u64,
+
+    /// Graceful-shutdown drain period in milliseconds.
+    #[arg(
+        long,
+        env = "BRISKDB_SHUTDOWN_GRACE_MS",
+        default_value_t = DEFAULT_SHUTDOWN_GRACE_MS
+    )]
+    shutdown_grace_ms: u64,
 }
 
 impl Args {
@@ -48,8 +81,14 @@ impl Args {
     /// Keeping this conversion ahead of `server::run_with_engine_options`
     /// ensures invalid limits cannot bind a listener or create database files.
     fn into_server_parts(self) -> EngineResult<(Config, EngineOptions)> {
+        let result_limits = ResultLimits::new(self.max_result_rows, self.max_result_bytes)?;
+        let request_timeout =
+            (self.request_timeout_ms != 0).then(|| Duration::from_millis(self.request_timeout_ms));
         let options =
-            EngineOptions::new(self.connections_per_shard, self.queue_capacity_per_shard)?;
+            EngineOptions::new(self.connections_per_shard, self.queue_capacity_per_shard)?
+                .with_result_limits(result_limits)
+                .with_request_timeout(request_timeout)?
+                .with_shutdown_grace(Duration::from_millis(self.shutdown_grace_ms))?;
         let config = Config {
             listen: self.listen,
             data_dir: self.data_dir,
@@ -91,6 +130,10 @@ mod tests {
             args.queue_capacity_per_shard,
             DEFAULT_QUEUE_CAPACITY_PER_SHARD
         );
+        assert_eq!(args.max_result_rows, DEFAULT_MAX_RESULT_ROWS);
+        assert_eq!(args.max_result_bytes, DEFAULT_MAX_RESULT_BYTES);
+        assert_eq!(args.request_timeout_ms, DEFAULT_REQUEST_TIMEOUT_MS);
+        assert_eq!(args.shutdown_grace_ms, DEFAULT_SHUTDOWN_GRACE_MS);
     }
 
     #[test]
@@ -107,6 +150,14 @@ mod tests {
             "3",
             "--queue-capacity-per-shard",
             "17",
+            "--max-result-rows",
+            "321",
+            "--max-result-bytes",
+            "654321",
+            "--request-timeout-ms",
+            "2500",
+            "--shutdown-grace-ms",
+            "4000",
         ])
         .unwrap();
 
@@ -115,6 +166,10 @@ mod tests {
         assert_eq!(args.shards, 8);
         assert_eq!(args.connections_per_shard, 3);
         assert_eq!(args.queue_capacity_per_shard, 17);
+        assert_eq!(args.max_result_rows, 321);
+        assert_eq!(args.max_result_bytes, 654_321);
+        assert_eq!(args.request_timeout_ms, 2_500);
+        assert_eq!(args.shutdown_grace_ms, 4_000);
     }
 
     #[test]
@@ -131,6 +186,14 @@ mod tests {
             "3",
             "--queue-capacity-per-shard",
             "17",
+            "--max-result-rows",
+            "321",
+            "--max-result-bytes",
+            "654321",
+            "--request-timeout-ms",
+            "2500",
+            "--shutdown-grace-ms",
+            "4000",
         ])
         .unwrap();
 
@@ -145,25 +208,41 @@ mod tests {
         );
         assert_eq!(options.connections_per_shard(), 3);
         assert_eq!(options.queue_capacity_per_shard(), 17);
+        assert_eq!(
+            options.result_limits(),
+            ResultLimits::new(321, 654_321).unwrap()
+        );
+        assert_eq!(
+            options.request_timeout(),
+            Some(Duration::from_millis(2_500))
+        );
+        assert_eq!(options.shutdown_grace(), Duration::from_millis(4_000));
     }
 
     #[test]
     fn invalid_cli_limits_fail_during_startup_conversion() {
         for arguments in [
-            [
+            vec![
                 "briskdb",
                 "--connections-per-shard",
                 "0",
                 "--queue-capacity-per-shard",
                 "1",
             ],
-            [
+            vec![
                 "briskdb",
                 "--connections-per-shard",
                 "1",
                 "--queue-capacity-per-shard",
                 "1025",
             ],
+            vec!["briskdb", "--max-result-rows", "0"],
+            vec!["briskdb", "--max-result-rows", "1000001"],
+            vec!["briskdb", "--max-result-bytes", "0"],
+            vec!["briskdb", "--max-result-bytes", "1073741825"],
+            vec!["briskdb", "--request-timeout-ms", "86400001"],
+            vec!["briskdb", "--shutdown-grace-ms", "0"],
+            vec!["briskdb", "--shutdown-grace-ms", "86400001"],
         ] {
             let error = Args::try_parse_from(arguments)
                 .unwrap()
@@ -177,7 +256,14 @@ mod tests {
     }
 
     #[test]
-    fn pool_flags_are_bound_to_the_documented_environment_variables() {
+    fn zero_request_timeout_explicitly_disables_only_the_engine_default() {
+        let args = Args::try_parse_from(["briskdb", "--request-timeout-ms", "0"]).unwrap();
+        let (_, options) = args.into_server_parts().unwrap();
+        assert_eq!(options.request_timeout(), None);
+    }
+
+    #[test]
+    fn resource_flags_are_bound_to_the_documented_environment_variables() {
         let command = Args::command();
         let connections = command
             .get_arguments()
@@ -187,6 +273,22 @@ mod tests {
             .get_arguments()
             .find(|argument| argument.get_id() == "queue_capacity_per_shard")
             .unwrap();
+        let rows = command
+            .get_arguments()
+            .find(|argument| argument.get_id() == "max_result_rows")
+            .unwrap();
+        let bytes = command
+            .get_arguments()
+            .find(|argument| argument.get_id() == "max_result_bytes")
+            .unwrap();
+        let timeout = command
+            .get_arguments()
+            .find(|argument| argument.get_id() == "request_timeout_ms")
+            .unwrap();
+        let shutdown = command
+            .get_arguments()
+            .find(|argument| argument.get_id() == "shutdown_grace_ms")
+            .unwrap();
 
         assert_eq!(
             connections.get_env(),
@@ -195,6 +297,19 @@ mod tests {
         assert_eq!(
             queue.get_env(),
             Some(OsStr::new("BRISKDB_QUEUE_CAPACITY_PER_SHARD"))
+        );
+        assert_eq!(rows.get_env(), Some(OsStr::new("BRISKDB_MAX_RESULT_ROWS")));
+        assert_eq!(
+            bytes.get_env(),
+            Some(OsStr::new("BRISKDB_MAX_RESULT_BYTES"))
+        );
+        assert_eq!(
+            timeout.get_env(),
+            Some(OsStr::new("BRISKDB_REQUEST_TIMEOUT_MS"))
+        );
+        assert_eq!(
+            shutdown.get_env(),
+            Some(OsStr::new("BRISKDB_SHUTDOWN_GRACE_MS"))
         );
     }
 
@@ -206,6 +321,10 @@ mod tests {
             let args = Args::try_parse_from(["briskdb"]).unwrap();
             assert_eq!(args.connections_per_shard, 6);
             assert_eq!(args.queue_capacity_per_shard, 41);
+            assert_eq!(args.max_result_rows, 500);
+            assert_eq!(args.max_result_bytes, 65_536);
+            assert_eq!(args.request_timeout_ms, 1_250);
+            assert_eq!(args.shutdown_grace_ms, 2_750);
             return;
         }
 
@@ -220,6 +339,10 @@ mod tests {
             .env("BRISKDB_SHARDS", "4")
             .env("BRISKDB_CONNECTIONS_PER_SHARD", "6")
             .env("BRISKDB_QUEUE_CAPACITY_PER_SHARD", "41")
+            .env("BRISKDB_MAX_RESULT_ROWS", "500")
+            .env("BRISKDB_MAX_RESULT_BYTES", "65536")
+            .env("BRISKDB_REQUEST_TIMEOUT_MS", "1250")
+            .env("BRISKDB_SHUTDOWN_GRACE_MS", "2750")
             .status()
             .unwrap();
 

--- a/src/protocol/error.rs
+++ b/src/protocol/error.rs
@@ -47,8 +47,10 @@ pub const fn http_error(kind: EngineErrorKind) -> HttpErrorMapping {
         EngineErrorKind::PermissionDenied | EngineErrorKind::ReadOnly => 403,
         EngineErrorKind::Busy
         | EngineErrorKind::OutOfMemory
-        | EngineErrorKind::StorageUnavailable => 503,
+        | EngineErrorKind::StorageUnavailable
+        | EngineErrorKind::ShuttingDown => 503,
         EngineErrorKind::Cancelled => 500,
+        EngineErrorKind::DeadlineExceeded => 504,
         EngineErrorKind::LimitExceeded => 422,
         EngineErrorKind::StorageFull => 507,
         EngineErrorKind::DataCorruption | EngineErrorKind::Internal => 500,
@@ -81,7 +83,9 @@ pub const fn postgres_error(kind: EngineErrorKind) -> PostgresErrorMapping {
         EngineErrorKind::ReadOnly => "25006",
         EngineErrorKind::Busy => "55P03",
         EngineErrorKind::Cancelled => "57014",
+        EngineErrorKind::DeadlineExceeded => "57014",
         EngineErrorKind::LimitExceeded => "54000",
+        EngineErrorKind::ShuttingDown => "57P01",
         EngineErrorKind::StorageFull => "53100",
         EngineErrorKind::OutOfMemory => "53200",
         EngineErrorKind::StorageUnavailable => "58030",
@@ -116,7 +120,9 @@ pub const fn mysql_error(kind: EngineErrorKind) -> MysqlErrorMapping {
         EngineErrorKind::ReadOnly => (1290, "HY000"),
         EngineErrorKind::Busy => (1205, "HY000"),
         EngineErrorKind::Cancelled => (1317, "70100"),
+        EngineErrorKind::DeadlineExceeded => (3024, "HY000"),
         EngineErrorKind::LimitExceeded => (1105, "HY000"),
+        EngineErrorKind::ShuttingDown => (1053, "08S01"),
         EngineErrorKind::StorageFull => (1114, "HY000"),
         EngineErrorKind::OutOfMemory => (1037, "HY001"),
         EngineErrorKind::StorageUnavailable
@@ -181,8 +187,14 @@ const fn problem_type(kind: EngineErrorKind) -> &'static str {
         EngineErrorKind::Cancelled => {
             "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#cancelled"
         }
+        EngineErrorKind::DeadlineExceeded => {
+            "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#deadline-exceeded"
+        }
         EngineErrorKind::LimitExceeded => {
             "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#limit-exceeded"
+        }
+        EngineErrorKind::ShuttingDown => {
+            "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#shutting-down"
         }
         EngineErrorKind::StorageFull => {
             "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#storage-full"
@@ -220,7 +232,9 @@ const fn title(kind: EngineErrorKind) -> &'static str {
         EngineErrorKind::ReadOnly => "Read-only storage",
         EngineErrorKind::Busy => "Database busy",
         EngineErrorKind::Cancelled => "Request cancelled",
+        EngineErrorKind::DeadlineExceeded => "Request deadline exceeded",
         EngineErrorKind::LimitExceeded => "Limit exceeded",
+        EngineErrorKind::ShuttingDown => "Server shutting down",
         EngineErrorKind::StorageFull => "Storage full",
         EngineErrorKind::OutOfMemory => "Out of memory",
         EngineErrorKind::StorageUnavailable => "Storage unavailable",
@@ -247,7 +261,11 @@ const fn detail(kind: EngineErrorKind) -> &'static str {
         EngineErrorKind::ReadOnly => "The storage is read-only.",
         EngineErrorKind::Busy => "The database is busy; retry the operation later.",
         EngineErrorKind::Cancelled => "The operation was cancelled.",
+        EngineErrorKind::DeadlineExceeded => "The operation exceeded its request deadline.",
         EngineErrorKind::LimitExceeded => "The request exceeds an engine limit.",
+        EngineErrorKind::ShuttingDown => {
+            "The server is shutting down and cannot accept the operation."
+        }
         EngineErrorKind::StorageFull => "The storage has no available space.",
         EngineErrorKind::OutOfMemory => "The engine does not have enough memory.",
         EngineErrorKind::StorageUnavailable => "The storage is unavailable.",
@@ -335,7 +353,15 @@ mod tests {
             (EngineErrorKind::ReadOnly, 403, "25006", 1290, "HY000"),
             (EngineErrorKind::Busy, 503, "55P03", 1205, "HY000"),
             (EngineErrorKind::Cancelled, 500, "57014", 1317, "70100"),
+            (
+                EngineErrorKind::DeadlineExceeded,
+                504,
+                "57014",
+                3024,
+                "HY000",
+            ),
             (EngineErrorKind::LimitExceeded, 422, "54000", 1105, "HY000"),
+            (EngineErrorKind::ShuttingDown, 503, "57P01", 1053, "08S01"),
             (EngineErrorKind::StorageFull, 507, "53100", 1114, "HY000"),
             (EngineErrorKind::OutOfMemory, 503, "53200", 1037, "HY001"),
             (

--- a/src/protocol/http.rs
+++ b/src/protocol/http.rs
@@ -257,7 +257,7 @@ impl IntoResponse for ApiError {
 
 #[cfg(test)]
 mod tests {
-    use std::io;
+    use std::{io, time::Duration};
 
     use axum::{
         body::{Body, to_bytes},
@@ -266,7 +266,7 @@ mod tests {
     use tower::ServiceExt;
 
     use super::*;
-    use crate::core::{Column, DataType, EngineErrorKind, Row};
+    use crate::core::{Column, DataType, EngineErrorKind, EngineOptions, ResultLimits, Row};
 
     fn engine_router(database: Arc<Database>) -> Router {
         router_with_engine(Engine::from_database(database))
@@ -519,6 +519,78 @@ mod tests {
             })
         );
         assert!(!body.to_string().contains("missing_table"));
+    }
+
+    #[tokio::test]
+    async fn result_limit_failures_return_only_a_safe_problem_without_partial_rows() {
+        let temp = tempfile::tempdir().unwrap();
+        let database = Arc::new(Database::open(temp.path(), 4).unwrap());
+        let options =
+            EngineOptions::default().with_result_limits(ResultLimits::new(1, 1_024).unwrap());
+        let application =
+            router_with_engine(Engine::from_database_with_options(database, options).unwrap());
+
+        let response = send_json(
+            &application,
+            Method::POST,
+            "/v1/query",
+            Some(json!({
+                "shard_key": "limited-query",
+                "sql": "SELECT 1 AS value UNION ALL SELECT 2"
+            })),
+        )
+        .await;
+        assert_eq!(
+            response.headers().get(CONTENT_TYPE).unwrap(),
+            "application/problem+json"
+        );
+        let (status, body) = response_json(response).await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(
+            body,
+            json!({
+                "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#limit-exceeded",
+                "title": "Limit exceeded",
+                "status": 422,
+                "detail": "The request exceeds an engine limit.",
+                "code": "limit_exceeded"
+            })
+        );
+        assert!(body.get("columns").is_none());
+        assert!(body.get("rows").is_none());
+    }
+
+    #[tokio::test]
+    async fn engine_deadlines_reach_http_as_safe_gateway_timeout_problems() {
+        let temp = tempfile::tempdir().unwrap();
+        let database = Arc::new(Database::open(temp.path(), 4).unwrap());
+        let options = EngineOptions::default()
+            .with_request_timeout(Some(Duration::from_millis(5)))
+            .unwrap();
+        let application =
+            router_with_engine(Engine::from_database_with_options(database, options).unwrap());
+
+        let (status, body) = request_json(
+            &application,
+            Method::POST,
+            "/v1/query",
+            Some(json!({
+                "shard_key": "deadline-query",
+                "sql": "WITH RECURSIVE numbers(value) AS (VALUES(0) UNION ALL SELECT value + 1 FROM numbers WHERE value < 1000000000) SELECT sum(value) FROM numbers"
+            })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::GATEWAY_TIMEOUT);
+        assert_eq!(
+            body,
+            json!({
+                "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#deadline-exceeded",
+                "title": "Request deadline exceeded",
+                "status": 504,
+                "detail": "The operation exceeded its request deadline.",
+                "code": "deadline_exceeded"
+            })
+        );
     }
 
     #[tokio::test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,9 +1,17 @@
 //! Server process assembly and listener lifecycle.
 
-use std::{net::SocketAddr, path::PathBuf};
+use std::{future::Future, net::SocketAddr, path::PathBuf, pin::Pin, sync::Arc, time::Duration};
 
 use anyhow::Context;
-use tracing::info;
+use axum::body::Body;
+use hyper::{Request, body::Incoming, server::conn::http1};
+use hyper_util::{rt::TokioIo, service::TowerToHyperService};
+use tokio::{
+    sync::{Notify, watch},
+    task::JoinSet,
+};
+use tower::ServiceExt;
+use tracing::{debug, info, warn};
 
 use crate::{
     core::{Engine, EngineOptions},
@@ -28,9 +36,32 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
 /// [`EngineOptions::default`].
 pub async fn run_with_engine_options(config: Config, options: EngineOptions) -> anyhow::Result<()> {
     let engine = Engine::open_with_options(&config.data_dir, config.shards, options).await?;
-    let listener = tokio::net::TcpListener::bind(config.listen)
+    let listener = match tokio::net::TcpListener::bind(config.listen)
         .await
-        .with_context(|| format!("failed to bind {}", config.listen))?;
+        .with_context(|| format!("failed to bind {}", config.listen))
+    {
+        Ok(listener) => listener,
+        Err(error) => {
+            engine.begin_shutdown();
+            if let Err(shutdown_error) = engine.shutdown().await {
+                warn!(error = %shutdown_error, "failed to clean up after listener startup error");
+            }
+            return Err(error);
+        }
+    };
+    // Tokio's portable `ctrl_c()` future installs its handler only when first
+    // polled. Construct platform signal streams synchronously here so a signal
+    // cannot land between the readiness log and handler installation.
+    let signal = match shutdown_signal() {
+        Ok(signal) => signal,
+        Err(error) => {
+            engine.begin_shutdown();
+            if let Err(shutdown_error) = engine.shutdown().await {
+                warn!(error = %shutdown_error, "failed to clean up after signal startup error");
+            }
+            return Err(error);
+        }
+    };
 
     info!(
         listen = %config.listen,
@@ -40,21 +71,283 @@ pub async fn run_with_engine_options(config: Config, options: EngineOptions) -> 
             * usize::from(engine.shard_count()),
         connections_per_shard = engine.options().connections_per_shard(),
         queue_capacity_per_shard = engine.options().queue_capacity_per_shard(),
+        max_result_rows = engine.options().result_limits().max_rows(),
+        max_result_bytes = engine.options().result_limits().max_bytes(),
+        request_timeout_ms = engine
+            .options()
+            .request_timeout()
+            .map(|timeout| timeout.as_millis()),
+        shutdown_grace_ms = engine.options().shutdown_grace().as_millis(),
         "BriskDB is ready"
     );
 
-    axum::serve(listener, http::router_with_engine(engine)).await?;
+    serve_with_shutdown(listener, engine, signal).await
+}
+
+async fn serve_with_shutdown<F>(
+    listener: tokio::net::TcpListener,
+    engine: Engine,
+    signal: F,
+) -> anyhow::Result<()>
+where
+    F: Future<Output = ()> + Send,
+{
+    serve_with_shutdown_observed(listener, engine, signal, None).await
+}
+
+async fn serve_with_shutdown_observed<F>(
+    listener: tokio::net::TcpListener,
+    engine: Engine,
+    signal: F,
+    accepted: Option<Arc<Notify>>,
+) -> anyhow::Result<()>
+where
+    F: Future<Output = ()> + Send,
+{
+    let mut shutdown_guard = ShutdownOnDrop::new(engine.clone());
+    let router = http::router_with_engine(engine.clone());
+    let (graceful_tx, _graceful_rx) = watch::channel(false);
+    let mut connections = JoinSet::new();
+    let mut server_error = None;
+    tokio::pin!(signal);
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = &mut signal => break,
+            Some(result) = connections.join_next(), if !connections.is_empty() => {
+                log_connection_join(result, false);
+            }
+            accepted_connection = listener.accept() => {
+                let (stream, peer) = match accepted_connection {
+                    Ok(connection) => connection,
+                    Err(error) => {
+                        server_error = Some(
+                            anyhow::Error::from(error).context("HTTP listener accept failed")
+                        );
+                        break;
+                    }
+                };
+                let service = TowerToHyperService::new(router.clone().map_request(
+                    |request: Request<Incoming>| request.map(Body::new),
+                ));
+                let graceful_rx = graceful_tx.subscribe();
+                let accepted = accepted.clone();
+                connections.spawn(async move {
+                    serve_http_connection(stream, peer, service, graceful_rx, accepted).await;
+                });
+            }
+        }
+    }
+
+    // Admission must close before the listener and connection signals so an
+    // already-accepted request cannot enter the core after draining starts.
+    engine.begin_shutdown();
+    drop(listener);
+    let http_grace = engine.options().shutdown_grace();
+    let core_shutdown = engine.shutdown();
+    let http_shutdown = drain_http_connections(graceful_tx, &mut connections, http_grace);
+    let (core_result, _) = tokio::join!(core_shutdown, http_shutdown);
+    let report = core_result?;
+    info!(forced = report.forced(), "BriskDB core shutdown completed");
+
+    shutdown_guard.disarm();
+    if let Some(server_error) = server_error {
+        return Err(server_error);
+    }
     Ok(())
+}
+
+async fn serve_http_connection<S>(
+    stream: tokio::net::TcpStream,
+    peer: SocketAddr,
+    service: S,
+    mut graceful_rx: watch::Receiver<bool>,
+    accepted: Option<Arc<Notify>>,
+) where
+    S: hyper::service::Service<
+            Request<Incoming>,
+            Response = axum::response::Response,
+            Error = std::convert::Infallible,
+        > + Send
+        + 'static,
+    S::Future: Send + 'static,
+{
+    let builder = http1::Builder::new();
+    let connection = builder
+        .serve_connection(TokioIo::new(stream), service)
+        .with_upgrades();
+    tokio::pin!(connection);
+    if let Some(accepted) = accepted {
+        accepted.notify_one();
+    }
+
+    let result = if *graceful_rx.borrow() {
+        connection.as_mut().graceful_shutdown();
+        connection.await
+    } else {
+        tokio::select! {
+            result = &mut connection => result,
+            _ = wait_for_http_shutdown(&mut graceful_rx) => {
+                connection.as_mut().graceful_shutdown();
+                connection.await
+            }
+        }
+    };
+    if let Err(error) = result {
+        debug!(%peer, %error, "HTTP connection ended with a protocol error");
+    }
+}
+
+async fn wait_for_http_shutdown(graceful_rx: &mut watch::Receiver<bool>) {
+    loop {
+        if *graceful_rx.borrow_and_update() {
+            return;
+        }
+        if graceful_rx.changed().await.is_err() {
+            return;
+        }
+    }
+}
+
+async fn drain_http_connections(
+    graceful_tx: watch::Sender<bool>,
+    connections: &mut JoinSet<()>,
+    grace: Duration,
+) -> bool {
+    let watched_connections = graceful_tx.receiver_count().saturating_sub(1);
+    graceful_tx.send_replace(true);
+    let graceful_drain = async {
+        while let Some(result) = connections.join_next().await {
+            log_connection_join(result, false);
+        }
+    };
+
+    if tokio::time::timeout(grace, graceful_drain).await.is_ok() {
+        false
+    } else {
+        let remaining = connections.len();
+        if remaining > 0 {
+            warn!(
+                grace_ms = grace.as_millis(),
+                connections = remaining,
+                watched_connections,
+                "HTTP connections exceeded the shutdown grace period; force-closing them"
+            );
+            connections.abort_all();
+            while let Some(result) = connections.join_next().await {
+                log_connection_join(result, true);
+            }
+        }
+        drop(graceful_tx);
+        remaining > 0
+    }
+}
+
+fn log_connection_join(result: Result<(), tokio::task::JoinError>, forced: bool) {
+    if let Err(error) = result {
+        if !(forced && error.is_cancelled()) {
+            warn!(%error, "HTTP connection task failed");
+        }
+    }
+}
+
+struct ShutdownOnDrop {
+    engine: Option<Engine>,
+}
+
+impl ShutdownOnDrop {
+    fn new(engine: Engine) -> Self {
+        Self {
+            engine: Some(engine),
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.engine = None;
+    }
+}
+
+impl Drop for ShutdownOnDrop {
+    fn drop(&mut self) {
+        if let Some(engine) = self.engine.take() {
+            // Drop cannot await cleanup, but it can atomically reject new work.
+            // The lifecycle remains resumable by any surviving Engine clone.
+            engine.begin_shutdown();
+        }
+    }
+}
+
+type PreparedShutdownSignal = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+
+#[cfg(unix)]
+fn shutdown_signal() -> anyhow::Result<PreparedShutdownSignal> {
+    use tokio::signal::unix::{SignalKind, signal};
+
+    let mut interrupt =
+        signal(SignalKind::interrupt()).context("failed to install SIGINT shutdown handler")?;
+    let mut terminate =
+        signal(SignalKind::terminate()).context("failed to install SIGTERM shutdown handler")?;
+    Ok(Box::pin(async move {
+        tokio::select! {
+            _ = interrupt.recv() => {}
+            _ = terminate.recv() => {}
+        }
+    }))
+}
+
+#[cfg(windows)]
+fn shutdown_signal() -> anyhow::Result<PreparedShutdownSignal> {
+    let mut ctrl_c =
+        tokio::signal::windows::ctrl_c().context("failed to install Ctrl-C shutdown handler")?;
+    Ok(Box::pin(async move {
+        ctrl_c.recv().await;
+    }))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn shutdown_signal() -> anyhow::Result<PreparedShutdownSignal> {
+    anyhow::bail!("process shutdown signals are unsupported on this target")
 }
 
 #[cfg(test)]
 mod tests {
+    use std::time::{Duration, Instant};
+
+    use axum::body::to_bytes;
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        time::timeout,
+    };
+
     use super::*;
 
     fn unavailable_address() -> (std::net::TcpListener, SocketAddr) {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let address = listener.local_addr().unwrap();
         (listener, address)
+    }
+
+    async fn assert_peer_closes(stream: &mut tokio::net::TcpStream) {
+        timeout(Duration::from_secs(1), async {
+            let mut buffer = [0_u8; 1_024];
+            loop {
+                match stream.read(&mut buffer).await {
+                    Ok(0) | Err(_) => return,
+                    Ok(_) => {}
+                }
+            }
+        })
+        .await
+        .expect("the tracked HTTP peer should be closed");
+    }
+
+    fn partial_json_request(content_length: usize) -> Vec<u8> {
+        format!(
+            "POST /v1/query HTTP/1.1\r\nHost: localhost\r\n\
+             Content-Type: application/json\r\nContent-Length: {content_length}\r\n\r\n{{"
+        )
+        .into_bytes()
     }
 
     #[tokio::test]
@@ -97,5 +390,250 @@ mod tests {
                 .contains("must contain between 1 and 512 total active connections")
         );
         assert!(!data_dir.exists());
+    }
+
+    #[tokio::test]
+    async fn injected_signal_stops_the_listener_and_fully_stops_the_engine() {
+        let temp = tempfile::tempdir().unwrap();
+        let options = EngineOptions::default()
+            .with_shutdown_grace(Duration::from_millis(50))
+            .unwrap();
+        let engine = Engine::open_with_options(temp.path(), 2, options)
+            .await
+            .unwrap();
+        let observer = engine.clone();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (signal_tx, signal_rx) = tokio::sync::oneshot::channel();
+        let send_signal = tokio::spawn(async move {
+            // Let the serve and signal futures both register before firing the
+            // injected process-level event.
+            tokio::task::yield_now().await;
+            signal_tx.send(()).unwrap();
+        });
+        timeout(
+            Duration::from_secs(2),
+            serve_with_shutdown(listener, engine, async move {
+                let _ = signal_rx.await;
+            }),
+        )
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "server should complete its injected graceful shutdown; engine state: {:?}",
+                observer.state()
+            )
+        })
+        .unwrap();
+        send_signal.await.unwrap();
+
+        assert_eq!(observer.state(), crate::core::EngineState::Stopped);
+        assert!(tokio::net::TcpStream::connect(address).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn already_ready_shutdown_signal_has_no_startup_lost_wakeup() {
+        let temp = tempfile::tempdir().unwrap();
+        let options = EngineOptions::default()
+            .with_shutdown_grace(Duration::from_millis(50))
+            .unwrap();
+        let engine = Engine::open_with_options(temp.path(), 2, options)
+            .await
+            .unwrap();
+        let observer = engine.clone();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+
+        timeout(
+            Duration::from_secs(2),
+            serve_with_shutdown(listener, engine, async {}),
+        )
+        .await
+        .expect("ready signal should shut down immediately")
+        .unwrap();
+        assert_eq!(observer.state(), crate::core::EngineState::Stopped);
+    }
+
+    #[tokio::test]
+    async fn stuck_request_body_is_force_closed_and_joined_at_http_deadline() {
+        let temp = tempfile::tempdir().unwrap();
+        let grace = Duration::from_millis(40);
+        let options = EngineOptions::default()
+            .with_request_timeout(None)
+            .unwrap()
+            .with_shutdown_grace(grace)
+            .unwrap();
+        let engine = Engine::open_with_options(temp.path(), 2, options)
+            .await
+            .unwrap();
+        let observer = engine.clone();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let accepted = Arc::new(Notify::new());
+        let accepted_for_server = Arc::clone(&accepted);
+        let (signal_tx, signal_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(serve_with_shutdown_observed(
+            listener,
+            engine,
+            async move {
+                let _ = signal_rx.await;
+            },
+            Some(accepted_for_server),
+        ));
+
+        let mut client = tokio::net::TcpStream::connect(address).await.unwrap();
+        client
+            .write_all(&partial_json_request(1_000))
+            .await
+            .unwrap();
+        timeout(Duration::from_secs(1), accepted.notified())
+            .await
+            .expect("the HTTP connection should be tracked before shutdown");
+        let started = Instant::now();
+        signal_tx.send(()).unwrap();
+        timeout(Duration::from_secs(2), server)
+            .await
+            .expect("forced HTTP draining should be bounded")
+            .unwrap()
+            .unwrap();
+        assert!(started.elapsed() >= grace);
+        assert_eq!(observer.state(), crate::core::EngineState::Stopped);
+        assert_peer_closes(&mut client).await;
+        assert!(tokio::net::TcpStream::connect(address).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn aborting_server_future_closes_connections_and_leaves_resumable_drain() {
+        let temp = tempfile::tempdir().unwrap();
+        let options = EngineOptions::default()
+            .with_request_timeout(None)
+            .unwrap()
+            .with_shutdown_grace(Duration::from_millis(50))
+            .unwrap();
+        let engine = Engine::open_with_options(temp.path(), 2, options)
+            .await
+            .unwrap();
+        let observer = engine.clone();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let accepted = Arc::new(Notify::new());
+        let accepted_for_server = Arc::clone(&accepted);
+        let server = tokio::spawn(serve_with_shutdown_observed(
+            listener,
+            engine,
+            std::future::pending(),
+            Some(accepted_for_server),
+        ));
+
+        let mut client = tokio::net::TcpStream::connect(address).await.unwrap();
+        client
+            .write_all(&partial_json_request(1_000))
+            .await
+            .unwrap();
+        timeout(Duration::from_secs(1), accepted.notified())
+            .await
+            .expect("the connection should be owned before aborting the server");
+        server.abort();
+        assert!(server.await.unwrap_err().is_cancelled());
+        assert_eq!(observer.state(), crate::core::EngineState::Draining);
+        assert_peer_closes(&mut client).await;
+        assert!(tokio::net::TcpStream::connect(address).await.is_err());
+
+        timeout(Duration::from_secs(2), observer.shutdown())
+            .await
+            .expect("a surviving engine clone should resume cleanup")
+            .unwrap();
+        assert_eq!(observer.state(), crate::core::EngineState::Stopped);
+    }
+
+    #[tokio::test]
+    async fn active_http_query_drains_through_core_cancellation() {
+        let temp = tempfile::tempdir().unwrap();
+        let grace = Duration::from_millis(20);
+        let options = EngineOptions::new(1, 1)
+            .unwrap()
+            .with_request_timeout(None)
+            .unwrap()
+            .with_shutdown_grace(grace)
+            .unwrap();
+        let engine = Engine::open_with_options(temp.path(), 2, options)
+            .await
+            .unwrap();
+        let observer = engine.clone();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let accepted = Arc::new(Notify::new());
+        let accepted_for_server = Arc::clone(&accepted);
+        let (signal_tx, signal_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(serve_with_shutdown_observed(
+            listener,
+            engine,
+            async move {
+                let _ = signal_rx.await;
+            },
+            Some(accepted_for_server),
+        ));
+
+        let body = serde_json::json!({
+            "shard_key": "active-http",
+            "sql": "WITH RECURSIVE numbers(value) AS (VALUES(0) UNION ALL SELECT value + 1 FROM numbers WHERE value < 1000000000) SELECT sum(value) FROM numbers",
+            "params": []
+        })
+        .to_string();
+        let request = format!(
+            "POST /v1/query HTTP/1.1\r\nHost: localhost\r\n\
+             Content-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let mut client = tokio::net::TcpStream::connect(address).await.unwrap();
+        client.write_all(request.as_bytes()).await.unwrap();
+        timeout(Duration::from_secs(1), accepted.notified())
+            .await
+            .expect("the active HTTP connection should be tracked");
+        timeout(Duration::from_secs(1), async {
+            while observer.active_operations_for_test() == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the HTTP query should enter the shared engine before shutdown");
+        signal_tx.send(()).unwrap();
+        timeout(Duration::from_secs(2), server)
+            .await
+            .expect("core cancellation should finish the active HTTP drain")
+            .unwrap()
+            .unwrap();
+        assert_eq!(observer.state(), crate::core::EngineState::Stopped);
+        assert!(observer.shutdown().await.unwrap().forced());
+        assert_peer_closes(&mut client).await;
+    }
+
+    #[tokio::test]
+    async fn draining_engine_returns_safe_service_unavailable_problem() {
+        let temp = tempfile::tempdir().unwrap();
+        let engine = Engine::open(temp.path(), 2).await.unwrap();
+        engine.begin_shutdown();
+        let response = http::router_with_engine(engine.clone())
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            axum::http::StatusCode::SERVICE_UNAVAILABLE
+        );
+        let body = to_bytes(response.into_body(), 16 * 1_024).await.unwrap();
+        let problem: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            problem["type"],
+            "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#shutting-down"
+        );
+        assert_eq!(problem["status"], 503);
+        assert!(!String::from_utf8_lossy(&body).contains(temp.path().to_string_lossy().as_ref()));
+        engine.shutdown().await.unwrap();
     }
 }

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -9,9 +9,18 @@ use rusqlite::{
 };
 
 use crate::{
-    core::{Column, DataType, EngineError, EngineErrorKind, EngineResult, ResultSet, Row, Value},
+    core::{
+        Column, DataType, EngineError, EngineErrorKind, EngineResult, ResultLimits, ResultSet, Row,
+        Value,
+    },
     sqlite_error,
 };
+
+const RESULT_ENVELOPE_BYTES: u64 = 16;
+const TYPE_TAG_BYTES: u64 = 1;
+const LENGTH_BYTES: u64 = 8;
+const ROW_FRAME_BYTES: u64 = 8;
+const FIXED_VALUE_PAYLOAD_BYTES: u64 = 8;
 
 pub(crate) fn execute(
     connection: &Connection,
@@ -32,6 +41,15 @@ pub(crate) fn query(
     statement: &str,
     params: &[Value],
 ) -> EngineResult<ResultSet> {
+    query_with_limits(connection, statement, params, ResultLimits::default())
+}
+
+pub(crate) fn query_with_limits(
+    connection: &Connection,
+    statement: &str,
+    params: &[Value],
+    limits: ResultLimits,
+) -> EngineResult<ResultSet> {
     let params = params
         .iter()
         .map(value_to_sql)
@@ -39,8 +57,22 @@ pub(crate) fn query(
     let mut statement = connection
         .prepare(statement)
         .map_err(sqlite_error::statement)?;
-    let columns = statement
-        .column_names()
+    if !statement.readonly() {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidQuery,
+            "query statements must be read-only",
+        ));
+    }
+
+    let column_names = statement.column_names();
+    let mut logical_bytes = account_bytes(0, RESULT_ENVELOPE_BYTES, limits.max_bytes())?;
+    for name in &column_names {
+        logical_bytes = account_bytes(logical_bytes, TYPE_TAG_BYTES, limits.max_bytes())?;
+        logical_bytes = account_bytes(logical_bytes, LENGTH_BYTES, limits.max_bytes())?;
+        logical_bytes =
+            account_bytes(logical_bytes, usize_to_u64(name.len())?, limits.max_bytes())?;
+    }
+    let columns = column_names
         .into_iter()
         .map(|name| Column::new(name, DataType::Unknown))
         .collect::<Vec<_>>();
@@ -48,8 +80,20 @@ pub(crate) fn query(
         .query(params_from_iter(params))
         .map_err(sqlite_error::statement)?;
     let mut rows = Vec::new();
+    let mut row_count = 0_u64;
 
     while let Some(sqlite_row) = sqlite_rows.next().map_err(sqlite_error::statement)? {
+        row_count = account_row(row_count, limits.max_rows())?;
+        let mut row_bytes = account_bytes(logical_bytes, ROW_FRAME_BYTES, limits.max_bytes())?;
+
+        // Account every borrowed SQLite value before cloning any payload into
+        // the protocol-neutral result. A rejected row is therefore never
+        // partially materialized.
+        for index in 0..columns.len() {
+            let value = sqlite_row.get_ref(index).map_err(sqlite_error::statement)?;
+            row_bytes = account_bytes(row_bytes, logical_value_bytes(value)?, limits.max_bytes())?;
+        }
+
         let mut values = Vec::with_capacity(columns.len());
         for index in 0..columns.len() {
             values.push(sql_to_value(
@@ -57,6 +101,7 @@ pub(crate) fn query(
             ));
         }
         rows.push(Row::new(values));
+        logical_bytes = row_bytes;
     }
     ResultSet::new(columns, rows).map_err(|error| {
         EngineError::from_source(
@@ -65,6 +110,54 @@ pub(crate) fn query(
             error,
         )
     })
+}
+
+fn account_row(current: u64, maximum: u64) -> EngineResult<u64> {
+    let next = current.checked_add(1).ok_or_else(row_limit_exceeded)?;
+    if next > maximum {
+        return Err(row_limit_exceeded());
+    }
+    Ok(next)
+}
+
+fn account_bytes(current: u64, additional: u64, maximum: u64) -> EngineResult<u64> {
+    let next = current
+        .checked_add(additional)
+        .ok_or_else(byte_limit_exceeded)?;
+    if next > maximum {
+        return Err(byte_limit_exceeded());
+    }
+    Ok(next)
+}
+
+fn logical_value_bytes(value: ValueRef<'_>) -> EngineResult<u64> {
+    let payload = match value {
+        ValueRef::Null => 0,
+        ValueRef::Integer(_) | ValueRef::Real(_) => FIXED_VALUE_PAYLOAD_BYTES,
+        ValueRef::Text(value) | ValueRef::Blob(value) => usize_to_u64(value.len())?,
+    };
+    TYPE_TAG_BYTES
+        .checked_add(LENGTH_BYTES)
+        .and_then(|framing| framing.checked_add(payload))
+        .ok_or_else(byte_limit_exceeded)
+}
+
+fn usize_to_u64(value: usize) -> EngineResult<u64> {
+    u64::try_from(value).map_err(|_| byte_limit_exceeded())
+}
+
+fn row_limit_exceeded() -> EngineError {
+    EngineError::new(
+        EngineErrorKind::LimitExceeded,
+        "query result exceeds the configured row limit",
+    )
+}
+
+fn byte_limit_exceeded() -> EngineError {
+    EngineError::new(
+        EngineErrorKind::LimitExceeded,
+        "query result exceeds the configured logical byte limit",
+    )
 }
 
 pub(crate) fn execute_batch(connection: &Connection, statement: &str) -> EngineResult<()> {
@@ -235,6 +328,197 @@ mod tests {
         assert_eq!(
             error.to_string(),
             "NaN has no lossless SQLite binding because SQLite converts it to NULL"
+        );
+    }
+
+    #[test]
+    fn logical_value_accounting_covers_every_sqlite_storage_class() {
+        assert_eq!(logical_value_bytes(ValueRef::Null).unwrap(), 9);
+        assert_eq!(logical_value_bytes(ValueRef::Integer(42)).unwrap(), 17);
+        assert_eq!(logical_value_bytes(ValueRef::Real(1.5)).unwrap(), 17);
+        assert_eq!(
+            logical_value_bytes(ValueRef::Text("é".as_bytes())).unwrap(),
+            11
+        );
+        assert_eq!(logical_value_bytes(ValueRef::Blob(&[0, 255])).unwrap(), 11);
+    }
+
+    #[test]
+    fn checked_accounting_accepts_equality_and_classifies_overflow() {
+        assert_eq!(account_row(1, 2).unwrap(), 2);
+        assert_eq!(account_bytes(75, 1, 76).unwrap(), 76);
+
+        for error in [
+            account_row(u64::MAX, u64::MAX).unwrap_err(),
+            account_bytes(u64::MAX, 1, u64::MAX).unwrap_err(),
+        ] {
+            assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+        }
+    }
+
+    #[test]
+    fn metadata_bytes_are_enforced_even_for_an_empty_result() {
+        let connection = Connection::open_in_memory().unwrap();
+        // Envelope (16) + column type (1) + name length (8) + "v" (1).
+        let exact = ResultLimits::new(1, 26).unwrap();
+        let result = query_with_limits(&connection, "SELECT 1 AS v WHERE 0", &[], exact).unwrap();
+        assert!(result.is_empty());
+
+        let one_byte_short = ResultLimits::new(1, 25).unwrap();
+        let error = query_with_limits(&connection, "SELECT 1 AS v WHERE 0", &[], one_byte_short)
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+        assert_eq!(
+            error.to_string(),
+            "query result exceeds the configured logical byte limit"
+        );
+    }
+
+    #[test]
+    fn exact_row_and_byte_limits_pass_and_one_over_returns_no_result() {
+        let connection = Connection::open_in_memory().unwrap();
+        // Metadata is 26 bytes. Each row is a row length (8), value type (1),
+        // value length (8), and integer payload (8), for 25 bytes per row.
+        let exact = ResultLimits::new(2, 76).unwrap();
+        let result =
+            query_with_limits(&connection, "SELECT 1 AS v UNION ALL SELECT 2", &[], exact).unwrap();
+        assert_eq!(result.rows().len(), 2);
+
+        let row_error = query_with_limits(
+            &connection,
+            "SELECT 1 AS v UNION ALL SELECT 2",
+            &[],
+            ResultLimits::new(1, 76).unwrap(),
+        )
+        .unwrap_err();
+        assert_eq!(row_error.kind(), EngineErrorKind::LimitExceeded);
+        assert_eq!(
+            row_error.to_string(),
+            "query result exceeds the configured row limit"
+        );
+
+        let byte_error = query_with_limits(
+            &connection,
+            "SELECT 1 AS v UNION ALL SELECT 2",
+            &[],
+            ResultLimits::new(2, 75).unwrap(),
+        )
+        .unwrap_err();
+        assert_eq!(byte_error.kind(), EngineErrorKind::LimitExceeded);
+
+        // A rejected materialization leaves the connection immediately usable.
+        assert_eq!(
+            query_with_limits(&connection, "SELECT 3 AS v", &[], exact)
+                .unwrap()
+                .rows()[0]
+                .get(0),
+            Some(&Value::from(3_i64))
+        );
+    }
+
+    #[test]
+    fn logical_bytes_use_utf8_and_blob_lengths_not_character_counts() {
+        let connection = Connection::open_in_memory().unwrap();
+        // Envelope (16), five one-byte column names (50), row frame (8), then
+        // null (9), integer (17), real (17), two-byte UTF-8 text (11), and a
+        // two-byte blob (11).
+        let exact = ResultLimits::new(1, 139).unwrap();
+        let sql = "SELECT NULL AS a, 42 AS b, 1.5 AS c, 'é' AS d, X'00FF' AS e";
+        let result = query_with_limits(&connection, sql, &[], exact).unwrap();
+        assert_eq!(result.rows().len(), 1);
+
+        assert_eq!(
+            query_with_limits(&connection, sql, &[], ResultLimits::new(1, 138).unwrap(),)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::LimitExceeded
+        );
+
+        // A two-byte UTF-8 column name makes this one-column result 52 bytes.
+        assert!(
+            query_with_limits(
+                &connection,
+                "SELECT 1 AS \"é\"",
+                &[],
+                ResultLimits::new(1, 52).unwrap(),
+            )
+            .is_ok()
+        );
+        assert_eq!(
+            query_with_limits(
+                &connection,
+                "SELECT 1 AS \"é\"",
+                &[],
+                ResultLimits::new(1, 51).unwrap(),
+            )
+            .unwrap_err()
+            .kind(),
+            EngineErrorKind::LimitExceeded
+        );
+    }
+
+    #[test]
+    fn query_rejects_write_capable_statements_before_they_can_change_sqlite() {
+        let connection = Connection::open_in_memory().unwrap();
+        execute_batch(
+            &connection,
+            "CREATE TABLE writes (id INTEGER PRIMARY KEY, value TEXT NOT NULL);
+             INSERT INTO writes (id, value) VALUES (1, 'original');",
+        )
+        .unwrap();
+        let limits = ResultLimits::default();
+
+        for statement in [
+            "INSERT INTO writes (id, value) VALUES (2, 'inserted') RETURNING id",
+            "UPDATE writes SET value = 'updated' WHERE id = 1 RETURNING id",
+            "DELETE FROM writes WHERE id = 1 RETURNING id",
+            "CREATE TABLE unexpected (id INTEGER)",
+        ] {
+            let error = query_with_limits(&connection, statement, &[], limits).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::InvalidQuery);
+            assert_eq!(error.to_string(), "query statements must be read-only");
+        }
+
+        assert_eq!(
+            connection
+                .query_row("SELECT COUNT(*), MIN(value) FROM writes", [], |row| Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?
+                )),)
+                .unwrap(),
+            (1, "original".to_owned())
+        );
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT COUNT(*) FROM sqlite_schema WHERE name = 'unexpected'",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn compatibility_query_is_bounded_by_default_row_limits() {
+        let connection = Connection::open_in_memory().unwrap();
+        let error = query(
+            &connection,
+            "WITH RECURSIVE numbers(value) AS (
+                 VALUES (1)
+                 UNION ALL
+                 SELECT value + 1 FROM numbers WHERE value < 10001
+             )
+             SELECT value AS v FROM numbers",
+            &[],
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+        assert_eq!(
+            error.to_string(),
+            "query result exceeds the configured row limit"
         );
     }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -24,6 +24,7 @@ use crate::{
 };
 
 const SCHEMA_VERSION: &str = "1";
+pub(crate) const CONNECTION_BUSY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
 #[derive(Debug, Clone)]
 pub(crate) struct Storage {
@@ -123,6 +124,12 @@ impl Storage {
     }
 
     pub(crate) fn open_shard(&self, shard: u16) -> EngineResult<Connection> {
+        let connection = self.open_unconfigured_shard(shard)?;
+        configure_connection(&connection)?;
+        Ok(connection)
+    }
+
+    fn open_unconfigured_shard(&self, shard: u16) -> EngineResult<Connection> {
         if shard >= self.shard_count {
             return Err(EngineError::new(
                 EngineErrorKind::Internal,
@@ -133,7 +140,6 @@ impl Storage {
         let connection = Connection::open(&path).map_err(|error| {
             sqlite_error::storage(error).context(format!("failed to open shard {}", path.display()))
         })?;
-        configure_connection(&connection)?;
         Ok(connection)
     }
 
@@ -142,6 +148,13 @@ impl Storage {
         shard: u16,
     ) -> EngineResult<(Connection, ConnectionHygiene)> {
         let connection = self.open_shard(shard)?;
+        self.attach_pool_hygiene(connection)
+    }
+
+    fn attach_pool_hygiene(
+        &self,
+        connection: Connection,
+    ) -> EngineResult<(Connection, ConnectionHygiene)> {
         let tainted = Arc::new(AtomicBool::new(false));
         let wrote = Arc::new(AtomicBool::new(false));
         let probing = Arc::new(AtomicBool::new(false));
@@ -265,8 +278,12 @@ fn action_writes_connection(action: AuthAction<'_>) -> bool {
 
 fn configure_connection(connection: &Connection) -> EngineResult<()> {
     connection
-        .busy_timeout(std::time::Duration::from_secs(5))
+        .busy_timeout(CONNECTION_BUSY_TIMEOUT)
         .map_err(sqlite_error::storage)?;
+    configure_connection_pragmas(connection)
+}
+
+fn configure_connection_pragmas(connection: &Connection) -> EngineResult<()> {
     connection
         .pragma_update(None, "journal_mode", "WAL")
         .map_err(sqlite_error::storage)?;

--- a/src/storage/pool.rs
+++ b/src/storage/pool.rs
@@ -1,8 +1,10 @@
 //! Bounded per-shard SQLite connection pools.
 
 use std::{
+    cell::RefCell,
     ops::Deref,
     sync::{Arc, Mutex, MutexGuard, atomic::Ordering},
+    time::{Duration, Instant},
 };
 
 #[cfg(test)]
@@ -11,9 +13,70 @@ use std::sync::atomic::AtomicU64;
 use rusqlite::Connection;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore, TryAcquireError};
 
-use crate::core::{EngineError, EngineErrorKind, EngineResult};
+use crate::{
+    core::{EngineError, EngineErrorKind, EngineResult, OperationControl},
+    sqlite_error,
+};
 
-use super::{ConnectionHygiene, Storage};
+use super::{CONNECTION_BUSY_TIMEOUT, ConnectionHygiene, Storage};
+
+thread_local! {
+    static BUSY_OPERATION: RefCell<Option<BusyOperation>> = const { RefCell::new(None) };
+}
+
+struct BusyOperation {
+    control: Arc<OperationControl>,
+    started: Instant,
+}
+
+struct BusyOperationGuard;
+
+impl BusyOperationGuard {
+    fn install(control: Arc<OperationControl>) -> Self {
+        BUSY_OPERATION.with(|operation| {
+            let previous = operation.replace(Some(BusyOperation {
+                control,
+                started: Instant::now(),
+            }));
+            debug_assert!(previous.is_none(), "SQLite busy controls cannot be nested");
+        });
+        Self
+    }
+}
+
+impl Drop for BusyOperationGuard {
+    fn drop(&mut self) {
+        BUSY_OPERATION.with(|operation| {
+            operation.replace(None);
+        });
+    }
+}
+
+fn cancellable_busy_handler(attempt: i32) -> bool {
+    BUSY_OPERATION.with(|operation| {
+        let operation = operation.borrow();
+        let Some(operation) = operation.as_ref() else {
+            return false;
+        };
+        if operation.control.should_stop() || operation.started.elapsed() >= CONNECTION_BUSY_TIMEOUT
+        {
+            return false;
+        }
+
+        // Poll cancellation frequently without turning a locked database into
+        // a spin loop. The total wait remains bounded by the configured
+        // five-second connection timeout.
+        let delay = match attempt {
+            ..=9 => Duration::from_millis(1),
+            10..=19 => Duration::from_millis(5),
+            _ => Duration::from_millis(10),
+        };
+        std::thread::sleep(
+            delay.min(CONNECTION_BUSY_TIMEOUT.saturating_sub(operation.started.elapsed())),
+        );
+        !operation.control.should_stop() && operation.started.elapsed() < CONNECTION_BUSY_TIMEOUT
+    })
+}
 
 /// Identity of the engine session allowed to observe a connection's write-local state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -33,6 +96,38 @@ pub(crate) struct ConnectionPools {
     pool_size: usize,
     #[cfg(test)]
     queue_capacity: usize,
+    #[cfg(test)]
+    close_idle_hook: Arc<Mutex<Option<CloseIdleHook>>>,
+}
+
+#[cfg(test)]
+#[derive(Debug)]
+struct CloseIdleHook {
+    started: std::sync::mpsc::Sender<()>,
+    release: std::sync::mpsc::Receiver<()>,
+}
+
+#[cfg(test)]
+#[derive(Debug)]
+struct ControlledBarrier {
+    started: std::sync::mpsc::Sender<()>,
+    release: std::sync::mpsc::Receiver<()>,
+}
+
+#[cfg(test)]
+impl ControlledBarrier {
+    fn wait(self, control: &OperationControl) {
+        let _ = self.started.send(());
+        loop {
+            if control.should_stop() {
+                return;
+            }
+            match self.release.recv_timeout(Duration::from_millis(1)) {
+                Ok(()) | Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => return,
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+            }
+        }
+    }
 }
 
 impl ConnectionPools {
@@ -74,6 +169,8 @@ impl ConnectionPools {
             pool_size,
             #[cfg(test)]
             queue_capacity,
+            #[cfg(test)]
+            close_idle_hook: Arc::new(Mutex::new(None)),
         })
     }
 
@@ -100,6 +197,103 @@ impl ConnectionPools {
             permits.push((shard, self.acquire_for_owner(shard, owner).await?));
         }
         Ok(permits)
+    }
+
+    /// Drain and close every currently idle SQLite handle.
+    ///
+    /// The engine calls this on a blocking worker only after the lifecycle's
+    /// active-operation count reaches zero, so no checked-out connection can
+    /// race back into these idle vectors.
+    pub(crate) fn close_idle(&self) -> EngineResult<usize> {
+        #[cfg(test)]
+        if let Some(hook) = self
+            .close_idle_hook
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take()
+        {
+            let _ = hook.started.send(());
+            hook.release
+                .recv()
+                .expect("the shutdown-finalizer test releases idle closing");
+        }
+
+        let mut closing = Vec::new();
+        for shard in &self.shards {
+            let mut idle = shard.inner.lock_idle()?;
+            closing.append(&mut idle);
+        }
+        let closed = closing.len();
+        drop(closing);
+        Ok(closed)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn block_next_close_idle(
+        &self,
+        started: std::sync::mpsc::Sender<()>,
+        release: std::sync::mpsc::Receiver<()>,
+    ) {
+        let previous = self
+            .close_idle_hook
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .replace(CloseIdleHook { started, release });
+        assert!(previous.is_none(), "only one close-idle hook may be armed");
+    }
+
+    #[cfg(test)]
+    pub(crate) fn block_next_connection_setup(
+        &self,
+        shard: u16,
+        started: std::sync::mpsc::Sender<()>,
+        release: std::sync::mpsc::Receiver<()>,
+    ) -> EngineResult<()> {
+        let previous = self
+            .shard(shard)?
+            .inner
+            .setup_hook
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .replace(ControlledBarrier { started, release });
+        assert!(previous.is_none(), "only one setup hook may be armed");
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn block_next_foreign_probe(
+        &self,
+        shard: u16,
+        started: std::sync::mpsc::Sender<()>,
+        release: std::sync::mpsc::Receiver<()>,
+    ) -> EngineResult<()> {
+        let previous = self
+            .shard(shard)?
+            .inner
+            .probe_hook
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .replace(ControlledBarrier { started, release });
+        assert!(previous.is_none(), "only one probe hook may be armed");
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn block_next_control_teardown(
+        &self,
+        shard: u16,
+        started: std::sync::mpsc::Sender<()>,
+        release: std::sync::mpsc::Receiver<()>,
+    ) -> EngineResult<()> {
+        let previous = self
+            .shard(shard)?
+            .inner
+            .teardown_hook
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .replace(ControlledBarrier { started, release });
+        assert!(previous.is_none(), "only one teardown hook may be armed");
+        Ok(())
     }
 
     #[cfg(test)]
@@ -169,6 +363,12 @@ impl ShardPool {
                 reused: AtomicU64::new(0),
                 #[cfg(test)]
                 retired: AtomicU64::new(0),
+                #[cfg(test)]
+                setup_hook: Mutex::new(None),
+                #[cfg(test)]
+                probe_hook: Mutex::new(None),
+                #[cfg(test)]
+                teardown_hook: Mutex::new(None),
             }),
         }
     }
@@ -255,6 +455,12 @@ struct ShardPoolInner {
     reused: AtomicU64,
     #[cfg(test)]
     retired: AtomicU64,
+    #[cfg(test)]
+    setup_hook: Mutex<Option<ControlledBarrier>>,
+    #[cfg(test)]
+    probe_hook: Mutex<Option<ControlledBarrier>>,
+    #[cfg(test)]
+    teardown_hook: Mutex<Option<ControlledBarrier>>,
 }
 
 impl ShardPoolInner {
@@ -270,7 +476,11 @@ impl ShardPoolInner {
         })
     }
 
-    fn checkout(&self, owner: ConnectionOwner) -> EngineResult<ManagedConnection> {
+    fn checkout(
+        &self,
+        owner: ConnectionOwner,
+        control: Option<Arc<OperationControl>>,
+    ) -> EngineResult<ManagedConnection> {
         let (reusable, foreign_write_connection) = {
             let mut idle = self.lock_idle()?;
             let reusable_index = idle
@@ -302,23 +512,73 @@ impl ShardPoolInner {
             return Ok(connection);
         }
 
-        self.open_connection()
+        match control {
+            Some(control) => self.open_connection_controlled(control),
+            None => self.open_connection(),
+        }
     }
 
     fn open_connection(&self) -> EngineResult<ManagedConnection> {
         let (connection, hygiene) = self.storage.open_pooled_shard(self.shard)?;
+        Ok(self.managed_connection(connection, hygiene))
+    }
+
+    fn open_connection_controlled(
+        &self,
+        control: Arc<OperationControl>,
+    ) -> EngineResult<ManagedConnection> {
+        let mut connection = self.storage.open_unconfigured_shard(self.shard)?;
+        configure_connection_controlled(
+            &mut connection,
+            Arc::clone(&control),
+            #[cfg(test)]
+            self.take_setup_hook(),
+        )?;
+        let (connection, hygiene) = self.storage.attach_pool_hygiene(connection)?;
+        Ok(self.managed_connection(connection, hygiene))
+    }
+
+    #[cfg(test)]
+    fn take_setup_hook(&self) -> Option<ControlledBarrier> {
+        self.setup_hook
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take()
+    }
+
+    #[cfg(test)]
+    fn take_probe_hook(&self) -> Option<ControlledBarrier> {
+        self.probe_hook
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take()
+    }
+
+    #[cfg(test)]
+    fn take_teardown_hook(&self) -> Option<ControlledBarrier> {
+        self.teardown_hook
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take()
+    }
+
+    fn managed_connection(
+        &self,
+        connection: Connection,
+        hygiene: ConnectionHygiene,
+    ) -> ManagedConnection {
         #[cfg(test)]
         let id = self.next_connection_id.fetch_add(1, Ordering::Relaxed);
         #[cfg(test)]
         self.opened.fetch_add(1, Ordering::Relaxed);
-        Ok(ManagedConnection {
+        ManagedConnection {
             #[cfg(test)]
             id,
             connection,
             hygiene,
             write_owner: None,
             origin_owner: None,
-        })
+        }
     }
 
     fn retire(&self, connection: ManagedConnection) {
@@ -376,14 +636,30 @@ pub(crate) struct PoolPermit {
 
 impl PoolPermit {
     /// Checkout or lazily open a connection. Call this on the blocking worker.
+    #[cfg(test)]
     pub(crate) fn checkout(self) -> EngineResult<PooledConnection> {
+        self.checkout_inner(None)
+    }
+
+    /// Checkout while making lazy SQLite configuration cancellable.
+    pub(crate) fn checkout_controlled(
+        self,
+        control: Arc<OperationControl>,
+    ) -> EngineResult<PooledConnection> {
+        self.checkout_inner(Some(control))
+    }
+
+    fn checkout_inner(
+        self,
+        control: Option<Arc<OperationControl>>,
+    ) -> EngineResult<PooledConnection> {
         let PoolPermit {
             pool,
             owner,
             admission,
             connection,
         } = self;
-        let managed = pool.inner.checkout(owner)?;
+        let managed = pool.inner.checkout(owner, control)?;
         let borrowed_from_other_owner = managed
             .origin_owner
             .is_some_and(|origin_owner| origin_owner != owner);
@@ -395,6 +671,7 @@ impl PoolPermit {
             managed: Some(managed),
             broken: false,
             borrowed_from_other_owner,
+            operation: None,
             _admission: admission,
             _connection: connection,
         })
@@ -409,6 +686,7 @@ pub(crate) struct PooledConnection {
     managed: Option<ManagedConnection>,
     broken: bool,
     borrowed_from_other_owner: bool,
+    operation: Option<Arc<OperationControl>>,
     _admission: OwnedSemaphorePermit,
     _connection: OwnedSemaphorePermit,
 }
@@ -427,6 +705,84 @@ impl PooledConnection {
         self.broken = true;
     }
 
+    /// Run work while cancellation is armed against exactly this leased handle.
+    ///
+    /// The progress hook closes the small race between starting SQLite and an
+    /// interrupt reaching the connection. It is always removed before the
+    /// handle can return to the pool. Interrupted handles are conservatively
+    /// retired so a late SQLite interrupt cannot affect the next owner.
+    pub(crate) fn run_controlled<T, F>(
+        &mut self,
+        control: Arc<OperationControl>,
+        work: F,
+    ) -> EngineResult<T>
+    where
+        F: FnOnce(&mut Self) -> EngineResult<T>,
+    {
+        debug_assert!(self.operation.is_none());
+        let _busy_operation = BusyOperationGuard::install(Arc::clone(&control));
+        if let Err(error) = self.busy_handler(Some(cancellable_busy_handler)) {
+            self.mark_broken();
+            return Err(sqlite_error::storage(error)
+                .context("failed to install the SQLite cancellable busy handler"));
+        }
+        let progress_control = Arc::clone(&control);
+        if let Err(error) =
+            self.progress_handler(1_000, Some(move || progress_control.should_stop()))
+        {
+            let _ = self.busy_timeout(CONNECTION_BUSY_TIMEOUT);
+            self.mark_broken();
+            return Err(sqlite_error::storage(error)
+                .context("failed to install the SQLite request progress hook"));
+        }
+
+        let interrupt_handle = self.get_interrupt_handle();
+        if let Err(reason) = control.arm(Arc::new(move || interrupt_handle.interrupt())) {
+            if self.progress_handler(0, None::<fn() -> bool>).is_err() {
+                self.mark_broken();
+            }
+            if self.busy_timeout(CONNECTION_BUSY_TIMEOUT).is_err() {
+                self.mark_broken();
+            }
+            return Err(reason.error());
+        }
+        self.operation = Some(control);
+
+        let result = work(self);
+        self.finish_controlled(result)
+    }
+
+    fn finish_controlled<T>(&mut self, result: EngineResult<T>) -> EngineResult<T> {
+        let control = self
+            .operation
+            .take()
+            .expect("a controlled SQLite operation is armed");
+        let cleanup = self
+            .progress_handler(0, None::<fn() -> bool>)
+            .map_err(sqlite_error::storage);
+        let busy_cleanup = self
+            .busy_timeout(CONNECTION_BUSY_TIMEOUT)
+            .map_err(sqlite_error::storage);
+        #[cfg(test)]
+        if let Some(barrier) = self.pool.inner.take_teardown_hook() {
+            barrier.wait(&control);
+        }
+        if control.disarm().is_some() {
+            self.mark_broken();
+        }
+        match (result, cleanup, busy_cleanup) {
+            (Ok(_), Err(error), _) => {
+                self.mark_broken();
+                Err(error.context("failed to remove the SQLite request progress hook"))
+            }
+            (Ok(_), Ok(()), Err(error)) => {
+                self.mark_broken();
+                Err(error.context("failed to restore the SQLite busy timeout"))
+            }
+            (result, _, _) => result,
+        }
+    }
+
     /// Ensure foreign SQL cannot inherit connection-local history or write on a
     /// handle whose physical history began under another session.
     ///
@@ -438,37 +794,68 @@ impl PooledConnection {
     /// handle. The probe error itself is never exposed; opening the replacement
     /// can return a storage error, and otherwise the real statement boundary is
     /// authoritative for the SQL result.
+    #[cfg(test)]
     pub(crate) fn isolate_foreign_sql(&mut self, sql: &str) -> EngineResult<()> {
         if !self.borrowed_from_other_owner {
             return Ok(());
         }
 
-        let requires_fresh = {
-            let managed = self
-                .managed
-                .as_ref()
-                .expect("a live pooled connection owns its SQLite handle");
-            let probe = managed.hygiene.begin_probe();
-            let prepared = managed.connection.prepare(sql);
-            let preparation_failed = prepared.is_err();
-            drop(prepared);
-            preparation_failed || probe.requires_fresh_connection()
-        };
+        let requires_fresh = self.foreign_sql_requires_fresh(sql);
         if requires_fresh {
             self.replace_with_fresh()?;
         }
         Ok(())
     }
 
-    /// Give a multi-statement operation a fresh handle when the checked-out
-    /// connection was last used by another session.
-    pub(crate) fn ensure_owner_local(&mut self) -> EngineResult<()> {
-        if self.borrowed_from_other_owner {
-            self.replace_with_fresh()?;
+    /// Probe foreign-owner SQL under the same cancellation hooks as execution.
+    pub(crate) fn isolate_foreign_sql_controlled(
+        &mut self,
+        control: Arc<OperationControl>,
+        sql: &str,
+    ) -> EngineResult<()> {
+        if !self.borrowed_from_other_owner {
+            return Ok(());
+        }
+        let requires_fresh = self.run_controlled(Arc::clone(&control), |connection| {
+            Ok(connection.foreign_sql_requires_fresh(sql))
+        })?;
+        if requires_fresh {
+            self.replace_with_fresh_controlled(control)?;
         }
         Ok(())
     }
 
+    fn foreign_sql_requires_fresh(&self, sql: &str) -> bool {
+        let managed = self
+            .managed
+            .as_ref()
+            .expect("a live pooled connection owns its SQLite handle");
+        let probe = managed.hygiene.begin_probe();
+        #[cfg(test)]
+        if let Some(barrier) = self.pool.inner.take_probe_hook() {
+            barrier.wait(
+                self.operation
+                    .as_deref()
+                    .expect("the foreign-owner probe is cancellation-controlled"),
+            );
+        }
+        let prepared = managed.connection.prepare(sql);
+        let preparation_failed = prepared.is_err();
+        drop(prepared);
+        preparation_failed || probe.requires_fresh_connection()
+    }
+
+    pub(crate) fn ensure_owner_local_controlled(
+        &mut self,
+        control: Arc<OperationControl>,
+    ) -> EngineResult<()> {
+        if self.borrowed_from_other_owner {
+            self.replace_with_fresh_controlled(control)?;
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
     fn replace_with_fresh(&mut self) -> EngineResult<()> {
         let previous = self
             .managed
@@ -478,6 +865,75 @@ impl PooledConnection {
         self.managed = Some(self.pool.inner.open_connection()?);
         self.borrowed_from_other_owner = false;
         Ok(())
+    }
+
+    fn replace_with_fresh_controlled(
+        &mut self,
+        control: Arc<OperationControl>,
+    ) -> EngineResult<()> {
+        let previous = self
+            .managed
+            .take()
+            .expect("a live pooled connection owns its SQLite handle");
+        self.pool.inner.retire(previous);
+        self.managed = Some(self.pool.inner.open_connection_controlled(control)?);
+        self.borrowed_from_other_owner = false;
+        Ok(())
+    }
+}
+
+fn configure_connection_controlled(
+    connection: &mut Connection,
+    control: Arc<OperationControl>,
+    #[cfg(test)] barrier: Option<ControlledBarrier>,
+) -> EngineResult<()> {
+    let _busy_operation = BusyOperationGuard::install(Arc::clone(&control));
+    connection
+        .busy_handler(Some(cancellable_busy_handler))
+        .map_err(sqlite_error::storage)?;
+    let progress_control = Arc::clone(&control);
+    if let Err(error) =
+        connection.progress_handler(1_000, Some(move || progress_control.should_stop()))
+    {
+        let _ = connection.busy_timeout(CONNECTION_BUSY_TIMEOUT);
+        return Err(sqlite_error::storage(error).context(
+            "failed to install the SQLite request progress hook during connection setup",
+        ));
+    }
+    let interrupt_handle = connection.get_interrupt_handle();
+    if let Err(reason) = control.arm(Arc::new(move || interrupt_handle.interrupt())) {
+        let _ = connection.progress_handler(0, None::<fn() -> bool>);
+        let _ = connection.busy_timeout(CONNECTION_BUSY_TIMEOUT);
+        return Err(reason.error());
+    }
+
+    #[cfg(test)]
+    if let Some(barrier) = barrier {
+        barrier.wait(&control);
+    }
+
+    // Do not call the ordinary configuration wrapper here: its fixed busy
+    // timeout would replace the cancellable handler before these pragmas can
+    // encounter a SQLite lock.
+    let result = super::configure_connection_pragmas(connection);
+    let progress_cleanup = connection
+        .progress_handler(0, None::<fn() -> bool>)
+        .map_err(sqlite_error::storage);
+    let busy_cleanup = connection
+        .busy_timeout(CONNECTION_BUSY_TIMEOUT)
+        .map_err(sqlite_error::storage);
+    let reason = control.disarm();
+    match (result, progress_cleanup, busy_cleanup, reason) {
+        (Err(_), _, _, Some(reason)) => Err(reason.error()),
+        (Err(error), _, _, None) => Err(error),
+        (Ok(()), _, _, Some(reason)) => Err(reason.error()),
+        (Ok(()), Err(error), _, None) => {
+            Err(error.context("failed to remove the SQLite request progress hook after setup"))
+        }
+        (Ok(()), Ok(()), Err(error), None) => {
+            Err(error.context("failed to restore the SQLite busy timeout after setup"))
+        }
+        (Ok(()), Ok(()), Ok(()), None) => Ok(()),
     }
 }
 
@@ -495,6 +951,12 @@ impl Deref for PooledConnection {
 
 impl Drop for PooledConnection {
     fn drop(&mut self) {
+        if let Some(control) = self.operation.take() {
+            let _ = self.progress_handler(0, None::<fn() -> bool>);
+            let _ = self.busy_timeout(CONNECTION_BUSY_TIMEOUT);
+            control.disarm();
+            self.broken = true;
+        }
         if let Some(connection) = self.managed.take() {
             self.pool
                 .inner

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -1,4 +1,7 @@
-use std::sync::Arc;
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use axum::Router;
 use briskdb::{
@@ -14,6 +17,11 @@ fn legacy_and_explicit_module_paths_are_both_available() {
     let _engine: Option<core::Engine> = None;
     let _engine_status: Option<core::EngineStatus> = None;
     let _engine_options: core::EngineOptions = core::EngineOptions::default();
+    let _result_limits: core::ResultLimits = core::ResultLimits::default();
+    let _request_context: core::RequestContext = core::RequestContext::new();
+    let _cancellation_token: core::CancellationToken = core::CancellationToken::new();
+    let _running = core::EngineState::Running;
+    let _shutdown_report: Option<core::ShutdownReport> = None;
     let _session: Option<core::Session> = None;
     let _ready = core::SessionState::Ready;
     let _closed = core::SessionState::Closed;
@@ -63,6 +71,22 @@ fn engine_options_are_public_validated_and_have_stable_defaults() {
         defaults.queue_capacity_per_shard(),
         core::DEFAULT_QUEUE_CAPACITY_PER_SHARD
     );
+    assert_eq!(
+        defaults.result_limits(),
+        core::ResultLimits::new(
+            core::DEFAULT_MAX_RESULT_ROWS,
+            core::DEFAULT_MAX_RESULT_BYTES,
+        )
+        .unwrap()
+    );
+    assert_eq!(
+        defaults.request_timeout(),
+        Some(Duration::from_millis(core::DEFAULT_REQUEST_TIMEOUT_MS))
+    );
+    assert_eq!(
+        defaults.shutdown_grace(),
+        Duration::from_millis(core::DEFAULT_SHUTDOWN_GRACE_MS)
+    );
 
     let minimum = core::EngineOptions::new(1, 1).unwrap();
     assert_eq!(minimum.connections_per_shard(), 1);
@@ -95,12 +119,30 @@ fn engine_options_are_public_validated_and_have_stable_defaults() {
             core::EngineErrorKind::InvalidArgument
         );
     }
+
+    let limits = core::ResultLimits::new(37, 4_096).unwrap();
+    let configured = minimum
+        .with_result_limits(limits)
+        .with_request_timeout(None)
+        .unwrap()
+        .with_shutdown_grace(Duration::from_millis(250))
+        .unwrap();
+    assert_eq!(configured.result_limits(), limits);
+    assert_eq!(configured.request_timeout(), None);
+    assert_eq!(configured.shutdown_grace(), Duration::from_millis(250));
 }
 
 #[tokio::test]
 async fn protocol_neutral_async_engine_surface_is_available() {
     let temp = tempfile::tempdir().unwrap();
-    let options = core::EngineOptions::new(2, 7).unwrap();
+    let limits = core::ResultLimits::new(50, 8_192).unwrap();
+    let options = core::EngineOptions::new(2, 7)
+        .unwrap()
+        .with_result_limits(limits)
+        .with_request_timeout(Some(Duration::from_secs(5)))
+        .unwrap()
+        .with_shutdown_grace(Duration::from_millis(100))
+        .unwrap();
     let engine = core::Engine::open_with_options(temp.path(), 4, options)
         .await
         .unwrap();
@@ -113,6 +155,30 @@ async fn protocol_neutral_async_engine_surface_is_available() {
     assert_eq!(status.max_blocking_workers(), 8);
     assert_eq!(status.connections_per_shard(), 2);
     assert_eq!(status.queue_capacity_per_shard(), 7);
+    assert_eq!(status.max_result_rows(), 50);
+    assert_eq!(status.max_result_bytes(), 8_192);
+    assert_eq!(status.request_timeout(), Some(Duration::from_secs(5)));
+    assert_eq!(status.shutdown_grace(), Duration::from_millis(100));
+
+    session.set_routing_key("public-controls").await.unwrap();
+    let token = core::CancellationToken::new();
+    let context = core::RequestContext::new()
+        .with_cancellation_token(token.clone())
+        .with_deadline(Instant::now() + Duration::from_secs(1))
+        .with_result_limits(core::ResultLimits::new(1, 512).unwrap());
+    let result = engine
+        .query_with_context(&session, core::Statement::new("SELECT 1", vec![]), context)
+        .await
+        .unwrap();
+    assert_eq!(result.value.rows().len(), 1);
+    token.cancel();
+    assert!(token.is_cancelled());
+
+    assert_eq!(engine.state(), core::EngineState::Running);
+    assert_eq!(engine.begin_shutdown(), core::EngineState::Draining);
+    let report = engine.shutdown().await.unwrap();
+    assert!(!report.forced());
+    assert_eq!(engine.state(), core::EngineState::Stopped);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- add protocol-neutral cancellation tokens, request deadlines, and per-request result limits while preserving the existing Engine method signatures
- enforce finite row/logical-byte query budgets with checked accounting and read-only query execution
- make queued, running, lazy-setup, foreign-owner probe, dropped-future, and shutdown cancellation race-safe around SQLite
- add shared Running → Draining → Stopped lifecycle hooks, bounded forced cleanup, and cancellation-safe finalization
- track HTTP/1 connection tasks so signal shutdown drains concurrently, force-closes at the grace deadline, and never detaches connections
- expose validated CLI/environment controls, exhaustive HTTP/PostgreSQL/MySQL error mappings, and the documented request-control contract

## Verification

- `cargo fmt --all -- --check`
- `cargo test --locked --all-targets --all-features` (167 library tests plus CLI, integration, public API, and benchmark smoke)
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --doc --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --no-deps --all-features`
- the same full test, Clippy, formatting, doc-test, and rustdoc gates on Rust 1.85.0
- independent API, concurrency/lifecycle, and server/HTTP reviews approved

Closes #11
