### PR TITLE
feat: activate virtual-bucket routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ minimum supported Rust version (MSRV) and the latest stable toolchain.
 
 ## Current foundation
 
-- Stable BLAKE3 routing from a caller-provided shard key
+- Versioned BLAKE3-to-virtual-bucket routing from a caller-provided shard key
 - A protocol-neutral async engine with per-request HTTP sessions
 - Bounded, lazy per-shard SQLite connection pools with explicit backpressure
 - Request cancellation and deadlines that interrupt SQLite and await cleanup
@@ -174,13 +174,13 @@ manifests to version 3 through one transaction per numbered step. Version 3
 persists hash, key-encoding, and bucket-algorithm versions, a generation-stamped
 4,096-bucket map, and active physical-shard lifecycle records. Newer or malformed
 manifests fail closed, and downgrade fences reject shipped version-1 and
-version-2 readers. Runtime routing deliberately remains the existing BLAKE3
-modulo calculation until the next roadmap item activates catalog lookup; the
-generation-1 ranges are constructed so that activation can preserve every
-existing placement, including non-power-of-two shard counts. This changes only
-`manifest.sqlite`, not shard files, SQL behavior, or wire contracts. The
-complete format and upgrade contract is in
-[manifest storage format](docs/STORAGE_FORMAT.md).
+version-2 readers. Startup loads the validated catalog into one immutable
+snapshot, and runtime routing hashes the exact key bytes, derives a virtual
+bucket, then reads that bucket's persisted physical-shard assignment. The
+generation-1 ranges preserve every earlier modulo placement, including
+non-power-of-two shard counts. This changes only routing internals, not shard
+files, SQL behavior, or wire contracts. The complete format and upgrade
+contract is in [manifest storage format](docs/STORAGE_FORMAT.md).
 Embedders should call
 `Engine::shutdown`; merely dropping the final `Engine` is not the explicit
 asynchronous cleanup contract.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -184,7 +184,7 @@ existing tests pass through the shared engine.
 - [x] Version the manifest schema with transactional migrations.
 - [x] Persist hash/key-encoding versions, 4,096 virtual buckets, physical shard
   records, map generation, and lifecycle state.
-- [ ] Replace modulo routing with virtual-bucket lookup and add golden routing
+- [x] Replace modulo routing with virtual-bucket lookup and add golden routing
   vectors so upgrades cannot silently move keys.
 - [ ] Add logical databases and table metadata, including table placement and
   shard-key column/type.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -96,11 +96,13 @@ manifest does not rewrite its journal mode or touch shard files.
 
 This is an internal storage-open concern. It changes no core or adapter
 signature, is unreachable from client SQL, and is atomic only within
-`manifest.sqlite`. Runtime routing still uses the legacy BLAKE3 modulo path;
-catalog lookup is the next isolated roadmap item. The generation-1 bucket ranges
-and versioned derivation are constructed to reproduce that placement for every
-supported initial shard count, including counts that do not divide 4,096. The
-catalog does not yet validate shard-file presence, identity, WAL, or schema
+`manifest.sqlite`. Validation returns an immutable catalog snapshot from the
+same locked transaction; `Storage` shares it across clones. Core routing hashes
+the exact key bytes, derives a versioned virtual bucket, and reads the final
+physical shard from that snapshot without querying SQLite. The generation-1
+bucket ranges reproduce prior modulo placement for every supported initial
+shard count, including counts that do not divide 4,096. The catalog does not yet
+validate shard-file presence, identity, WAL, or schema
 generation, and it is not the future cross-shard application-schema migration
 journal. The exact format, downgrade policy, recovery cases, and tests are
 documented in [manifest storage format](STORAGE_FORMAT.md).

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -328,9 +328,12 @@ underlying execution semantics.
 ### Current
 
 - The caller supplies an opaque `shard_key` independently from the SQL text.
-- BLAKE3 hashing followed by modulo shard count selects one physical shard.
-- Manifest version 3 already persists the versioned 4,096-bucket catalog, but
-  runtime lookup is deliberately deferred to the next routing milestone.
+- Exact key bytes are hashed with version-1 BLAKE3; the little-endian 64-bit
+  prefix selects one of 4,096 virtual buckets through the versioned
+  compatibility algorithm.
+- The final physical shard is read from the validated, generation-stamped
+  bucket map loaded from manifest version 3. Generation 1 preserves the earlier
+  modulo placement for every supported shard count.
 - Point queries and writes visit only that shard.
 - No scatter/gather query path exists.
 - Unique constraints and transactions are local to one SQLite shard.

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -91,10 +91,11 @@ bucket = offset + ((H / N) % size)
 ```
 
 The generation-1 catalog maps that bucket back to `s`, so
-`map[bucket(H)] == H % N` for every supported shard count. This issue persists
-and validates the catalog but deliberately leaves runtime routing on the legacy
-direct-modulo path. The next routing change can activate catalog lookup without
-moving existing keys, and golden vectors must freeze the full calculation.
+`map[bucket(H)] == H % N` for every supported shard count. Runtime routing uses
+the complete calculation and always obtains its final physical shard from
+`map[bucket(H)]`; it does not recompute modulo as the final routing step. Golden
+vectors freeze the exact key bytes, BLAKE3 prefix, little-endian hash integer,
+bucket ID, and persisted physical shard.
 
 `map_generation` is separate from manifest `user_version` and from the future
 application-schema generation. Version 3 accepts only generation 1 and validates
@@ -108,7 +109,10 @@ At each open, BriskDB validates the exact objects, columns, strict flags, frozen
 schema SQL, singleton rows, supported algorithm values, contiguous physical and
 bucket IDs, active lifecycle states, assignments, coverage, and foreign keys.
 A recognized version-3 manifest that violates any of these invariants is
-`DataCorruption` and is rejected before shard connections are opened.
+`DataCorruption` and is rejected before shard connections are opened. The same
+locked transaction returns the validated routing rows as an immutable in-memory
+snapshot, so request routing performs no manifest query and cannot fall back to
+modulo after a failed validation.
 
 ## Previous version 2
 
@@ -218,8 +222,10 @@ no-op reopen, both recognized legacy headers, the interrupted empty-table state,
 exact schema and relational corruption, future and foreign formats, both old-
 reader fences, errors and panics on both sides of the version stamp, multi-step
 resume, observer atomicity, and concurrent openers with matching and conflicting
-shard counts. They also prove catalog persistence does not activate routing one
-issue early. Process termination and filesystem faults remain part of the later
+shard counts. Routing tests additionally freeze golden hash/bucket/shard vectors,
+cover every algorithm state for every supported shard count, prove the final map
+lookup with a synthetic reassignment, and exercise parallel and reopen stability.
+Process termination and filesystem faults remain part of the later
 storage-hardening suite. Every new migration must extend the registry,
 destination validator, format documentation, and the same
 normal/error/concurrency/recovery matrix.

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -8,6 +8,7 @@ mod engine;
 mod error;
 mod lifecycle;
 mod options;
+mod routing;
 mod session;
 mod types;
 pub(crate) mod worker;
@@ -25,6 +26,10 @@ pub use options::{
     DEFAULT_QUEUE_CAPACITY_PER_SHARD, DEFAULT_REQUEST_TIMEOUT_MS, DEFAULT_SHUTDOWN_GRACE_MS,
     EngineOptions, MAX_CONNECTIONS_PER_SHARD, MAX_QUEUE_CAPACITY_PER_SHARD, MAX_REQUEST_TIMEOUT_MS,
     MAX_RESULT_BYTES, MAX_RESULT_ROWS, MAX_SHUTDOWN_GRACE_MS, ResultLimits,
+};
+pub(crate) use routing::{
+    BUCKET_ALGORITHM_VERSION, HASH_VERSION, INITIAL_MAP_GENERATION, KEY_ENCODING_VERSION,
+    RoutingCatalog, VIRTUAL_BUCKET_COUNT, initial_physical_shard,
 };
 pub use session::{Session, SessionId, SessionState};
 pub use types::{
@@ -61,11 +66,7 @@ impl Database {
     }
 
     pub fn shard_for_key(&self, key: &[u8]) -> u16 {
-        let digest = blake3::hash(key);
-        let prefix: [u8; 8] = digest.as_bytes()[..8]
-            .try_into()
-            .expect("BLAKE3 digest always contains eight bytes");
-        (u64::from_le_bytes(prefix) % u64::from(self.shard_count())) as u16
+        self.storage.shard_for_key(key)
     }
 
     pub fn execute_routed(
@@ -141,7 +142,7 @@ mod tests {
     }
 
     #[test]
-    fn catalog_creation_does_not_activate_bucket_routing_early() {
+    fn catalog_lookup_preserves_legacy_v1_placement() {
         let keys: [&[u8]; 6] = [
             b"",
             b"customer-42",
@@ -150,7 +151,7 @@ mod tests {
             &[0, 1, 2, 0xff],
             "snowman-☃".as_bytes(),
         ];
-        for shard_count in [3_u16, 5, 7, 63] {
+        for shard_count in [3_u16, 5, 6, 10, 63, 64] {
             let temp = tempfile::tempdir().unwrap();
             let database = Database::open(temp.path(), shard_count).unwrap();
             for key in keys {
@@ -162,6 +163,52 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn routing_is_stable_across_close_and_reopen() {
+        let temp = tempfile::tempdir().unwrap();
+        let keys: [&[u8]; 6] = [
+            b"",
+            b"customer-42",
+            b"tenant/alpha",
+            b"a\0b",
+            &[0, 1, 2, 0xff],
+            "snowman-☃".as_bytes(),
+        ];
+        let before = {
+            let database = Database::open(temp.path(), 10).unwrap();
+            keys.map(|key| database.shard_for_key(key))
+        };
+
+        let reopened = Database::open(temp.path(), 10).unwrap();
+        assert_eq!(
+            keys.map(|key| reopened.shard_for_key(key)),
+            before,
+            "reopening must load the same persisted routing snapshot"
+        );
+    }
+
+    #[test]
+    fn an_open_database_routes_from_its_immutable_validated_snapshot() {
+        let temp = tempfile::tempdir().unwrap();
+        let database = Database::open(temp.path(), 4).unwrap();
+        let keys: [&[u8]; 4] = [b"alpha", b"beta", b"a\0b", &[0, 1, 2, 0xff]];
+        let expected = keys.map(|key| database.shard_for_key(key));
+
+        let manifest = rusqlite::Connection::open(temp.path().join("manifest.sqlite")).unwrap();
+        manifest
+            .execute(
+                "UPDATE briskdb_virtual_buckets
+                 SET physical_shard_id = (physical_shard_id + 1) % 4",
+                [],
+            )
+            .unwrap();
+        drop(manifest);
+
+        assert_eq!(keys.map(|key| database.shard_for_key(key)), expected);
+        let error = Database::open(temp.path(), 4).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
     }
 
     #[test]

--- a/src/core/routing.rs
+++ b/src/core/routing.rs
@@ -1,0 +1,331 @@
+//! Protocol-neutral, versioned key routing.
+
+pub(crate) const HASH_VERSION: u32 = 1;
+pub(crate) const KEY_ENCODING_VERSION: u32 = 1;
+pub(crate) const BUCKET_ALGORITHM_VERSION: u32 = 1;
+pub(crate) const VIRTUAL_BUCKET_COUNT: u16 = 4_096;
+pub(crate) const INITIAL_MAP_GENERATION: u64 = 1;
+
+/// Validated, immutable routing state loaded from one manifest snapshot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RoutingCatalog {
+    initial_shard_count: u16,
+    hash_version: u32,
+    key_encoding_version: u32,
+    bucket_algorithm_version: u32,
+    map_generation: u64,
+    buckets: Box<[u16]>,
+}
+
+impl RoutingCatalog {
+    /// Construct a catalog from data already validated by the storage boundary.
+    pub(crate) fn from_validated_parts(
+        initial_shard_count: u16,
+        hash_version: u32,
+        key_encoding_version: u32,
+        bucket_algorithm_version: u32,
+        map_generation: u64,
+        buckets: Box<[u16]>,
+    ) -> Self {
+        debug_assert!((2..=64).contains(&initial_shard_count));
+        debug_assert_eq!(hash_version, HASH_VERSION);
+        debug_assert_eq!(key_encoding_version, KEY_ENCODING_VERSION);
+        debug_assert_eq!(bucket_algorithm_version, BUCKET_ALGORITHM_VERSION);
+        debug_assert_eq!(map_generation, INITIAL_MAP_GENERATION);
+        debug_assert_eq!(buckets.len(), usize::from(VIRTUAL_BUCKET_COUNT));
+        debug_assert!(buckets.iter().all(|shard| *shard < initial_shard_count));
+        Self {
+            initial_shard_count,
+            hash_version,
+            key_encoding_version,
+            bucket_algorithm_version,
+            map_generation,
+            buckets,
+        }
+    }
+
+    pub(crate) const fn shard_count(&self) -> u16 {
+        self.initial_shard_count
+    }
+
+    pub(crate) fn shard_for_key(&self, key: &[u8]) -> u16 {
+        let bucket = usize::from(self.bucket_for_key(key));
+        self.buckets[bucket]
+    }
+
+    fn bucket_for_key(&self, key: &[u8]) -> u16 {
+        self.bucket_for_hash(self.hash_for_key(key))
+    }
+
+    fn hash_for_key(&self, key: &[u8]) -> u64 {
+        let canonical_key = match self.key_encoding_version {
+            KEY_ENCODING_VERSION => key,
+            _ => unreachable!("only validated key encodings enter the routing catalog"),
+        };
+        match self.hash_version {
+            HASH_VERSION => {
+                let digest = blake3::hash(canonical_key);
+                let prefix: [u8; 8] = digest.as_bytes()[..8]
+                    .try_into()
+                    .expect("BLAKE3 digest always contains eight bytes");
+                u64::from_le_bytes(prefix)
+            }
+            _ => unreachable!("only validated hashes enter the routing catalog"),
+        }
+    }
+
+    fn bucket_for_hash(&self, hash: u64) -> u16 {
+        match self.bucket_algorithm_version {
+            BUCKET_ALGORITHM_VERSION => self.bucket_for_hash_v1(hash),
+            _ => unreachable!("only validated bucket algorithms enter the routing catalog"),
+        }
+    }
+
+    fn bucket_for_hash_v1(&self, hash: u64) -> u16 {
+        debug_assert_eq!(self.map_generation, INITIAL_MAP_GENERATION);
+        let shard_count = u64::from(self.initial_shard_count);
+        let bucket_count = u64::from(VIRTUAL_BUCKET_COUNT);
+        let legacy_shard = hash % shard_count;
+        let base_size = bucket_count / shard_count;
+        let wider_shards = bucket_count % shard_count;
+        let group_size = base_size + u64::from(legacy_shard < wider_shards);
+        let offset = legacy_shard * base_size + legacy_shard.min(wider_shards);
+        let bucket = offset + (hash / shard_count) % group_size;
+        u16::try_from(bucket).expect("a validated hash maps into the virtual bucket range")
+    }
+}
+
+/// Return the generation-1 owner of a virtual bucket.
+pub(crate) fn initial_physical_shard(bucket_id: u16, shard_count: u16) -> u16 {
+    debug_assert!((2..=64).contains(&shard_count));
+    debug_assert!(bucket_id < VIRTUAL_BUCKET_COUNT);
+
+    let bucket_count = u32::from(VIRTUAL_BUCKET_COUNT);
+    let shard_count = u32::from(shard_count);
+    let bucket_id = u32::from(bucket_id);
+    let base_size = bucket_count / shard_count;
+    let wider_shards = bucket_count % shard_count;
+    let wider_span = (base_size + 1) * wider_shards;
+    let shard = if bucket_id < wider_span {
+        bucket_id / (base_size + 1)
+    } else {
+        wider_shards + (bucket_id - wider_span) / base_size
+    };
+    u16::try_from(shard).expect("a virtual bucket maps to a supported shard")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::Arc, thread};
+
+    use super::*;
+
+    fn generation_one_catalog(shard_count: u16) -> RoutingCatalog {
+        RoutingCatalog::from_validated_parts(
+            shard_count,
+            HASH_VERSION,
+            KEY_ENCODING_VERSION,
+            BUCKET_ALGORITHM_VERSION,
+            INITIAL_MAP_GENERATION,
+            (0..VIRTUAL_BUCKET_COUNT)
+                .map(|bucket| initial_physical_shard(bucket, shard_count))
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        )
+    }
+
+    #[test]
+    fn golden_vectors_freeze_hash_bucket_and_shard() {
+        struct GoldenVector {
+            key: &'static [u8],
+            shard_count: u16,
+            digest_prefix: [u8; 8],
+            hash: u64,
+            bucket: u16,
+            shard: u16,
+        }
+
+        let vectors = [
+            GoldenVector {
+                key: b"",
+                shard_count: 3,
+                digest_prefix: [0xaf, 0x13, 0x49, 0xb9, 0xf5, 0xf9, 0xa1, 0xa6],
+                hash: 0xa6a1_f9f5_b949_13af,
+                bucket: 1_730,
+                shard: 1,
+            },
+            GoldenVector {
+                key: b"\x00\x01\x02",
+                shard_count: 6,
+                digest_prefix: [0xe1, 0xbe, 0x4d, 0x7a, 0x8a, 0xb5, 0x56, 0x0a],
+                hash: 0x0a56_b58a_7a4d_bee1,
+                bucket: 2_460,
+                shard: 3,
+            },
+            GoldenVector {
+                key: b"\x00\x01\x02",
+                shard_count: 10,
+                digest_prefix: [0xe1, 0xbe, 0x4d, 0x7a, 0x8a, 0xb5, 0x56, 0x0a],
+                hash: 0x0a56_b58a_7a4d_bee1,
+                bucket: 3_754,
+                shard: 9,
+            },
+            GoldenVector {
+                key: b"abc",
+                shard_count: 4,
+                digest_prefix: [0x64, 0x37, 0xb3, 0xac, 0x38, 0x46, 0x51, 0x33],
+                hash: 0x3351_4638_acb3_3764,
+                bucket: 473,
+                shard: 0,
+            },
+            GoldenVector {
+                key: b"customer-42",
+                shard_count: 6,
+                digest_prefix: [0x57, 0x9d, 0x61, 0xfc, 0xa7, 0x21, 0x36, 0xd2],
+                hash: 0xd236_21a7_fc61_9d57,
+                bucket: 768,
+                shard: 1,
+            },
+            GoldenVector {
+                key: b"tenant/alpha",
+                shard_count: 10,
+                digest_prefix: [0x21, 0x1a, 0xb7, 0x84, 0x48, 0x11, 0x1e, 0x6e],
+                hash: 0x6e1e_1148_84b7_1a21,
+                bucket: 1_283,
+                shard: 3,
+            },
+            GoldenVector {
+                key: b"\x00\x01\x02\xff",
+                shard_count: 63,
+                digest_prefix: [0x10, 0xf8, 0x47, 0x93, 0x6e, 0xb4, 0xf5, 0x65],
+                hash: 0x65f5_b46e_9347_f810,
+                bucket: 1_546,
+                shard: 23,
+            },
+            GoldenVector {
+                key: "snowman-☃".as_bytes(),
+                shard_count: 64,
+                digest_prefix: [0x81, 0x36, 0xa2, 0x00, 0xe9, 0x3c, 0x61, 0xf3],
+                hash: 0xf361_3ce9_00a2_3681,
+                bucket: 90,
+                shard: 1,
+            },
+            GoldenVector {
+                key: b"a\0b",
+                shard_count: 6,
+                digest_prefix: [0xfd, 0xeb, 0x88, 0xa4, 0xc6, 0xf0, 0x22, 0x46],
+                hash: 0x4622_f0c6_a488_ebfd,
+                bucket: 1_310,
+                shard: 1,
+            },
+        ];
+
+        for vector in vectors {
+            let catalog = generation_one_catalog(vector.shard_count);
+            let digest = blake3::hash(vector.key);
+            assert_eq!(&digest.as_bytes()[..8], vector.digest_prefix);
+            assert_eq!(catalog.hash_for_key(vector.key), vector.hash);
+            assert_eq!(catalog.bucket_for_key(vector.key), vector.bucket);
+            assert_eq!(catalog.buckets[usize::from(vector.bucket)], vector.shard);
+            assert_eq!(catalog.shard_for_key(vector.key), vector.shard);
+            assert_eq!(catalog.hash_version, 1);
+            assert_eq!(catalog.key_encoding_version, 1);
+            assert_eq!(catalog.bucket_algorithm_version, 1);
+            assert_eq!(catalog.buckets.len(), 4_096);
+            assert_eq!(catalog.map_generation, 1);
+        }
+    }
+
+    #[test]
+    fn bucket_boundaries_are_frozen_for_wide_and_narrow_ranges() {
+        let vectors = [
+            (6, 0, 0, 0),
+            (6, 3, 2_049, 3),
+            (6, 4, 2_732, 4),
+            (6, 5, 3_414, 5),
+            (6, 6, 1, 0),
+            (6, u64::MAX, 2_646, 3),
+            (64, 63, 4_032, 63),
+            (64, 64, 1, 0),
+            (64, u64::MAX, 4_095, 63),
+        ];
+
+        for (shard_count, hash, expected_bucket, expected_shard) in vectors {
+            let catalog = generation_one_catalog(shard_count);
+            let bucket = catalog.bucket_for_hash(hash);
+            assert_eq!(bucket, expected_bucket);
+            assert_eq!(catalog.buckets[usize::from(bucket)], expected_shard);
+        }
+    }
+
+    #[test]
+    fn every_bucket_is_reachable_and_generation_one_preserves_modulo_placement() {
+        for shard_count in 2..=64_u16 {
+            let catalog = generation_one_catalog(shard_count);
+            let bucket_count = u64::from(VIRTUAL_BUCKET_COUNT);
+            let shard_count_u64 = u64::from(shard_count);
+            let base_size = bucket_count / shard_count_u64;
+            let wider_shards = bucket_count % shard_count_u64;
+            let mut reached = vec![false; usize::from(VIRTUAL_BUCKET_COUNT)];
+
+            for shard in 0..shard_count_u64 {
+                let size = base_size + u64::from(shard < wider_shards);
+                let offset = shard * base_size + shard.min(wider_shards);
+                for ordinal in 0..size {
+                    let hash = shard_count_u64 * ordinal + shard;
+                    let bucket = catalog.bucket_for_hash(hash);
+                    assert_eq!(u64::from(bucket), offset + ordinal);
+                    assert_eq!(catalog.buckets[usize::from(bucket)], shard as u16);
+                    assert_eq!(
+                        catalog.buckets[usize::from(bucket)],
+                        (hash % shard_count_u64) as u16
+                    );
+                    reached[usize::from(bucket)] = true;
+                }
+            }
+
+            let max_bucket = catalog.bucket_for_hash(u64::MAX);
+            assert_eq!(
+                catalog.buckets[usize::from(max_bucket)],
+                (u64::MAX % shard_count_u64) as u16
+            );
+            assert!(reached.into_iter().all(|was_reached| was_reached));
+        }
+    }
+
+    #[test]
+    fn routing_reads_the_bucket_map_instead_of_recomputing_modulo() {
+        let key = b"catalog-lookup-proof";
+        let mut catalog = generation_one_catalog(6);
+        let hash = catalog.hash_for_key(key);
+        let legacy_shard = (hash % 6) as u16;
+        let bucket = catalog.bucket_for_key(key);
+        let remapped_shard = (legacy_shard + 1) % 6;
+
+        catalog.buckets[usize::from(bucket)] = remapped_shard;
+
+        assert_ne!(remapped_shard, legacy_shard);
+        assert_eq!(catalog.shard_for_key(key), remapped_shard);
+    }
+
+    #[test]
+    fn immutable_catalog_is_send_sync_and_routes_deterministically_in_parallel() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<RoutingCatalog>();
+
+        let catalog = Arc::new(generation_one_catalog(10));
+        let expected = catalog.shard_for_key(b"parallel-routing");
+        let mut threads = Vec::new();
+        for _ in 0..8 {
+            let catalog = Arc::clone(&catalog);
+            threads.push(thread::spawn(move || {
+                for _ in 0..10_000 {
+                    assert_eq!(catalog.shard_for_key(b"parallel-routing"), expected);
+                }
+            }));
+        }
+        for thread in threads {
+            thread.join().unwrap();
+        }
+    }
+}

--- a/src/storage/manifest.rs
+++ b/src/storage/manifest.rs
@@ -3,7 +3,11 @@
 use rusqlite::{Connection, Transaction, TransactionBehavior};
 
 use crate::{
-    core::{EngineError, EngineErrorKind, EngineResult},
+    core::{
+        BUCKET_ALGORITHM_VERSION, EngineError, EngineErrorKind, EngineResult, HASH_VERSION,
+        INITIAL_MAP_GENERATION, KEY_ENCODING_VERSION, RoutingCatalog, VIRTUAL_BUCKET_COUNT,
+        initial_physical_shard,
+    },
     sqlite_error,
 };
 
@@ -14,12 +18,6 @@ const V2_SCHEMA_VERSION: u32 = 2;
 const V3_SCHEMA_VERSION: u32 = 3;
 pub(super) const CURRENT_SCHEMA_VERSION: u32 = V3_SCHEMA_VERSION;
 const MAX_TABLE_SQL_BYTES: i64 = 4_096;
-
-pub(super) const HASH_VERSION: u32 = 1;
-pub(super) const KEY_ENCODING_VERSION: u32 = 1;
-pub(super) const BUCKET_ALGORITHM_VERSION: u32 = 1;
-pub(super) const VIRTUAL_BUCKET_COUNT: u16 = 4_096;
-pub(super) const INITIAL_MAP_GENERATION: u64 = 1;
 
 const ACTIVE_LIFECYCLE_STATE: &str = "active";
 
@@ -57,13 +55,27 @@ const V3_VIRTUAL_BUCKETS_TABLE_SQL: &str = "CREATE TABLE briskdb_virtual_buckets
     FOREIGN KEY (physical_shard_id) REFERENCES briskdb_physical_shards (shard_id)
 ) STRICT";
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RoutingConfiguration {
+    hash_version: u32,
+    key_encoding_version: u32,
+    bucket_algorithm_version: u32,
+    map_generation: u64,
+}
+
 #[derive(Clone, Copy)]
 struct Migration {
     from: u32,
     to: u32,
     name: &'static str,
     apply: fn(&Transaction<'_>, u16) -> EngineResult<()>,
-    validate: fn(&Connection, u16, &[SchemaObject]) -> EngineResult<u16>,
+    validate: fn(&Connection, u16, &[SchemaObject]) -> EngineResult<ManifestSnapshot>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ManifestSnapshot {
+    shard_count: u16,
+    routing_catalog: Option<RoutingCatalog>,
 }
 
 const MIGRATIONS: &[Migration] = &[
@@ -116,12 +128,17 @@ struct MigrationPoint {
     phase: MigrationPhase,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum ManifestState {
     Empty,
     LegacyUninitialized,
-    LegacyV1 { shard_count: u16 },
-    Versioned { version: u32, shard_count: u16 },
+    LegacyV1 {
+        shard_count: u16,
+    },
+    Versioned {
+        version: u32,
+        snapshot: ManifestSnapshot,
+    },
 }
 
 /// Initialize or advance the manifest under an immediate transaction.
@@ -129,6 +146,20 @@ enum ManifestState {
 /// The state is inspected again after the write lock is acquired, so two
 /// concurrent openers cannot both act on a stale version. Each numbered
 /// migration owns its transaction and stamps the new version last.
+pub(super) fn load_or_create_catalog(
+    connection: &mut Connection,
+    requested_shards: u16,
+) -> EngineResult<RoutingCatalog> {
+    let snapshot = load_or_create_snapshot_with_hook(connection, requested_shards, |_| Ok(()))?;
+    snapshot.routing_catalog.ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::Internal,
+            "current manifest validation did not produce a routing catalog",
+        )
+    })
+}
+
+#[cfg(test)]
 pub(super) fn load_or_create(
     connection: &mut Connection,
     requested_shards: u16,
@@ -136,6 +167,7 @@ pub(super) fn load_or_create(
     load_or_create_with_hook(connection, requested_shards, |_| Ok(()))
 }
 
+#[cfg(test)]
 fn load_or_create_with_hook<F>(
     connection: &mut Connection,
     requested_shards: u16,
@@ -144,15 +176,27 @@ fn load_or_create_with_hook<F>(
 where
     F: FnMut(MigrationPoint) -> EngineResult<()>,
 {
-    load_or_create_with_plan(connection, requested_shards, CURRENT_PLAN, &mut hook)
+    load_or_create_snapshot_with_plan(connection, requested_shards, CURRENT_PLAN, &mut hook)
+        .map(|snapshot| snapshot.shard_count)
 }
 
-fn load_or_create_with_plan<F>(
+fn load_or_create_snapshot_with_hook<F>(
+    connection: &mut Connection,
+    requested_shards: u16,
+    mut hook: F,
+) -> EngineResult<ManifestSnapshot>
+where
+    F: FnMut(MigrationPoint) -> EngineResult<()>,
+{
+    load_or_create_snapshot_with_plan(connection, requested_shards, CURRENT_PLAN, &mut hook)
+}
+
+fn load_or_create_snapshot_with_plan<F>(
     connection: &mut Connection,
     requested_shards: u16,
     plan: MigrationPlan<'_>,
     hook: &mut F,
-) -> EngineResult<u16>
+) -> EngineResult<ManifestSnapshot>
 where
     F: FnMut(MigrationPoint) -> EngineResult<()>,
 {
@@ -162,12 +206,9 @@ where
             .map_err(sqlite_error::storage)?;
 
         let (from, shard_count) = match inspect_with_plan(&transaction, requested_shards, plan)? {
-            ManifestState::Versioned {
-                version,
-                shard_count,
-            } if version == plan.current_version => {
+            ManifestState::Versioned { version, snapshot } if version == plan.current_version => {
                 transaction.commit().map_err(sqlite_error::storage)?;
-                return Ok(shard_count);
+                return Ok(snapshot);
             }
             ManifestState::Empty => {
                 return apply_schema_change(
@@ -184,10 +225,7 @@ where
             }
             ManifestState::LegacyUninitialized => (LEGACY_SCHEMA_VERSION, requested_shards),
             ManifestState::LegacyV1 { shard_count } => (LEGACY_SCHEMA_VERSION, shard_count),
-            ManifestState::Versioned {
-                version,
-                shard_count,
-            } => (version, shard_count),
+            ManifestState::Versioned { version, snapshot } => (version, snapshot.shard_count),
         };
 
         let migration = migration_from(plan.migrations, from)?;
@@ -236,7 +274,7 @@ fn apply_schema_change<F>(
     change: SchemaChange,
     plan: MigrationPlan<'_>,
     hook: &mut F,
-) -> EngineResult<u16>
+) -> EngineResult<ManifestSnapshot>
 where
     F: FnMut(MigrationPoint) -> EngineResult<()>,
 {
@@ -255,12 +293,9 @@ where
     })?;
 
     match inspect_with_plan(&transaction, shard_count, plan)? {
-        ManifestState::Versioned {
-            version,
-            shard_count: validated,
-        } if version == change.to => {
+        ManifestState::Versioned { version, snapshot } if version == change.to => {
             transaction.commit().map_err(sqlite_error::storage)?;
-            Ok(validated)
+            Ok(snapshot)
         }
         _ => Err(EngineError::new(
             EngineErrorKind::Internal,
@@ -393,30 +428,6 @@ fn migrate_v2_to_v3(transaction: &Transaction<'_>, shard_count: u16) -> EngineRe
     Ok(())
 }
 
-/// Partition the virtual bucket space into deterministic contiguous ranges.
-///
-/// Hash version 1 will choose a range using the legacy `hash % shard_count`
-/// result, then choose a bucket within that range. Consequently, activating
-/// catalog lookup can preserve every existing placement even when the shard
-/// count does not divide 4,096.
-fn initial_physical_shard(bucket_id: u16, shard_count: u16) -> u16 {
-    debug_assert!((2..=64).contains(&shard_count));
-    debug_assert!(bucket_id < VIRTUAL_BUCKET_COUNT);
-
-    let bucket_count = u32::from(VIRTUAL_BUCKET_COUNT);
-    let shard_count = u32::from(shard_count);
-    let bucket_id = u32::from(bucket_id);
-    let base_size = bucket_count / shard_count;
-    let wider_shards = bucket_count % shard_count;
-    let wider_span = (base_size + 1) * wider_shards;
-    let shard = if bucket_id < wider_span {
-        bucket_id / (base_size + 1)
-    } else {
-        wider_shards + (bucket_id - wider_span) / base_size
-    };
-    u16::try_from(shard).expect("a virtual bucket maps to a supported shard")
-}
-
 fn set_identity(connection: &Connection, version: u32) -> EngineResult<()> {
     connection
         .pragma_update(None, "application_id", MANIFEST_APPLICATION_ID)
@@ -479,12 +490,8 @@ fn inspect_with_plan(
                     ),
                 )
             })?;
-        return validator(connection, requested_shards, &objects).map(|shard_count| {
-            ManifestState::Versioned {
-                version,
-                shard_count,
-            }
-        });
+        return validator(connection, requested_shards, &objects)
+            .map(|snapshot| ManifestState::Versioned { version, snapshot });
     }
 
     if application_id != 0 {
@@ -836,7 +843,7 @@ fn validate_v2(
     connection: &Connection,
     requested_shards: u16,
     objects: &[SchemaObject],
-) -> EngineResult<u16> {
+) -> EngineResult<ManifestSnapshot> {
     if objects != v2_objects() {
         return Err(EngineError::new(
             EngineErrorKind::DataCorruption,
@@ -869,14 +876,17 @@ fn validate_v2(
 
     let shard_count = validate_manifest_configuration(connection, requested_shards)?;
     validate_downgrade_fence(connection, V2_SCHEMA_VERSION)?;
-    Ok(shard_count)
+    Ok(ManifestSnapshot {
+        shard_count,
+        routing_catalog: None,
+    })
 }
 
 fn validate_v3(
     connection: &Connection,
     requested_shards: u16,
     objects: &[SchemaObject],
-) -> EngineResult<u16> {
+) -> EngineResult<ManifestSnapshot> {
     if objects != v3_objects() {
         return Err(EngineError::new(
             EngineErrorKind::DataCorruption,
@@ -952,11 +962,21 @@ fn validate_v3(
 
     let shard_count = validate_manifest_configuration(connection, requested_shards)?;
     validate_downgrade_fence(connection, V3_SCHEMA_VERSION)?;
-    validate_routing_configuration(connection)?;
+    let routing = validate_routing_configuration(connection)?;
     validate_physical_shards(connection, shard_count)?;
-    validate_virtual_buckets(connection, shard_count)?;
+    let buckets = validate_virtual_buckets(connection, shard_count)?;
     validate_foreign_keys(connection)?;
-    Ok(shard_count)
+    Ok(ManifestSnapshot {
+        shard_count,
+        routing_catalog: Some(RoutingCatalog::from_validated_parts(
+            shard_count,
+            routing.hash_version,
+            routing.key_encoding_version,
+            routing.bucket_algorithm_version,
+            routing.map_generation,
+            buckets,
+        )),
+    })
 }
 
 fn validate_manifest_configuration(
@@ -1008,7 +1028,7 @@ fn validate_downgrade_fence(connection: &Connection, expected_version: u32) -> E
     Ok(())
 }
 
-fn validate_routing_configuration(connection: &Connection) -> EngineResult<()> {
+fn validate_routing_configuration(connection: &Connection) -> EngineResult<RoutingConfiguration> {
     let mut statement = connection
         .prepare(
             "SELECT singleton,
@@ -1088,7 +1108,12 @@ fn validate_routing_configuration(connection: &Connection) -> EngineResult<()> {
             format!("manifest has unsupported map generation {map_generation}"),
         ));
     }
-    Ok(())
+    Ok(RoutingConfiguration {
+        hash_version: HASH_VERSION,
+        key_encoding_version: KEY_ENCODING_VERSION,
+        bucket_algorithm_version: BUCKET_ALGORITHM_VERSION,
+        map_generation,
+    })
 }
 
 fn validate_physical_shards(connection: &Connection, shard_count: u16) -> EngineResult<()> {
@@ -1133,7 +1158,7 @@ fn validate_physical_shards(connection: &Connection, shard_count: u16) -> Engine
     Ok(())
 }
 
-fn validate_virtual_buckets(connection: &Connection, shard_count: u16) -> EngineResult<()> {
+fn validate_virtual_buckets(connection: &Connection, shard_count: u16) -> EngineResult<Box<[u16]>> {
     let mut statement = connection
         .prepare(
             "SELECT bucket_id, physical_shard_id
@@ -1158,6 +1183,7 @@ fn validate_virtual_buckets(connection: &Connection, shard_count: u16) -> Engine
     }
 
     let mut assignments = vec![0_u16; usize::from(shard_count)];
+    let mut buckets = Vec::with_capacity(usize::from(VIRTUAL_BUCKET_COUNT));
     for (expected, (stored_bucket, stored_shard)) in (0..VIRTUAL_BUCKET_COUNT).zip(rows) {
         if stored_bucket != i64::from(expected) {
             return Err(EngineError::new(
@@ -1185,6 +1211,7 @@ fn validate_virtual_buckets(connection: &Connection, shard_count: u16) -> Engine
             ));
         }
         assignments[usize::from(stored_shard)] += 1;
+        buckets.push(stored_shard);
     }
     if let Some(unassigned) = assignments.iter().position(|count| *count == 0) {
         return Err(EngineError::new(
@@ -1192,7 +1219,7 @@ fn validate_virtual_buckets(connection: &Connection, shard_count: u16) -> Engine
             format!("active physical shard {unassigned} has no virtual buckets"),
         ));
     }
-    Ok(())
+    Ok(buckets.into_boxed_slice())
 }
 
 fn validate_foreign_keys(connection: &Connection) -> EngineResult<()> {
@@ -1519,19 +1546,28 @@ mod tests {
     fn fresh_and_v2_upgraded_catalogs_are_identical_for_every_shard_count() {
         for shard_count in 2..=64 {
             let mut fresh = Connection::open_in_memory().unwrap();
-            assert_eq!(
-                load_or_create(&mut fresh, shard_count).unwrap(),
-                shard_count
-            );
+            let fresh_catalog = load_or_create_catalog(&mut fresh, shard_count).unwrap();
+            assert_eq!(fresh_catalog.shard_count(), shard_count);
             assert_generation_one_catalog(&fresh, shard_count);
 
             let mut upgraded = Connection::open_in_memory().unwrap();
             create_v2_manifest(&mut upgraded, shard_count);
-            assert_eq!(
-                load_or_create(&mut upgraded, shard_count).unwrap(),
-                shard_count
-            );
+            let upgraded_catalog = load_or_create_catalog(&mut upgraded, shard_count).unwrap();
+            assert_eq!(upgraded_catalog.shard_count(), shard_count);
             assert_generation_one_catalog(&upgraded, shard_count);
+            assert_eq!(fresh_catalog, upgraded_catalog);
+            for key in [
+                b"".as_slice(),
+                b"customer-42".as_slice(),
+                b"a\0b".as_slice(),
+                [0_u8, 1, 2, 0xff].as_slice(),
+                "snowman-☃".as_bytes(),
+            ] {
+                assert_eq!(
+                    fresh_catalog.shard_for_key(key),
+                    upgraded_catalog.shard_for_key(key)
+                );
+            }
             assert_eq!(
                 routing_configuration(&fresh),
                 routing_configuration(&upgraded)

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -21,7 +21,7 @@ use rusqlite::{
 
 pub use crate::core::Database;
 use crate::{
-    core::{EngineError, EngineErrorKind, EngineResult},
+    core::{EngineError, EngineErrorKind, EngineResult, RoutingCatalog},
     sqlite_error,
 };
 
@@ -30,7 +30,7 @@ pub(crate) const CONNECTION_BUSY_TIMEOUT: std::time::Duration = std::time::Durat
 #[derive(Debug, Clone)]
 pub(crate) struct Storage {
     root: PathBuf,
-    shard_count: u16,
+    catalog: Arc<RoutingCatalog>,
 }
 
 impl Storage {
@@ -48,22 +48,29 @@ impl Storage {
                 .context(format!("failed to open {}", manifest_path.display()))
         })?;
         configure_manifest_connection(&manifest)?;
-        let shard_count = manifest::load_or_create(&mut manifest, requested_shards)?;
+        let catalog = Arc::new(manifest::load_or_create_catalog(
+            &mut manifest,
+            requested_shards,
+        )?);
         configure_journal_mode(&manifest)?;
 
         fs::create_dir_all(&shards_dir).map_err(|error| {
             sqlite_error::storage_io(error, format!("failed to create {}", shards_dir.display()))
         })?;
 
-        let storage = Self { root, shard_count };
-        for shard in 0..shard_count {
+        let storage = Self { root, catalog };
+        for shard in 0..storage.shard_count() {
             storage.open_shard(shard)?;
         }
         Ok(storage)
     }
 
     pub(crate) fn shard_count(&self) -> u16 {
-        self.shard_count
+        self.catalog.shard_count()
+    }
+
+    pub(crate) fn shard_for_key(&self, key: &[u8]) -> u16 {
+        self.catalog.shard_for_key(key)
     }
 
     fn shard_path(&self, shard: u16) -> PathBuf {
@@ -77,7 +84,7 @@ impl Storage {
     }
 
     fn open_unconfigured_shard(&self, shard: u16) -> EngineResult<Connection> {
-        if shard >= self.shard_count {
+        if shard >= self.shard_count() {
             return Err(EngineError::new(
                 EngineErrorKind::Internal,
                 format!("shard {shard} is outside the configured range"),


### PR DESCRIPTION
Closes #14

## Summary
- hydrate an immutable routing catalog from the same locked manifest transaction that validates it
- route exact key bytes through versioned BLAKE3 hashing, the 4,096-bucket compatibility algorithm, and the persisted bucket map
- share one lock-free catalog snapshot across storage clones and fail closed on malformed or unsupported catalog data
- add golden hash/bucket/shard vectors, exhaustive compatibility coverage for every supported shard count, synthetic remap proof, and upgrade/reopen/concurrency/recovery tests
- update the roadmap and routing/storage documentation

## Verification
- cargo fmt --all --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-targets --all-features (stable)
- cargo test --locked --doc --all-features (stable)
- cargo +1.85.0 test --locked --all-targets --all-features
- cargo +1.85.0 test --locked --doc --all-features
- three independent reviews; final re-reviews clear