### PR TITLE
feat(storage): validate physical shard layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ minimum supported Rust version (MSRV) and the latest stable toolchain.
 - Protocol-neutral typed values, ordered columns, positional rows, and results
 - A transactionally versioned `manifest.sqlite` with durable 4,096-bucket
   routing plus logical-database and table metadata
-- One WAL-enabled SQLite database per shard
+- Identity-bound, WAL-enabled SQLite shard files that are never silently
+  recreated after initialization
 - Routed execute and query endpoints
 - A broadcast endpoint for initializing schema on every shard
 - Full SQLite synchronous durability and a five-second busy timeout
@@ -155,6 +156,12 @@ are retired rather than reused by another session. Clean read handles can be
 shared for ordinary SQL, but a deny-only authorizer probe moves connection-local
 SQL such as `PRAGMA data_version`, plus any cross-owner write, to a fresh
 disposable handle before execution.
+BriskDB-owned shard metadata and storage-control PRAGMA mutations, including
+`application_id`, `user_version`, `journal_mode`, `schema_version`, and
+`writable_schema`, are denied through every client SQL surface rather than
+allowed to invalidate the storage layout. `ALTER TABLE` is currently denied as
+well because SQLite's authorizer does not expose a rename destination, which
+would otherwise let a client enter the reserved `briskdb_*` namespace.
 A handle that performed an ordinary write may return to the same session,
 preserving SQLite write counters, but is replaced before a different session can
 observe `last_insert_rowid()`, `changes()`, or `total_changes()`. Those functions
@@ -169,20 +176,33 @@ Queries have finite row and logical-byte budgets, account values before cloning
 payloads, and return no partial result on `LimitExceeded`.
 Broadcast changes and future scatter operations are not atomic across shard
 files. The initial shard count is immutable, so resharding will require an
-explicit migration workflow. Opening upgrades exact version-1, version-2, and
-version-3 manifests to version 4 through one transaction per numbered step.
+explicit migration workflow. Opening upgrades exact version-1 through
+version-4 manifests to version 5 through ordered, resumable steps.
 Version 3 introduced the versioned, generation-stamped 4,096-bucket routing
 map. Version 4 adds schema generation 0 and immutable logical metadata with
 default database ID 1 named `default`; identifier encoding version 1 accepts
 only canonical lowercase ASCII names. Table rows can describe sharded, global,
 or catalog placement and a sharded table's `Int64`, text, or binary key.
 
-The v3-to-v4 step is atomic within `manifest.sqlite` and installs a version-4
-downgrade fence. It deliberately leaves the table catalog empty: it neither
-infers nor adopts tables already present in physical shard files. The public
-catalog returned by `Database::catalog()` and `Engine::catalog()` is an
-immutable, read-only advisory view. Current execute, query, broadcast, routing,
-shard files, SQLite behavior, HTTP shapes, and wire contracts are unchanged.
+Version 5 binds the manifest and every shard to one random 16-byte layout ID.
+Its `Creating`, `Adopting`, and `Ready` states make fresh provisioning and the
+one-time adoption of exact legacy version-4 shard headers resumable without
+claiming cross-file atomicity. A ready layout opens every shard read-write with
+no-create and no-follow semantics and validates its physical ID, `BRSH`
+application ID, schema-generation user version, metadata, and existing WAL
+mode at startup and whenever another connection is opened. Missing, swapped,
+foreign, non-WAL, stale-generation, and unexpected canonical shard files fail
+closed, as do shards cloned into the wrong slot or from another layout. They are
+not repaired or recreated. The layout ID is an accidental wrong-file guard, not
+authentication or tamper protection.
+
+The v3-to-v4 step deliberately leaves the table catalog empty: it neither
+infers nor adopts tables already present in physical shard files. The v4-to-v5
+upgrade retains every validated v4 catalog row, while shard adoption preserves
+physical application tables and their data. The public catalog returned by
+`Database::catalog()` and `Engine::catalog()` remains an immutable, read-only
+advisory view. Current execute, query, broadcast, routing, SQLite behavior,
+HTTP shapes, and wire contracts are otherwise unchanged.
 Startup loads routing and logical metadata in one validated immutable snapshot;
 runtime routing continues to hash the exact key bytes, derive a virtual bucket,
 and read its persisted physical-shard assignment. The generation-1 ranges

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -188,7 +188,7 @@ existing tests pass through the shared engine.
   vectors so upgrades cannot silently move keys.
 - [x] Add logical databases and table metadata, including table placement and
   shard-key column/type.
-- [ ] Validate at startup that every shard is present, uses WAL, has the expected
+- [x] Validate at startup that every shard is present, uses WAL, has the expected
   application ID/user version, and matches the cataloged schema generation.
 - [ ] Implement a crash-resumable schema migration journal instead of the
   current best-effort broadcast endpoint.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -90,21 +90,47 @@ records a stable positive ID, owning database, name, and one of sharded,
 global, or catalog placement; only a sharded table also records one `Int64`,
 text, or binary shard-key column.
 
-Each version retains an intentionally incompatible `briskdb_metadata`
-definition and row as a downgrade fence. The v3-to-v4 migration replaces that
-fence, creates the logical tables and initial rows, validates the complete v4
-destination, and stamps version 4 in the same manifest transaction. Failure
-rolls the step back to the exact committed v3 state; a v3 binary rejects a
-committed v4 manifest rather than interpreting it.
+Version 5 adds physical-layout identity and recovery state. The manifest's
+`briskdb_shard_layout` singleton stores one random 16-byte layout ID, the
+expected `BRSH` shard application ID, metadata encoding version 1, and state
+code 1 (`Creating`), 2 (`Adopting`), or 3 (`Ready`). Every current shard has
+the same layout ID in its exact BriskDB-owned metadata row, its cataloged
+physical shard ID, `application_id = BRSH`, and `user_version` equal to the
+cataloged application-schema generation, currently 0. The layout ID catches
+accidental copies, swaps, and cross-layout placement; it is not a secret,
+checksum, or security boundary.
 
-Startup acquires `BEGIN IMMEDIATE` before making any migration decision. Each
-registered numbered step rewrites schema/data, stamps and reads back its target
-identity/version, validates the destination, and commits in its own transaction.
-Concurrent openers therefore serialize and re-evaluate committed state. A
-failed or interrupted step rolls back to the previous complete version and can
-be retried. Persistent WAL configuration and shard creation occur only after a
-compatible current manifest is committed, so rejecting a foreign or future
-manifest does not rewrite its journal mode or touch shard files.
+Each manifest version retains an intentionally incompatible
+`briskdb_metadata` definition and row as a downgrade fence. The v3-to-v4
+migration remains manifest-atomic. The v4-to-v5 step first validates the v4
+source and commits state `Adopting`, fencing older binaries before any shard is
+changed. Fresh initialization commits `Creating` only for an otherwise empty
+layout. Cross-file work then proceeds one shard at a time and a final manifest
+transaction moves to `Ready` only after strict revalidation of the complete
+layout. A failure or panic leaves `Creating` or `Adopting` durable, so the next
+open resumes instead of guessing whether a missing or partly stamped file is
+safe.
+
+Startup acquires `BEGIN IMMEDIATE` before making a manifest migration or layout
+state decision. Numbered manifest-only steps rewrite schema/data, stamp and read
+back their target identity/version, validate the destination, and commit in
+their own transaction. After those steps commit, layout reconciliation acquires
+a new immediate manifest transaction, re-reads and validates the layout state
+under that write lock, and holds the lock through independently durable
+per-shard work and `Ready` publication. Concurrent openers therefore serialize:
+a lagging opener re-reads `Ready` and strictly validates instead of provisioning
+from a stale `Creating` observation. Only a locked, durable `Creating` state
+permits missing canonical shard files to be created and WAL to be enabled.
+
+`Adopting` recognizes only existing legacy shard files with exact zero
+application-ID/user-version headers and an existing WAL mode. It writes current
+identity metadata without changing application tables or rows. `Ready` and all
+runtime connection opens use read-write, no-create, no-follow SQLite flags and
+require the exact path, layout ID, shard ID, application ID, metadata encoding,
+schema generation, and WAL mode. Missing, extra canonical, foreign, non-WAL,
+and wrong-generation files fail closed, as do swapped files and files cloned
+into a wrong slot or layout. WAL and shared-memory sidecars are transient and
+are not required layout members.
 
 This is an internal storage-open concern, is unreachable from client SQL, and
 is atomic only within `manifest.sqlite`. Validation returns routing and logical
@@ -112,23 +138,33 @@ metadata from the same locked transaction as one immutable snapshot that
 `Storage` shares across clones. `Database::catalog()` and `Engine::catalog()`
 expose the logical portion as a read-only `Catalog` with lookup accessors.
 
-The version-4 logical catalog is advisory: there is no catalog mutation API,
-planner integration, or schema enforcement yet. Fresh and upgraded manifests
-contain no table rows, and migration does not inspect, infer, or adopt physical
-tables already present in shard files. Those tables remain reachable through
-the existing explicit-key execute/query and broadcast surfaces. Core routing
-still hashes the exact caller-provided key bytes, derives a versioned virtual
-bucket, and reads the final physical shard from the snapshot without querying
-SQLite. The generation-1 ranges reproduce prior modulo placement for every
-supported initial shard count, including counts that do not divide 4,096.
-Consequently v4 changes no current SQL execution, HTTP behavior, routing result,
-or shard file.
+The logical catalog remains advisory: there is no catalog mutation API,
+planner integration, or schema enforcement yet. Fresh manifests and upgrades
+originating before v4 contain no table rows; a v4-to-v5 upgrade retains every
+validated v4 logical-catalog row. Migration does not inspect, infer, or adopt
+physical tables already present in shard files. Those tables remain reachable
+through the existing explicit-key execute/query and broadcast surfaces. Core
+routing still hashes the exact caller-provided key bytes, derives a versioned
+virtual bucket, and reads the final physical shard from the snapshot without
+querying SQLite. The generation-1 ranges reproduce prior modulo placement for
+every supported initial shard count, including counts that do not divide 4,096.
+Version-5 adoption adds only BriskDB identity metadata to legacy shards and
+preserves their application schema and data. It changes no current SQL planning,
+HTTP shape, routing result, or broadcast ordering.
 
-The catalog does not yet validate shard-file presence, identity, WAL, or the
-cataloged schema generation against shard files, and it is not the future
-cross-shard application-schema migration journal. The exact format, numeric
-codes, downgrade policy, recovery cases, and tests are documented in
-[manifest storage format](STORAGE_FORMAT.md).
+The storage-owned `briskdb_shard_metadata` table is inaccessible through client
+SQL, and creation of new objects in the reserved `briskdb_*` namespace is
+denied by the SQLite authorizer. Client attempts to mutate `application_id`,
+`user_version`, persistent `journal_mode`, `schema_version`, or
+`writable_schema` are also denied. This prevents a pass-through statement from
+invalidating the validated layout. All `ALTER TABLE` statements are currently
+denied because SQLite's authorizer does not expose the destination of a rename;
+allowing the operation would leave a path into the reserved namespace. The
+application-schema generation is still fixed at 0 and there is not
+yet a cross-shard schema migration journal; that later format must explicitly
+authorize any temporary generation mismatch. The exact format, numeric codes,
+downgrade policy, recovery cases, and tests are documented in [manifest storage
+format](STORAGE_FORMAT.md).
 
 ## Session and asynchronous engine boundary
 
@@ -189,15 +225,17 @@ broadcasts from deadlocking each other.
 Pool checkout also establishes a connection-hygiene boundary. SQLite authorizer
 events identify operations that can persist connection-local state, including
 transaction and savepoint control, `PRAGMA`, `ATTACH`/`DETACH`, and temporary
-objects. The operation is allowed under the current one-call SQLite
-pass-through behavior, but that behavior remains uncontracted. Clean read
-handles may cross sessions for ordinary statements. The pool retains the first
-session associated with each physical handle; an ordinary foreign read does not
-relabel that history. Before a routed statement uses such a foreign handle, the
-engine prepares it under a deny-only authorizer probe. The first
-connection-local or write action is rejected before it can run—even for PRAGMAs
-with prepare-time effects—and the real statement is then executed once on a
-fresh handle. This also gives every cross-owner write clean SQLite counter state.
+objects. BriskDB-owned metadata access and storage-control PRAGMA mutations are
+always denied. Other connection-local operations remain allowed under the
+current one-call SQLite pass-through behavior, but that behavior is
+uncontracted. Clean read handles may cross sessions for ordinary statements.
+The pool retains the first session associated with each physical handle; an
+ordinary foreign read does not relabel that history. Before a routed statement
+uses such a foreign handle, the engine prepares it under a deny-only authorizer
+probe. The first connection-local or write action is rejected before it can
+run—even for PRAGMAs with prepare-time effects—and the real statement is then
+executed once on a fresh handle. This also gives every cross-owner write clean
+SQLite counter state.
 The expected probe error is never exposed to the caller. Any other probe error
 also fails closed to a fresh handle. Opening that replacement can surface its own
 storage error; otherwise only the real execution determines the caller-visible

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -115,13 +115,26 @@ Manifest compatibility uses the same protocol-neutral kinds. A foreign file,
 a manifest newer than the running binary, or a requested shard-count mismatch
 is `FailedPrecondition`; the file is not downgraded. A recognized BriskDB
 manifest whose identity, schema, or invariant rows disagree is
-`DataCorruption`. SQLite lock contention while an opener waits for the manifest
-migration transaction remains retryable `Busy`. These diagnostics originate in
-storage and are never serialized directly by an adapter.
+`DataCorruption`.
 
-The earlier taxonomy change affected reporting only; the later manifest-format
-migration described above is the storage-layer change. Neither alters shard
-files, stored application values, routing, or wire configuration.
+Shard-layout validation follows the same distinction. A foreign shard
+application ID, unexpected canonical four-digit `.sqlite` shard file or
+symbolic link, persistent journal mode other than WAL, or shard generation
+newer than the catalog is
+`FailedPrecondition`; BriskDB neither claims, downgrades, nor repairs it. A
+layout in `Adopting` or `Ready` with a missing shard is `DataCorruption`. In
+`Ready`, missing identity metadata, a wrong layout or physical-shard ID, an
+older mismatched generation, or otherwise invalid recognized BriskDB metadata
+is also `DataCorruption`. SQLite lock contention while an opener waits for a
+manifest or shard transaction remains retryable `Busy`; permission, read-only,
+full, and I/O failures retain their precise storage kinds. Client access to
+BriskDB-owned metadata or mutation of a storage-control PRAGMA is
+`PermissionDenied`. These diagnostics originate in storage and are never
+serialized directly by an adapter.
+
+The earlier taxonomy change affected reporting only. Manifest v5 is a later
+storage-layer change: it adds identity metadata to shard files while preserving
+legacy application tables, rows, routing, SQL results, and wire configuration.
 
 This is a pre-1.0 Rust API migration: public `Database` operations now return
 `EngineResult<T>` instead of `anyhow::Result<T>`. The `?` operator still

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -88,6 +88,19 @@ without allowing connection-local state or observer metadata such as
 `PRAGMA data_version` to leak into another ephemeral HTTP session; it does not
 add multi-request transactions or promise compatibility for those statements.
 
+The pass-through boundary excludes BriskDB-owned storage identity. Client SQL
+may not read or mutate `briskdb_shard_metadata`, create objects in the reserved
+`briskdb_*` namespace, or mutate `application_id`, `user_version`, persistent
+`journal_mode`, `schema_version`, or `writable_schema`. The SQLite authorizer
+denies those operations through routed and broadcast execution. These controls
+are reserved for startup validation and future schema migrations, so denial is
+stable BriskDB behavior rather than connection-hygiene policy.
+
+`ALTER TABLE` is also denied on every client surface. SQLite reports the source
+table to its authorizer but not a `RENAME TO` destination, so selectively
+allowing it would let a client create a name inside the reserved `briskdb_*`
+namespace. A future schema API can coordinate and validate those changes.
+
 SQLite also retains `last_insert_rowid()`, `changes()`, and `total_changes()` on
 the physical connection after ordinary writes. A write-bearing handle may be
 reused by its owning BriskDB `Session`, but the pool closes and replaces it
@@ -332,14 +345,19 @@ underlying execution semantics.
   prefix selects one of 4,096 virtual buckets through the versioned
   compatibility algorithm.
 - The final physical shard is read from the validated, generation-stamped
-  bucket map retained in manifest version 4. Routing generation 1 preserves
+  bucket map retained in manifest version 5. Routing generation 1 preserves
   the earlier modulo placement for every supported shard count.
-- Manifest version 4 also exposes an immutable logical catalog with schema
-  generation 0 and default database ID 1 named `default`. Its optional table
-  rows can describe sharded, global, or catalog placement and a sharded table's
-  `Int64`, text, or binary key column.
-- Logical metadata is currently read-only and advisory. Fresh and upgraded
-  manifests contain no table rows, existing physical tables are not inferred
+- Manifest version 5 retains the immutable logical catalog introduced in v4,
+  with schema generation 0 and default database ID 1 named `default`. Its
+  optional table rows can describe sharded, global, or catalog placement and a
+  sharded table's `Int64`, text, or binary key column.
+- A ready v5 layout binds every shard to one random 16-byte layout ID and its
+  physical shard ID. Each connection is opened without create or symlink
+  following and must match the `BRSH` application ID, schema-generation-0 user
+  version, exact metadata, and existing WAL mode.
+- Logical metadata is currently read-only and advisory. Fresh manifests and
+  upgrades originating before v4 contain no table rows; v4-to-v5 retains every
+  validated v4 logical-catalog row. Existing physical tables are not inferred
   or adopted, and catalog contents do not alter SQL planning or execution.
 - Point queries and writes visit only that shard.
 - No scatter/gather query path exists.
@@ -375,7 +393,11 @@ run internally during storage open, are transactional only within
 statement. The atomic version-3-to-version-4 manifest upgrade adds only
 read-only advisory logical metadata and its downgrade fence. It does not infer
 or adopt existing physical tables and does not change shard schemas, supported
-SQLite syntax, result conversion, routing, or broadcast semantics.
+SQLite syntax, result conversion, routing, or broadcast semantics. Version 5
+then adds a resumable physical-layout state machine. Its `Adopting` path accepts
+only exact legacy zero-header WAL shards, preserves their tables and rows, and
+adds BriskDB identity metadata. It does not make application-schema changes or
+turn sequential broadcast into an atomic cross-file operation.
 See the [manifest storage-format contract](STORAGE_FORMAT.md).
 
 Scatter reads will combine committed results from multiple SQLite files. They

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -5,22 +5,23 @@ never exposed through HTTP, PostgreSQL, MySQL, or the SQL execution API. The
 format is pre-1.0, but every format change must still have an ordered migration,
 failure coverage, and an explicit compatibility decision.
 
-## Current format: version 4
+## Current format: version 5
 
 SQLite header fields identify the file and its format:
 
 | Header field | Value | Meaning |
 | --- | --- | --- |
 | `PRAGMA application_id` | `0x42524442` (`BRDB`) | Permanent BriskDB manifest-family marker |
-| `PRAGMA user_version` | `4` | Authoritative manifest schema version |
+| `PRAGMA user_version` | `5` | Authoritative manifest schema version |
 
 The application ID prevents an accidental foreign SQLite file from being
 adopted as a manifest. It is not authentication or tamper protection: a process
 that can write the data directory can forge it. Checksums and explicit degraded
 states remain separate roadmap work.
 
-Version 4 has eight strict tables. The routing tables are unchanged from
-version 3; the downgrade fence and three logical-schema tables are new.
+Version 5 has nine strict manifest tables. It retains the v4 routing and
+logical-schema tables, replaces the downgrade fence, and adds the physical
+shard-layout singleton.
 
 ```sql
 CREATE TABLE briskdb_manifest (
@@ -30,7 +31,7 @@ CREATE TABLE briskdb_manifest (
 
 CREATE TABLE briskdb_metadata (
     requires_manifest_version INTEGER NOT NULL
-        CHECK (requires_manifest_version >= 4)
+        CHECK (requires_manifest_version >= 5)
 ) STRICT;
 
 CREATE TABLE briskdb_routing (
@@ -122,23 +123,33 @@ CREATE TABLE briskdb_tables (
         )
     )
 ) STRICT;
+
+CREATE TABLE briskdb_shard_layout (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    layout_id BLOB NOT NULL
+        CHECK (typeof(layout_id) = 'blob' AND length(layout_id) = 16),
+    shard_application_id INTEGER NOT NULL CHECK (shard_application_id = 1112691528),
+    shard_metadata_version INTEGER NOT NULL CHECK (shard_metadata_version = 1),
+    layout_state INTEGER NOT NULL CHECK (layout_state IN (1, 2, 3))
+) STRICT;
 ```
 
-The manifest, metadata, routing, and schema-catalog tables each contain exactly
-one row. The v4 downgrade-fence row is exactly `4`.
+The manifest, metadata, routing, schema-catalog, and shard-layout tables each
+contain exactly one row. The v5 downgrade-fence row is exactly `5`.
 `briskdb_manifest.shard_count` is immutable and is the initial routing modulus;
 it is also the live physical-shard count. Physical IDs are exactly
 `0..shard_count - 1`. Filenames remain derived by trusted code as
 `shards/{shard_id:04}.sqlite` and are never read from catalog-controlled paths.
-Version 4 supports only the `active` lifecycle state. Adding resumable
-provisioning, draining, or retirement states requires a later format and
-state-machine change.
+Version 5 supports only the `active` physical-shard lifecycle state. Adding
+provisioning, draining, or retirement states to the routing catalog requires a
+later format and state-machine change. The separate shard-layout state governs
+only startup identity reconciliation.
 
 ### Logical catalog
 
-Every fresh or upgraded v4 manifest contains logical database ID `1` named
+Every fresh or upgraded v5 manifest contains logical database ID `1` named
 `default`. The schema-catalog singleton contains identifier encoding version
-`1`, application-schema generation `0`, and default database ID `1`. Version 4
+`1`, application-schema generation `0`, and default database ID `1`. Version 5
 can interpret only schema generation 0. It permits at most 64 logical databases
 and 4,096 table rows. Database and table IDs are positive; table names are
 unique within their owning database, and every table references an existing
@@ -170,14 +181,89 @@ Table placement and shard-key type use stable numeric codes:
 are key-routed. `Global` describes small replicated lookup data. `Catalog`
 describes manifest-owned metadata rather than a user shard table.
 
-The loaded `Catalog` is immutable and read-only. It is advisory in version 4:
-there is no catalog mutation API, planner integration, or enforcement against
-physical shard schemas. Fresh initialization and every v1/v2/v3 upgrade leave
-`briskdb_tables` empty. Migration does not inspect, infer, or adopt tables that
-already exist in shard files. Such tables remain usable through the existing
-explicit-key execute/query API and broadcast API; absence from the catalog does
-not mean physical absence. Version 4 therefore changes no current SQL
-execution, routing result, broadcast behavior, shard file, or wire contract.
+The loaded `Catalog` is immutable and read-only. It remains advisory in version
+5: there is no catalog mutation API, planner integration, or enforcement
+against physical shard schemas. Fresh initialization and every v1/v2/v3
+upgrade leave `briskdb_tables` empty; a v4-to-v5 upgrade retains every validated
+v4 catalog row. Migration does not inspect, infer, or adopt tables that already
+exist in shard files. Such tables remain usable through the existing explicit-
+key execute/query API and broadcast API; absence from the catalog does not mean
+physical absence. Version-5 adoption preserves those tables and rows while
+adding only BriskDB-owned shard identity metadata. It changes no current SQL
+planning, routing result, broadcast ordering, or wire contract.
+
+### Physical shard layout
+
+The `briskdb_shard_layout` row is the durable authority for cross-file startup:
+
+| Field | Value | Contract |
+| --- | --- | --- |
+| `layout_id` | 16 random bytes | Accidental binding shared by this manifest and all of its shards |
+| `shard_application_id` | `0x42525348` (`BRSH`) | Distinguishes a BriskDB shard from `BRDB` manifest and foreign SQLite files |
+| `shard_metadata_version` | `1` | Exact physical-shard metadata encoding described below |
+| `layout_state` | `1` | `Creating`: fresh provisioning may create expected missing shards and enable WAL |
+| `layout_state` | `2` | `Adopting`: existing legacy v4 shards may receive identity metadata |
+| `layout_state` | `3` | `Ready`: only strict validation is allowed |
+
+`layout_id` is generated with SQLite `randomblob(16)` when the v5 manifest row
+is created and never changes. It detects an accidental shard copy from another
+layout. Because the value and all other identity fields are stored in writable
+files, they are not authentication, tamper protection, or proof of provenance.
+
+Every current shard uses these persistent SQLite settings:
+
+| Shard property | Required value | Meaning |
+| --- | --- | --- |
+| `PRAGMA application_id` | `0x42525348` (`BRSH`) | Permanent BriskDB shard-family marker |
+| `PRAGMA user_version` | `0` | Must equal the manifest's committed application-schema generation |
+| `PRAGMA journal_mode` | `wal` | Required persistent journal mode |
+
+Metadata encoding version 1 requires this exact strict identity table:
+
+```sql
+CREATE TABLE briskdb_shard_metadata (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    layout_id BLOB NOT NULL
+        CHECK (typeof(layout_id) = 'blob' AND length(layout_id) = 16),
+    shard_id INTEGER NOT NULL CHECK (shard_id BETWEEN 0 AND 63)
+) STRICT;
+```
+
+It contains exactly `(1, manifest_layout_id, physical_shard_id)`. The physical
+ID is derived from the canonical filename rather than trusted from the table.
+Header identity, frozen table SQL, columns, strict flag, singleton row, value
+types, layout ID, shard ID, and case-insensitive conflicts with the reserved
+metadata name are all validated.
+
+Startup scans the shard directory for the exact expected filenames from
+`0000.sqlite` through the zero-padded final physical ID and rejects an
+unexpected canonical four-digit `.sqlite` shard filename in every layout
+state. Every existing
+shard is opened read-write with SQLite create and symbolic-link following
+disabled; only `Creating` may open a missing canonical path with create enabled.
+An unrelated non-symlink entry with a UTF-8, noncanonical name is ignored for
+an already recognized layout; symlinks and non-UTF-8 names fail closed. Any
+pre-existing entry blocks fresh-manifest initialization because BriskDB cannot
+prove that the physical layout is new.
+Runtime pool opens use the same no-create path and validator, so deleting or
+replacing a shard after startup cannot make a later checkout create or accept a
+new file. A copied shard in a different slot fails its physical ID, a swapped
+pair fails both IDs, and a shard from another data directory fails its layout
+ID.
+
+WAL validation reads `PRAGMA journal_mode` without assigning it. Only
+`Creating` may issue `PRAGMA journal_mode=WAL`; `Adopting` and `Ready` reject a
+different persisted mode. The transient `-wal`, `-shm`, and rollback-journal
+sidecars can be absent and are not counted as canonical shard files.
+
+Creation of new objects in the `briskdb_*` namespace is reserved. The metadata
+table and persistent `application_id`, `user_version`, `journal_mode`,
+`schema_version`, and `writable_schema` controls are BriskDB-owned. The SQL
+authorizer denies client access to the metadata, creation of reserved objects,
+and client mutation of those controls through routed and broadcast paths. It
+also denies all `ALTER TABLE` statements because SQLite does not expose a
+rename destination to the authorizer. A future schema-migration journal, not
+client SQL, must coordinate changes to `user_version`.
 
 ### Routing catalog
 
@@ -189,7 +275,7 @@ The routing singleton contains exactly these generation-1 values:
 | `key_encoding_version` | `1` | Exact caller-supplied bytes; string shard keys contribute their UTF-8 bytes, with no Unicode normalization |
 | `bucket_algorithm_version` | `1` | Compatibility-preserving range algorithm below |
 | `virtual_bucket_count` | `4096` | Fixed virtual bucket space `0..4095` |
-| `map_generation` | `1` | Initial committed bucket map and the only generation version 4 can interpret |
+| `map_generation` | `1` | Initial committed bucket map and the only generation version 5 can interpret |
 
 Every bucket ID exists exactly once and references an active physical shard.
 Every physical shard owns at least one bucket. The generation-1 map partitions
@@ -218,7 +304,7 @@ vectors freeze the exact key bytes, BLAKE3 prefix, little-endian hash integer,
 bucket ID, and persisted physical shard.
 
 `map_generation` is separate from manifest `user_version` and from
-`schema_generation`. Version 4 accepts only routing generation 1 and validates
+`schema_generation`. Version 5 accepts only routing generation 1 and validates
 its exact deterministic assignment; no public map-mutation operation exists
 yet. A future format that can commit a changed map must bump `user_version` and
 its downgrade fence as well as `map_generation`. That requirement makes this
@@ -229,11 +315,35 @@ At each open, BriskDB validates the exact objects, columns, strict flags, frozen
 schema SQL, singleton rows, logical identifiers and limits, metadata codes,
 supported algorithm values, contiguous physical and bucket IDs, active
 lifecycle states, assignments, coverage, and foreign keys. A recognized
-version-4 manifest that violates any invariant is `DataCorruption` and is
+version-5 manifest that violates any invariant is `DataCorruption` and is
 rejected before shard connections are opened. The same locked transaction
 returns routing and logical rows as one immutable in-memory snapshot, so
 request routing performs no manifest query and cannot fall back to modulo after
 a failed validation.
+
+## Previous version 4
+
+Version 4 has the first eight manifest tables shown above and no
+`briskdb_shard_layout` table. Its exact downgrade fence is:
+
+```sql
+CREATE TABLE briskdb_metadata (
+    requires_manifest_version INTEGER NOT NULL
+        CHECK (requires_manifest_version >= 4)
+) STRICT;
+```
+
+The fence contains exactly `4`, and `PRAGMA user_version` is `4`. Version 4 did
+not own shard header fields or an identity table: shard files created by shipped
+v4 code have `application_id = 0` and `user_version = 0`, while ordinary storage
+open configured them for WAL. It also opened shards with create-capable flags,
+so a missing file could previously be recreated silently.
+
+A v5 opener fully validates the v4 manifest before committing a random layout
+ID and state `Adopting` in the atomic v4-to-v5 manifest migration. Cross-file
+adoption then accepts only existing WAL shard files with the exact legacy
+zero/zero header or already valid resumable v5 identity. It never infers that a
+missing shard is empty, changes an application table, or adopts a foreign header.
 
 ## Previous version 3
 
@@ -271,7 +381,7 @@ CREATE TABLE briskdb_metadata (
 ```
 
 The fence contains exactly `2`. A current opener validates this complete format
-before applying the numbered v2-to-v3 and v3-to-v4 transactions.
+before applying the numbered v2-to-v3, v3-to-v4, and v4-to-v5 transactions.
 
 ## Legacy version 1
 
@@ -297,8 +407,8 @@ non-canonically encoded legacy states are `DataCorruption`.
 
 ## Upgrade and startup algorithm
 
-Opening a `Database` or `Engine`, including server startup, may automatically
-upgrade the manifest before any shard connection is opened:
+Opening a `Database` or `Engine`, including server startup, may upgrade the
+manifest and reconcile the physical shard layout before returning an engine:
 
 1. Validate the requested shard-count range and open the manifest with a finite
    busy timeout, `synchronous=FULL`, and foreign keys enabled.
@@ -306,58 +416,84 @@ upgrade the manifest before any shard connection is opened:
    configuration under that write lock.
 3. Reject a foreign file, a newer version, a requested shard-count mismatch, or
    an invalid recognized schema before changing it.
-4. Apply one compile-time registered migration using static SQL and bound data.
-5. Write and read back `application_id` and the destination `user_version` as
-   the final mutations, validate the complete destination schema, and commit.
-6. Re-lock and repeat if more than one numbered step is required. Each step has
-   its own transaction, so restart begins at the last committed version.
-7. After a compatible current manifest is committed, enable and verify WAL mode
-   and only then create/open the shard layout.
+4. Apply each compile-time registered manifest migration with static SQL and
+   bound data. The destination application ID and `user_version` are the final
+   mutations; validate the complete destination and commit one numbered step at
+   a time.
+5. Fresh initialization is allowed only beside an otherwise empty physical
+   layout and commits v5 state `Creating`. An existing v1/v2/v3 manifest first
+   advances through v4; the v4-to-v5 transaction commits a random 16-byte
+   layout ID and state `Adopting` before any shard file changes.
+6. Acquire a new `BEGIN IMMEDIATE`, then re-read and validate the committed
+   layout identity and state under that manifest write lock. Reconcile every
+   expected physical ID in ascending order while retaining the lock. Only
+   `Creating` may create a missing file and enable WAL. `Adopting` requires an
+   existing WAL file and accepts either the exact legacy zero/zero header or the
+   exact current metadata left by an earlier attempt. `Ready` accepts only the
+   exact current format.
+7. Still holding the manifest lock, re-scan for unexpected canonical shard
+   filenames and strictly revalidate every expected file. Verify that the
+   layout identity did not change, move its state to `Ready`, revalidate the
+   ready manifest, and commit. A lagging opener then acquires the lock, re-reads
+   `Ready`, and cannot provision from a stale `Creating` observation.
+8. The final strict startup validation pass and every later runtime connection
+   open use read-write, no-create, no-follow flags. Apply connection-local
+   durability and foreign-key settings only after the file passes identity,
+   generation, and WAL checks.
 
-Fresh initialization creates the complete v4 schema and initial rows in one
-transaction before stamping version 4. For an existing manifest, SQLite
-transactional DDL makes each numbered step's schema, catalog rows, downgrade
-fence, and header stamps one transaction within `manifest.sqlite`. A version-1
-upgrade commits version 2, then version 3, then version 4; a version-2 upgrade
-commits version 3 before beginning version 4.
+SQLite transactional DDL keeps each numbered manifest step atomic within
+`manifest.sqlite`. A version-1 upgrade commits versions 2, 3, 4, and then 5; a
+version-2 upgrade begins at 3, and so on. The v3-to-v4 step still creates the
+logical catalog, inserts database ID 1 named `default` plus the
+schema-generation-0 singleton, and leaves the table catalog empty.
 
-The v3-to-v4 step atomically replaces the version-3 fence with the version-4
-fence, creates the three logical-catalog tables, inserts database ID 1 named
-`default` plus the schema-generation-0 singleton, and leaves the table catalog
-empty. The destination is fully validated and the header is stamped last before
-commit. An error or panic rolls the whole step back to the exact v3 source, so a
-later open can retry it. The step never opens or inspects shard files and never
-infers or adopts an existing physical table.
+The v4-to-v5 manifest transaction replaces the downgrade fence, creates the
+shard-layout row in `Adopting`, and stamps version 5 before cross-file work.
+Shard adoption is deliberately not one SQLite transaction across files. Each
+completed shard keeps its metadata, while the durable manifest state remains
+`Adopting`; a later open validates the completed prefix and resumes. The same
+rule applies to partially completed fresh `Creating`. State becomes `Ready`
+only after a full strict revalidation, so a ready manifest certifies the exact
+layout observed at that transition.
 
-Tests prove rollback and retry after injected errors and Rust panic unwinding.
-SQLite is intended to recover an uncommitted transaction after process loss,
-but BriskDB has not yet certified process-kill, power-loss, or filesystem-fault
-recovery. Concurrent open calls within the supported single-process deployment
-serialize on the immediate transaction and re-read the version after acquiring
-it.
+The adoption path changes no application table or row and does not derive
+identity from application schema. A legacy shard with a nonzero header, a
+non-WAL mode, or a missing file is rejected without being repaired or replaced.
+Catalog schema generation remains 0; matching that number validates the shard's
+declared generation, not the advisory table catalog against physical DDL.
 
-This guarantee is manifest-local. The schema generation and table rows are
-read-only advisory metadata, not an application-table migration API. They do
-not make broadcast atomic across shard files and are not the planned
-crash-resumable cross-shard schema migration journal. Catalog validation also
-does not yet establish shard-file health: current startup can recreate a
-missing shard file. No-create opening, per-shard identity/version, WAL, and
-schema-generation checks belong to the later shard-validation milestone.
+Tests prove retry after injected errors and Rust panic unwinding at cross-file
+persistence boundaries. SQLite is intended to recover its own uncommitted
+transactions after process loss, but BriskDB has not yet certified arbitrary
+process-kill, machine power-loss, torn-write, or filesystem-fault recovery.
+The layout state machine is therefore a deterministic software-interruption
+contract, not the later storage-hardening certification.
 
 ## Compatibility and operations
 
-- Version 1 upgrades through versions 2 and 3 to version 4; version 2 upgrades
-  through version 3; version 3 upgrades directly to version 4. Opening is
-  therefore potentially mutating.
+- Version 1 upgrades through versions 2, 3, and 4 to version 5; version 2 begins
+  at version 3, version 3 begins at version 4, and version 4 upgrades directly
+  to version 5. Opening is therefore potentially mutating.
 - There is no automatic downgrade. Older readers are fenced by the incompatible
-  metadata schema and authoritative header; in particular, a version-3 reader
-  rejects `user_version = 4`.
+  metadata schema and authoritative header; in particular, a version-4 reader
+  rejects `user_version = 5` before it can bypass no-create validation.
 - A manifest with the BriskDB application ID and a `user_version` newer than the
   binary supports fails with non-retryable `FailedPrecondition`; it is not
   downgraded or switched to WAL, and shard files are not opened.
 - A foreign nonzero application ID or unrelated unversioned SQLite database is
   a failed precondition. A recognized BriskDB identity whose schema, rows, or
   invariants disagree is `DataCorruption`.
+- In `Ready` or `Adopting`, a missing shard is never created and a non-WAL shard
+  is never switched to WAL. Extra four-digit `.sqlite` shard filenames are
+  rejected rather than ignored. SQLite's transient `-wal` and `-shm` sidecars
+  are not canonical shard files and need not exist after a clean close.
+- The layout ID and application IDs detect accidental wrong-file placement;
+  they are forgeable by anyone who can modify the directory and are not a
+  security or checksum mechanism.
+- BriskDB owns the shard identity table and the persistent `application_id`,
+  `user_version`, and `journal_mode` settings. Client SQL access to the identity
+  table and mutation of those settings is denied. `user_version` is the
+  application-schema generation, not SQLite's internal `schema_version`.
 - SQLite lock contention remains retryable `Busy`; permission, read-only, full,
   and I/O failures retain the storage error taxonomy.
 
@@ -365,23 +501,38 @@ Do not edit the header, tables, or rows manually. Until the checksum milestone,
 a coordinated manual edit that still satisfies every structural invariant
 cannot be distinguished from an intentional catalog update. The current
 deployment boundary remains local storage and one BriskDB process per data
-directory. A formal backup/restore workflow is not implemented; recovery to an
-older binary requires a known-good copy made while BriskDB was stopped.
+directory. A formal backup/restore workflow is not implemented; recovery from
+a missing, swapped, or otherwise incompatible shard—including one cloned into
+the wrong slot or from another layout—requires the correct complete layout or a
+known-good copy made while BriskDB was stopped. Recovery to an older binary
+likewise requires a pre-v5 backup.
+
+A future application-schema migration format must bump the manifest version and
+downgrade fence, journal its source and target generations, and explicitly
+authorize any temporary mixed shard generations. It must update each shard's
+`user_version` atomically with that shard's DDL and advance the committed
+catalog generation only after every shard verifies. A v5 opener has no such
+journal and rejects every generation other than 0.
 
 ## Verification contract
 
-Tests cover fresh and v1/v2/v3-to-v4 catalog creation, the exact default logical
-database and schema singleton, every placement and shard-key type code,
-identifier and relational corruption, catalog row limits, immutable public
-lookups, deterministic and balanced bucket ownership, non-divisor
-compatibility, and no-op reopen. Migration coverage includes both recognized
-legacy headers, the interrupted empty-table state, future and foreign formats,
-old-reader fences, errors and panics on both sides of every version stamp,
-multi-step resume, v3-to-v4 observer atomicity, and concurrent openers with
-matching and conflicting shard counts. Routing tests additionally freeze golden
-hash/bucket/shard vectors, cover every algorithm state for every supported shard
-count, prove the final map lookup with a synthetic reassignment, and exercise
-parallel and reopen stability. Process termination and filesystem faults remain
-part of the later storage-hardening suite. Every new migration must extend the
-registry, destination validator, format documentation, and the same
+Tests cover fresh and v1/v2/v3/v4-to-v5 creation, every manifest layout state,
+the exact shard header and metadata row, application-schema generation 0, and
+no-op ready reopen. Failure coverage includes missing and extra canonical files,
+foreign headers, non-WAL mode, malformed metadata, cross-layout shard clones,
+shard swaps, symlinks, wrong generations, client attempts to reach storage-owned
+state, and runtime pool replacement opens. Injection around each manifest and
+per-shard persistence boundary proves resumability in `Creating` and `Adopting`
+and prevents `Ready` from being published before full strict revalidation.
+Concurrent openers exercise matching and conflicting shard counts and layout
+transitions.
+
+Catalog tests continue to cover default logical metadata, every placement and
+shard-key type code, identifier and relational corruption, row limits, and
+immutable public lookups. Routing tests freeze golden hash/bucket/shard vectors,
+cover every algorithm state for every supported shard count, prove the final
+map lookup with a synthetic reassignment, and exercise parallel and reopen
+stability. Process termination and filesystem faults remain part of the later
+storage-hardening suite. Every new migration must extend the registry,
+destination validator, format documentation, and the same
 normal/error/concurrency/recovery matrix.

--- a/docs/SUPPORTED_PLATFORMS.md
+++ b/docs/SUPPORTED_PLATFORMS.md
@@ -45,11 +45,18 @@ storage behavior.
 ## Filesystem and deployment boundary
 
 All BriskDB data files must reside on storage local to the server host with
-working file locks and durable synchronization semantics. The current engine
-enables SQLite WAL mode and `synchronous=FULL` for the manifest and every
-shard. Network filesystems such as NFS or SMB, cloud-synchronized folders,
-userspace filesystems with unverified locking, and sharing one data directory
-between hosts are unsupported.
+working file locks and durable synchronization semantics. Fresh shard
+provisioning in `Creating` enables SQLite WAL mode; every `Adopting`, `Ready`,
+and runtime shard open requires the persisted mode to already be WAL and does
+not silently repair another mode. Every connection uses `synchronous=FULL`.
+Network filesystems such as NFS or SMB, cloud-synchronized folders, userspace
+filesystems with unverified locking, and sharing one data directory between
+hosts are unsupported.
+
+WAL, shared-memory, and rollback-journal sidecars may be absent and are not
+layout members by themselves. The directory must nevertheless permit SQLite to
+create and recover its sidecars. Do not infer damage from a missing sidecar;
+BriskDB validates the database's persistent journal mode instead.
 
 Only a single BriskDB server process per data directory is currently tested.
 Do not copy, move, edit, or separately open the manifest, shard, WAL, or shared
@@ -58,10 +65,19 @@ access, filesystem-fault behavior, and crash-recovery guarantees will become
 supported only when their roadmap issues add the corresponding automated
 tests.
 
-Opening a data directory can transactionally upgrade `manifest.sqlite`; see the
-[manifest storage-format contract](STORAGE_FORMAT.md). A future or foreign
-manifest is rejected before BriskDB enables WAL for it or opens shard files.
-The application ID is an accidental wrong-file guard, not a security boundary.
+Opening a data directory can transactionally upgrade `manifest.sqlite` and can
+resume a manifest-recorded cross-file shard provisioning or adoption step; see
+the [manifest storage-format contract](STORAGE_FORMAT.md). Outside the explicit
+`Creating` state, every shard is opened read-write with SQLite create and
+symbolic-link following disabled. A missing, extra canonical, swapped, foreign,
+non-WAL, or wrong-generation shard file is rejected, as is a shard cloned into
+another slot or layout. It is not recreated, reassigned, or silently
+reconfigured. Recovery requires restoring the correct complete layout.
+
+Manifest and shard application IDs plus the random 16-byte layout ID guard
+against accidental wrong-file placement. They are not authentication, checksums,
+or protection from a process that can write the data directory. Process-kill,
+power-loss, and filesystem-fault certification remains later hardening work.
 
 When reporting a platform problem, include the BriskDB revision, `rustc -Vv`,
 operating-system and architecture details, filesystem type, mount options, and

--- a/src/storage/manifest.rs
+++ b/src/storage/manifest.rs
@@ -14,13 +14,16 @@ use crate::{
     sqlite_error,
 };
 
+use super::shard::{SHARD_APPLICATION_ID, SHARD_METADATA_VERSION, ShardLayout, ShardLayoutState};
+
 /// `BRDB` encoded as SQLite's 32-bit application identifier.
 pub(super) const MANIFEST_APPLICATION_ID: i64 = 0x4252_4442;
 const LEGACY_SCHEMA_VERSION: u32 = 1;
 const V2_SCHEMA_VERSION: u32 = 2;
 const V3_SCHEMA_VERSION: u32 = 3;
 const V4_SCHEMA_VERSION: u32 = 4;
-pub(super) const CURRENT_SCHEMA_VERSION: u32 = V4_SCHEMA_VERSION;
+const V5_SCHEMA_VERSION: u32 = 5;
+pub(super) const CURRENT_SCHEMA_VERSION: u32 = V5_SCHEMA_VERSION;
 const MAX_TABLE_SQL_BYTES: i64 = 4_096;
 
 const INITIAL_SCHEMA_GENERATION: u64 = 0;
@@ -52,6 +55,10 @@ const V3_DOWNGRADE_FENCE_SQL: &str = "CREATE TABLE briskdb_metadata (
 const V4_DOWNGRADE_FENCE_SQL: &str = "CREATE TABLE briskdb_metadata (
     requires_manifest_version INTEGER NOT NULL
         CHECK (requires_manifest_version >= 4)
+) STRICT";
+const V5_DOWNGRADE_FENCE_SQL: &str = "CREATE TABLE briskdb_metadata (
+    requires_manifest_version INTEGER NOT NULL
+        CHECK (requires_manifest_version >= 5)
 ) STRICT";
 const V3_ROUTING_TABLE_SQL: &str = "CREATE TABLE briskdb_routing (
     singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
@@ -137,6 +144,14 @@ const V4_TABLES_TABLE_SQL: &str = "CREATE TABLE briskdb_tables (
         )
     )
 ) STRICT";
+const V5_SHARD_LAYOUT_TABLE_SQL: &str = "CREATE TABLE briskdb_shard_layout (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    layout_id BLOB NOT NULL
+        CHECK (typeof(layout_id) = 'blob' AND length(layout_id) = 16),
+    shard_application_id INTEGER NOT NULL CHECK (shard_application_id = 1112691528),
+    shard_metadata_version INTEGER NOT NULL CHECK (shard_metadata_version = 1),
+    layout_state INTEGER NOT NULL CHECK (layout_state IN (1, 2, 3))
+) STRICT";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct RoutingConfiguration {
@@ -167,6 +182,19 @@ struct ManifestSnapshot {
     shard_count: u16,
     routing_catalog: Option<RoutingCatalog>,
     logical_catalog: Option<Catalog>,
+    shard_layout: Option<ShardLayout>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct LoadedManifest {
+    catalog: CatalogSnapshot,
+    shard_layout: ShardLayout,
+}
+
+impl LoadedManifest {
+    pub(super) fn into_parts(self) -> (CatalogSnapshot, ShardLayout) {
+        (self.catalog, self.shard_layout)
+    }
 }
 
 const MIGRATIONS: &[Migration] = &[
@@ -191,6 +219,13 @@ const MIGRATIONS: &[Migration] = &[
         apply: migrate_v3_to_v4,
         validate: validate_v4,
     },
+    Migration {
+        from: V4_SCHEMA_VERSION,
+        to: V5_SCHEMA_VERSION,
+        name: "validated_physical_shard_layout",
+        apply: migrate_v4_to_v5,
+        validate: validate_v5,
+    },
 ];
 
 #[derive(Clone, Copy)]
@@ -198,12 +233,14 @@ struct MigrationPlan<'a> {
     current_version: u32,
     migrations: &'a [Migration],
     initialize_current: fn(&Transaction<'_>, u16) -> EngineResult<()>,
+    initialize_interrupted_legacy: fn(&Transaction<'_>, u16) -> EngineResult<()>,
 }
 
 const CURRENT_PLAN: MigrationPlan<'static> = MigrationPlan {
     current_version: CURRENT_SCHEMA_VERSION,
     migrations: MIGRATIONS,
-    initialize_current: create_v4_schema,
+    initialize_current: create_v5_schema,
+    initialize_interrupted_legacy: migrate_interrupted_legacy_to_v5,
 };
 
 #[derive(Clone, Copy)]
@@ -244,11 +281,26 @@ enum ManifestState {
 /// The state is inspected again after the write lock is acquired, so two
 /// concurrent openers cannot both act on a stale version. Each numbered
 /// migration owns its transaction and stamps the new version last.
-pub(super) fn load_or_create_catalog(
+#[cfg(test)]
+fn load_or_create_manifest(
     connection: &mut Connection,
     requested_shards: u16,
-) -> EngineResult<CatalogSnapshot> {
-    let snapshot = load_or_create_snapshot_with_hook(connection, requested_shards, |_| Ok(()))?;
+) -> EngineResult<LoadedManifest> {
+    load_or_create_manifest_with_fresh_layout(connection, requested_shards, true)
+}
+
+pub(super) fn load_or_create_manifest_with_fresh_layout(
+    connection: &mut Connection,
+    requested_shards: u16,
+    fresh_layout_allowed: bool,
+) -> EngineResult<LoadedManifest> {
+    let snapshot = load_or_create_snapshot_with_plan(
+        connection,
+        requested_shards,
+        CURRENT_PLAN,
+        fresh_layout_allowed,
+        &mut |_| Ok(()),
+    )?;
     let routing = snapshot.routing_catalog.ok_or_else(|| {
         EngineError::new(
             EngineErrorKind::Internal,
@@ -261,7 +313,126 @@ pub(super) fn load_or_create_catalog(
             "current manifest validation did not produce a logical catalog",
         )
     })?;
-    Ok(CatalogSnapshot::from_validated_parts(routing, logical))
+    let shard_layout = snapshot.shard_layout.ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::Internal,
+            "current manifest validation did not produce a physical shard layout",
+        )
+    })?;
+    Ok(LoadedManifest {
+        catalog: CatalogSnapshot::from_validated_parts(routing, logical),
+        shard_layout,
+    })
+}
+
+#[cfg(test)]
+fn load_or_create_catalog(
+    connection: &mut Connection,
+    requested_shards: u16,
+) -> EngineResult<CatalogSnapshot> {
+    load_or_create_manifest(connection, requested_shards).map(|loaded| loaded.catalog)
+}
+
+#[cfg(test)]
+pub(super) fn mark_shard_layout_ready(
+    connection: &mut Connection,
+    requested_shards: u16,
+    expected: &ShardLayout,
+) -> EngineResult<()> {
+    reconcile_shard_layout(connection, requested_shards, expected, |_| Ok(())).map(|_| ())
+}
+
+/// Serialize physical reconciliation and the final `Ready` publication under
+/// one manifest write lock. The callback receives the state re-read after that
+/// lock is acquired, so a lagging opener can never provision from a stale
+/// `Creating` observation after another opener has committed `Ready`.
+pub(super) fn reconcile_shard_layout<F>(
+    connection: &mut Connection,
+    requested_shards: u16,
+    expected: &ShardLayout,
+    reconcile: F,
+) -> EngineResult<ShardLayout>
+where
+    F: FnOnce(&ShardLayout) -> EngineResult<()>,
+{
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    let observed = match inspect_with_plan(&transaction, requested_shards, CURRENT_PLAN)? {
+        ManifestState::Versioned { version, snapshot } if version == CURRENT_SCHEMA_VERSION => {
+            snapshot.shard_layout.ok_or_else(|| {
+                EngineError::new(
+                    EngineErrorKind::Internal,
+                    "current manifest validation omitted its physical shard layout",
+                )
+            })?
+        }
+        _ => {
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                "physical shard layout changed before it could be marked ready",
+            ));
+        }
+    };
+    ensure_same_shard_layout(&observed, expected)?;
+    reconcile(&observed)?;
+
+    if observed.state() != ShardLayoutState::Ready {
+        transaction
+            .execute(
+                "UPDATE briskdb_shard_layout
+                 SET layout_state = ?1
+                 WHERE singleton = 1 AND layout_id = ?2",
+                rusqlite::params![
+                    ShardLayoutState::Ready.code(),
+                    expected.layout_id().as_slice()
+                ],
+            )
+            .map_err(sqlite_error::storage)?;
+
+        let ready = match inspect_with_plan(&transaction, requested_shards, CURRENT_PLAN)? {
+            ManifestState::Versioned { version, snapshot } if version == CURRENT_SCHEMA_VERSION => {
+                snapshot.shard_layout.ok_or_else(|| {
+                    EngineError::new(
+                        EngineErrorKind::Internal,
+                        "ready manifest validation omitted its physical shard layout",
+                    )
+                })?
+            }
+            _ => {
+                return Err(EngineError::new(
+                    EngineErrorKind::Internal,
+                    "physical shard layout ready transition did not produce a current manifest",
+                ));
+            }
+        };
+        ensure_same_shard_layout(&ready, expected)?;
+        if ready.state() != ShardLayoutState::Ready {
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                "physical shard layout did not persist its ready state",
+            ));
+        }
+        transaction.commit().map_err(sqlite_error::storage)?;
+        return Ok(ready);
+    }
+
+    transaction.commit().map_err(sqlite_error::storage)?;
+    Ok(observed)
+}
+
+fn ensure_same_shard_layout(observed: &ShardLayout, expected: &ShardLayout) -> EngineResult<()> {
+    if observed.layout_id() != expected.layout_id()
+        || observed.expected_application_id() != expected.expected_application_id()
+        || observed.metadata_version() != expected.metadata_version()
+        || (observed.state() != expected.state() && observed.state() != ShardLayoutState::Ready)
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "physical shard layout identity changed during startup",
+        ));
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -281,25 +452,15 @@ fn load_or_create_with_hook<F>(
 where
     F: FnMut(MigrationPoint) -> EngineResult<()>,
 {
-    load_or_create_snapshot_with_plan(connection, requested_shards, CURRENT_PLAN, &mut hook)
+    load_or_create_snapshot_with_plan(connection, requested_shards, CURRENT_PLAN, true, &mut hook)
         .map(|snapshot| snapshot.shard_count)
-}
-
-fn load_or_create_snapshot_with_hook<F>(
-    connection: &mut Connection,
-    requested_shards: u16,
-    mut hook: F,
-) -> EngineResult<ManifestSnapshot>
-where
-    F: FnMut(MigrationPoint) -> EngineResult<()>,
-{
-    load_or_create_snapshot_with_plan(connection, requested_shards, CURRENT_PLAN, &mut hook)
 }
 
 fn load_or_create_snapshot_with_plan<F>(
     connection: &mut Connection,
     requested_shards: u16,
     plan: MigrationPlan<'_>,
+    fresh_layout_allowed: bool,
     hook: &mut F,
 ) -> EngineResult<ManifestSnapshot>
 where
@@ -316,6 +477,12 @@ where
                 return Ok(snapshot);
             }
             ManifestState::Empty => {
+                if !fresh_layout_allowed {
+                    return Err(EngineError::new(
+                        EngineErrorKind::FailedPrecondition,
+                        "cannot initialize an empty manifest beside an existing shard layout",
+                    ));
+                }
                 return apply_schema_change(
                     transaction,
                     requested_shards,
@@ -328,7 +495,25 @@ where
                     hook,
                 );
             }
-            ManifestState::LegacyUninitialized => (LEGACY_SCHEMA_VERSION, requested_shards),
+            ManifestState::LegacyUninitialized => {
+                if !fresh_layout_allowed {
+                    return Err(EngineError::new(
+                        EngineErrorKind::FailedPrecondition,
+                        "cannot recover interrupted legacy initialization beside an existing shard layout",
+                    ));
+                }
+                return apply_schema_change(
+                    transaction,
+                    requested_shards,
+                    SchemaChange {
+                        from: LEGACY_SCHEMA_VERSION,
+                        to: plan.current_version,
+                        apply: plan.initialize_interrupted_legacy,
+                    },
+                    plan,
+                    hook,
+                );
+            }
             ManifestState::LegacyV1 { shard_count } => (LEGACY_SCHEMA_VERSION, shard_count),
             ManifestState::Versioned { version, snapshot } => (version, snapshot.shard_count),
         };
@@ -453,6 +638,43 @@ fn create_v3_schema(transaction: &Transaction<'_>, shard_count: u16) -> EngineRe
 fn create_v4_schema(transaction: &Transaction<'_>, shard_count: u16) -> EngineResult<()> {
     create_v3_schema(transaction, shard_count)?;
     migrate_v3_to_v4(transaction, shard_count)
+}
+
+fn create_v5_schema(transaction: &Transaction<'_>, shard_count: u16) -> EngineResult<()> {
+    create_v4_schema(transaction, shard_count)?;
+    add_v5_schema(transaction, ShardLayoutState::Creating)
+}
+
+fn migrate_interrupted_legacy_to_v5(
+    transaction: &Transaction<'_>,
+    shard_count: u16,
+) -> EngineResult<()> {
+    transaction
+        .execute_batch("DROP TABLE briskdb_metadata;")
+        .map_err(sqlite_error::storage)?;
+    create_v5_schema(transaction, shard_count)
+}
+
+#[cfg(test)]
+fn migrate_interrupted_legacy_to_v3(
+    transaction: &Transaction<'_>,
+    shard_count: u16,
+) -> EngineResult<()> {
+    transaction
+        .execute_batch("DROP TABLE briskdb_metadata;")
+        .map_err(sqlite_error::storage)?;
+    create_v3_schema(transaction, shard_count)
+}
+
+#[cfg(test)]
+fn migrate_interrupted_legacy_to_v4(
+    transaction: &Transaction<'_>,
+    shard_count: u16,
+) -> EngineResult<()> {
+    transaction
+        .execute_batch("DROP TABLE briskdb_metadata;")
+        .map_err(sqlite_error::storage)?;
+    create_v4_schema(transaction, shard_count)
 }
 
 fn migrate_v2_to_v3(transaction: &Transaction<'_>, shard_count: u16) -> EngineResult<()> {
@@ -590,6 +812,41 @@ fn migrate_v3_to_v4(transaction: &Transaction<'_>, _shard_count: u16) -> EngineR
         .execute_batch(V4_TABLES_TABLE_SQL)
         .map_err(sqlite_error::storage)?;
 
+    Ok(())
+}
+
+fn migrate_v4_to_v5(transaction: &Transaction<'_>, _shard_count: u16) -> EngineResult<()> {
+    add_v5_schema(transaction, ShardLayoutState::Adopting)
+}
+
+fn add_v5_schema(transaction: &Transaction<'_>, state: ShardLayoutState) -> EngineResult<()> {
+    transaction
+        .execute_batch("DROP TABLE briskdb_metadata;")
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch(V5_DOWNGRADE_FENCE_SQL)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "INSERT INTO briskdb_metadata (requires_manifest_version) VALUES (?1)",
+            [V5_SCHEMA_VERSION],
+        )
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch(V5_SHARD_LAYOUT_TABLE_SQL)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "INSERT INTO briskdb_shard_layout (
+                singleton,
+                layout_id,
+                shard_application_id,
+                shard_metadata_version,
+                layout_state
+             ) VALUES (1, randomblob(16), ?1, ?2, ?3)",
+            rusqlite::params![SHARD_APPLICATION_ID, SHARD_METADATA_VERSION, state.code(),],
+        )
+        .map_err(sqlite_error::storage)?;
     Ok(())
 }
 
@@ -811,6 +1068,18 @@ fn v4_objects() -> Vec<SchemaObject> {
     ]
 }
 
+fn v5_objects() -> Vec<SchemaObject> {
+    let mut objects = v4_objects();
+    objects.push(SchemaObject {
+        object_type: "table".to_owned(),
+        name: "briskdb_shard_layout".to_owned(),
+    });
+    objects.sort_by(|left, right| {
+        (&left.object_type, &left.name).cmp(&(&right.object_type, &right.name))
+    });
+    objects
+}
+
 fn schema_objects(connection: &Connection) -> EngineResult<Vec<SchemaObject>> {
     let mut statement = connection
         .prepare(
@@ -907,6 +1176,10 @@ fn validate_table(
         "briskdb_tables" => {
             "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden
              FROM pragma_table_xinfo('briskdb_tables') LIMIT ?1"
+        }
+        "briskdb_shard_layout" => {
+            "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden
+             FROM pragma_table_xinfo('briskdb_shard_layout') LIMIT ?1"
         }
         _ => {
             return Err(EngineError::new(
@@ -1094,6 +1367,7 @@ fn validate_v2(
         shard_count,
         routing_catalog: None,
         logical_catalog: None,
+        shard_layout: None,
     })
 }
 
@@ -1120,6 +1394,7 @@ fn validate_v3(
         shard_count,
         routing_catalog: Some(routing_catalog),
         logical_catalog: None,
+        shard_layout: None,
     })
 }
 
@@ -1218,18 +1493,70 @@ fn validate_v4(
     requested_shards: u16,
     objects: &[SchemaObject],
 ) -> EngineResult<ManifestSnapshot> {
-    if objects != v4_objects() {
+    validate_catalog_manifest(
+        connection,
+        requested_shards,
+        objects,
+        V4_SCHEMA_VERSION,
+        V4_DOWNGRADE_FENCE_SQL,
+        &v4_objects(),
+    )
+}
+
+fn validate_v5(
+    connection: &Connection,
+    requested_shards: u16,
+    objects: &[SchemaObject],
+) -> EngineResult<ManifestSnapshot> {
+    let mut snapshot = validate_catalog_manifest(
+        connection,
+        requested_shards,
+        objects,
+        V5_SCHEMA_VERSION,
+        V5_DOWNGRADE_FENCE_SQL,
+        &v5_objects(),
+    )?;
+    validate_table(
+        connection,
+        "briskdb_shard_layout",
+        &[
+            TableColumn::expected(0, "singleton", "INTEGER", false, 1),
+            TableColumn::expected(1, "layout_id", "BLOB", true, 0),
+            TableColumn::expected(2, "shard_application_id", "INTEGER", true, 0),
+            TableColumn::expected(3, "shard_metadata_version", "INTEGER", true, 0),
+            TableColumn::expected(4, "layout_state", "INTEGER", true, 0),
+        ],
+        true,
+    )?;
+    validate_table_sql(
+        connection,
+        "briskdb_shard_layout",
+        V5_SHARD_LAYOUT_TABLE_SQL,
+    )?;
+    snapshot.shard_layout = Some(validate_shard_layout(connection)?);
+    Ok(snapshot)
+}
+
+fn validate_catalog_manifest(
+    connection: &Connection,
+    requested_shards: u16,
+    objects: &[SchemaObject],
+    expected_version: u32,
+    downgrade_fence_sql: &str,
+    expected_objects: &[SchemaObject],
+) -> EngineResult<ManifestSnapshot> {
+    if objects != expected_objects {
         return Err(EngineError::new(
             EngineErrorKind::DataCorruption,
-            "manifest schema version 4 has unexpected database objects",
+            format!("manifest schema version {expected_version} has unexpected database objects"),
         ));
     }
 
     let (shard_count, routing_catalog) = validate_routing_manifest(
         connection,
         requested_shards,
-        V4_SCHEMA_VERSION,
-        V4_DOWNGRADE_FENCE_SQL,
+        expected_version,
+        downgrade_fence_sql,
     )?;
     validate_table(
         connection,
@@ -1292,7 +1619,78 @@ fn validate_v4(
             databases,
             tables,
         )),
+        shard_layout: None,
     })
+}
+
+fn validate_shard_layout(connection: &Connection) -> EngineResult<ShardLayout> {
+    let mut statement = connection
+        .prepare(
+            "SELECT singleton,
+                    layout_id,
+                    shard_application_id,
+                    shard_metadata_version,
+                    layout_state
+             FROM briskdb_shard_layout
+             ORDER BY singleton
+             LIMIT 3",
+        )
+        .map_err(|error| manifest_read_error(error, "failed to read physical shard layout"))?;
+    let rows = statement
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, Vec<u8>>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, i64>(3)?,
+                row.get::<_, i64>(4)?,
+            ))
+        })
+        .map_err(|error| manifest_read_error(error, "failed to read physical shard layout"))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| manifest_read_error(error, "failed to read physical shard layout"))?;
+    if rows.len() != 1 || rows[0].0 != 1 {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "physical shard layout must contain exactly its singleton row",
+        ));
+    }
+
+    let (_, layout_id, application_id, metadata_version, state) = &rows[0];
+    let layout_id: [u8; 16] = layout_id.as_slice().try_into().map_err(|_| {
+        EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "physical shard layout identifier must contain exactly 16 bytes",
+        )
+    })?;
+    if *application_id != SHARD_APPLICATION_ID {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!(
+                "physical shard layout has unsupported application identifier {application_id:#010x}"
+            ),
+        ));
+    }
+    let metadata_version = u32::try_from(*metadata_version).map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::DataCorruption,
+            "physical shard metadata version is outside the supported numeric range",
+            error,
+        )
+    })?;
+    if metadata_version != SHARD_METADATA_VERSION {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!("physical shard layout has unsupported metadata version {metadata_version}"),
+        ));
+    }
+    let state = ShardLayoutState::from_code(*state)?;
+    Ok(ShardLayout::from_validated_parts(
+        layout_id,
+        *application_id,
+        metadata_version,
+        state,
+    ))
 }
 
 fn validate_schema_catalog_configuration(
@@ -1879,6 +2277,16 @@ fn manifest_read_error(error: rusqlite::Error, diagnostic: &'static str) -> Engi
 }
 
 #[cfg(test)]
+pub(super) fn create_v4_fixture(connection: &mut Connection, shard_count: u16) {
+    let transaction = connection
+        .transaction()
+        .expect("v4 fixture transaction starts");
+    create_v4_schema(&transaction, shard_count).expect("v4 fixture schema is valid");
+    set_identity(&transaction, V4_SCHEMA_VERSION).expect("v4 fixture identity is valid");
+    transaction.commit().expect("v4 fixture commits");
+}
+
+#[cfg(test)]
 mod tests {
     use std::{
         panic::{AssertUnwindSafe, catch_unwind},
@@ -1935,6 +2343,25 @@ mod tests {
         create_v3_schema(&transaction, shards).unwrap();
         set_identity(&transaction, V3_SCHEMA_VERSION).unwrap();
         transaction.commit().unwrap();
+    }
+
+    fn create_v4_manifest(connection: &mut Connection, shards: u16) {
+        create_v4_fixture(connection, shards);
+    }
+
+    fn shard_layout_row(connection: &Connection) -> (Vec<u8>, i64, i64, i64) {
+        connection
+            .query_row(
+                "SELECT layout_id,
+                        shard_application_id,
+                        shard_metadata_version,
+                        layout_state
+                 FROM briskdb_shard_layout
+                 WHERE singleton = 1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap()
     }
 
     fn routing_configuration(connection: &Connection) -> (i64, i64, i64, i64, i64, i64) {
@@ -2068,7 +2495,7 @@ mod tests {
             identity(connection),
             (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
         );
-        assert_eq!(schema_objects(connection).unwrap(), v4_objects());
+        assert_eq!(schema_objects(connection).unwrap(), v5_objects());
         assert_eq!(
             connection
                 .query_row(
@@ -2077,7 +2504,7 @@ mod tests {
                     |row| row.get::<_, i64>(0),
                 )
                 .unwrap(),
-            i64::from(V4_SCHEMA_VERSION)
+            i64::from(V5_SCHEMA_VERSION)
         );
         assert_eq!(
             routing_configuration(connection),
@@ -2118,6 +2545,11 @@ mod tests {
             [(1, DEFAULT_LOGICAL_DATABASE_NAME.to_owned())]
         );
         assert!(table_metadata_rows(connection).is_empty());
+        let (layout_id, application_id, metadata_version, state) = shard_layout_row(connection);
+        assert_eq!(layout_id.len(), 16);
+        assert_eq!(application_id, SHARD_APPLICATION_ID);
+        assert_eq!(metadata_version, i64::from(SHARD_METADATA_VERSION));
+        assert!(matches!(state, 1..=3));
         validate_foreign_keys(connection).unwrap();
     }
 
@@ -2207,7 +2639,7 @@ mod tests {
             .unwrap(),
             4
         );
-        assert_eq!(resumed_steps, [(2, 3), (3, 4)]);
+        assert_eq!(resumed_steps, [(2, 3), (3, 4), (4, 5)]);
         assert_generation_one_catalog(&connection, 4);
         assert_eq!(quick_check(&connection), "ok");
     }
@@ -2232,6 +2664,160 @@ mod tests {
             .pragma_query_value(None, "data_version", |row| row.get(0))
             .unwrap();
         assert_eq!(before, after, "a current-version reopen must not write");
+    }
+
+    #[test]
+    fn fresh_manifest_persists_one_layout_identity_and_ready_transition() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        let (_, creating) = load_or_create_manifest(&mut connection, 4)
+            .unwrap()
+            .into_parts();
+
+        assert_eq!(creating.state(), ShardLayoutState::Creating);
+        assert_eq!(creating.expected_application_id(), SHARD_APPLICATION_ID);
+        assert_eq!(creating.metadata_version(), SHARD_METADATA_VERSION);
+
+        let (_, reopened) = load_or_create_manifest(&mut connection, 4)
+            .unwrap()
+            .into_parts();
+        assert_eq!(reopened, creating);
+
+        mark_shard_layout_ready(&mut connection, 4, &creating).unwrap();
+        let (_, ready) = load_or_create_manifest(&mut connection, 4)
+            .unwrap()
+            .into_parts();
+        assert_eq!(ready.layout_id(), creating.layout_id());
+        assert_eq!(ready.state(), ShardLayoutState::Ready);
+
+        mark_shard_layout_ready(&mut connection, 4, &ready).unwrap();
+        assert_eq!(
+            shard_layout_row(&connection).3,
+            ShardLayoutState::Ready.code()
+        );
+    }
+
+    #[test]
+    fn lagging_reconciler_rereads_ready_instead_of_using_stale_creating_state() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("manifest.sqlite");
+        let mut first = Connection::open(&path).unwrap();
+        let (_, first_creating) = load_or_create_manifest(&mut first, 4).unwrap().into_parts();
+        let mut lagging = Connection::open(&path).unwrap();
+        let (_, stale_creating) = load_or_create_manifest(&mut lagging, 4)
+            .unwrap()
+            .into_parts();
+        assert_eq!(first_creating, stale_creating);
+
+        let ready = reconcile_shard_layout(&mut first, 4, &first_creating, |_| Ok(())).unwrap();
+        assert_eq!(ready.state(), ShardLayoutState::Ready);
+
+        let mut state_under_lock = None;
+        let observed = reconcile_shard_layout(&mut lagging, 4, &stale_creating, |locked| {
+            state_under_lock = Some(locked.state());
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(state_under_lock, Some(ShardLayoutState::Ready));
+        assert_eq!(observed, ready);
+    }
+
+    #[test]
+    fn version_four_upgrade_enters_adopting_and_preserves_catalog_rows() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        create_v4_manifest(&mut connection, 4);
+        insert_valid_table_catalog(&connection);
+
+        let (catalog, layout) = load_or_create_manifest(&mut connection, 4)
+            .unwrap()
+            .into_parts();
+
+        assert_eq!(layout.state(), ShardLayoutState::Adopting);
+        assert_eq!(catalog.logical().logical_databases().len(), 2);
+        assert_eq!(catalog.logical().tables().len(), 5);
+        assert_eq!(
+            identity(&connection),
+            (MANIFEST_APPLICATION_ID, i64::from(V5_SCHEMA_VERSION))
+        );
+        assert_eq!(schema_objects(&connection).unwrap(), v5_objects());
+        assert_eq!(
+            shard_layout_row(&connection).3,
+            ShardLayoutState::Adopting.code()
+        );
+        assert_eq!(quick_check(&connection), "ok");
+    }
+
+    #[test]
+    fn ready_transition_rejects_different_layout_identity_or_state_without_mutation() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        let (_, expected) = load_or_create_manifest(&mut connection, 4)
+            .unwrap()
+            .into_parts();
+        let wrong_state = ShardLayout::from_validated_parts(
+            expected.layout_id(),
+            expected.expected_application_id(),
+            expected.metadata_version(),
+            ShardLayoutState::Adopting,
+        );
+        let error = mark_shard_layout_ready(&mut connection, 4, &wrong_state).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+
+        let mut wrong_id = expected.layout_id();
+        wrong_id[0] ^= 0xff;
+        let wrong = ShardLayout::from_validated_parts(
+            wrong_id,
+            expected.expected_application_id(),
+            expected.metadata_version(),
+            expected.state(),
+        );
+
+        let error = mark_shard_layout_ready(&mut connection, 4, &wrong).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+        let (_, observed) = load_or_create_manifest(&mut connection, 4)
+            .unwrap()
+            .into_parts();
+        assert_eq!(observed, expected);
+    }
+
+    #[test]
+    fn fresh_initialization_is_rejected_beside_an_existing_layout() {
+        let mut empty = Connection::open_in_memory().unwrap();
+        let error = load_or_create_manifest_with_fresh_layout(&mut empty, 4, false).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert_eq!(identity(&empty), (0, 0));
+        assert!(schema_objects(&empty).unwrap().is_empty());
+
+        let mut interrupted = Connection::open_in_memory().unwrap();
+        create_empty_legacy_manifest(&interrupted);
+        let error =
+            load_or_create_manifest_with_fresh_layout(&mut interrupted, 4, false).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert_eq!(identity(&interrupted), (0, 0));
+        assert_eq!(schema_objects(&interrupted).unwrap(), legacy_objects());
+    }
+
+    #[test]
+    fn rejects_corrupt_physical_layout_rows() {
+        for mutation in [
+            "DELETE FROM briskdb_shard_layout",
+            "UPDATE briskdb_shard_layout SET layout_id = x'01'",
+            "UPDATE briskdb_shard_layout SET shard_application_id = 7",
+            "UPDATE briskdb_shard_layout SET shard_metadata_version = 2",
+            "UPDATE briskdb_shard_layout SET layout_state = 9",
+            "INSERT INTO briskdb_shard_layout VALUES (2, randomblob(16), 1112691528, 1, 1)",
+        ] {
+            let mut connection = Connection::open_in_memory().unwrap();
+            load_or_create(&mut connection, 4).unwrap();
+            connection
+                .execute_batch("PRAGMA ignore_check_constraints = ON;")
+                .unwrap();
+            connection.execute_batch(mutation).unwrap();
+            connection
+                .execute_batch("PRAGMA ignore_check_constraints = OFF;")
+                .unwrap();
+
+            let error = load_or_create(&mut connection, 4).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::DataCorruption, "{mutation}");
+        }
     }
 
     #[test]
@@ -2339,12 +2925,20 @@ mod tests {
             let fresh_catalog = load_or_create_catalog(&mut fresh, shard_count).unwrap();
             assert_eq!(fresh_catalog.routing().shard_count(), shard_count);
             assert_generation_one_catalog(&fresh, shard_count);
+            assert_eq!(
+                shard_layout_row(&fresh).3,
+                ShardLayoutState::Creating.code()
+            );
 
             let mut upgraded = Connection::open_in_memory().unwrap();
             create_v2_manifest(&mut upgraded, shard_count);
             let upgraded_catalog = load_or_create_catalog(&mut upgraded, shard_count).unwrap();
             assert_eq!(upgraded_catalog.routing().shard_count(), shard_count);
             assert_generation_one_catalog(&upgraded, shard_count);
+            assert_eq!(
+                shard_layout_row(&upgraded).3,
+                ShardLayoutState::Adopting.code()
+            );
             assert_eq!(fresh_catalog, upgraded_catalog);
             for key in [
                 b"".as_slice(),
@@ -2371,6 +2965,10 @@ mod tests {
                 load_or_create_catalog(&mut version_three, shard_count).unwrap();
             assert_eq!(fresh_catalog, version_three_catalog);
             assert_generation_one_catalog(&version_three, shard_count);
+            assert_eq!(
+                shard_layout_row(&version_three).3,
+                ShardLayoutState::Adopting.code()
+            );
         }
     }
 
@@ -2443,6 +3041,10 @@ mod tests {
             assert_eq!(load_or_create(&mut connection, 4).unwrap(), 4);
             assert_eq!(current_shard_count(&connection), 4);
             assert_generation_one_catalog(&connection, 4);
+            assert_eq!(
+                shard_layout_row(&connection).3,
+                ShardLayoutState::Adopting.code()
+            );
             assert_eq!(quick_check(&connection), "ok");
         }
     }
@@ -2455,6 +3057,10 @@ mod tests {
         assert_eq!(load_or_create(&mut connection, 8).unwrap(), 8);
         assert_eq!(current_shard_count(&connection), 8);
         assert_generation_one_catalog(&connection, 8);
+        assert_eq!(
+            shard_layout_row(&connection).3,
+            ShardLayoutState::Creating.code()
+        );
     }
 
     #[test]
@@ -2709,6 +3315,114 @@ mod tests {
             assert_eq!(load_or_create(&mut connection, 3).unwrap(), 3);
             assert_generation_one_catalog(&connection, 3);
         }
+    }
+
+    #[test]
+    fn physical_layout_migration_failures_roll_back_to_exact_v4_and_retry() {
+        for failing_phase in [
+            MigrationPhase::AfterSchemaChange,
+            MigrationPhase::AfterVersionStamp,
+        ] {
+            let mut connection = Connection::open_in_memory().unwrap();
+            create_v4_manifest(&mut connection, 4);
+            insert_valid_table_catalog(&connection);
+            let databases_before = logical_databases(&connection);
+            let tables_before = table_metadata_rows(&connection);
+
+            let error = load_or_create_with_hook(&mut connection, 4, |point| {
+                if point.from == V4_SCHEMA_VERSION && point.phase == failing_phase {
+                    Err(EngineError::new(
+                        EngineErrorKind::Internal,
+                        "injected physical layout migration failure",
+                    ))
+                } else {
+                    Ok(())
+                }
+            })
+            .unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::Internal);
+            assert_eq!(
+                identity(&connection),
+                (MANIFEST_APPLICATION_ID, i64::from(V4_SCHEMA_VERSION))
+            );
+            assert_eq!(schema_objects(&connection).unwrap(), v4_objects());
+            assert_eq!(logical_databases(&connection), databases_before);
+            assert_eq!(table_metadata_rows(&connection), tables_before);
+            assert_eq!(quick_check(&connection), "ok");
+
+            let (_, layout) = load_or_create_manifest(&mut connection, 4)
+                .unwrap()
+                .into_parts();
+            assert_eq!(layout.state(), ShardLayoutState::Adopting);
+        }
+    }
+
+    #[test]
+    fn physical_layout_migration_panics_roll_back_to_exact_v4_and_retry() {
+        for failing_phase in [
+            MigrationPhase::AfterSchemaChange,
+            MigrationPhase::AfterVersionStamp,
+        ] {
+            let mut connection = Connection::open_in_memory().unwrap();
+            create_v4_manifest(&mut connection, 3);
+
+            let panic = catch_unwind(AssertUnwindSafe(|| {
+                let _ = load_or_create_with_hook(&mut connection, 3, |point| {
+                    if point.from == V4_SCHEMA_VERSION && point.phase == failing_phase {
+                        panic!("injected physical layout migration panic");
+                    }
+                    Ok(())
+                });
+            }));
+            assert!(panic.is_err());
+            assert_eq!(
+                identity(&connection),
+                (MANIFEST_APPLICATION_ID, i64::from(V4_SCHEMA_VERSION))
+            );
+            assert_eq!(schema_objects(&connection).unwrap(), v4_objects());
+            assert_eq!(quick_check(&connection), "ok");
+
+            let (_, layout) = load_or_create_manifest(&mut connection, 3)
+                .unwrap()
+                .into_parts();
+            assert_eq!(layout.state(), ShardLayoutState::Adopting);
+        }
+    }
+
+    #[test]
+    fn reconciliation_error_and_panic_leave_provisioning_state_resumable() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        let (_, creating) = load_or_create_manifest(&mut connection, 4)
+            .unwrap()
+            .into_parts();
+
+        let error = reconcile_shard_layout(&mut connection, 4, &creating, |locked| {
+            assert_eq!(locked.state(), ShardLayoutState::Creating);
+            Err(EngineError::new(
+                EngineErrorKind::Internal,
+                "injected shard reconciliation failure",
+            ))
+        })
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Internal);
+        assert_eq!(
+            shard_layout_row(&connection).3,
+            ShardLayoutState::Creating.code()
+        );
+
+        let panic = catch_unwind(AssertUnwindSafe(|| {
+            let _ = reconcile_shard_layout(&mut connection, 4, &creating, |_| {
+                panic!("injected shard reconciliation panic");
+            });
+        }));
+        assert!(panic.is_err());
+        assert_eq!(
+            shard_layout_row(&connection).3,
+            ShardLayoutState::Creating.code()
+        );
+
+        let ready = reconcile_shard_layout(&mut connection, 4, &creating, |_| Ok(())).unwrap();
+        assert_eq!(ready.state(), ShardLayoutState::Ready);
     }
 
     #[test]
@@ -3002,6 +3716,7 @@ mod tests {
             current_version: V2_SCHEMA_VERSION,
             migrations: OLD_MIGRATIONS,
             initialize_current: create_v2_schema,
+            initialize_interrupted_legacy: migrate_v1_to_v2,
         };
 
         let mut connection = Connection::open_in_memory().unwrap();
@@ -3015,7 +3730,7 @@ mod tests {
     }
 
     #[test]
-    fn version_three_reader_rejects_version_four_without_mutating_it() {
+    fn version_three_reader_rejects_current_manifest_without_mutating_it() {
         const OLD_MIGRATIONS: &[Migration] = &[
             Migration {
                 from: LEGACY_SCHEMA_VERSION,
@@ -3036,6 +3751,7 @@ mod tests {
             current_version: V3_SCHEMA_VERSION,
             migrations: OLD_MIGRATIONS,
             initialize_current: create_v3_schema,
+            initialize_interrupted_legacy: migrate_interrupted_legacy_to_v3,
         };
 
         let mut connection = Connection::open_in_memory().unwrap();
@@ -3048,6 +3764,52 @@ mod tests {
         assert_eq!(schema_objects(&connection).unwrap(), objects);
         assert_eq!(logical_databases(&connection), databases);
         assert_generation_one_catalog(&connection, 4);
+    }
+
+    #[test]
+    fn version_four_reader_rejects_version_five_without_mutating_it() {
+        const OLD_MIGRATIONS: &[Migration] = &[
+            Migration {
+                from: LEGACY_SCHEMA_VERSION,
+                to: V2_SCHEMA_VERSION,
+                name: "typed_manifest_and_downgrade_fence",
+                apply: migrate_v1_to_v2,
+                validate: validate_v2,
+            },
+            Migration {
+                from: V2_SCHEMA_VERSION,
+                to: V3_SCHEMA_VERSION,
+                name: "durable_shard_catalog",
+                apply: migrate_v2_to_v3,
+                validate: validate_v3,
+            },
+            Migration {
+                from: V3_SCHEMA_VERSION,
+                to: V4_SCHEMA_VERSION,
+                name: "logical_database_and_table_catalog",
+                apply: migrate_v3_to_v4,
+                validate: validate_v4,
+            },
+        ];
+        const OLD_PLAN: MigrationPlan<'static> = MigrationPlan {
+            current_version: V4_SCHEMA_VERSION,
+            migrations: OLD_MIGRATIONS,
+            initialize_current: create_v4_schema,
+            initialize_interrupted_legacy: migrate_interrupted_legacy_to_v4,
+        };
+
+        let mut connection = Connection::open_in_memory().unwrap();
+        load_or_create(&mut connection, 4).unwrap();
+        let identity_before = identity(&connection);
+        let objects_before = schema_objects(&connection).unwrap();
+        let layout_before = shard_layout_row(&connection);
+
+        let error = inspect_with_plan(&connection, 4, OLD_PLAN).unwrap_err();
+
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert_eq!(identity(&connection), identity_before);
+        assert_eq!(schema_objects(&connection).unwrap(), objects_before);
+        assert_eq!(shard_layout_row(&connection), layout_before);
     }
 
     #[test]
@@ -3093,7 +3855,7 @@ mod tests {
         for mutation in [
             "DELETE FROM briskdb_metadata",
             "DELETE FROM briskdb_manifest",
-            "INSERT INTO briskdb_metadata VALUES (4)",
+            "INSERT INTO briskdb_metadata VALUES (5)",
             "DELETE FROM briskdb_routing",
             "DELETE FROM briskdb_virtual_buckets WHERE bucket_id = 4095",
             "DELETE FROM briskdb_physical_shards WHERE shard_id = 3",
@@ -3372,6 +4134,16 @@ mod tests {
                 shard_key_column TEXT,
                 shard_key_type INTEGER
              ) STRICT;",
+            "DROP TABLE briskdb_shard_layout;
+             CREATE TABLE briskdb_shard_layout (
+                singleton INTEGER PRIMARY KEY,
+                layout_id BLOB NOT NULL,
+                shard_application_id INTEGER NOT NULL,
+                shard_metadata_version INTEGER NOT NULL,
+                layout_state INTEGER NOT NULL
+             ) STRICT;
+             INSERT INTO briskdb_shard_layout
+             VALUES (1, randomblob(16), 1112691528, 1, 1);",
         ] {
             let mut connection = Connection::open_in_memory().unwrap();
             load_or_create(&mut connection, 4).unwrap();

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,6 +1,7 @@
 //! SQLite file layout, versioned manifest management, and connection configuration.
 
 mod manifest;
+mod shard;
 
 pub(crate) mod pool;
 pub(crate) use pool::{ConnectionOwner, ConnectionPools, PooledConnection};
@@ -31,6 +32,7 @@ pub(crate) const CONNECTION_BUSY_TIMEOUT: std::time::Duration = std::time::Durat
 pub(crate) struct Storage {
     root: PathBuf,
     catalog: Arc<CatalogSnapshot>,
+    shard_layout: shard::ShardLayout,
 }
 
 impl Storage {
@@ -42,23 +44,41 @@ impl Storage {
             sqlite_error::storage_io(error, format!("failed to create {}", root.display()))
         })?;
         let shards_dir = root.join("shards");
+        let fresh_layout_allowed = physical_layout_is_empty(&shards_dir)?;
         let manifest_path = root.join("manifest.sqlite");
         let mut manifest = Connection::open(&manifest_path).map_err(|error| {
             sqlite_error::storage(error)
                 .context(format!("failed to open {}", manifest_path.display()))
         })?;
         configure_manifest_connection(&manifest)?;
-        let catalog = Arc::new(manifest::load_or_create_catalog(
+        let loaded = manifest::load_or_create_manifest_with_fresh_layout(
             &mut manifest,
             requested_shards,
-        )?);
+            fresh_layout_allowed,
+        )?;
         configure_journal_mode(&manifest)?;
+        let (catalog, shard_layout) = loaded.into_parts();
+        let schema_generation = catalog.logical().schema_generation();
 
-        fs::create_dir_all(&shards_dir).map_err(|error| {
-            sqlite_error::storage_io(error, format!("failed to create {}", shards_dir.display()))
-        })?;
+        let ready_layout = manifest::reconcile_shard_layout(
+            &mut manifest,
+            requested_shards,
+            &shard_layout,
+            |locked_layout| {
+                shard::prepare_layout(
+                    &shards_dir,
+                    catalog.routing().shard_count(),
+                    schema_generation,
+                    locked_layout,
+                )
+            },
+        )?;
 
-        let storage = Self { root, catalog };
+        let storage = Self {
+            root,
+            catalog: Arc::new(catalog),
+            shard_layout: ready_layout,
+        };
         for shard in 0..storage.shard_count() {
             storage.open_shard(shard)?;
         }
@@ -82,23 +102,42 @@ impl Storage {
     }
 
     pub(crate) fn open_shard(&self, shard: u16) -> EngineResult<Connection> {
-        let connection = self.open_unconfigured_shard(shard)?;
-        configure_connection(&connection)?;
+        self.ensure_shard_in_range(shard)?;
+        let path = self.shard_path(shard);
+        let connection = shard::open_existing(
+            &path,
+            shard,
+            self.catalog.logical().schema_generation(),
+            &self.shard_layout,
+        )?;
+        attach_storage_authorizer(&connection)?;
         Ok(connection)
     }
 
     fn open_unconfigured_shard(&self, shard: u16) -> EngineResult<Connection> {
+        self.ensure_shard_in_range(shard)?;
+        shard::open_required_file(&self.shard_path(shard))
+    }
+
+    fn validate_unconfigured_shard(&self, connection: &Connection, shard: u16) -> EngineResult<()> {
+        self.ensure_shard_in_range(shard)?;
+        shard::validate_open_connection(
+            connection,
+            &self.shard_path(shard),
+            shard,
+            self.catalog.logical().schema_generation(),
+            &self.shard_layout,
+        )
+    }
+
+    fn ensure_shard_in_range(&self, shard: u16) -> EngineResult<()> {
         if shard >= self.shard_count() {
             return Err(EngineError::new(
                 EngineErrorKind::Internal,
                 format!("shard {shard} is outside the configured range"),
             ));
         }
-        let path = self.shard_path(shard);
-        let connection = Connection::open(&path).map_err(|error| {
-            sqlite_error::storage(error).context(format!("failed to open shard {}", path.display()))
-        })?;
-        Ok(connection)
+        Ok(())
     }
 
     pub(crate) fn open_pooled_shard(
@@ -125,6 +164,9 @@ impl Storage {
         let authorizer_probe_wrote = Arc::clone(&probe_wrote);
         connection
             .authorizer(Some(move |context: AuthContext<'_>| {
+                if shard::denies_client_action(context.action) {
+                    return Authorization::Deny;
+                }
                 if action_taints_connection(context.action) {
                     if authorizer_probing.load(Ordering::Relaxed) {
                         authorizer_probe_tainted.store(true, Ordering::Relaxed);
@@ -153,6 +195,54 @@ impl Storage {
             },
         ))
     }
+}
+
+fn physical_layout_is_empty(shards_dir: &Path) -> EngineResult<bool> {
+    let metadata = match fs::symlink_metadata(shards_dir) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(true),
+        Err(error) => {
+            return Err(sqlite_error::storage_io(
+                error,
+                format!("failed to inspect {}", shards_dir.display()),
+            ));
+        }
+    };
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!(
+                "shard path {} is not a real directory",
+                shards_dir.display()
+            ),
+        ));
+    }
+    let mut entries = fs::read_dir(shards_dir).map_err(|error| {
+        sqlite_error::storage_io(
+            error,
+            format!("failed to enumerate {}", shards_dir.display()),
+        )
+    })?;
+    match entries.next() {
+        None => Ok(true),
+        Some(Ok(_)) => Ok(false),
+        Some(Err(error)) => Err(sqlite_error::storage_io(
+            error,
+            format!("failed to enumerate {}", shards_dir.display()),
+        )),
+    }
+}
+
+fn attach_storage_authorizer(connection: &Connection) -> EngineResult<()> {
+    connection
+        .authorizer(Some(|context: AuthContext<'_>| {
+            if shard::denies_client_action(context.action) {
+                Authorization::Deny
+            } else {
+                Authorization::Allow
+            }
+        }))
+        .map_err(sqlite_error::storage)
 }
 
 #[derive(Debug)]
@@ -234,13 +324,6 @@ fn action_writes_connection(action: AuthAction<'_>) -> bool {
     )
 }
 
-fn configure_connection(connection: &Connection) -> EngineResult<()> {
-    connection
-        .busy_timeout(CONNECTION_BUSY_TIMEOUT)
-        .map_err(sqlite_error::storage)?;
-    configure_connection_pragmas(connection)
-}
-
 fn configure_manifest_connection(connection: &Connection) -> EngineResult<()> {
     connection
         .busy_timeout(CONNECTION_BUSY_TIMEOUT)
@@ -267,17 +350,6 @@ fn configure_journal_mode(connection: &Connection) -> EngineResult<()> {
     Ok(())
 }
 
-fn configure_connection_pragmas(connection: &Connection) -> EngineResult<()> {
-    configure_journal_mode(connection)?;
-    connection
-        .pragma_update(None, "synchronous", "FULL")
-        .map_err(sqlite_error::storage)?;
-    connection
-        .pragma_update(None, "foreign_keys", "ON")
-        .map_err(sqlite_error::storage)?;
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use std::{
@@ -288,6 +360,53 @@ mod tests {
 
     use super::*;
 
+    fn shard_file(root: &Path, shard: u16) -> PathBuf {
+        root.join("shards").join(format!("{shard:04}.sqlite"))
+    }
+
+    fn manifest_layout_row(root: &Path) -> (Vec<u8>, i64, i64, i64) {
+        Connection::open(root.join("manifest.sqlite"))
+            .unwrap()
+            .query_row(
+                "SELECT layout_id,
+                        shard_application_id,
+                        shard_metadata_version,
+                        layout_state
+                 FROM briskdb_shard_layout
+                 WHERE singleton = 1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap()
+    }
+
+    fn create_v4_layout(root: &Path, shard_count: u16) {
+        let mut manifest = Connection::open(root.join("manifest.sqlite")).unwrap();
+        manifest::create_v4_fixture(&mut manifest, shard_count);
+        fs::create_dir(root.join("shards")).unwrap();
+        for shard in 0..shard_count {
+            let connection = Connection::open(shard_file(root, shard)).unwrap();
+            connection
+                .execute_batch(
+                    "CREATE TABLE legacy_rows (
+                        shard_id INTEGER PRIMARY KEY,
+                        value TEXT NOT NULL
+                     );",
+                )
+                .unwrap();
+            connection
+                .execute(
+                    "INSERT INTO legacy_rows (shard_id, value) VALUES (?1, ?2)",
+                    rusqlite::params![i64::from(shard), format!("legacy-{shard}")],
+                )
+                .unwrap();
+            let mode = connection
+                .pragma_update_and_check(None, "journal_mode", "WAL", |row| row.get::<_, String>(0))
+                .unwrap();
+            assert_eq!(mode.to_ascii_lowercase(), "wal");
+        }
+    }
+
     #[test]
     fn creates_layout_and_reopens_with_the_same_shard_count() {
         let temp = tempfile::tempdir().unwrap();
@@ -296,7 +415,40 @@ mod tests {
         assert_eq!(storage.shard_count(), 4);
         assert!(temp.path().join("manifest.sqlite").exists());
         assert!(temp.path().join("shards/0003.sqlite").exists());
-        assert!(Storage::open(temp.path(), 4).is_ok());
+
+        let observer_paths = std::iter::once(temp.path().join("manifest.sqlite"))
+            .chain((0..4).map(|shard| shard_file(temp.path(), shard)))
+            .collect::<Vec<_>>();
+        let observers = observer_paths
+            .iter()
+            .map(|path| Connection::open(path).unwrap())
+            .collect::<Vec<_>>();
+        let data_versions_before = observers
+            .iter()
+            .map(|connection| {
+                connection
+                    .pragma_query_value(None, "data_version", |row| row.get::<_, i64>(0))
+                    .unwrap()
+            })
+            .collect::<Vec<_>>();
+
+        drop(Storage::open(temp.path(), 4).unwrap());
+
+        for (index, (connection, before)) in observers
+            .iter()
+            .zip(data_versions_before.iter())
+            .enumerate()
+        {
+            let after = connection
+                .pragma_query_value(None, "data_version", |row| row.get::<_, i64>(0))
+                .unwrap();
+            assert_eq!(
+                *before,
+                after,
+                "ready reopen wrote to {}",
+                observer_paths[index].display()
+            );
+        }
 
         let manifest = Connection::open(temp.path().join("manifest.sqlite")).unwrap();
         assert_eq!(
@@ -321,6 +473,337 @@ mod tests {
                 .unwrap(),
             manifest::CURRENT_SCHEMA_VERSION
         );
+        let (layout_id, application_id, metadata_version, state) = manifest_layout_row(temp.path());
+        assert_eq!(layout_id.len(), 16);
+        assert_eq!(application_id, shard::SHARD_APPLICATION_ID);
+        assert_eq!(metadata_version, i64::from(shard::SHARD_METADATA_VERSION));
+        assert_eq!(state, shard::ShardLayoutState::Ready.code());
+        for shard_id in 0..4 {
+            let connection = Connection::open(shard_file(temp.path(), shard_id)).unwrap();
+            assert_eq!(
+                connection
+                    .pragma_query_value(None, "application_id", |row| row.get::<_, i64>(0))
+                    .unwrap(),
+                shard::SHARD_APPLICATION_ID
+            );
+            assert_eq!(
+                connection
+                    .pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
+                    .unwrap(),
+                0
+            );
+            assert_eq!(
+                connection
+                    .query_row(
+                        "SELECT layout_id, shard_id FROM briskdb_shard_metadata",
+                        [],
+                        |row| Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, u16>(1)?)),
+                    )
+                    .unwrap(),
+                (layout_id.clone(), shard_id)
+            );
+        }
+    }
+
+    #[test]
+    fn version_four_layout_is_adopted_without_changing_application_data() {
+        let temp = tempfile::tempdir().unwrap();
+        create_v4_layout(temp.path(), 4);
+
+        let storage = Storage::open(temp.path(), 4).unwrap();
+        assert_eq!(storage.shard_count(), 4);
+        assert_eq!(
+            manifest_layout_row(temp.path()).3,
+            shard::ShardLayoutState::Ready.code()
+        );
+        for shard_id in 0..4 {
+            let connection = storage.open_shard(shard_id).unwrap();
+            assert_eq!(
+                connection
+                    .query_row(
+                        "SELECT value FROM legacy_rows WHERE shard_id = ?1",
+                        [shard_id],
+                        |row| row.get::<_, String>(0),
+                    )
+                    .unwrap(),
+                format!("legacy-{shard_id}")
+            );
+        }
+    }
+
+    #[test]
+    fn failed_version_four_preflight_stays_adopting_and_changes_no_legacy_shard() {
+        let temp = tempfile::tempdir().unwrap();
+        create_v4_layout(temp.path(), 2);
+        let first = shard_file(temp.path(), 0);
+        let missing = shard_file(temp.path(), 1);
+        fs::remove_file(&missing).unwrap();
+
+        let error = Storage::open(temp.path(), 2).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+        assert!(!missing.exists());
+        assert_eq!(
+            manifest_layout_row(temp.path()).3,
+            shard::ShardLayoutState::Adopting.code()
+        );
+        let connection = Connection::open(first).unwrap();
+        assert_eq!(
+            connection
+                .pragma_query_value(None, "application_id", |row| row.get::<_, i64>(0))
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            connection
+                .query_row("SELECT value FROM legacy_rows", [], |row| {
+                    row.get::<_, String>(0)
+                })
+                .unwrap(),
+            "legacy-0"
+        );
+    }
+
+    #[test]
+    fn partial_creating_layout_resumes_through_storage_open_and_publishes_ready() {
+        let temp = tempfile::tempdir().unwrap();
+        let shards_dir = temp.path().join("shards");
+        let mut manifest = Connection::open(temp.path().join("manifest.sqlite")).unwrap();
+        configure_manifest_connection(&manifest).unwrap();
+        let loaded =
+            manifest::load_or_create_manifest_with_fresh_layout(&mut manifest, 2, true).unwrap();
+        configure_journal_mode(&manifest).unwrap();
+        let (catalog, layout) = loaded.into_parts();
+
+        let error = manifest::reconcile_shard_layout(&mut manifest, 2, &layout, |locked| {
+            shard::prepare_layout_with_hook(
+                &shards_dir,
+                2,
+                catalog.logical().schema_generation(),
+                locked,
+                |shard_id| {
+                    if shard_id == 0 {
+                        Err(EngineError::new(
+                            EngineErrorKind::Internal,
+                            "injected failure after first fresh shard",
+                        ))
+                    } else {
+                        Ok(())
+                    }
+                },
+            )
+        })
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Internal);
+        drop(manifest);
+        assert_eq!(
+            manifest_layout_row(temp.path()).3,
+            shard::ShardLayoutState::Creating.code()
+        );
+        assert!(shard_file(temp.path(), 0).exists());
+        assert!(!shard_file(temp.path(), 1).exists());
+
+        drop(Storage::open(temp.path(), 2).unwrap());
+        assert_eq!(
+            manifest_layout_row(temp.path()).3,
+            shard::ShardLayoutState::Ready.code()
+        );
+        assert!(shard_file(temp.path(), 1).exists());
+    }
+
+    #[test]
+    fn partial_adopting_layout_resumes_through_storage_open_and_preserves_data() {
+        let temp = tempfile::tempdir().unwrap();
+        create_v4_layout(temp.path(), 2);
+        let shards_dir = temp.path().join("shards");
+        let mut manifest = Connection::open(temp.path().join("manifest.sqlite")).unwrap();
+        configure_manifest_connection(&manifest).unwrap();
+        let loaded =
+            manifest::load_or_create_manifest_with_fresh_layout(&mut manifest, 2, false).unwrap();
+        configure_journal_mode(&manifest).unwrap();
+        let (catalog, layout) = loaded.into_parts();
+        assert_eq!(layout.state(), shard::ShardLayoutState::Adopting);
+
+        let error = manifest::reconcile_shard_layout(&mut manifest, 2, &layout, |locked| {
+            shard::prepare_layout_with_hook(
+                &shards_dir,
+                2,
+                catalog.logical().schema_generation(),
+                locked,
+                |shard_id| {
+                    if shard_id == 0 {
+                        Err(EngineError::new(
+                            EngineErrorKind::Internal,
+                            "injected failure after first adopted shard",
+                        ))
+                    } else {
+                        Ok(())
+                    }
+                },
+            )
+        })
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Internal);
+        drop(manifest);
+        assert_eq!(
+            manifest_layout_row(temp.path()).3,
+            shard::ShardLayoutState::Adopting.code()
+        );
+        let first = Connection::open(shard_file(temp.path(), 0)).unwrap();
+        let second = Connection::open(shard_file(temp.path(), 1)).unwrap();
+        assert_eq!(
+            first
+                .pragma_query_value(None, "application_id", |row| row.get::<_, i64>(0))
+                .unwrap(),
+            shard::SHARD_APPLICATION_ID
+        );
+        assert_eq!(
+            second
+                .pragma_query_value(None, "application_id", |row| row.get::<_, i64>(0))
+                .unwrap(),
+            0
+        );
+        drop((first, second));
+
+        let storage = Storage::open(temp.path(), 2).unwrap();
+        assert_eq!(
+            manifest_layout_row(temp.path()).3,
+            shard::ShardLayoutState::Ready.code()
+        );
+        for shard_id in 0..2 {
+            let value = storage
+                .open_shard(shard_id)
+                .unwrap()
+                .query_row("SELECT value FROM legacy_rows", [], |row| {
+                    row.get::<_, String>(0)
+                })
+                .unwrap();
+            assert_eq!(value, format!("legacy-{shard_id}"));
+        }
+    }
+
+    #[test]
+    fn ready_layout_never_recreates_a_missing_shard_at_startup_or_runtime() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = Storage::open(temp.path(), 2).unwrap();
+        let missing = shard_file(temp.path(), 1);
+        fs::remove_file(&missing).unwrap();
+
+        let runtime = storage.open_shard(1).unwrap_err();
+        assert_eq!(runtime.kind(), EngineErrorKind::DataCorruption);
+        assert!(!missing.exists());
+        let pooled = storage.open_pooled_shard(1).unwrap_err();
+        assert_eq!(pooled.kind(), EngineErrorKind::DataCorruption);
+        assert!(!missing.exists());
+        drop(storage);
+
+        let startup = Storage::open(temp.path(), 2).unwrap_err();
+        assert_eq!(startup.kind(), EngineErrorKind::DataCorruption);
+        assert!(!missing.exists());
+        assert_eq!(
+            manifest_layout_row(temp.path()).3,
+            shard::ShardLayoutState::Ready.code()
+        );
+    }
+
+    #[test]
+    fn startup_rejects_swapped_and_cross_layout_shards() {
+        let swapped = tempfile::tempdir().unwrap();
+        drop(Storage::open(swapped.path(), 2).unwrap());
+        let first = shard_file(swapped.path(), 0);
+        let second = shard_file(swapped.path(), 1);
+        let temporary = swapped.path().join("shards/swap.tmp");
+        fs::rename(&first, &temporary).unwrap();
+        fs::rename(&second, &first).unwrap();
+        fs::rename(&temporary, &second).unwrap();
+        let error = Storage::open(swapped.path(), 2).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+
+        let source = tempfile::tempdir().unwrap();
+        let target = tempfile::tempdir().unwrap();
+        drop(Storage::open(source.path(), 2).unwrap());
+        drop(Storage::open(target.path(), 2).unwrap());
+        fs::copy(shard_file(source.path(), 0), shard_file(target.path(), 0)).unwrap();
+        let error = Storage::open(target.path(), 2).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+    }
+
+    #[test]
+    fn startup_rejects_header_generation_and_wal_tampering_without_repair() {
+        let foreign = tempfile::tempdir().unwrap();
+        drop(Storage::open(foreign.path(), 2).unwrap());
+        Connection::open(shard_file(foreign.path(), 0))
+            .unwrap()
+            .pragma_update(None, "application_id", 0x1234)
+            .unwrap();
+        let error = Storage::open(foreign.path(), 2).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+
+        let future = tempfile::tempdir().unwrap();
+        drop(Storage::open(future.path(), 2).unwrap());
+        Connection::open(shard_file(future.path(), 0))
+            .unwrap()
+            .pragma_update(None, "user_version", 1)
+            .unwrap();
+        let error = Storage::open(future.path(), 2).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+
+        let non_wal = tempfile::tempdir().unwrap();
+        drop(Storage::open(non_wal.path(), 2).unwrap());
+        let path = shard_file(non_wal.path(), 0);
+        let connection = Connection::open(&path).unwrap();
+        let mode = connection
+            .pragma_update_and_check(None, "journal_mode", "DELETE", |row| {
+                row.get::<_, String>(0)
+            })
+            .unwrap();
+        assert_eq!(mode.to_ascii_lowercase(), "delete");
+        drop(connection);
+        let error = Storage::open(non_wal.path(), 2).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert_eq!(
+            Connection::open(path)
+                .unwrap()
+                .pragma_query_value(None, "journal_mode", |row| row.get::<_, String>(0))
+                .unwrap()
+                .to_ascii_lowercase(),
+            "delete"
+        );
+    }
+
+    #[test]
+    fn unrelated_files_are_tolerated_but_extra_canonical_shards_fail_startup() {
+        let temp = tempfile::tempdir().unwrap();
+        drop(Storage::open(temp.path(), 2).unwrap());
+        fs::write(
+            temp.path().join("shards/operator-notes.sqlite"),
+            b"not a canonical shard",
+        )
+        .unwrap();
+        drop(Storage::open(temp.path(), 2).unwrap());
+
+        fs::copy(
+            shard_file(temp.path(), 0),
+            temp.path().join("shards/0002.sqlite"),
+        )
+        .unwrap();
+        let error = Storage::open(temp.path(), 2).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn runtime_open_rejects_replacing_the_shards_directory_with_a_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let storage = Storage::open(temp.path(), 2).unwrap();
+        let shards = temp.path().join("shards");
+        let moved = temp.path().join("moved-shards");
+        fs::rename(&shards, &moved).unwrap();
+        symlink(&moved, &shards).unwrap();
+
+        let error = storage.open_shard(0).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
     }
 
     #[test]
@@ -340,6 +823,34 @@ mod tests {
         assert_eq!(
             changed.to_string(),
             "database was created with 4 shards, but 8 were requested"
+        );
+    }
+
+    #[test]
+    fn fresh_manifest_is_not_initialized_beside_unexplained_physical_files() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::create_dir(temp.path().join("shards")).unwrap();
+        fs::write(temp.path().join("shards/operator-note"), b"do not adopt").unwrap();
+
+        let error = Storage::open(temp.path(), 2).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert!(!shard_file(temp.path(), 0).exists());
+        let manifest = Connection::open(temp.path().join("manifest.sqlite")).unwrap();
+        assert_eq!(
+            manifest
+                .pragma_query_value(None, "application_id", |row| row.get::<_, i64>(0))
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            manifest
+                .query_row(
+                    "SELECT COUNT(*) FROM sqlite_schema WHERE name NOT LIKE 'sqlite_%'",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            0
         );
     }
 
@@ -577,5 +1088,87 @@ mod tests {
                 .unwrap(),
             5_000
         );
+    }
+
+    #[test]
+    fn every_connection_surface_denies_storage_owned_sql_and_preserves_identity() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = Storage::open(temp.path(), 2).unwrap();
+
+        for connection in [
+            storage.open_shard(0).unwrap(),
+            storage.open_pooled_shard(0).unwrap().0,
+        ] {
+            connection
+                .execute_batch(
+                    "CREATE TABLE IF NOT EXISTS application_rows (id INTEGER PRIMARY KEY);
+                     INSERT OR IGNORE INTO application_rows VALUES (1);",
+                )
+                .unwrap();
+            for statement in [
+                "PRAGMA application_id = 7",
+                "PRAGMA user_version = 7",
+                "PRAGMA journal_mode = DELETE",
+                "PRAGMA writable_schema = ON",
+                "UPDATE briskdb_shard_metadata SET shard_id = 1",
+                "SELECT * FROM briskdb_shard_metadata",
+                "DROP TABLE briskdb_shard_metadata",
+                "CREATE TABLE briskdb_future (id INTEGER)",
+                "ALTER TABLE application_rows RENAME TO briskdb_future",
+            ] {
+                assert!(
+                    connection.execute_batch(statement).is_err(),
+                    "storage-owned statement was authorized: {statement}"
+                );
+            }
+            assert_eq!(
+                connection
+                    .query_row(
+                        "SELECT count(*) FROM sqlite_schema
+                         WHERE type = 'table' AND name = 'application_rows'",
+                        [],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .unwrap(),
+                1
+            );
+        }
+
+        let raw = Connection::open(shard_file(temp.path(), 0)).unwrap();
+        assert_eq!(
+            raw.pragma_query_value(None, "application_id", |row| row.get::<_, i64>(0))
+                .unwrap(),
+            shard::SHARD_APPLICATION_ID
+        );
+        assert_eq!(
+            raw.pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            raw.pragma_query_value(None, "journal_mode", |row| row.get::<_, String>(0))
+                .unwrap()
+                .to_ascii_lowercase(),
+            "wal"
+        );
+    }
+
+    #[test]
+    fn protocol_neutral_database_surfaces_report_storage_denials() {
+        let temp = tempfile::tempdir().unwrap();
+        let database = Database::open(temp.path(), 2).unwrap();
+
+        let pragma = database
+            .execute("tenant", "PRAGMA user_version = 7", &[])
+            .unwrap_err();
+        assert_eq!(pragma.kind(), EngineErrorKind::PermissionDenied);
+        let metadata = database
+            .query("tenant", "SELECT shard_id FROM briskdb_shard_metadata", &[])
+            .unwrap_err();
+        assert_eq!(metadata.kind(), EngineErrorKind::PermissionDenied);
+        let broadcast = database
+            .broadcast("UPDATE briskdb_shard_metadata SET shard_id = 1")
+            .unwrap_err();
+        assert_eq!(broadcast.kind(), EngineErrorKind::PermissionDenied);
     }
 }

--- a/src/storage/pool.rs
+++ b/src/storage/pool.rs
@@ -531,6 +531,8 @@ impl ShardPoolInner {
         configure_connection_controlled(
             &mut connection,
             Arc::clone(&control),
+            &self.storage,
+            self.shard,
             #[cfg(test)]
             self.take_setup_hook(),
         )?;
@@ -885,6 +887,8 @@ impl PooledConnection {
 fn configure_connection_controlled(
     connection: &mut Connection,
     control: Arc<OperationControl>,
+    storage: &Storage,
+    shard: u16,
     #[cfg(test)] barrier: Option<ControlledBarrier>,
 ) -> EngineResult<()> {
     let _busy_operation = BusyOperationGuard::install(Arc::clone(&control));
@@ -915,7 +919,7 @@ fn configure_connection_controlled(
     // Do not call the ordinary configuration wrapper here: its fixed busy
     // timeout would replace the cancellable handler before these pragmas can
     // encounter a SQLite lock.
-    let result = super::configure_connection_pragmas(connection);
+    let result = storage.validate_unconfigured_shard(connection, shard);
     let progress_cleanup = connection
         .progress_handler(0, None::<fn() -> bool>)
         .map_err(sqlite_error::storage);
@@ -1437,7 +1441,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn authorizer_probe_denies_prepare_time_pragma_effects_until_real_execution() {
+    async fn storage_owned_pragmas_remain_denied_after_probe_isolation() {
         let (temp, pools) = pools(1, 0);
         let first_owner = ConnectionOwner::new(11);
         let second_owner = ConnectionOwner::new(22);
@@ -1476,19 +1480,23 @@ mod tests {
             "the authorizer probe must deny the PRAGMA before any prepare-time effect"
         );
 
-        second.execute_batch("PRAGMA user_version = 7").unwrap();
+        let error = second.execute_batch("PRAGMA user_version = 7").unwrap_err();
+        assert!(matches!(
+            error,
+            rusqlite::Error::SqliteFailure(_, _) | rusqlite::Error::SqlInputError { .. }
+        ));
         assert_eq!(
             control
                 .query_row("PRAGMA user_version", [], |row| row.get::<_, i64>(0))
                 .unwrap(),
-            7
+            0
         );
         drop(second);
 
         let snapshot = pools.snapshot().unwrap().shards[0];
         assert_eq!(snapshot.opened, 2);
-        assert_eq!(snapshot.retired, 2);
-        assert_eq!(snapshot.idle, 0);
+        assert_eq!(snapshot.retired, 1);
+        assert_eq!(snapshot.idle, 1);
     }
 
     #[tokio::test]
@@ -1555,7 +1563,7 @@ mod tests {
         let error = second
             .isolate_foreign_sql("PRAGMA data_version")
             .unwrap_err();
-        assert_eq!(error.kind(), EngineErrorKind::StorageUnavailable);
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
         drop(second);
 
         let failed = pools.snapshot().unwrap().shards[0];

--- a/src/storage/shard.rs
+++ b/src/storage/shard.rs
@@ -1,0 +1,1658 @@
+//! Physical-shard identity, provisioning, and strict reopen validation.
+
+use std::{
+    collections::HashSet,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use rusqlite::{Connection, MAIN_DB, OpenFlags, TransactionBehavior, hooks::AuthAction};
+
+use crate::{
+    core::{EngineError, EngineErrorKind, EngineResult},
+    sqlite_error,
+};
+
+use super::CONNECTION_BUSY_TIMEOUT;
+
+/// `BRSH` encoded as SQLite's 32-bit application identifier.
+pub(super) const SHARD_APPLICATION_ID: i64 = 0x4252_5348;
+/// Version of the storage-owned shard metadata table.
+pub(super) const SHARD_METADATA_VERSION: u32 = 1;
+
+const SHARD_METADATA_TABLE: &str = "briskdb_shard_metadata";
+const MAX_SHARDS: u16 = 64;
+const MAX_DIRECTORY_ENTRIES: usize = 512;
+const MAX_SCHEMA_SQL_BYTES: usize = 4_096;
+
+const SHARD_METADATA_TABLE_SQL: &str = "CREATE TABLE briskdb_shard_metadata (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    layout_id BLOB NOT NULL
+        CHECK (typeof(layout_id) = 'blob' AND length(layout_id) = 16),
+    shard_id INTEGER NOT NULL CHECK (shard_id BETWEEN 0 AND 63)
+) STRICT";
+
+/// Durable state of physical-shard layout preparation in the manifest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i64)]
+pub(super) enum ShardLayoutState {
+    Creating = 1,
+    Adopting = 2,
+    Ready = 3,
+}
+
+impl ShardLayoutState {
+    pub(super) const fn code(self) -> i64 {
+        self as i64
+    }
+
+    pub(super) fn from_code(code: i64) -> EngineResult<Self> {
+        match code {
+            1 => Ok(Self::Creating),
+            2 => Ok(Self::Adopting),
+            3 => Ok(Self::Ready),
+            _ => Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!("manifest has unsupported shard-layout state {code}"),
+            )),
+        }
+    }
+}
+
+/// Validated physical-shard format expectations loaded from the manifest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct ShardLayout {
+    layout_id: [u8; 16],
+    expected_application_id: i64,
+    metadata_version: u32,
+    state: ShardLayoutState,
+}
+
+impl ShardLayout {
+    pub(super) fn from_validated_parts(
+        layout_id: [u8; 16],
+        expected_application_id: i64,
+        metadata_version: u32,
+        state: ShardLayoutState,
+    ) -> Self {
+        debug_assert_eq!(expected_application_id, SHARD_APPLICATION_ID);
+        debug_assert_eq!(metadata_version, SHARD_METADATA_VERSION);
+        Self {
+            layout_id,
+            expected_application_id,
+            metadata_version,
+            state,
+        }
+    }
+
+    pub(super) const fn layout_id(self) -> [u8; 16] {
+        self.layout_id
+    }
+
+    pub(super) const fn expected_application_id(self) -> i64 {
+        self.expected_application_id
+    }
+
+    pub(super) const fn metadata_version(self) -> u32 {
+        self.metadata_version
+    }
+
+    pub(super) const fn state(self) -> ShardLayoutState {
+        self.state
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PreflightState {
+    Missing,
+    Empty,
+    Legacy,
+    Exact,
+}
+
+#[derive(Debug)]
+struct PreflightShard {
+    shard_id: u16,
+    path: PathBuf,
+    state: PreflightState,
+}
+
+/// Preflight every expected file before changing any shard, provision only the
+/// eligible states, then perform one strict no-create validation pass.
+pub(super) fn prepare_layout(
+    shards_dir: &Path,
+    shard_count: u16,
+    schema_generation: u64,
+    layout: &ShardLayout,
+) -> EngineResult<()> {
+    prepare_layout_with_hook(shards_dir, shard_count, schema_generation, layout, |_| {
+        Ok(())
+    })
+}
+
+pub(super) fn prepare_layout_with_hook<F>(
+    shards_dir: &Path,
+    shard_count: u16,
+    schema_generation: u64,
+    layout: &ShardLayout,
+    mut hook: F,
+) -> EngineResult<()>
+where
+    F: FnMut(u16) -> EngineResult<()>,
+{
+    validate_inputs(shard_count, schema_generation, layout)?;
+    let preflight = preflight_all(shards_dir, shard_count, schema_generation, layout)?;
+
+    if preflight
+        .iter()
+        .any(|shard| shard.state == PreflightState::Missing)
+    {
+        create_shards_directory(shards_dir, shard_count)?;
+    }
+
+    for shard in &preflight {
+        match shard.state {
+            PreflightState::Missing | PreflightState::Empty | PreflightState::Legacy => {
+                provision_shard(
+                    &shard.path,
+                    shard.shard_id,
+                    schema_generation,
+                    layout,
+                    |_| {},
+                )?;
+            }
+            PreflightState::Exact => {}
+        }
+        hook(shard.shard_id)?;
+    }
+
+    // Re-scan after provisioning so a concurrent unexpected file or a partial
+    // SQLite state cannot be certified by the manifest caller.
+    validate_directory(shards_dir, shard_count, false)?;
+    for shard_id in 0..shard_count {
+        let path = shard_path(shards_dir, shard_id);
+        drop(open_existing(&path, shard_id, schema_generation, layout)?);
+    }
+    Ok(())
+}
+
+/// Open a required shard without create or symlink traversal and return it only
+/// after its persistent identity, generation, metadata, and WAL mode validate.
+pub(super) fn open_existing(
+    path: &Path,
+    shard_id: u16,
+    schema_generation: u64,
+    layout: &ShardLayout,
+) -> EngineResult<Connection> {
+    let connection = open_required_file(path)?;
+    configure_busy_timeout(&connection)?;
+    validate_open_connection(&connection, path, shard_id, schema_generation, layout)?;
+    Ok(connection)
+}
+
+/// Open the required path with strict filesystem and SQLite no-create/no-follow
+/// semantics, but leave database validation to the caller. The controlled pool
+/// path uses this split to install cancellation hooks before validation can
+/// wait on SQLite locks.
+pub(super) fn open_required_file(path: &Path) -> EngineResult<Connection> {
+    validate_existing_file(path)?;
+    open_existing_connection(path)
+}
+
+/// Validate and configure an already-open required shard connection without
+/// replacing its busy handler or progress hook.
+pub(super) fn validate_open_connection(
+    connection: &Connection,
+    path: &Path,
+    shard_id: u16,
+    schema_generation: u64,
+    layout: &ShardLayout,
+) -> EngineResult<()> {
+    validate_shard_id(shard_id)?;
+    let expected_user_version = expected_user_version(schema_generation)?;
+    require_writable(connection)?;
+    validate_exact_shard(connection, path, shard_id, expected_user_version, layout)?;
+    configure_connection_pragmas(connection)
+}
+
+fn preflight_all(
+    shards_dir: &Path,
+    shard_count: u16,
+    schema_generation: u64,
+    layout: &ShardLayout,
+) -> EngineResult<Vec<PreflightShard>> {
+    let directory_exists = validate_directory(
+        shards_dir,
+        shard_count,
+        layout.state() == ShardLayoutState::Creating,
+    )?;
+    let expected_user_version = expected_user_version(schema_generation)?;
+    let mut shards = Vec::with_capacity(usize::from(shard_count));
+
+    for shard_id in 0..shard_count {
+        let path = shard_path(shards_dir, shard_id);
+        let state = if !directory_exists || !path_exists(&path)? {
+            if layout.state() == ShardLayoutState::Creating {
+                PreflightState::Missing
+            } else {
+                return Err(missing_shard(&path, shard_id));
+            }
+        } else {
+            validate_existing_file(&path)?;
+            let connection = open_existing_connection(&path)?;
+            configure_connection_safety(&connection)?;
+            classify_shard(&connection, &path, shard_id, expected_user_version, layout)?
+        };
+        shards.push(PreflightShard {
+            shard_id,
+            path,
+            state,
+        });
+    }
+    Ok(shards)
+}
+
+fn validate_inputs(
+    shard_count: u16,
+    schema_generation: u64,
+    layout: &ShardLayout,
+) -> EngineResult<()> {
+    if !(2..=MAX_SHARDS).contains(&shard_count) {
+        return Err(EngineError::new(
+            EngineErrorKind::Internal,
+            "validated shard layout has an invalid shard count",
+        ));
+    }
+    expected_user_version(schema_generation)?;
+    if layout.expected_application_id() != SHARD_APPLICATION_ID
+        || layout.metadata_version() != SHARD_METADATA_VERSION
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "manifest shard-layout format is unsupported",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_shard_id(shard_id: u16) -> EngineResult<()> {
+    if shard_id < MAX_SHARDS {
+        Ok(())
+    } else {
+        Err(EngineError::new(
+            EngineErrorKind::Internal,
+            format!("shard {shard_id} is outside the supported range"),
+        ))
+    }
+}
+
+fn expected_user_version(schema_generation: u64) -> EngineResult<i64> {
+    i32::try_from(schema_generation)
+        .map(i64::from)
+        .map_err(|error| {
+            EngineError::from_source(
+                EngineErrorKind::FailedPrecondition,
+                "catalog schema generation does not fit SQLite user_version",
+                error,
+            )
+        })
+}
+
+fn validate_directory(
+    shards_dir: &Path,
+    shard_count: u16,
+    missing_allowed: bool,
+) -> EngineResult<bool> {
+    let metadata = match fs::symlink_metadata(shards_dir) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound && missing_allowed => {
+            return Ok(false);
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err(EngineError::from_source(
+                EngineErrorKind::DataCorruption,
+                format!(
+                    "required shard directory {} is missing",
+                    shards_dir.display()
+                ),
+                error,
+            ));
+        }
+        Err(error) => {
+            return Err(sqlite_error::storage_io(
+                error,
+                format!("failed to inspect {}", shards_dir.display()),
+            ));
+        }
+    };
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!(
+                "shard path {} is not a real directory",
+                shards_dir.display()
+            ),
+        ));
+    }
+
+    let expected = (0..shard_count).map(shard_filename).collect::<HashSet<_>>();
+    let mut entries = fs::read_dir(shards_dir).map_err(|error| {
+        sqlite_error::storage_io(
+            error,
+            format!("failed to enumerate {}", shards_dir.display()),
+        )
+    })?;
+    for index in 0..=MAX_DIRECTORY_ENTRIES {
+        let Some(entry) = entries.next() else {
+            return Ok(true);
+        };
+        if index == MAX_DIRECTORY_ENTRIES {
+            return Err(EngineError::new(
+                EngineErrorKind::LimitExceeded,
+                format!(
+                    "shard directory {} exceeds its bounded entry limit",
+                    shards_dir.display()
+                ),
+            ));
+        }
+        let entry = entry.map_err(|error| {
+            sqlite_error::storage_io(
+                error,
+                format!("failed to enumerate {}", shards_dir.display()),
+            )
+        })?;
+        let name = entry.file_name().into_string().map_err(|_| {
+            EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "shard directory contains a non-UTF-8 entry name",
+            )
+        })?;
+        let file_type = entry.file_type().map_err(|error| {
+            sqlite_error::storage_io(
+                error,
+                format!("failed to inspect {}", entry.path().display()),
+            )
+        })?;
+        if file_type.is_symlink() {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "shard directory entry {} is a symbolic link",
+                    entry.path().display()
+                ),
+            ));
+        }
+        if expected.contains(&name) {
+            if !file_type.is_file() {
+                return Err(EngineError::new(
+                    EngineErrorKind::FailedPrecondition,
+                    format!(
+                        "required shard {} is not a regular file",
+                        entry.path().display()
+                    ),
+                ));
+            }
+            continue;
+        }
+        if is_expected_sidecar(&name, &expected) {
+            if !file_type.is_file() {
+                return Err(EngineError::new(
+                    EngineErrorKind::FailedPrecondition,
+                    format!(
+                        "SQLite sidecar {} is not a regular file",
+                        entry.path().display()
+                    ),
+                ));
+            }
+            continue;
+        }
+        if is_canonical_shard_filename(&name) {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!("shard directory contains unexpected database file {name}"),
+            ));
+        }
+    }
+    unreachable!("bounded directory loop always returns")
+}
+
+fn is_expected_sidecar(name: &str, expected: &HashSet<String>) -> bool {
+    ["-wal", "-shm", "-journal"].iter().any(|suffix| {
+        name.strip_suffix(suffix)
+            .is_some_and(|base| expected.contains(base))
+    })
+}
+
+fn is_canonical_shard_filename(name: &str) -> bool {
+    let Some(shard_id) = name.strip_suffix(".sqlite") else {
+        return false;
+    };
+    shard_id.len() == 4 && shard_id.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+fn path_exists(path: &Path) -> EngineResult<bool> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(sqlite_error::storage_io(
+            error,
+            format!("failed to inspect {}", path.display()),
+        )),
+    }
+}
+
+fn validate_existing_file(path: &Path) -> EngineResult<()> {
+    let metadata = fs::symlink_metadata(path).map_err(|error| {
+        if error.kind() == std::io::ErrorKind::NotFound {
+            EngineError::from_source(
+                EngineErrorKind::DataCorruption,
+                format!("required shard {} is missing", path.display()),
+                error,
+            )
+        } else {
+            sqlite_error::storage_io(error, format!("failed to inspect {}", path.display()))
+        }
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!("required shard {} is not a real file", path.display()),
+        ));
+    }
+    Ok(())
+}
+
+fn create_shards_directory(shards_dir: &Path, shard_count: u16) -> EngineResult<()> {
+    match fs::create_dir(shards_dir) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            validate_directory(shards_dir, shard_count, false).map(|_| ())
+        }
+        Err(error) => Err(sqlite_error::storage_io(
+            error,
+            format!("failed to create {}", shards_dir.display()),
+        )),
+    }
+}
+
+fn shard_filename(shard_id: u16) -> String {
+    format!("{shard_id:04}.sqlite")
+}
+
+fn shard_path(shards_dir: &Path, shard_id: u16) -> PathBuf {
+    shards_dir.join(shard_filename(shard_id))
+}
+
+fn open_existing_connection(path: &Path) -> EngineResult<Connection> {
+    let flags = OpenFlags::SQLITE_OPEN_READ_WRITE
+        | OpenFlags::SQLITE_OPEN_NO_MUTEX
+        | OpenFlags::SQLITE_OPEN_NOFOLLOW
+        | OpenFlags::SQLITE_OPEN_EXRESCODE;
+    let open_path = canonical_open_path(path)?;
+    Connection::open_with_flags(open_path, flags).map_err(|error| {
+        sqlite_error::storage(error).context(format!("failed to open shard {}", path.display()))
+    })
+}
+
+fn open_creating_connection(path: &Path) -> EngineResult<Connection> {
+    let flags = OpenFlags::SQLITE_OPEN_READ_WRITE
+        | OpenFlags::SQLITE_OPEN_CREATE
+        | OpenFlags::SQLITE_OPEN_NO_MUTEX
+        | OpenFlags::SQLITE_OPEN_NOFOLLOW
+        | OpenFlags::SQLITE_OPEN_EXRESCODE;
+    let open_path = canonical_open_path(path)?;
+    Connection::open_with_flags(open_path, flags).map_err(|error| {
+        sqlite_error::storage(error).context(format!("failed to create shard {}", path.display()))
+    })
+}
+
+// SQLite's NOFOLLOW flag rejects a path containing any symlink component. On
+// macOS, tempfile paths commonly begin with `/var`, which is itself a system
+// symlink. Resolve only the already-validated parent and retain the final shard
+// component so NOFOLLOW still protects the database file from replacement.
+fn canonical_open_path(path: &Path) -> EngineResult<PathBuf> {
+    let parent = path.parent().ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!("shard path {} has no parent directory", path.display()),
+        )
+    })?;
+    let parent = if parent.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        parent
+    };
+    let parent_metadata = fs::symlink_metadata(parent).map_err(|error| {
+        sqlite_error::storage_io(
+            error,
+            format!("failed to inspect shard directory {}", parent.display()),
+        )
+    })?;
+    if parent_metadata.file_type().is_symlink() || !parent_metadata.is_dir() {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!("shard path {} is not a real directory", parent.display()),
+        ));
+    }
+    let file_name = path.file_name().ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!("shard path {} has no file name", path.display()),
+        )
+    })?;
+    let canonical_parent = fs::canonicalize(parent).map_err(|error| {
+        sqlite_error::storage_io(
+            error,
+            format!("failed to resolve shard directory {}", parent.display()),
+        )
+    })?;
+    Ok(canonical_parent.join(file_name))
+}
+
+fn configure_connection_safety(connection: &Connection) -> EngineResult<()> {
+    configure_busy_timeout(connection)?;
+    require_writable(connection)
+}
+
+fn configure_busy_timeout(connection: &Connection) -> EngineResult<()> {
+    connection
+        .busy_timeout(CONNECTION_BUSY_TIMEOUT)
+        .map_err(sqlite_error::storage)
+}
+
+fn require_writable(connection: &Connection) -> EngineResult<()> {
+    if connection
+        .is_readonly(MAIN_DB)
+        .map_err(sqlite_error::storage)?
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::ReadOnly,
+            "required shard opened read-only",
+        ));
+    }
+    Ok(())
+}
+
+fn configure_connection_pragmas(connection: &Connection) -> EngineResult<()> {
+    connection
+        .pragma_update(None, "synchronous", "FULL")
+        .map_err(sqlite_error::storage)?;
+    connection
+        .pragma_update(None, "foreign_keys", "ON")
+        .map_err(sqlite_error::storage)?;
+    Ok(())
+}
+
+fn classify_shard(
+    connection: &Connection,
+    path: &Path,
+    shard_id: u16,
+    expected_user_version: i64,
+    layout: &ShardLayout,
+) -> EngineResult<PreflightState> {
+    let (application_id, user_version) = read_identity(connection)?;
+    if application_id == layout.expected_application_id() {
+        if user_version > expected_user_version {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "shard {shard_id} schema generation {user_version} is newer than the catalog generation {expected_user_version}"
+                ),
+            ));
+        }
+        if user_version != expected_user_version {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!(
+                    "shard {shard_id} schema generation {user_version} does not match catalog generation {expected_user_version}"
+                ),
+            ));
+        }
+        require_wal(connection, path)?;
+        validate_metadata(connection, shard_id, layout.layout_id())?;
+        return Ok(PreflightState::Exact);
+    }
+
+    if application_id != 0 || user_version != 0 {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!(
+                "shard {shard_id} has foreign identity application_id={application_id:#010x}, user_version={user_version}"
+            ),
+        ));
+    }
+    if layout.state() == ShardLayoutState::Ready {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!("ready shard {shard_id} is missing its BriskDB identity"),
+        ));
+    }
+    if has_metadata_object(connection)? {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!("shard {shard_id} has a conflicting {SHARD_METADATA_TABLE} object"),
+        ));
+    }
+
+    match layout.state() {
+        ShardLayoutState::Creating => {
+            if has_application_schema_objects(connection)? {
+                Err(EngineError::new(
+                    EngineErrorKind::FailedPrecondition,
+                    format!(
+                        "new shard {} is not an exact empty SQLite database",
+                        path.display()
+                    ),
+                ))
+            } else {
+                Ok(PreflightState::Empty)
+            }
+        }
+        ShardLayoutState::Adopting => {
+            require_wal(connection, path)?;
+            Ok(PreflightState::Legacy)
+        }
+        ShardLayoutState::Ready => unreachable!("ready legacy state returned above"),
+    }
+}
+
+fn provision_shard<F>(
+    path: &Path,
+    shard_id: u16,
+    schema_generation: u64,
+    layout: &ShardLayout,
+    mut hook: F,
+) -> EngineResult<()>
+where
+    F: FnMut(ProvisionPoint),
+{
+    let expected_user_version = expected_user_version(schema_generation)?;
+    let mut connection = if path_exists(path)? {
+        validate_existing_file(path)?;
+        open_existing_connection(path)?
+    } else if layout.state() == ShardLayoutState::Creating {
+        open_creating_connection(path)?
+    } else {
+        return Err(missing_shard(path, shard_id));
+    };
+    configure_connection_safety(&connection)?;
+
+    // Reclassify after opening so replacement between preflight and provisioning
+    // cannot be overwritten as if it were the previously inspected file.
+    let state = classify_shard(&connection, path, shard_id, expected_user_version, layout)?;
+    if state == PreflightState::Exact {
+        return Ok(());
+    }
+    configure_connection_pragmas(&connection)?;
+    if state == PreflightState::Empty {
+        enable_wal(&connection, path)?;
+        hook(ProvisionPoint::WalPersisted);
+    }
+
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    // A second startup may have completed this shard while this connection
+    // waited for the write lock. Reclassifying under that lock makes an exact
+    // concurrent result idempotent and prevents a CREATE TABLE race.
+    let locked_state = classify_shard(&transaction, path, shard_id, expected_user_version, layout)?;
+    if locked_state == PreflightState::Exact {
+        return Ok(());
+    }
+    transaction
+        .execute_batch(SHARD_METADATA_TABLE_SQL)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "INSERT INTO briskdb_shard_metadata (singleton, layout_id, shard_id)
+             VALUES (1, ?1, ?2)",
+            rusqlite::params![layout.layout_id().as_slice(), i64::from(shard_id)],
+        )
+        .map_err(sqlite_error::storage)?;
+    hook(ProvisionPoint::MetadataWritten);
+    transaction
+        .pragma_update(None, "application_id", layout.expected_application_id())
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .pragma_update(None, "user_version", expected_user_version)
+        .map_err(sqlite_error::storage)?;
+    hook(ProvisionPoint::IdentityWritten);
+    validate_exact_shard(&transaction, path, shard_id, expected_user_version, layout)?;
+    transaction.commit().map_err(sqlite_error::storage)?;
+    validate_exact_shard(&connection, path, shard_id, expected_user_version, layout)?;
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProvisionPoint {
+    WalPersisted,
+    MetadataWritten,
+    IdentityWritten,
+}
+
+fn validate_exact_shard(
+    connection: &Connection,
+    path: &Path,
+    shard_id: u16,
+    expected_user_version: i64,
+    layout: &ShardLayout,
+) -> EngineResult<()> {
+    let (application_id, user_version) = read_identity(connection)?;
+    if application_id != layout.expected_application_id() {
+        return if application_id == 0 {
+            Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!("ready shard {shard_id} is missing its BriskDB application ID"),
+            ))
+        } else {
+            Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "shard {shard_id} has foreign application identifier {application_id:#010x}"
+                ),
+            ))
+        };
+    }
+    if user_version > expected_user_version {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!("shard {shard_id} was written by a newer schema generation"),
+        ));
+    }
+    if user_version != expected_user_version {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!("shard {shard_id} schema generation does not match its catalog"),
+        ));
+    }
+    require_wal(connection, path)?;
+    validate_metadata(connection, shard_id, layout.layout_id())
+}
+
+fn read_identity(connection: &Connection) -> EngineResult<(i64, i64)> {
+    let application_id = connection
+        .pragma_query_value(None, "application_id", |row| row.get(0))
+        .map_err(|error| shard_read_error(error, "failed to read shard application ID"))?;
+    let user_version = connection
+        .pragma_query_value(None, "user_version", |row| row.get(0))
+        .map_err(|error| shard_read_error(error, "failed to read shard schema generation"))?;
+    Ok((application_id, user_version))
+}
+
+fn journal_mode(connection: &Connection) -> EngineResult<String> {
+    connection
+        .pragma_query_value(None, "journal_mode", |row| row.get(0))
+        .map_err(|error| shard_read_error(error, "failed to read shard journal mode"))
+}
+
+fn require_wal(connection: &Connection, path: &Path) -> EngineResult<()> {
+    let mode = journal_mode(connection)?;
+    if mode.eq_ignore_ascii_case("wal") {
+        Ok(())
+    } else {
+        Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!(
+                "shard {} uses journal mode {mode}, expected WAL",
+                path.display()
+            ),
+        ))
+    }
+}
+
+fn enable_wal(connection: &Connection, path: &Path) -> EngineResult<()> {
+    let mode = connection
+        .pragma_update_and_check(None, "journal_mode", "WAL", |row| row.get::<_, String>(0))
+        .map_err(sqlite_error::storage)?;
+    if mode.eq_ignore_ascii_case("wal") {
+        Ok(())
+    } else {
+        Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!(
+                "SQLite retained journal mode {mode} instead of enabling WAL for {}",
+                path.display()
+            ),
+        ))
+    }
+}
+
+fn has_application_schema_objects(connection: &Connection) -> EngineResult<bool> {
+    connection
+        .query_row(
+            "SELECT EXISTS(
+                 SELECT 1 FROM sqlite_schema
+                 WHERE name NOT LIKE 'sqlite_%'
+                 LIMIT 1
+             )",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|error| shard_read_error(error, "failed to inspect new shard schema"))
+}
+
+fn has_metadata_object(connection: &Connection) -> EngineResult<bool> {
+    connection
+        .query_row(
+            "SELECT EXISTS(
+                 SELECT 1 FROM sqlite_schema
+                 WHERE name = ?1 COLLATE NOCASE
+                 LIMIT 1
+             )",
+            [SHARD_METADATA_TABLE],
+            |row| row.get(0),
+        )
+        .map_err(|error| shard_read_error(error, "failed to inspect shard metadata objects"))
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct TableColumn {
+    id: i64,
+    name: String,
+    declared_type: String,
+    not_null: bool,
+    default_value: Option<String>,
+    primary_key_position: i64,
+    hidden: i64,
+}
+
+impl TableColumn {
+    fn expected(
+        id: i64,
+        name: &str,
+        declared_type: &str,
+        not_null: bool,
+        primary_key_position: i64,
+    ) -> Self {
+        Self {
+            id,
+            name: name.to_owned(),
+            declared_type: declared_type.to_owned(),
+            not_null,
+            default_value: None,
+            primary_key_position,
+            hidden: 0,
+        }
+    }
+}
+
+fn validate_metadata(
+    connection: &Connection,
+    expected_shard_id: u16,
+    expected_layout_id: [u8; 16],
+) -> EngineResult<()> {
+    let objects = connection
+        .prepare(
+            "SELECT type, name, sql
+             FROM sqlite_schema
+             WHERE name = 'briskdb_shard_metadata' COLLATE NOCASE
+             LIMIT 2",
+        )
+        .and_then(|mut statement| {
+            statement
+                .query_map([], |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, Option<String>>(2)?,
+                    ))
+                })?
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .map_err(|error| shard_read_error(error, "failed to inspect shard metadata schema"))?;
+    if objects.len() != 1
+        || objects[0].0 != "table"
+        || objects[0].1 != SHARD_METADATA_TABLE
+        || objects[0].2.as_deref().is_none_or(|sql| {
+            sql.len() > MAX_SCHEMA_SQL_BYTES
+                || normalize_schema_sql(sql) != normalize_schema_sql(SHARD_METADATA_TABLE_SQL)
+        })
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "shard metadata table has an incompatible schema",
+        ));
+    }
+
+    let columns = connection
+        .prepare(
+            "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden
+             FROM pragma_table_xinfo('briskdb_shard_metadata')
+             LIMIT 4",
+        )
+        .and_then(|mut statement| {
+            statement
+                .query_map([], |row| {
+                    Ok(TableColumn {
+                        id: row.get(0)?,
+                        name: row.get(1)?,
+                        declared_type: row.get(2)?,
+                        not_null: row.get::<_, i64>(3)? != 0,
+                        default_value: row.get(4)?,
+                        primary_key_position: row.get(5)?,
+                        hidden: row.get(6)?,
+                    })
+                })?
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .map_err(|error| shard_read_error(error, "failed to inspect shard metadata columns"))?;
+    let expected_columns = [
+        TableColumn::expected(0, "singleton", "INTEGER", false, 1),
+        TableColumn::expected(1, "layout_id", "BLOB", true, 0),
+        TableColumn::expected(2, "shard_id", "INTEGER", true, 0),
+    ];
+    if columns != expected_columns {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "shard metadata table has incompatible columns",
+        ));
+    }
+    let strict: Option<i64> = connection
+        .query_row(
+            "SELECT strict
+             FROM pragma_table_list
+             WHERE schema = 'main' AND name = 'briskdb_shard_metadata'",
+            [],
+            |row| row.get(0),
+        )
+        .map(Some)
+        .or_else(|error| match error {
+            rusqlite::Error::QueryReturnedNoRows => Ok(None),
+            error => Err(error),
+        })
+        .map_err(|error| shard_read_error(error, "failed to inspect shard metadata flags"))?;
+    if strict != Some(1) {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "shard metadata table is not STRICT",
+        ));
+    }
+
+    let rows = connection
+        .prepare(
+            "SELECT singleton, layout_id, shard_id
+             FROM briskdb_shard_metadata
+             ORDER BY singleton
+             LIMIT 3",
+        )
+        .and_then(|mut statement| {
+            statement
+                .query_map([], |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, Vec<u8>>(1)?,
+                        row.get::<_, i64>(2)?,
+                    ))
+                })?
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .map_err(|error| shard_read_error(error, "failed to read shard metadata"))?;
+    if rows.len() != 1 || rows[0].0 != 1 {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "shard metadata must contain exactly its singleton row",
+        ));
+    }
+    if rows[0].1.as_slice() != expected_layout_id {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "shard belongs to a different BriskDB layout",
+        ));
+    }
+    if rows[0].2 != i64::from(expected_shard_id) {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!(
+                "shard metadata identifies physical shard {}, expected {expected_shard_id}",
+                rows[0].2
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn normalize_schema_sql(sql: &str) -> String {
+    sql.split_ascii_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn missing_shard(path: &Path, shard_id: u16) -> EngineError {
+    EngineError::new(
+        EngineErrorKind::DataCorruption,
+        format!("required shard {shard_id} is missing at {}", path.display()),
+    )
+}
+
+fn shard_read_error(error: rusqlite::Error, diagnostic: &'static str) -> EngineError {
+    let classified = sqlite_error::storage(error);
+    if matches!(
+        classified.kind(),
+        EngineErrorKind::Busy
+            | EngineErrorKind::Cancelled
+            | EngineErrorKind::PermissionDenied
+            | EngineErrorKind::ReadOnly
+            | EngineErrorKind::StorageFull
+            | EngineErrorKind::OutOfMemory
+            | EngineErrorKind::StorageUnavailable
+    ) {
+        classified.context(diagnostic)
+    } else {
+        EngineError::from_source(EngineErrorKind::DataCorruption, diagnostic, classified)
+    }
+}
+
+/// Return whether a client statement action would mutate storage-owned shard
+/// identity, durability configuration, or the reserved metadata namespace.
+pub(super) fn denies_client_action(action: AuthAction<'_>) -> bool {
+    match action {
+        AuthAction::Pragma {
+            pragma_name,
+            pragma_value: Some(_),
+        } => matches_persistent_pragma(pragma_name),
+        AuthAction::Insert { table_name }
+        | AuthAction::Delete { table_name }
+        | AuthAction::DropTable { table_name }
+        | AuthAction::DropVtable {
+            table_name,
+            module_name: _,
+        } => is_metadata_table(table_name),
+        AuthAction::Update {
+            table_name,
+            column_name: _,
+        }
+        | AuthAction::Read {
+            table_name,
+            column_name: _,
+        } => is_metadata_table(table_name),
+        // SQLite's authorizer reports the source table for ALTER TABLE but
+        // does not expose a RENAME TO destination. Deny the whole operation
+        // so a client cannot move an application table into the reserved
+        // namespace without the authorizer seeing the new name.
+        AuthAction::AlterTable {
+            database_name: _,
+            table_name: _,
+        } => true,
+        AuthAction::CreateTable { table_name }
+        | AuthAction::CreateTempTable { table_name }
+        | AuthAction::CreateVtable {
+            table_name,
+            module_name: _,
+        } => is_reserved_name(table_name),
+        AuthAction::CreateIndex {
+            index_name,
+            table_name,
+        }
+        | AuthAction::CreateTempIndex {
+            index_name,
+            table_name,
+        } => is_reserved_name(index_name) || is_metadata_table(table_name),
+        AuthAction::CreateTrigger {
+            trigger_name,
+            table_name,
+        }
+        | AuthAction::CreateTempTrigger {
+            trigger_name,
+            table_name,
+        } => is_reserved_name(trigger_name) || is_metadata_table(table_name),
+        AuthAction::CreateView { view_name } | AuthAction::CreateTempView { view_name } => {
+            is_reserved_name(view_name)
+        }
+        AuthAction::DropIndex {
+            index_name,
+            table_name,
+        }
+        | AuthAction::DropTempIndex {
+            index_name,
+            table_name,
+        } => is_reserved_name(index_name) || is_metadata_table(table_name),
+        AuthAction::DropTrigger {
+            trigger_name,
+            table_name,
+        }
+        | AuthAction::DropTempTrigger {
+            trigger_name,
+            table_name,
+        } => is_reserved_name(trigger_name) || is_metadata_table(table_name),
+        AuthAction::Reindex { index_name } => is_reserved_name(index_name),
+        AuthAction::Analyze { table_name } => is_metadata_table(table_name),
+        _ => false,
+    }
+}
+
+fn matches_persistent_pragma(name: &str) -> bool {
+    [
+        "application_id",
+        "user_version",
+        "journal_mode",
+        "writable_schema",
+        "schema_version",
+    ]
+    .iter()
+    .any(|protected| name.eq_ignore_ascii_case(protected))
+}
+
+fn is_metadata_table(name: &str) -> bool {
+    name.eq_ignore_ascii_case(SHARD_METADATA_TABLE)
+}
+
+fn is_reserved_name(name: &str) -> bool {
+    name.as_bytes()
+        .get(.."briskdb_".len())
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case(b"briskdb_"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        panic::{AssertUnwindSafe, catch_unwind},
+        sync::Arc,
+        thread,
+    };
+
+    use rusqlite::hooks::TransactionOperation;
+
+    use super::*;
+
+    const LAYOUT_ID: [u8; 16] = *b"brisk-layout-001";
+
+    fn layout(state: ShardLayoutState) -> ShardLayout {
+        ShardLayout::from_validated_parts(
+            LAYOUT_ID,
+            SHARD_APPLICATION_ID,
+            SHARD_METADATA_VERSION,
+            state,
+        )
+    }
+
+    fn create_legacy(path: &Path, wal: bool, schema: &str) {
+        let connection = Connection::open(path).unwrap();
+        connection.execute_batch(schema).unwrap();
+        if wal {
+            enable_wal(&connection, path).unwrap();
+        }
+    }
+
+    fn identity(path: &Path) -> (i64, i64) {
+        let connection = Connection::open(path).unwrap();
+        read_identity(&connection).unwrap()
+    }
+
+    fn has_metadata(path: &Path) -> bool {
+        let connection = Connection::open(path).unwrap();
+        has_metadata_object(&connection).unwrap()
+    }
+
+    #[test]
+    fn layout_codes_parts_and_accessors_are_exact() {
+        assert_eq!(ShardLayoutState::Creating.code(), 1);
+        assert_eq!(ShardLayoutState::Adopting.code(), 2);
+        assert_eq!(ShardLayoutState::Ready.code(), 3);
+        for state in [
+            ShardLayoutState::Creating,
+            ShardLayoutState::Adopting,
+            ShardLayoutState::Ready,
+        ] {
+            assert_eq!(ShardLayoutState::from_code(state.code()).unwrap(), state);
+            let layout = layout(state);
+            assert_eq!(layout.layout_id(), LAYOUT_ID);
+            assert_eq!(layout.expected_application_id(), SHARD_APPLICATION_ID);
+            assert_eq!(layout.metadata_version(), SHARD_METADATA_VERSION);
+            assert_eq!(layout.state(), state);
+        }
+        assert_eq!(
+            ShardLayoutState::from_code(4).unwrap_err().kind(),
+            EngineErrorKind::DataCorruption
+        );
+    }
+
+    #[test]
+    fn creating_provisions_exact_wal_shards_and_ready_reopens_without_mutation() {
+        let temp = tempfile::tempdir().unwrap();
+        let shards = temp.path().join("shards");
+        prepare_layout(&shards, 4, 0, &layout(ShardLayoutState::Creating)).unwrap();
+
+        for shard_id in 0..4 {
+            let path = shard_path(&shards, shard_id);
+            let connection =
+                open_existing(&path, shard_id, 0, &layout(ShardLayoutState::Ready)).unwrap();
+            assert_eq!(
+                journal_mode(&connection).unwrap().to_ascii_lowercase(),
+                "wal"
+            );
+            assert_eq!(
+                read_identity(&connection).unwrap(),
+                (SHARD_APPLICATION_ID, 0)
+            );
+        }
+    }
+
+    #[test]
+    fn unrelated_files_are_ignored_but_extra_canonical_shards_are_rejected() {
+        let temp = tempfile::tempdir().unwrap();
+        let shards = temp.path().join("shards");
+        fs::create_dir(&shards).unwrap();
+        fs::write(shards.join("operator-notes.sqlite"), b"not a shard").unwrap();
+        fs::write(shards.join("README"), b"layout notes").unwrap();
+        prepare_layout(&shards, 2, 0, &layout(ShardLayoutState::Creating)).unwrap();
+
+        fs::copy(shard_path(&shards, 0), shard_path(&shards, 2)).unwrap();
+        let error = prepare_layout(&shards, 2, 0, &layout(ShardLayoutState::Ready)).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+    }
+
+    #[test]
+    fn preflight_rejects_a_late_foreign_shard_before_stamping_any_eligible_shard() {
+        let temp = tempfile::tempdir().unwrap();
+        let shards = temp.path().join("shards");
+        fs::create_dir(&shards).unwrap();
+        let first = shard_path(&shards, 0);
+        let second = shard_path(&shards, 1);
+        create_legacy(&first, true, "CREATE TABLE user_data (id INTEGER);");
+        create_legacy(&second, true, "CREATE TABLE user_data (id INTEGER);");
+        let foreign = Connection::open(&second).unwrap();
+        foreign
+            .pragma_update(None, "application_id", 0x1234)
+            .unwrap();
+        drop(foreign);
+
+        let error = prepare_layout(&shards, 2, 0, &layout(ShardLayoutState::Adopting)).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert_eq!(identity(&first), (0, 0));
+        assert!(!has_metadata(&first));
+    }
+
+    #[test]
+    fn adopting_preserves_legacy_schema_and_is_idempotent_after_partial_work() {
+        let temp = tempfile::tempdir().unwrap();
+        let shards = temp.path().join("shards");
+        fs::create_dir(&shards).unwrap();
+        for shard_id in 0..2 {
+            create_legacy(
+                &shard_path(&shards, shard_id),
+                true,
+                "CREATE TABLE widgets (id INTEGER PRIMARY KEY, value TEXT);",
+            );
+        }
+        let adopting = layout(ShardLayoutState::Adopting);
+        provision_shard(&shard_path(&shards, 0), 0, 0, &adopting, |_| {}).unwrap();
+        prepare_layout(&shards, 2, 0, &adopting).unwrap();
+
+        for shard_id in 0..2 {
+            let connection = open_existing(
+                &shard_path(&shards, shard_id),
+                shard_id,
+                0,
+                &layout(ShardLayoutState::Ready),
+            )
+            .unwrap();
+            assert_eq!(
+                connection
+                    .query_row(
+                        "SELECT COUNT(*) FROM sqlite_schema WHERE name = 'widgets'",
+                        [],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .unwrap(),
+                1
+            );
+        }
+    }
+
+    #[test]
+    fn adopting_and_ready_never_create_a_missing_shard() {
+        for state in [ShardLayoutState::Adopting, ShardLayoutState::Ready] {
+            let temp = tempfile::tempdir().unwrap();
+            let shards = temp.path().join("shards");
+            fs::create_dir(&shards).unwrap();
+            let missing = shard_path(&shards, 1);
+            create_legacy(&shard_path(&shards, 0), true, "");
+
+            let error = prepare_layout(&shards, 2, 0, &layout(state)).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+            assert!(!missing.exists());
+        }
+    }
+
+    #[test]
+    fn only_creating_may_enable_wal() {
+        let temp = tempfile::tempdir().unwrap();
+        let shards = temp.path().join("shards");
+        fs::create_dir(&shards).unwrap();
+        for shard_id in 0..2 {
+            create_legacy(&shard_path(&shards, shard_id), false, "");
+        }
+        let error = prepare_layout(&shards, 2, 0, &layout(ShardLayoutState::Adopting)).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert_eq!(
+            journal_mode(&Connection::open(shard_path(&shards, 0)).unwrap())
+                .unwrap()
+                .to_ascii_lowercase(),
+            "delete"
+        );
+
+        prepare_layout(&shards, 2, 0, &layout(ShardLayoutState::Creating)).unwrap();
+        assert_eq!(
+            journal_mode(&Connection::open(shard_path(&shards, 0)).unwrap())
+                .unwrap()
+                .to_ascii_lowercase(),
+            "wal"
+        );
+    }
+
+    #[test]
+    fn ready_validation_never_repairs_a_changed_journal_mode() {
+        let temp = tempfile::tempdir().unwrap();
+        let shards = temp.path().join("shards");
+        prepare_layout(&shards, 2, 0, &layout(ShardLayoutState::Creating)).unwrap();
+        let path = shard_path(&shards, 0);
+        let connection = Connection::open(&path).unwrap();
+        let mode = connection
+            .pragma_update_and_check(None, "journal_mode", "DELETE", |row| {
+                row.get::<_, String>(0)
+            })
+            .unwrap();
+        assert_eq!(mode.to_ascii_lowercase(), "delete");
+        drop(connection);
+
+        let error = open_existing(&path, 0, 0, &layout(ShardLayoutState::Ready)).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert_eq!(
+            journal_mode(&Connection::open(path).unwrap())
+                .unwrap()
+                .to_ascii_lowercase(),
+            "delete"
+        );
+    }
+
+    #[test]
+    fn creating_rejects_a_nonempty_unmarked_database() {
+        let temp = tempfile::tempdir().unwrap();
+        let shards = temp.path().join("shards");
+        fs::create_dir(&shards).unwrap();
+        create_legacy(
+            &shard_path(&shards, 0),
+            false,
+            "CREATE TABLE foreign_data (id INTEGER);",
+        );
+        create_legacy(&shard_path(&shards, 1), false, "");
+
+        let error = prepare_layout(&shards, 2, 0, &layout(ShardLayoutState::Creating)).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert_eq!(identity(&shard_path(&shards, 1)), (0, 0));
+    }
+
+    #[test]
+    fn exact_validation_rejects_foreign_future_layout_and_shard_identity() {
+        let temp = tempfile::tempdir().unwrap();
+        let shards = temp.path().join("shards");
+        prepare_layout(&shards, 2, 0, &layout(ShardLayoutState::Creating)).unwrap();
+        let ready = layout(ShardLayoutState::Ready);
+
+        let path = shard_path(&shards, 0);
+        let connection = Connection::open(&path).unwrap();
+        connection
+            .pragma_update(None, "application_id", 0x1234)
+            .unwrap();
+        drop(connection);
+        assert_eq!(
+            open_existing(&path, 0, 0, &ready).unwrap_err().kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+        assert_eq!(identity(&path), (0x1234, 0));
+
+        let connection = Connection::open(&path).unwrap();
+        connection.pragma_update(None, "application_id", 0).unwrap();
+        drop(connection);
+        assert_eq!(
+            open_existing(&path, 0, 0, &ready).unwrap_err().kind(),
+            EngineErrorKind::DataCorruption
+        );
+        assert_eq!(identity(&path), (0, 0));
+
+        let connection = Connection::open(&path).unwrap();
+        connection
+            .pragma_update(None, "application_id", SHARD_APPLICATION_ID)
+            .unwrap();
+        drop(connection);
+        let connection = Connection::open(&path).unwrap();
+        connection.pragma_update(None, "user_version", 1).unwrap();
+        drop(connection);
+        assert_eq!(
+            open_existing(&path, 0, 0, &ready).unwrap_err().kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+
+        let connection = Connection::open(&path).unwrap();
+        connection.pragma_update(None, "user_version", 0).unwrap();
+        connection
+            .execute("UPDATE briskdb_shard_metadata SET shard_id = 1", [])
+            .unwrap();
+        drop(connection);
+        assert_eq!(
+            open_existing(&path, 0, 0, &ready).unwrap_err().kind(),
+            EngineErrorKind::DataCorruption
+        );
+
+        let connection = Connection::open(&path).unwrap();
+        connection
+            .execute(
+                "UPDATE briskdb_shard_metadata SET shard_id = 0, layout_id = zeroblob(16)",
+                [],
+            )
+            .unwrap();
+        drop(connection);
+        assert_eq!(
+            open_existing(&path, 0, 0, &ready).unwrap_err().kind(),
+            EngineErrorKind::DataCorruption
+        );
+    }
+
+    #[test]
+    fn altered_metadata_schema_and_conflicting_legacy_object_fail_closed() {
+        let temp = tempfile::tempdir().unwrap();
+        let shards = temp.path().join("shards");
+        fs::create_dir(&shards).unwrap();
+        for shard_id in 0..2 {
+            create_legacy(&shard_path(&shards, shard_id), true, "");
+        }
+        Connection::open(shard_path(&shards, 0))
+            .unwrap()
+            .execute_batch("CREATE TABLE briskdb_shard_metadata (shard_id INTEGER);")
+            .unwrap();
+        let error = prepare_layout(&shards, 2, 0, &layout(ShardLayoutState::Adopting)).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+
+        let other = tempfile::tempdir().unwrap();
+        let other_shards = other.path().join("shards");
+        prepare_layout(&other_shards, 2, 0, &layout(ShardLayoutState::Creating)).unwrap();
+        let path = shard_path(&other_shards, 0);
+        let connection = Connection::open(&path).unwrap();
+        connection.execute_batch(
+            "DROP TABLE briskdb_shard_metadata;
+             CREATE TABLE briskdb_shard_metadata (
+                 singleton INTEGER PRIMARY KEY,
+                 layout_id BLOB NOT NULL,
+                 shard_id INTEGER NOT NULL
+             ) STRICT;
+             INSERT INTO briskdb_shard_metadata VALUES (1, x'627269736b2d6c61796f75742d303031', 0);",
+        ).unwrap();
+        drop(connection);
+        assert_eq!(
+            open_existing(&path, 0, 0, &layout(ShardLayoutState::Ready))
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::DataCorruption
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_shards_and_nonfiles_are_rejected_without_following() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let shards = temp.path().join("shards");
+        fs::create_dir(&shards).unwrap();
+        let target = temp.path().join("target.sqlite");
+        create_legacy(&target, true, "");
+        symlink(&target, shard_path(&shards, 0)).unwrap();
+        fs::create_dir(shard_path(&shards, 1)).unwrap();
+
+        let error = prepare_layout(&shards, 2, 0, &layout(ShardLayoutState::Adopting)).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert_eq!(identity(&target), (0, 0));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn runtime_open_rejects_a_symlinked_shard_directory() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let real_shards = temp.path().join("real-shards");
+        prepare_layout(&real_shards, 2, 0, &layout(ShardLayoutState::Creating)).unwrap();
+        let linked_shards = temp.path().join("linked-shards");
+        symlink(&real_shards, &linked_shards).unwrap();
+
+        let error = open_existing(
+            &shard_path(&linked_shards, 0),
+            0,
+            0,
+            &layout(ShardLayoutState::Ready),
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+    }
+
+    #[test]
+    fn corrupt_required_shard_is_reported_without_replacement() {
+        let temp = tempfile::tempdir().unwrap();
+        let shards = temp.path().join("shards");
+        fs::create_dir(&shards).unwrap();
+        let path = shard_path(&shards, 0);
+        fs::write(&path, b"not a sqlite database").unwrap();
+
+        let error = open_existing(&path, 0, 0, &layout(ShardLayoutState::Ready)).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+        assert_eq!(fs::read(path).unwrap(), b"not a sqlite database");
+    }
+
+    #[test]
+    fn provisioning_panics_roll_back_and_retry_in_creating_and_adopting() {
+        for state in [ShardLayoutState::Creating, ShardLayoutState::Adopting] {
+            let points: &[ProvisionPoint] = if state == ShardLayoutState::Creating {
+                &[
+                    ProvisionPoint::WalPersisted,
+                    ProvisionPoint::MetadataWritten,
+                    ProvisionPoint::IdentityWritten,
+                ]
+            } else {
+                &[
+                    ProvisionPoint::MetadataWritten,
+                    ProvisionPoint::IdentityWritten,
+                ]
+            };
+            for &point in points {
+                let temp = tempfile::tempdir().unwrap();
+                let shards = temp.path().join("shards");
+                fs::create_dir(&shards).unwrap();
+                let path = shard_path(&shards, 0);
+                create_legacy(&path, state == ShardLayoutState::Adopting, "");
+
+                let panic = catch_unwind(AssertUnwindSafe(|| {
+                    let _ = provision_shard(&path, 0, 0, &layout(state), |seen| {
+                        if seen == point {
+                            panic!("injected shard provisioning panic");
+                        }
+                    });
+                }));
+                assert!(panic.is_err());
+                assert_eq!(identity(&path), (0, 0));
+                assert!(!has_metadata(&path));
+                assert_eq!(
+                    journal_mode(&Connection::open(&path).unwrap())
+                        .unwrap()
+                        .to_ascii_lowercase(),
+                    "wal"
+                );
+
+                provision_shard(&path, 0, 0, &layout(state), |_| {}).unwrap();
+                open_existing(&path, 0, 0, &layout(ShardLayoutState::Ready)).unwrap();
+            }
+        }
+    }
+
+    #[test]
+    fn strict_existing_opens_are_deterministic_in_parallel() {
+        let temp = tempfile::tempdir().unwrap();
+        let shards = temp.path().join("shards");
+        prepare_layout(&shards, 2, 0, &layout(ShardLayoutState::Creating)).unwrap();
+        let path = Arc::new(shard_path(&shards, 0));
+        let workers = (0..8)
+            .map(|_| {
+                let path = Arc::clone(&path);
+                thread::spawn(move || {
+                    for _ in 0..100 {
+                        let connection =
+                            open_existing(path.as_ref(), 0, 0, &layout(ShardLayoutState::Ready))
+                                .unwrap();
+                        assert_eq!(
+                            read_identity(&connection).unwrap(),
+                            (SHARD_APPLICATION_ID, 0)
+                        );
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+        for worker in workers {
+            worker.join().unwrap();
+        }
+    }
+
+    #[test]
+    fn protected_client_actions_are_exact_and_application_reads_remain_allowed() {
+        for pragma in [
+            "application_id",
+            "USER_VERSION",
+            "journal_mode",
+            "writable_schema",
+            "schema_version",
+        ] {
+            assert!(denies_client_action(AuthAction::Pragma {
+                pragma_name: pragma,
+                pragma_value: Some("1"),
+            }));
+            assert!(!denies_client_action(AuthAction::Pragma {
+                pragma_name: pragma,
+                pragma_value: None,
+            }));
+        }
+        assert!(denies_client_action(AuthAction::Insert {
+            table_name: "BRISKDB_SHARD_METADATA",
+        }));
+        assert!(denies_client_action(AuthAction::Update {
+            table_name: SHARD_METADATA_TABLE,
+            column_name: "shard_id",
+        }));
+        assert!(denies_client_action(AuthAction::DropTable {
+            table_name: SHARD_METADATA_TABLE,
+        }));
+        assert!(denies_client_action(AuthAction::CreateTable {
+            table_name: "briskdb_future",
+        }));
+        assert!(denies_client_action(AuthAction::AlterTable {
+            database_name: "main",
+            table_name: "widgets",
+        }));
+        assert!(denies_client_action(AuthAction::Read {
+            table_name: SHARD_METADATA_TABLE,
+            column_name: "shard_id",
+        }));
+        assert!(!denies_client_action(AuthAction::Read {
+            table_name: "widgets",
+            column_name: "value",
+        }));
+        assert!(!denies_client_action(AuthAction::Transaction {
+            operation: TransactionOperation::Begin,
+        }));
+    }
+}


### PR DESCRIPTION
## Summary

- add manifest format v5 with durable Creating, Adopting, and Ready shard-layout states plus a random layout identity
- provision or adopt every physical shard under serialized manifest reconciliation, then strictly validate WAL, application ID, schema generation, metadata, and physical shard identity
- make startup and runtime opens fail closed with read-write/no-create/no-follow semantics and protect storage-owned state on every SQL connection surface
- document the format, recovery, compatibility, errors, and platform boundary; mark the roadmap item complete

## Testing

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features`
- `cargo test --locked --doc --all-features`
- `rustup run 1.85.0 cargo test --locked --all-targets --all-features`
- `rustup run 1.85.0 cargo test --locked --doc --all-features`

Closes #16