### PR TITLE
feat: add durable shard catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ minimum supported Rust version (MSRV) and the latest stable toolchain.
 - Finite per-query row/logical-byte budgets with no partial results
 - Explicit graceful drain, forced cancellation, and blocking handle cleanup
 - Protocol-neutral typed values, ordered columns, positional rows, and results
-- A transactionally versioned `manifest.sqlite` with a fixed shard count
+- A transactionally versioned `manifest.sqlite` with a durable 4,096-bucket
+  shard catalog
 - One WAL-enabled SQLite database per shard
 - Routed execute and query endpoints
 - A broadcast endpoint for initializing schema on every shard
@@ -167,13 +168,19 @@ still commit.
 Queries have finite row and logical-byte budgets, account values before cloning
 payloads, and return no partial result on `LimitExceeded`.
 Broadcast changes and future scatter operations are not atomic across shard
-files. The shard count is immutable after database creation, so resharding will
-require an explicit migration workflow. Opening now upgrades the exact legacy
-manifest format to version 2 atomically; newer or malformed manifests fail
-closed, and an intentional downgrade fence prevents the shipped legacy opener
-from silently reading version 2. This changes only `manifest.sqlite`, not shard
-files, routing, SQL behavior, or wire contracts. The complete format and
-upgrade contract is in [manifest storage format](docs/STORAGE_FORMAT.md).
+files. The initial shard count is immutable, so resharding will require an
+explicit migration workflow. Opening upgrades exact version-1 and version-2
+manifests to version 3 through one transaction per numbered step. Version 3
+persists hash, key-encoding, and bucket-algorithm versions, a generation-stamped
+4,096-bucket map, and active physical-shard lifecycle records. Newer or malformed
+manifests fail closed, and downgrade fences reject shipped version-1 and
+version-2 readers. Runtime routing deliberately remains the existing BLAKE3
+modulo calculation until the next roadmap item activates catalog lookup; the
+generation-1 ranges are constructed so that activation can preserve every
+existing placement, including non-power-of-two shard counts. This changes only
+`manifest.sqlite`, not shard files, SQL behavior, or wire contracts. The
+complete format and upgrade contract is in
+[manifest storage format](docs/STORAGE_FORMAT.md).
 Embedders should call
 `Engine::shutdown`; merely dropping the final `Engine` is not the explicit
 asynchronous cleanup contract.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -182,7 +182,7 @@ existing tests pass through the shared engine.
 ### 2. Durable shard catalog and routing
 
 - [x] Version the manifest schema with transactional migrations.
-- [ ] Persist hash/key-encoding versions, 4,096 virtual buckets, physical shard
+- [x] Persist hash/key-encoding versions, 4,096 virtual buckets, physical shard
   records, map generation, and lifecycle state.
 - [ ] Replace modulo routing with virtual-bucket lookup and add golden routing
   vectors so upgrades cannot silently move keys.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -74,13 +74,16 @@ the controlled defaults.
 
 ## Manifest storage boundary
 
-The storage module now owns an ordered manifest-format migration runner. It
+The storage module owns an ordered manifest-format migration runner. It
 identifies a current manifest with SQLite `application_id = 0x42524442` and uses
-`user_version` as the single authoritative schema version. Version 2 replaces
-the legacy key/value configuration with a strict singleton shard-count table
-and retains an intentionally incompatible `briskdb_metadata` table as a
-downgrade fence. This prevents the shipped legacy opener—which did not check a
-version marker—from silently accepting the new format.
+`user_version` as the single authoritative schema version. Version 2 replaced
+the legacy key/value configuration with a strict singleton shard-count table.
+Version 3 adds the durable routing catalog: independently versioned hash, key
+encoding, and bucket derivation; the initial map generation; exactly 4,096
+virtual buckets; and contiguous, active physical-shard records. Each version
+retains an intentionally incompatible `briskdb_metadata` definition and row as
+a downgrade fence. Shipped version-1 and version-2 readers therefore fail
+closed instead of interpreting a newer manifest.
 
 Startup acquires `BEGIN IMMEDIATE` before making any migration decision. Each
 registered numbered step rewrites schema/data, stamps and reads back its target
@@ -93,10 +96,14 @@ manifest does not rewrite its journal mode or touch shard files.
 
 This is an internal storage-open concern. It changes no core or adapter
 signature, is unreachable from client SQL, and is atomic only within
-`manifest.sqlite`. It neither changes current modulo routing nor implements the
-future cross-shard application-schema migration journal. The exact format,
-downgrade policy, recovery cases, and tests are documented in
-[manifest storage format](STORAGE_FORMAT.md).
+`manifest.sqlite`. Runtime routing still uses the legacy BLAKE3 modulo path;
+catalog lookup is the next isolated roadmap item. The generation-1 bucket ranges
+and versioned derivation are constructed to reproduce that placement for every
+supported initial shard count, including counts that do not divide 4,096. The
+catalog does not yet validate shard-file presence, identity, WAL, or schema
+generation, and it is not the future cross-shard application-schema migration
+journal. The exact format, downgrade policy, recovery cases, and tests are
+documented in [manifest storage format](STORAGE_FORMAT.md).
 
 ## Session and asynchronous engine boundary
 

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -329,6 +329,8 @@ underlying execution semantics.
 
 - The caller supplies an opaque `shard_key` independently from the SQL text.
 - BLAKE3 hashing followed by modulo shard count selects one physical shard.
+- Manifest version 3 already persists the versioned 4,096-bucket catalog, but
+  runtime lookup is deliberately deferred to the next routing milestone.
 - Point queries and writes visit only that shard.
 - No scatter/gather query path exists.
 - Unique constraints and transactions are local to one SQLite shard.
@@ -360,7 +362,7 @@ reject cross-shard access.
 Manifest-format migrations are separate from application SQL migrations. They
 run internally during storage open, are transactional only within
 `manifest.sqlite`, and cannot be requested through any protocol or SQL
-statement. The version-2 manifest upgrade does not change shard schemas,
+statement. The version-3 manifest upgrade does not change shard schemas,
 supported SQLite syntax, result conversion, routing, or broadcast semantics.
 See the [manifest storage-format contract](STORAGE_FORMAT.md).
 

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -5,21 +5,115 @@ never exposed through HTTP, PostgreSQL, MySQL, or the SQL execution API. The
 format is pre-1.0, but every format change must still have an ordered migration,
 failure coverage, and an explicit compatibility decision.
 
-## Current format: version 2
+## Current format: version 3
 
 SQLite header fields identify the file and its format:
 
 | Header field | Value | Meaning |
 | --- | --- | --- |
 | `PRAGMA application_id` | `0x42524442` (`BRDB`) | Permanent BriskDB manifest-family marker |
-| `PRAGMA user_version` | `2` | Authoritative manifest schema version |
+| `PRAGMA user_version` | `3` | Authoritative manifest schema version |
 
 The application ID prevents an accidental foreign SQLite file from being
 adopted as a manifest. It is not authentication or tamper protection: a process
 that can write the data directory can forge it. Checksums and explicit degraded
 states remain separate roadmap work.
 
-Version 2 has two strict tables:
+Version 3 has five strict tables:
+
+```sql
+CREATE TABLE briskdb_manifest (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    shard_count INTEGER NOT NULL CHECK (shard_count BETWEEN 2 AND 64)
+) STRICT;
+
+CREATE TABLE briskdb_metadata (
+    requires_manifest_version INTEGER NOT NULL
+        CHECK (requires_manifest_version >= 3)
+) STRICT;
+
+CREATE TABLE briskdb_routing (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    hash_version INTEGER NOT NULL CHECK (hash_version = 1),
+    key_encoding_version INTEGER NOT NULL CHECK (key_encoding_version = 1),
+    bucket_algorithm_version INTEGER NOT NULL CHECK (bucket_algorithm_version = 1),
+    virtual_bucket_count INTEGER NOT NULL CHECK (virtual_bucket_count = 4096),
+    map_generation INTEGER NOT NULL CHECK (map_generation = 1)
+) STRICT;
+
+CREATE TABLE briskdb_physical_shards (
+    shard_id INTEGER PRIMARY KEY CHECK (shard_id BETWEEN 0 AND 63),
+    lifecycle_state TEXT NOT NULL CHECK (lifecycle_state = 'active')
+) STRICT;
+
+CREATE TABLE briskdb_virtual_buckets (
+    bucket_id INTEGER PRIMARY KEY CHECK (bucket_id BETWEEN 0 AND 4095),
+    physical_shard_id INTEGER NOT NULL,
+    FOREIGN KEY (physical_shard_id) REFERENCES briskdb_physical_shards (shard_id)
+) STRICT;
+```
+
+Both singleton tables contain exactly one row. `briskdb_manifest.shard_count`
+is immutable and is the initial routing modulus. In version 3 it is also the
+live physical-shard count. Physical IDs are exactly `0..shard_count`; filenames
+remain derived by trusted code as `shards/{shard_id:04}.sqlite` and are never
+read from catalog-controlled paths. Version 3 supports only the `active`
+lifecycle state. Adding resumable provisioning, draining, or retirement states
+requires a later format and state-machine change.
+
+The routing singleton contains exactly these generation-1 values:
+
+| Field | Value | Contract |
+| --- | --- | --- |
+| `hash_version` | `1` | BLAKE3 of the canonical key bytes, using digest bytes `0..8` as an unsigned little-endian `u64` |
+| `key_encoding_version` | `1` | Exact caller-supplied bytes; string shard keys contribute their UTF-8 bytes, with no Unicode normalization |
+| `bucket_algorithm_version` | `1` | Compatibility-preserving range algorithm below |
+| `virtual_bucket_count` | `4096` | Fixed virtual bucket space `0..4095` |
+| `map_generation` | `1` | Initial committed bucket map and the only generation version 3 can interpret |
+
+Every bucket ID exists exactly once and references an active physical shard.
+Every physical shard owns at least one bucket. The generation-1 map partitions
+the 4,096 bucket IDs into contiguous ranges whose sizes differ by at most one.
+For initial shard count `N`, shard `s` owns the range beginning at
+`s * base + min(s, extra)`, where `base = 4096 / N` and
+`extra = 4096 % N`.
+
+Bucket algorithm version 1 deliberately preserves legacy placement even when
+`N` does not divide 4,096. Given the version-1 64-bit hash `H`:
+
+```text
+s      = H % N
+base   = 4096 / N
+extra  = 4096 % N
+size   = base + (s < extra ? 1 : 0)
+offset = s * base + min(s, extra)
+bucket = offset + ((H / N) % size)
+```
+
+The generation-1 catalog maps that bucket back to `s`, so
+`map[bucket(H)] == H % N` for every supported shard count. This issue persists
+and validates the catalog but deliberately leaves runtime routing on the legacy
+direct-modulo path. The next routing change can activate catalog lookup without
+moving existing keys, and golden vectors must freeze the full calculation.
+
+`map_generation` is separate from manifest `user_version` and from the future
+application-schema generation. Version 3 accepts only generation 1 and validates
+its exact deterministic assignment; no public map-mutation operation exists yet.
+A future format that can commit a changed map must bump `user_version` and its
+downgrade fence as well as `map_generation`. That requirement makes this
+pre-lookup binary reject the manifest instead of silently using legacy modulo
+routing against a remapped catalog.
+
+At each open, BriskDB validates the exact objects, columns, strict flags, frozen
+schema SQL, singleton rows, supported algorithm values, contiguous physical and
+bucket IDs, active lifecycle states, assignments, coverage, and foreign keys.
+A recognized version-3 manifest that violates any of these invariants is
+`DataCorruption` and is rejected before shard connections are opened.
+
+## Previous version 2
+
+Version 2 introduced the application ID, authoritative `user_version`, typed
+shard count, and old-reader fence. Its exact two-table schema is:
 
 ```sql
 CREATE TABLE briskdb_manifest (
@@ -33,21 +127,14 @@ CREATE TABLE briskdb_metadata (
 ) STRICT;
 ```
 
-`briskdb_manifest` contains exactly the singleton row. Its `shard_count` remains
-immutable after creation. `briskdb_metadata` contains exactly the value `2` and
-is an intentional downgrade fence, not a second version authority. The shipped
-version-1 startup code expects `briskdb_metadata(key, value)`; retaining that
-name with an incompatible shape makes an old binary fail instead of silently
-opening a version-2 manifest. `user_version` is the sole canonical version.
-
-Version 2 changes only `manifest.sqlite`. It does not alter shard contents,
-shard filenames, BLAKE3 modulo routing, public Rust signatures, CLI options, or
-any wire request or response.
+The fence contains exactly `2`. A current opener validates this complete format
+before transactionally constructing the version-3 catalog and replacing the
+fence with its version-3 definition and row.
 
 ## Legacy version 1
 
-The original format has `application_id = 0`, `user_version = 0`, and this
-key/value table:
+The original format has `application_id = 0`, normally `user_version = 0`, and
+this key/value table:
 
 ```sql
 CREATE TABLE briskdb_metadata (
@@ -61,7 +148,7 @@ and `shard_count` rows. BriskDB also accepts `user_version = 1` with that exact
 shape. No other unmarked SQLite schema is adopted.
 
 The old initializer created the table before transactionally inserting its two
-rows. A crash could therefore leave the exact empty table. Version 2 recognizes
+rows. A crash could therefore leave the exact empty table. BriskDB recognizes
 only that empty shape as interrupted initialization and safely initializes it
 using the requested shard count. One-row, extra-row, malformed, or
 non-canonically encoded legacy states are `DataCorruption`.
@@ -72,7 +159,7 @@ Opening a `Database` or `Engine`, including server startup, may automatically
 upgrade the manifest before any shard connection is opened:
 
 1. Validate the requested shard-count range and open the manifest with a finite
-   busy timeout plus `synchronous=FULL`.
+   busy timeout, `synchronous=FULL`, and foreign keys enabled.
 2. Acquire `BEGIN IMMEDIATE`, then read identity, version, schema, and stored
    configuration under that write lock.
 3. Reject a foreign file, a newer version, a requested shard-count mismatch, or
@@ -85,24 +172,28 @@ upgrade the manifest before any shard connection is opened:
 7. After a compatible current manifest is committed, enable and verify WAL mode
    and only then create/open the shard layout.
 
-SQLite transactional DDL makes the schema rewrite, copied configuration, and
-header stamps one transaction within `manifest.sqlite`. Tests prove rollback
-and retry after injected errors and Rust panic unwinding. SQLite is intended to
-recover an uncommitted transaction after process loss, but BriskDB has not yet
-certified process-kill, power-loss, or filesystem-fault recovery. Concurrent
-open calls within the supported single-process deployment serialize on the
-immediate transaction and re-read the version after acquiring it.
+SQLite transactional DDL makes the schema, catalog rows, downgrade fence, and
+header stamps one transaction within `manifest.sqlite`. A version-1 upgrade
+commits version 2 before beginning version 3. Tests prove rollback and retry
+after injected errors and Rust panic unwinding. SQLite is intended to recover an
+uncommitted transaction after process loss, but BriskDB has not yet certified
+process-kill, power-loss, or filesystem-fault recovery. Concurrent open calls
+within the supported single-process deployment serialize on the immediate
+transaction and re-read the version after acquiring it.
 
 This guarantee is manifest-local. It is not an application-table migration API,
 does not make broadcast atomic across shard files, and is not the planned
-crash-resumable cross-shard schema migration journal.
+crash-resumable cross-shard schema migration journal. Catalog validation also
+does not yet establish shard-file health: current startup can recreate a missing
+shard file. No-create opening, per-shard identity/version, WAL, and schema-
+generation checks belong to the later shard-validation milestone.
 
 ## Compatibility and operations
 
-- A version-1 manifest upgrades automatically to version 2 on first open by a
-  current binary. Opening is therefore potentially mutating.
-- There is no automatic downgrade. A pre-version-2 binary is intentionally
-  fenced out after upgrade.
+- Version 1 upgrades through version 2 to version 3; version 2 upgrades directly
+  to version 3. Opening is therefore potentially mutating.
+- There is no automatic downgrade. Version-1 code is fenced by the incompatible
+  metadata table, and a version-2 reader rejects `user_version = 3`.
 - A manifest with the BriskDB application ID and a `user_version` newer than the
   binary supports fails with non-retryable `FailedPrecondition`; it is not
   downgraded or switched to WAL, and shard files are not opened.
@@ -112,18 +203,23 @@ crash-resumable cross-shard schema migration journal.
 - SQLite lock contention remains retryable `Busy`; permission, read-only, full,
   and I/O failures retain the storage error taxonomy.
 
-Do not edit the header, tables, or rows manually. The current deployment
-boundary remains local storage and one BriskDB process per data directory. A
-formal backup/restore workflow is not implemented; recovery to an older binary
-requires a known-good copy made while BriskDB was stopped.
+Do not edit the header, tables, or rows manually. Until the checksum milestone,
+a coordinated manual edit that still satisfies every structural invariant
+cannot be distinguished from an intentional catalog update. The current
+deployment boundary remains local storage and one BriskDB process per data
+directory. A formal backup/restore workflow is not implemented; recovery to an
+older binary requires a known-good copy made while BriskDB was stopped.
 
 ## Verification contract
 
-Tests cover fresh creation and no-op reopen, both recognized legacy headers,
-the interrupted empty-table state, incompatible and future formats, canonical
-metadata, old-reader fencing, errors and panics on both sides of the version
-stamp, retry recovery, reader atomicity, and concurrent openers with matching
-and conflicting shard counts. Process termination and filesystem faults remain
-part of the later storage-hardening suite. Every new migration must extend the
-registry, destination validator, format documentation, and the same
+Tests cover fresh and version-2 catalog creation for every supported shard
+count, deterministic and balanced bucket ownership, non-divisor compatibility,
+no-op reopen, both recognized legacy headers, the interrupted empty-table state,
+exact schema and relational corruption, future and foreign formats, both old-
+reader fences, errors and panics on both sides of the version stamp, multi-step
+resume, observer atomicity, and concurrent openers with matching and conflicting
+shard counts. They also prove catalog persistence does not activate routing one
+issue early. Process termination and filesystem faults remain part of the later
+storage-hardening suite. Every new migration must extend the registry,
+destination validator, format documentation, and the same
 normal/error/concurrency/recovery matrix.

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -141,6 +141,30 @@ mod tests {
     }
 
     #[test]
+    fn catalog_creation_does_not_activate_bucket_routing_early() {
+        let keys: [&[u8]; 6] = [
+            b"",
+            b"customer-42",
+            b"tenant/alpha",
+            b"non-power-of-two",
+            &[0, 1, 2, 0xff],
+            "snowman-☃".as_bytes(),
+        ];
+        for shard_count in [3_u16, 5, 7, 63] {
+            let temp = tempfile::tempdir().unwrap();
+            let database = Database::open(temp.path(), shard_count).unwrap();
+            for key in keys {
+                let digest = blake3::hash(key);
+                let hash = u64::from_le_bytes(digest.as_bytes()[..8].try_into().unwrap());
+                assert_eq!(
+                    database.shard_for_key(key),
+                    (hash % u64::from(shard_count)) as u16
+                );
+            }
+        }
+    }
+
+    #[test]
     fn routed_execute_and_query_report_the_selected_shard() {
         let temp = tempfile::tempdir().unwrap();
         let database = Database::open(temp.path(), 4).unwrap();

--- a/src/storage/manifest.rs
+++ b/src/storage/manifest.rs
@@ -1158,8 +1158,7 @@ fn validate_virtual_buckets(connection: &Connection, shard_count: u16) -> Engine
     }
 
     let mut assignments = vec![0_u16; usize::from(shard_count)];
-    for (expected, (stored_bucket, stored_shard)) in (0..VIRTUAL_BUCKET_COUNT).zip(rows.into_iter())
-    {
+    for (expected, (stored_bucket, stored_shard)) in (0..VIRTUAL_BUCKET_COUNT).zip(rows) {
         if stored_bucket != i64::from(expected) {
             return Err(EngineError::new(
                 EngineErrorKind::DataCorruption,

--- a/src/storage/manifest.rs
+++ b/src/storage/manifest.rs
@@ -11,8 +11,17 @@ use crate::{
 pub(super) const MANIFEST_APPLICATION_ID: i64 = 0x4252_4442;
 const LEGACY_SCHEMA_VERSION: u32 = 1;
 const V2_SCHEMA_VERSION: u32 = 2;
-pub(super) const CURRENT_SCHEMA_VERSION: u32 = V2_SCHEMA_VERSION;
+const V3_SCHEMA_VERSION: u32 = 3;
+pub(super) const CURRENT_SCHEMA_VERSION: u32 = V3_SCHEMA_VERSION;
 const MAX_TABLE_SQL_BYTES: i64 = 4_096;
+
+pub(super) const HASH_VERSION: u32 = 1;
+pub(super) const KEY_ENCODING_VERSION: u32 = 1;
+pub(super) const BUCKET_ALGORITHM_VERSION: u32 = 1;
+pub(super) const VIRTUAL_BUCKET_COUNT: u16 = 4_096;
+pub(super) const INITIAL_MAP_GENERATION: u64 = 1;
+
+const ACTIVE_LIFECYCLE_STATE: &str = "active";
 
 const LEGACY_METADATA_TABLE_SQL: &str = "CREATE TABLE briskdb_metadata (
     key TEXT PRIMARY KEY,
@@ -26,6 +35,27 @@ const V2_DOWNGRADE_FENCE_SQL: &str = "CREATE TABLE briskdb_metadata (
     requires_manifest_version INTEGER NOT NULL
         CHECK (requires_manifest_version >= 2)
 ) STRICT";
+const V3_DOWNGRADE_FENCE_SQL: &str = "CREATE TABLE briskdb_metadata (
+    requires_manifest_version INTEGER NOT NULL
+        CHECK (requires_manifest_version >= 3)
+) STRICT";
+const V3_ROUTING_TABLE_SQL: &str = "CREATE TABLE briskdb_routing (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    hash_version INTEGER NOT NULL CHECK (hash_version = 1),
+    key_encoding_version INTEGER NOT NULL CHECK (key_encoding_version = 1),
+    bucket_algorithm_version INTEGER NOT NULL CHECK (bucket_algorithm_version = 1),
+    virtual_bucket_count INTEGER NOT NULL CHECK (virtual_bucket_count = 4096),
+    map_generation INTEGER NOT NULL CHECK (map_generation = 1)
+) STRICT";
+const V3_PHYSICAL_SHARDS_TABLE_SQL: &str = "CREATE TABLE briskdb_physical_shards (
+    shard_id INTEGER PRIMARY KEY CHECK (shard_id BETWEEN 0 AND 63),
+    lifecycle_state TEXT NOT NULL CHECK (lifecycle_state = 'active')
+) STRICT";
+const V3_VIRTUAL_BUCKETS_TABLE_SQL: &str = "CREATE TABLE briskdb_virtual_buckets (
+    bucket_id INTEGER PRIMARY KEY CHECK (bucket_id BETWEEN 0 AND 4095),
+    physical_shard_id INTEGER NOT NULL,
+    FOREIGN KEY (physical_shard_id) REFERENCES briskdb_physical_shards (shard_id)
+) STRICT";
 
 #[derive(Clone, Copy)]
 struct Migration {
@@ -36,13 +66,22 @@ struct Migration {
     validate: fn(&Connection, u16, &[SchemaObject]) -> EngineResult<u16>,
 }
 
-const MIGRATIONS: &[Migration] = &[Migration {
-    from: LEGACY_SCHEMA_VERSION,
-    to: V2_SCHEMA_VERSION,
-    name: "typed_manifest_and_downgrade_fence",
-    apply: migrate_v1_to_v2,
-    validate: validate_v2,
-}];
+const MIGRATIONS: &[Migration] = &[
+    Migration {
+        from: LEGACY_SCHEMA_VERSION,
+        to: V2_SCHEMA_VERSION,
+        name: "typed_manifest_and_downgrade_fence",
+        apply: migrate_v1_to_v2,
+        validate: validate_v2,
+    },
+    Migration {
+        from: V2_SCHEMA_VERSION,
+        to: V3_SCHEMA_VERSION,
+        name: "durable_shard_catalog",
+        apply: migrate_v2_to_v3,
+        validate: validate_v3,
+    },
+];
 
 #[derive(Clone, Copy)]
 struct MigrationPlan<'a> {
@@ -54,7 +93,7 @@ struct MigrationPlan<'a> {
 const CURRENT_PLAN: MigrationPlan<'static> = MigrationPlan {
     current_version: CURRENT_SCHEMA_VERSION,
     migrations: MIGRATIONS,
-    initialize_current: create_v2_schema,
+    initialize_current: create_v3_schema,
 };
 
 #[derive(Clone, Copy)]
@@ -266,6 +305,118 @@ fn insert_v2_rows(transaction: &Transaction<'_>, shard_count: u16) -> EngineResu
     Ok(())
 }
 
+fn create_v3_schema(transaction: &Transaction<'_>, shard_count: u16) -> EngineResult<()> {
+    create_v2_schema(transaction, shard_count)?;
+    migrate_v2_to_v3(transaction, shard_count)
+}
+
+fn migrate_v2_to_v3(transaction: &Transaction<'_>, shard_count: u16) -> EngineResult<()> {
+    transaction
+        .execute_batch("DROP TABLE briskdb_metadata;")
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch(V3_DOWNGRADE_FENCE_SQL)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "INSERT INTO briskdb_metadata (requires_manifest_version) VALUES (?1)",
+            [V3_SCHEMA_VERSION],
+        )
+        .map_err(sqlite_error::storage)?;
+
+    transaction
+        .execute_batch(V3_ROUTING_TABLE_SQL)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch(V3_PHYSICAL_SHARDS_TABLE_SQL)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch(V3_VIRTUAL_BUCKETS_TABLE_SQL)
+        .map_err(sqlite_error::storage)?;
+
+    transaction
+        .execute(
+            "INSERT INTO briskdb_routing (
+                singleton,
+                hash_version,
+                key_encoding_version,
+                bucket_algorithm_version,
+                virtual_bucket_count,
+                map_generation
+             ) VALUES (1, ?1, ?2, ?3, ?4, ?5)",
+            [
+                i64::from(HASH_VERSION),
+                i64::from(KEY_ENCODING_VERSION),
+                i64::from(BUCKET_ALGORITHM_VERSION),
+                i64::from(VIRTUAL_BUCKET_COUNT),
+                i64::try_from(INITIAL_MAP_GENERATION).expect("initial generation fits in SQLite"),
+            ],
+        )
+        .map_err(sqlite_error::storage)?;
+
+    {
+        let mut insert_shard = transaction
+            .prepare(
+                "INSERT INTO briskdb_physical_shards (shard_id, lifecycle_state)
+                 VALUES (?1, ?2)",
+            )
+            .map_err(sqlite_error::storage)?;
+        for shard_id in 0..shard_count {
+            insert_shard
+                .execute(rusqlite::params![
+                    i64::from(shard_id),
+                    ACTIVE_LIFECYCLE_STATE
+                ])
+                .map_err(sqlite_error::storage)?;
+        }
+    }
+
+    {
+        let mut insert_bucket = transaction
+            .prepare(
+                "INSERT INTO briskdb_virtual_buckets (
+                    bucket_id,
+                    physical_shard_id
+                 ) VALUES (?1, ?2)",
+            )
+            .map_err(sqlite_error::storage)?;
+        for bucket_id in 0..VIRTUAL_BUCKET_COUNT {
+            insert_bucket
+                .execute([
+                    i64::from(bucket_id),
+                    i64::from(initial_physical_shard(bucket_id, shard_count)),
+                ])
+                .map_err(sqlite_error::storage)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Partition the virtual bucket space into deterministic contiguous ranges.
+///
+/// Hash version 1 will choose a range using the legacy `hash % shard_count`
+/// result, then choose a bucket within that range. Consequently, activating
+/// catalog lookup can preserve every existing placement even when the shard
+/// count does not divide 4,096.
+fn initial_physical_shard(bucket_id: u16, shard_count: u16) -> u16 {
+    debug_assert!((2..=64).contains(&shard_count));
+    debug_assert!(bucket_id < VIRTUAL_BUCKET_COUNT);
+
+    let bucket_count = u32::from(VIRTUAL_BUCKET_COUNT);
+    let shard_count = u32::from(shard_count);
+    let bucket_id = u32::from(bucket_id);
+    let base_size = bucket_count / shard_count;
+    let wider_shards = bucket_count % shard_count;
+    let wider_span = (base_size + 1) * wider_shards;
+    let shard = if bucket_id < wider_span {
+        bucket_id / (base_size + 1)
+    } else {
+        wider_shards + (bucket_id - wider_span) / base_size
+    };
+    u16::try_from(shard).expect("a virtual bucket maps to a supported shard")
+}
+
 fn set_identity(connection: &Connection, version: u32) -> EngineResult<()> {
     connection
         .pragma_update(None, "application_id", MANIFEST_APPLICATION_ID)
@@ -426,6 +577,31 @@ fn v2_objects() -> Vec<SchemaObject> {
     ]
 }
 
+fn v3_objects() -> Vec<SchemaObject> {
+    vec![
+        SchemaObject {
+            object_type: "table".to_owned(),
+            name: "briskdb_manifest".to_owned(),
+        },
+        SchemaObject {
+            object_type: "table".to_owned(),
+            name: "briskdb_metadata".to_owned(),
+        },
+        SchemaObject {
+            object_type: "table".to_owned(),
+            name: "briskdb_physical_shards".to_owned(),
+        },
+        SchemaObject {
+            object_type: "table".to_owned(),
+            name: "briskdb_routing".to_owned(),
+        },
+        SchemaObject {
+            object_type: "table".to_owned(),
+            name: "briskdb_virtual_buckets".to_owned(),
+        },
+    ]
+}
+
 fn schema_objects(connection: &Connection) -> EngineResult<Vec<SchemaObject>> {
     let mut statement = connection
         .prepare(
@@ -499,10 +675,17 @@ fn validate_table(
             "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden
              FROM pragma_table_xinfo('briskdb_metadata') LIMIT ?1"
         }
-        #[cfg(test)]
-        "briskdb_v3_marker" => {
+        "briskdb_physical_shards" => {
             "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden
-             FROM pragma_table_xinfo('briskdb_v3_marker') LIMIT ?1"
+             FROM pragma_table_xinfo('briskdb_physical_shards') LIMIT ?1"
+        }
+        "briskdb_routing" => {
+            "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden
+             FROM pragma_table_xinfo('briskdb_routing') LIMIT ?1"
+        }
+        "briskdb_virtual_buckets" => {
+            "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden
+             FROM pragma_table_xinfo('briskdb_virtual_buckets') LIMIT ?1"
         }
         _ => {
             return Err(EngineError::new(
@@ -684,6 +867,102 @@ fn validate_v2(
     )?;
     validate_table_sql(connection, "briskdb_metadata", V2_DOWNGRADE_FENCE_SQL)?;
 
+    let shard_count = validate_manifest_configuration(connection, requested_shards)?;
+    validate_downgrade_fence(connection, V2_SCHEMA_VERSION)?;
+    Ok(shard_count)
+}
+
+fn validate_v3(
+    connection: &Connection,
+    requested_shards: u16,
+    objects: &[SchemaObject],
+) -> EngineResult<u16> {
+    if objects != v3_objects() {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "manifest schema version 3 has unexpected database objects",
+        ));
+    }
+
+    validate_table(
+        connection,
+        "briskdb_manifest",
+        &[
+            TableColumn::expected(0, "singleton", "INTEGER", false, 1),
+            TableColumn::expected(1, "shard_count", "INTEGER", true, 0),
+        ],
+        true,
+    )?;
+    validate_table_sql(connection, "briskdb_manifest", V2_MANIFEST_TABLE_SQL)?;
+    validate_table(
+        connection,
+        "briskdb_metadata",
+        &[TableColumn::expected(
+            0,
+            "requires_manifest_version",
+            "INTEGER",
+            true,
+            0,
+        )],
+        true,
+    )?;
+    validate_table_sql(connection, "briskdb_metadata", V3_DOWNGRADE_FENCE_SQL)?;
+    validate_table(
+        connection,
+        "briskdb_routing",
+        &[
+            TableColumn::expected(0, "singleton", "INTEGER", false, 1),
+            TableColumn::expected(1, "hash_version", "INTEGER", true, 0),
+            TableColumn::expected(2, "key_encoding_version", "INTEGER", true, 0),
+            TableColumn::expected(3, "bucket_algorithm_version", "INTEGER", true, 0),
+            TableColumn::expected(4, "virtual_bucket_count", "INTEGER", true, 0),
+            TableColumn::expected(5, "map_generation", "INTEGER", true, 0),
+        ],
+        true,
+    )?;
+    validate_table_sql(connection, "briskdb_routing", V3_ROUTING_TABLE_SQL)?;
+    validate_table(
+        connection,
+        "briskdb_physical_shards",
+        &[
+            TableColumn::expected(0, "shard_id", "INTEGER", false, 1),
+            TableColumn::expected(1, "lifecycle_state", "TEXT", true, 0),
+        ],
+        true,
+    )?;
+    validate_table_sql(
+        connection,
+        "briskdb_physical_shards",
+        V3_PHYSICAL_SHARDS_TABLE_SQL,
+    )?;
+    validate_table(
+        connection,
+        "briskdb_virtual_buckets",
+        &[
+            TableColumn::expected(0, "bucket_id", "INTEGER", false, 1),
+            TableColumn::expected(1, "physical_shard_id", "INTEGER", true, 0),
+        ],
+        true,
+    )?;
+    validate_table_sql(
+        connection,
+        "briskdb_virtual_buckets",
+        V3_VIRTUAL_BUCKETS_TABLE_SQL,
+    )?;
+
+    let shard_count = validate_manifest_configuration(connection, requested_shards)?;
+    validate_downgrade_fence(connection, V3_SCHEMA_VERSION)?;
+    validate_routing_configuration(connection)?;
+    validate_physical_shards(connection, shard_count)?;
+    validate_virtual_buckets(connection, shard_count)?;
+    validate_foreign_keys(connection)?;
+    Ok(shard_count)
+}
+
+fn validate_manifest_configuration(
+    connection: &Connection,
+    requested_shards: u16,
+) -> EngineResult<u16> {
     let mut config_statement = connection
         .prepare("SELECT singleton, shard_count FROM briskdb_manifest ORDER BY singleton LIMIT 3")
         .map_err(|error| manifest_read_error(error, "failed to read manifest configuration"))?;
@@ -708,6 +987,10 @@ fn validate_v2(
     validate_shard_range(shard_count)?;
     ensure_requested_shards(shard_count, requested_shards)?;
 
+    Ok(shard_count)
+}
+
+fn validate_downgrade_fence(connection: &Connection, expected_version: u32) -> EngineResult<()> {
     let mut fence_statement = connection
         .prepare("SELECT requires_manifest_version FROM briskdb_metadata ORDER BY rowid LIMIT 3")
         .map_err(|error| manifest_read_error(error, "failed to read manifest downgrade fence"))?;
@@ -716,13 +999,223 @@ fn validate_v2(
         .map_err(|error| manifest_read_error(error, "failed to read manifest downgrade fence"))?
         .collect::<Result<Vec<_>, _>>()
         .map_err(|error| manifest_read_error(error, "failed to read manifest downgrade fence"))?;
-    if fence != [i64::from(V2_SCHEMA_VERSION)] {
+    if fence != [i64::from(expected_version)] {
         return Err(EngineError::new(
             EngineErrorKind::DataCorruption,
             "manifest downgrade fence does not match its schema version",
         ));
     }
-    Ok(shard_count)
+    Ok(())
+}
+
+fn validate_routing_configuration(connection: &Connection) -> EngineResult<()> {
+    let mut statement = connection
+        .prepare(
+            "SELECT singleton,
+                    hash_version,
+                    key_encoding_version,
+                    bucket_algorithm_version,
+                    virtual_bucket_count,
+                    map_generation
+             FROM briskdb_routing
+             ORDER BY singleton
+             LIMIT 3",
+        )
+        .map_err(|error| manifest_read_error(error, "failed to read routing configuration"))?;
+    let rows = statement
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, i64>(3)?,
+                row.get::<_, i64>(4)?,
+                row.get::<_, i64>(5)?,
+            ))
+        })
+        .map_err(|error| manifest_read_error(error, "failed to read routing configuration"))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| manifest_read_error(error, "failed to read routing configuration"))?;
+    if rows.len() != 1 || rows[0].0 != 1 {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "routing configuration must contain exactly its singleton row",
+        ));
+    }
+
+    let (
+        _,
+        hash_version,
+        key_encoding_version,
+        bucket_algorithm_version,
+        bucket_count,
+        map_generation,
+    ) = rows[0];
+    if hash_version != i64::from(HASH_VERSION) {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!("manifest has unsupported hash version {hash_version}"),
+        ));
+    }
+    if key_encoding_version != i64::from(KEY_ENCODING_VERSION) {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!("manifest has unsupported key-encoding version {key_encoding_version}"),
+        ));
+    }
+    if bucket_algorithm_version != i64::from(BUCKET_ALGORITHM_VERSION) {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!("manifest has unsupported bucket-algorithm version {bucket_algorithm_version}"),
+        ));
+    }
+    if bucket_count != i64::from(VIRTUAL_BUCKET_COUNT) {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!("manifest has unsupported virtual-bucket count {bucket_count}"),
+        ));
+    }
+    let map_generation = u64::try_from(map_generation).map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::DataCorruption,
+            "manifest map generation is outside the supported numeric range",
+            error,
+        )
+    })?;
+    if map_generation != INITIAL_MAP_GENERATION {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!("manifest has unsupported map generation {map_generation}"),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_physical_shards(connection: &Connection, shard_count: u16) -> EngineResult<()> {
+    let mut statement = connection
+        .prepare(
+            "SELECT shard_id, lifecycle_state
+             FROM briskdb_physical_shards
+             ORDER BY shard_id
+             LIMIT 65",
+        )
+        .map_err(|error| manifest_read_error(error, "failed to read physical shard catalog"))?;
+    let rows = statement
+        .query_map([], |row| {
+            Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+        })
+        .map_err(|error| manifest_read_error(error, "failed to read physical shard catalog"))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| manifest_read_error(error, "failed to read physical shard catalog"))?;
+    if rows.len() != usize::from(shard_count) {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!(
+                "physical shard catalog has {} rows, expected {shard_count}",
+                rows.len()
+            ),
+        ));
+    }
+    for (expected, (stored, state)) in (0..shard_count).zip(rows) {
+        if stored != i64::from(expected) {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "physical shard IDs must be contiguous from zero",
+            ));
+        }
+        if state != ACTIVE_LIFECYCLE_STATE {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!("physical shard {expected} has unsupported lifecycle state {state}"),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_virtual_buckets(connection: &Connection, shard_count: u16) -> EngineResult<()> {
+    let mut statement = connection
+        .prepare(
+            "SELECT bucket_id, physical_shard_id
+             FROM briskdb_virtual_buckets
+             ORDER BY bucket_id
+             LIMIT 4097",
+        )
+        .map_err(|error| manifest_read_error(error, "failed to read virtual bucket map"))?;
+    let rows = statement
+        .query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)))
+        .map_err(|error| manifest_read_error(error, "failed to read virtual bucket map"))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| manifest_read_error(error, "failed to read virtual bucket map"))?;
+    if rows.len() != usize::from(VIRTUAL_BUCKET_COUNT) {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!(
+                "virtual bucket map has {} rows, expected {VIRTUAL_BUCKET_COUNT}",
+                rows.len()
+            ),
+        ));
+    }
+
+    let mut assignments = vec![0_u16; usize::from(shard_count)];
+    for (expected, (stored_bucket, stored_shard)) in (0..VIRTUAL_BUCKET_COUNT).zip(rows.into_iter())
+    {
+        if stored_bucket != i64::from(expected) {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "virtual bucket IDs must be contiguous from zero",
+            ));
+        }
+        let stored_shard = u16::try_from(stored_shard).map_err(|error| {
+            EngineError::from_source(
+                EngineErrorKind::DataCorruption,
+                format!("virtual bucket {expected} has an invalid physical shard ID"),
+                error,
+            )
+        })?;
+        if stored_shard >= shard_count {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!("virtual bucket {expected} references unknown shard {stored_shard}"),
+            ));
+        }
+        if stored_shard != initial_physical_shard(expected, shard_count) {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!("virtual bucket {expected} disagrees with the generation-1 map"),
+            ));
+        }
+        assignments[usize::from(stored_shard)] += 1;
+    }
+    if let Some(unassigned) = assignments.iter().position(|count| *count == 0) {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!("active physical shard {unassigned} has no virtual buckets"),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_foreign_keys(connection: &Connection) -> EngineResult<()> {
+    let violation = connection
+        .query_row(
+            "SELECT 1 FROM pragma_foreign_key_check LIMIT 1",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .map(Some)
+        .or_else(|error| match error {
+            rusqlite::Error::QueryReturnedNoRows => Ok(None),
+            error => Err(error),
+        })
+        .map_err(|error| manifest_read_error(error, "failed to validate manifest foreign keys"))?;
+    if violation.is_some() {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "manifest contains a foreign-key violation",
+        ));
+    }
+    Ok(())
 }
 
 fn validate_shard_range(shard_count: u16) -> EngineResult<()> {
@@ -776,144 +1269,6 @@ mod tests {
 
     use super::*;
 
-    const SYNTHETIC_V3_SCHEMA_VERSION: u32 = 3;
-    const SYNTHETIC_MIGRATIONS: &[Migration] = &[
-        Migration {
-            from: LEGACY_SCHEMA_VERSION,
-            to: V2_SCHEMA_VERSION,
-            name: "typed_manifest_and_downgrade_fence",
-            apply: migrate_v1_to_v2,
-            validate: validate_v2,
-        },
-        Migration {
-            from: V2_SCHEMA_VERSION,
-            to: SYNTHETIC_V3_SCHEMA_VERSION,
-            name: "synthetic_v3",
-            apply: migrate_v2_to_synthetic_v3,
-            validate: validate_synthetic_v3,
-        },
-    ];
-    const SYNTHETIC_PLAN: MigrationPlan<'static> = MigrationPlan {
-        current_version: SYNTHETIC_V3_SCHEMA_VERSION,
-        migrations: SYNTHETIC_MIGRATIONS,
-        initialize_current: initialize_synthetic_v3,
-    };
-
-    fn migrate_v2_to_synthetic_v3(
-        transaction: &Transaction<'_>,
-        _shard_count: u16,
-    ) -> EngineResult<()> {
-        transaction
-            .execute_batch(
-                "CREATE TABLE briskdb_v3_marker (value INTEGER NOT NULL) STRICT;
-                 INSERT INTO briskdb_v3_marker VALUES (42);
-                 UPDATE briskdb_metadata SET requires_manifest_version = 3;",
-            )
-            .map_err(sqlite_error::storage)
-    }
-
-    fn initialize_synthetic_v3(
-        transaction: &Transaction<'_>,
-        shard_count: u16,
-    ) -> EngineResult<()> {
-        create_v2_schema(transaction, shard_count)?;
-        migrate_v2_to_synthetic_v3(transaction, shard_count)
-    }
-
-    fn validate_synthetic_v3(
-        connection: &Connection,
-        requested_shards: u16,
-        objects: &[SchemaObject],
-    ) -> EngineResult<u16> {
-        let expected_objects = [
-            SchemaObject {
-                object_type: "table".to_owned(),
-                name: "briskdb_manifest".to_owned(),
-            },
-            SchemaObject {
-                object_type: "table".to_owned(),
-                name: "briskdb_metadata".to_owned(),
-            },
-            SchemaObject {
-                object_type: "table".to_owned(),
-                name: "briskdb_v3_marker".to_owned(),
-            },
-        ];
-        if objects != expected_objects {
-            return Err(EngineError::new(
-                EngineErrorKind::DataCorruption,
-                "synthetic manifest schema version 3 has unexpected objects",
-            ));
-        }
-        validate_table(
-            connection,
-            "briskdb_manifest",
-            &[
-                TableColumn::expected(0, "singleton", "INTEGER", false, 1),
-                TableColumn::expected(1, "shard_count", "INTEGER", true, 0),
-            ],
-            true,
-        )?;
-        validate_table(
-            connection,
-            "briskdb_metadata",
-            &[TableColumn::expected(
-                0,
-                "requires_manifest_version",
-                "INTEGER",
-                true,
-                0,
-            )],
-            true,
-        )?;
-        validate_table(
-            connection,
-            "briskdb_v3_marker",
-            &[TableColumn::expected(0, "value", "INTEGER", true, 0)],
-            true,
-        )?;
-
-        let (singleton, stored_shards): (i64, i64) = connection
-            .query_row(
-                "SELECT singleton, shard_count FROM briskdb_manifest",
-                [],
-                |row| Ok((row.get(0)?, row.get(1)?)),
-            )
-            .map_err(|error| {
-                manifest_read_error(error, "failed to read synthetic manifest configuration")
-            })?;
-        let fence: i64 = connection
-            .query_row(
-                "SELECT requires_manifest_version FROM briskdb_metadata",
-                [],
-                |row| row.get(0),
-            )
-            .map_err(|error| {
-                manifest_read_error(error, "failed to read synthetic manifest fence")
-            })?;
-        let marker: i64 = connection
-            .query_row("SELECT value FROM briskdb_v3_marker", [], |row| row.get(0))
-            .map_err(|error| {
-                manifest_read_error(error, "failed to read synthetic manifest marker")
-            })?;
-        let shard_count = u16::try_from(stored_shards).map_err(|error| {
-            EngineError::from_source(
-                EngineErrorKind::DataCorruption,
-                "synthetic manifest shard count is invalid",
-                error,
-            )
-        })?;
-        if singleton != 1 || fence != 3 || marker != 42 {
-            return Err(EngineError::new(
-                EngineErrorKind::DataCorruption,
-                "synthetic manifest version 3 has invalid rows",
-            ));
-        }
-        validate_shard_range(shard_count)?;
-        ensure_requested_shards(shard_count, requested_shards)?;
-        Ok(shard_count)
-    }
-
     fn create_legacy_manifest(connection: &Connection, shards: u16, version: u32) {
         create_empty_legacy_manifest(connection);
         connection
@@ -942,6 +1297,110 @@ mod tests {
                 );",
             )
             .unwrap();
+    }
+
+    fn create_v2_manifest(connection: &mut Connection, shards: u16) {
+        let transaction = connection.transaction().unwrap();
+        create_v2_schema(&transaction, shards).unwrap();
+        set_identity(&transaction, V2_SCHEMA_VERSION).unwrap();
+        transaction.commit().unwrap();
+    }
+
+    fn routing_configuration(connection: &Connection) -> (i64, i64, i64, i64, i64, i64) {
+        connection
+            .query_row(
+                "SELECT singleton,
+                        hash_version,
+                        key_encoding_version,
+                        bucket_algorithm_version,
+                        virtual_bucket_count,
+                        map_generation
+                 FROM briskdb_routing",
+                [],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                        row.get(5)?,
+                    ))
+                },
+            )
+            .unwrap()
+    }
+
+    fn physical_shards(connection: &Connection) -> Vec<(i64, String)> {
+        let mut statement = connection
+            .prepare(
+                "SELECT shard_id, lifecycle_state
+                 FROM briskdb_physical_shards
+                 ORDER BY shard_id",
+            )
+            .unwrap();
+        statement
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+    }
+
+    fn virtual_buckets(connection: &Connection) -> Vec<(i64, i64)> {
+        let mut statement = connection
+            .prepare(
+                "SELECT bucket_id, physical_shard_id
+                 FROM briskdb_virtual_buckets
+                 ORDER BY bucket_id",
+            )
+            .unwrap();
+        statement
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+    }
+
+    fn assert_generation_one_catalog(connection: &Connection, shard_count: u16) {
+        assert_eq!(
+            identity(connection),
+            (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
+        );
+        assert_eq!(schema_objects(connection).unwrap(), v3_objects());
+        assert_eq!(
+            routing_configuration(connection),
+            (
+                1,
+                i64::from(HASH_VERSION),
+                i64::from(KEY_ENCODING_VERSION),
+                i64::from(BUCKET_ALGORITHM_VERSION),
+                i64::from(VIRTUAL_BUCKET_COUNT),
+                i64::try_from(INITIAL_MAP_GENERATION).unwrap(),
+            )
+        );
+        assert_eq!(
+            physical_shards(connection),
+            (0..shard_count)
+                .map(|shard| (i64::from(shard), ACTIVE_LIFECYCLE_STATE.to_owned()))
+                .collect::<Vec<_>>()
+        );
+
+        let buckets = virtual_buckets(connection);
+        assert_eq!(buckets.len(), usize::from(VIRTUAL_BUCKET_COUNT));
+        let mut assignments = vec![0_u16; usize::from(shard_count)];
+        for (expected, (bucket_id, physical_shard)) in (0..VIRTUAL_BUCKET_COUNT).zip(buckets) {
+            assert_eq!(bucket_id, i64::from(expected));
+            assert_eq!(
+                physical_shard,
+                i64::from(initial_physical_shard(expected, shard_count))
+            );
+            assignments[usize::try_from(physical_shard).unwrap()] += 1;
+        }
+        let smallest = assignments.iter().min().unwrap();
+        let largest = assignments.iter().max().unwrap();
+        assert!(*smallest > 0);
+        assert!(*largest - *smallest <= 1);
+        validate_foreign_keys(connection).unwrap();
     }
 
     fn identity(connection: &Connection) -> (i64, i64) {
@@ -1000,13 +1459,13 @@ mod tests {
         let mut connection = Connection::open_in_memory().unwrap();
         create_legacy_manifest(&connection, 4, 0);
         let mut first_attempt = Vec::new();
-        let error = load_or_create_with_plan(&mut connection, 4, SYNTHETIC_PLAN, &mut |point| {
+        let error = load_or_create_with_hook(&mut connection, 4, |point| {
             if point.phase == MigrationPhase::AfterVersionStamp {
                 first_attempt.push((point.from, point.to));
                 if point.from == V2_SCHEMA_VERSION {
                     return Err(EngineError::new(
                         EngineErrorKind::Internal,
-                        "injected synthetic v3 failure",
+                        "injected catalog migration failure",
                     ));
                 }
             }
@@ -1021,25 +1480,17 @@ mod tests {
 
         let mut resumed_steps = Vec::new();
         assert_eq!(
-            load_or_create_with_plan(&mut connection, 4, SYNTHETIC_PLAN, &mut |point| {
+            load_or_create_with_hook(&mut connection, 4, |point| {
                 if point.phase == MigrationPhase::AfterVersionStamp {
                     resumed_steps.push((point.from, point.to));
                 }
                 Ok(())
-            },)
+            })
             .unwrap(),
             4
         );
         assert_eq!(resumed_steps, [(2, 3)]);
-        assert_eq!(identity(&connection), (MANIFEST_APPLICATION_ID, 3));
-        assert_eq!(
-            connection
-                .query_row("SELECT value FROM briskdb_v3_marker", [], |row| {
-                    row.get::<_, i64>(0)
-                })
-                .unwrap(),
-            42
-        );
+        assert_generation_one_catalog(&connection, 4);
         assert_eq!(quick_check(&connection), "ok");
     }
 
@@ -1050,9 +1501,8 @@ mod tests {
         let mut connection = Connection::open(&path).unwrap();
 
         assert_eq!(load_or_create(&mut connection, 4).unwrap(), 4);
-        assert_eq!(identity(&connection), (MANIFEST_APPLICATION_ID, 2));
         assert_eq!(current_shard_count(&connection), 4);
-        assert_eq!(schema_objects(&connection).unwrap(), v2_objects());
+        assert_generation_one_catalog(&connection, 4);
         assert_eq!(quick_check(&connection), "ok");
 
         let observer = Connection::open(&path).unwrap();
@@ -1067,14 +1517,100 @@ mod tests {
     }
 
     #[test]
+    fn fresh_and_v2_upgraded_catalogs_are_identical_for_every_shard_count() {
+        for shard_count in 2..=64 {
+            let mut fresh = Connection::open_in_memory().unwrap();
+            assert_eq!(
+                load_or_create(&mut fresh, shard_count).unwrap(),
+                shard_count
+            );
+            assert_generation_one_catalog(&fresh, shard_count);
+
+            let mut upgraded = Connection::open_in_memory().unwrap();
+            create_v2_manifest(&mut upgraded, shard_count);
+            assert_eq!(
+                load_or_create(&mut upgraded, shard_count).unwrap(),
+                shard_count
+            );
+            assert_generation_one_catalog(&upgraded, shard_count);
+            assert_eq!(
+                routing_configuration(&fresh),
+                routing_configuration(&upgraded)
+            );
+            assert_eq!(physical_shards(&fresh), physical_shards(&upgraded));
+            assert_eq!(virtual_buckets(&fresh), virtual_buckets(&upgraded));
+        }
+    }
+
+    #[test]
+    fn generation_one_bucket_ranges_can_preserve_legacy_modulo_placement() {
+        let hashes = [
+            0,
+            1,
+            2,
+            4_095,
+            4_096,
+            65_535,
+            0x0123_4567_89ab_cdef,
+            u64::MAX,
+        ];
+        for shard_count in 2..=64_u16 {
+            let base_size = u64::from(VIRTUAL_BUCKET_COUNT / shard_count);
+            let wider_shards = u64::from(VIRTUAL_BUCKET_COUNT % shard_count);
+            for hash in hashes {
+                let legacy_shard = hash % u64::from(shard_count);
+                let group_size = base_size + u64::from(legacy_shard < wider_shards);
+                let offset = legacy_shard * base_size + legacy_shard.min(wider_shards);
+                let bucket = offset + (hash / u64::from(shard_count)) % group_size;
+                let bucket = u16::try_from(bucket).unwrap();
+
+                assert!(bucket < VIRTUAL_BUCKET_COUNT);
+                assert_eq!(
+                    initial_physical_shard(bucket, shard_count),
+                    u16::try_from(legacy_shard).unwrap()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn rejects_a_later_map_generation_until_the_manifest_format_supports_it() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        load_or_create(&mut connection, 4).unwrap();
+        connection
+            .execute_batch(
+                "PRAGMA ignore_check_constraints = ON;
+                 BEGIN IMMEDIATE;
+                 UPDATE briskdb_virtual_buckets
+                 SET physical_shard_id = 1
+                 WHERE bucket_id = 0;
+                 UPDATE briskdb_virtual_buckets
+                 SET physical_shard_id = 0
+                 WHERE bucket_id = 1024;
+                 UPDATE briskdb_routing SET map_generation = 2;
+                 COMMIT;
+                 PRAGMA ignore_check_constraints = OFF;",
+            )
+            .unwrap();
+
+        let error = load_or_create(&mut connection, 4).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+        assert_eq!(
+            error.to_string(),
+            "manifest has unsupported map generation 2"
+        );
+        assert_eq!(routing_configuration(&connection).5, 2);
+    }
+
+    #[test]
     fn upgrades_unversioned_and_explicitly_versioned_legacy_manifests() {
         for legacy_header in [0, 1] {
             let mut connection = Connection::open_in_memory().unwrap();
             create_legacy_manifest(&connection, 4, legacy_header);
 
             assert_eq!(load_or_create(&mut connection, 4).unwrap(), 4);
-            assert_eq!(identity(&connection), (MANIFEST_APPLICATION_ID, 2));
             assert_eq!(current_shard_count(&connection), 4);
+            assert_generation_one_catalog(&connection, 4);
             assert_eq!(quick_check(&connection), "ok");
         }
     }
@@ -1085,8 +1621,8 @@ mod tests {
         create_empty_legacy_manifest(&connection);
 
         assert_eq!(load_or_create(&mut connection, 8).unwrap(), 8);
-        assert_eq!(identity(&connection), (MANIFEST_APPLICATION_ID, 2));
         assert_eq!(current_shard_count(&connection), 8);
+        assert_generation_one_catalog(&connection, 8);
     }
 
     #[test]
@@ -1167,6 +1703,18 @@ mod tests {
     }
 
     #[test]
+    fn shard_mismatch_does_not_upgrade_a_version_two_manifest() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        create_v2_manifest(&mut connection, 3);
+
+        let error = load_or_create(&mut connection, 5).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert_eq!(identity(&connection), (MANIFEST_APPLICATION_ID, 2));
+        assert_eq!(schema_objects(&connection).unwrap(), v2_objects());
+        assert_eq!(quick_check(&connection), "ok");
+    }
+
+    #[test]
     fn failures_before_and_after_version_stamping_roll_back_and_retry() {
         for failing_phase in [
             MigrationPhase::AfterSchemaChange,
@@ -1192,8 +1740,72 @@ mod tests {
             assert_eq!(quick_check(&connection), "ok");
 
             assert_eq!(load_or_create(&mut connection, 4).unwrap(), 4);
-            assert_eq!(identity(&connection), (MANIFEST_APPLICATION_ID, 2));
+            assert_generation_one_catalog(&connection, 4);
         }
+    }
+
+    #[test]
+    fn catalog_migration_failures_roll_back_to_exact_v2_and_retry() {
+        for failing_phase in [
+            MigrationPhase::AfterSchemaChange,
+            MigrationPhase::AfterVersionStamp,
+        ] {
+            let mut connection = Connection::open_in_memory().unwrap();
+            create_v2_manifest(&mut connection, 5);
+
+            let error = load_or_create_with_hook(&mut connection, 5, |point| {
+                if point.from == V2_SCHEMA_VERSION && point.phase == failing_phase {
+                    Err(EngineError::new(
+                        EngineErrorKind::Internal,
+                        "injected catalog migration failure",
+                    ))
+                } else {
+                    Ok(())
+                }
+            })
+            .unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::Internal);
+            assert_eq!(identity(&connection), (MANIFEST_APPLICATION_ID, 2));
+            assert_eq!(schema_objects(&connection).unwrap(), v2_objects());
+            assert_eq!(
+                connection
+                    .query_row(
+                        "SELECT requires_manifest_version FROM briskdb_metadata",
+                        [],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .unwrap(),
+                2
+            );
+            assert_eq!(quick_check(&connection), "ok");
+
+            assert_eq!(load_or_create(&mut connection, 5).unwrap(), 5);
+            assert_generation_one_catalog(&connection, 5);
+        }
+    }
+
+    #[test]
+    fn panic_during_catalog_migration_rolls_back_to_v2_and_retry_succeeds() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        create_v2_manifest(&mut connection, 3);
+
+        let panic = catch_unwind(AssertUnwindSafe(|| {
+            let _ = load_or_create_with_hook(&mut connection, 3, |point| {
+                if point.from == V2_SCHEMA_VERSION
+                    && point.phase == MigrationPhase::AfterVersionStamp
+                {
+                    panic!("injected catalog migration panic");
+                }
+                Ok(())
+            });
+        }));
+        assert!(panic.is_err());
+        assert_eq!(identity(&connection), (MANIFEST_APPLICATION_ID, 2));
+        assert_eq!(schema_objects(&connection).unwrap(), v2_objects());
+        assert_eq!(quick_check(&connection), "ok");
+
+        assert_eq!(load_or_create(&mut connection, 3).unwrap(), 3);
+        assert_generation_one_catalog(&connection, 3);
     }
 
     #[test]
@@ -1220,8 +1832,8 @@ mod tests {
     fn an_observer_never_sees_a_partially_migrated_schema() {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("manifest.sqlite");
-        let connection = Connection::open(&path).unwrap();
-        create_legacy_manifest(&connection, 4, 0);
+        let mut connection = Connection::open(&path).unwrap();
+        create_v2_manifest(&mut connection, 4);
         drop(connection);
 
         let (paused_tx, paused_rx) = mpsc::channel();
@@ -1230,7 +1842,9 @@ mod tests {
         let worker = thread::spawn(move || {
             let mut connection = Connection::open(migration_path).unwrap();
             load_or_create_with_hook(&mut connection, 4, |point| {
-                if point.phase == MigrationPhase::AfterVersionStamp {
+                if point.from == V2_SCHEMA_VERSION
+                    && point.phase == MigrationPhase::AfterVersionStamp
+                {
                     paused_tx.send(()).unwrap();
                     resume_rx.recv_timeout(Duration::from_secs(5)).unwrap();
                 }
@@ -1241,13 +1855,12 @@ mod tests {
 
         paused_rx.recv_timeout(Duration::from_secs(5)).unwrap();
         let observer = Connection::open(&path).unwrap();
-        assert_eq!(identity(&observer), (0, 0));
-        assert_eq!(schema_objects(&observer).unwrap(), legacy_objects());
+        assert_eq!(identity(&observer), (MANIFEST_APPLICATION_ID, 2));
+        assert_eq!(schema_objects(&observer).unwrap(), v2_objects());
         resume_tx.send(()).unwrap();
         worker.join().unwrap();
 
-        assert_eq!(identity(&observer), (MANIFEST_APPLICATION_ID, 2));
-        assert_eq!(schema_objects(&observer).unwrap(), v2_objects());
+        assert_generation_one_catalog(&observer, 4);
     }
 
     #[test]
@@ -1278,8 +1891,40 @@ mod tests {
         }
 
         let connection = Connection::open(path).unwrap();
-        assert_eq!(identity(&connection), (MANIFEST_APPLICATION_ID, 2));
         assert_eq!(current_shard_count(&connection), 4);
+        assert_generation_one_catalog(&connection, 4);
+    }
+
+    #[test]
+    fn concurrent_version_two_openers_create_one_complete_catalog() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("manifest.sqlite");
+        let mut connection = Connection::open(&path).unwrap();
+        create_v2_manifest(&mut connection, 5);
+        drop(connection);
+
+        let barrier = Arc::new(Barrier::new(4));
+        let workers = (0..4)
+            .map(|_| {
+                let path = path.clone();
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    let mut connection = Connection::open(path).unwrap();
+                    connection
+                        .busy_timeout(std::time::Duration::from_secs(5))
+                        .unwrap();
+                    barrier.wait();
+                    load_or_create(&mut connection, 5)
+                })
+            })
+            .collect::<Vec<_>>();
+        for worker in workers {
+            assert_eq!(worker.join().unwrap().unwrap(), 5);
+        }
+
+        let connection = Connection::open(path).unwrap();
+        assert_generation_one_catalog(&connection, 5);
+        assert_eq!(quick_check(&connection), "ok");
     }
 
     #[test]
@@ -1322,7 +1967,7 @@ mod tests {
 
         let connection = Connection::open(path).unwrap();
         assert_eq!(current_shard_count(&connection), i64::from(winner));
-        assert_eq!(identity(&connection), (MANIFEST_APPLICATION_ID, 2));
+        assert_generation_one_catalog(&connection, winner);
     }
 
     #[test]
@@ -1335,19 +1980,55 @@ mod tests {
             error,
             rusqlite::Error::SqliteFailure(_, _) | rusqlite::Error::SqlInputError { .. }
         ));
-        assert_eq!(identity(&connection), (MANIFEST_APPLICATION_ID, 2));
+        assert_eq!(
+            identity(&connection),
+            (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
+        );
         assert_eq!(current_shard_count(&connection), 4);
+    }
+
+    #[test]
+    fn version_two_reader_rejects_version_three_without_mutating_it() {
+        const OLD_MIGRATIONS: &[Migration] = &[Migration {
+            from: LEGACY_SCHEMA_VERSION,
+            to: V2_SCHEMA_VERSION,
+            name: "typed_manifest_and_downgrade_fence",
+            apply: migrate_v1_to_v2,
+            validate: validate_v2,
+        }];
+        const OLD_PLAN: MigrationPlan<'static> = MigrationPlan {
+            current_version: V2_SCHEMA_VERSION,
+            migrations: OLD_MIGRATIONS,
+            initialize_current: create_v2_schema,
+        };
+
+        let mut connection = Connection::open_in_memory().unwrap();
+        load_or_create(&mut connection, 4).unwrap();
+        let before = virtual_buckets(&connection);
+        let error = inspect_with_plan(&connection, 4, OLD_PLAN).unwrap_err();
+
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert_generation_one_catalog(&connection, 4);
+        assert_eq!(virtual_buckets(&connection), before);
     }
 
     #[test]
     fn rejects_future_and_foreign_manifests_without_mutating_them() {
         let mut future = Connection::open_in_memory().unwrap();
         load_or_create(&mut future, 4).unwrap();
-        future.pragma_update(None, "user_version", 3).unwrap();
+        future
+            .pragma_update(None, "user_version", CURRENT_SCHEMA_VERSION + 1)
+            .unwrap();
         let objects = schema_objects(&future).unwrap();
         let error = load_or_create(&mut future, 4).unwrap_err();
         assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
-        assert_eq!(identity(&future), (MANIFEST_APPLICATION_ID, 3));
+        assert_eq!(
+            identity(&future),
+            (
+                MANIFEST_APPLICATION_ID,
+                i64::from(CURRENT_SCHEMA_VERSION + 1)
+            )
+        );
         assert_eq!(schema_objects(&future).unwrap(), objects);
 
         let mut foreign = Connection::open_in_memory().unwrap();
@@ -1374,7 +2055,13 @@ mod tests {
         for mutation in [
             "DELETE FROM briskdb_metadata",
             "DELETE FROM briskdb_manifest",
-            "INSERT INTO briskdb_metadata VALUES (2)",
+            "INSERT INTO briskdb_metadata VALUES (3)",
+            "DELETE FROM briskdb_routing",
+            "DELETE FROM briskdb_virtual_buckets WHERE bucket_id = 4095",
+            "DELETE FROM briskdb_physical_shards WHERE shard_id = 3",
+            "UPDATE briskdb_virtual_buckets
+             SET physical_shard_id = 1
+             WHERE bucket_id = 0",
             "CREATE TABLE unexpected (value TEXT)",
             "DROP TABLE briskdb_manifest;
              CREATE TABLE briskdb_manifest (
@@ -1386,10 +2073,13 @@ mod tests {
              CREATE TABLE briskdb_metadata (
                 requires_manifest_version INTEGER NOT NULL
              ) STRICT;
-             INSERT INTO briskdb_metadata VALUES (2);",
+             INSERT INTO briskdb_metadata VALUES (3);",
         ] {
             let mut connection = Connection::open_in_memory().unwrap();
             load_or_create(&mut connection, 4).unwrap();
+            connection
+                .execute_batch("PRAGMA foreign_keys = OFF;")
+                .unwrap();
             connection.execute_batch(mutation).unwrap();
             let error = load_or_create(&mut connection, 4).unwrap_err();
             assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
@@ -1426,6 +2116,78 @@ mod tests {
             schema_objects(&mismatched_legacy).unwrap(),
             legacy_objects()
         );
+    }
+
+    #[test]
+    fn rejects_catalog_values_that_bypass_sql_constraints() {
+        for mutation in [
+            "UPDATE briskdb_routing SET singleton = 2",
+            "UPDATE briskdb_routing SET hash_version = 2",
+            "UPDATE briskdb_routing SET key_encoding_version = 2",
+            "UPDATE briskdb_routing SET bucket_algorithm_version = 2",
+            "UPDATE briskdb_routing SET virtual_bucket_count = 4095",
+            "UPDATE briskdb_routing SET map_generation = 0",
+            "UPDATE briskdb_physical_shards
+             SET lifecycle_state = 'retired'
+             WHERE shard_id = 0",
+            "UPDATE briskdb_physical_shards SET shard_id = 7 WHERE shard_id = 3",
+            "UPDATE briskdb_virtual_buckets
+             SET physical_shard_id = 63
+             WHERE bucket_id = 0",
+            "UPDATE briskdb_virtual_buckets SET bucket_id = 4096 WHERE bucket_id = 4095",
+            "INSERT INTO briskdb_virtual_buckets VALUES (4096, 0)",
+        ] {
+            let mut connection = Connection::open_in_memory().unwrap();
+            load_or_create(&mut connection, 4).unwrap();
+            connection
+                .execute_batch(
+                    "PRAGMA foreign_keys = OFF;
+                     PRAGMA ignore_check_constraints = ON;",
+                )
+                .unwrap();
+            connection.execute_batch(mutation).unwrap();
+            connection
+                .execute_batch("PRAGMA ignore_check_constraints = OFF;")
+                .unwrap();
+
+            let error = load_or_create(&mut connection, 4).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::DataCorruption, "{mutation}");
+        }
+    }
+
+    #[test]
+    fn rejects_altered_catalog_table_definitions() {
+        for mutation in [
+            "DROP TABLE briskdb_routing;
+             CREATE TABLE briskdb_routing (
+                singleton INTEGER PRIMARY KEY,
+                hash_version INTEGER NOT NULL,
+                key_encoding_version INTEGER NOT NULL,
+                virtual_bucket_count INTEGER NOT NULL,
+                map_generation INTEGER NOT NULL
+             ) STRICT;
+             INSERT INTO briskdb_routing VALUES (1, 1, 1, 4096, 1);",
+            "DROP TABLE briskdb_virtual_buckets;
+             CREATE TABLE briskdb_virtual_buckets (
+                bucket_id INTEGER PRIMARY KEY,
+                physical_shard_id INTEGER NOT NULL
+             ) STRICT;",
+            "DROP TABLE briskdb_physical_shards;
+             CREATE TABLE briskdb_physical_shards (
+                shard_id INTEGER PRIMARY KEY,
+                lifecycle_state TEXT NOT NULL
+             ) STRICT;",
+        ] {
+            let mut connection = Connection::open_in_memory().unwrap();
+            load_or_create(&mut connection, 4).unwrap();
+            connection
+                .execute_batch("PRAGMA foreign_keys = OFF;")
+                .unwrap();
+            connection.execute_batch(mutation).unwrap();
+
+            let error = load_or_create(&mut connection, 4).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::DataCorruption, "{mutation}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #13

## Summary
- migrate manifest.sqlite to schema version 3 with frozen routing, physical-shard, and 4,096-bucket tables
- seed and validate a compatibility-preserving generation-1 map for every supported shard count
- fail closed on malformed catalogs, unknown algorithms, later map generations, old readers, and interrupted migrations
- document the on-disk contract and keep runtime routing unchanged until issue #14

## Tests
- cover fresh and v2-upgraded catalogs for every shard count from 2 through 64
- cover v1 to v2 to v3 resume, rollback, panic, observer atomicity, and concurrent openers
- cover schema, row, foreign-key, lifecycle, algorithm, generation, and assignment corruption
- prove non-divisor compatibility and that catalog creation does not activate routing early

## Verification
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --locked --all-targets --all-features on stable and Rust 1.85.0
- cargo test --locked --doc --all-features on stable and Rust 1.85.0
- RUSTDOCFLAGS=-D warnings cargo doc --locked --all-features --no-deps
- cargo bench --locked --all-features --no-run
- three independent read-only reviews; no blockers