### PR TITLE
feat: add logical database and table catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ minimum supported Rust version (MSRV) and the latest stable toolchain.
 - Finite per-query row/logical-byte budgets with no partial results
 - Explicit graceful drain, forced cancellation, and blocking handle cleanup
 - Protocol-neutral typed values, ordered columns, positional rows, and results
-- A transactionally versioned `manifest.sqlite` with a durable 4,096-bucket
-  shard catalog
+- A transactionally versioned `manifest.sqlite` with durable 4,096-bucket
+  routing plus logical-database and table metadata
 - One WAL-enabled SQLite database per shard
 - Routed execute and query endpoints
 - A broadcast endpoint for initializing schema on every shard
@@ -169,18 +169,26 @@ Queries have finite row and logical-byte budgets, account values before cloning
 payloads, and return no partial result on `LimitExceeded`.
 Broadcast changes and future scatter operations are not atomic across shard
 files. The initial shard count is immutable, so resharding will require an
-explicit migration workflow. Opening upgrades exact version-1 and version-2
-manifests to version 3 through one transaction per numbered step. Version 3
-persists hash, key-encoding, and bucket-algorithm versions, a generation-stamped
-4,096-bucket map, and active physical-shard lifecycle records. Newer or malformed
-manifests fail closed, and downgrade fences reject shipped version-1 and
-version-2 readers. Startup loads the validated catalog into one immutable
-snapshot, and runtime routing hashes the exact key bytes, derives a virtual
-bucket, then reads that bucket's persisted physical-shard assignment. The
-generation-1 ranges preserve every earlier modulo placement, including
-non-power-of-two shard counts. This changes only routing internals, not shard
-files, SQL behavior, or wire contracts. The complete format and upgrade
-contract is in [manifest storage format](docs/STORAGE_FORMAT.md).
+explicit migration workflow. Opening upgrades exact version-1, version-2, and
+version-3 manifests to version 4 through one transaction per numbered step.
+Version 3 introduced the versioned, generation-stamped 4,096-bucket routing
+map. Version 4 adds schema generation 0 and immutable logical metadata with
+default database ID 1 named `default`; identifier encoding version 1 accepts
+only canonical lowercase ASCII names. Table rows can describe sharded, global,
+or catalog placement and a sharded table's `Int64`, text, or binary key.
+
+The v3-to-v4 step is atomic within `manifest.sqlite` and installs a version-4
+downgrade fence. It deliberately leaves the table catalog empty: it neither
+infers nor adopts tables already present in physical shard files. The public
+catalog returned by `Database::catalog()` and `Engine::catalog()` is an
+immutable, read-only advisory view. Current execute, query, broadcast, routing,
+shard files, SQLite behavior, HTTP shapes, and wire contracts are unchanged.
+Startup loads routing and logical metadata in one validated immutable snapshot;
+runtime routing continues to hash the exact key bytes, derive a virtual bucket,
+and read its persisted physical-shard assignment. The generation-1 ranges
+preserve every earlier modulo placement, including non-power-of-two shard
+counts. Newer or malformed manifests fail closed. The complete format and
+upgrade contract is in [manifest storage format](docs/STORAGE_FORMAT.md).
 Embedders should call
 `Engine::shutdown`; merely dropping the final `Engine` is not the explicit
 asynchronous cleanup contract.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -186,7 +186,7 @@ existing tests pass through the shared engine.
   records, map generation, and lifecycle state.
 - [x] Replace modulo routing with virtual-bucket lookup and add golden routing
   vectors so upgrades cannot silently move keys.
-- [ ] Add logical databases and table metadata, including table placement and
+- [x] Add logical databases and table metadata, including table placement and
   shard-key column/type.
 - [ ] Validate at startup that every shard is present, uses WAL, has the expected
   application ID/user version, and matches the cataloged schema generation.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,8 +21,8 @@ server ---------> protocol::http
 
 | Module | Responsibility | Must not own |
 | --- | --- | --- |
-| `core` | Protocol-neutral `Engine`, `Session`, statements, values, results, and errors; stable key routing; bounded per-shard admission and connection pools; routed execute/query and schema broadcast | JSON/HTTP types, listeners, or Axum handlers |
-| `storage` | Manifest and shard layout, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
+| `core` | Protocol-neutral `Engine`, `Session`, statements, values, results, errors, and immutable logical catalog; stable key routing; bounded per-shard admission and connection pools; routed execute/query and schema broadcast | JSON/HTTP types, listeners, or Axum handlers |
+| `storage` | Versioned routing/logical manifest, shard layout, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
 | `sql` | SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, routing, filesystem layout, or protocol responses |
 | `protocol::http` | HTTP request extraction plus JSON/BriskDB value and RFC 9457 problem-detail encoding | BLAKE3 routing, shard files, or rusqlite calls |
 | `protocol::error` | Exhaustive HTTP, PostgreSQL, and MySQL mappings from stable engine error kinds | SQLite errors, routing decisions, or wire-protocol session state |
@@ -78,12 +78,24 @@ The storage module owns an ordered manifest-format migration runner. It
 identifies a current manifest with SQLite `application_id = 0x42524442` and uses
 `user_version` as the single authoritative schema version. Version 2 replaced
 the legacy key/value configuration with a strict singleton shard-count table.
-Version 3 adds the durable routing catalog: independently versioned hash, key
+Version 3 added the durable routing catalog: independently versioned hash, key
 encoding, and bucket derivation; the initial map generation; exactly 4,096
-virtual buckets; and contiguous, active physical-shard records. Each version
-retains an intentionally incompatible `briskdb_metadata` definition and row as
-a downgrade fence. Shipped version-1 and version-2 readers therefore fail
-closed instead of interpreting a newer manifest.
+virtual buckets; and contiguous, active physical-shard records. Version 4 adds
+logical databases, table metadata, and an application-schema generation. Its
+initial catalog has schema generation 0, identifier encoding version 1, and
+default logical database ID 1 named `default`. Version-1 identifiers are 1 to
+63 bytes of lowercase ASCII, begin with a letter or underscore, and exclude
+the reserved `briskdb`, `briskdb_*`, and `sqlite_*` namespaces. Table metadata
+records a stable positive ID, owning database, name, and one of sharded,
+global, or catalog placement; only a sharded table also records one `Int64`,
+text, or binary shard-key column.
+
+Each version retains an intentionally incompatible `briskdb_metadata`
+definition and row as a downgrade fence. The v3-to-v4 migration replaces that
+fence, creates the logical tables and initial rows, validates the complete v4
+destination, and stamps version 4 in the same manifest transaction. Failure
+rolls the step back to the exact committed v3 state; a v3 binary rejects a
+committed v4 manifest rather than interpreting it.
 
 Startup acquires `BEGIN IMMEDIATE` before making any migration decision. Each
 registered numbered step rewrites schema/data, stamps and reads back its target
@@ -94,18 +106,29 @@ be retried. Persistent WAL configuration and shard creation occur only after a
 compatible current manifest is committed, so rejecting a foreign or future
 manifest does not rewrite its journal mode or touch shard files.
 
-This is an internal storage-open concern. It changes no core or adapter
-signature, is unreachable from client SQL, and is atomic only within
-`manifest.sqlite`. Validation returns an immutable catalog snapshot from the
-same locked transaction; `Storage` shares it across clones. Core routing hashes
-the exact key bytes, derives a versioned virtual bucket, and reads the final
-physical shard from that snapshot without querying SQLite. The generation-1
-bucket ranges reproduce prior modulo placement for every supported initial
-shard count, including counts that do not divide 4,096. The catalog does not yet
-validate shard-file presence, identity, WAL, or schema
-generation, and it is not the future cross-shard application-schema migration
-journal. The exact format, downgrade policy, recovery cases, and tests are
-documented in [manifest storage format](STORAGE_FORMAT.md).
+This is an internal storage-open concern, is unreachable from client SQL, and
+is atomic only within `manifest.sqlite`. Validation returns routing and logical
+metadata from the same locked transaction as one immutable snapshot that
+`Storage` shares across clones. `Database::catalog()` and `Engine::catalog()`
+expose the logical portion as a read-only `Catalog` with lookup accessors.
+
+The version-4 logical catalog is advisory: there is no catalog mutation API,
+planner integration, or schema enforcement yet. Fresh and upgraded manifests
+contain no table rows, and migration does not inspect, infer, or adopt physical
+tables already present in shard files. Those tables remain reachable through
+the existing explicit-key execute/query and broadcast surfaces. Core routing
+still hashes the exact caller-provided key bytes, derives a versioned virtual
+bucket, and reads the final physical shard from the snapshot without querying
+SQLite. The generation-1 ranges reproduce prior modulo placement for every
+supported initial shard count, including counts that do not divide 4,096.
+Consequently v4 changes no current SQL execution, HTTP behavior, routing result,
+or shard file.
+
+The catalog does not yet validate shard-file presence, identity, WAL, or the
+cataloged schema generation against shard files, and it is not the future
+cross-shard application-schema migration journal. The exact format, numeric
+codes, downgrade policy, recovery cases, and tests are documented in
+[manifest storage format](STORAGE_FORMAT.md).
 
 ## Session and asynchronous engine boundary
 

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -332,8 +332,15 @@ underlying execution semantics.
   prefix selects one of 4,096 virtual buckets through the versioned
   compatibility algorithm.
 - The final physical shard is read from the validated, generation-stamped
-  bucket map loaded from manifest version 3. Generation 1 preserves the earlier
-  modulo placement for every supported shard count.
+  bucket map retained in manifest version 4. Routing generation 1 preserves
+  the earlier modulo placement for every supported shard count.
+- Manifest version 4 also exposes an immutable logical catalog with schema
+  generation 0 and default database ID 1 named `default`. Its optional table
+  rows can describe sharded, global, or catalog placement and a sharded table's
+  `Int64`, text, or binary key column.
+- Logical metadata is currently read-only and advisory. Fresh and upgraded
+  manifests contain no table rows, existing physical tables are not inferred
+  or adopted, and catalog contents do not alter SQL planning or execution.
 - Point queries and writes visit only that shard.
 - No scatter/gather query path exists.
 - Unique constraints and transactions are local to one SQLite shard.
@@ -365,8 +372,10 @@ reject cross-shard access.
 Manifest-format migrations are separate from application SQL migrations. They
 run internally during storage open, are transactional only within
 `manifest.sqlite`, and cannot be requested through any protocol or SQL
-statement. The version-3 manifest upgrade does not change shard schemas,
-supported SQLite syntax, result conversion, routing, or broadcast semantics.
+statement. The atomic version-3-to-version-4 manifest upgrade adds only
+read-only advisory logical metadata and its downgrade fence. It does not infer
+or adopt existing physical tables and does not change shard schemas, supported
+SQLite syntax, result conversion, routing, or broadcast semantics.
 See the [manifest storage-format contract](STORAGE_FORMAT.md).
 
 Scatter reads will combine committed results from multiple SQLite files. They

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -5,21 +5,22 @@ never exposed through HTTP, PostgreSQL, MySQL, or the SQL execution API. The
 format is pre-1.0, but every format change must still have an ordered migration,
 failure coverage, and an explicit compatibility decision.
 
-## Current format: version 3
+## Current format: version 4
 
 SQLite header fields identify the file and its format:
 
 | Header field | Value | Meaning |
 | --- | --- | --- |
 | `PRAGMA application_id` | `0x42524442` (`BRDB`) | Permanent BriskDB manifest-family marker |
-| `PRAGMA user_version` | `3` | Authoritative manifest schema version |
+| `PRAGMA user_version` | `4` | Authoritative manifest schema version |
 
 The application ID prevents an accidental foreign SQLite file from being
 adopted as a manifest. It is not authentication or tamper protection: a process
 that can write the data directory can forge it. Checksums and explicit degraded
 states remain separate roadmap work.
 
-Version 3 has five strict tables:
+Version 4 has eight strict tables. The routing tables are unchanged from
+version 3; the downgrade fence and three logical-schema tables are new.
 
 ```sql
 CREATE TABLE briskdb_manifest (
@@ -29,7 +30,7 @@ CREATE TABLE briskdb_manifest (
 
 CREATE TABLE briskdb_metadata (
     requires_manifest_version INTEGER NOT NULL
-        CHECK (requires_manifest_version >= 3)
+        CHECK (requires_manifest_version >= 4)
 ) STRICT;
 
 CREATE TABLE briskdb_routing (
@@ -51,15 +52,134 @@ CREATE TABLE briskdb_virtual_buckets (
     physical_shard_id INTEGER NOT NULL,
     FOREIGN KEY (physical_shard_id) REFERENCES briskdb_physical_shards (shard_id)
 ) STRICT;
+
+CREATE TABLE briskdb_logical_databases (
+    database_id INTEGER PRIMARY KEY CHECK (database_id > 0),
+    database_name TEXT NOT NULL COLLATE BINARY UNIQUE
+        CHECK (
+            length(database_name) BETWEEN 1 AND 63
+            AND instr(database_name, char(0)) = 0
+            AND database_name NOT GLOB '*[^a-z0-9_]*'
+            AND substr(database_name, 1, 1) GLOB '[a-z_]'
+            AND database_name <> 'briskdb'
+            AND database_name NOT GLOB 'briskdb_*'
+            AND database_name NOT GLOB 'sqlite_*'
+        )
+) STRICT;
+
+CREATE TABLE briskdb_schema_catalog (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    identifier_encoding_version INTEGER NOT NULL CHECK (identifier_encoding_version = 1),
+    schema_generation INTEGER NOT NULL CHECK (schema_generation = 0),
+    default_database_id INTEGER NOT NULL CHECK (default_database_id = 1),
+    FOREIGN KEY (default_database_id)
+        REFERENCES briskdb_logical_databases (database_id)
+) STRICT;
+
+CREATE TABLE briskdb_tables (
+    table_id INTEGER PRIMARY KEY CHECK (table_id > 0),
+    database_id INTEGER NOT NULL,
+    table_name TEXT NOT NULL COLLATE BINARY
+        CHECK (
+            length(table_name) BETWEEN 1 AND 63
+            AND instr(table_name, char(0)) = 0
+            AND table_name NOT GLOB '*[^a-z0-9_]*'
+            AND substr(table_name, 1, 1) GLOB '[a-z_]'
+            AND table_name <> 'briskdb'
+            AND table_name NOT GLOB 'briskdb_*'
+            AND table_name NOT GLOB 'sqlite_*'
+        ),
+    placement INTEGER NOT NULL CHECK (placement IN (1, 2, 3)),
+    shard_key_column TEXT COLLATE BINARY
+        CHECK (
+            shard_key_column IS NULL OR (
+                length(shard_key_column) BETWEEN 1 AND 63
+                AND instr(shard_key_column, char(0)) = 0
+                AND shard_key_column NOT GLOB '*[^a-z0-9_]*'
+                AND substr(shard_key_column, 1, 1) GLOB '[a-z_]'
+                AND shard_key_column <> 'briskdb'
+                AND shard_key_column NOT GLOB 'briskdb_*'
+                AND shard_key_column NOT GLOB 'sqlite_*'
+            )
+        ),
+    shard_key_type INTEGER
+        CHECK (shard_key_type IS NULL OR shard_key_type IN (1, 2, 3)),
+    UNIQUE (database_id, table_name),
+    FOREIGN KEY (database_id)
+        REFERENCES briskdb_logical_databases (database_id)
+        ON DELETE RESTRICT,
+    CHECK (
+        (
+            placement = 1
+            AND shard_key_column IS NOT NULL
+            AND shard_key_type IS NOT NULL
+        )
+        OR
+        (
+            placement IN (2, 3)
+            AND shard_key_column IS NULL
+            AND shard_key_type IS NULL
+        )
+    )
+) STRICT;
 ```
 
-Both singleton tables contain exactly one row. `briskdb_manifest.shard_count`
-is immutable and is the initial routing modulus. In version 3 it is also the
-live physical-shard count. Physical IDs are exactly `0..shard_count`; filenames
-remain derived by trusted code as `shards/{shard_id:04}.sqlite` and are never
-read from catalog-controlled paths. Version 3 supports only the `active`
-lifecycle state. Adding resumable provisioning, draining, or retirement states
-requires a later format and state-machine change.
+The manifest, metadata, routing, and schema-catalog tables each contain exactly
+one row. The v4 downgrade-fence row is exactly `4`.
+`briskdb_manifest.shard_count` is immutable and is the initial routing modulus;
+it is also the live physical-shard count. Physical IDs are exactly
+`0..shard_count - 1`. Filenames remain derived by trusted code as
+`shards/{shard_id:04}.sqlite` and are never read from catalog-controlled paths.
+Version 4 supports only the `active` lifecycle state. Adding resumable
+provisioning, draining, or retirement states requires a later format and
+state-machine change.
+
+### Logical catalog
+
+Every fresh or upgraded v4 manifest contains logical database ID `1` named
+`default`. The schema-catalog singleton contains identifier encoding version
+`1`, application-schema generation `0`, and default database ID `1`. Version 4
+can interpret only schema generation 0. It permits at most 64 logical databases
+and 4,096 table rows. Database and table IDs are positive; table names are
+unique within their owning database, and every table references an existing
+database.
+
+Identifier encoding version 1 is a canonical lowercase ASCII contract for
+logical-database names, table names, and shard-key column names:
+
+- the encoded name is 1 to 63 bytes;
+- the first byte is `a` through `z` or `_`;
+- every later byte is `a` through `z`, `0` through `9`, or `_`; and
+- `briskdb`, every `briskdb_*` name, and every `sqlite_*` name are reserved.
+
+Names use binary comparison. There is no case folding, quoting transform, or
+Unicode normalization; a caller must supply the canonical lowercase name.
+
+Table placement and shard-key type use stable numeric codes:
+
+| Column | Code | Rust meaning | Stored metadata |
+| --- | --- | --- | --- |
+| `placement` | `1` | `Sharded` | One non-null shard-key column and type are required |
+| `placement` | `2` | `Global` | Shard-key column and type must both be null |
+| `placement` | `3` | `Catalog` | Shard-key column and type must both be null |
+| `shard_key_type` | `1` | `Int64` | Signed 64-bit integer |
+| `shard_key_type` | `2` | `Text` | UTF-8 text without Unicode normalization |
+| `shard_key_type` | `3` | `Binary` | Arbitrary bytes |
+
+`Sharded` means the same logical schema is expected on every shard and rows
+are key-routed. `Global` describes small replicated lookup data. `Catalog`
+describes manifest-owned metadata rather than a user shard table.
+
+The loaded `Catalog` is immutable and read-only. It is advisory in version 4:
+there is no catalog mutation API, planner integration, or enforcement against
+physical shard schemas. Fresh initialization and every v1/v2/v3 upgrade leave
+`briskdb_tables` empty. Migration does not inspect, infer, or adopt tables that
+already exist in shard files. Such tables remain usable through the existing
+explicit-key execute/query API and broadcast API; absence from the catalog does
+not mean physical absence. Version 4 therefore changes no current SQL
+execution, routing result, broadcast behavior, shard file, or wire contract.
+
+### Routing catalog
 
 The routing singleton contains exactly these generation-1 values:
 
@@ -69,7 +189,7 @@ The routing singleton contains exactly these generation-1 values:
 | `key_encoding_version` | `1` | Exact caller-supplied bytes; string shard keys contribute their UTF-8 bytes, with no Unicode normalization |
 | `bucket_algorithm_version` | `1` | Compatibility-preserving range algorithm below |
 | `virtual_bucket_count` | `4096` | Fixed virtual bucket space `0..4095` |
-| `map_generation` | `1` | Initial committed bucket map and the only generation version 3 can interpret |
+| `map_generation` | `1` | Initial committed bucket map and the only generation version 4 can interpret |
 
 Every bucket ID exists exactly once and references an active physical shard.
 Every physical shard owns at least one bucket. The generation-1 map partitions
@@ -97,22 +217,41 @@ the complete calculation and always obtains its final physical shard from
 vectors freeze the exact key bytes, BLAKE3 prefix, little-endian hash integer,
 bucket ID, and persisted physical shard.
 
-`map_generation` is separate from manifest `user_version` and from the future
-application-schema generation. Version 3 accepts only generation 1 and validates
-its exact deterministic assignment; no public map-mutation operation exists yet.
-A future format that can commit a changed map must bump `user_version` and its
-downgrade fence as well as `map_generation`. That requirement makes this
+`map_generation` is separate from manifest `user_version` and from
+`schema_generation`. Version 4 accepts only routing generation 1 and validates
+its exact deterministic assignment; no public map-mutation operation exists
+yet. A future format that can commit a changed map must bump `user_version` and
+its downgrade fence as well as `map_generation`. That requirement makes this
 pre-lookup binary reject the manifest instead of silently using legacy modulo
 routing against a remapped catalog.
 
 At each open, BriskDB validates the exact objects, columns, strict flags, frozen
-schema SQL, singleton rows, supported algorithm values, contiguous physical and
-bucket IDs, active lifecycle states, assignments, coverage, and foreign keys.
-A recognized version-3 manifest that violates any of these invariants is
-`DataCorruption` and is rejected before shard connections are opened. The same
-locked transaction returns the validated routing rows as an immutable in-memory
-snapshot, so request routing performs no manifest query and cannot fall back to
-modulo after a failed validation.
+schema SQL, singleton rows, logical identifiers and limits, metadata codes,
+supported algorithm values, contiguous physical and bucket IDs, active
+lifecycle states, assignments, coverage, and foreign keys. A recognized
+version-4 manifest that violates any invariant is `DataCorruption` and is
+rejected before shard connections are opened. The same locked transaction
+returns routing and logical rows as one immutable in-memory snapshot, so
+request routing performs no manifest query and cannot fall back to modulo after
+a failed validation.
+
+## Previous version 3
+
+Version 3 uses the same manifest, routing, physical-shard, and virtual-bucket
+table definitions shown above. It has no logical-database, schema-catalog, or
+table-metadata tables. Its fifth table is this exact downgrade fence:
+
+```sql
+CREATE TABLE briskdb_metadata (
+    requires_manifest_version INTEGER NOT NULL
+        CHECK (requires_manifest_version >= 3)
+) STRICT;
+```
+
+The fence contains exactly `3`, and `PRAGMA user_version` is `3`. Version 3
+supports only routing generation 1 and validates the same deterministic bucket
+map. A current opener validates the complete v3 source before applying the
+atomic v3-to-v4 migration.
 
 ## Previous version 2
 
@@ -132,8 +271,7 @@ CREATE TABLE briskdb_metadata (
 ```
 
 The fence contains exactly `2`. A current opener validates this complete format
-before transactionally constructing the version-3 catalog and replacing the
-fence with its version-3 definition and row.
+before applying the numbered v2-to-v3 and v3-to-v4 transactions.
 
 ## Legacy version 1
 
@@ -176,28 +314,44 @@ upgrade the manifest before any shard connection is opened:
 7. After a compatible current manifest is committed, enable and verify WAL mode
    and only then create/open the shard layout.
 
-SQLite transactional DDL makes the schema, catalog rows, downgrade fence, and
-header stamps one transaction within `manifest.sqlite`. A version-1 upgrade
-commits version 2 before beginning version 3. Tests prove rollback and retry
-after injected errors and Rust panic unwinding. SQLite is intended to recover an
-uncommitted transaction after process loss, but BriskDB has not yet certified
-process-kill, power-loss, or filesystem-fault recovery. Concurrent open calls
-within the supported single-process deployment serialize on the immediate
-transaction and re-read the version after acquiring it.
+Fresh initialization creates the complete v4 schema and initial rows in one
+transaction before stamping version 4. For an existing manifest, SQLite
+transactional DDL makes each numbered step's schema, catalog rows, downgrade
+fence, and header stamps one transaction within `manifest.sqlite`. A version-1
+upgrade commits version 2, then version 3, then version 4; a version-2 upgrade
+commits version 3 before beginning version 4.
 
-This guarantee is manifest-local. It is not an application-table migration API,
-does not make broadcast atomic across shard files, and is not the planned
+The v3-to-v4 step atomically replaces the version-3 fence with the version-4
+fence, creates the three logical-catalog tables, inserts database ID 1 named
+`default` plus the schema-generation-0 singleton, and leaves the table catalog
+empty. The destination is fully validated and the header is stamped last before
+commit. An error or panic rolls the whole step back to the exact v3 source, so a
+later open can retry it. The step never opens or inspects shard files and never
+infers or adopts an existing physical table.
+
+Tests prove rollback and retry after injected errors and Rust panic unwinding.
+SQLite is intended to recover an uncommitted transaction after process loss,
+but BriskDB has not yet certified process-kill, power-loss, or filesystem-fault
+recovery. Concurrent open calls within the supported single-process deployment
+serialize on the immediate transaction and re-read the version after acquiring
+it.
+
+This guarantee is manifest-local. The schema generation and table rows are
+read-only advisory metadata, not an application-table migration API. They do
+not make broadcast atomic across shard files and are not the planned
 crash-resumable cross-shard schema migration journal. Catalog validation also
-does not yet establish shard-file health: current startup can recreate a missing
-shard file. No-create opening, per-shard identity/version, WAL, and schema-
-generation checks belong to the later shard-validation milestone.
+does not yet establish shard-file health: current startup can recreate a
+missing shard file. No-create opening, per-shard identity/version, WAL, and
+schema-generation checks belong to the later shard-validation milestone.
 
 ## Compatibility and operations
 
-- Version 1 upgrades through version 2 to version 3; version 2 upgrades directly
-  to version 3. Opening is therefore potentially mutating.
-- There is no automatic downgrade. Version-1 code is fenced by the incompatible
-  metadata table, and a version-2 reader rejects `user_version = 3`.
+- Version 1 upgrades through versions 2 and 3 to version 4; version 2 upgrades
+  through version 3; version 3 upgrades directly to version 4. Opening is
+  therefore potentially mutating.
+- There is no automatic downgrade. Older readers are fenced by the incompatible
+  metadata schema and authoritative header; in particular, a version-3 reader
+  rejects `user_version = 4`.
 - A manifest with the BriskDB application ID and a `user_version` newer than the
   binary supports fails with non-retryable `FailedPrecondition`; it is not
   downgraded or switched to WAL, and shard files are not opened.
@@ -216,16 +370,18 @@ older binary requires a known-good copy made while BriskDB was stopped.
 
 ## Verification contract
 
-Tests cover fresh and version-2 catalog creation for every supported shard
-count, deterministic and balanced bucket ownership, non-divisor compatibility,
-no-op reopen, both recognized legacy headers, the interrupted empty-table state,
-exact schema and relational corruption, future and foreign formats, both old-
-reader fences, errors and panics on both sides of the version stamp, multi-step
-resume, observer atomicity, and concurrent openers with matching and conflicting
-shard counts. Routing tests additionally freeze golden hash/bucket/shard vectors,
-cover every algorithm state for every supported shard count, prove the final map
-lookup with a synthetic reassignment, and exercise parallel and reopen stability.
-Process termination and filesystem faults remain part of the later
-storage-hardening suite. Every new migration must extend the registry,
-destination validator, format documentation, and the same
+Tests cover fresh and v1/v2/v3-to-v4 catalog creation, the exact default logical
+database and schema singleton, every placement and shard-key type code,
+identifier and relational corruption, catalog row limits, immutable public
+lookups, deterministic and balanced bucket ownership, non-divisor
+compatibility, and no-op reopen. Migration coverage includes both recognized
+legacy headers, the interrupted empty-table state, future and foreign formats,
+old-reader fences, errors and panics on both sides of every version stamp,
+multi-step resume, v3-to-v4 observer atomicity, and concurrent openers with
+matching and conflicting shard counts. Routing tests additionally freeze golden
+hash/bucket/shard vectors, cover every algorithm state for every supported shard
+count, prove the final map lookup with a synthetic reassignment, and exercise
+parallel and reopen stability. Process termination and filesystem faults remain
+part of the later storage-hardening suite. Every new migration must extend the
+registry, destination validator, format documentation, and the same
 normal/error/concurrency/recovery matrix.

--- a/src/core/catalog.rs
+++ b/src/core/catalog.rs
@@ -1,0 +1,522 @@
+//! Protocol-neutral logical database and table metadata.
+
+use std::fmt;
+
+use super::{EngineError, EngineErrorKind, EngineResult, RoutingCatalog};
+
+pub(crate) const IDENTIFIER_ENCODING_VERSION: u32 = 1;
+pub(crate) const DEFAULT_LOGICAL_DATABASE_ID: u64 = 1;
+pub(crate) const DEFAULT_LOGICAL_DATABASE_NAME: &str = "default";
+pub(crate) const MAX_CATALOG_IDENTIFIER_BYTES: usize = 63;
+pub(crate) const MAX_LOGICAL_DATABASES: usize = 64;
+pub(crate) const MAX_TABLES: usize = 4_096;
+
+/// Stable identity of a logical database in the manifest catalog.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct LogicalDatabaseId(u64);
+
+impl LogicalDatabaseId {
+    /// Construct a positive stable logical-database identity.
+    pub fn new(value: u64) -> EngineResult<Self> {
+        if value == 0 {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "logical database IDs must be positive",
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    pub(crate) const fn from_validated(value: u64) -> Self {
+        debug_assert!(value > 0);
+        Self(value)
+    }
+
+    /// Return the persisted numeric identity.
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+impl fmt::Display for LogicalDatabaseId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+/// Stable identity of a table in the manifest catalog.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct TableId(u64);
+
+impl TableId {
+    /// Construct a positive stable table identity.
+    pub fn new(value: u64) -> EngineResult<Self> {
+        if value == 0 {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "table IDs must be positive",
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    pub(crate) const fn from_validated(value: u64) -> Self {
+        debug_assert!(value > 0);
+        Self(value)
+    }
+
+    /// Return the persisted numeric identity.
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+impl fmt::Display for TableId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+/// Logical database metadata loaded from the manifest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LogicalDatabaseMetadata {
+    id: LogicalDatabaseId,
+    name: String,
+}
+
+impl LogicalDatabaseMetadata {
+    pub(crate) fn from_validated(id: u64, name: String) -> Self {
+        debug_assert!(id > 0);
+        debug_assert!(validate_catalog_identifier(&name));
+        Self {
+            id: LogicalDatabaseId::from_validated(id),
+            name,
+        }
+    }
+
+    /// Return the stable catalog identity.
+    pub const fn id(&self) -> LogicalDatabaseId {
+        self.id
+    }
+
+    /// Return the canonical lowercase catalog name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+/// Versioned declared type of a non-null shard-key column.
+///
+/// Manifest v4 exposes this as read-only metadata. Routed execution continues
+/// to accept the caller's opaque routing-key bytes and does not yet encode keys
+/// from table values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ShardKeyType {
+    /// Signed 64-bit integer.
+    Int64,
+    /// UTF-8 text, declared without Unicode normalization.
+    Text,
+    /// Arbitrary bytes.
+    Binary,
+}
+
+/// Single-column shard-key declaration for a sharded table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShardKeyMetadata {
+    column: String,
+    key_type: ShardKeyType,
+}
+
+impl ShardKeyMetadata {
+    pub(crate) fn from_validated(column: String, key_type: ShardKeyType) -> Self {
+        debug_assert!(validate_catalog_identifier(&column));
+        Self { column, key_type }
+    }
+
+    /// Return the canonical lowercase column name.
+    pub fn column(&self) -> &str {
+        &self.column
+    }
+
+    /// Return the declared shard-key type.
+    pub const fn key_type(&self) -> ShardKeyType {
+        self.key_type
+    }
+}
+
+/// Declared physical placement of a logical table.
+///
+/// These declarations are advisory in manifest v4. Schema-journal work will
+/// make them authoritative for physical DDL and query planning.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TablePlacement {
+    /// Intended for the same logical schema on every shard and key-routed rows.
+    Sharded(ShardKeyMetadata),
+    /// Intended for a small lookup table replicated to every shard.
+    Global,
+    /// Intended for manifest-owned metadata rather than a user shard table.
+    Catalog,
+}
+
+/// Logical table metadata loaded from the manifest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TableMetadata {
+    id: TableId,
+    database_id: LogicalDatabaseId,
+    name: String,
+    placement: TablePlacement,
+}
+
+impl TableMetadata {
+    pub(crate) fn from_validated(
+        id: u64,
+        database_id: u64,
+        name: String,
+        placement: TablePlacement,
+    ) -> Self {
+        debug_assert!(id > 0);
+        debug_assert!(database_id > 0);
+        debug_assert!(validate_catalog_identifier(&name));
+        Self {
+            id: TableId::from_validated(id),
+            database_id: LogicalDatabaseId::from_validated(database_id),
+            name,
+            placement,
+        }
+    }
+
+    /// Return the stable catalog identity.
+    pub const fn id(&self) -> TableId {
+        self.id
+    }
+
+    /// Return the owning logical database identity.
+    pub const fn database_id(&self) -> LogicalDatabaseId {
+        self.database_id
+    }
+
+    /// Return the canonical lowercase table name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Return the table placement and any shard-key declaration.
+    pub const fn placement(&self) -> &TablePlacement {
+        &self.placement
+    }
+}
+
+/// Immutable logical schema metadata loaded atomically with routing state.
+///
+/// The manifest v4 catalog is read-only and advisory. Existing raw SQLite
+/// tables are not inferred or adopted, and current execution behavior remains
+/// unchanged until cataloged DDL and schema journaling are implemented.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Catalog {
+    identifier_encoding_version: u32,
+    schema_generation: u64,
+    default_database_id: LogicalDatabaseId,
+    databases: Box<[LogicalDatabaseMetadata]>,
+    tables: Box<[TableMetadata]>,
+}
+
+impl Catalog {
+    pub(crate) fn from_validated_parts(
+        identifier_encoding_version: u32,
+        schema_generation: u64,
+        default_database_id: u64,
+        databases: Box<[LogicalDatabaseMetadata]>,
+        tables: Box<[TableMetadata]>,
+    ) -> Self {
+        debug_assert_eq!(identifier_encoding_version, IDENTIFIER_ENCODING_VERSION);
+        debug_assert!(!databases.is_empty());
+        debug_assert!(databases.len() <= MAX_LOGICAL_DATABASES);
+        debug_assert!(tables.len() <= MAX_TABLES);
+        debug_assert!(databases.windows(2).all(|rows| rows[0].id < rows[1].id));
+        debug_assert!(tables.windows(2).all(|rows| {
+            (rows[0].database_id, rows[0].name.as_str())
+                < (rows[1].database_id, rows[1].name.as_str())
+        }));
+        debug_assert!(databases.iter().any(|database| {
+            database.id.get() == default_database_id
+                && database.name == DEFAULT_LOGICAL_DATABASE_NAME
+        }));
+        debug_assert!(tables.iter().all(|table| {
+            databases
+                .binary_search_by_key(&table.database_id, |database| database.id)
+                .is_ok()
+        }));
+        Self {
+            identifier_encoding_version,
+            schema_generation,
+            default_database_id: LogicalDatabaseId::from_validated(default_database_id),
+            databases,
+            tables,
+        }
+    }
+
+    /// Return the persisted identifier-encoding version.
+    pub const fn identifier_encoding_version(&self) -> u32 {
+        self.identifier_encoding_version
+    }
+
+    /// Return the cataloged application-schema generation.
+    pub const fn schema_generation(&self) -> u64 {
+        self.schema_generation
+    }
+
+    /// Return the storage-default logical database.
+    pub fn default_database(&self) -> &LogicalDatabaseMetadata {
+        self.database_by_id(self.default_database_id)
+            .expect("the validated catalog contains its default database")
+    }
+
+    /// Return logical databases in stable numeric-ID order.
+    pub fn logical_databases(&self) -> &[LogicalDatabaseMetadata] {
+        &self.databases
+    }
+
+    /// Return tables in logical-database-ID then canonical-name order.
+    pub fn tables(&self) -> &[TableMetadata] {
+        &self.tables
+    }
+
+    /// Look up a logical database by stable ID.
+    pub fn database_by_id(&self, id: LogicalDatabaseId) -> Option<&LogicalDatabaseMetadata> {
+        self.databases
+            .binary_search_by_key(&id, |database| database.id)
+            .ok()
+            .map(|index| &self.databases[index])
+    }
+
+    /// Look up a logical database by canonical name.
+    pub fn database(&self, name: &str) -> EngineResult<Option<&LogicalDatabaseMetadata>> {
+        ensure_catalog_identifier(name)?;
+        Ok(self.databases.iter().find(|database| database.name == name))
+    }
+
+    /// Look up a table by logical database and canonical table name.
+    pub fn table(&self, database: &str, table: &str) -> EngineResult<Option<&TableMetadata>> {
+        let Some(database) = self.database(database)? else {
+            ensure_catalog_identifier(table)?;
+            return Ok(None);
+        };
+        ensure_catalog_identifier(table)?;
+        Ok(self
+            .tables
+            .binary_search_by(|metadata| {
+                (metadata.database_id, metadata.name.as_str()).cmp(&(database.id, table))
+            })
+            .ok()
+            .map(|index| &self.tables[index]))
+    }
+
+    /// Look up a table by stable ID.
+    pub fn table_by_id(&self, id: TableId) -> Option<&TableMetadata> {
+        self.tables.iter().find(|table| table.id == id)
+    }
+}
+
+/// Routing and logical metadata loaded from one committed manifest snapshot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CatalogSnapshot {
+    routing: RoutingCatalog,
+    logical: Catalog,
+}
+
+impl CatalogSnapshot {
+    pub(crate) fn from_validated_parts(routing: RoutingCatalog, logical: Catalog) -> Self {
+        Self { routing, logical }
+    }
+
+    pub(crate) const fn routing(&self) -> &RoutingCatalog {
+        &self.routing
+    }
+
+    pub(crate) const fn logical(&self) -> &Catalog {
+        &self.logical
+    }
+}
+
+pub(crate) fn validate_catalog_identifier(identifier: &str) -> bool {
+    let bytes = identifier.as_bytes();
+    if bytes.is_empty() || bytes.len() > MAX_CATALOG_IDENTIFIER_BYTES {
+        return false;
+    }
+    if !matches!(bytes[0], b'a'..=b'z' | b'_')
+        || !bytes
+            .iter()
+            .all(|byte| matches!(byte, b'a'..=b'z' | b'0'..=b'9' | b'_'))
+    {
+        return false;
+    }
+    identifier != "briskdb"
+        && !identifier.starts_with("briskdb_")
+        && !identifier.starts_with("sqlite_")
+}
+
+fn ensure_catalog_identifier(identifier: &str) -> EngineResult<()> {
+    if validate_catalog_identifier(identifier) {
+        Ok(())
+    } else {
+        Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            "catalog identifiers must be 1 to 63 bytes of lowercase ASCII, start with a letter or underscore, and not use a reserved prefix",
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_catalog() -> Catalog {
+        Catalog::from_validated_parts(
+            1,
+            7,
+            1,
+            vec![
+                LogicalDatabaseMetadata::from_validated(1, "default".to_owned()),
+                LogicalDatabaseMetadata::from_validated(9, "tenant".to_owned()),
+            ]
+            .into_boxed_slice(),
+            vec![
+                TableMetadata::from_validated(
+                    3,
+                    1,
+                    "accounts".to_owned(),
+                    TablePlacement::Sharded(ShardKeyMetadata::from_validated(
+                        "tenant_id".to_owned(),
+                        ShardKeyType::Text,
+                    )),
+                ),
+                TableMetadata::from_validated(8, 1, "countries".to_owned(), TablePlacement::Global),
+                TableMetadata::from_validated(
+                    21,
+                    9,
+                    "accounts".to_owned(),
+                    TablePlacement::Catalog,
+                ),
+            ]
+            .into_boxed_slice(),
+        )
+    }
+
+    #[test]
+    fn identifiers_have_one_narrow_protocol_neutral_contract() {
+        for valid in [
+            "a",
+            "_",
+            "_9",
+            "briskdbx",
+            "sqlite",
+            "tenant_42",
+            &"a".repeat(63),
+        ] {
+            assert!(validate_catalog_identifier(valid), "{valid}");
+        }
+        for invalid in [
+            "",
+            "9tenant",
+            "Tenant",
+            "two-words",
+            "a\0b",
+            "snowman_☃",
+            "briskdb",
+            "briskdb_tables",
+            "sqlite_master",
+            &"a".repeat(64),
+        ] {
+            assert!(!validate_catalog_identifier(invalid), "{invalid}");
+        }
+    }
+
+    #[test]
+    fn metadata_accessors_and_lookups_are_stable_and_database_scoped() {
+        let catalog = sample_catalog();
+        assert_eq!(LogicalDatabaseId::new(9).unwrap().get(), 9);
+        assert_eq!(TableId::new(8).unwrap().get(), 8);
+        assert_eq!(
+            LogicalDatabaseId::new(0).unwrap_err().kind(),
+            EngineErrorKind::InvalidArgument
+        );
+        assert_eq!(
+            TableId::new(0).unwrap_err().kind(),
+            EngineErrorKind::InvalidArgument
+        );
+        assert_eq!(catalog.identifier_encoding_version(), 1);
+        assert_eq!(catalog.schema_generation(), 7);
+        assert_eq!(catalog.default_database().id().get(), 1);
+        assert_eq!(catalog.default_database().name(), "default");
+        assert_eq!(catalog.logical_databases().len(), 2);
+        assert_eq!(catalog.tables().len(), 3);
+        assert_eq!(catalog.database("missing").unwrap(), None);
+        assert_eq!(catalog.database("tenant").unwrap().unwrap().id().get(), 9);
+        assert_eq!(
+            catalog
+                .table("default", "accounts")
+                .unwrap()
+                .unwrap()
+                .id()
+                .get(),
+            3
+        );
+        assert_eq!(
+            catalog
+                .table("tenant", "accounts")
+                .unwrap()
+                .unwrap()
+                .id()
+                .get(),
+            21
+        );
+        assert_eq!(catalog.table("tenant", "missing").unwrap(), None);
+        assert_eq!(
+            catalog
+                .table_by_id(TableId::new(8).unwrap())
+                .unwrap()
+                .name(),
+            "countries"
+        );
+
+        let accounts = catalog.table("default", "accounts").unwrap().unwrap();
+        assert_eq!(accounts.database_id().get(), 1);
+        match accounts.placement() {
+            TablePlacement::Sharded(shard_key) => {
+                assert_eq!(shard_key.column(), "tenant_id");
+                assert_eq!(shard_key.key_type(), ShardKeyType::Text);
+            }
+            placement => panic!("unexpected placement {placement:?}"),
+        }
+    }
+
+    #[test]
+    fn malformed_lookup_identifiers_are_distinct_from_unknown_names() {
+        let catalog = sample_catalog();
+        for invalid in ["", "Tenant", "two-words", "sqlite_master"] {
+            assert_eq!(
+                catalog.database(invalid).unwrap_err().kind(),
+                EngineErrorKind::InvalidArgument
+            );
+            assert_eq!(
+                catalog.table("default", invalid).unwrap_err().kind(),
+                EngineErrorKind::InvalidArgument
+            );
+        }
+        assert_eq!(catalog.database("unknown").unwrap(), None);
+        assert_eq!(catalog.table("unknown", "accounts").unwrap(), None);
+    }
+
+    #[test]
+    fn public_catalog_metadata_is_send_sync_and_owned() {
+        fn assert_send_sync_static<T: Send + Sync + 'static>() {}
+        assert_send_sync_static::<Catalog>();
+        assert_send_sync_static::<LogicalDatabaseMetadata>();
+        assert_send_sync_static::<TableMetadata>();
+        assert_send_sync_static::<TablePlacement>();
+        assert_send_sync_static::<ShardKeyMetadata>();
+        assert_send_sync_static::<ShardKeyType>();
+    }
+}

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -284,6 +284,11 @@ impl Engine {
         self.inner.database.shard_count()
     }
 
+    /// Return the immutable logical database and table catalog.
+    pub fn catalog(&self) -> &super::Catalog {
+        self.inner.database.catalog()
+    }
+
     /// Return the engine's immutable pool and admission options.
     pub fn options(&self) -> EngineOptions {
         self.inner.options

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,6 +3,7 @@
 //! This module owns routing and coordinates storage and SQL execution. It does
 //! not depend on a network protocol.
 
+mod catalog;
 mod control;
 mod engine;
 mod error;
@@ -13,6 +14,14 @@ mod session;
 mod types;
 pub(crate) mod worker;
 
+pub use catalog::{
+    Catalog, LogicalDatabaseId, LogicalDatabaseMetadata, ShardKeyMetadata, ShardKeyType, TableId,
+    TableMetadata, TablePlacement,
+};
+pub(crate) use catalog::{
+    CatalogSnapshot, DEFAULT_LOGICAL_DATABASE_ID, DEFAULT_LOGICAL_DATABASE_NAME,
+    IDENTIFIER_ENCODING_VERSION, MAX_LOGICAL_DATABASES, MAX_TABLES, validate_catalog_identifier,
+};
 pub(crate) use control::{
     CancelOnDrop, CancellationReason, OperationControl, wait_for_cancellation, wait_pending,
 };
@@ -63,6 +72,11 @@ impl Database {
 
     pub fn shard_count(&self) -> u16 {
         self.storage.shard_count()
+    }
+
+    /// Return the immutable logical database and table catalog.
+    pub fn catalog(&self) -> &Catalog {
+        self.storage.logical_catalog()
     }
 
     pub fn shard_for_key(&self, key: &[u8]) -> u16 {

--- a/src/storage/manifest.rs
+++ b/src/storage/manifest.rs
@@ -4,9 +4,12 @@ use rusqlite::{Connection, Transaction, TransactionBehavior};
 
 use crate::{
     core::{
-        BUCKET_ALGORITHM_VERSION, EngineError, EngineErrorKind, EngineResult, HASH_VERSION,
-        INITIAL_MAP_GENERATION, KEY_ENCODING_VERSION, RoutingCatalog, VIRTUAL_BUCKET_COUNT,
-        initial_physical_shard,
+        BUCKET_ALGORITHM_VERSION, Catalog, CatalogSnapshot, DEFAULT_LOGICAL_DATABASE_ID,
+        DEFAULT_LOGICAL_DATABASE_NAME, EngineError, EngineErrorKind, EngineResult, HASH_VERSION,
+        IDENTIFIER_ENCODING_VERSION, INITIAL_MAP_GENERATION, KEY_ENCODING_VERSION,
+        LogicalDatabaseMetadata, MAX_LOGICAL_DATABASES, MAX_TABLES, RoutingCatalog,
+        ShardKeyMetadata, ShardKeyType, TableMetadata, TablePlacement, VIRTUAL_BUCKET_COUNT,
+        initial_physical_shard, validate_catalog_identifier,
     },
     sqlite_error,
 };
@@ -16,8 +19,17 @@ pub(super) const MANIFEST_APPLICATION_ID: i64 = 0x4252_4442;
 const LEGACY_SCHEMA_VERSION: u32 = 1;
 const V2_SCHEMA_VERSION: u32 = 2;
 const V3_SCHEMA_VERSION: u32 = 3;
-pub(super) const CURRENT_SCHEMA_VERSION: u32 = V3_SCHEMA_VERSION;
+const V4_SCHEMA_VERSION: u32 = 4;
+pub(super) const CURRENT_SCHEMA_VERSION: u32 = V4_SCHEMA_VERSION;
 const MAX_TABLE_SQL_BYTES: i64 = 4_096;
+
+const INITIAL_SCHEMA_GENERATION: u64 = 0;
+const SHARDED_PLACEMENT: i64 = 1;
+const GLOBAL_PLACEMENT: i64 = 2;
+const CATALOG_PLACEMENT: i64 = 3;
+const INT64_SHARD_KEY_TYPE: i64 = 1;
+const TEXT_SHARD_KEY_TYPE: i64 = 2;
+const BINARY_SHARD_KEY_TYPE: i64 = 3;
 
 const ACTIVE_LIFECYCLE_STATE: &str = "active";
 
@@ -37,6 +49,10 @@ const V3_DOWNGRADE_FENCE_SQL: &str = "CREATE TABLE briskdb_metadata (
     requires_manifest_version INTEGER NOT NULL
         CHECK (requires_manifest_version >= 3)
 ) STRICT";
+const V4_DOWNGRADE_FENCE_SQL: &str = "CREATE TABLE briskdb_metadata (
+    requires_manifest_version INTEGER NOT NULL
+        CHECK (requires_manifest_version >= 4)
+) STRICT";
 const V3_ROUTING_TABLE_SQL: &str = "CREATE TABLE briskdb_routing (
     singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
     hash_version INTEGER NOT NULL CHECK (hash_version = 1),
@@ -54,6 +70,73 @@ const V3_VIRTUAL_BUCKETS_TABLE_SQL: &str = "CREATE TABLE briskdb_virtual_buckets
     physical_shard_id INTEGER NOT NULL,
     FOREIGN KEY (physical_shard_id) REFERENCES briskdb_physical_shards (shard_id)
 ) STRICT";
+const V4_LOGICAL_DATABASES_TABLE_SQL: &str = "CREATE TABLE briskdb_logical_databases (
+    database_id INTEGER PRIMARY KEY CHECK (database_id > 0),
+    database_name TEXT NOT NULL COLLATE BINARY UNIQUE
+        CHECK (
+            length(database_name) BETWEEN 1 AND 63
+            AND instr(database_name, char(0)) = 0
+            AND database_name NOT GLOB '*[^a-z0-9_]*'
+            AND substr(database_name, 1, 1) GLOB '[a-z_]'
+            AND database_name <> 'briskdb'
+            AND database_name NOT GLOB 'briskdb_*'
+            AND database_name NOT GLOB 'sqlite_*'
+        )
+) STRICT";
+const V4_SCHEMA_CATALOG_TABLE_SQL: &str = "CREATE TABLE briskdb_schema_catalog (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    identifier_encoding_version INTEGER NOT NULL CHECK (identifier_encoding_version = 1),
+    schema_generation INTEGER NOT NULL CHECK (schema_generation = 0),
+    default_database_id INTEGER NOT NULL CHECK (default_database_id = 1),
+    FOREIGN KEY (default_database_id)
+        REFERENCES briskdb_logical_databases (database_id)
+) STRICT";
+const V4_TABLES_TABLE_SQL: &str = "CREATE TABLE briskdb_tables (
+    table_id INTEGER PRIMARY KEY CHECK (table_id > 0),
+    database_id INTEGER NOT NULL,
+    table_name TEXT NOT NULL COLLATE BINARY
+        CHECK (
+            length(table_name) BETWEEN 1 AND 63
+            AND instr(table_name, char(0)) = 0
+            AND table_name NOT GLOB '*[^a-z0-9_]*'
+            AND substr(table_name, 1, 1) GLOB '[a-z_]'
+            AND table_name <> 'briskdb'
+            AND table_name NOT GLOB 'briskdb_*'
+            AND table_name NOT GLOB 'sqlite_*'
+        ),
+    placement INTEGER NOT NULL CHECK (placement IN (1, 2, 3)),
+    shard_key_column TEXT COLLATE BINARY
+        CHECK (
+            shard_key_column IS NULL OR (
+                length(shard_key_column) BETWEEN 1 AND 63
+                AND instr(shard_key_column, char(0)) = 0
+                AND shard_key_column NOT GLOB '*[^a-z0-9_]*'
+                AND substr(shard_key_column, 1, 1) GLOB '[a-z_]'
+                AND shard_key_column <> 'briskdb'
+                AND shard_key_column NOT GLOB 'briskdb_*'
+                AND shard_key_column NOT GLOB 'sqlite_*'
+            )
+        ),
+    shard_key_type INTEGER
+        CHECK (shard_key_type IS NULL OR shard_key_type IN (1, 2, 3)),
+    UNIQUE (database_id, table_name),
+    FOREIGN KEY (database_id)
+        REFERENCES briskdb_logical_databases (database_id)
+        ON DELETE RESTRICT,
+    CHECK (
+        (
+            placement = 1
+            AND shard_key_column IS NOT NULL
+            AND shard_key_type IS NOT NULL
+        )
+        OR
+        (
+            placement IN (2, 3)
+            AND shard_key_column IS NULL
+            AND shard_key_type IS NULL
+        )
+    )
+) STRICT";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct RoutingConfiguration {
@@ -61,6 +144,13 @@ struct RoutingConfiguration {
     key_encoding_version: u32,
     bucket_algorithm_version: u32,
     map_generation: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SchemaCatalogConfiguration {
+    identifier_encoding_version: u32,
+    schema_generation: u64,
+    default_database_id: u64,
 }
 
 #[derive(Clone, Copy)]
@@ -76,6 +166,7 @@ struct Migration {
 struct ManifestSnapshot {
     shard_count: u16,
     routing_catalog: Option<RoutingCatalog>,
+    logical_catalog: Option<Catalog>,
 }
 
 const MIGRATIONS: &[Migration] = &[
@@ -93,6 +184,13 @@ const MIGRATIONS: &[Migration] = &[
         apply: migrate_v2_to_v3,
         validate: validate_v3,
     },
+    Migration {
+        from: V3_SCHEMA_VERSION,
+        to: V4_SCHEMA_VERSION,
+        name: "logical_database_and_table_catalog",
+        apply: migrate_v3_to_v4,
+        validate: validate_v4,
+    },
 ];
 
 #[derive(Clone, Copy)]
@@ -105,7 +203,7 @@ struct MigrationPlan<'a> {
 const CURRENT_PLAN: MigrationPlan<'static> = MigrationPlan {
     current_version: CURRENT_SCHEMA_VERSION,
     migrations: MIGRATIONS,
-    initialize_current: create_v3_schema,
+    initialize_current: create_v4_schema,
 };
 
 #[derive(Clone, Copy)]
@@ -149,14 +247,21 @@ enum ManifestState {
 pub(super) fn load_or_create_catalog(
     connection: &mut Connection,
     requested_shards: u16,
-) -> EngineResult<RoutingCatalog> {
+) -> EngineResult<CatalogSnapshot> {
     let snapshot = load_or_create_snapshot_with_hook(connection, requested_shards, |_| Ok(()))?;
-    snapshot.routing_catalog.ok_or_else(|| {
+    let routing = snapshot.routing_catalog.ok_or_else(|| {
         EngineError::new(
             EngineErrorKind::Internal,
             "current manifest validation did not produce a routing catalog",
         )
-    })
+    })?;
+    let logical = snapshot.logical_catalog.ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::Internal,
+            "current manifest validation did not produce a logical catalog",
+        )
+    })?;
+    Ok(CatalogSnapshot::from_validated_parts(routing, logical))
 }
 
 #[cfg(test)]
@@ -345,6 +450,11 @@ fn create_v3_schema(transaction: &Transaction<'_>, shard_count: u16) -> EngineRe
     migrate_v2_to_v3(transaction, shard_count)
 }
 
+fn create_v4_schema(transaction: &Transaction<'_>, shard_count: u16) -> EngineResult<()> {
+    create_v3_schema(transaction, shard_count)?;
+    migrate_v3_to_v4(transaction, shard_count)
+}
+
 fn migrate_v2_to_v3(transaction: &Transaction<'_>, shard_count: u16) -> EngineResult<()> {
     transaction
         .execute_batch("DROP TABLE briskdb_metadata;")
@@ -424,6 +534,61 @@ fn migrate_v2_to_v3(transaction: &Transaction<'_>, shard_count: u16) -> EngineRe
                 .map_err(sqlite_error::storage)?;
         }
     }
+
+    Ok(())
+}
+
+fn migrate_v3_to_v4(transaction: &Transaction<'_>, _shard_count: u16) -> EngineResult<()> {
+    transaction
+        .execute_batch("DROP TABLE briskdb_metadata;")
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch(V4_DOWNGRADE_FENCE_SQL)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "INSERT INTO briskdb_metadata (requires_manifest_version) VALUES (?1)",
+            [V4_SCHEMA_VERSION],
+        )
+        .map_err(sqlite_error::storage)?;
+
+    transaction
+        .execute_batch(V4_LOGICAL_DATABASES_TABLE_SQL)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "INSERT INTO briskdb_logical_databases (database_id, database_name)
+             VALUES (?1, ?2)",
+            rusqlite::params![
+                i64::try_from(DEFAULT_LOGICAL_DATABASE_ID)
+                    .expect("default logical database ID fits in SQLite"),
+                DEFAULT_LOGICAL_DATABASE_NAME
+            ],
+        )
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch(V4_SCHEMA_CATALOG_TABLE_SQL)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "INSERT INTO briskdb_schema_catalog (
+                singleton,
+                identifier_encoding_version,
+                schema_generation,
+                default_database_id
+             ) VALUES (1, ?1, ?2, ?3)",
+            rusqlite::params![
+                i64::from(IDENTIFIER_ENCODING_VERSION),
+                i64::try_from(INITIAL_SCHEMA_GENERATION)
+                    .expect("initial schema generation fits in SQLite"),
+                i64::try_from(DEFAULT_LOGICAL_DATABASE_ID)
+                    .expect("default logical database ID fits in SQLite"),
+            ],
+        )
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch(V4_TABLES_TABLE_SQL)
+        .map_err(sqlite_error::storage)?;
 
     Ok(())
 }
@@ -609,6 +774,43 @@ fn v3_objects() -> Vec<SchemaObject> {
     ]
 }
 
+fn v4_objects() -> Vec<SchemaObject> {
+    vec![
+        SchemaObject {
+            object_type: "table".to_owned(),
+            name: "briskdb_logical_databases".to_owned(),
+        },
+        SchemaObject {
+            object_type: "table".to_owned(),
+            name: "briskdb_manifest".to_owned(),
+        },
+        SchemaObject {
+            object_type: "table".to_owned(),
+            name: "briskdb_metadata".to_owned(),
+        },
+        SchemaObject {
+            object_type: "table".to_owned(),
+            name: "briskdb_physical_shards".to_owned(),
+        },
+        SchemaObject {
+            object_type: "table".to_owned(),
+            name: "briskdb_routing".to_owned(),
+        },
+        SchemaObject {
+            object_type: "table".to_owned(),
+            name: "briskdb_schema_catalog".to_owned(),
+        },
+        SchemaObject {
+            object_type: "table".to_owned(),
+            name: "briskdb_tables".to_owned(),
+        },
+        SchemaObject {
+            object_type: "table".to_owned(),
+            name: "briskdb_virtual_buckets".to_owned(),
+        },
+    ]
+}
+
 fn schema_objects(connection: &Connection) -> EngineResult<Vec<SchemaObject>> {
     let mut statement = connection
         .prepare(
@@ -693,6 +895,18 @@ fn validate_table(
         "briskdb_virtual_buckets" => {
             "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden
              FROM pragma_table_xinfo('briskdb_virtual_buckets') LIMIT ?1"
+        }
+        "briskdb_logical_databases" => {
+            "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden
+             FROM pragma_table_xinfo('briskdb_logical_databases') LIMIT ?1"
+        }
+        "briskdb_schema_catalog" => {
+            "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden
+             FROM pragma_table_xinfo('briskdb_schema_catalog') LIMIT ?1"
+        }
+        "briskdb_tables" => {
+            "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden
+             FROM pragma_table_xinfo('briskdb_tables') LIMIT ?1"
         }
         _ => {
             return Err(EngineError::new(
@@ -879,6 +1093,7 @@ fn validate_v2(
     Ok(ManifestSnapshot {
         shard_count,
         routing_catalog: None,
+        logical_catalog: None,
     })
 }
 
@@ -894,6 +1109,26 @@ fn validate_v3(
         ));
     }
 
+    let (shard_count, routing_catalog) = validate_routing_manifest(
+        connection,
+        requested_shards,
+        V3_SCHEMA_VERSION,
+        V3_DOWNGRADE_FENCE_SQL,
+    )?;
+    validate_foreign_keys(connection)?;
+    Ok(ManifestSnapshot {
+        shard_count,
+        routing_catalog: Some(routing_catalog),
+        logical_catalog: None,
+    })
+}
+
+fn validate_routing_manifest(
+    connection: &Connection,
+    requested_shards: u16,
+    expected_version: u32,
+    downgrade_fence_sql: &str,
+) -> EngineResult<(u16, RoutingCatalog)> {
     validate_table(
         connection,
         "briskdb_manifest",
@@ -916,7 +1151,7 @@ fn validate_v3(
         )],
         true,
     )?;
-    validate_table_sql(connection, "briskdb_metadata", V3_DOWNGRADE_FENCE_SQL)?;
+    validate_table_sql(connection, "briskdb_metadata", downgrade_fence_sql)?;
     validate_table(
         connection,
         "briskdb_routing",
@@ -961,22 +1196,383 @@ fn validate_v3(
     )?;
 
     let shard_count = validate_manifest_configuration(connection, requested_shards)?;
-    validate_downgrade_fence(connection, V3_SCHEMA_VERSION)?;
+    validate_downgrade_fence(connection, expected_version)?;
     let routing = validate_routing_configuration(connection)?;
     validate_physical_shards(connection, shard_count)?;
     let buckets = validate_virtual_buckets(connection, shard_count)?;
-    validate_foreign_keys(connection)?;
-    Ok(ManifestSnapshot {
+    Ok((
         shard_count,
-        routing_catalog: Some(RoutingCatalog::from_validated_parts(
+        RoutingCatalog::from_validated_parts(
             shard_count,
             routing.hash_version,
             routing.key_encoding_version,
             routing.bucket_algorithm_version,
             routing.map_generation,
             buckets,
+        ),
+    ))
+}
+
+fn validate_v4(
+    connection: &Connection,
+    requested_shards: u16,
+    objects: &[SchemaObject],
+) -> EngineResult<ManifestSnapshot> {
+    if objects != v4_objects() {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "manifest schema version 4 has unexpected database objects",
+        ));
+    }
+
+    let (shard_count, routing_catalog) = validate_routing_manifest(
+        connection,
+        requested_shards,
+        V4_SCHEMA_VERSION,
+        V4_DOWNGRADE_FENCE_SQL,
+    )?;
+    validate_table(
+        connection,
+        "briskdb_logical_databases",
+        &[
+            TableColumn::expected(0, "database_id", "INTEGER", false, 1),
+            TableColumn::expected(1, "database_name", "TEXT", true, 0),
+        ],
+        true,
+    )?;
+    validate_table_sql(
+        connection,
+        "briskdb_logical_databases",
+        V4_LOGICAL_DATABASES_TABLE_SQL,
+    )?;
+    validate_table(
+        connection,
+        "briskdb_schema_catalog",
+        &[
+            TableColumn::expected(0, "singleton", "INTEGER", false, 1),
+            TableColumn::expected(1, "identifier_encoding_version", "INTEGER", true, 0),
+            TableColumn::expected(2, "schema_generation", "INTEGER", true, 0),
+            TableColumn::expected(3, "default_database_id", "INTEGER", true, 0),
+        ],
+        true,
+    )?;
+    validate_table_sql(
+        connection,
+        "briskdb_schema_catalog",
+        V4_SCHEMA_CATALOG_TABLE_SQL,
+    )?;
+    validate_table(
+        connection,
+        "briskdb_tables",
+        &[
+            TableColumn::expected(0, "table_id", "INTEGER", false, 1),
+            TableColumn::expected(1, "database_id", "INTEGER", true, 0),
+            TableColumn::expected(2, "table_name", "TEXT", true, 0),
+            TableColumn::expected(3, "placement", "INTEGER", true, 0),
+            TableColumn::expected(4, "shard_key_column", "TEXT", false, 0),
+            TableColumn::expected(5, "shard_key_type", "INTEGER", false, 0),
+        ],
+        true,
+    )?;
+    validate_table_sql(connection, "briskdb_tables", V4_TABLES_TABLE_SQL)?;
+
+    let catalog_configuration = validate_schema_catalog_configuration(connection)?;
+    let databases =
+        validate_logical_databases(connection, catalog_configuration.default_database_id)?;
+    let tables = validate_table_metadata(connection, &databases)?;
+    validate_foreign_keys(connection)?;
+
+    Ok(ManifestSnapshot {
+        shard_count,
+        routing_catalog: Some(routing_catalog),
+        logical_catalog: Some(Catalog::from_validated_parts(
+            catalog_configuration.identifier_encoding_version,
+            catalog_configuration.schema_generation,
+            catalog_configuration.default_database_id,
+            databases,
+            tables,
         )),
     })
+}
+
+fn validate_schema_catalog_configuration(
+    connection: &Connection,
+) -> EngineResult<SchemaCatalogConfiguration> {
+    let mut statement = connection
+        .prepare(
+            "SELECT singleton,
+                    identifier_encoding_version,
+                    schema_generation,
+                    default_database_id
+             FROM briskdb_schema_catalog
+             ORDER BY singleton
+             LIMIT 3",
+        )
+        .map_err(|error| {
+            manifest_read_error(error, "failed to read schema catalog configuration")
+        })?;
+    let rows = statement
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, i64>(3)?,
+            ))
+        })
+        .map_err(|error| manifest_read_error(error, "failed to read schema catalog configuration"))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| {
+            manifest_read_error(error, "failed to read schema catalog configuration")
+        })?;
+    if rows.len() != 1 || rows[0].0 != 1 {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "schema catalog configuration must contain exactly its singleton row",
+        ));
+    }
+
+    let (_, identifier_encoding_version, schema_generation, default_database_id) = rows[0];
+    if identifier_encoding_version != i64::from(IDENTIFIER_ENCODING_VERSION) {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!(
+                "manifest has unsupported identifier-encoding version {identifier_encoding_version}"
+            ),
+        ));
+    }
+    let schema_generation = u64::try_from(schema_generation).map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::DataCorruption,
+            "schema generation is outside the supported numeric range",
+            error,
+        )
+    })?;
+    if schema_generation != INITIAL_SCHEMA_GENERATION {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!("manifest has unsupported schema generation {schema_generation}"),
+        ));
+    }
+    let default_database_id = u64::try_from(default_database_id).map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::DataCorruption,
+            "default logical database ID is outside the supported numeric range",
+            error,
+        )
+    })?;
+    if default_database_id != DEFAULT_LOGICAL_DATABASE_ID {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!("manifest has unsupported default logical database ID {default_database_id}"),
+        ));
+    }
+
+    Ok(SchemaCatalogConfiguration {
+        identifier_encoding_version: IDENTIFIER_ENCODING_VERSION,
+        schema_generation,
+        default_database_id,
+    })
+}
+
+fn validate_logical_databases(
+    connection: &Connection,
+    default_database_id: u64,
+) -> EngineResult<Box<[LogicalDatabaseMetadata]>> {
+    let mut statement = connection
+        .prepare(
+            "SELECT database_id, database_name
+             FROM briskdb_logical_databases
+             ORDER BY database_id
+             LIMIT ?1",
+        )
+        .map_err(|error| manifest_read_error(error, "failed to read logical database catalog"))?;
+    let limit = i64::try_from(MAX_LOGICAL_DATABASES + 1)
+        .expect("logical database inspection limit fits in SQLite");
+    let rows = statement
+        .query_map([limit], |row| {
+            Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+        })
+        .map_err(|error| manifest_read_error(error, "failed to read logical database catalog"))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| manifest_read_error(error, "failed to read logical database catalog"))?;
+    if rows.is_empty() || rows.len() > MAX_LOGICAL_DATABASES {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!(
+                "logical database catalog must contain between 1 and {MAX_LOGICAL_DATABASES} rows"
+            ),
+        ));
+    }
+
+    let mut databases = Vec::with_capacity(rows.len());
+    for (stored_id, name) in rows {
+        let id = u64::try_from(stored_id).map_err(|error| {
+            EngineError::from_source(
+                EngineErrorKind::DataCorruption,
+                "logical database ID is outside the supported numeric range",
+                error,
+            )
+        })?;
+        if id == 0 {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "logical database IDs must be positive",
+            ));
+        }
+        if !validate_catalog_identifier(&name) {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!("logical database {id} has an invalid catalog name"),
+            ));
+        }
+        databases.push(LogicalDatabaseMetadata::from_validated(id, name));
+    }
+
+    let default = databases
+        .iter()
+        .find(|database| database.id().get() == default_database_id)
+        .ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "logical database catalog is missing its configured default",
+            )
+        })?;
+    if default.name() != DEFAULT_LOGICAL_DATABASE_NAME {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!("default logical database must be named {DEFAULT_LOGICAL_DATABASE_NAME}"),
+        ));
+    }
+
+    Ok(databases.into_boxed_slice())
+}
+
+fn validate_table_metadata(
+    connection: &Connection,
+    databases: &[LogicalDatabaseMetadata],
+) -> EngineResult<Box<[TableMetadata]>> {
+    let mut statement = connection
+        .prepare(
+            "SELECT table_id,
+                    database_id,
+                    table_name,
+                    placement,
+                    shard_key_column,
+                    shard_key_type
+             FROM briskdb_tables
+             ORDER BY database_id, table_name, table_id
+             LIMIT ?1",
+        )
+        .map_err(|error| manifest_read_error(error, "failed to read table metadata catalog"))?;
+    let limit = i64::try_from(MAX_TABLES + 1).expect("table inspection limit fits in SQLite");
+    let rows = statement
+        .query_map([limit], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, i64>(3)?,
+                row.get::<_, Option<String>>(4)?,
+                row.get::<_, Option<i64>>(5)?,
+            ))
+        })
+        .map_err(|error| manifest_read_error(error, "failed to read table metadata catalog"))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| manifest_read_error(error, "failed to read table metadata catalog"))?;
+    if rows.len() > MAX_TABLES {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!("table metadata catalog exceeds its {MAX_TABLES}-row limit"),
+        ));
+    }
+
+    let mut tables = Vec::with_capacity(rows.len());
+    for (stored_table_id, stored_database_id, name, placement, column, key_type) in rows {
+        let table_id = positive_catalog_id(stored_table_id, "table")?;
+        let database_id = positive_catalog_id(stored_database_id, "logical database")?;
+        if databases
+            .binary_search_by_key(&database_id, |database| database.id().get())
+            .is_err()
+        {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!("table {table_id} references unknown logical database {database_id}"),
+            ));
+        }
+        if !validate_catalog_identifier(&name) {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!("table {table_id} has an invalid catalog name"),
+            ));
+        }
+
+        let placement = match (placement, column, key_type) {
+            (SHARDED_PLACEMENT, Some(column), Some(key_type)) => {
+                if !validate_catalog_identifier(&column) {
+                    return Err(EngineError::new(
+                        EngineErrorKind::DataCorruption,
+                        format!("table {table_id} has an invalid shard-key column"),
+                    ));
+                }
+                TablePlacement::Sharded(ShardKeyMetadata::from_validated(
+                    column,
+                    decode_shard_key_type(key_type, table_id)?,
+                ))
+            }
+            (GLOBAL_PLACEMENT, None, None) => TablePlacement::Global,
+            (CATALOG_PLACEMENT, None, None) => TablePlacement::Catalog,
+            (placement, _, _) if !matches!(placement, 1..=3) => {
+                return Err(EngineError::new(
+                    EngineErrorKind::DataCorruption,
+                    format!("table {table_id} has unsupported placement code {placement}"),
+                ));
+            }
+            _ => {
+                return Err(EngineError::new(
+                    EngineErrorKind::DataCorruption,
+                    format!("table {table_id} has inconsistent placement and shard-key metadata"),
+                ));
+            }
+        };
+        tables.push(TableMetadata::from_validated(
+            table_id,
+            database_id,
+            name,
+            placement,
+        ));
+    }
+
+    Ok(tables.into_boxed_slice())
+}
+
+fn positive_catalog_id(value: i64, entity: &str) -> EngineResult<u64> {
+    let id = u64::try_from(value).map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::DataCorruption,
+            format!("{entity} ID is outside the supported numeric range"),
+            error,
+        )
+    })?;
+    if id == 0 {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!("{entity} IDs must be positive"),
+        ));
+    }
+    Ok(id)
+}
+
+fn decode_shard_key_type(code: i64, table_id: u64) -> EngineResult<ShardKeyType> {
+    match code {
+        INT64_SHARD_KEY_TYPE => Ok(ShardKeyType::Int64),
+        TEXT_SHARD_KEY_TYPE => Ok(ShardKeyType::Text),
+        BINARY_SHARD_KEY_TYPE => Ok(ShardKeyType::Binary),
+        code => Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!("table {table_id} has unsupported shard-key type code {code}"),
+        )),
+    }
 }
 
 fn validate_manifest_configuration(
@@ -1295,6 +1891,8 @@ mod tests {
 
     use super::*;
 
+    type StoredTableMetadataRow = (i64, i64, String, i64, Option<String>, Option<i64>);
+
     fn create_legacy_manifest(connection: &Connection, shards: u16, version: u32) {
         create_empty_legacy_manifest(connection);
         connection
@@ -1329,6 +1927,13 @@ mod tests {
         let transaction = connection.transaction().unwrap();
         create_v2_schema(&transaction, shards).unwrap();
         set_identity(&transaction, V2_SCHEMA_VERSION).unwrap();
+        transaction.commit().unwrap();
+    }
+
+    fn create_v3_manifest(connection: &mut Connection, shards: u16) {
+        let transaction = connection.transaction().unwrap();
+        create_v3_schema(&transaction, shards).unwrap();
+        set_identity(&transaction, V3_SCHEMA_VERSION).unwrap();
         transaction.commit().unwrap();
     }
 
@@ -1387,12 +1992,93 @@ mod tests {
             .unwrap()
     }
 
+    fn schema_catalog_configuration(connection: &Connection) -> (i64, i64, i64, i64) {
+        connection
+            .query_row(
+                "SELECT singleton,
+                        identifier_encoding_version,
+                        schema_generation,
+                        default_database_id
+                 FROM briskdb_schema_catalog",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap()
+    }
+
+    fn logical_databases(connection: &Connection) -> Vec<(i64, String)> {
+        let mut statement = connection
+            .prepare(
+                "SELECT database_id, database_name
+                 FROM briskdb_logical_databases
+                 ORDER BY database_id",
+            )
+            .unwrap();
+        statement
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+    }
+
+    fn table_metadata_rows(connection: &Connection) -> Vec<StoredTableMetadataRow> {
+        let mut statement = connection
+            .prepare(
+                "SELECT table_id,
+                        database_id,
+                        table_name,
+                        placement,
+                        shard_key_column,
+                        shard_key_type
+                 FROM briskdb_tables
+                 ORDER BY database_id, table_name, table_id",
+            )
+            .unwrap();
+        statement
+            .query_map([], |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                ))
+            })
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+    }
+
+    fn insert_valid_table_catalog(connection: &Connection) {
+        connection
+            .execute_batch(
+                "INSERT INTO briskdb_logical_databases VALUES (9, 'tenant');
+                 INSERT INTO briskdb_tables VALUES (3, 1, 'accounts', 1, 'tenant_id', 2);
+                 INSERT INTO briskdb_tables VALUES (8, 1, 'countries', 2, NULL, NULL);
+                 INSERT INTO briskdb_tables VALUES (21, 9, 'audit_log', 3, NULL, NULL);
+                 INSERT INTO briskdb_tables VALUES (34, 9, 'binary_keys', 1, 'key_bytes', 3);
+                 INSERT INTO briskdb_tables VALUES (55, 9, 'counters', 1, 'counter_id', 1);",
+            )
+            .unwrap();
+    }
+
     fn assert_generation_one_catalog(connection: &Connection, shard_count: u16) {
         assert_eq!(
             identity(connection),
             (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
         );
-        assert_eq!(schema_objects(connection).unwrap(), v3_objects());
+        assert_eq!(schema_objects(connection).unwrap(), v4_objects());
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT requires_manifest_version FROM briskdb_metadata",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            i64::from(V4_SCHEMA_VERSION)
+        );
         assert_eq!(
             routing_configuration(connection),
             (
@@ -1426,6 +2112,12 @@ mod tests {
         let largest = assignments.iter().max().unwrap();
         assert!(*smallest > 0);
         assert!(*largest - *smallest <= 1);
+        assert_eq!(schema_catalog_configuration(connection), (1, 1, 0, 1));
+        assert_eq!(
+            logical_databases(connection),
+            [(1, DEFAULT_LOGICAL_DATABASE_NAME.to_owned())]
+        );
+        assert!(table_metadata_rows(connection).is_empty());
         validate_foreign_keys(connection).unwrap();
     }
 
@@ -1515,7 +2207,7 @@ mod tests {
             .unwrap(),
             4
         );
-        assert_eq!(resumed_steps, [(2, 3)]);
+        assert_eq!(resumed_steps, [(2, 3), (3, 4)]);
         assert_generation_one_catalog(&connection, 4);
         assert_eq!(quick_check(&connection), "ok");
     }
@@ -1543,17 +2235,115 @@ mod tests {
     }
 
     #[test]
-    fn fresh_and_v2_upgraded_catalogs_are_identical_for_every_shard_count() {
+    fn valid_logical_database_and_table_metadata_round_trips_all_supported_codes() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        load_or_create(&mut connection, 4).unwrap();
+        insert_valid_table_catalog(&connection);
+
+        let first = load_or_create_catalog(&mut connection, 4).unwrap();
+        let catalog = first.logical();
+        assert_eq!(catalog.identifier_encoding_version(), 1);
+        assert_eq!(catalog.schema_generation(), 0);
+        assert_eq!(catalog.default_database().name(), "default");
+        assert_eq!(catalog.logical_databases().len(), 2);
+        assert_eq!(catalog.tables().len(), 5);
+        assert_eq!(
+            catalog
+                .table("default", "accounts")
+                .unwrap()
+                .unwrap()
+                .id()
+                .get(),
+            3
+        );
+        assert!(matches!(
+            catalog
+                .table("default", "countries")
+                .unwrap()
+                .unwrap()
+                .placement(),
+            TablePlacement::Global
+        ));
+        assert!(matches!(
+            catalog
+                .table("tenant", "audit_log")
+                .unwrap()
+                .unwrap()
+                .placement(),
+            TablePlacement::Catalog
+        ));
+        for (table, expected_type) in [
+            ("binary_keys", ShardKeyType::Binary),
+            ("counters", ShardKeyType::Int64),
+        ] {
+            match catalog.table("tenant", table).unwrap().unwrap().placement() {
+                TablePlacement::Sharded(shard_key) => {
+                    assert_eq!(shard_key.key_type(), expected_type);
+                }
+                placement => panic!("unexpected placement {placement:?}"),
+            }
+        }
+
+        let reopened = load_or_create_catalog(&mut connection, 4).unwrap();
+        assert_eq!(first, reopened);
+        assert_eq!(quick_check(&connection), "ok");
+    }
+
+    #[test]
+    fn logical_catalog_sql_constraints_reject_invalid_rows() {
+        for invalid_insert in [
+            "INSERT INTO briskdb_logical_databases VALUES (2, 'Tenant')",
+            "INSERT INTO briskdb_logical_databases VALUES (2, '9tenant')",
+            "INSERT INTO briskdb_logical_databases VALUES (2, 'briskdb_private')",
+            "INSERT INTO briskdb_logical_databases VALUES (2, 'sqlite_private')",
+            "INSERT INTO briskdb_logical_databases VALUES (2, 'a' || char(0) || 'UPPER')",
+            "INSERT INTO briskdb_tables VALUES (1, 1, 'Widgets', 2, NULL, NULL)",
+            "INSERT INTO briskdb_tables VALUES (1, 1, 'a' || char(0) || 'UPPER', 2, NULL, NULL)",
+            "INSERT INTO briskdb_tables VALUES (1, 1, 'widgets', 4, NULL, NULL)",
+            "INSERT INTO briskdb_tables VALUES (1, 1, 'widgets', 1, NULL, NULL)",
+            "INSERT INTO briskdb_tables VALUES (1, 1, 'widgets', 2, 'tenant_id', 2)",
+            "INSERT INTO briskdb_tables VALUES (1, 1, 'widgets', 1, 'TenantId', 2)",
+            "INSERT INTO briskdb_tables VALUES (1, 1, 'widgets', 1, 'a' || char(0) || 'UPPER', 2)",
+            "INSERT INTO briskdb_tables VALUES (1, 1, 'widgets', 1, 'tenant_id', 4)",
+        ] {
+            let mut connection = Connection::open_in_memory().unwrap();
+            load_or_create(&mut connection, 4).unwrap();
+
+            assert!(
+                connection.execute_batch(invalid_insert).is_err(),
+                "SQLite accepted invalid catalog row: {invalid_insert}"
+            );
+            assert_generation_one_catalog(&connection, 4);
+        }
+
+        let mut foreign_key = Connection::open_in_memory().unwrap();
+        foreign_key
+            .pragma_update(None, "foreign_keys", "ON")
+            .unwrap();
+        load_or_create(&mut foreign_key, 4).unwrap();
+        assert!(
+            foreign_key
+                .execute_batch(
+                    "INSERT INTO briskdb_tables
+                     VALUES (1, 9, 'widgets', 2, NULL, NULL)"
+                )
+                .is_err()
+        );
+        assert_generation_one_catalog(&foreign_key, 4);
+    }
+
+    #[test]
+    fn fresh_v2_and_v3_upgraded_catalogs_are_identical_for_every_shard_count() {
         for shard_count in 2..=64 {
             let mut fresh = Connection::open_in_memory().unwrap();
             let fresh_catalog = load_or_create_catalog(&mut fresh, shard_count).unwrap();
-            assert_eq!(fresh_catalog.shard_count(), shard_count);
+            assert_eq!(fresh_catalog.routing().shard_count(), shard_count);
             assert_generation_one_catalog(&fresh, shard_count);
 
             let mut upgraded = Connection::open_in_memory().unwrap();
             create_v2_manifest(&mut upgraded, shard_count);
             let upgraded_catalog = load_or_create_catalog(&mut upgraded, shard_count).unwrap();
-            assert_eq!(upgraded_catalog.shard_count(), shard_count);
+            assert_eq!(upgraded_catalog.routing().shard_count(), shard_count);
             assert_generation_one_catalog(&upgraded, shard_count);
             assert_eq!(fresh_catalog, upgraded_catalog);
             for key in [
@@ -1564,8 +2354,8 @@ mod tests {
                 "snowman-☃".as_bytes(),
             ] {
                 assert_eq!(
-                    fresh_catalog.shard_for_key(key),
-                    upgraded_catalog.shard_for_key(key)
+                    fresh_catalog.routing().shard_for_key(key),
+                    upgraded_catalog.routing().shard_for_key(key)
                 );
             }
             assert_eq!(
@@ -1574,6 +2364,13 @@ mod tests {
             );
             assert_eq!(physical_shards(&fresh), physical_shards(&upgraded));
             assert_eq!(virtual_buckets(&fresh), virtual_buckets(&upgraded));
+
+            let mut version_three = Connection::open_in_memory().unwrap();
+            create_v3_manifest(&mut version_three, shard_count);
+            let version_three_catalog =
+                load_or_create_catalog(&mut version_three, shard_count).unwrap();
+            assert_eq!(fresh_catalog, version_three_catalog);
+            assert_generation_one_catalog(&version_three, shard_count);
         }
     }
 
@@ -1844,6 +2641,77 @@ mod tests {
     }
 
     #[test]
+    fn logical_catalog_migration_failures_roll_back_to_exact_v3_and_retry() {
+        for failing_phase in [
+            MigrationPhase::AfterSchemaChange,
+            MigrationPhase::AfterVersionStamp,
+        ] {
+            let mut connection = Connection::open_in_memory().unwrap();
+            create_v3_manifest(&mut connection, 5);
+            let routing_before = routing_configuration(&connection);
+            let shards_before = physical_shards(&connection);
+            let buckets_before = virtual_buckets(&connection);
+
+            let error = load_or_create_with_hook(&mut connection, 5, |point| {
+                if point.from == V3_SCHEMA_VERSION && point.phase == failing_phase {
+                    Err(EngineError::new(
+                        EngineErrorKind::Internal,
+                        "injected logical catalog migration failure",
+                    ))
+                } else {
+                    Ok(())
+                }
+            })
+            .unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::Internal);
+            assert_eq!(
+                identity(&connection),
+                (MANIFEST_APPLICATION_ID, i64::from(V3_SCHEMA_VERSION))
+            );
+            assert_eq!(schema_objects(&connection).unwrap(), v3_objects());
+            assert_eq!(routing_configuration(&connection), routing_before);
+            assert_eq!(physical_shards(&connection), shards_before);
+            assert_eq!(virtual_buckets(&connection), buckets_before);
+            assert_eq!(quick_check(&connection), "ok");
+
+            assert_eq!(load_or_create(&mut connection, 5).unwrap(), 5);
+            assert_generation_one_catalog(&connection, 5);
+        }
+    }
+
+    #[test]
+    fn panics_on_both_sides_of_the_logical_catalog_stamp_roll_back_and_retry() {
+        for failing_phase in [
+            MigrationPhase::AfterSchemaChange,
+            MigrationPhase::AfterVersionStamp,
+        ] {
+            let mut connection = Connection::open_in_memory().unwrap();
+            create_v3_manifest(&mut connection, 3);
+            let buckets_before = virtual_buckets(&connection);
+
+            let panic = catch_unwind(AssertUnwindSafe(|| {
+                let _ = load_or_create_with_hook(&mut connection, 3, |point| {
+                    if point.from == V3_SCHEMA_VERSION && point.phase == failing_phase {
+                        panic!("injected logical catalog migration panic");
+                    }
+                    Ok(())
+                });
+            }));
+            assert!(panic.is_err());
+            assert_eq!(
+                identity(&connection),
+                (MANIFEST_APPLICATION_ID, i64::from(V3_SCHEMA_VERSION))
+            );
+            assert_eq!(schema_objects(&connection).unwrap(), v3_objects());
+            assert_eq!(virtual_buckets(&connection), buckets_before);
+            assert_eq!(quick_check(&connection), "ok");
+
+            assert_eq!(load_or_create(&mut connection, 3).unwrap(), 3);
+            assert_generation_one_catalog(&connection, 3);
+        }
+    }
+
+    #[test]
     fn panic_during_fresh_initialization_rolls_back_and_retry_succeeds() {
         let mut connection = Connection::open_in_memory().unwrap();
 
@@ -1892,6 +2760,46 @@ mod tests {
         let observer = Connection::open(&path).unwrap();
         assert_eq!(identity(&observer), (MANIFEST_APPLICATION_ID, 2));
         assert_eq!(schema_objects(&observer).unwrap(), v2_objects());
+        resume_tx.send(()).unwrap();
+        worker.join().unwrap();
+
+        assert_generation_one_catalog(&observer, 4);
+    }
+
+    #[test]
+    fn an_observer_sees_exact_v3_until_the_logical_catalog_commits() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("manifest.sqlite");
+        let mut connection = Connection::open(&path).unwrap();
+        create_v3_manifest(&mut connection, 4);
+        let buckets_before = virtual_buckets(&connection);
+        drop(connection);
+
+        let (paused_tx, paused_rx) = mpsc::channel();
+        let (resume_tx, resume_rx) = mpsc::channel();
+        let migration_path = path.clone();
+        let worker = thread::spawn(move || {
+            let mut connection = Connection::open(migration_path).unwrap();
+            load_or_create_with_hook(&mut connection, 4, |point| {
+                if point.from == V3_SCHEMA_VERSION
+                    && point.phase == MigrationPhase::AfterVersionStamp
+                {
+                    paused_tx.send(()).unwrap();
+                    resume_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+                }
+                Ok(())
+            })
+            .unwrap();
+        });
+
+        paused_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        let observer = Connection::open(&path).unwrap();
+        assert_eq!(
+            identity(&observer),
+            (MANIFEST_APPLICATION_ID, i64::from(V3_SCHEMA_VERSION))
+        );
+        assert_eq!(schema_objects(&observer).unwrap(), v3_objects());
+        assert_eq!(virtual_buckets(&observer), buckets_before);
         resume_tx.send(()).unwrap();
         worker.join().unwrap();
 
@@ -1963,6 +2871,65 @@ mod tests {
     }
 
     #[test]
+    fn concurrent_version_three_openers_share_one_complete_logical_catalog() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("manifest.sqlite");
+        let mut connection = Connection::open(&path).unwrap();
+        create_v3_manifest(&mut connection, 5);
+        drop(connection);
+
+        let barrier = Arc::new(Barrier::new(4));
+        let workers = (0..4)
+            .map(|_| {
+                let path = path.clone();
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    let mut connection = Connection::open(path).unwrap();
+                    connection
+                        .busy_timeout(std::time::Duration::from_secs(5))
+                        .unwrap();
+                    barrier.wait();
+                    load_or_create_catalog(&mut connection, 5)
+                })
+            })
+            .collect::<Vec<_>>();
+        let snapshots = workers
+            .into_iter()
+            .map(|worker| worker.join().unwrap().unwrap())
+            .collect::<Vec<_>>();
+        assert!(snapshots.windows(2).all(|pair| pair[0] == pair[1]));
+        assert_eq!(snapshots[0].logical().default_database().name(), "default");
+        assert!(snapshots[0].logical().tables().is_empty());
+
+        let connection = Connection::open(path).unwrap();
+        assert_generation_one_catalog(&connection, 5);
+        assert_eq!(quick_check(&connection), "ok");
+    }
+
+    #[test]
+    fn v3_upgrade_lock_contention_is_retryable_and_leaves_v3_unchanged() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("manifest.sqlite");
+        let mut owner = Connection::open(&path).unwrap();
+        create_v3_manifest(&mut owner, 4);
+        owner.execute_batch("BEGIN IMMEDIATE;").unwrap();
+
+        let mut contender = Connection::open(&path).unwrap();
+        contender.busy_timeout(Duration::ZERO).unwrap();
+        let error = load_or_create(&mut contender, 4).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Busy);
+        owner.execute_batch("ROLLBACK;").unwrap();
+
+        assert_eq!(
+            identity(&contender),
+            (MANIFEST_APPLICATION_ID, i64::from(V3_SCHEMA_VERSION))
+        );
+        assert_eq!(schema_objects(&contender).unwrap(), v3_objects());
+        assert_eq!(load_or_create(&mut contender, 4).unwrap(), 4);
+        assert_generation_one_catalog(&contender, 4);
+    }
+
+    #[test]
     fn concurrent_initializers_choose_exactly_one_shard_count() {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("manifest.sqlite");
@@ -2023,7 +2990,7 @@ mod tests {
     }
 
     #[test]
-    fn version_two_reader_rejects_version_three_without_mutating_it() {
+    fn version_two_reader_rejects_current_manifest_without_mutating_it() {
         const OLD_MIGRATIONS: &[Migration] = &[Migration {
             from: LEGACY_SCHEMA_VERSION,
             to: V2_SCHEMA_VERSION,
@@ -2045,6 +3012,42 @@ mod tests {
         assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
         assert_generation_one_catalog(&connection, 4);
         assert_eq!(virtual_buckets(&connection), before);
+    }
+
+    #[test]
+    fn version_three_reader_rejects_version_four_without_mutating_it() {
+        const OLD_MIGRATIONS: &[Migration] = &[
+            Migration {
+                from: LEGACY_SCHEMA_VERSION,
+                to: V2_SCHEMA_VERSION,
+                name: "typed_manifest_and_downgrade_fence",
+                apply: migrate_v1_to_v2,
+                validate: validate_v2,
+            },
+            Migration {
+                from: V2_SCHEMA_VERSION,
+                to: V3_SCHEMA_VERSION,
+                name: "durable_shard_catalog",
+                apply: migrate_v2_to_v3,
+                validate: validate_v3,
+            },
+        ];
+        const OLD_PLAN: MigrationPlan<'static> = MigrationPlan {
+            current_version: V3_SCHEMA_VERSION,
+            migrations: OLD_MIGRATIONS,
+            initialize_current: create_v3_schema,
+        };
+
+        let mut connection = Connection::open_in_memory().unwrap();
+        load_or_create(&mut connection, 4).unwrap();
+        let objects = schema_objects(&connection).unwrap();
+        let databases = logical_databases(&connection);
+        let error = inspect_with_plan(&connection, 4, OLD_PLAN).unwrap_err();
+
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert_eq!(schema_objects(&connection).unwrap(), objects);
+        assert_eq!(logical_databases(&connection), databases);
+        assert_generation_one_catalog(&connection, 4);
     }
 
     #[test]
@@ -2090,7 +3093,7 @@ mod tests {
         for mutation in [
             "DELETE FROM briskdb_metadata",
             "DELETE FROM briskdb_manifest",
-            "INSERT INTO briskdb_metadata VALUES (3)",
+            "INSERT INTO briskdb_metadata VALUES (4)",
             "DELETE FROM briskdb_routing",
             "DELETE FROM briskdb_virtual_buckets WHERE bucket_id = 4095",
             "DELETE FROM briskdb_physical_shards WHERE shard_id = 3",
@@ -2191,6 +3194,142 @@ mod tests {
     }
 
     #[test]
+    fn rejects_invalid_logical_catalog_values_when_sql_checks_are_bypassed() {
+        for mutation in [
+            "UPDATE briskdb_schema_catalog SET singleton = 2",
+            "UPDATE briskdb_schema_catalog SET identifier_encoding_version = 2",
+            "UPDATE briskdb_schema_catalog SET schema_generation = 1",
+            "UPDATE briskdb_schema_catalog SET default_database_id = 2",
+            "DELETE FROM briskdb_logical_databases WHERE database_id = 1",
+            "UPDATE briskdb_logical_databases SET database_name = 'Default'",
+            "UPDATE briskdb_logical_databases SET database_name = 'a' || char(0) || 'UPPER'",
+            "UPDATE briskdb_logical_databases SET database_name = 'briskdb_internal'",
+            "INSERT INTO briskdb_logical_databases VALUES (0, 'zero')",
+            "INSERT INTO briskdb_logical_databases VALUES (2, CAST(x'80' AS TEXT))",
+            "INSERT INTO briskdb_tables VALUES (0, 1, 'widgets', 2, NULL, NULL)",
+            "INSERT INTO briskdb_tables VALUES (1, 9, 'widgets', 2, NULL, NULL)",
+            "INSERT INTO briskdb_tables VALUES (1, 1, 'Widgets', 2, NULL, NULL)",
+            "INSERT INTO briskdb_tables VALUES (1, 1, 'a' || char(0) || 'UPPER', 2, NULL, NULL)",
+            "INSERT INTO briskdb_tables VALUES (1, 1, 'widgets', 4, NULL, NULL)",
+            "INSERT INTO briskdb_tables VALUES (1, 1, 'widgets', 1, NULL, NULL)",
+            "INSERT INTO briskdb_tables VALUES (1, 1, 'widgets', 2, 'tenant_id', 2)",
+            "INSERT INTO briskdb_tables VALUES (1, 1, 'widgets', 1, 'TenantId', 2)",
+            "INSERT INTO briskdb_tables VALUES (1, 1, 'widgets', 1, 'a' || char(0) || 'UPPER', 2)",
+            "INSERT INTO briskdb_tables VALUES (1, 1, 'widgets', 1, 'tenant_id', 4)",
+            "INSERT INTO briskdb_tables VALUES (1, 1, CAST(x'80' AS TEXT), 2, NULL, NULL)",
+        ] {
+            let mut connection = Connection::open_in_memory().unwrap();
+            load_or_create(&mut connection, 4).unwrap();
+            connection
+                .execute_batch(
+                    "PRAGMA foreign_keys = OFF;
+                     PRAGMA ignore_check_constraints = ON;",
+                )
+                .unwrap();
+            connection.execute_batch(mutation).unwrap();
+            connection
+                .execute_batch("PRAGMA ignore_check_constraints = OFF;")
+                .unwrap();
+
+            let error = load_or_create(&mut connection, 4).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::DataCorruption, "{mutation}");
+        }
+    }
+
+    #[test]
+    fn logical_database_and_table_catalog_limits_are_exact_and_bounded() {
+        let mut databases = Connection::open_in_memory().unwrap();
+        load_or_create(&mut databases, 4).unwrap();
+        {
+            let transaction = databases.transaction().unwrap();
+            let mut insert = transaction
+                .prepare(
+                    "INSERT INTO briskdb_logical_databases (database_id, database_name)
+                     VALUES (?1, ?2)",
+                )
+                .unwrap();
+            for id in 2..=MAX_LOGICAL_DATABASES {
+                insert
+                    .execute(rusqlite::params![
+                        i64::try_from(id).unwrap(),
+                        format!("db_{id:02}")
+                    ])
+                    .unwrap();
+            }
+            drop(insert);
+            transaction.commit().unwrap();
+        }
+        assert_eq!(
+            load_or_create_catalog(&mut databases, 4)
+                .unwrap()
+                .logical()
+                .logical_databases()
+                .len(),
+            MAX_LOGICAL_DATABASES
+        );
+        databases
+            .execute(
+                "INSERT INTO briskdb_logical_databases (database_id, database_name)
+                 VALUES (?1, ?2)",
+                rusqlite::params![
+                    i64::try_from(MAX_LOGICAL_DATABASES + 1).unwrap(),
+                    "one_too_many"
+                ],
+            )
+            .unwrap();
+        assert_eq!(
+            load_or_create(&mut databases, 4).unwrap_err().kind(),
+            EngineErrorKind::DataCorruption
+        );
+
+        let mut tables = Connection::open_in_memory().unwrap();
+        load_or_create(&mut tables, 4).unwrap();
+        {
+            let transaction = tables.transaction().unwrap();
+            let mut insert = transaction
+                .prepare(
+                    "INSERT INTO briskdb_tables (
+                        table_id,
+                        database_id,
+                        table_name,
+                        placement,
+                        shard_key_column,
+                        shard_key_type
+                     ) VALUES (?1, 1, ?2, 2, NULL, NULL)",
+                )
+                .unwrap();
+            for id in 1..=MAX_TABLES {
+                insert
+                    .execute(rusqlite::params![
+                        i64::try_from(id).unwrap(),
+                        format!("table_{id:04}")
+                    ])
+                    .unwrap();
+            }
+            drop(insert);
+            transaction.commit().unwrap();
+        }
+        assert_eq!(
+            load_or_create_catalog(&mut tables, 4)
+                .unwrap()
+                .logical()
+                .tables()
+                .len(),
+            MAX_TABLES
+        );
+        tables
+            .execute(
+                "INSERT INTO briskdb_tables VALUES (?1, 1, ?2, 2, NULL, NULL)",
+                rusqlite::params![i64::try_from(MAX_TABLES + 1).unwrap(), "one_too_many"],
+            )
+            .unwrap();
+        assert_eq!(
+            load_or_create(&mut tables, 4).unwrap_err().kind(),
+            EngineErrorKind::DataCorruption
+        );
+    }
+
+    #[test]
     fn rejects_altered_catalog_table_definitions() {
         for mutation in [
             "DROP TABLE briskdb_routing;
@@ -2211,6 +3350,27 @@ mod tests {
              CREATE TABLE briskdb_physical_shards (
                 shard_id INTEGER PRIMARY KEY,
                 lifecycle_state TEXT NOT NULL
+             ) STRICT;",
+            "DROP TABLE briskdb_logical_databases;
+             CREATE TABLE briskdb_logical_databases (
+                database_id INTEGER PRIMARY KEY,
+                database_name TEXT NOT NULL UNIQUE
+             ) STRICT;",
+            "DROP TABLE briskdb_schema_catalog;
+             CREATE TABLE briskdb_schema_catalog (
+                singleton INTEGER PRIMARY KEY,
+                identifier_encoding_version INTEGER NOT NULL,
+                schema_generation INTEGER NOT NULL,
+                default_database_id INTEGER NOT NULL
+             ) STRICT;",
+            "DROP TABLE briskdb_tables;
+             CREATE TABLE briskdb_tables (
+                table_id INTEGER PRIMARY KEY,
+                database_id INTEGER NOT NULL,
+                table_name TEXT NOT NULL,
+                placement INTEGER NOT NULL,
+                shard_key_column TEXT,
+                shard_key_type INTEGER
              ) STRICT;",
         ] {
             let mut connection = Connection::open_in_memory().unwrap();

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -21,7 +21,7 @@ use rusqlite::{
 
 pub use crate::core::Database;
 use crate::{
-    core::{EngineError, EngineErrorKind, EngineResult, RoutingCatalog},
+    core::{Catalog, CatalogSnapshot, EngineError, EngineErrorKind, EngineResult},
     sqlite_error,
 };
 
@@ -30,7 +30,7 @@ pub(crate) const CONNECTION_BUSY_TIMEOUT: std::time::Duration = std::time::Durat
 #[derive(Debug, Clone)]
 pub(crate) struct Storage {
     root: PathBuf,
-    catalog: Arc<RoutingCatalog>,
+    catalog: Arc<CatalogSnapshot>,
 }
 
 impl Storage {
@@ -66,11 +66,15 @@ impl Storage {
     }
 
     pub(crate) fn shard_count(&self) -> u16 {
-        self.catalog.shard_count()
+        self.catalog.routing().shard_count()
     }
 
     pub(crate) fn shard_for_key(&self, key: &[u8]) -> u16 {
-        self.catalog.shard_for_key(key)
+        self.catalog.routing().shard_for_key(key)
+    }
+
+    pub(crate) fn logical_catalog(&self) -> &Catalog {
+        self.catalog.logical()
     }
 
     fn shard_path(&self, shard: u16) -> PathBuf {

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -1,5 +1,7 @@
 use std::{
+    path::Path,
     sync::Arc,
+    thread,
     time::{Duration, Instant},
 };
 
@@ -9,6 +11,85 @@ use briskdb::{
     protocol::{error, http},
     server, storage,
 };
+
+fn insert_catalog_fixture(root: &Path) {
+    let manifest = rusqlite::Connection::open(root.join("manifest.sqlite")).unwrap();
+    manifest
+        .execute_batch(
+            "PRAGMA foreign_keys = ON;
+             BEGIN IMMEDIATE;
+             INSERT INTO briskdb_logical_databases (database_id, database_name)
+             VALUES (9, 'tenant');
+             INSERT INTO briskdb_tables (
+                table_id,
+                database_id,
+                table_name,
+                placement,
+                shard_key_column,
+                shard_key_type
+             ) VALUES
+                (20, 1, 'countries', 2, NULL, NULL),
+                (30, 9, 'accounts', 1, 'tenant_id', 2),
+                (40, 9, 'internal_catalog', 3, NULL, NULL);
+             COMMIT;",
+        )
+        .unwrap();
+}
+
+fn assert_catalog_fixture(catalog: &core::Catalog) {
+    assert_eq!(catalog.identifier_encoding_version(), 1);
+    assert_eq!(catalog.schema_generation(), 0);
+    assert_eq!(catalog.default_database().id().get(), 1);
+    assert_eq!(catalog.default_database().name(), "default");
+    assert_eq!(catalog.logical_databases().len(), 2);
+    assert_eq!(catalog.tables().len(), 3);
+
+    let tenant = catalog.database("tenant").unwrap().unwrap();
+    assert_eq!(tenant.id().get(), 9);
+    assert_eq!(tenant.id().to_string(), "9");
+    assert_eq!(catalog.database_by_id(tenant.id()), Some(tenant));
+
+    let countries = catalog.table("default", "countries").unwrap().unwrap();
+    assert_eq!(countries.id().get(), 20);
+    assert_eq!(countries.id().to_string(), "20");
+    assert_eq!(countries.database_id().get(), 1);
+    assert!(matches!(
+        countries.placement(),
+        core::TablePlacement::Global
+    ));
+    assert_eq!(
+        catalog.table_by_id(core::TableId::new(countries.id().get()).unwrap()),
+        Some(countries)
+    );
+
+    let accounts = catalog.table("tenant", "accounts").unwrap().unwrap();
+    assert_eq!(accounts.id().get(), 30);
+    assert_eq!(accounts.database_id(), tenant.id());
+    match accounts.placement() {
+        core::TablePlacement::Sharded(shard_key) => {
+            assert_eq!(shard_key.column(), "tenant_id");
+            assert_eq!(shard_key.key_type(), core::ShardKeyType::Text);
+        }
+        placement => panic!("unexpected accounts placement: {placement:?}"),
+    }
+
+    assert!(matches!(
+        catalog
+            .table("tenant", "internal_catalog")
+            .unwrap()
+            .unwrap()
+            .placement(),
+        core::TablePlacement::Catalog
+    ));
+    assert_eq!(
+        catalog
+            .tables()
+            .iter()
+            .map(|table| (table.database_id().get(), table.name()))
+            .collect::<Vec<_>>(),
+        [(1, "countries"), (9, "accounts"), (9, "internal_catalog")]
+    );
+}
 
 #[test]
 fn legacy_and_explicit_module_paths_are_both_available() {
@@ -58,6 +139,60 @@ fn legacy_and_explicit_module_paths_are_both_available() {
         error::mysql_error(core::EngineErrorKind::UniqueViolation).error_number,
         1062
     );
+}
+
+#[test]
+fn logical_catalog_types_and_access_are_public_and_protocol_neutral() {
+    fn assert_public_metadata<T: Clone + Send + Sync + 'static>() {}
+
+    assert_public_metadata::<core::Catalog>();
+    assert_public_metadata::<core::LogicalDatabaseId>();
+    assert_public_metadata::<core::LogicalDatabaseMetadata>();
+    assert_public_metadata::<core::TableId>();
+    assert_public_metadata::<core::TableMetadata>();
+    assert_public_metadata::<core::TablePlacement>();
+    assert_public_metadata::<core::ShardKeyMetadata>();
+    assert_public_metadata::<core::ShardKeyType>();
+
+    let _signed = core::ShardKeyType::Int64;
+    let _text = core::ShardKeyType::Text;
+    let _binary = core::ShardKeyType::Binary;
+    let _global = core::TablePlacement::Global;
+    let _catalog = core::TablePlacement::Catalog;
+
+    let temp = tempfile::tempdir().unwrap();
+    let database = Arc::new(core::Database::open(temp.path(), 4).unwrap());
+    let catalog: &core::Catalog = database.catalog();
+    let default: &core::LogicalDatabaseMetadata = catalog.default_database();
+    let default_id: core::LogicalDatabaseId = default.id();
+    let reconstructed_default = core::LogicalDatabaseId::new(default_id.get()).unwrap();
+
+    assert_eq!(catalog.identifier_encoding_version(), 1);
+    assert_eq!(catalog.schema_generation(), 0);
+    assert_eq!(default_id.get(), 1);
+    assert_eq!(default_id.to_string(), "1");
+    assert_eq!(catalog.database_by_id(reconstructed_default), Some(default));
+    assert_eq!(default.name(), "default");
+    assert_eq!(catalog.logical_databases(), std::slice::from_ref(default));
+    assert!(catalog.tables().is_empty());
+    assert_eq!(catalog.database_by_id(default_id), Some(default));
+    assert_eq!(catalog.database("missing").unwrap(), None);
+    assert_eq!(catalog.table("default", "missing").unwrap(), None);
+    assert_eq!(
+        core::LogicalDatabaseId::new(0).unwrap_err().kind(),
+        core::EngineErrorKind::InvalidArgument
+    );
+    assert_eq!(
+        core::TableId::new(0).unwrap_err().kind(),
+        core::EngineErrorKind::InvalidArgument
+    );
+    assert_eq!(
+        catalog.database("NotCanonical").unwrap_err().kind(),
+        core::EngineErrorKind::InvalidArgument
+    );
+
+    let engine = core::Engine::from_database(Arc::clone(&database));
+    assert!(std::ptr::eq(engine.catalog(), database.catalog()));
 }
 
 #[test]
@@ -199,4 +334,142 @@ async fn default_and_wrapped_database_engine_constructors_remain_available() {
     assert_eq!(status.max_blocking_workers(), 12);
     assert_eq!(status.connections_per_shard(), 3);
     assert_eq!(status.queue_capacity_per_shard(), 11);
+}
+
+#[test]
+fn catalog_snapshot_is_immutable_and_reopen_observes_only_valid_commits() {
+    let temp = tempfile::tempdir().unwrap();
+    let keys: [&[u8]; 5] = [
+        b"",
+        b"customer-42",
+        b"a\0b",
+        &[0, 1, 2, 0xff],
+        "snowman-☃".as_bytes(),
+    ];
+    let database = core::Database::open(temp.path(), 10).unwrap();
+    let expected_routes = keys.map(|key| database.shard_for_key(key));
+    assert_eq!(database.catalog().logical_databases().len(), 1);
+    assert!(database.catalog().tables().is_empty());
+
+    insert_catalog_fixture(temp.path());
+
+    assert_eq!(database.catalog().logical_databases().len(), 1);
+    assert!(database.catalog().tables().is_empty());
+    assert_eq!(database.catalog().database("tenant").unwrap(), None);
+    assert_eq!(keys.map(|key| database.shard_for_key(key)), expected_routes);
+
+    let reopened = core::Database::open(temp.path(), 10).unwrap();
+    assert_catalog_fixture(reopened.catalog());
+    assert_eq!(keys.map(|key| reopened.shard_for_key(key)), expected_routes);
+
+    let manifest = rusqlite::Connection::open(temp.path().join("manifest.sqlite")).unwrap();
+    manifest
+        .execute_batch(
+            "PRAGMA ignore_check_constraints = ON;
+             UPDATE briskdb_tables SET placement = 99 WHERE table_id = 30;
+             PRAGMA ignore_check_constraints = OFF;",
+        )
+        .unwrap();
+    drop(manifest);
+
+    assert_catalog_fixture(reopened.catalog());
+    assert_eq!(keys.map(|key| reopened.shard_for_key(key)), expected_routes);
+    let error = core::Database::open(temp.path(), 10).unwrap_err();
+    assert_eq!(error.kind(), core::EngineErrorKind::DataCorruption);
+
+    assert_eq!(database.catalog().logical_databases().len(), 1);
+    assert!(database.catalog().tables().is_empty());
+    assert_eq!(keys.map(|key| database.shard_for_key(key)), expected_routes);
+}
+
+#[test]
+fn database_and_engine_catalog_reads_are_deterministic_in_parallel() {
+    let temp = tempfile::tempdir().unwrap();
+    drop(core::Database::open(temp.path(), 6).unwrap());
+    insert_catalog_fixture(temp.path());
+
+    let database = Arc::new(core::Database::open(temp.path(), 6).unwrap());
+    let engine = core::Engine::from_database(Arc::clone(&database));
+    assert!(std::ptr::eq(database.catalog(), engine.catalog()));
+    assert_catalog_fixture(database.catalog());
+
+    let expected_catalog = Arc::new(database.catalog().clone());
+    let expected_shard = database.shard_for_key(b"parallel-catalog");
+    let workers = (0..8)
+        .map(|_| {
+            let database = Arc::clone(&database);
+            let engine = engine.clone();
+            let expected_catalog = Arc::clone(&expected_catalog);
+            thread::spawn(move || {
+                for _ in 0..2_000 {
+                    assert_eq!(database.catalog(), expected_catalog.as_ref());
+                    assert_eq!(engine.catalog(), expected_catalog.as_ref());
+                    assert_eq!(
+                        database
+                            .catalog()
+                            .table("tenant", "accounts")
+                            .unwrap()
+                            .unwrap()
+                            .id()
+                            .get(),
+                        30
+                    );
+                    assert_eq!(database.shard_for_key(b"parallel-catalog"), expected_shard);
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+
+    for worker in workers {
+        worker.join().unwrap();
+    }
+}
+
+#[test]
+fn broadcast_created_shard_tables_are_not_inferred_into_the_catalog() {
+    let temp = tempfile::tempdir().unwrap();
+    let database = core::Database::open(temp.path(), 4).unwrap();
+    database
+        .broadcast(
+            "CREATE TABLE physical_widgets (
+                id TEXT PRIMARY KEY,
+                tenant_id TEXT NOT NULL
+             );",
+        )
+        .unwrap();
+    database
+        .execute(
+            "tenant-1",
+            "INSERT INTO physical_widgets (id, tenant_id) VALUES (?1, ?2)",
+            &[core::Value::from("widget-1"), core::Value::from("tenant-1")],
+        )
+        .unwrap();
+
+    assert!(database.catalog().tables().is_empty());
+    assert_eq!(
+        database
+            .catalog()
+            .table("default", "physical_widgets")
+            .unwrap(),
+        None
+    );
+    drop(database);
+
+    let reopened = core::Database::open(temp.path(), 4).unwrap();
+    assert!(reopened.catalog().tables().is_empty());
+    assert_eq!(
+        reopened
+            .catalog()
+            .table("default", "physical_widgets")
+            .unwrap(),
+        None
+    );
+    let rows = reopened
+        .query(
+            "tenant-1",
+            "SELECT id, tenant_id FROM physical_widgets WHERE id = ?1",
+            &[core::Value::from("widget-1")],
+        )
+        .unwrap();
+    assert_eq!(rows.rows().len(), 1);
 }


### PR DESCRIPTION
## Summary

- advance `manifest.sqlite` to v4 with logical databases, schema generation, and bounded table metadata for sharded/global/catalog placement and typed shard keys
- load routing and logical metadata from one validated transaction into an immutable snapshot exposed through protocol-neutral `Database::catalog()` and `Engine::catalog()` APIs
- seed stable default database ID 1/name `default`, preserve all v1-v3 routes, and deliberately avoid inferring or adopting existing physical SQLite tables
- freeze lowercase-ASCII identifier v1 and numeric metadata codes, including fail-closed schema/corruption validation and a v4 downgrade fence
- document the storage, compatibility, recovery, and advisory/read-only behavior; mark roadmap issue #15 complete

## Tests

- [x] Unit tests were added or updated for behavior-changing code.
- [x] Boundary/integration tests were added where the change crosses SQLite,
      HTTP, protocol, filesystem, or process boundaries.
- [x] A regression test accompanies each bug fix.
- [ ] No automated test is applicable; the explanation is included above.
- [x] `cargo fmt --check` passes.
- [x] `cargo test` passes.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes.

Additional verification:

- `cargo test --locked --all-targets --all-features`
- `cargo test --locked --doc --all-features`
- `cargo +1.85.0 test --locked --all-targets --all-features`
- `cargo +1.85.0 test --locked --doc --all-features`
- focused 36-test manifest migration/corruption/concurrency/recovery suite
- 8 public API/integration tests, including immutable reopen behavior, parallel reads, stable-ID reconstruction, NUL rejection, unchanged routing, and no physical-table inference
- two independent final reviews clear after fixes

## Compatibility and operations

- [x] Public behavior and compatibility documentation were updated where needed.
- [x] Storage-format, migration, security, and recovery effects were considered.

The v3-to-v4 migration is atomic within the manifest, stamps the version last, and rolls back exactly on injected errors or panics before and after stamping. Table metadata remains read-only and advisory until the schema-journal roadmap work; routed SQL and broadcast behavior are unchanged.

Closes #15
