### PR TITLE
Add crash-resumable schema migration journal

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ minimum supported Rust version (MSRV) and the latest stable toolchain.
 - Identity-bound, WAL-enabled SQLite shard files that are never silently
   recreated after initialization
 - Routed execute and query endpoints
-- A broadcast endpoint for initializing schema on every shard
+- A crash-resumable, journaled schema-migration endpoint for every shard
 - Full SQLite synchronous durability and a five-second busy timeout
 - Reproducible point-read, point-write, and four-shard write benchmarks
 
@@ -97,6 +97,13 @@ curl -X POST http://127.0.0.1:7654/v1/admin/broadcast \
   -d '{"sql":"CREATE TABLE widgets (id TEXT PRIMARY KEY, name TEXT NOT NULL)"}'
 ```
 
+The retained migration journal identifies this batch by the BLAKE3 digest of
+its exact UTF-8 bytes. A byte-identical retry is idempotent; even whitespace or
+casing changes identify a new migration. Batches must contain 1 through 65,536
+bytes and no NUL. The endpoint retains its experimental `broadcast` name and
+returns `{"completed_shards":[...]}`, but it is the only client surface allowed
+to change persistent application schema.
+
 Insert a keyed row:
 
 ```bash
@@ -145,8 +152,9 @@ routed work queued for one shard does not consume another shard's capacity.
 Pool admission happens before blocking SQLite work: once a shard's active slots
 and queue are full, the engine returns retryable `Busy` (HTTP 503) instead of
 growing work without bound. Connections are opened lazily and reused. Broadcast
-is the deliberate cross-shard exception: it reserves one slot from every shard
-before dispatch and can therefore occupy capacity in several pools at once.
+is now a journaled schema migration: it excludes new ordinary work, waits for
+previously admitted operations to drain, and uses dedicated migration
+connections rather than reserving every shard pool.
 
 `EngineOptions` permits 1–16 active connections and 1–1,024 queued operations
 per shard, with at most 512 active connections across all shards.
@@ -159,9 +167,10 @@ disposable handle before execution.
 BriskDB-owned shard metadata and storage-control PRAGMA mutations, including
 `application_id`, `user_version`, `journal_mode`, `schema_version`, and
 `writable_schema`, are denied through every client SQL surface rather than
-allowed to invalidate the storage layout. `ALTER TABLE` is currently denied as
-well because SQLite's authorizer does not expose a rename destination, which
-would otherwise let a client enter the reserved `briskdb_*` namespace.
+allowed to invalidate the storage layout. Persistent DDL, including
+`ALTER TABLE`, is denied through ordinary routed SQL and is allowed only inside
+the journaled migration path, where BriskDB protects and revalidates its
+reserved `briskdb` and `briskdb_*` namespaces.
 A handle that performed an ordinary write may return to the same session,
 preserving SQLite write counters, but is replaced before a different session can
 observe `last_insert_rowid()`, `changes()`, or `total_changes()`. Those functions
@@ -174,10 +183,20 @@ success; BriskDB never reports cancellation while a known running write might
 still commit.
 Queries have finite row and logical-byte budgets, account values before cloning
 payloads, and return no partial result on `LimitExceeded`.
-Broadcast changes and future scatter operations are not atomic across shard
-files. The initial shard count is immutable, so resharding will require an
-explicit migration workflow. Opening upgrades exact version-1 through
-version-4 manifests to version 5 through ordered, resumable steps.
+Schema migrations preflight the complete batch on every shard before publishing
+a journal. Each shard then commits the SQL batch and its next `user_version` in
+one SQLite transaction, in ascending shard order. There is no cross-shard
+transaction: interruption can retain a committed prefix, which a byte-identical
+retry or the next startup validates and resumes. While a migration is running,
+new ordinary operations and a second coordinator receive retryable `Busy`.
+After durable partial progress, ordinary work receives non-retryable
+`FailedPrecondition` until the same migration resumes. The exact SQL text is
+retained permanently for recovery and idempotency, so migration batches must
+not contain passwords, tokens, or other sensitive literals.
+
+The initial shard count is immutable, so resharding will require an explicit
+migration workflow. Opening upgrades exact version-1 through version-5
+manifests to version 6 through ordered, resumable steps.
 Version 3 introduced the versioned, generation-stamped 4,096-bucket routing
 map. Version 4 adds schema generation 0 and immutable logical metadata with
 default database ID 1 named `default`; identifier encoding version 1 accepts
@@ -196,14 +215,24 @@ closed, as do shards cloned into the wrong slot or from another layout. They are
 not repaired or recreated. The layout ID is an accidental wrong-file guard, not
 authentication or tamper protection.
 
+Version 6 adds the retained schema-migration journal and permits committed
+application-schema generations from 0 through 2,147,483,647. A fresh migration
+advances exactly one generation. After manifest load or upgrade, startup resumes
+any active schema migration before ordinary physical-layout reconciliation and
+final strict shard validation, then returns an engine. Completed journal rows
+remain as the exact generation history; schema equivalence checks, checksums,
+and explicit degraded states remain issue #18.
+
 The v3-to-v4 step deliberately leaves the table catalog empty: it neither
 infers nor adopts tables already present in physical shard files. The v4-to-v5
 upgrade retains every validated v4 catalog row, while shard adoption preserves
 physical application tables and their data. The public catalog returned by
-`Database::catalog()` and `Engine::catalog()` remains an immutable, read-only
-advisory view. Current execute, query, broadcast, routing, SQLite behavior,
-HTTP shapes, and wire contracts are otherwise unchanged.
-Startup loads routing and logical metadata in one validated immutable snapshot;
+`Database::catalog()` and `Engine::catalog()` remains read-only and advisory.
+Its database and table entries stay immutable, while its schema generation
+advances after migration finalization; migrations neither infer nor mutate
+`briskdb_tables`. Current query results, routing, SQLite value behavior, HTTP
+shapes, and wire contracts are otherwise unchanged.
+Startup loads routing and logical metadata in one validated shared snapshot;
 runtime routing continues to hash the exact key bytes, derive a virtual bucket,
 and read its persisted physical-shard assignment. The generation-1 ranges
 preserve every earlier modulo placement, including non-power-of-two shard
@@ -212,10 +241,13 @@ upgrade contract is in [manifest storage format](docs/STORAGE_FORMAT.md).
 Embedders should call
 `Engine::shutdown`; merely dropping the final `Engine` is not the explicit
 asynchronous cleanup contract.
+Independent `Database` and `Engine` handles in one process that resolve to the
+same canonical data directory share schema coordination. Separate BriskDB
+server processes must not use the same data directory.
 
-Near-term work includes authentication, application-schema migrations,
-scatter/gather reads, observability, backup tooling, and failure-injection
-tests for multi-shard operations.
+Near-term work includes authentication, richer migration administration and
+status APIs in issue #53, schema checksums and degraded-state handling in issue
+#18, scatter/gather reads, observability, and backup tooling.
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -81,7 +81,7 @@ The core boundary should use protocol-neutral Rust types:
   a backpressured row stream rather than buffering unbounded results.
 - `EngineError`: stable internal error kinds mapped to PostgreSQL SQLSTATE,
   MySQL error number/SQLSTATE, and HTTP status/problem details.
-- `QueryPlan`: single shard, scatter read, schema broadcast, manifest operation,
+- `QueryPlan`: single shard, scatter read, schema migration, manifest operation,
   or rejected unsupported operation.
 
 Protocol handlers may encode and decode messages, but must not open SQLite
@@ -190,8 +190,8 @@ existing tests pass through the shared engine.
   shard-key column/type.
 - [x] Validate at startup that every shard is present, uses WAL, has the expected
   application ID/user version, and matches the cataloged schema generation.
-- [ ] Implement a crash-resumable schema migration journal instead of the
-  current best-effort broadcast endpoint.
+- [x] Implement a crash-resumable schema migration journal instead of the
+  previous unjournaled broadcast behavior.
 - [ ] Add checksums/integrity checks and explicit states for degraded or
   partially migrated databases.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,8 +21,8 @@ server ---------> protocol::http
 
 | Module | Responsibility | Must not own |
 | --- | --- | --- |
-| `core` | Protocol-neutral `Engine`, `Session`, statements, values, results, errors, and immutable logical catalog; stable key routing; bounded per-shard admission and connection pools; routed execute/query and schema broadcast | JSON/HTTP types, listeners, or Axum handlers |
-| `storage` | Versioned routing/logical manifest, shard layout, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
+| `core` | Protocol-neutral `Engine`, `Session`, statements, values, results, errors, and read-only logical catalog; stable key routing; bounded per-shard admission and connection pools; routed execute/query and journaled schema migration | JSON/HTTP types, listeners, or Axum handlers |
+| `storage` | Versioned routing/logical manifest, shard layout, migration journal and recovery, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
 | `sql` | SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, routing, filesystem layout, or protocol responses |
 | `protocol::http` | HTTP request extraction plus JSON/BriskDB value and RFC 9457 problem-detail encoding | BLAKE3 routing, shard files, or rusqlite calls |
 | `protocol::error` | Exhaustive HTTP, PostgreSQL, and MySQL mappings from stable engine error kinds | SQLite errors, routing decisions, or wire-protocol session state |
@@ -65,6 +65,15 @@ routed reads, and structured problem-detail serialization through the shared
 engine. Unit tests remain colocated with sessions, engine orchestration,
 routing, storage, SQL conversion, CLI, and server assembly.
 
+Issue #17 intentionally changed the behavior behind the preserved
+`/v1/admin/broadcast`, `Database::broadcast`, and `Engine::broadcast` shapes.
+They now submit one journaled application-schema migration instead of an
+untracked sequential batch. The HTTP success body remains
+`{"completed_shards":[...]}`. A retained `Catalog` reference now observes a
+durably published generation in place; consequently, its public
+`schema_generation` accessor is no longer usable in a Rust `const` context.
+That is an intentional pre-1.0 source-level change.
+
 The module names are stable boundaries, not a claim that later roadmap work is
 already complete. The async engine, session lifecycle, bounded per-shard pools,
 request controls, and explicit shutdown lifecycle are now in place. The
@@ -96,9 +105,19 @@ expected `BRSH` shard application ID, metadata encoding version 1, and state
 code 1 (`Creating`), 2 (`Adopting`), or 3 (`Ready`). Every current shard has
 the same layout ID in its exact BriskDB-owned metadata row, its cataloged
 physical shard ID, `application_id = BRSH`, and `user_version` equal to the
-cataloged application-schema generation, currently 0. The layout ID catches
+cataloged application-schema generation. The layout ID catches
 accidental copies, swaps, and cross-layout placement; it is not a secret,
 checksum, or security boundary.
+
+Version 6 adds the retained `briskdb_schema_migrations` journal and expands the
+catalog generation from fixed zero to the range 0 through 2,147,483,647. Each
+row records consecutive source and target generations, the shard count, an
+ascending durable prefix, state `Applying` or `Complete`, the exact SQL text,
+and its digest. Digest version 1 is the full BLAKE3 digest of the exact UTF-8
+SQL bytes. Input is limited to 1 through 65,536 bytes with no NUL. Completed
+history is contiguous and retained permanently; at most one active row may
+target the generation immediately after the committed catalog. Exact SQL is
+therefore operational metadata that may reveal sensitive literals.
 
 Each manifest version retains an intentionally incompatible
 `briskdb_metadata` definition and row as a downgrade fence. The v3-to-v4
@@ -111,16 +130,34 @@ layout. A failure or panic leaves `Creating` or `Adopting` durable, so the next
 open resumes instead of guessing whether a missing or partly stamped file is
 safe.
 
-Startup acquires `BEGIN IMMEDIATE` before making a manifest migration or layout
-state decision. Numbered manifest-only steps rewrite schema/data, stamp and read
-back their target identity/version, validate the destination, and commit in
-their own transaction. After those steps commit, layout reconciliation acquires
-a new immediate manifest transaction, re-reads and validates the layout state
-under that write lock, and holds the lock through independently durable
-per-shard work and `Ready` publication. Concurrent openers therefore serialize:
-a lagging opener re-reads `Ready` and strictly validates instead of provisioning
+The v5-to-v6 step is manifest-only: it preserves layout state, routing, logical
+metadata, and data while rebuilding the schema-generation constraint, creating
+an empty journal, and fencing v5 readers. There is no automatic downgrade; an
+older binary requires a pre-v6 backup.
+
+Startup first canonicalizes the data-directory path and joins the process-wide
+root coordination keyed by that path. It acquires the shared schema gate before
+loading the manifest, so independent `Storage`, `Database`, and `Engine` handles
+in one process serialize startup and migration against ordinary admission and
+share catalog-generation publication.
+
+Manifest loading acquires `BEGIN IMMEDIATE` before making a format migration or
+layout-state decision. Numbered manifest-only steps rewrite schema/data, stamp
+and read back their target identity/version, validate the destination, and
+commit in their own transaction. If the resulting v6 manifest contains an
+`Applying` schema migration, startup validates and resumes it immediately. A
+journal can exist only with a durable `Ready` layout, and recovery publishes its
+target generation before ordinary layout reconciliation or final shard opens.
+
+Layout reconciliation then acquires a new immediate manifest transaction,
+re-reads and validates the layout state under that write lock, and holds the
+lock through independently durable per-shard work and `Ready` publication. A
+lagging opener re-reads `Ready` and strictly validates instead of provisioning
 from a stale `Creating` observation. Only a locked, durable `Creating` state
-permits missing canonical shard files to be created and WAL to be enabled.
+permits missing canonical shard files to be created and WAL to be enabled. The
+final strict shard opens and catalog reconciliation complete before the startup
+guard publishes `Ready`; ordinary work is never served against a persisted
+mixed-generation prefix.
 
 `Adopting` recognizes only existing legacy shard files with exact zero
 application-ID/user-version headers and an existing WAL mode. It writes current
@@ -134,37 +171,42 @@ are not required layout members.
 
 This is an internal storage-open concern, is unreachable from client SQL, and
 is atomic only within `manifest.sqlite`. Validation returns routing and logical
-metadata from the same locked transaction as one immutable snapshot that
-`Storage` shares across clones. `Database::catalog()` and `Engine::catalog()`
-expose the logical portion as a read-only `Catalog` with lookup accessors.
+metadata from the same locked transaction as one shared snapshot. The migration
+coordinator publishes a newly committed generation into that snapshot only
+after every shard verifies. `Database::catalog()` and `Engine::catalog()` expose
+the logical portion as a read-only `Catalog` with lookup accessors.
 
 The logical catalog remains advisory: there is no catalog mutation API,
 planner integration, or schema enforcement yet. Fresh manifests and upgrades
 originating before v4 contain no table rows; a v4-to-v5 upgrade retains every
-validated v4 logical-catalog row. Migration does not inspect, infer, or adopt
-physical tables already present in shard files. Those tables remain reachable
-through the existing explicit-key execute/query and broadcast surfaces. Core
+validated v4 logical-catalog row. Schema migration does not inspect, infer, or
+mutate `briskdb_tables`, nor does it prove physical schema equivalence. Existing
+tables remain reachable through the explicit-key execute/query surfaces. Core
 routing still hashes the exact caller-provided key bytes, derives a versioned
 virtual bucket, and reads the final physical shard from the snapshot without
 querying SQLite. The generation-1 ranges reproduce prior modulo placement for
 every supported initial shard count, including counts that do not divide 4,096.
 Version-5 adoption adds only BriskDB identity metadata to legacy shards and
-preserves their application schema and data. It changes no current SQL planning,
-HTTP shape, routing result, or broadcast ordering.
+preserves their application schema and data. It changes no SQL planning, HTTP
+shape, or routing result.
 
 The storage-owned `briskdb_shard_metadata` table is inaccessible through client
-SQL, and creation of new objects in the reserved `briskdb_*` namespace is
+SQL, and creation of new objects in the reserved `briskdb` or `briskdb_*`
+namespaces is
 denied by the SQLite authorizer. Client attempts to mutate `application_id`,
 `user_version`, persistent `journal_mode`, `schema_version`, or
 `writable_schema` are also denied. This prevents a pass-through statement from
-invalidating the validated layout. All `ALTER TABLE` statements are currently
-denied because SQLite's authorizer does not expose the destination of a rename;
-allowing the operation would leave a path into the reserved namespace. The
-application-schema generation is still fixed at 0 and there is not
-yet a cross-shard schema migration journal; that later format must explicitly
-authorize any temporary generation mismatch. The exact format, numeric codes,
-downgrade policy, recovery cases, and tests are documented in [manifest storage
-format](STORAGE_FORMAT.md).
+invalidating the validated layout. Ordinary routed SQL also denies every
+persistent DDL action. The journaled migration connection is the sole exception:
+it allows main-schema DDL and DML, including `ALTER TABLE`, inside BriskDB's
+transaction while denying transaction escape, attachments, temporary/virtual
+objects, and reserved-state access. Because SQLite does not reveal an
+`ALTER TABLE ... RENAME TO` destination to the authorizer, the coordinator also
+compares the reserved schema before and after the batch. The exact format,
+numeric codes, downgrade policy, recovery cases, and tests are documented in
+[manifest storage format](STORAGE_FORMAT.md).
+Schema checksums and explicit degraded states remain issue #18; richer
+migration administration and status surfaces remain issue #53.
 
 ## Session and asynchronous engine boundary
 
@@ -187,8 +229,8 @@ count needed by health reporting without exposing the storage implementation.
 HTTP is stateless at this stage: each execute or query request creates a fresh
 session and initializes its routing context from the request's `shard_key`.
 Consequently, session settings and transactions cannot span HTTP requests.
-Schema broadcast and status calls also go through the shared engine, but do not
-perform a routing decision in the adapter.
+Schema-migration broadcast and status calls also go through the shared engine,
+but do not perform a routing decision in the adapter.
 
 ### Bounded worker and connection-pool boundary
 
@@ -215,12 +257,31 @@ them as `--max-result-rows`, `--max-result-bytes`,
 When a shard has no active slot and its admission queue is full, a new operation
 fails immediately with retryable `Busy`, which the HTTP adapter maps to 503.
 Capacity for routed work belongs to its selected shard: saturation on shard A
-neither consumes shard B's slots nor delays work already admitted there. Schema
-broadcast is the deliberate cross-shard exception. It reserves one slot from
-every shard in ascending order before dispatch, so it can occupy capacity in
-several pools while waiting; it then checks out each connection only when that
-shard's turn arrives. The deterministic reservation order prevents concurrent
-broadcasts from deadlocking each other.
+neither consumes shard B's slots nor delays work already admitted there.
+
+Schema migration uses a separate, shared admission gate. Transitioning from
+`Ready` to `Migrating` immediately rejects new ordinary operations and a second
+coordinator with retryable `Busy`, then asynchronously waits for already
+admitted work to drain. The engine retires idle pooled handles and performs the
+migration on fresh coordinator-owned connections; it no longer reserves one
+slot in every shard pool. If a durable journal survives an error, panic,
+cancellation, or dropped future, the gate becomes `Pending`. Ordinary work then
+receives non-retryable `FailedPrecondition`, while a new migration call may
+enter `Migrating` to resume the byte-identical SQL. Startup recovery completes
+an active journal while holding the same in-process gate. Independent handles
+for the same canonical root share the gate and live catalog publication.
+Separate server processes for one data directory are unsupported; the gate is
+not a distributed coordination mechanism.
+
+After every-shard preflight succeeds, the coordinator records the exact SQL and
+its BLAKE3 identity, then visits shards in ascending order. One shard's complete
+batch and target `user_version` commit atomically, followed by a separate
+manifest prefix update. There is no cross-shard transaction. Recovery accepts
+the committed prefix plus the single possible shard commit whose acknowledgement
+was interrupted, and never skips ahead. Finalization marks the retained row
+complete and publishes the catalog generation only after every shard validates.
+A byte-identical retry is idempotent; alternate whitespace or casing is a new
+migration identity.
 
 Pool checkout also establishes a connection-hygiene boundary. SQLite authorizer
 events identify operations that can persist connection-local state, including
@@ -239,9 +300,10 @@ SQLite counter state.
 The expected probe error is never exposed to the caller. Any other probe error
 also fails closed to a fresh handle. Opening that replacement can surface its own
 storage error; otherwise only the real execution determines the caller-visible
-SQL result. Broadcast batches are not preflighted because later statements can
-depend on earlier schema changes; instead, a foreign handle is replaced before
-the batch begins.
+SQL result. The schema-migration path is outside this pool-owner probe. Before
+publishing its journal, it executes the complete batch on every shard in a
+rollback-only transaction, so later statements may depend on earlier schema
+changes while a failure still leaves every shard unchanged.
 
 A connection marked tainted by real execution is closed after the call instead
 of returning to the pool. If a call leaves a transaction open, rollback is
@@ -298,10 +360,10 @@ single-shard pinning remain deferred to the PostgreSQL and MySQL transaction
 work in issues #34 and #47. `Ready` and `Closed` therefore describe session
 lifecycle, not SQL transaction state.
 
-This boundary changes Rust orchestration and adds opt-in `EngineOptions` plus
-pool-sizing CLI/environment configuration. It does not change existing option
-defaults, HTTP routes or JSON shapes, shard routing, manifest schema, SQLite
-files, WAL or synchronous settings, or any stored data.
+The pool/request-control boundary changed Rust orchestration and added opt-in
+`EngineOptions` plus pool-sizing CLI/environment configuration. That earlier
+change did not alter option defaults, HTTP routes or JSON shapes, shard routing,
+storage formats, WAL or synchronous settings, or stored data.
 
 ## Error boundary
 
@@ -315,13 +377,14 @@ implemented listeners.
 
 Client responses use fixed, safe text for the error kind. Diagnostic display
 text and source chains stay available internally but are never serialized, so
-SQLite messages, SQL text, and filesystem paths do not leak through an adapter.
+SQLite messages, SQL text—including SQL retained in a migration journal—and
+filesystem paths do not leak through an adapter.
 Only `Busy` advertises that retrying may succeed; a 5xx status alone is not a
 retry signal. The complete taxonomy and mapping table are in the
 [error contract](ERRORS.md).
 
-This boundary changes reporting, not persistence: the manifest schema, shard
-files, stored values, routing, and configuration formats are unchanged.
+The error boundary changes reporting, not persistence; storage-format changes
+are owned and documented separately by the manifest boundary above.
 
 ## Typed result boundary
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -7,10 +7,11 @@ a claim about production capacity or a timing threshold for shared CI runners.
 ## Workload contract
 
 Every benchmark creates a fresh temporary BriskDB database with exactly four
-shards, broadcasts the same table definition to each shard, and seeds one
-primary-key row per shard. Point updates keep the database size constant,
-preventing ever-growing insert cost from distorting later samples. Concurrent
-workloads deterministically find and verify one key for every physical shard.
+shards, applies the same untimed journaled schema migration to every shard, and
+seeds one primary-key row per shard. Point updates keep the database size
+constant, preventing ever-growing insert cost from distorting later samples.
+Concurrent workloads deterministically find and verify one key for every
+physical shard.
 
 The original `storage/*` group is retained unchanged as the synchronous,
 unpooled control. Timed operations use the public
@@ -54,7 +55,7 @@ The `storage/*` measurements include:
   timeout.
 
 They exclude HTTP parsing, networking, Tokio scheduling, server startup,
-database creation, schema broadcast, key discovery, and seed inserts.
+database creation, schema migration, key discovery, and seed inserts.
 
 The `engine/*` measurements include routing, session serialization, asynchronous
 admission, blocking-worker dispatch, pooled connection checkout and return,

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -53,9 +53,22 @@ configured connection slots active and its per-shard admission queue is full.
 The HTTP response is therefore the fixed 503 problem detail above. Admission
 accounting is per shard, so one shard returning `Busy` does not by itself imply
 that another shard is saturated. Routed single-shard requests consume only
-their selected pool; broadcast is the intentional exception and reserves one
-slot in every pool. Clients that retry should use the same bounded exponential
-backoff and jitter as for SQLite-originated `Busy` failures.
+their selected pool. Schema migration instead uses an in-process gate shared by
+handles for the same canonical root, plus fresh coordinator-owned connections.
+While that gate is `Migrating`, new
+ordinary operations and another migration coordinator receive retryable
+`Busy`. Clients that retry should use the same bounded exponential backoff and
+jitter as for SQLite-originated `Busy` failures.
+
+If a failed, cancelled, or dropped migration has already published a durable
+journal row, the gate becomes `Pending`. Ordinary operations then receive
+non-retryable `FailedPrecondition` (HTTP 409), because retrying arbitrary data
+work cannot repair a mixed-generation prefix. A migration call may resume the
+byte-identical SQL; a different migration is a failed precondition while the
+active row remains. Startup automatically attempts the recorded SQL before it
+returns an engine. `Cancelled` and `DeadlineExceeded` themselves remain
+non-retryable classifications even though an operator may deliberately submit
+the exact migration again.
 
 An explicit cancellation is `Cancelled`; expiration of an absolute request
 deadline is `DeadlineExceeded`, even though PostgreSQL represents both with
@@ -64,7 +77,8 @@ caller drops an operation future, there is no client left to receive either
 error. Requests rejected after graceful shutdown begins use `ShuttingDown`.
 Queue depth, pool internals, SQL text, deadline values, and connection-cleanup
 details remain diagnostic data and must not be added to the fixed public
-problem detail.
+problem detail. This includes migration SQL retained in the manifest, which may
+contain sensitive literals.
 
 MySQL has separate foreign-key errors for the parent and child directions.
 `ForeignKeyViolation` does not retain that direction, so BriskDB deliberately
@@ -117,10 +131,26 @@ is `FailedPrecondition`; the file is not downgraded. A recognized BriskDB
 manifest whose identity, schema, or invariant rows disagree is
 `DataCorruption`.
 
+Manifest v6 applies the same boundary to its retained migration journal. A
+malformed digest, SQL limit violation, noncontiguous generation history,
+inconsistent state/progress, wrong stored shard count, multiple or misplaced
+active rows, or an active row that disagrees with the catalog is
+`DataCorruption`. A recognized shard below the active source generation or in
+an invalid source/target position is also corruption. A shard or manifest newer
+than the coordinator can safely interpret is `FailedPrecondition`. Lock
+contention during preflight, apply, progress, or startup recovery remains
+retryable `Busy`.
+
+For submitted migration input, an empty batch, a batch over 65,536 UTF-8 bytes,
+or a NUL byte is `InvalidArgument`. SQLite syntax or statement-shape failures
+retain the normal SQL classification, and attempts to reach the reserved
+BriskDB schema or storage controls are `PermissionDenied`. The public problem
+detail never includes the retained SQL.
+
 Shard-layout validation follows the same distinction. A foreign shard
 application ID, unexpected canonical four-digit `.sqlite` shard file or
 symbolic link, persistent journal mode other than WAL, or shard generation
-newer than the catalog is
+newer than the catalog and outside an authorized active migration prefix is
 `FailedPrecondition`; BriskDB neither claims, downgrades, nor repairs it. A
 layout in `Adopting` or `Ready` with a missing shard is `DataCorruption`. In
 `Ready`, missing identity metadata, a wrong layout or physical-shard ID, an
@@ -132,9 +162,10 @@ BriskDB-owned metadata or mutation of a storage-control PRAGMA is
 `PermissionDenied`. These diagnostics originate in storage and are never
 serialized directly by an adapter.
 
-The earlier taxonomy change affected reporting only. Manifest v5 is a later
-storage-layer change: it adds identity metadata to shard files while preserving
-legacy application tables, rows, routing, SQL results, and wire configuration.
+The earlier taxonomy change affected reporting only. Manifest v5 later added
+identity metadata to shard files; manifest v6 adds retained, crash-resumable
+application-schema history. Both preserve legacy application tables, rows,
+routing, SQL results, and wire configuration during format upgrade.
 
 This is a pre-1.0 Rust API migration: public `Database` operations now return
 `EngineResult<T>` instead of `anyhow::Result<T>`. The `?` operator still

--- a/docs/REQUEST_CONTROLS.md
+++ b/docs/REQUEST_CONTROLS.md
@@ -7,9 +7,10 @@ therefore share the same resource and cleanup semantics.
 ## Per-request context
 
 The existing `Engine::execute`, `query`, `broadcast`, and `status` methods keep
-their signatures and use a default `RequestContext`. Frontends that have their
-own cancellation or deadline source can call the corresponding
-`*_with_context` method:
+their signatures and use a default `RequestContext`. `broadcast` now means a
+journaled application-schema migration. Frontends that have their own
+cancellation or deadline source can call the corresponding `*_with_context`
+method:
 
 ```rust
 use std::time::Duration;
@@ -85,10 +86,40 @@ a blob expands bytes into JSON integers.
 
 The query path accepts only SQLite statements reported as read-only. This
 prevents an early result-budget failure from accompanying a partially consumed
-DML `RETURNING` statement. Execute and broadcast do not materialize a
+DML `RETURNING` statement. Execute and schema migration do not materialize a
 `ResultSet` and are unaffected by query result budgets. A future scatter/gather
 implementation must apply one budget to the combined result, not a fresh budget
 for every shard.
+
+## Schema-migration controls
+
+A schema-migration request first acquires the exclusive schema gate and waits
+for all previously admitted ordinary work to drain. New ordinary operations and
+a second migration coordinator receive retryable `Busy` while that request is
+preflighting or applying. The migration then uses fresh connections with the
+same sticky cancellation token, deadline, cancellable busy handler, SQLite
+progress callback, and exact-handle interrupt behavior as ordinary work.
+
+Before the durable journal is created, cancellation or deadline expiration
+rolls back the current preflight transaction, leaves every shard at the source
+generation, and returns the gate to `Ready`. After journal creation, an
+interrupted shard transaction rolls back but already committed shards remain as
+an ascending prefix; the gate becomes `Pending` and rejects ordinary work with
+non-retryable `FailedPrecondition`. Submitting byte-identical SQL or restarting
+BriskDB validates and resumes that prefix. A shard commit can win a close
+cancellation race; recovery recognizes the one committed-but-not-yet-recorded
+prefix boundary and does not apply its SQL twice.
+
+Request cancellation is checked before each manifest commit begins. Once
+SQLite has attempted `COMMIT`, a cleanup or I/O error can make the outcome
+ambiguous; BriskDB conservatively leaves the gate `Pending` so startup or an
+exact retry can validate the durable journal before ordinary work resumes.
+
+Dropping the migration future follows the same cleanup path. Its lifecycle and
+worker lease remain live until SQLite cleanup finishes, and the gate publishes
+`Ready` or restores `Pending` according to whether a durable journal exists.
+The exact SQL is retained in that journal, so callers must not embed secrets or
+other sensitive literals.
 
 ## Graceful shutdown
 
@@ -118,6 +149,7 @@ supported Unix hosts. It transitions the engine to `Draining` before dropping
 the listener and signaling each tracked HTTP/1 connection. HTTP draining and
 core shutdown start together. A connection still active at the HTTP grace
 deadline is aborted and joined before server shutdown returns; core cleanup may
-continue through its separately documented forced-cleanup grace. Broadcast
-remains sequential and non-atomic across shard files: cancellation preserves
-the committed prefix and prevents later shards from starting.
+continue through its separately documented forced-cleanup grace. A forced
+cancellation cannot erase committed schema-migration progress: the current
+shard transaction rolls back if still running, the retained prefix remains
+resumable, and the next startup finishes it before serving ordinary work.

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -47,7 +47,7 @@ translation layer. HTTP requests send SQLite SQL directly to `rusqlite`.
 | --- | --- | --- | --- |
 | HTTP `/v1/execute` | Experimental | One SQLite statement with positional parameters | Required caller-provided `shard_key` |
 | HTTP `/v1/query` | Experimental | One prepared SQLite statement executed through the row-returning path | Required caller-provided `shard_key` |
-| HTTP `/v1/admin/broadcast` | Experimental | A parameterless SQLite statement batch | Sequentially applied to every shard |
+| HTTP `/v1/admin/broadcast` | Experimental | A journaled parameterless SQLite schema batch | Preflight on every shard, then ascending resumable apply |
 | PostgreSQL wire protocol | Planned | Common subset plus documented PostgreSQL normalization | SQL/bound-parameter inference with explicit session fallback |
 | MySQL wire protocol | Planned | Common subset plus documented MySQL normalization | SQL/bound-parameter inference with explicit session fallback |
 
@@ -65,8 +65,9 @@ accepts 1–16 active connections and 1–1,024 queued operations per shard,
 provided the configured shard count and per-shard active limit do not exceed
 512 total active connections. Connections are opened lazily and reused. A full
 queue returns the retryable `Busy` error (HTTP 503), while single-shard routed
-work waiting on one shard does not consume another shard's capacity. Broadcast
-intentionally reserves one slot in every shard pool before it dispatches.
+work waiting on one shard does not consume another shard's capacity. Schema
+migration drains admitted ordinary work and uses fresh coordinator-owned
+connections instead of reserving every shard pool.
 
 SQLite forms that can leave connection-local state remain allowed by the
 current one-call pass-through, but they are uncontracted. The pool observes
@@ -80,26 +81,28 @@ starts with fresh SQLite counter state. The real statement then runs once on the
 fresh handle. Any other probe error also fails closed to a fresh handle, after
 which replacement acquisition can return a storage error; otherwise the normal
 statement boundary produces the public SQL result or error. Broadcast batches
-instead receive a fresh handle up front when ownership changes, avoiding any
-multi-statement preflight. After the call, a tainted connection is closed instead
-of being reused. A connection left in a transaction is also retired after
-rollback cleanup is attempted. This preserves existing one-call SQLite behavior
-without allowing connection-local state or observer metadata such as
-`PRAGMA data_version` to leak into another ephemeral HTTP session; it does not
-add multi-request transactions or promise compatibility for those statements.
+use dedicated handles and the migration-specific authorizer described below.
+After an ordinary call, a tainted connection is closed instead of being reused.
+A connection left in a transaction is also retired after rollback cleanup is
+attempted. This preserves existing one-call SQLite behavior without allowing
+connection-local state or observer metadata such as `PRAGMA data_version` to
+leak into another ephemeral HTTP session; it does not add multi-request
+transactions or promise compatibility for those statements.
 
 The pass-through boundary excludes BriskDB-owned storage identity. Client SQL
 may not read or mutate `briskdb_shard_metadata`, create objects in the reserved
-`briskdb_*` namespace, or mutate `application_id`, `user_version`, persistent
+`briskdb` or `briskdb_*` namespaces, or mutate `application_id`, `user_version`, persistent
 `journal_mode`, `schema_version`, or `writable_schema`. The SQLite authorizer
-denies those operations through routed and broadcast execution. These controls
-are reserved for startup validation and future schema migrations, so denial is
-stable BriskDB behavior rather than connection-hygiene policy.
+denies those operations through every client execution path. Ordinary routed
+SQL also denies persistent schema DDL. These controls are reserved for startup
+validation and the journaled migration coordinator, so denial is stable
+BriskDB behavior rather than connection-hygiene policy.
 
-`ALTER TABLE` is also denied on every client surface. SQLite reports the source
-table to its authorizer but not a `RENAME TO` destination, so selectively
-allowing it would let a client create a name inside the reserved `briskdb_*`
-namespace. A future schema API can coordinate and validate those changes.
+`ALTER TABLE` is denied through ordinary execute/query SQL but permitted inside
+the journaled migration batch. That coordinator denies transaction/savepoint
+escape, attachments, temporary and virtual objects, and storage-owned state.
+SQLite reports the source table but not a `RENAME TO` destination, so BriskDB
+also compares the reserved schema before and after the migration transaction.
 
 SQLite also retains `last_insert_rowid()`, `changes()`, and `total_changes()` on
 the physical connection after ordinary writes. A write-bearing handle may be
@@ -124,13 +127,34 @@ forms such as DML `RETURNING`; callers must use the execute surface, whose
 result is rows affected rather than returned rows. Exact accounting and
 configuration semantics are in [request controls](REQUEST_CONTROLS.md).
 
-Broadcast execution remains non-atomic: its parameterless SQL batch is not
-wrapped in a transaction on each shard, and shards are processed sequentially.
-A failure can therefore leave earlier statements committed on the failing
-shard as well as leave earlier shards fully or partially updated. Cancellation
-preserves the completed shard prefix and stops before later shards. Pooling and
-request controls do not change the manifest schema, shard files, or stored-data
-format.
+The `broadcast` surface now implements one application-schema migration. Before
+it creates a journal, BriskDB runs the complete batch on every shard in an
+immediate transaction and rolls each preflight transaction back. It then
+records the exact SQL, applies shards in ascending order, and commits one
+shard's complete batch together with its next `user_version` atomically. There
+is no transaction across shard files. A failure or cancellation after journal
+publication retains a valid committed prefix, and the byte-identical request or
+the next startup resumes it before ordinary work may continue.
+
+Migration identity is digest version 1: the full BLAKE3 digest of the exact
+UTF-8 SQL bytes. SQL must contain 1 through 65,536 bytes and no NUL. Whitespace,
+comments, and casing are identity-significant. Completed journal rows and their
+exact SQL remain in the manifest, so callers must not include credentials or
+other sensitive literals. A byte-identical retry of completed SQL is
+idempotent and does not advance the schema generation again.
+The migration does not infer or update advisory `briskdb_tables` rows. Richer
+migration/history APIs remain issue #53, and schema-equivalence checks,
+checksums, and explicit degraded states remain issue #18.
+
+The schema gate admits no new routed work after migration begins and waits for
+previously admitted operations to drain. During active preflight or apply,
+ordinary requests and a second migration coordinator receive retryable `Busy`
+(HTTP 503). If durable journal progress remains after failure or cancellation,
+ordinary requests receive non-retryable `FailedPrecondition` (HTTP 409); the
+same migration call may resume it. Cancellation before journal creation leaves
+no schema change. Cancellation during one shard transaction rolls that
+transaction back, although a commit that wins a close race remains durable and
+is reconciled from the retained journal prefix.
 
 ### Current parameter and result conversion
 
@@ -222,7 +246,7 @@ SQLite library and used through the matching HTTP endpoint:
 
 | Operation | Current contract | Important boundary |
 | --- | --- | --- |
-| `CREATE TABLE`, `CREATE INDEX` | Execute through the broadcast endpoint | Sequential, non-atomic across shards |
+| Persistent DDL, including `CREATE`, `DROP`, and `ALTER` | Execute only through the migration/broadcast endpoint | Per-shard atomic and crash-resumable; not atomic across shards |
 | `INSERT`, `UPDATE`, `DELETE` | Execute on the shard selected by `shard_key` | BriskDB does not yet prove that SQL values match the supplied key |
 | `SELECT` | Query the shard selected by `shard_key` | No scatter/gather path |
 | SQLite expressions and functions | Passed through without translation | Semantics are SQLite semantics |
@@ -231,11 +255,12 @@ SQLite library and used through the matching HTTP endpoint:
 Other SQLite syntax may happen to pass through, but it is not a stable BriskDB
 contract until it appears in this table and has conformance tests. In
 particular, multi-request transactions, multi-shard writes, multiple statements
-outside the broadcast endpoint, and attached-database operations are
-uncontracted public API behavior today. DML `RETURNING` is explicitly rejected
-from the query surface, and the execute surface exposes only a rows-affected
-count, never a returned rowset. The experimental raw HTTP path uses those same
-engine boundaries.
+outside the migration endpoint, and attached-database operations are
+uncontracted public API behavior today. Persistent DDL outside the migration
+endpoint is explicitly denied. DML `RETURNING` is explicitly rejected from the
+query surface, and the execute surface exposes only a rows-affected count,
+never a returned rowset. The experimental raw HTTP path uses those same engine
+boundaries.
 
 The current `Session` `Ready`/`Closed` lifecycle is not a transaction state
 machine. Real `BEGIN`/`COMMIT`/`ROLLBACK`, failed-transaction behavior, and
@@ -250,7 +275,7 @@ authorize an adapter to bypass the shared asynchronous boundary.
 
 The first driver-capable SQL subset will include:
 
-- `CREATE TABLE` and `CREATE INDEX` through cataloged schema migrations;
+- `CREATE TABLE` and `CREATE INDEX` through journaled schema migrations;
 - `SELECT`, including documented filters, ordering, limits, and aggregates;
 - `INSERT`, `UPDATE`, and `DELETE` when a single shard can be proven;
 - `BEGIN`, `COMMIT`, and `ROLLBACK` for transactions pinned to one shard; and
@@ -345,16 +370,18 @@ underlying execution semantics.
   prefix selects one of 4,096 virtual buckets through the versioned
   compatibility algorithm.
 - The final physical shard is read from the validated, generation-stamped
-  bucket map retained in manifest version 5. Routing generation 1 preserves
+  bucket map retained in manifest version 6. Routing generation 1 preserves
   the earlier modulo placement for every supported shard count.
-- Manifest version 5 retains the immutable logical catalog introduced in v4,
-  with schema generation 0 and default database ID 1 named `default`. Its
-  optional table rows can describe sharded, global, or catalog placement and a
-  sharded table's `Int64`, text, or binary key column.
-- A ready v5 layout binds every shard to one random 16-byte layout ID and its
+- Manifest version 6 retains the read-only logical catalog introduced in v4,
+  with a journaled schema generation from 0 through 2,147,483,647 and default
+  database ID 1 named `default`. Its optional table rows can describe sharded,
+  global, or catalog placement and a sharded table's `Int64`, text, or binary
+  key column.
+- The ready layout retained from v5 binds every shard to one random 16-byte
+  layout ID and its
   physical shard ID. Each connection is opened without create or symlink
-  following and must match the `BRSH` application ID, schema-generation-0 user
-  version, exact metadata, and existing WAL mode.
+  following and must match the `BRSH` application ID, expected schema
+  generation, exact metadata, and existing WAL mode.
 - Logical metadata is currently read-only and advisory. Fresh manifests and
   upgrades originating before v4 contain no table rows; v4-to-v5 retains every
   validated v4 logical-catalog row. Existing physical tables are not inferred
@@ -362,7 +389,9 @@ underlying execution semantics.
 - Point queries and writes visit only that shard.
 - No scatter/gather query path exists.
 - Unique constraints and transactions are local to one SQLite shard.
-- Schema broadcast applies sequentially and can be partially completed.
+- Schema migration preflights every shard, then commits an ascending prefix
+  under a retained journal. Each shard is atomic; the shard set is not one
+  transaction, and startup resumes a partial prefix before serving work.
 
 ### Planned stable contract
 
@@ -393,11 +422,14 @@ run internally during storage open, are transactional only within
 statement. The atomic version-3-to-version-4 manifest upgrade adds only
 read-only advisory logical metadata and its downgrade fence. It does not infer
 or adopt existing physical tables and does not change shard schemas, supported
-SQLite syntax, result conversion, routing, or broadcast semantics. Version 5
-then adds a resumable physical-layout state machine. Its `Adopting` path accepts
-only exact legacy zero-header WAL shards, preserves their tables and rows, and
-adds BriskDB identity metadata. It does not make application-schema changes or
-turn sequential broadcast into an atomic cross-file operation.
+SQLite syntax, result conversion, or routing. Version 5 then adds a resumable
+physical-layout state machine. Its `Adopting` path accepts only exact legacy
+zero-header WAL shards, preserves their tables and rows, and adds BriskDB
+identity metadata. Version 6 adds the application-schema journal. A migration
+batch and generation are atomic within each shard, and final journal state plus
+catalog generation are atomic within the manifest, but no transaction spans
+those files. Ascending-prefix validation and replay provide recovery rather
+than cross-file atomicity.
 See the [manifest storage-format contract](STORAGE_FORMAT.md).
 
 Scatter reads will combine committed results from multiple SQLite files. They

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -5,23 +5,30 @@ never exposed through HTTP, PostgreSQL, MySQL, or the SQL execution API. The
 format is pre-1.0, but every format change must still have an ordered migration,
 failure coverage, and an explicit compatibility decision.
 
-## Current format: version 5
+The final `manifest.sqlite` path component must be a regular file, never a
+symbolic link. Startup may create that exact file when a fresh layout is
+permitted; later migration opens never create a missing replacement, use
+SQLite's no-follow mode, and revalidate the freshly opened layout identity
+inside the same manifest transaction before changing journal state.
+
+## Current format: version 6
 
 SQLite header fields identify the file and its format:
 
 | Header field | Value | Meaning |
 | --- | --- | --- |
 | `PRAGMA application_id` | `0x42524442` (`BRDB`) | Permanent BriskDB manifest-family marker |
-| `PRAGMA user_version` | `5` | Authoritative manifest schema version |
+| `PRAGMA user_version` | `6` | Authoritative manifest schema version |
 
 The application ID prevents an accidental foreign SQLite file from being
 adopted as a manifest. It is not authentication or tamper protection: a process
 that can write the data directory can forge it. Checksums and explicit degraded
-states remain separate roadmap work.
+states remain issue #18.
 
-Version 5 has nine strict manifest tables. It retains the v4 routing and
-logical-schema tables, replaces the downgrade fence, and adds the physical
-shard-layout singleton.
+Version 6 has ten strict manifest tables. It retains the v5 routing, logical
+catalog, and physical-layout tables; rebuilds the schema-catalog singleton to
+allow journaled generations; replaces the downgrade fence; and adds the
+application-schema migration journal.
 
 ```sql
 CREATE TABLE briskdb_manifest (
@@ -31,7 +38,7 @@ CREATE TABLE briskdb_manifest (
 
 CREATE TABLE briskdb_metadata (
     requires_manifest_version INTEGER NOT NULL
-        CHECK (requires_manifest_version >= 5)
+        CHECK (requires_manifest_version >= 6)
 ) STRICT;
 
 CREATE TABLE briskdb_routing (
@@ -71,7 +78,8 @@ CREATE TABLE briskdb_logical_databases (
 CREATE TABLE briskdb_schema_catalog (
     singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
     identifier_encoding_version INTEGER NOT NULL CHECK (identifier_encoding_version = 1),
-    schema_generation INTEGER NOT NULL CHECK (schema_generation = 0),
+    schema_generation INTEGER NOT NULL
+        CHECK (schema_generation BETWEEN 0 AND 2147483647),
     default_database_id INTEGER NOT NULL CHECK (default_database_id = 1),
     FOREIGN KEY (default_database_id)
         REFERENCES briskdb_logical_databases (database_id)
@@ -132,28 +140,49 @@ CREATE TABLE briskdb_shard_layout (
     shard_metadata_version INTEGER NOT NULL CHECK (shard_metadata_version = 1),
     layout_state INTEGER NOT NULL CHECK (layout_state IN (1, 2, 3))
 ) STRICT;
+
+CREATE TABLE briskdb_schema_migrations (
+    target_generation INTEGER PRIMARY KEY
+        CHECK (target_generation BETWEEN 1 AND 2147483647),
+    source_generation INTEGER NOT NULL
+        CHECK (source_generation = target_generation - 1),
+    migration_id BLOB NOT NULL UNIQUE
+        CHECK (typeof(migration_id) = 'blob' AND length(migration_id) = 32),
+    digest_version INTEGER NOT NULL CHECK (digest_version = 1),
+    sql_text TEXT NOT NULL
+        CHECK (
+            typeof(sql_text) = 'text'
+            AND length(CAST(sql_text AS BLOB)) BETWEEN 1 AND 65536
+            AND instr(sql_text, char(0)) = 0
+        ),
+    shard_count INTEGER NOT NULL CHECK (shard_count BETWEEN 2 AND 64),
+    migration_state INTEGER NOT NULL CHECK (migration_state IN (1, 2)),
+    next_shard INTEGER NOT NULL CHECK (next_shard BETWEEN 0 AND shard_count),
+    CHECK (migration_state = 1 OR next_shard = shard_count)
+) STRICT;
 ```
 
 The manifest, metadata, routing, schema-catalog, and shard-layout tables each
-contain exactly one row. The v5 downgrade-fence row is exactly `5`.
+contain exactly one row. The v6 downgrade-fence row is exactly `6`.
 `briskdb_manifest.shard_count` is immutable and is the initial routing modulus;
 it is also the live physical-shard count. Physical IDs are exactly
 `0..shard_count - 1`. Filenames remain derived by trusted code as
 `shards/{shard_id:04}.sqlite` and are never read from catalog-controlled paths.
-Version 5 supports only the `active` physical-shard lifecycle state. Adding
+Version 6 supports only the `active` physical-shard lifecycle state. Adding
 provisioning, draining, or retirement states to the routing catalog requires a
 later format and state-machine change. The separate shard-layout state governs
 only startup identity reconciliation.
 
 ### Logical catalog
 
-Every fresh or upgraded v5 manifest contains logical database ID `1` named
-`default`. The schema-catalog singleton contains identifier encoding version
-`1`, application-schema generation `0`, and default database ID `1`. Version 5
-can interpret only schema generation 0. It permits at most 64 logical databases
-and 4,096 table rows. Database and table IDs are positive; table names are
-unique within their owning database, and every table references an existing
-database.
+Every fresh or upgraded v6 manifest contains logical database ID `1` named
+`default`. A fresh or v5-upgraded manifest begins at application-schema
+generation `0`; each completed journal row advances it by exactly one, through
+a maximum of `2,147,483,647`. The schema-catalog singleton also contains
+identifier encoding version `1` and default database ID `1`. Version 6 permits
+at most 64 logical databases and 4,096 table rows. Database and table IDs are
+positive; table names are unique within their owning database, and every table
+references an existing database.
 
 Identifier encoding version 1 is a canonical lowercase ASCII contract for
 logical-database names, table names, and shard-key column names:
@@ -181,16 +210,52 @@ Table placement and shard-key type use stable numeric codes:
 are key-routed. `Global` describes small replicated lookup data. `Catalog`
 describes manifest-owned metadata rather than a user shard table.
 
-The loaded `Catalog` is immutable and read-only. It remains advisory in version
-5: there is no catalog mutation API, planner integration, or enforcement
-against physical shard schemas. Fresh initialization and every v1/v2/v3
-upgrade leave `briskdb_tables` empty; a v4-to-v5 upgrade retains every validated
-v4 catalog row. Migration does not inspect, infer, or adopt tables that already
-exist in shard files. Such tables remain usable through the existing explicit-
-key execute/query API and broadcast API; absence from the catalog does not mean
-physical absence. Version-5 adoption preserves those tables and rows while
-adding only BriskDB-owned shard identity metadata. It changes no current SQL
-planning, routing result, broadcast ordering, or wire contract.
+The loaded `Catalog` is read-only to callers and remains advisory in version 6:
+there is no table-catalog mutation API, planner integration, or enforcement
+against physical shard schemas. The engine publishes a newly committed schema
+generation into its shared catalog snapshot only after every shard has reached
+that generation. Fresh initialization and every v1/v2/v3 upgrade leave
+`briskdb_tables` empty; a v4-to-v5 upgrade retains every validated v4 catalog
+row. Schema migration does not inspect, infer, or mutate `briskdb_tables`, and
+it does not compare the journaled SQL with physical schema equivalence. Tables
+that are absent from the advisory catalog remain usable through the existing
+explicit-key execute/query API. Version-5 adoption preserves existing tables
+and rows while adding only BriskDB-owned shard identity metadata.
+
+### Application-schema migration journal
+
+`briskdb_schema_migrations` is retained generation history, not a transient
+work queue. `migration_state = 1` means `Applying`; `migration_state = 2` means
+`Complete`. `next_shard` is the ascending durable prefix boundary. Complete
+rows always have `next_shard = shard_count` and are never deleted by the
+current implementation.
+
+Digest version 1 defines `migration_id` as the full 32-byte BLAKE3 digest of
+the exact UTF-8 bytes in `sql_text`. There is no whitespace normalization,
+case folding, comment removal, or statement parsing for identity. A
+byte-identical retry finds and validates its existing active or completed row;
+changing even insignificant-looking SQL bytes identifies a different
+migration. Public migration SQL must be nonempty, at most 65,536 UTF-8 bytes,
+and contain no NUL. The exact SQL remains in the manifest permanently so that
+startup can recover without an external migration file. Operators must not put
+passwords, access tokens, personal data, or other sensitive literals in a
+migration batch.
+
+Journal generations are contiguous from target generation 1 through the
+committed catalog generation. Every such row is `Complete`. At most one
+additional `Applying` row may exist, and it must target
+`schema_generation + 1`. Its stored source generation, shard count, SQL text,
+digest, state, and progress are validated on every manifest open. Any journal
+history requires the physical layout to be `Ready`; `Creating` and `Adopting`
+manifests have an empty journal. Fresh v6 initialization and v5-to-v6 upgrade
+also create an empty journal at generation 0.
+
+The retained journal proves which exact batches BriskDB coordinated; it does
+not prove that a shard schema is equivalent to another schema or that its file
+contents are untampered. Checksums, schema-equivalence checks, and explicit
+degraded states remain issue #18. Richer migration submission, history, and
+status APIs remain issue #53; the current public entry point retains the
+`broadcast` name and response shape.
 
 ### Physical shard layout
 
@@ -215,7 +280,7 @@ Every current shard uses these persistent SQLite settings:
 | Shard property | Required value | Meaning |
 | --- | --- | --- |
 | `PRAGMA application_id` | `0x42525348` (`BRSH`) | Permanent BriskDB shard-family marker |
-| `PRAGMA user_version` | `0` | Must equal the manifest's committed application-schema generation |
+| `PRAGMA user_version` | Current generation | Must equal the manifest's committed generation, except for the narrowly authorized source/target prefix of one active migration |
 | `PRAGMA journal_mode` | `wal` | Required persistent journal mode |
 
 Metadata encoding version 1 requires this exact strict identity table:
@@ -256,14 +321,16 @@ WAL validation reads `PRAGMA journal_mode` without assigning it. Only
 different persisted mode. The transient `-wal`, `-shm`, and rollback-journal
 sidecars can be absent and are not counted as canonical shard files.
 
-Creation of new objects in the `briskdb_*` namespace is reserved. The metadata
+Creation of new objects named `briskdb` or in the `briskdb_*` namespace is reserved. The metadata
 table and persistent `application_id`, `user_version`, `journal_mode`,
 `schema_version`, and `writable_schema` controls are BriskDB-owned. The SQL
 authorizer denies client access to the metadata, creation of reserved objects,
-and client mutation of those controls through routed and broadcast paths. It
-also denies all `ALTER TABLE` statements because SQLite does not expose a
-rename destination to the authorizer. A future schema-migration journal, not
-client SQL, must coordinate changes to `user_version`.
+and client mutation of those controls through every SQL path. Ordinary routed SQL
+also denies all persistent DDL. Only the journaled migration connection permits
+application DDL, including `ALTER TABLE`; it denies transaction/savepoint
+escape, attachments, temporary and virtual objects, and storage-owned controls,
+then compares the reserved schema before and after the batch. BriskDB, not the
+submitted SQL, stamps `user_version` inside the shard transaction.
 
 ### Routing catalog
 
@@ -275,7 +342,7 @@ The routing singleton contains exactly these generation-1 values:
 | `key_encoding_version` | `1` | Exact caller-supplied bytes; string shard keys contribute their UTF-8 bytes, with no Unicode normalization |
 | `bucket_algorithm_version` | `1` | Compatibility-preserving range algorithm below |
 | `virtual_bucket_count` | `4096` | Fixed virtual bucket space `0..4095` |
-| `map_generation` | `1` | Initial committed bucket map and the only generation version 5 can interpret |
+| `map_generation` | `1` | Initial committed bucket map and the only generation version 6 can interpret |
 
 Every bucket ID exists exactly once and references an active physical shard.
 Every physical shard owns at least one bucket. The generation-1 map partitions
@@ -304,7 +371,7 @@ vectors freeze the exact key bytes, BLAKE3 prefix, little-endian hash integer,
 bucket ID, and persisted physical shard.
 
 `map_generation` is separate from manifest `user_version` and from
-`schema_generation`. Version 5 accepts only routing generation 1 and validates
+`schema_generation`. Version 6 accepts only routing generation 1 and validates
 its exact deterministic assignment; no public map-mutation operation exists
 yet. A future format that can commit a changed map must bump `user_version` and
 its downgrade fence as well as `map_generation`. That requirement makes this
@@ -315,16 +382,42 @@ At each open, BriskDB validates the exact objects, columns, strict flags, frozen
 schema SQL, singleton rows, logical identifiers and limits, metadata codes,
 supported algorithm values, contiguous physical and bucket IDs, active
 lifecycle states, assignments, coverage, and foreign keys. A recognized
-version-5 manifest that violates any invariant is `DataCorruption` and is
+version-6 manifest that violates any invariant is `DataCorruption` and is
 rejected before shard connections are opened. The same locked transaction
-returns routing and logical rows as one immutable in-memory snapshot, so
-request routing performs no manifest query and cannot fall back to modulo after
-a failed validation.
+returns routing and logical rows as one coherent shared snapshot. Request
+routing performs no manifest query and cannot fall back to modulo after a failed
+validation; only successful migration finalization publishes a newer logical
+schema generation into the snapshot.
+
+## Previous version 5
+
+Version 5 has the first nine current tables and no
+`briskdb_schema_migrations` table. Its schema-catalog definition constrains
+`schema_generation = 0`, and its exact downgrade fence is:
+
+```sql
+CREATE TABLE briskdb_metadata (
+    requires_manifest_version INTEGER NOT NULL
+        CHECK (requires_manifest_version >= 5)
+) STRICT;
+```
+
+The fence contains exactly `5`, and `PRAGMA user_version` is `5`. A v6 opener
+fully validates the v5 manifest, then atomically rebuilds only the
+schema-catalog table, creates the empty migration journal, replaces the fence,
+and stamps manifest version 6. It preserves the layout ID and state, routing,
+logical databases, table-catalog rows, and every application table and row.
+After that manifest-only step, an unfinished v5 `Creating` or `Adopting` layout
+is reconciled exactly as before. That upgrade creates no active migration. In a
+later v6 open, an active journal can exist only beside a durable `Ready` layout
+and is resumed before ordinary layout reconciliation and final shard opens.
 
 ## Previous version 4
 
-Version 4 has the first eight manifest tables shown above and no
-`briskdb_shard_layout` table. Its exact downgrade fence is:
+Version 4 has the first eight manifest-table roles shown above, uses the fixed
+`schema_generation = 0` schema-catalog definition described for v5, and has no
+`briskdb_shard_layout` or `briskdb_schema_migrations` table. Its exact downgrade
+fence is:
 
 ```sql
 CREATE TABLE briskdb_metadata (
@@ -381,7 +474,8 @@ CREATE TABLE briskdb_metadata (
 ```
 
 The fence contains exactly `2`. A current opener validates this complete format
-before applying the numbered v2-to-v3, v3-to-v4, and v4-to-v5 transactions.
+before applying the numbered v2-to-v3, v3-to-v4, v4-to-v5, and v5-to-v6
+transactions.
 
 ## Legacy version 1
 
@@ -408,42 +502,54 @@ non-canonically encoded legacy states are `DataCorruption`.
 ## Upgrade and startup algorithm
 
 Opening a `Database` or `Engine`, including server startup, may upgrade the
-manifest and reconcile the physical shard layout before returning an engine:
+manifest, recover schema migration, and reconcile physical layout before
+returning:
 
-1. Validate the requested shard-count range and open the manifest with a finite
-   busy timeout, `synchronous=FULL`, and foreign keys enabled.
-2. Acquire `BEGIN IMMEDIATE`, then read identity, version, schema, and stored
+1. Validate the requested shard-count range, create and canonicalize the data
+   directory, join its process-wide root coordination, and acquire the shared
+   schema gate. Independent in-process handles resolving to the same canonical
+   path therefore coordinate startup, migrations, admissions, and live catalog
+   generation.
+2. Determine whether fresh layout creation is allowed, validate the canonical
+   parent and regular final file, then open the manifest with no symbolic-link
+   following, a finite busy timeout, `synchronous=FULL`, and foreign keys
+   enabled.
+3. Acquire `BEGIN IMMEDIATE`, then read identity, version, schema, and stored
    configuration under that write lock.
-3. Reject a foreign file, a newer version, a requested shard-count mismatch, or
+4. Reject a foreign file, a newer version, a requested shard-count mismatch, or
    an invalid recognized schema before changing it.
-4. Apply each compile-time registered manifest migration with static SQL and
+5. Apply each compile-time registered manifest migration with static SQL and
    bound data. The destination application ID and `user_version` are the final
    mutations; validate the complete destination and commit one numbered step at
    a time.
-5. Fresh initialization is allowed only beside an otherwise empty physical
-   layout and commits v5 state `Creating`. An existing v1/v2/v3 manifest first
-   advances through v4; the v4-to-v5 transaction commits a random 16-byte
-   layout ID and state `Adopting` before any shard file changes.
-6. Acquire a new `BEGIN IMMEDIATE`, then re-read and validate the committed
-   layout identity and state under that manifest write lock. Reconcile every
-   expected physical ID in ascending order while retaining the lock. Only
-   `Creating` may create a missing file and enable WAL. `Adopting` requires an
-   existing WAL file and accepts either the exact legacy zero/zero header or the
-   exact current metadata left by an earlier attempt. `Ready` accepts only the
-   exact current format.
-7. Still holding the manifest lock, re-scan for unexpected canonical shard
-   filenames and strictly revalidate every expected file. Verify that the
-   layout identity did not change, move its state to `Ready`, revalidate the
-   ready manifest, and commit. A lagging opener then acquires the lock, re-reads
-   `Ready`, and cannot provision from a stale `Creating` observation.
-8. The final strict startup validation pass and every later runtime connection
-   open use read-write, no-create, no-follow flags. Apply connection-local
-   durability and foreign-key settings only after the file passes identity,
-   generation, and WAL checks.
+6. Fresh initialization is allowed only beside an otherwise empty physical
+   layout and commits v6 state `Creating` with generation 0 and an empty
+   migration journal. An existing v1/v2/v3 manifest first advances through v4;
+   the v4-to-v5 transaction commits a random 16-byte layout ID and state
+   `Adopting` before any shard file changes. The v5-to-v6 manifest-only step
+   preserves that state and creates an empty journal.
+7. If the validated v6 manifest contains one `Applying` schema migration, mark
+   startup as pending on interruption, validate its exact source/target shard
+   prefix, and resume it in ascending order. Its layout is necessarily already
+   durable `Ready`. The final migration transaction publishes `Complete` and
+   the target catalog generation before ordinary layout reconciliation begins.
+8. Acquire a new `BEGIN IMMEDIATE`, re-read and validate the committed layout
+   identity and state, and reconcile every expected physical ID in ascending
+   order while retaining the lock. Only `Creating` may create a missing file
+   and enable WAL. `Adopting` requires an existing WAL file and accepts either
+   the exact legacy zero/zero header or resumable current metadata. `Ready`
+   accepts only the exact current format. Re-scan for unexpected canonical
+   shard filenames, strictly revalidate every expected file, publish `Ready`
+   only after full validation, and commit.
+9. Open every shard once more with read-write, no-create, no-follow flags;
+   apply connection-local durability and foreign-key settings only after
+   identity, generation, and WAL validation. Reconcile the validated catalog
+   generation with other live handles for the canonical root, publish the
+   startup gate `Ready`, and only then return `Storage`, `Database`, or `Engine`.
 
 SQLite transactional DDL keeps each numbered manifest step atomic within
-`manifest.sqlite`. A version-1 upgrade commits versions 2, 3, 4, and then 5; a
-version-2 upgrade begins at 3, and so on. The v3-to-v4 step still creates the
+`manifest.sqlite`. A version-1 upgrade commits versions 2, 3, 4, 5, and then 6;
+a version-2 upgrade begins at 3, and so on. The v3-to-v4 step still creates the
 logical catalog, inserts database ID 1 named `default` plus the
 schema-generation-0 singleton, and leaves the table catalog empty.
 
@@ -459,24 +565,71 @@ layout observed at that transition.
 The adoption path changes no application table or row and does not derive
 identity from application schema. A legacy shard with a nonzero header, a
 non-WAL mode, or a missing file is rejected without being repaired or replaced.
-Catalog schema generation remains 0; matching that number validates the shard's
-declared generation, not the advisory table catalog against physical DDL.
+The v5-to-v6 step does not change any shard because a valid v5 database is at
+schema generation 0 and has no journal history. Matching a shard generation
+validates only the declared generation; `briskdb_tables` remains advisory and
+is not checked against physical DDL.
+
+A new application-schema migration follows a separate durable protocol:
+
+1. Acquire the sole in-process schema-migration gate, stop admitting ordinary
+   operations, and wait for operations already admitted to finish.
+2. Validate the SQL identity and limits, then execute the complete batch inside
+   a rollback-only immediate transaction on every shard at the source
+   generation. The preflight also runs `PRAGMA main.foreign_key_check` after
+   the batch so deferred violations cannot survive until a real commit. If any
+   preflight fails or the request is cancelled, no journal or shard change is
+   retained and ordinary work becomes ready again.
+3. Append one `Applying` journal row at target generation
+   `source_generation + 1` with `next_shard = 0`.
+4. For each shard in ascending physical-ID order, execute the complete SQL
+   batch and stamp its target `user_version` in the same immediate SQLite
+   transaction. After that shard commit, advance the journal prefix by one in
+   a separate manifest transaction.
+5. Strictly validate every shard at the target generation, then atomically mark
+   the journal row `Complete` and advance the schema-catalog generation in one
+   final manifest transaction. Publish the new in-memory generation and admit
+   ordinary work again.
+
+There is deliberately no transaction spanning shard files and the manifest.
+A crash after a shard commit but before its journal acknowledgement leaves the
+durable prefix one position behind. Recovery permits exactly that one
+already-target shard at the boundary, revalidates it, and advances without
+executing the batch twice. Any other hole, regression, or out-of-range shard
+generation is rejected. A byte-identical public retry resumes an active row or
+validates and returns an already completed row without creating another
+generation.
+
+The controlled migration path installs cancellation-aware busy, progress, and
+interrupt hooks. Cancellation or deadline expiration rolls back the currently
+running shard transaction. Before journal publication it restores ordinary
+admission with no durable migration; afterward, the committed prefix and
+`Applying` row remain and ordinary operations fail with
+`FailedPrecondition` until the same SQL or startup resumes. While a coordinator
+is actively preflighting or applying, new ordinary work and another migration
+coordinator receive retryable `Busy`. If SQLite attempts a manifest `COMMIT`
+but reports an ambiguous cleanup or I/O failure, admission remains `Pending`
+until recovery validates whether that boundary became durable.
 
 Tests prove retry after injected errors and Rust panic unwinding at cross-file
-persistence boundaries. SQLite is intended to recover its own uncommitted
-transactions after process loss, but BriskDB has not yet certified arbitrary
-process-kill, machine power-loss, torn-write, or filesystem-fault recovery.
-The layout state machine is therefore a deterministic software-interruption
-contract, not the later storage-hardening certification.
+persistence boundaries. Targeted subprocess-abort tests also prove migration
+recovery when termination lands inside a shard transaction after its SQL or
+generation stamp, and after the journal commit, a shard commit, or a
+journal-progress commit. SQLite rolls the tested uncommitted shard transaction
+back before exact retry. BriskDB has not certified arbitrary
+process-kill timing, machine power loss, torn writes, or filesystem faults. The
+state machines are therefore defined software-interruption contracts, not the
+later storage-hardening certification.
 
 ## Compatibility and operations
 
-- Version 1 upgrades through versions 2, 3, and 4 to version 5; version 2 begins
-  at version 3, version 3 begins at version 4, and version 4 upgrades directly
-  to version 5. Opening is therefore potentially mutating.
+- Version 1 upgrades through versions 2, 3, 4, and 5 to version 6; version 2
+  begins at version 3, version 3 begins at version 4, version 4 begins at
+  version 5, and version 5 upgrades directly to version 6. Opening is therefore
+  potentially mutating.
 - There is no automatic downgrade. Older readers are fenced by the incompatible
-  metadata schema and authoritative header; in particular, a version-4 reader
-  rejects `user_version = 5` before it can bypass no-create validation.
+  metadata schema and authoritative header; in particular, a version-5 reader
+  rejects `user_version = 6` before it can ignore the migration journal.
 - A manifest with the BriskDB application ID and a `user_version` newer than the
   binary supports fails with non-retryable `FailedPrecondition`; it is not
   downgraded or switched to WAL, and shard files are not opened.
@@ -501,38 +654,39 @@ Do not edit the header, tables, or rows manually. Until the checksum milestone,
 a coordinated manual edit that still satisfies every structural invariant
 cannot be distinguished from an intentional catalog update. The current
 deployment boundary remains local storage and one BriskDB process per data
-directory. A formal backup/restore workflow is not implemented; recovery from
-a missing, swapped, or otherwise incompatible shard—including one cloned into
-the wrong slot or from another layout—requires the correct complete layout or a
-known-good copy made while BriskDB was stopped. Recovery to an older binary
-likewise requires a pre-v5 backup.
-
-A future application-schema migration format must bump the manifest version and
-downgrade fence, journal its source and target generations, and explicitly
-authorize any temporary mixed shard generations. It must update each shard's
-`user_version` atomically with that shard's DDL and advance the committed
-catalog generation only after every shard verifies. A v5 opener has no such
-journal and rejects every generation other than 0.
+directory. Independent handles inside that process share a gate and live
+catalog coordination keyed by the canonical root. A formal backup/restore
+workflow is not implemented; recovery from a missing, swapped, or otherwise
+incompatible shard—including one cloned into the wrong slot or from another
+layout—requires the correct complete layout or a known-good copy made while
+BriskDB was stopped. Recovery to an older binary likewise requires a pre-v6
+backup. Separate server processes against one data directory are unsupported
+even though SQLite and the manifest use file locks; the in-process coordination
+is intentionally not a distributed lock.
 
 ## Verification contract
 
-Tests cover fresh and v1/v2/v3/v4-to-v5 creation, every manifest layout state,
-the exact shard header and metadata row, application-schema generation 0, and
-no-op ready reopen. Failure coverage includes missing and extra canonical files,
-foreign headers, non-WAL mode, malformed metadata, cross-layout shard clones,
-shard swaps, symlinks, wrong generations, client attempts to reach storage-owned
-state, and runtime pool replacement opens. Injection around each manifest and
-per-shard persistence boundary proves resumability in `Creating` and `Adopting`
-and prevents `Ready` from being published before full strict revalidation.
-Concurrent openers exercise matching and conflicting shard counts and layout
-transitions.
+Tests cover fresh creation and every v1/v2/v3/v4/v5-to-v6 upgrade, every
+manifest layout state, the exact shard header and metadata row, dynamic schema
+generations, retained migration history, and no-op ready reopen. Failure
+coverage includes missing and extra canonical files, foreign headers, non-WAL
+mode, malformed metadata or journal rows, cross-layout shard clones, shard
+swaps, symlinks, wrong generations, client attempts to reach storage-owned
+state, and runtime pool replacement opens. Injection around each manifest,
+layout, shard-migration, journal-progress, and finalization persistence boundary
+proves resumability and prevents a ready layout or completed generation from
+being published before full strict revalidation. Concurrent openers exercise
+matching and conflicting shard counts and layout transitions.
 
 Catalog tests continue to cover default logical metadata, every placement and
 shard-key type code, identifier and relational corruption, row limits, and
 immutable public lookups. Routing tests freeze golden hash/bucket/shard vectors,
 cover every algorithm state for every supported shard count, prove the final
 map lookup with a synthetic reassignment, and exercise parallel and reopen
-stability. Process termination and filesystem faults remain part of the later
-storage-hardening suite. Every new migration must extend the registry,
-destination validator, format documentation, and the same
+stability. Schema-migration tests cover exact identity and input limits,
+byte-identical retry, preflight rollback, per-shard atomicity, gate states,
+cancellation, panic, and targeted process abort at durable boundaries.
+Arbitrary process termination and filesystem faults remain part of the later
+storage-hardening suite. Every new manifest-format migration must extend the
+registry, destination validator, format documentation, and the same
 normal/error/concurrency/recovery matrix.

--- a/docs/SUPPORTED_PLATFORMS.md
+++ b/docs/SUPPORTED_PLATFORMS.md
@@ -58,7 +58,10 @@ layout members by themselves. The directory must nevertheless permit SQLite to
 create and recover its sidecars. Do not infer damage from a missing sidecar;
 BriskDB validates the database's persistent journal mode instead.
 
-Only a single BriskDB server process per data directory is currently tested.
+Only a single BriskDB server process per data directory is supported. The
+process-wide registry makes independent `Database` and `Engine` handles that
+resolve to the same canonical root share schema admission and catalog
+publication. It does not coordinate separate server processes.
 Do not copy, move, edit, or separately open the manifest, shard, WAL, or shared
 memory files while the server is running. Backup, restore, multi-process
 access, filesystem-fault behavior, and crash-recovery guarantees will become
@@ -66,18 +69,33 @@ supported only when their roadmap issues add the corresponding automated
 tests.
 
 Opening a data directory can transactionally upgrade `manifest.sqlite` and can
-resume a manifest-recorded cross-file shard provisioning or adoption step; see
-the [manifest storage-format contract](STORAGE_FORMAT.md). Outside the explicit
-`Creating` state, every shard is opened read-write with SQLite create and
-symbolic-link following disabled. A missing, extra canonical, swapped, foreign,
-non-WAL, or wrong-generation shard file is rejected, as is a shard cloned into
-another slot or layout. It is not recreated, reassigned, or silently
-reconfigured. Recovery requires restoring the correct complete layout.
+resume a manifest-recorded cross-file shard provisioning, adoption, or
+application-schema migration step; see the
+[manifest storage-format contract](STORAGE_FORMAT.md). After manifest load or
+upgrade, an active schema migration is resumed before ordinary layout
+reconciliation and final strict shard validation. All startup work finishes
+before the server accepts requests. Outside the explicit `Creating` state,
+every shard is opened read-write with SQLite create and symbolic-link following
+disabled. A missing, extra canonical, swapped, foreign, non-WAL, or
+wrong-generation shard file is rejected, as is a shard cloned into another slot
+or layout. It is not recreated, reassigned, or silently reconfigured. Recovery
+requires restoring the correct complete layout.
+
+The manifest final path component is likewise required to be a regular file.
+Startup and runtime migration opens disable symbolic-link following; a runtime
+open will not create a missing manifest and rechecks the opened layout identity
+before journal mutation.
+
+Manifest v6 retains each migration's exact SQL text for idempotency and startup
+recovery. Treat the data directory accordingly and do not include credentials,
+tokens, or other sensitive literals in migration SQL.
 
 Manifest and shard application IDs plus the random 16-byte layout ID guard
 against accidental wrong-file placement. They are not authentication, checksums,
-or protection from a process that can write the data directory. Process-kill,
-power-loss, and filesystem-fault certification remains later hardening work.
+or protection from a process that can write the data directory. Targeted
+subprocess-abort tests cover schema-journal persistence boundaries, but
+arbitrary process-kill timing, power-loss, and filesystem-fault certification
+remain later hardening work.
 
 When reporting a platform problem, include the BriskDB revision, `rustc -Vv`,
 operating-system and architecture details, filesystem type, mount options, and

--- a/src/core/catalog.rs
+++ b/src/core/catalog.rs
@@ -1,6 +1,9 @@
 //! Protocol-neutral logical database and table metadata.
 
-use std::fmt;
+use std::{
+    fmt,
+    sync::atomic::{AtomicU64, Ordering},
+};
 
 use super::{EngineError, EngineErrorKind, EngineResult, RoutingCatalog};
 
@@ -208,19 +211,65 @@ impl TableMetadata {
     }
 }
 
-/// Immutable logical schema metadata loaded atomically with routing state.
+/// Stable logical schema metadata loaded atomically with routing state.
 ///
-/// The manifest v4 catalog is read-only and advisory. Existing raw SQLite
-/// tables are not inferred or adopted, and current execution behavior remains
-/// unchanged until cataloged DDL and schema journaling are implemented.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// Database and table entries remain immutable for the lifetime of this view.
+/// Its application-schema generation advances in place only after the durable
+/// migration coordinator commits a new generation, so existing `&Catalog`
+/// references observe publication without replacing the catalog allocation.
 pub struct Catalog {
     identifier_encoding_version: u32,
-    schema_generation: u64,
+    schema_generation: AtomicU64,
     default_database_id: LogicalDatabaseId,
     databases: Box<[LogicalDatabaseMetadata]>,
     tables: Box<[TableMetadata]>,
 }
+
+impl fmt::Debug for Catalog {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("Catalog")
+            .field(
+                "identifier_encoding_version",
+                &self.identifier_encoding_version,
+            )
+            .field("schema_generation", &self.schema_generation())
+            .field("default_database_id", &self.default_database_id)
+            .field("databases", &self.databases)
+            .field("tables", &self.tables)
+            .finish()
+    }
+}
+
+impl Clone for Catalog {
+    fn clone(&self) -> Self {
+        Self {
+            identifier_encoding_version: self.identifier_encoding_version,
+            // Catalog clones retain value semantics: a clone is an independent
+            // metadata snapshot at the generation observed here. Shared live
+            // views use the existing Arc<CatalogSnapshot> storage boundary.
+            schema_generation: AtomicU64::new(self.schema_generation()),
+            default_database_id: self.default_database_id,
+            databases: self.databases.clone(),
+            tables: self.tables.clone(),
+        }
+    }
+}
+
+impl PartialEq for Catalog {
+    fn eq(&self, other: &Self) -> bool {
+        if std::ptr::eq(self, other) {
+            return true;
+        }
+        self.identifier_encoding_version == other.identifier_encoding_version
+            && self.schema_generation() == other.schema_generation()
+            && self.default_database_id == other.default_database_id
+            && self.databases == other.databases
+            && self.tables == other.tables
+    }
+}
+
+impl Eq for Catalog {}
 
 impl Catalog {
     pub(crate) fn from_validated_parts(
@@ -250,7 +299,7 @@ impl Catalog {
         }));
         Self {
             identifier_encoding_version,
-            schema_generation,
+            schema_generation: AtomicU64::new(schema_generation),
             default_database_id: LogicalDatabaseId::from_validated(default_database_id),
             databases,
             tables,
@@ -262,9 +311,46 @@ impl Catalog {
         self.identifier_encoding_version
     }
 
-    /// Return the cataloged application-schema generation.
-    pub const fn schema_generation(&self) -> u64 {
-        self.schema_generation
+    /// Return the latest durably published application-schema generation.
+    pub fn schema_generation(&self) -> u64 {
+        self.schema_generation.load(Ordering::Acquire)
+    }
+
+    /// Publish one committed application-schema generation in place.
+    ///
+    /// Re-publishing the already visible target is idempotent. Every other
+    /// stale, skipped, or regressing transition is an internal coordination
+    /// error: manifest validation is responsible for establishing the durable
+    /// source and target before this in-memory publication occurs.
+    pub(crate) fn publish_schema_generation(
+        &self,
+        expected_generation: u64,
+        target_generation: u64,
+    ) -> EngineResult<()> {
+        if expected_generation.checked_add(1) != Some(target_generation) {
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                format!(
+                    "invalid in-memory schema-generation transition {expected_generation} -> {target_generation}"
+                ),
+            ));
+        }
+
+        match self.schema_generation.compare_exchange(
+            expected_generation,
+            target_generation,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
+            Ok(_) => Ok(()),
+            Err(observed) if observed == target_generation => Ok(()),
+            Err(observed) => Err(EngineError::new(
+                EngineErrorKind::Internal,
+                format!(
+                    "cannot publish schema generation {target_generation}; in-memory catalog is at generation {observed}"
+                ),
+            )),
+        }
     }
 
     /// Return the storage-default logical database.
@@ -370,6 +456,11 @@ fn ensure_catalog_identifier(identifier: &str) -> EngineResult<()> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{
+        Arc, Barrier,
+        atomic::{AtomicBool, Ordering},
+    };
+
     use super::*;
 
     fn sample_catalog() -> Catalog {
@@ -518,5 +609,101 @@ mod tests {
         assert_send_sync_static::<TablePlacement>();
         assert_send_sync_static::<ShardKeyMetadata>();
         assert_send_sync_static::<ShardKeyType>();
+    }
+
+    #[test]
+    fn schema_generation_publication_is_monotonic_idempotent_and_visible_in_place() {
+        let catalog = sample_catalog();
+        let retained_reference = &catalog;
+
+        catalog.publish_schema_generation(7, 8).unwrap();
+        assert_eq!(retained_reference.schema_generation(), 8);
+        catalog.publish_schema_generation(7, 8).unwrap();
+        assert_eq!(catalog.schema_generation(), 8);
+
+        for (source, target) in [(8, 8), (8, 7), (8, 10), (u64::MAX, 0)] {
+            let error = catalog
+                .publish_schema_generation(source, target)
+                .unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::Internal);
+            assert_eq!(catalog.schema_generation(), 8);
+        }
+
+        catalog.publish_schema_generation(7, 8).unwrap();
+        assert_eq!(catalog.schema_generation(), 8);
+        assert_eq!(
+            catalog.publish_schema_generation(9, 10).unwrap_err().kind(),
+            EngineErrorKind::Internal
+        );
+    }
+
+    #[test]
+    fn clone_debug_and_equality_keep_snapshot_value_semantics() {
+        let catalog = sample_catalog();
+        assert_eq!(catalog, catalog);
+        let cloned = catalog.clone();
+        assert_eq!(catalog, cloned);
+        assert_eq!(format!("{catalog:?}"), format!("{cloned:?}"));
+
+        catalog.publish_schema_generation(7, 8).unwrap();
+        assert_eq!(catalog.schema_generation(), 8);
+        assert_eq!(cloned.schema_generation(), 7);
+        assert_ne!(catalog, cloned);
+        assert!(format!("{catalog:?}").contains("schema_generation: 8"));
+        assert!(format!("{cloned:?}").contains("schema_generation: 7"));
+    }
+
+    #[test]
+    fn concurrent_publishers_and_readers_never_observe_a_generation_regression() {
+        let catalog = Arc::new(sample_catalog());
+        let publishers = 8;
+        let publish_barrier = Arc::new(Barrier::new(publishers + 1));
+        let mut publish_threads = Vec::new();
+        for _ in 0..publishers {
+            let catalog = Arc::clone(&catalog);
+            let barrier = Arc::clone(&publish_barrier);
+            publish_threads.push(std::thread::spawn(move || {
+                barrier.wait();
+                catalog.publish_schema_generation(7, 8)
+            }));
+        }
+        publish_barrier.wait();
+        for thread in publish_threads {
+            thread.join().unwrap().unwrap();
+        }
+        assert_eq!(catalog.schema_generation(), 8);
+
+        let readers = 8;
+        let read_barrier = Arc::new(Barrier::new(readers + 1));
+        let finished = Arc::new(AtomicBool::new(false));
+        let mut read_threads = Vec::new();
+        for _ in 0..readers {
+            let catalog = Arc::clone(&catalog);
+            let barrier = Arc::clone(&read_barrier);
+            let finished = Arc::clone(&finished);
+            read_threads.push(std::thread::spawn(move || {
+                barrier.wait();
+                let mut observed = catalog.schema_generation();
+                while !finished.load(Ordering::Acquire) {
+                    let next = catalog.schema_generation();
+                    assert!(next >= observed);
+                    observed = next;
+                    std::hint::spin_loop();
+                }
+                assert!(catalog.schema_generation() >= observed);
+            }));
+        }
+
+        read_barrier.wait();
+        for generation in 9..=1_024 {
+            catalog
+                .publish_schema_generation(generation - 1, generation)
+                .unwrap();
+        }
+        finished.store(true, Ordering::Release);
+        for thread in read_threads {
+            thread.join().unwrap();
+        }
+        assert_eq!(catalog.schema_generation(), 1_024);
     }
 }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -2216,7 +2216,7 @@ mod tests {
             2
         );
         wait_for_pool_occupancy(&engine, 0, 0, 0).await;
-        assert_eq!(engine.inner.workers.available_permits(), 2);
+        wait_for_worker_capacity(&engine, 2).await;
     }
 
     #[tokio::test]

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -19,7 +19,7 @@ use super::{
 };
 use crate::{
     sql,
-    storage::{ConnectionOwner, ConnectionPools, PooledConnection},
+    storage::{ConnectionOwner, ConnectionPools, PooledConnection, SchemaOperationGuard},
 };
 
 static NEXT_ENGINE_ID: AtomicU64 = AtomicU64::new(1);
@@ -465,6 +465,10 @@ impl Engine {
         context: RequestContext,
     ) -> EngineResult<Routed<usize>> {
         let mut operation = self.operation(context)?;
+        let schema_operation = match self.inner.database.storage.enter_schema_operation() {
+            Ok(guard) => guard,
+            Err(error) => return operation.finish(Err(error)),
+        };
         let guard = match operation.wait_pending(self.ready_session(session)).await {
             Ok(guard) => guard,
             Err(error) => return operation.finish(Err(error)),
@@ -482,6 +486,7 @@ impl Engine {
                 &mut operation,
                 shard,
                 owner,
+                schema_operation,
                 guard,
                 move |connection, control| {
                     connection.isolate_foreign_sql_controlled(Arc::clone(&control), &sql)?;
@@ -514,6 +519,10 @@ impl Engine {
         context: RequestContext,
     ) -> EngineResult<Routed<ResultSet>> {
         let mut operation = self.operation(context)?;
+        let schema_operation = match self.inner.database.storage.enter_schema_operation() {
+            Ok(guard) => guard,
+            Err(error) => return operation.finish(Err(error)),
+        };
         let guard = match operation.wait_pending(self.ready_session(session)).await {
             Ok(guard) => guard,
             Err(error) => return operation.finish(Err(error)),
@@ -532,6 +541,7 @@ impl Engine {
                 &mut operation,
                 shard,
                 owner,
+                schema_operation,
                 guard,
                 move |connection, control| {
                     connection.isolate_foreign_sql_controlled(Arc::clone(&control), &sql)?;
@@ -545,7 +555,7 @@ impl Engine {
         Ok(Routed { shard, value })
     }
 
-    /// Execute a parameterless SQL batch sequentially on every shard.
+    /// Apply a parameterless SQL migration batch through the durable shard journal.
     pub async fn broadcast(&self, session: &Session, sql: String) -> EngineResult<Vec<u16>> {
         self.broadcast_with_context(session, sql, RequestContext::new())
             .await
@@ -553,8 +563,8 @@ impl Engine {
 
     /// Execute a parameterless SQL batch on every shard with explicit request controls.
     ///
-    /// Shards are processed in order. Cancellation stops before the next shard,
-    /// but statements already committed on earlier shards remain committed.
+    /// Shards are processed in order under a durable journal. Cancellation may
+    /// leave resumable progress, which the same SQL or the next startup resumes.
     pub async fn broadcast_with_context(
         &self,
         session: &Session,
@@ -562,16 +572,27 @@ impl Engine {
         context: RequestContext,
     ) -> EngineResult<Vec<u16>> {
         let mut operation = self.operation(context)?;
-        let guard = match operation.wait_pending(self.ready_session(session)).await {
+        if session.owner != self.inner.id {
+            return operation.finish(Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "the session belongs to a different engine",
+            )));
+        }
+        let mut migration = match self.inner.database.storage.begin_schema_migration() {
             Ok(guard) => guard,
             Err(error) => return operation.finish(Err(error)),
         };
-        let owner = ConnectionOwner::new(session.id().get());
-        let permits = match operation
-            .wait_pending(self.inner.connections.acquire_all_for_owner(owner))
-            .await
-        {
-            Ok(permits) => permits,
+        let quiesced = operation
+            .wait_pending(async {
+                migration.wait_for_quiescence().await;
+                Ok(())
+            })
+            .await;
+        if let Err(error) = quiesced {
+            return operation.finish(Err(error));
+        }
+        let session_guard = match operation.wait_pending(self.ready_session(session)).await {
+            Ok(guard) => guard,
             Err(error) => return operation.finish(Err(error)),
         };
         let worker = match operation.wait_pending(self.inner.workers.acquire()).await {
@@ -582,39 +603,25 @@ impl Engine {
             return operation.finish(Err(error));
         }
         let lease = operation.take_lease();
-        let control = Arc::clone(&operation.control);
-        let worker_control = Arc::clone(&control);
+        let worker_control = Arc::clone(&operation.control);
+        let storage = self.inner.database.storage.clone();
+        let connections = self.inner.connections.clone();
         let join = worker.spawn(move || {
             let _lease = lease;
-            let _session = guard;
-            let result = (|| {
-                let mut completed = Vec::with_capacity(permits.len());
-                for (shard, permit) in permits {
-                    if let Some(reason) = worker_control.reason() {
-                        return Err(reason.error());
-                    }
-                    let mut connection = permit
-                        .checkout_controlled(Arc::clone(&worker_control))
-                        .map_err(|error| {
-                            error.context(format!("broadcast failed to open shard {shard}"))
-                        })?;
-                    connection
-                        .ensure_owner_local_controlled(Arc::clone(&worker_control))
-                        .map_err(|error| {
-                            error.context(format!("broadcast failed to isolate shard {shard}"))
-                        })?;
-                    let result = connection
-                        .run_controlled(Arc::clone(&worker_control), |connection| {
-                            sql::execute_batch(connection, &sql)
-                        });
-                    retire_if_broken(&mut connection, &result);
-                    if let Err(error) = result {
-                        return Err(error.context(format!("broadcast failed on shard {shard}")));
-                    }
-                    completed.push(shard);
-                }
-                Ok(completed)
-            })();
+            let _session = session_guard;
+            let result = connections
+                .retire_idle_for_schema_migration()
+                .and_then(|_| {
+                    storage.apply_schema_migration(
+                        &sql,
+                        &mut migration,
+                        Some(Arc::clone(&worker_control)),
+                    )
+                })
+                .and_then(|completed| {
+                    migration.publish_ready()?;
+                    Ok(completed)
+                });
             worker_control.complete(result)
         });
         let result = operation.wait_started(join).await;
@@ -626,6 +633,7 @@ impl Engine {
         operation: &mut Operation,
         shard: u16,
         owner: ConnectionOwner,
+        schema_operation: SchemaOperationGuard,
         session: OwnedMutexGuard<SessionInner>,
         work: F,
     ) -> EngineResult<T>
@@ -653,6 +661,7 @@ impl Engine {
         let join = worker.spawn(move || {
             let _lease = lease;
             let _session = session;
+            let _schema_operation = schema_operation;
             let result = permit
                 .checkout_controlled(Arc::clone(&worker_control))
                 .and_then(|mut connection| {
@@ -690,17 +699,25 @@ impl Engine {
         release: std::sync::mpsc::Receiver<()>,
     ) -> EngineResult<()> {
         let mut operation = self.operation(RequestContext::new())?;
+        let schema_operation = self.inner.database.storage.enter_schema_operation()?;
         let guard = match operation.wait_pending(self.ready_session(session)).await {
             Ok(guard) => guard,
             Err(error) => return operation.finish(Err(error)),
         };
         let owner = ConnectionOwner::new(session.id().get());
         let result = self
-            .run_on_shard(&mut operation, shard, owner, guard, move |_, _| {
-                let _ = started.send(());
-                release.recv().expect("test releases the blocking worker");
-                Ok(())
-            })
+            .run_on_shard(
+                &mut operation,
+                shard,
+                owner,
+                schema_operation,
+                guard,
+                move |_, _| {
+                    let _ = started.send(());
+                    release.recv().expect("test releases the blocking worker");
+                    Ok(())
+                },
+            )
             .await;
         operation.finish_started(result)
     }
@@ -708,15 +725,21 @@ impl Engine {
     #[cfg(test)]
     async fn panic_worker_for_test(&self, session: &Session, shard: u16) -> EngineResult<()> {
         let mut operation = self.operation(RequestContext::new())?;
+        let schema_operation = self.inner.database.storage.enter_schema_operation()?;
         let guard = match operation.wait_pending(self.ready_session(session)).await {
             Ok(guard) => guard,
             Err(error) => return operation.finish(Err(error)),
         };
         let owner = ConnectionOwner::new(session.id().get());
         let result = self
-            .run_on_shard(&mut operation, shard, owner, guard, move |_, _| {
-                panic!("intentional blocking worker panic")
-            })
+            .run_on_shard(
+                &mut operation,
+                shard,
+                owner,
+                schema_operation,
+                guard,
+                move |_, _| panic!("intentional blocking worker panic"),
+            )
             .await;
         operation.finish_started(result)
     }
@@ -728,6 +751,7 @@ impl Engine {
         shard: u16,
     ) -> EngineResult<()> {
         let mut operation = self.operation(RequestContext::new())?;
+        let schema_operation = self.inner.database.storage.enter_schema_operation()?;
         let guard = match operation.wait_pending(self.ready_session(session)).await {
             Ok(guard) => guard,
             Err(error) => return operation.finish(Err(error)),
@@ -738,6 +762,7 @@ impl Engine {
                 &mut operation,
                 shard,
                 owner,
+                schema_operation,
                 guard,
                 move |connection, control| {
                     connection.run_controlled(control, |_connection| -> EngineResult<()> {
@@ -763,15 +788,21 @@ impl Engine {
         context: RequestContext,
     ) -> EngineResult<u64> {
         let mut operation = self.operation(context)?;
+        let schema_operation = self.inner.database.storage.enter_schema_operation()?;
         let guard = match operation.wait_pending(self.ready_session(session)).await {
             Ok(guard) => guard,
             Err(error) => return operation.finish(Err(error)),
         };
         let owner = ConnectionOwner::new(session.id().get());
         let result = self
-            .run_on_shard(&mut operation, shard, owner, guard, move |connection, _| {
-                Ok(connection.connection_id())
-            })
+            .run_on_shard(
+                &mut operation,
+                shard,
+                owner,
+                schema_operation,
+                guard,
+                move |connection, _| Ok(connection.connection_id()),
+            )
             .await;
         operation.finish_started(result)
     }
@@ -954,6 +985,15 @@ mod tests {
         );
         session.set_routing_key("widget-1").await.unwrap();
 
+        let routed_ddl = engine
+            .execute(
+                &session,
+                Statement::new("CREATE TABLE bypassed_migration (id INTEGER)", vec![]),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(routed_ddl.kind(), EngineErrorKind::PermissionDenied);
+
         let write = engine
             .execute(
                 &session,
@@ -999,13 +1039,15 @@ mod tests {
         for shard in &pools.shards {
             assert_eq!(shard.active, 0);
             assert_eq!(shard.queued, 0);
-            assert_eq!(shard.opened, 1);
-            assert_eq!(shard.idle, 1);
             if shard.shard == write.shard {
+                assert_eq!(shard.opened, 1);
+                assert_eq!(shard.idle, 1);
                 assert_eq!(shard.checkouts, 3);
                 assert_eq!(shard.reused, 2);
             } else {
-                assert_eq!(shard.checkouts, 1);
+                assert_eq!(shard.opened, 0);
+                assert_eq!(shard.idle, 0);
+                assert_eq!(shard.checkouts, 0);
                 assert_eq!(shard.reused, 0);
             }
             assert_eq!(shard.retired, 0);
@@ -1116,27 +1158,50 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn partial_broadcast_failure_can_recover_through_the_engine() {
+    async fn failed_migration_preflight_is_atomic_and_retryable_through_the_engine() {
         let temp = tempfile::tempdir().unwrap();
         let database = Arc::new(Database::open(temp.path(), 4).unwrap());
+        database
+            .broadcast("CREATE TABLE marker (id INTEGER NOT NULL)")
+            .unwrap();
         let shard_one = database.storage.open_shard(1).unwrap();
-        crate::sql::execute_batch(&shard_one, "CREATE TABLE marker (id INTEGER)").unwrap();
+        shard_one
+            .execute_batch("INSERT INTO marker VALUES (1), (1)")
+            .unwrap();
         let engine = Engine::from_database(database);
         let session = engine.session();
 
         let error = engine
-            .broadcast(&session, "CREATE TABLE marker (id INTEGER)".to_owned())
+            .broadcast(
+                &session,
+                "CREATE UNIQUE INDEX marker_id ON marker (id)".to_owned(),
+            )
             .await
             .unwrap_err();
-        assert_eq!(error.kind(), EngineErrorKind::InvalidQuery);
-        assert!(error.source().is_some());
+        assert_eq!(error.kind(), EngineErrorKind::UniqueViolation);
         assert_eq!(session.state().await, SessionState::Ready);
+        for shard in 0..4 {
+            let connection = engine.inner.database.storage.open_shard(shard).unwrap();
+            assert!(
+                !connection
+                    .query_row(
+                        "SELECT EXISTS(SELECT 1 FROM sqlite_schema WHERE name = 'marker_id')",
+                        [],
+                        |row| row.get::<_, bool>(0),
+                    )
+                    .unwrap()
+            );
+        }
+
+        shard_one
+            .execute("DELETE FROM marker WHERE rowid = 2", [])
+            .unwrap();
 
         assert_eq!(
             engine
                 .broadcast(
                     &session,
-                    "CREATE TABLE IF NOT EXISTS marker (id INTEGER)".to_owned(),
+                    "CREATE UNIQUE INDEX marker_id ON marker (id)".to_owned(),
                 )
                 .await
                 .unwrap(),
@@ -1145,7 +1210,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn concurrent_broadcasts_use_ordered_pool_acquisition_without_deadlock() {
+    async fn migration_waits_for_in_flight_work_and_rejects_a_second_coordinator() {
         let (_temp, engine) = engine_with_options(2, 1, 1);
         let holder_session = Arc::new(engine.session());
         let (holder_started_tx, holder_started_rx) = oneshot::channel();
@@ -1178,22 +1243,27 @@ mod tests {
                 )
                 .await
         });
-        wait_for_pool_occupancy(&engine, 0, 1, 0).await;
-        wait_for_pool_occupancy(&engine, 1, 1, 1).await;
+        timeout(Duration::from_secs(2), async {
+            while engine.inner.database.storage.schema_gate_snapshot().state
+                != crate::storage::SchemaGateState::Migrating
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the first migration should own schema admission");
 
-        let second_session = Arc::new(engine.session());
-        let second_engine = engine.clone();
-        let second_session_for_task = Arc::clone(&second_session);
-        let second = tokio::spawn(async move {
-            second_engine
-                .broadcast(
-                    &second_session_for_task,
-                    "CREATE TABLE IF NOT EXISTS broadcast_marker (id INTEGER)".to_owned(),
-                )
-                .await
-        });
-        wait_for_pool_occupancy(&engine, 0, 1, 1).await;
-        assert_eq!(engine.inner.workers.available_permits(), 1);
+        let second_session = engine.session();
+        let second_error = engine
+            .broadcast(
+                &second_session,
+                "CREATE TABLE IF NOT EXISTS broadcast_marker (id INTEGER)".to_owned(),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(second_error.kind(), EngineErrorKind::Busy);
+        assert!(second_error.is_retryable());
+        wait_for_pool_occupancy(&engine, 1, 1, 0).await;
 
         holder_release_tx.send(()).unwrap();
         holder.await.unwrap().unwrap();
@@ -1206,10 +1276,12 @@ mod tests {
             [0, 1]
         );
         assert_eq!(
-            timeout(Duration::from_secs(2), second)
+            engine
+                .broadcast(
+                    &second_session,
+                    "CREATE TABLE IF NOT EXISTS broadcast_marker (id INTEGER)".to_owned(),
+                )
                 .await
-                .expect("second ordered broadcast should complete")
-                .unwrap()
                 .unwrap(),
             [0, 1]
         );
@@ -1221,7 +1293,97 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn aborting_a_dispatched_broadcast_stops_before_the_blocked_shard() {
+    async fn independent_engines_share_schema_exclusion_publication_and_pool_retirement() {
+        let temp = tempfile::tempdir().unwrap();
+        let options = EngineOptions::new(1, 1).unwrap();
+        let first = Engine::from_database_with_options(
+            Arc::new(Database::open(temp.path(), 2).unwrap()),
+            options,
+        )
+        .unwrap();
+        let second = Engine::from_database_with_options(
+            Arc::new(Database::open(temp.path(), 2).unwrap()),
+            options,
+        )
+        .unwrap();
+        let holder_session = Arc::new(first.session());
+        let original_connection = first
+            .connection_id_for_test(&holder_session, 0)
+            .await
+            .unwrap();
+
+        let (holder_started_tx, holder_started_rx) = oneshot::channel();
+        let (holder_release_tx, holder_release_rx) = mpsc::channel();
+        let holder_engine = first.clone();
+        let held_session = Arc::clone(&holder_session);
+        let holder = tokio::spawn(async move {
+            holder_engine
+                .hold_session_for_test(&held_session, 0, holder_started_tx, holder_release_rx)
+                .await
+        });
+        timeout(Duration::from_secs(2), holder_started_rx)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let migration_session = Arc::new(second.session());
+        let migration_engine = second.clone();
+        let migration_session_for_task = Arc::clone(&migration_session);
+        let migration = tokio::spawn(async move {
+            migration_engine
+                .broadcast(
+                    &migration_session_for_task,
+                    "CREATE TABLE shared_schema (id INTEGER PRIMARY KEY)".to_owned(),
+                )
+                .await
+        });
+        timeout(Duration::from_secs(2), async {
+            while first.inner.database.storage.schema_gate_snapshot().state
+                != crate::storage::SchemaGateState::Migrating
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the second engine should exclude work admitted through the first");
+
+        let rejected_session = first.session();
+        rejected_session
+            .set_routing_key(&routing_key_for_shard(&first, 0))
+            .await
+            .unwrap();
+        let error = first
+            .query(&rejected_session, Statement::new("SELECT 1", vec![]))
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Busy);
+
+        holder_release_tx.send(()).unwrap();
+        holder.await.unwrap().unwrap();
+        assert_eq!(migration.await.unwrap().unwrap(), [0, 1]);
+        assert_eq!(first.catalog().schema_generation(), 1);
+        assert_eq!(second.catalog().schema_generation(), 1);
+
+        let replacement_connection = first
+            .connection_id_for_test(&holder_session, 0)
+            .await
+            .unwrap();
+        assert_ne!(replacement_connection, original_connection);
+        let pool = first.inner.connections.snapshot().unwrap().shards[0];
+        assert_eq!(pool.retired, 1);
+
+        let result = first
+            .query(
+                &rejected_session,
+                Statement::new("SELECT COUNT(*) FROM shared_schema", vec![]),
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.value.rows()[0].get(0), Some(&Value::from(0_i64)));
+    }
+
+    #[tokio::test]
+    async fn aborting_migration_preflight_cleans_up_and_changes_no_shard() {
         let (_temp, engine) = engine_with_options(2, 1, 1);
         let blocker = engine.inner.database.storage.open_shard(1).unwrap();
         blocker.execute_batch("BEGIN EXCLUSIVE").unwrap();
@@ -1238,24 +1400,15 @@ mod tests {
                 .await
         });
 
-        let shard_zero = engine.inner.database.storage.open_shard(0).unwrap();
         timeout(Duration::from_secs(2), async {
-            loop {
-                let exists = shard_zero
-                    .query_row(
-                        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE name = 'abort_marker')",
-                        [],
-                        |row| row.get::<_, bool>(0),
-                    )
-                    .unwrap();
-                if exists {
-                    break;
-                }
+            while engine.inner.database.storage.schema_gate_snapshot().state
+                != crate::storage::SchemaGateState::Migrating
+            {
                 tokio::task::yield_now().await;
             }
         })
         .await
-        .expect("broadcast should complete shard zero before blocking on shard one");
+        .expect("migration should own schema admission while preflight is blocked");
 
         broadcast.abort();
         assert!(broadcast.await.unwrap_err().is_cancelled());
@@ -1268,20 +1421,119 @@ mod tests {
             .unwrap();
         assert_eq!(status.shard_count(), 2);
         blocker.execute_batch("COMMIT").unwrap();
-        assert!(
-            !blocker
-                .query_row(
-                    "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE name = 'abort_marker')",
-                    [],
-                    |row| row.get::<_, bool>(0),
+        for shard in 0..2 {
+            let connection = engine.inner.database.storage.open_shard(shard).unwrap();
+            assert!(
+                !connection
+                    .query_row(
+                        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE name = 'abort_marker')",
+                        [],
+                        |row| row.get::<_, bool>(0),
+                    )
+                    .unwrap()
+            );
+        }
+        assert_eq!(
+            engine
+                .broadcast(
+                    &session,
+                    "CREATE TABLE abort_marker (id INTEGER)".to_owned(),
                 )
+                .await
                 .unwrap(),
-            "the committed shard-zero prefix is retained, but cancellation must not execute shard one"
+            [0, 1]
         );
         for shard in 0..2 {
             wait_for_pool_occupancy(&engine, shard, 0, 0).await;
         }
         assert_eq!(engine.inner.workers.available_permits(), 2);
+    }
+
+    #[tokio::test]
+    async fn cancellation_after_durable_journal_waits_for_cleanup_and_exact_retry_recovers() {
+        let (_temp, engine) = engine_with_options(2, 1, 1);
+        let sql = "CREATE TABLE durable_cancel_marker (id INTEGER)";
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        engine
+            .inner
+            .database
+            .storage
+            .install_schema_migration_test_block(
+                crate::storage::SchemaMigrationCoordinatorPoint::JournalCommitted,
+                started_tx,
+                release_rx,
+            )
+            .unwrap();
+
+        let token = CancellationToken::new();
+        let session = Arc::new(engine.session());
+        let broadcast_engine = engine.clone();
+        let broadcast_session = Arc::clone(&session);
+        let context = RequestContext::new().with_cancellation_token(token.clone());
+        let mut broadcast = tokio::spawn(async move {
+            broadcast_engine
+                .broadcast_with_context(&broadcast_session, sql.to_owned(), context)
+                .await
+        });
+        wait_for_blocking_signal(started_rx, "migration journal should become durable").await;
+        assert_eq!(engine.catalog().schema_generation(), 0);
+        assert_eq!(
+            engine.inner.database.storage.schema_gate_snapshot().state,
+            crate::storage::SchemaGateState::Migrating
+        );
+
+        assert!(token.cancel());
+        assert!(
+            timeout(Duration::from_millis(20), &mut broadcast)
+                .await
+                .is_err(),
+            "the public future must await blocking-worker cleanup"
+        );
+        release_tx.send(()).unwrap();
+        let error = timeout(Duration::from_secs(2), broadcast)
+            .await
+            .expect("cancelled migration cleanup should finish")
+            .unwrap()
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Cancelled);
+        assert_eq!(session.state().await, SessionState::Ready);
+        assert_eq!(engine.active_operations_for_test(), 0);
+        assert_eq!(engine.inner.workers.available_permits(), 2);
+        assert_eq!(
+            engine.inner.database.storage.schema_gate_snapshot().state,
+            crate::storage::SchemaGateState::Pending
+        );
+
+        let ordinary = engine.session();
+        ordinary.set_routing_key("pending-work").await.unwrap();
+        assert_eq!(
+            engine
+                .query(&ordinary, Statement::new("SELECT 1", vec![]))
+                .await
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+
+        let retry = engine.session();
+        assert_eq!(
+            engine.broadcast(&retry, sql.to_owned()).await.unwrap(),
+            [0, 1]
+        );
+        assert_eq!(engine.catalog().schema_generation(), 1);
+        assert_eq!(
+            engine.inner.database.storage.schema_gate_snapshot().state,
+            crate::storage::SchemaGateState::Ready
+        );
+        let recovered = engine
+            .query(
+                &ordinary,
+                Statement::new("SELECT COUNT(*) FROM durable_cancel_marker", vec![]),
+            )
+            .await
+            .unwrap();
+        assert_eq!(recovered.value.rows()[0].get(0), Some(&Value::from(0_i64)));
     }
 
     #[tokio::test]
@@ -1331,6 +1583,14 @@ mod tests {
     async fn pragma_data_version_never_exposes_a_foreign_pooled_handles_history() {
         let (_temp, engine) = engine_with_options(2, 2, 1);
         let shard = 0;
+        let schema = engine.session();
+        engine
+            .broadcast(
+                &schema,
+                "CREATE TABLE data_version_marker (id INTEGER PRIMARY KEY)".to_owned(),
+            )
+            .await
+            .unwrap();
         let routing_key = (0_u32..10_000)
             .map(|candidate| format!("data-version-{candidate}"))
             .find(|candidate| engine.inner.database.shard_for_key(candidate.as_bytes()) == shard)
@@ -1361,10 +1621,7 @@ mod tests {
         engine
             .execute(
                 &writer,
-                Statement::new(
-                    "CREATE TABLE data_version_marker (id INTEGER PRIMARY KEY)",
-                    vec![],
-                ),
+                Statement::new("INSERT INTO data_version_marker VALUES (1)", vec![]),
             )
             .await
             .unwrap();
@@ -1455,7 +1712,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn foreign_owner_broadcast_batches_execute_once_without_statement_preflight() {
+    async fn migration_batches_preflight_then_execute_once_per_shard() {
         let (_temp, engine) = engine_with_options(2, 1, 1);
         let first = engine.session();
         assert_eq!(
@@ -1555,8 +1812,8 @@ mod tests {
         );
 
         let snapshot = engine.inner.connections.snapshot().unwrap().shards[usize::from(shard)];
-        assert_eq!(snapshot.opened, 3);
-        assert_eq!(snapshot.retired, 2);
+        assert_eq!(snapshot.opened, 2);
+        assert_eq!(snapshot.retired, 1);
         assert_eq!(snapshot.idle, 1);
     }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -89,6 +89,7 @@ impl Database {
         statement: &str,
         params: &[Value],
     ) -> EngineResult<Routed<usize>> {
+        let _schema_operation = self.storage.enter_schema_operation()?;
         let shard = self.shard_for_key(shard_key.as_bytes());
         let connection = self.storage.open_shard(shard)?;
         let value = sql::execute(&connection, statement, params)?;
@@ -101,6 +102,7 @@ impl Database {
         statement: &str,
         params: &[Value],
     ) -> EngineResult<Routed<ResultSet>> {
+        let _schema_operation = self.storage.enter_schema_operation()?;
         let shard = self.shard_for_key(shard_key.as_bytes());
         let connection = self.storage.open_shard(shard)?;
         let value = sql::query(&connection, statement, params)?;
@@ -126,23 +128,18 @@ impl Database {
     }
 
     pub fn broadcast(&self, statement: &str) -> EngineResult<Vec<u16>> {
-        let mut completed = Vec::with_capacity(usize::from(self.shard_count()));
-        for shard in 0..self.shard_count() {
-            let connection = self.storage.open_shard(shard).map_err(|error| {
-                error.context(format!("broadcast failed to open shard {shard}"))
-            })?;
-            sql::execute_batch(&connection, statement)
-                .map_err(|error| error.context(format!("broadcast failed on shard {shard}")))?;
-            completed.push(shard);
-        }
+        let mut migration = self.storage.begin_schema_migration()?;
+        migration.wait_for_quiescence_blocking();
+        let completed = self
+            .storage
+            .apply_schema_migration(statement, &mut migration, None)?;
+        migration.publish_ready()?;
         Ok(completed)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::error::Error as _;
-
     use super::*;
 
     #[test]
@@ -335,42 +332,54 @@ mod tests {
     }
 
     #[test]
-    fn broadcast_failure_preserves_kind_and_can_recover_remaining_shards() {
+    fn broadcast_preflight_failure_changes_no_shard_and_can_retry() {
         let temp = tempfile::tempdir().unwrap();
         let database = Database::open(temp.path(), 4).unwrap();
+        database
+            .broadcast("CREATE TABLE recovery_marker (id INTEGER NOT NULL);")
+            .unwrap();
         let shard_one = database.storage.open_shard(1).unwrap();
-        sql::execute_batch(&shard_one, "CREATE TABLE recovery_marker (id INTEGER);").unwrap();
+        shard_one
+            .execute_batch("INSERT INTO recovery_marker VALUES (1), (1)")
+            .unwrap();
 
         let error = database
-            .broadcast("CREATE TABLE recovery_marker (id INTEGER);")
+            .broadcast("CREATE UNIQUE INDEX recovery_marker_id ON recovery_marker (id);")
             .unwrap_err();
-        assert_eq!(error.kind(), EngineErrorKind::InvalidQuery);
-        assert_eq!(error.to_string(), "broadcast failed on shard 1");
-        assert!(error.source().is_some());
+        assert_eq!(error.kind(), EngineErrorKind::UniqueViolation);
+        assert_eq!(
+            error.to_string(),
+            "schema migration preflight failed on shard 1"
+        );
 
         let shard_zero = database.storage.open_shard(0).unwrap();
         let shard_two = database.storage.open_shard(2).unwrap();
-        let table_exists = |connection: &rusqlite::Connection| {
+        let index_exists = |connection: &rusqlite::Connection| {
             connection
                 .query_row(
                     "SELECT EXISTS (
                         SELECT 1 FROM sqlite_schema
-                        WHERE type = 'table' AND name = 'recovery_marker'
+                        WHERE type = 'index' AND name = 'recovery_marker_id'
                     )",
                     [],
                     |row| row.get::<_, bool>(0),
                 )
                 .unwrap()
         };
-        assert!(table_exists(&shard_zero));
-        assert!(!table_exists(&shard_two));
+        assert!(!index_exists(&shard_zero));
+        assert!(!index_exists(&shard_two));
+
+        shard_one
+            .execute("DELETE FROM recovery_marker WHERE rowid = 2", [])
+            .unwrap();
 
         assert_eq!(
             database
-                .broadcast("CREATE TABLE IF NOT EXISTS recovery_marker (id INTEGER);")
+                .broadcast("CREATE UNIQUE INDEX recovery_marker_id ON recovery_marker (id);")
                 .unwrap(),
             [0, 1, 2, 3]
         );
-        assert!(table_exists(&shard_two));
+        assert!(index_exists(&shard_zero));
+        assert!(index_exists(&shard_two));
     }
 }

--- a/src/protocol/http.rs
+++ b/src/protocol/http.rs
@@ -338,6 +338,28 @@ mod tests {
                 "/v1/execute",
                 Some(json!({
                     "shard_key": "widget-1",
+                    "sql": "CREATE TABLE bypassed_migration (id INTEGER)"
+                })),
+            )
+            .await,
+            (
+                StatusCode::FORBIDDEN,
+                json!({
+                    "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#permission-denied",
+                    "title": "Permission denied",
+                    "status": 403,
+                    "detail": "The operation is not permitted.",
+                    "code": "permission_denied"
+                }),
+            )
+        );
+        assert_eq!(
+            request_json(
+                &application,
+                Method::POST,
+                "/v1/execute",
+                Some(json!({
+                    "shard_key": "widget-1",
                     "sql": "INSERT INTO widgets (id, name) VALUES (?1, ?2)",
                     "params": ["widget-1", "First widget"]
                 })),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -128,13 +128,18 @@ where
                         break;
                     }
                 };
+                let accepted = accepted.clone();
                 let service = TowerToHyperService::new(router.clone().map_request(
-                    |request: Request<Incoming>| request.map(Body::new),
+                    move |request: Request<Incoming>| {
+                        if let Some(accepted) = &accepted {
+                            accepted.notify_one();
+                        }
+                        request.map(Body::new)
+                    },
                 ));
                 let graceful_rx = graceful_tx.subscribe();
-                let accepted = accepted.clone();
                 connections.spawn(async move {
-                    serve_http_connection(stream, peer, service, graceful_rx, accepted).await;
+                    serve_http_connection(stream, peer, service, graceful_rx).await;
                 });
             }
         }
@@ -163,7 +168,6 @@ async fn serve_http_connection<S>(
     peer: SocketAddr,
     service: S,
     mut graceful_rx: watch::Receiver<bool>,
-    accepted: Option<Arc<Notify>>,
 ) where
     S: hyper::service::Service<
             Request<Incoming>,
@@ -178,9 +182,6 @@ async fn serve_http_connection<S>(
         .serve_connection(TokioIo::new(stream), service)
         .with_upgrades();
     tokio::pin!(connection);
-    if let Some(accepted) = accepted {
-        accepted.notify_one();
-    }
 
     let result = if *graceful_rx.borrow() {
         connection.as_mut().graceful_shutdown();

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -160,6 +160,7 @@ fn byte_limit_exceeded() -> EngineError {
     )
 }
 
+#[cfg(test)]
 pub(crate) fn execute_batch(connection: &Connection, statement: &str) -> EngineResult<()> {
     connection
         .execute_batch(statement)

--- a/src/storage/manifest.rs
+++ b/src/storage/manifest.rs
@@ -23,8 +23,15 @@ const V2_SCHEMA_VERSION: u32 = 2;
 const V3_SCHEMA_VERSION: u32 = 3;
 const V4_SCHEMA_VERSION: u32 = 4;
 const V5_SCHEMA_VERSION: u32 = 5;
-pub(super) const CURRENT_SCHEMA_VERSION: u32 = V5_SCHEMA_VERSION;
+const V6_SCHEMA_VERSION: u32 = 6;
+pub(super) const CURRENT_SCHEMA_VERSION: u32 = V6_SCHEMA_VERSION;
 const MAX_TABLE_SQL_BYTES: i64 = 4_096;
+
+pub(super) const MAX_SCHEMA_MIGRATION_SQL_BYTES: usize = 65_536;
+pub(super) const MAX_SCHEMA_GENERATION: u64 = i32::MAX as u64;
+const SCHEMA_MIGRATION_DIGEST_VERSION: u32 = 1;
+const SCHEMA_MIGRATION_APPLYING: i64 = 1;
+const SCHEMA_MIGRATION_COMPLETE: i64 = 2;
 
 const INITIAL_SCHEMA_GENERATION: u64 = 0;
 const SHARDED_PLACEMENT: i64 = 1;
@@ -60,6 +67,10 @@ const V5_DOWNGRADE_FENCE_SQL: &str = "CREATE TABLE briskdb_metadata (
     requires_manifest_version INTEGER NOT NULL
         CHECK (requires_manifest_version >= 5)
 ) STRICT";
+const V6_DOWNGRADE_FENCE_SQL: &str = "CREATE TABLE briskdb_metadata (
+    requires_manifest_version INTEGER NOT NULL
+        CHECK (requires_manifest_version >= 6)
+) STRICT";
 const V3_ROUTING_TABLE_SQL: &str = "CREATE TABLE briskdb_routing (
     singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
     hash_version INTEGER NOT NULL CHECK (hash_version = 1),
@@ -94,6 +105,15 @@ const V4_SCHEMA_CATALOG_TABLE_SQL: &str = "CREATE TABLE briskdb_schema_catalog (
     singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
     identifier_encoding_version INTEGER NOT NULL CHECK (identifier_encoding_version = 1),
     schema_generation INTEGER NOT NULL CHECK (schema_generation = 0),
+    default_database_id INTEGER NOT NULL CHECK (default_database_id = 1),
+    FOREIGN KEY (default_database_id)
+        REFERENCES briskdb_logical_databases (database_id)
+) STRICT";
+const V6_SCHEMA_CATALOG_TABLE_SQL: &str = "CREATE TABLE briskdb_schema_catalog (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    identifier_encoding_version INTEGER NOT NULL CHECK (identifier_encoding_version = 1),
+    schema_generation INTEGER NOT NULL
+        CHECK (schema_generation BETWEEN 0 AND 2147483647),
     default_database_id INTEGER NOT NULL CHECK (default_database_id = 1),
     FOREIGN KEY (default_database_id)
         REFERENCES briskdb_logical_databases (database_id)
@@ -152,6 +172,25 @@ const V5_SHARD_LAYOUT_TABLE_SQL: &str = "CREATE TABLE briskdb_shard_layout (
     shard_metadata_version INTEGER NOT NULL CHECK (shard_metadata_version = 1),
     layout_state INTEGER NOT NULL CHECK (layout_state IN (1, 2, 3))
 ) STRICT";
+const V6_SCHEMA_MIGRATIONS_TABLE_SQL: &str = "CREATE TABLE briskdb_schema_migrations (
+    target_generation INTEGER PRIMARY KEY
+        CHECK (target_generation BETWEEN 1 AND 2147483647),
+    source_generation INTEGER NOT NULL
+        CHECK (source_generation = target_generation - 1),
+    migration_id BLOB NOT NULL UNIQUE
+        CHECK (typeof(migration_id) = 'blob' AND length(migration_id) = 32),
+    digest_version INTEGER NOT NULL CHECK (digest_version = 1),
+    sql_text TEXT NOT NULL
+        CHECK (
+            typeof(sql_text) = 'text'
+            AND length(CAST(sql_text AS BLOB)) BETWEEN 1 AND 65536
+            AND instr(sql_text, char(0)) = 0
+        ),
+    shard_count INTEGER NOT NULL CHECK (shard_count BETWEEN 2 AND 64),
+    migration_state INTEGER NOT NULL CHECK (migration_state IN (1, 2)),
+    next_shard INTEGER NOT NULL CHECK (next_shard BETWEEN 0 AND shard_count),
+    CHECK (migration_state = 1 OR next_shard = shard_count)
+) STRICT";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct RoutingConfiguration {
@@ -166,6 +205,79 @@ struct SchemaCatalogConfiguration {
     identifier_encoding_version: u32,
     schema_generation: u64,
     default_database_id: u64,
+}
+
+/// One fully validated application-schema migration journal row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct SchemaMigration {
+    source_generation: u64,
+    target_generation: u64,
+    migration_id: [u8; 32],
+    sql_text: String,
+    shard_count: u16,
+    state: SchemaMigrationState,
+    next_shard: u16,
+}
+
+impl SchemaMigration {
+    pub(super) const fn source_generation(&self) -> u64 {
+        self.source_generation
+    }
+
+    pub(super) const fn target_generation(&self) -> u64 {
+        self.target_generation
+    }
+
+    pub(super) const fn migration_id(&self) -> [u8; 32] {
+        self.migration_id
+    }
+
+    pub(super) fn sql_text(&self) -> &str {
+        &self.sql_text
+    }
+
+    pub(super) const fn shard_count(&self) -> u16 {
+        self.shard_count
+    }
+
+    pub(super) const fn is_applying(&self) -> bool {
+        matches!(self.state, SchemaMigrationState::Applying)
+    }
+
+    pub(super) const fn is_complete(&self) -> bool {
+        matches!(self.state, SchemaMigrationState::Complete)
+    }
+
+    pub(super) const fn next_shard(&self) -> u16 {
+        self.next_shard
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SchemaMigrationState {
+    Applying,
+    Complete,
+}
+
+impl SchemaMigrationState {
+    fn from_code(code: i64) -> EngineResult<Self> {
+        match code {
+            SCHEMA_MIGRATION_APPLYING => Ok(Self::Applying),
+            SCHEMA_MIGRATION_COMPLETE => Ok(Self::Complete),
+            _ => Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!("manifest has unsupported schema-migration state {code}"),
+            )),
+        }
+    }
+}
+
+/// Result of looking up the migration identified by exact SQL bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum SchemaMigrationClassification {
+    Absent,
+    Active(SchemaMigration),
+    Complete(SchemaMigration),
 }
 
 #[derive(Clone, Copy)]
@@ -183,17 +295,31 @@ struct ManifestSnapshot {
     routing_catalog: Option<RoutingCatalog>,
     logical_catalog: Option<Catalog>,
     shard_layout: Option<ShardLayout>,
+    active_migration: Option<SchemaMigration>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct LoadedManifest {
     catalog: CatalogSnapshot,
     shard_layout: ShardLayout,
+    active_migration: Option<SchemaMigration>,
 }
 
 impl LoadedManifest {
+    #[cfg(test)]
     pub(super) fn into_parts(self) -> (CatalogSnapshot, ShardLayout) {
         (self.catalog, self.shard_layout)
+    }
+
+    #[cfg(test)]
+    pub(super) fn active_migration(&self) -> Option<&SchemaMigration> {
+        self.active_migration.as_ref()
+    }
+
+    pub(super) fn into_parts_with_migration(
+        self,
+    ) -> (CatalogSnapshot, ShardLayout, Option<SchemaMigration>) {
+        (self.catalog, self.shard_layout, self.active_migration)
     }
 }
 
@@ -226,6 +352,13 @@ const MIGRATIONS: &[Migration] = &[
         apply: migrate_v4_to_v5,
         validate: validate_v5,
     },
+    Migration {
+        from: V5_SCHEMA_VERSION,
+        to: V6_SCHEMA_VERSION,
+        name: "application_schema_migration_journal",
+        apply: migrate_v5_to_v6,
+        validate: validate_v6,
+    },
 ];
 
 #[derive(Clone, Copy)]
@@ -239,8 +372,8 @@ struct MigrationPlan<'a> {
 const CURRENT_PLAN: MigrationPlan<'static> = MigrationPlan {
     current_version: CURRENT_SCHEMA_VERSION,
     migrations: MIGRATIONS,
-    initialize_current: create_v5_schema,
-    initialize_interrupted_legacy: migrate_interrupted_legacy_to_v5,
+    initialize_current: create_v6_schema,
+    initialize_interrupted_legacy: migrate_interrupted_legacy_to_v6,
 };
 
 #[derive(Clone, Copy)]
@@ -272,7 +405,7 @@ enum ManifestState {
     },
     Versioned {
         version: u32,
-        snapshot: ManifestSnapshot,
+        snapshot: Box<ManifestSnapshot>,
     },
 }
 
@@ -322,6 +455,7 @@ pub(super) fn load_or_create_manifest_with_fresh_layout(
     Ok(LoadedManifest {
         catalog: CatalogSnapshot::from_validated_parts(routing, logical),
         shard_layout,
+        active_migration: snapshot.active_migration,
     })
 }
 
@@ -331,6 +465,511 @@ fn load_or_create_catalog(
     requested_shards: u16,
 ) -> EngineResult<CatalogSnapshot> {
     load_or_create_manifest(connection, requested_shards).map(|loaded| loaded.catalog)
+}
+
+/// Classify the migration identified by the exact UTF-8 SQL bytes.
+#[cfg(test)]
+pub(super) fn classify_schema_migration(
+    connection: &mut Connection,
+    requested_shards: u16,
+    sql: &str,
+) -> EngineResult<SchemaMigrationClassification> {
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    let classification =
+        classify_schema_migration_in_transaction(&transaction, requested_shards, sql)?;
+    transaction.commit().map_err(sqlite_error::storage)?;
+    Ok(classification)
+}
+
+pub(super) fn classify_schema_migration_in_transaction(
+    transaction: &Connection,
+    requested_shards: u16,
+    sql: &str,
+) -> EngineResult<SchemaMigrationClassification> {
+    let migration_id = schema_migration_id(sql)?;
+    let snapshot = current_manifest_snapshot(transaction, requested_shards)?;
+    if let Some(active) = snapshot.active_migration {
+        if active.migration_id != migration_id {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "a different schema migration is already active",
+            ));
+        }
+        return classify_matching_schema_migration(Some(active), sql);
+    }
+    let migration = find_schema_migration(transaction, snapshot.shard_count, &migration_id)?;
+    classify_matching_schema_migration(migration, sql)
+}
+
+/// Load the single active journal row under a manifest write transaction.
+#[cfg(test)]
+pub(super) fn load_active_schema_migration(
+    connection: &mut Connection,
+    requested_shards: u16,
+) -> EngineResult<Option<SchemaMigration>> {
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    let active = load_active_schema_migration_in_transaction(&transaction, requested_shards)?;
+    transaction.commit().map_err(sqlite_error::storage)?;
+    Ok(active)
+}
+
+pub(super) fn load_active_schema_migration_in_transaction(
+    transaction: &Connection,
+    requested_shards: u16,
+) -> EngineResult<Option<SchemaMigration>> {
+    Ok(current_manifest_snapshot(transaction, requested_shards)?.active_migration)
+}
+
+pub(super) fn ensure_schema_migration_layout(
+    connection: &Connection,
+    requested_shards: u16,
+    expected: &ShardLayout,
+) -> EngineResult<()> {
+    let observed = current_manifest_snapshot(connection, requested_shards)?
+        .shard_layout
+        .ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::Internal,
+                "current manifest validation omitted its physical shard layout",
+            )
+        })?;
+    if observed != *expected || observed.state() != ShardLayoutState::Ready {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "manifest physical layout does not match the opened storage root",
+        ));
+    }
+    Ok(())
+}
+
+/// Atomically append a new active journal row after the caller has preflighted
+/// every shard at `expected_source_generation`.
+///
+/// Repeating the exact SQL is idempotent and returns its existing active or
+/// completed row. Only one different migration may be active at a time.
+#[cfg(test)]
+pub(super) fn begin_schema_migration(
+    connection: &mut Connection,
+    requested_shards: u16,
+    expected_source_generation: u64,
+    sql: &str,
+) -> EngineResult<SchemaMigration> {
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    let migration = begin_schema_migration_in_transaction(
+        &transaction,
+        requested_shards,
+        expected_source_generation,
+        sql,
+    )?;
+    transaction.commit().map_err(sqlite_error::storage)?;
+    Ok(migration)
+}
+
+pub(super) fn begin_schema_migration_in_transaction(
+    transaction: &Connection,
+    requested_shards: u16,
+    expected_source_generation: u64,
+    sql: &str,
+) -> EngineResult<SchemaMigration> {
+    let migration_id = schema_migration_id(sql)?;
+    let snapshot = current_manifest_snapshot(transaction, requested_shards)?;
+
+    if let Some(active) = snapshot.active_migration {
+        if active.migration_id != migration_id {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "a different schema migration is already active",
+            ));
+        }
+        if active.sql_text != sql {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "schema migration identifier collides with different SQL bytes",
+            ));
+        }
+        return Ok(active);
+    }
+    if let Some(existing) = find_schema_migration(transaction, snapshot.shard_count, &migration_id)?
+    {
+        if existing.sql_text != sql {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "schema migration identifier collides with different SQL bytes",
+            ));
+        }
+        return Ok(existing);
+    }
+    let layout = snapshot.shard_layout.ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::Internal,
+            "current manifest validation omitted its physical shard layout",
+        )
+    })?;
+    if layout.state() != ShardLayoutState::Ready {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "schema migration requires a ready physical shard layout",
+        ));
+    }
+    let catalog_generation = snapshot
+        .logical_catalog
+        .as_ref()
+        .ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::Internal,
+                "current manifest validation omitted its logical catalog",
+            )
+        })?
+        .schema_generation();
+    if catalog_generation != expected_source_generation {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!(
+                "schema migration preflight used generation {expected_source_generation}, but the catalog is at generation {catalog_generation}"
+            ),
+        ));
+    }
+    let target_generation = catalog_generation.checked_add(1).ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "schema migration generation is exhausted",
+        )
+    })?;
+    if target_generation > MAX_SCHEMA_GENERATION {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "schema migration generation is exhausted",
+        ));
+    }
+    transaction
+        .execute(
+            "INSERT INTO briskdb_schema_migrations (
+                target_generation,
+                source_generation,
+                migration_id,
+                digest_version,
+                sql_text,
+                shard_count,
+                migration_state,
+                next_shard
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0)",
+            rusqlite::params![
+                i64::try_from(target_generation).expect("schema generation fits in SQLite"),
+                i64::try_from(catalog_generation).expect("schema generation fits in SQLite"),
+                migration_id.as_slice(),
+                SCHEMA_MIGRATION_DIGEST_VERSION,
+                sql,
+                snapshot.shard_count,
+                SCHEMA_MIGRATION_APPLYING,
+            ],
+        )
+        .map_err(sqlite_error::storage)?;
+    let validated = current_manifest_snapshot(transaction, requested_shards)?
+        .active_migration
+        .ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::Internal,
+                "new schema migration did not produce an active journal row",
+            )
+        })?;
+    if validated.migration_id != migration_id || validated.sql_text != sql {
+        return Err(EngineError::new(
+            EngineErrorKind::Internal,
+            "new schema migration did not preserve its identity",
+        ));
+    }
+    Ok(validated)
+}
+
+/// Advance an active migration's durable prefix by at most one shard.
+/// Repeating an already-persisted position is an idempotent no-op.
+#[cfg(test)]
+pub(super) fn advance_schema_migration(
+    connection: &mut Connection,
+    requested_shards: u16,
+    expected: &SchemaMigration,
+    next_shard: u16,
+) -> EngineResult<SchemaMigration> {
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    let migration = advance_schema_migration_in_transaction(
+        &transaction,
+        requested_shards,
+        expected,
+        next_shard,
+    )?;
+    transaction.commit().map_err(sqlite_error::storage)?;
+    Ok(migration)
+}
+
+pub(super) fn advance_schema_migration_in_transaction(
+    transaction: &Connection,
+    requested_shards: u16,
+    expected: &SchemaMigration,
+    next_shard: u16,
+) -> EngineResult<SchemaMigration> {
+    let snapshot = current_manifest_snapshot(transaction, requested_shards)?;
+    let Some(active) = snapshot.active_migration else {
+        let completed =
+            find_schema_migration(transaction, snapshot.shard_count, &expected.migration_id)?
+                .filter(|migration| migration.is_complete());
+        if let Some(completed) = completed {
+            ensure_same_schema_migration(&completed, expected)?;
+            return Ok(completed);
+        }
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "schema migration is no longer active",
+        ));
+    };
+    ensure_same_schema_migration(&active, expected)?;
+    if next_shard > active.shard_count {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            "schema migration progress exceeds its shard count",
+        ));
+    }
+    if next_shard <= active.next_shard {
+        return Ok(active);
+    }
+    if next_shard != active.next_shard + 1 {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "schema migration progress cannot skip a shard",
+        ));
+    }
+    transaction
+        .execute(
+            "UPDATE briskdb_schema_migrations
+             SET next_shard = ?1
+             WHERE target_generation = ?2
+               AND migration_state = ?3
+               AND next_shard = ?4",
+            rusqlite::params![
+                next_shard,
+                i64::try_from(active.target_generation).expect("schema generation fits in SQLite"),
+                SCHEMA_MIGRATION_APPLYING,
+                active.next_shard,
+            ],
+        )
+        .map_err(sqlite_error::storage)?;
+    let advanced = current_manifest_snapshot(transaction, requested_shards)?
+        .active_migration
+        .ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::Internal,
+                "schema migration progress update lost its active row",
+            )
+        })?;
+    ensure_same_schema_migration(&advanced, expected)?;
+    if advanced.next_shard != next_shard {
+        return Err(EngineError::new(
+            EngineErrorKind::Internal,
+            "schema migration progress update did not persist",
+        ));
+    }
+    Ok(advanced)
+}
+
+/// Atomically publish a fully applied migration as the new catalog generation.
+#[cfg(test)]
+pub(super) fn finalize_schema_migration(
+    connection: &mut Connection,
+    requested_shards: u16,
+    expected: &SchemaMigration,
+) -> EngineResult<SchemaMigration> {
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    let migration =
+        finalize_schema_migration_in_transaction(&transaction, requested_shards, expected)?;
+    transaction.commit().map_err(sqlite_error::storage)?;
+    Ok(migration)
+}
+
+pub(super) fn finalize_schema_migration_in_transaction(
+    transaction: &Connection,
+    requested_shards: u16,
+    expected: &SchemaMigration,
+) -> EngineResult<SchemaMigration> {
+    let snapshot = current_manifest_snapshot(transaction, requested_shards)?;
+    let Some(active) = snapshot.active_migration else {
+        let completed =
+            find_schema_migration(transaction, snapshot.shard_count, &expected.migration_id)?
+                .filter(|migration| migration.is_complete())
+                .ok_or_else(|| {
+                    EngineError::new(
+                        EngineErrorKind::FailedPrecondition,
+                        "schema migration is no longer active",
+                    )
+                })?;
+        ensure_same_schema_migration(&completed, expected)?;
+        return Ok(completed);
+    };
+    ensure_same_schema_migration(&active, expected)?;
+    if active.next_shard != active.shard_count {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "schema migration cannot finish before every shard is durable",
+        ));
+    }
+    transaction
+        .execute(
+            "UPDATE briskdb_schema_catalog
+             SET schema_generation = ?1
+             WHERE singleton = 1 AND schema_generation = ?2",
+            rusqlite::params![
+                i64::try_from(active.target_generation).expect("schema generation fits in SQLite"),
+                i64::try_from(active.source_generation).expect("schema generation fits in SQLite"),
+            ],
+        )
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "UPDATE briskdb_schema_migrations
+             SET migration_state = ?1
+             WHERE target_generation = ?2
+               AND migration_state = ?3
+               AND next_shard = shard_count",
+            rusqlite::params![
+                SCHEMA_MIGRATION_COMPLETE,
+                i64::try_from(active.target_generation).expect("schema generation fits in SQLite"),
+                SCHEMA_MIGRATION_APPLYING,
+            ],
+        )
+        .map_err(sqlite_error::storage)?;
+    let finalized_snapshot = current_manifest_snapshot(transaction, requested_shards)?;
+    if finalized_snapshot.active_migration.is_some()
+        || finalized_snapshot
+            .logical_catalog
+            .as_ref()
+            .map(Catalog::schema_generation)
+            != Some(active.target_generation)
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::Internal,
+            "schema migration finalization did not publish its target generation",
+        ));
+    }
+    let completed = find_schema_migration(
+        transaction,
+        finalized_snapshot.shard_count,
+        &active.migration_id,
+    )?
+    .ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::Internal,
+            "schema migration finalization lost its journal row",
+        )
+    })?;
+    if !completed.is_complete() {
+        return Err(EngineError::new(
+            EngineErrorKind::Internal,
+            "schema migration finalization did not complete its journal row",
+        ));
+    }
+    Ok(completed)
+}
+
+fn current_manifest_snapshot(
+    connection: &Connection,
+    requested_shards: u16,
+) -> EngineResult<ManifestSnapshot> {
+    match inspect_with_plan(connection, requested_shards, CURRENT_PLAN)? {
+        ManifestState::Versioned { version, snapshot } if version == CURRENT_SCHEMA_VERSION => {
+            Ok(*snapshot)
+        }
+        _ => Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "schema migrations require a current manifest",
+        )),
+    }
+}
+
+fn find_schema_migration(
+    connection: &Connection,
+    expected_shard_count: u16,
+    migration_id: &[u8; 32],
+) -> EngineResult<Option<SchemaMigration>> {
+    connection
+        .query_row(
+            "SELECT target_generation,
+                    source_generation,
+                    migration_id,
+                    digest_version,
+                    sql_text,
+                    shard_count,
+                    migration_state,
+                    next_shard
+             FROM briskdb_schema_migrations
+             WHERE migration_id = ?1",
+            [migration_id.as_slice()],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                    row.get(6)?,
+                    row.get(7)?,
+                ))
+            },
+        )
+        .map(Some)
+        .or_else(|error| match error {
+            rusqlite::Error::QueryReturnedNoRows => Ok(None),
+            error => Err(error),
+        })
+        .map_err(|error| manifest_read_error(error, "failed to read schema migration journal"))?
+        .map(|stored| schema_migration_from_stored(stored, expected_shard_count))
+        .transpose()
+}
+
+fn classify_matching_schema_migration(
+    migration: Option<SchemaMigration>,
+    sql: &str,
+) -> EngineResult<SchemaMigrationClassification> {
+    let Some(migration) = migration else {
+        return Ok(SchemaMigrationClassification::Absent);
+    };
+    if migration.sql_text != sql {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "schema migration identifier collides with different SQL bytes",
+        ));
+    }
+    if migration.is_applying() {
+        Ok(SchemaMigrationClassification::Active(migration))
+    } else {
+        Ok(SchemaMigrationClassification::Complete(migration))
+    }
+}
+
+fn ensure_same_schema_migration(
+    observed: &SchemaMigration,
+    expected: &SchemaMigration,
+) -> EngineResult<()> {
+    if observed.source_generation != expected.source_generation
+        || observed.target_generation != expected.target_generation
+        || observed.migration_id != expected.migration_id
+        || observed.sql_text != expected.sql_text
+        || observed.shard_count != expected.shard_count
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "schema migration identity changed while it was being applied",
+        ));
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -474,7 +1113,7 @@ where
         let (from, shard_count) = match inspect_with_plan(&transaction, requested_shards, plan)? {
             ManifestState::Versioned { version, snapshot } if version == plan.current_version => {
                 transaction.commit().map_err(sqlite_error::storage)?;
-                return Ok(snapshot);
+                return Ok(*snapshot);
             }
             ManifestState::Empty => {
                 if !fresh_layout_allowed {
@@ -585,7 +1224,7 @@ where
     match inspect_with_plan(&transaction, shard_count, plan)? {
         ManifestState::Versioned { version, snapshot } if version == change.to => {
             transaction.commit().map_err(sqlite_error::storage)?;
-            Ok(snapshot)
+            Ok(*snapshot)
         }
         _ => Err(EngineError::new(
             EngineErrorKind::Internal,
@@ -645,14 +1284,19 @@ fn create_v5_schema(transaction: &Transaction<'_>, shard_count: u16) -> EngineRe
     add_v5_schema(transaction, ShardLayoutState::Creating)
 }
 
-fn migrate_interrupted_legacy_to_v5(
+fn create_v6_schema(transaction: &Transaction<'_>, shard_count: u16) -> EngineResult<()> {
+    create_v5_schema(transaction, shard_count)?;
+    migrate_v5_to_v6(transaction, shard_count)
+}
+
+fn migrate_interrupted_legacy_to_v6(
     transaction: &Transaction<'_>,
     shard_count: u16,
 ) -> EngineResult<()> {
     transaction
         .execute_batch("DROP TABLE briskdb_metadata;")
         .map_err(sqlite_error::storage)?;
-    create_v5_schema(transaction, shard_count)
+    create_v6_schema(transaction, shard_count)
 }
 
 #[cfg(test)]
@@ -675,6 +1319,17 @@ fn migrate_interrupted_legacy_to_v4(
         .execute_batch("DROP TABLE briskdb_metadata;")
         .map_err(sqlite_error::storage)?;
     create_v4_schema(transaction, shard_count)
+}
+
+#[cfg(test)]
+fn migrate_interrupted_legacy_to_v5(
+    transaction: &Transaction<'_>,
+    shard_count: u16,
+) -> EngineResult<()> {
+    transaction
+        .execute_batch("DROP TABLE briskdb_metadata;")
+        .map_err(sqlite_error::storage)?;
+    create_v5_schema(transaction, shard_count)
 }
 
 fn migrate_v2_to_v3(transaction: &Transaction<'_>, shard_count: u16) -> EngineResult<()> {
@@ -819,6 +1474,54 @@ fn migrate_v4_to_v5(transaction: &Transaction<'_>, _shard_count: u16) -> EngineR
     add_v5_schema(transaction, ShardLayoutState::Adopting)
 }
 
+fn migrate_v5_to_v6(transaction: &Transaction<'_>, _shard_count: u16) -> EngineResult<()> {
+    transaction
+        .execute_batch("DROP TABLE briskdb_metadata;")
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch(V6_DOWNGRADE_FENCE_SQL)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "INSERT INTO briskdb_metadata (requires_manifest_version) VALUES (?1)",
+            [V6_SCHEMA_VERSION],
+        )
+        .map_err(sqlite_error::storage)?;
+
+    transaction
+        .execute_batch(
+            "ALTER TABLE briskdb_schema_catalog
+                 RENAME TO briskdb_schema_catalog_v5;",
+        )
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch(V6_SCHEMA_CATALOG_TABLE_SQL)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "INSERT INTO briskdb_schema_catalog (
+                singleton,
+                identifier_encoding_version,
+                schema_generation,
+                default_database_id
+             )
+             SELECT singleton,
+                    identifier_encoding_version,
+                    schema_generation,
+                    default_database_id
+             FROM briskdb_schema_catalog_v5",
+            [],
+        )
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch("DROP TABLE briskdb_schema_catalog_v5;")
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch(V6_SCHEMA_MIGRATIONS_TABLE_SQL)
+        .map_err(sqlite_error::storage)?;
+    Ok(())
+}
+
 fn add_v5_schema(transaction: &Transaction<'_>, state: ShardLayoutState) -> EngineResult<()> {
     transaction
         .execute_batch("DROP TABLE briskdb_metadata;")
@@ -912,8 +1615,12 @@ fn inspect_with_plan(
                     ),
                 )
             })?;
-        return validator(connection, requested_shards, &objects)
-            .map(|snapshot| ManifestState::Versioned { version, snapshot });
+        return validator(connection, requested_shards, &objects).map(|snapshot| {
+            ManifestState::Versioned {
+                version,
+                snapshot: Box::new(snapshot),
+            }
+        });
     }
 
     if application_id != 0 {
@@ -1080,6 +1787,18 @@ fn v5_objects() -> Vec<SchemaObject> {
     objects
 }
 
+fn v6_objects() -> Vec<SchemaObject> {
+    let mut objects = v5_objects();
+    objects.push(SchemaObject {
+        object_type: "table".to_owned(),
+        name: "briskdb_schema_migrations".to_owned(),
+    });
+    objects.sort_by(|left, right| {
+        (&left.object_type, &left.name).cmp(&(&right.object_type, &right.name))
+    });
+    objects
+}
+
 fn schema_objects(connection: &Connection) -> EngineResult<Vec<SchemaObject>> {
     let mut statement = connection
         .prepare(
@@ -1180,6 +1899,10 @@ fn validate_table(
         "briskdb_shard_layout" => {
             "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden
              FROM pragma_table_xinfo('briskdb_shard_layout') LIMIT ?1"
+        }
+        "briskdb_schema_migrations" => {
+            "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden
+             FROM pragma_table_xinfo('briskdb_schema_migrations') LIMIT ?1"
         }
         _ => {
             return Err(EngineError::new(
@@ -1368,6 +2091,7 @@ fn validate_v2(
         routing_catalog: None,
         logical_catalog: None,
         shard_layout: None,
+        active_migration: None,
     })
 }
 
@@ -1395,6 +2119,7 @@ fn validate_v3(
         routing_catalog: Some(routing_catalog),
         logical_catalog: None,
         shard_layout: None,
+        active_migration: None,
     })
 }
 
@@ -1497,9 +2222,13 @@ fn validate_v4(
         connection,
         requested_shards,
         objects,
-        V4_SCHEMA_VERSION,
-        V4_DOWNGRADE_FENCE_SQL,
-        &v4_objects(),
+        CatalogManifestDefinition {
+            version: V4_SCHEMA_VERSION,
+            downgrade_fence_sql: V4_DOWNGRADE_FENCE_SQL,
+            expected_objects: &v4_objects(),
+            schema_catalog_sql: V4_SCHEMA_CATALOG_TABLE_SQL,
+            generation_policy: SchemaGenerationPolicy::InitialOnly,
+        },
     )
 }
 
@@ -1512,9 +2241,13 @@ fn validate_v5(
         connection,
         requested_shards,
         objects,
-        V5_SCHEMA_VERSION,
-        V5_DOWNGRADE_FENCE_SQL,
-        &v5_objects(),
+        CatalogManifestDefinition {
+            version: V5_SCHEMA_VERSION,
+            downgrade_fence_sql: V5_DOWNGRADE_FENCE_SQL,
+            expected_objects: &v5_objects(),
+            schema_catalog_sql: V4_SCHEMA_CATALOG_TABLE_SQL,
+            generation_policy: SchemaGenerationPolicy::InitialOnly,
+        },
     )?;
     validate_table(
         connection,
@@ -1537,26 +2270,131 @@ fn validate_v5(
     Ok(snapshot)
 }
 
+fn validate_v6(
+    connection: &Connection,
+    requested_shards: u16,
+    objects: &[SchemaObject],
+) -> EngineResult<ManifestSnapshot> {
+    let mut snapshot = validate_catalog_manifest(
+        connection,
+        requested_shards,
+        objects,
+        CatalogManifestDefinition {
+            version: V6_SCHEMA_VERSION,
+            downgrade_fence_sql: V6_DOWNGRADE_FENCE_SQL,
+            expected_objects: &v6_objects(),
+            schema_catalog_sql: V6_SCHEMA_CATALOG_TABLE_SQL,
+            generation_policy: SchemaGenerationPolicy::Journaled,
+        },
+    )?;
+    validate_table(
+        connection,
+        "briskdb_shard_layout",
+        &[
+            TableColumn::expected(0, "singleton", "INTEGER", false, 1),
+            TableColumn::expected(1, "layout_id", "BLOB", true, 0),
+            TableColumn::expected(2, "shard_application_id", "INTEGER", true, 0),
+            TableColumn::expected(3, "shard_metadata_version", "INTEGER", true, 0),
+            TableColumn::expected(4, "layout_state", "INTEGER", true, 0),
+        ],
+        true,
+    )?;
+    validate_table_sql(
+        connection,
+        "briskdb_shard_layout",
+        V5_SHARD_LAYOUT_TABLE_SQL,
+    )?;
+    let layout = validate_shard_layout(connection)?;
+
+    validate_table(
+        connection,
+        "briskdb_schema_migrations",
+        &[
+            TableColumn::expected(0, "target_generation", "INTEGER", false, 1),
+            TableColumn::expected(1, "source_generation", "INTEGER", true, 0),
+            TableColumn::expected(2, "migration_id", "BLOB", true, 0),
+            TableColumn::expected(3, "digest_version", "INTEGER", true, 0),
+            TableColumn::expected(4, "sql_text", "TEXT", true, 0),
+            TableColumn::expected(5, "shard_count", "INTEGER", true, 0),
+            TableColumn::expected(6, "migration_state", "INTEGER", true, 0),
+            TableColumn::expected(7, "next_shard", "INTEGER", true, 0),
+        ],
+        true,
+    )?;
+    validate_table_sql(
+        connection,
+        "briskdb_schema_migrations",
+        V6_SCHEMA_MIGRATIONS_TABLE_SQL,
+    )?;
+
+    let catalog_generation = snapshot
+        .logical_catalog
+        .as_ref()
+        .ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::Internal,
+                "current manifest validation omitted its logical catalog",
+            )
+        })?
+        .schema_generation();
+    let active =
+        validate_schema_migration_history(connection, snapshot.shard_count, catalog_generation)?;
+    let has_history = connection
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM briskdb_schema_migrations)",
+            [],
+            |row| row.get::<_, bool>(0),
+        )
+        .map_err(|error| {
+            manifest_read_error(error, "failed to inspect schema migration journal")
+        })?;
+    if has_history && layout.state() != ShardLayoutState::Ready {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "schema migration history requires a ready physical shard layout",
+        ));
+    }
+    snapshot.shard_layout = Some(layout);
+    snapshot.active_migration = active;
+    Ok(snapshot)
+}
+
+#[derive(Debug, Clone, Copy)]
+enum SchemaGenerationPolicy {
+    InitialOnly,
+    Journaled,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CatalogManifestDefinition<'a> {
+    version: u32,
+    downgrade_fence_sql: &'a str,
+    expected_objects: &'a [SchemaObject],
+    schema_catalog_sql: &'a str,
+    generation_policy: SchemaGenerationPolicy,
+}
+
 fn validate_catalog_manifest(
     connection: &Connection,
     requested_shards: u16,
     objects: &[SchemaObject],
-    expected_version: u32,
-    downgrade_fence_sql: &str,
-    expected_objects: &[SchemaObject],
+    definition: CatalogManifestDefinition<'_>,
 ) -> EngineResult<ManifestSnapshot> {
-    if objects != expected_objects {
+    if objects != definition.expected_objects {
         return Err(EngineError::new(
             EngineErrorKind::DataCorruption,
-            format!("manifest schema version {expected_version} has unexpected database objects"),
+            format!(
+                "manifest schema version {} has unexpected database objects",
+                definition.version
+            ),
         ));
     }
 
     let (shard_count, routing_catalog) = validate_routing_manifest(
         connection,
         requested_shards,
-        expected_version,
-        downgrade_fence_sql,
+        definition.version,
+        definition.downgrade_fence_sql,
     )?;
     validate_table(
         connection,
@@ -1586,7 +2424,7 @@ fn validate_catalog_manifest(
     validate_table_sql(
         connection,
         "briskdb_schema_catalog",
-        V4_SCHEMA_CATALOG_TABLE_SQL,
+        definition.schema_catalog_sql,
     )?;
     validate_table(
         connection,
@@ -1603,7 +2441,8 @@ fn validate_catalog_manifest(
     )?;
     validate_table_sql(connection, "briskdb_tables", V4_TABLES_TABLE_SQL)?;
 
-    let catalog_configuration = validate_schema_catalog_configuration(connection)?;
+    let catalog_configuration =
+        validate_schema_catalog_configuration(connection, definition.generation_policy)?;
     let databases =
         validate_logical_databases(connection, catalog_configuration.default_database_id)?;
     let tables = validate_table_metadata(connection, &databases)?;
@@ -1620,6 +2459,7 @@ fn validate_catalog_manifest(
             tables,
         )),
         shard_layout: None,
+        active_migration: None,
     })
 }
 
@@ -1695,6 +2535,7 @@ fn validate_shard_layout(connection: &Connection) -> EngineResult<ShardLayout> {
 
 fn validate_schema_catalog_configuration(
     connection: &Connection,
+    generation_policy: SchemaGenerationPolicy,
 ) -> EngineResult<SchemaCatalogConfiguration> {
     let mut statement = connection
         .prepare(
@@ -1746,11 +2587,20 @@ fn validate_schema_catalog_configuration(
             error,
         )
     })?;
-    if schema_generation != INITIAL_SCHEMA_GENERATION {
-        return Err(EngineError::new(
-            EngineErrorKind::DataCorruption,
-            format!("manifest has unsupported schema generation {schema_generation}"),
-        ));
+    match generation_policy {
+        SchemaGenerationPolicy::InitialOnly if schema_generation != INITIAL_SCHEMA_GENERATION => {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!("manifest has unsupported schema generation {schema_generation}"),
+            ));
+        }
+        SchemaGenerationPolicy::Journaled if schema_generation > MAX_SCHEMA_GENERATION => {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!("manifest has unsupported schema generation {schema_generation}"),
+            ));
+        }
+        SchemaGenerationPolicy::InitialOnly | SchemaGenerationPolicy::Journaled => {}
     }
     let default_database_id = u64::try_from(default_database_id).map_err(|error| {
         EngineError::from_source(
@@ -1771,6 +2621,253 @@ fn validate_schema_catalog_configuration(
         schema_generation,
         default_database_id,
     })
+}
+
+type StoredSchemaMigrationRow = (i64, i64, Vec<u8>, i64, String, i64, i64, i64);
+
+fn validate_schema_migration_history(
+    connection: &Connection,
+    expected_shard_count: u16,
+    catalog_generation: u64,
+) -> EngineResult<Option<SchemaMigration>> {
+    let mut statement = connection
+        .prepare(
+            "SELECT target_generation,
+                    source_generation,
+                    migration_id,
+                    digest_version,
+                    sql_text,
+                    shard_count,
+                    migration_state,
+                    next_shard
+             FROM briskdb_schema_migrations
+             ORDER BY target_generation",
+        )
+        .map_err(|error| manifest_read_error(error, "failed to read schema migration journal"))?;
+    let mut rows = statement
+        .query([])
+        .map_err(|error| manifest_read_error(error, "failed to read schema migration journal"))?;
+
+    let mut expected_target = 1_u64;
+    let mut active = None;
+    while let Some(row) = rows
+        .next()
+        .map_err(|error| manifest_read_error(error, "failed to read schema migration journal"))?
+    {
+        let stored: StoredSchemaMigrationRow = (
+            row.get(0).map_err(|error| {
+                manifest_read_error(error, "failed to read schema migration journal")
+            })?,
+            row.get(1).map_err(|error| {
+                manifest_read_error(error, "failed to read schema migration journal")
+            })?,
+            row.get(2).map_err(|error| {
+                manifest_read_error(error, "failed to read schema migration journal")
+            })?,
+            row.get(3).map_err(|error| {
+                manifest_read_error(error, "failed to read schema migration journal")
+            })?,
+            row.get(4).map_err(|error| {
+                manifest_read_error(error, "failed to read schema migration journal")
+            })?,
+            row.get(5).map_err(|error| {
+                manifest_read_error(error, "failed to read schema migration journal")
+            })?,
+            row.get(6).map_err(|error| {
+                manifest_read_error(error, "failed to read schema migration journal")
+            })?,
+            row.get(7).map_err(|error| {
+                manifest_read_error(error, "failed to read schema migration journal")
+            })?,
+        );
+        let migration = schema_migration_from_stored(stored, expected_shard_count)?;
+        if migration.target_generation != expected_target {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!(
+                    "schema migration journal is not contiguous at generation {expected_target}"
+                ),
+            ));
+        }
+
+        if migration.target_generation <= catalog_generation {
+            if !migration.is_complete() {
+                return Err(EngineError::new(
+                    EngineErrorKind::DataCorruption,
+                    format!(
+                        "committed schema generation {} has an incomplete journal row",
+                        migration.target_generation
+                    ),
+                ));
+            }
+        } else if migration.target_generation == catalog_generation.saturating_add(1) {
+            if !migration.is_applying() || active.is_some() {
+                return Err(EngineError::new(
+                    EngineErrorKind::DataCorruption,
+                    "schema migration journal has an invalid active row",
+                ));
+            }
+            active = Some(migration);
+        } else {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "schema migration journal extends beyond the next catalog generation",
+            ));
+        }
+        expected_target = expected_target.checked_add(1).ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "schema migration journal generation overflowed",
+            )
+        })?;
+    }
+
+    if expected_target <= catalog_generation {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!("schema migration journal is missing committed generation {expected_target}"),
+        ));
+    }
+    Ok(active)
+}
+
+fn schema_migration_from_stored(
+    stored: StoredSchemaMigrationRow,
+    expected_shard_count: u16,
+) -> EngineResult<SchemaMigration> {
+    let (
+        target_generation,
+        source_generation,
+        migration_id,
+        digest_version,
+        sql_text,
+        shard_count,
+        migration_state,
+        next_shard,
+    ) = stored;
+    let target_generation = u64::try_from(target_generation).map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::DataCorruption,
+            "schema migration target generation is outside the supported range",
+            error,
+        )
+    })?;
+    let source_generation = u64::try_from(source_generation).map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::DataCorruption,
+            "schema migration source generation is outside the supported range",
+            error,
+        )
+    })?;
+    if !(1..=MAX_SCHEMA_GENERATION).contains(&target_generation)
+        || source_generation.checked_add(1) != Some(target_generation)
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "schema migration generations are not consecutive",
+        ));
+    }
+    let migration_id: [u8; 32] = migration_id.as_slice().try_into().map_err(|_| {
+        EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "schema migration identifier must contain exactly 32 bytes",
+        )
+    })?;
+    if digest_version != i64::from(SCHEMA_MIGRATION_DIGEST_VERSION) {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!("schema migration has unsupported digest version {digest_version}"),
+        ));
+    }
+    validate_stored_schema_migration_sql(&sql_text)?;
+    if schema_migration_digest(&sql_text) != migration_id {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "schema migration identifier does not match its exact SQL bytes",
+        ));
+    }
+    let shard_count = u16::try_from(shard_count).map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::DataCorruption,
+            "schema migration shard count is outside the supported range",
+            error,
+        )
+    })?;
+    if shard_count != expected_shard_count {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!(
+                "schema migration targets {shard_count} shards but the manifest has {expected_shard_count}"
+            ),
+        ));
+    }
+    let state = SchemaMigrationState::from_code(migration_state)?;
+    let next_shard = u16::try_from(next_shard).map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::DataCorruption,
+            "schema migration progress is outside the supported range",
+            error,
+        )
+    })?;
+    if next_shard > shard_count
+        || (state == SchemaMigrationState::Complete && next_shard != shard_count)
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "schema migration progress is inconsistent with its state",
+        ));
+    }
+
+    Ok(SchemaMigration {
+        source_generation,
+        target_generation,
+        migration_id,
+        sql_text,
+        shard_count,
+        state,
+        next_shard,
+    })
+}
+
+fn validate_stored_schema_migration_sql(sql: &str) -> EngineResult<()> {
+    if sql.is_empty() || sql.len() > MAX_SCHEMA_MIGRATION_SQL_BYTES || sql.as_bytes().contains(&0) {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "schema migration SQL violates its storage limits",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_schema_migration_sql(sql: &str) -> EngineResult<()> {
+    if sql.is_empty() {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            "schema migration SQL cannot be empty",
+        ));
+    }
+    if sql.len() > MAX_SCHEMA_MIGRATION_SQL_BYTES {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            format!("schema migration SQL exceeds the {MAX_SCHEMA_MIGRATION_SQL_BYTES}-byte limit"),
+        ));
+    }
+    if sql.as_bytes().contains(&0) {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            "schema migration SQL cannot contain a NUL byte",
+        ));
+    }
+    Ok(())
+}
+
+fn schema_migration_digest(sql: &str) -> [u8; 32] {
+    *blake3::hash(sql.as_bytes()).as_bytes()
+}
+
+pub(super) fn schema_migration_id(sql: &str) -> EngineResult<[u8; 32]> {
+    validate_schema_migration_sql(sql)?;
+    Ok(schema_migration_digest(sql))
 }
 
 fn validate_logical_databases(
@@ -2287,6 +3384,28 @@ pub(super) fn create_v4_fixture(connection: &mut Connection, shard_count: u16) {
 }
 
 #[cfg(test)]
+pub(super) fn create_v5_fixture(connection: &mut Connection, shard_count: u16) {
+    let transaction = connection
+        .transaction()
+        .expect("v5 fixture transaction starts");
+    create_v5_schema(&transaction, shard_count).expect("v5 fixture schema is valid");
+    transaction
+        .execute(
+            "UPDATE briskdb_shard_layout SET layout_state = ?1 WHERE singleton = 1",
+            [ShardLayoutState::Ready.code()],
+        )
+        .expect("v5 fixture layout becomes ready");
+    set_identity(&transaction, V5_SCHEMA_VERSION).expect("v5 fixture identity is valid");
+    validate_v5(
+        &transaction,
+        shard_count,
+        &schema_objects(&transaction).unwrap(),
+    )
+    .expect("v5 fixture validates");
+    transaction.commit().expect("v5 fixture commits");
+}
+
+#[cfg(test)]
 mod tests {
     use std::{
         panic::{AssertUnwindSafe, catch_unwind},
@@ -2347,6 +3466,34 @@ mod tests {
 
     fn create_v4_manifest(connection: &mut Connection, shards: u16) {
         create_v4_fixture(connection, shards);
+    }
+
+    fn create_v5_manifest(connection: &mut Connection, shards: u16) {
+        create_v5_fixture(connection, shards);
+    }
+
+    fn create_ready_current_manifest(connection: &mut Connection, shards: u16) {
+        let (_, creating) = load_or_create_manifest(connection, shards)
+            .unwrap()
+            .into_parts();
+        if creating.state() != ShardLayoutState::Ready {
+            mark_shard_layout_ready(connection, shards, &creating).unwrap();
+        }
+    }
+
+    fn complete_manifest_migration(
+        connection: &mut Connection,
+        shards: u16,
+        expected_source: u64,
+        sql: &str,
+    ) -> SchemaMigration {
+        let mut migration =
+            begin_schema_migration(connection, shards, expected_source, sql).unwrap();
+        while migration.next_shard() < migration.shard_count() {
+            let next = migration.next_shard() + 1;
+            migration = advance_schema_migration(connection, shards, &migration, next).unwrap();
+        }
+        finalize_schema_migration(connection, shards, &migration).unwrap()
     }
 
     fn shard_layout_row(connection: &Connection) -> (Vec<u8>, i64, i64, i64) {
@@ -2495,7 +3642,7 @@ mod tests {
             identity(connection),
             (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
         );
-        assert_eq!(schema_objects(connection).unwrap(), v5_objects());
+        assert_eq!(schema_objects(connection).unwrap(), v6_objects());
         assert_eq!(
             connection
                 .query_row(
@@ -2504,7 +3651,7 @@ mod tests {
                     |row| row.get::<_, i64>(0),
                 )
                 .unwrap(),
-            i64::from(V5_SCHEMA_VERSION)
+            i64::from(V6_SCHEMA_VERSION)
         );
         assert_eq!(
             routing_configuration(connection),
@@ -2550,6 +3697,16 @@ mod tests {
         assert_eq!(application_id, SHARD_APPLICATION_ID);
         assert_eq!(metadata_version, i64::from(SHARD_METADATA_VERSION));
         assert!(matches!(state, 1..=3));
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT COUNT(*) FROM briskdb_schema_migrations",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            0
+        );
         validate_foreign_keys(connection).unwrap();
     }
 
@@ -2639,7 +3796,7 @@ mod tests {
             .unwrap(),
             4
         );
-        assert_eq!(resumed_steps, [(2, 3), (3, 4), (4, 5)]);
+        assert_eq!(resumed_steps, [(2, 3), (3, 4), (4, 5), (5, 6)]);
         assert_generation_one_catalog(&connection, 4);
         assert_eq!(quick_check(&connection), "ok");
     }
@@ -2736,14 +3893,506 @@ mod tests {
         assert_eq!(catalog.logical().tables().len(), 5);
         assert_eq!(
             identity(&connection),
-            (MANIFEST_APPLICATION_ID, i64::from(V5_SCHEMA_VERSION))
+            (MANIFEST_APPLICATION_ID, i64::from(V6_SCHEMA_VERSION))
         );
-        assert_eq!(schema_objects(&connection).unwrap(), v5_objects());
+        assert_eq!(schema_objects(&connection).unwrap(), v6_objects());
         assert_eq!(
             shard_layout_row(&connection).3,
             ShardLayoutState::Adopting.code()
         );
         assert_eq!(quick_check(&connection), "ok");
+    }
+
+    #[test]
+    fn version_five_upgrade_preserves_ready_layout_catalog_and_empty_history() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        create_v5_manifest(&mut connection, 4);
+        insert_valid_table_catalog(&connection);
+        let layout_before = shard_layout_row(&connection);
+        let databases_before = logical_databases(&connection);
+        let tables_before = table_metadata_rows(&connection);
+
+        let loaded = load_or_create_manifest(&mut connection, 4).unwrap();
+        assert!(loaded.active_migration().is_none());
+        let (catalog, layout, active) = loaded.into_parts_with_migration();
+
+        assert_eq!(identity(&connection), (MANIFEST_APPLICATION_ID, 6));
+        assert_eq!(schema_objects(&connection).unwrap(), v6_objects());
+        assert_eq!(layout.state(), ShardLayoutState::Ready);
+        assert_eq!(shard_layout_row(&connection), layout_before);
+        assert_eq!(catalog.logical().schema_generation(), 0);
+        assert_eq!(logical_databases(&connection), databases_before);
+        assert_eq!(table_metadata_rows(&connection), tables_before);
+        assert!(active.is_none());
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT COUNT(*) FROM briskdb_schema_migrations",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            0
+        );
+        assert_eq!(quick_check(&connection), "ok");
+    }
+
+    #[test]
+    fn version_six_migration_error_and_panic_restore_exact_v5_then_retry() {
+        for failing_phase in [
+            MigrationPhase::AfterSchemaChange,
+            MigrationPhase::AfterVersionStamp,
+        ] {
+            let mut connection = Connection::open_in_memory().unwrap();
+            create_v5_manifest(&mut connection, 4);
+            let layout_before = shard_layout_row(&connection);
+
+            let error = load_or_create_with_hook(&mut connection, 4, |point| {
+                if point.from == V5_SCHEMA_VERSION && point.phase == failing_phase {
+                    Err(EngineError::new(
+                        EngineErrorKind::Internal,
+                        "injected schema journal migration failure",
+                    ))
+                } else {
+                    Ok(())
+                }
+            })
+            .unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::Internal);
+            assert_eq!(identity(&connection), (MANIFEST_APPLICATION_ID, 5));
+            assert_eq!(schema_objects(&connection).unwrap(), v5_objects());
+            assert_eq!(shard_layout_row(&connection), layout_before);
+            assert_eq!(quick_check(&connection), "ok");
+
+            load_or_create_manifest(&mut connection, 4).unwrap();
+            assert_eq!(identity(&connection), (MANIFEST_APPLICATION_ID, 6));
+            assert_eq!(schema_objects(&connection).unwrap(), v6_objects());
+        }
+
+        let mut connection = Connection::open_in_memory().unwrap();
+        create_v5_manifest(&mut connection, 4);
+        let panic = catch_unwind(AssertUnwindSafe(|| {
+            let _ = load_or_create_with_hook(&mut connection, 4, |point| {
+                if point.from == V5_SCHEMA_VERSION
+                    && point.phase == MigrationPhase::AfterVersionStamp
+                {
+                    panic!("injected schema journal migration panic");
+                }
+                Ok(())
+            });
+        }));
+        assert!(panic.is_err());
+        assert_eq!(identity(&connection), (MANIFEST_APPLICATION_ID, 5));
+        assert_eq!(schema_objects(&connection).unwrap(), v5_objects());
+        load_or_create_manifest(&mut connection, 4).unwrap();
+        assert_eq!(identity(&connection), (MANIFEST_APPLICATION_ID, 6));
+    }
+
+    #[test]
+    fn schema_migration_journal_is_exact_idempotent_and_monotonic() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        create_ready_current_manifest(&mut connection, 4);
+        let first_sql = "CREATE TABLE widgets (id INTEGER PRIMARY KEY)";
+
+        assert_eq!(
+            classify_schema_migration(&mut connection, 4, first_sql).unwrap(),
+            SchemaMigrationClassification::Absent
+        );
+        let active = begin_schema_migration(&mut connection, 4, 0, first_sql).unwrap();
+        assert_eq!(active.source_generation(), 0);
+        assert_eq!(active.target_generation(), 1);
+        assert_eq!(
+            active.migration_id(),
+            schema_migration_id(first_sql).unwrap()
+        );
+        assert_eq!(active.sql_text(), first_sql);
+        assert_eq!(active.shard_count(), 4);
+        assert_eq!(active.next_shard(), 0);
+        assert!(active.is_applying());
+        assert_eq!(
+            load_active_schema_migration(&mut connection, 4).unwrap(),
+            Some(active.clone())
+        );
+        assert_eq!(
+            begin_schema_migration(&mut connection, 4, 0, first_sql).unwrap(),
+            active
+        );
+        assert_eq!(
+            classify_schema_migration(&mut connection, 4, first_sql).unwrap(),
+            SchemaMigrationClassification::Active(active.clone())
+        );
+
+        let conflict =
+            begin_schema_migration(&mut connection, 4, 0, "CREATE TABLE different (id INTEGER)")
+                .unwrap_err();
+        assert_eq!(conflict.kind(), EngineErrorKind::FailedPrecondition);
+        let skipped = advance_schema_migration(&mut connection, 4, &active, 2).unwrap_err();
+        assert_eq!(skipped.kind(), EngineErrorKind::FailedPrecondition);
+        let premature = finalize_schema_migration(&mut connection, 4, &active).unwrap_err();
+        assert_eq!(premature.kind(), EngineErrorKind::FailedPrecondition);
+
+        let one = advance_schema_migration(&mut connection, 4, &active, 1).unwrap();
+        assert_eq!(one.next_shard(), 1);
+        assert_eq!(
+            advance_schema_migration(&mut connection, 4, &one, 1).unwrap(),
+            one
+        );
+        let two = advance_schema_migration(&mut connection, 4, &one, 2).unwrap();
+        let three = advance_schema_migration(&mut connection, 4, &two, 3).unwrap();
+        let four = advance_schema_migration(&mut connection, 4, &three, 4).unwrap();
+        let complete = finalize_schema_migration(&mut connection, 4, &four).unwrap();
+        assert!(complete.is_complete());
+        assert_eq!(complete.next_shard(), 4);
+        assert!(
+            load_active_schema_migration(&mut connection, 4)
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(
+            classify_schema_migration(&mut connection, 4, first_sql).unwrap(),
+            SchemaMigrationClassification::Complete(complete.clone())
+        );
+        assert_eq!(
+            begin_schema_migration(&mut connection, 4, 0, first_sql).unwrap(),
+            complete
+        );
+        assert_eq!(
+            load_or_create_manifest(&mut connection, 4)
+                .unwrap()
+                .into_parts()
+                .0
+                .logical()
+                .schema_generation(),
+            1
+        );
+
+        let stale = begin_schema_migration(
+            &mut connection,
+            4,
+            0,
+            "CREATE INDEX widget_ids ON widgets(id)",
+        )
+        .unwrap_err();
+        assert_eq!(stale.kind(), EngineErrorKind::FailedPrecondition);
+        let second = complete_manifest_migration(
+            &mut connection,
+            4,
+            1,
+            "CREATE INDEX widget_ids ON widgets(id)",
+        );
+        assert_eq!(second.target_generation(), 2);
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT COUNT(*) FROM briskdb_schema_migrations",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            2
+        );
+        assert_eq!(
+            load_or_create_manifest(&mut connection, 4)
+                .unwrap()
+                .into_parts()
+                .0
+                .logical()
+                .schema_generation(),
+            2
+        );
+    }
+
+    #[test]
+    fn exact_sql_bytes_define_the_bounded_migration_identity() {
+        assert_eq!(
+            schema_migration_id("").unwrap_err().kind(),
+            EngineErrorKind::InvalidArgument
+        );
+        assert_eq!(
+            schema_migration_id("SELECT 1\0SELECT 2")
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::InvalidArgument
+        );
+        let at_limit = "x".repeat(MAX_SCHEMA_MIGRATION_SQL_BYTES);
+        assert_eq!(
+            schema_migration_id(&at_limit).unwrap(),
+            schema_migration_digest(&at_limit)
+        );
+        assert_eq!(
+            schema_migration_id(&format!("{at_limit}x"))
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::InvalidArgument
+        );
+        assert_ne!(
+            schema_migration_id("CREATE TABLE t(id INTEGER)").unwrap(),
+            schema_migration_id("CREATE TABLE t (id INTEGER)").unwrap()
+        );
+    }
+
+    #[test]
+    fn a_different_active_migration_takes_precedence_over_history_and_absence() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        create_ready_current_manifest(&mut connection, 4);
+        let completed_sql = "CREATE TABLE completed_marker (id INTEGER)";
+        complete_manifest_migration(&mut connection, 4, 0, completed_sql);
+        let active_sql = "CREATE TABLE active_marker (id INTEGER)";
+        let active = begin_schema_migration(&mut connection, 4, 1, active_sql).unwrap();
+
+        assert_eq!(
+            classify_schema_migration(&mut connection, 4, active_sql).unwrap(),
+            SchemaMigrationClassification::Active(active)
+        );
+        for conflicting_sql in [
+            completed_sql,
+            "CREATE TABLE previously_absent_marker (id INTEGER)",
+        ] {
+            let error = classify_schema_migration(&mut connection, 4, conflicting_sql).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+            assert_eq!(
+                error.to_string(),
+                "a different schema migration is already active"
+            );
+            let error = begin_schema_migration(&mut connection, 4, 1, conflicting_sql).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+            assert_eq!(
+                error.to_string(),
+                "a different schema migration is already active"
+            );
+        }
+    }
+
+    #[test]
+    fn held_transaction_journal_mutations_roll_back_on_error_and_panic() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        create_ready_current_manifest(&mut connection, 4);
+        let sql = "CREATE TABLE rollback_marker (id INTEGER)";
+
+        {
+            let transaction = connection
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .unwrap();
+            let active = begin_schema_migration_in_transaction(&transaction, 4, 0, sql).unwrap();
+            assert_eq!(active.next_shard(), 0);
+            drop(transaction);
+        }
+        assert!(matches!(
+            classify_schema_migration(&mut connection, 4, sql).unwrap(),
+            SchemaMigrationClassification::Absent
+        ));
+
+        let panic = catch_unwind(AssertUnwindSafe(|| {
+            let transaction = connection
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .unwrap();
+            begin_schema_migration_in_transaction(&transaction, 4, 0, sql).unwrap();
+            panic!("injected journal creation panic");
+        }));
+        assert!(panic.is_err());
+        assert!(
+            load_active_schema_migration(&mut connection, 4)
+                .unwrap()
+                .is_none()
+        );
+
+        let active = begin_schema_migration(&mut connection, 4, 0, sql).unwrap();
+        {
+            let transaction = connection
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .unwrap();
+            let advanced =
+                advance_schema_migration_in_transaction(&transaction, 4, &active, 1).unwrap();
+            assert_eq!(advanced.next_shard(), 1);
+            drop(transaction);
+        }
+        assert_eq!(
+            load_active_schema_migration(&mut connection, 4)
+                .unwrap()
+                .unwrap()
+                .next_shard(),
+            0
+        );
+
+        let mut active = active;
+        for next in 1..=4 {
+            active = advance_schema_migration(&mut connection, 4, &active, next).unwrap();
+        }
+        {
+            let transaction = connection
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .unwrap();
+            let complete =
+                finalize_schema_migration_in_transaction(&transaction, 4, &active).unwrap();
+            assert!(complete.is_complete());
+            drop(transaction);
+        }
+        let still_active = load_active_schema_migration(&mut connection, 4)
+            .unwrap()
+            .unwrap();
+        assert!(still_active.is_applying());
+        assert_eq!(
+            load_or_create_manifest(&mut connection, 4)
+                .unwrap()
+                .into_parts()
+                .0
+                .logical()
+                .schema_generation(),
+            0
+        );
+        finalize_schema_migration(&mut connection, 4, &still_active).unwrap();
+    }
+
+    #[test]
+    fn non_ready_layouts_require_an_empty_schema_migration_history() {
+        let mut creating = Connection::open_in_memory().unwrap();
+        let loaded = load_or_create_manifest(&mut creating, 4).unwrap();
+        assert_eq!(loaded.into_parts().1.state(), ShardLayoutState::Creating);
+        let error = begin_schema_migration(
+            &mut creating,
+            4,
+            0,
+            "CREATE TABLE cannot_start (id INTEGER)",
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+
+        creating
+            .execute(
+                "INSERT INTO briskdb_schema_migrations VALUES (
+                    1, 0, ?1, 1, ?2, 4, 1, 0
+                 )",
+                rusqlite::params![
+                    schema_migration_digest("CREATE TABLE injected (id INTEGER)").as_slice(),
+                    "CREATE TABLE injected (id INTEGER)"
+                ],
+            )
+            .unwrap();
+        assert_eq!(
+            load_or_create_manifest(&mut creating, 4)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::DataCorruption
+        );
+
+        let mut adopting = Connection::open_in_memory().unwrap();
+        create_v4_manifest(&mut adopting, 4);
+        let loaded = load_or_create_manifest(&mut adopting, 4).unwrap();
+        assert_eq!(loaded.into_parts().1.state(), ShardLayoutState::Adopting);
+        assert!(
+            load_active_schema_migration(&mut adopting, 4)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn schema_migration_history_corruption_fails_closed() {
+        for mutation in [
+            "UPDATE briskdb_schema_migrations SET migration_id = zeroblob(32)",
+            "UPDATE briskdb_schema_migrations SET digest_version = 2",
+            "UPDATE briskdb_schema_migrations SET source_generation = 7",
+            "UPDATE briskdb_schema_migrations SET migration_state = 1",
+            "UPDATE briskdb_schema_migrations SET next_shard = 3",
+            "UPDATE briskdb_schema_migrations SET shard_count = 3",
+            "UPDATE briskdb_schema_migrations SET sql_text = sql_text || char(0)",
+            "UPDATE briskdb_schema_catalog SET schema_generation = 2",
+        ] {
+            let mut connection = Connection::open_in_memory().unwrap();
+            create_ready_current_manifest(&mut connection, 4);
+            complete_manifest_migration(
+                &mut connection,
+                4,
+                0,
+                "CREATE TABLE corruption_target (id INTEGER)",
+            );
+            connection
+                .execute_batch("PRAGMA ignore_check_constraints = ON;")
+                .unwrap();
+            connection.execute_batch(mutation).unwrap();
+            connection
+                .execute_batch("PRAGMA ignore_check_constraints = OFF;")
+                .unwrap();
+
+            let error = load_or_create_manifest(&mut connection, 4).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::DataCorruption, "{mutation}");
+        }
+
+        let mut invalid_text = Connection::open_in_memory().unwrap();
+        create_ready_current_manifest(&mut invalid_text, 4);
+        complete_manifest_migration(
+            &mut invalid_text,
+            4,
+            0,
+            "CREATE TABLE invalid_text_target (id INTEGER)",
+        );
+        invalid_text
+            .execute_batch(
+                "PRAGMA ignore_check_constraints = ON;
+                 UPDATE briskdb_schema_migrations SET sql_text = CAST(x'80' AS TEXT);
+                 PRAGMA ignore_check_constraints = OFF;",
+            )
+            .unwrap();
+        assert_eq!(
+            load_or_create_manifest(&mut invalid_text, 4)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::DataCorruption
+        );
+    }
+
+    #[test]
+    fn concurrent_journal_creators_converge_or_reject_a_conflict() {
+        fn run(sqls: [&'static str; 2]) -> Vec<EngineResult<SchemaMigration>> {
+            let temp = tempfile::tempdir().unwrap();
+            let path = temp.path().join("manifest.sqlite");
+            let mut setup = Connection::open(&path).unwrap();
+            create_ready_current_manifest(&mut setup, 4);
+            drop(setup);
+
+            let barrier = Arc::new(Barrier::new(2));
+            let workers = sqls.map(|sql| {
+                let path = path.clone();
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    let mut connection = Connection::open(path).unwrap();
+                    connection.busy_timeout(Duration::from_secs(5)).unwrap();
+                    barrier.wait();
+                    begin_schema_migration(&mut connection, 4, 0, sql)
+                })
+            });
+            workers
+                .into_iter()
+                .map(|worker| worker.join().unwrap())
+                .collect()
+        }
+
+        let identical = run([
+            "CREATE TABLE concurrent_same (id INTEGER)",
+            "CREATE TABLE concurrent_same (id INTEGER)",
+        ]);
+        assert!(identical.iter().all(Result::is_ok));
+        assert_eq!(
+            identical[0].as_ref().unwrap().migration_id(),
+            identical[1].as_ref().unwrap().migration_id()
+        );
+
+        let conflicting = run([
+            "CREATE TABLE concurrent_first (id INTEGER)",
+            "CREATE TABLE concurrent_second (id INTEGER)",
+        ]);
+        assert_eq!(
+            conflicting.iter().filter(|result| result.is_ok()).count(),
+            1
+        );
+        assert_eq!(
+            conflicting
+                .iter()
+                .find_map(|result| result.as_ref().err())
+                .unwrap()
+                .kind(),
+            EngineErrorKind::FailedPrecondition
+        );
     }
 
     #[test]
@@ -3813,6 +5462,67 @@ mod tests {
     }
 
     #[test]
+    fn version_five_reader_rejects_version_six_without_mutating_it() {
+        const OLD_MIGRATIONS: &[Migration] = &[
+            Migration {
+                from: LEGACY_SCHEMA_VERSION,
+                to: V2_SCHEMA_VERSION,
+                name: "typed_manifest_and_downgrade_fence",
+                apply: migrate_v1_to_v2,
+                validate: validate_v2,
+            },
+            Migration {
+                from: V2_SCHEMA_VERSION,
+                to: V3_SCHEMA_VERSION,
+                name: "durable_shard_catalog",
+                apply: migrate_v2_to_v3,
+                validate: validate_v3,
+            },
+            Migration {
+                from: V3_SCHEMA_VERSION,
+                to: V4_SCHEMA_VERSION,
+                name: "logical_database_and_table_catalog",
+                apply: migrate_v3_to_v4,
+                validate: validate_v4,
+            },
+            Migration {
+                from: V4_SCHEMA_VERSION,
+                to: V5_SCHEMA_VERSION,
+                name: "validated_physical_shard_layout",
+                apply: migrate_v4_to_v5,
+                validate: validate_v5,
+            },
+        ];
+        const OLD_PLAN: MigrationPlan<'static> = MigrationPlan {
+            current_version: V5_SCHEMA_VERSION,
+            migrations: OLD_MIGRATIONS,
+            initialize_current: create_v5_schema,
+            initialize_interrupted_legacy: migrate_interrupted_legacy_to_v5,
+        };
+
+        let mut connection = Connection::open_in_memory().unwrap();
+        load_or_create(&mut connection, 4).unwrap();
+        let identity_before = identity(&connection);
+        let objects_before = schema_objects(&connection).unwrap();
+
+        let error = inspect_with_plan(&connection, 4, OLD_PLAN).unwrap_err();
+
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert_eq!(identity(&connection), identity_before);
+        assert_eq!(schema_objects(&connection).unwrap(), objects_before);
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT requires_manifest_version FROM briskdb_metadata",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            i64::from(V6_SCHEMA_VERSION)
+        );
+    }
+
+    #[test]
     fn rejects_future_and_foreign_manifests_without_mutating_them() {
         let mut future = Connection::open_in_memory().unwrap();
         load_or_create(&mut future, 4).unwrap();
@@ -3855,7 +5565,7 @@ mod tests {
         for mutation in [
             "DELETE FROM briskdb_metadata",
             "DELETE FROM briskdb_manifest",
-            "INSERT INTO briskdb_metadata VALUES (5)",
+            "INSERT INTO briskdb_metadata VALUES (7)",
             "DELETE FROM briskdb_routing",
             "DELETE FROM briskdb_virtual_buckets WHERE bucket_id = 4095",
             "DELETE FROM briskdb_physical_shards WHERE shard_id = 3",
@@ -4144,6 +5854,17 @@ mod tests {
              ) STRICT;
              INSERT INTO briskdb_shard_layout
              VALUES (1, randomblob(16), 1112691528, 1, 1);",
+            "DROP TABLE briskdb_schema_migrations;
+             CREATE TABLE briskdb_schema_migrations (
+                target_generation INTEGER PRIMARY KEY,
+                source_generation INTEGER NOT NULL,
+                migration_id BLOB NOT NULL,
+                digest_version INTEGER NOT NULL,
+                sql_text TEXT NOT NULL,
+                shard_count INTEGER NOT NULL,
+                migration_state INTEGER NOT NULL,
+                next_shard INTEGER NOT NULL
+             ) STRICT;",
         ] {
             let mut connection = Connection::open_in_memory().unwrap();
             load_or_create(&mut connection, 4).unwrap();

--- a/src/storage/migration.rs
+++ b/src/storage/migration.rs
@@ -1,0 +1,1812 @@
+//! Crash-resumable application-schema migration coordination.
+
+use std::{
+    cell::RefCell,
+    panic::{AssertUnwindSafe, catch_unwind, resume_unwind},
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+#[cfg(test)]
+use std::cell::Cell;
+#[cfg(test)]
+use std::{
+    collections::{HashMap, hash_map::Entry},
+    sync::{Mutex, OnceLock, mpsc},
+};
+
+use rusqlite::Connection;
+
+use crate::{
+    core::{
+        CancellationReason, CatalogSnapshot, EngineError, EngineErrorKind, EngineResult,
+        OperationControl,
+    },
+    sqlite_error,
+};
+
+use super::{
+    CONNECTION_BUSY_TIMEOUT, RootSchemaCoordination, SchemaMigrationGuard, Storage,
+    configure_journal_mode, configure_manifest_connection, manifest,
+    manifest::{SchemaMigration, SchemaMigrationClassification},
+    open_existing_manifest, shard,
+};
+
+thread_local! {
+    static MIGRATION_BUSY_OPERATION: RefCell<Option<MigrationBusyOperation>> = const {
+        RefCell::new(None)
+    };
+}
+
+#[cfg(test)]
+thread_local! {
+    static FAIL_NEXT_MANIFEST_COMMIT_CLEANUP: Cell<bool> = const { Cell::new(false) };
+}
+
+struct MigrationBusyOperation {
+    control: Arc<OperationControl>,
+    started: Instant,
+}
+
+struct MigrationBusyGuard;
+
+impl MigrationBusyGuard {
+    fn install(control: Arc<OperationControl>) -> Self {
+        MIGRATION_BUSY_OPERATION.with(|operation| {
+            let previous = operation.replace(Some(MigrationBusyOperation {
+                control,
+                started: Instant::now(),
+            }));
+            debug_assert!(
+                previous.is_none(),
+                "migration SQLite controls cannot be nested"
+            );
+        });
+        Self
+    }
+}
+
+impl Drop for MigrationBusyGuard {
+    fn drop(&mut self) {
+        MIGRATION_BUSY_OPERATION.with(|operation| {
+            operation.replace(None);
+        });
+    }
+}
+
+fn cancellable_busy_handler(attempt: i32) -> bool {
+    MIGRATION_BUSY_OPERATION.with(|operation| {
+        let operation = operation.borrow();
+        let Some(operation) = operation.as_ref() else {
+            return false;
+        };
+        if operation.control.should_stop() || operation.started.elapsed() >= CONNECTION_BUSY_TIMEOUT
+        {
+            return false;
+        }
+        let delay = match attempt {
+            ..=9 => Duration::from_millis(1),
+            10..=19 => Duration::from_millis(5),
+            _ => Duration::from_millis(10),
+        };
+        std::thread::sleep(
+            delay.min(CONNECTION_BUSY_TIMEOUT.saturating_sub(operation.started.elapsed())),
+        );
+        !operation.control.should_stop() && operation.started.elapsed() < CONNECTION_BUSY_TIMEOUT
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SchemaMigrationCoordinatorPoint {
+    JournalCommitted,
+    ShardCommitted(u16),
+    ProgressPrepared(u16),
+    ProgressCommitted(u16),
+    FinalizationPrepared,
+    FinalizationCommitted,
+}
+
+#[cfg(test)]
+struct SchemaMigrationTestBlock {
+    point: SchemaMigrationCoordinatorPoint,
+    started: mpsc::Sender<()>,
+    release: mpsc::Receiver<()>,
+}
+
+#[cfg(test)]
+static SCHEMA_MIGRATION_TEST_BLOCKS: OnceLock<Mutex<HashMap<PathBuf, SchemaMigrationTestBlock>>> =
+    OnceLock::new();
+
+#[cfg(test)]
+pub(super) fn install_schema_migration_test_block(
+    root: &Path,
+    point: SchemaMigrationCoordinatorPoint,
+    started: mpsc::Sender<()>,
+    release: mpsc::Receiver<()>,
+) -> EngineResult<()> {
+    let blocks = SCHEMA_MIGRATION_TEST_BLOCKS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut blocks = blocks.lock().map_err(|error| {
+        EngineError::new(
+            EngineErrorKind::Internal,
+            format!("schema-migration test coordination is poisoned: {error}"),
+        )
+    })?;
+    match blocks.entry(root.to_path_buf()) {
+        Entry::Vacant(entry) => {
+            entry.insert(SchemaMigrationTestBlock {
+                point,
+                started,
+                release,
+            });
+            Ok(())
+        }
+        Entry::Occupied(_) => Err(EngineError::new(
+            EngineErrorKind::Internal,
+            "a schema-migration test block is already installed for this root",
+        )),
+    }
+}
+
+#[cfg(test)]
+fn run_schema_migration_test_block(
+    root: &Path,
+    point: SchemaMigrationCoordinatorPoint,
+) -> EngineResult<()> {
+    let Some(blocks) = SCHEMA_MIGRATION_TEST_BLOCKS.get() else {
+        return Ok(());
+    };
+    let block = {
+        let mut blocks = blocks.lock().map_err(|error| {
+            EngineError::new(
+                EngineErrorKind::Internal,
+                format!("schema-migration test coordination is poisoned: {error}"),
+            )
+        })?;
+        if blocks.get(root).is_some_and(|block| block.point == point) {
+            blocks.remove(root)
+        } else {
+            None
+        }
+    };
+    let Some(block) = block else {
+        return Ok(());
+    };
+    block.started.send(()).map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::Internal,
+            "failed to signal the schema-migration test block",
+            error,
+        )
+    })?;
+    block.release.recv().map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::Internal,
+            "failed to release the schema-migration test block",
+            error,
+        )
+    })
+}
+
+struct SchemaMigrationCoordinator<'a> {
+    root: &'a Path,
+    manifest_connection: &'a mut Connection,
+    requested_shards: u16,
+    catalog: &'a CatalogSnapshot,
+    schema_coordination: &'a RootSchemaCoordination,
+    layout: &'a shard::ShardLayout,
+    control: Option<Arc<OperationControl>>,
+}
+
+pub(super) fn resume_schema_migration_on_startup(
+    root: &Path,
+    manifest_connection: &mut Connection,
+    requested_shards: u16,
+    catalog: &CatalogSnapshot,
+    layout: &shard::ShardLayout,
+    schema_coordination: &RootSchemaCoordination,
+    migration: SchemaMigration,
+) -> EngineResult<()> {
+    let mut no_hook = |_| Ok(());
+    resume_active_schema_migration(
+        SchemaMigrationCoordinator {
+            root,
+            manifest_connection,
+            requested_shards,
+            catalog,
+            schema_coordination,
+            layout,
+            control: None,
+        },
+        migration,
+        &mut no_hook,
+    )
+}
+
+pub(super) fn apply_schema_migration(
+    storage: &Storage,
+    sql: &str,
+    guard: &mut SchemaMigrationGuard,
+    control: Option<Arc<OperationControl>>,
+) -> EngineResult<Vec<u16>> {
+    #[cfg(test)]
+    {
+        apply_schema_migration_with_hook(storage, sql, guard, control, |point| {
+            run_schema_migration_test_block(&storage.root, point)
+        })
+    }
+    #[cfg(not(test))]
+    {
+        apply_schema_migration_with_hook(storage, sql, guard, control, |_| Ok(()))
+    }
+}
+
+fn apply_schema_migration_with_hook<F>(
+    storage: &Storage,
+    sql: &str,
+    guard: &mut SchemaMigrationGuard,
+    control: Option<Arc<OperationControl>>,
+    mut hook: F,
+) -> EngineResult<Vec<u16>>
+where
+    F: FnMut(SchemaMigrationCoordinatorPoint) -> EngineResult<()>,
+{
+    check_cancelled(control.as_deref())?;
+    // Validate public input before touching any shard or creating a journal.
+    let _ = manifest::schema_migration_id(sql)?;
+
+    let manifest_path = storage.root.join("manifest.sqlite");
+    let mut manifest_connection = open_existing_manifest(&manifest_path)?;
+    configure_manifest_connection(&manifest_connection)?;
+    configure_journal_mode(&manifest_connection)?;
+
+    match classify_schema_migration(
+        &mut manifest_connection,
+        storage.shard_count(),
+        &storage.shard_layout,
+        sql,
+        control.as_ref(),
+    )? {
+        SchemaMigrationClassification::Complete(migration) => {
+            finish_completed_schema_migration(storage, &migration, control.as_ref())?;
+            return Ok(all_shards(storage.shard_count()));
+        }
+        SchemaMigrationClassification::Active(migration) => {
+            guard.mark_pending_on_drop();
+            resume_active_schema_migration(
+                SchemaMigrationCoordinator {
+                    root: &storage.root,
+                    manifest_connection: &mut manifest_connection,
+                    requested_shards: storage.shard_count(),
+                    catalog: &storage.catalog,
+                    schema_coordination: &storage.schema_coordination,
+                    layout: &storage.shard_layout,
+                    control,
+                },
+                migration,
+                &mut hook,
+            )?;
+            return Ok(all_shards(storage.shard_count()));
+        }
+        SchemaMigrationClassification::Absent => {}
+    }
+
+    let source_generation = storage.current_schema_generation();
+    let target_generation = source_generation.checked_add(1).ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "schema migration generation is exhausted",
+        )
+    })?;
+    let shards_dir = storage.root.join("shards");
+    for shard_id in 0..storage.shard_count() {
+        check_cancelled(control.as_deref())?;
+        let path = shard_path(&shards_dir, shard_id);
+        let state = preflight_one_shard(
+            &path,
+            shard_id,
+            source_generation,
+            target_generation,
+            &storage.shard_layout,
+            sql,
+            control.as_ref(),
+        )
+        .map_err(|error| sanitized_shard_error(error, "preflight", shard_id))?;
+        if state != shard::SchemaMigrationShardState::Source {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!(
+                    "schema migration preflight found shard {shard_id} at the target generation without an active journal"
+                ),
+            ));
+        }
+    }
+    check_cancelled(control.as_deref())?;
+
+    let migration = begin_schema_migration(
+        &mut manifest_connection,
+        storage.shard_count(),
+        &storage.shard_layout,
+        source_generation,
+        sql,
+        control.as_ref(),
+        guard,
+    )?;
+    if migration.is_complete() {
+        finish_completed_schema_migration(storage, &migration, control.as_ref())?;
+        return Ok(all_shards(storage.shard_count()));
+    }
+    hook(SchemaMigrationCoordinatorPoint::JournalCommitted)?;
+    resume_active_schema_migration(
+        SchemaMigrationCoordinator {
+            root: &storage.root,
+            manifest_connection: &mut manifest_connection,
+            requested_shards: storage.shard_count(),
+            catalog: &storage.catalog,
+            schema_coordination: &storage.schema_coordination,
+            layout: &storage.shard_layout,
+            control,
+        },
+        migration,
+        &mut hook,
+    )?;
+    Ok(all_shards(storage.shard_count()))
+}
+
+fn classify_schema_migration(
+    connection: &mut Connection,
+    requested_shards: u16,
+    layout: &shard::ShardLayout,
+    sql: &str,
+    control: Option<&Arc<OperationControl>>,
+) -> EngineResult<SchemaMigrationClassification> {
+    let mut transaction = ManifestTransaction::begin(connection, control)?;
+    let classification = transaction.run(|connection| {
+        manifest::ensure_schema_migration_layout(connection, requested_shards, layout)?;
+        manifest::classify_schema_migration_in_transaction(connection, requested_shards, sql)
+    })?;
+    transaction.commit()?;
+    Ok(classification)
+}
+
+fn begin_schema_migration(
+    connection: &mut Connection,
+    requested_shards: u16,
+    layout: &shard::ShardLayout,
+    source_generation: u64,
+    sql: &str,
+    control: Option<&Arc<OperationControl>>,
+    guard: &mut SchemaMigrationGuard,
+) -> EngineResult<SchemaMigration> {
+    let mut transaction = ManifestTransaction::begin(connection, control)?;
+    let migration = transaction.run(|connection| {
+        manifest::ensure_schema_migration_layout(connection, requested_shards, layout)?;
+        manifest::begin_schema_migration_in_transaction(
+            connection,
+            requested_shards,
+            source_generation,
+            sql,
+        )
+    })?;
+    transaction.commit_with_durability_boundary(|| guard.mark_pending_on_drop())?;
+    Ok(migration)
+}
+
+struct ManifestTransaction<'a> {
+    connection: &'a mut Connection,
+    control: Option<Arc<OperationControl>>,
+    active: bool,
+}
+
+impl<'a> ManifestTransaction<'a> {
+    fn begin(
+        connection: &'a mut Connection,
+        control: Option<&Arc<OperationControl>>,
+    ) -> EngineResult<Self> {
+        check_cancelled(control.map(Arc::as_ref))?;
+        match control {
+            Some(control) => {
+                run_connection_controlled(connection, Arc::clone(control), |connection| {
+                    connection
+                        .execute_batch("BEGIN IMMEDIATE")
+                        .map_err(sqlite_error::storage)
+                })?
+            }
+            None => connection
+                .execute_batch("BEGIN IMMEDIATE")
+                .map_err(sqlite_error::storage)?,
+        }
+        Ok(Self {
+            connection,
+            control: control.cloned(),
+            active: true,
+        })
+    }
+
+    fn run<T>(&mut self, work: impl FnOnce(&Connection) -> EngineResult<T>) -> EngineResult<T> {
+        match self.control.as_ref() {
+            Some(control) => {
+                let control = Arc::clone(control);
+                run_connection_controlled(self.connection, control, |connection| work(connection))
+            }
+            None => work(self.connection),
+        }
+    }
+
+    fn commit(self) -> EngineResult<()> {
+        self.commit_with_durability_boundary(|| {})
+    }
+
+    fn commit_with_durability_boundary(
+        mut self,
+        on_commit_attempted: impl FnOnce(),
+    ) -> EngineResult<()> {
+        let mut committed = false;
+        let result = self.run(|connection| {
+            // Once COMMIT is attempted, an I/O error can be durability-
+            // ambiguous. Publish the caller's fail-closed state immediately
+            // before entering SQLite, but only after request controls have
+            // allowed the work closure to start.
+            on_commit_attempted();
+            connection
+                .execute_batch("COMMIT")
+                .map_err(sqlite_error::storage)?;
+            committed = true;
+            Ok(())
+        });
+        #[cfg(test)]
+        let result = {
+            let inject = FAIL_NEXT_MANIFEST_COMMIT_CLEANUP.with(|fail| fail.replace(false));
+            if inject && result.is_ok() {
+                Err(EngineError::new(
+                    EngineErrorKind::Internal,
+                    "injected manifest post-commit cleanup failure",
+                ))
+            } else {
+                result
+            }
+        };
+        if committed {
+            self.active = false;
+        }
+        result
+    }
+
+    fn rollback(mut self) -> EngineResult<()> {
+        let result = self
+            .connection
+            .execute_batch("ROLLBACK")
+            .map_err(sqlite_error::storage);
+        if result.is_ok() {
+            self.active = false;
+        }
+        result
+    }
+}
+
+impl Drop for ManifestTransaction<'_> {
+    fn drop(&mut self) {
+        if self.active {
+            let _ = self.connection.execute_batch("ROLLBACK");
+        }
+    }
+}
+
+fn resume_active_schema_migration<F>(
+    coordinator: SchemaMigrationCoordinator<'_>,
+    mut migration: SchemaMigration,
+    hook: &mut F,
+) -> EngineResult<()>
+where
+    F: FnMut(SchemaMigrationCoordinatorPoint) -> EngineResult<()>,
+{
+    let SchemaMigrationCoordinator {
+        root,
+        manifest_connection,
+        requested_shards,
+        catalog,
+        schema_coordination,
+        layout,
+        control,
+    } = coordinator;
+    ensure_active_matches_catalog(&migration, catalog, requested_shards)?;
+    let shards_dir = root.join("shards");
+    validate_schema_migration_prefix(
+        &shards_dir,
+        requested_shards,
+        migration.next_shard(),
+        migration.source_generation(),
+        migration.target_generation(),
+        layout,
+        control.as_ref(),
+    )?;
+
+    while migration.next_shard() < requested_shards {
+        check_cancelled(control.as_deref())?;
+        let mut transaction = ManifestTransaction::begin(manifest_connection, control.as_ref())?;
+        let Some(locked) = transaction.run(|connection| {
+            manifest::load_active_schema_migration_in_transaction(connection, requested_shards)
+        })?
+        else {
+            transaction.rollback()?;
+            return finish_completed_by_sql(
+                manifest_connection,
+                requested_shards,
+                schema_coordination,
+                layout,
+                &shards_dir,
+                migration.sql_text(),
+                control.as_ref(),
+            );
+        };
+        ensure_same_migration(&migration, &locked)?;
+        migration = locked;
+        if migration.next_shard() == requested_shards {
+            transaction.commit()?;
+            break;
+        }
+
+        let shard_id = migration.next_shard();
+        let path = shard_path(&shards_dir, shard_id);
+        apply_one_shard(
+            &path,
+            shard_id,
+            migration.source_generation(),
+            migration.target_generation(),
+            layout,
+            migration.sql_text(),
+            control.as_ref(),
+        )
+        .map_err(|error| sanitized_shard_error(error, "apply", shard_id))?;
+        hook(SchemaMigrationCoordinatorPoint::ShardCommitted(shard_id))?;
+        check_cancelled(control.as_deref())?;
+
+        let next_shard = shard_id + 1;
+        migration = transaction.run(|connection| {
+            manifest::advance_schema_migration_in_transaction(
+                connection,
+                requested_shards,
+                &migration,
+                next_shard,
+            )
+        })?;
+        hook(SchemaMigrationCoordinatorPoint::ProgressPrepared(shard_id))?;
+        transaction.commit()?;
+        hook(SchemaMigrationCoordinatorPoint::ProgressCommitted(shard_id))?;
+    }
+
+    check_cancelled(control.as_deref())?;
+    validate_schema_migration_prefix(
+        &shards_dir,
+        requested_shards,
+        requested_shards,
+        migration.source_generation(),
+        migration.target_generation(),
+        layout,
+        control.as_ref(),
+    )?;
+
+    let mut transaction = ManifestTransaction::begin(manifest_connection, control.as_ref())?;
+    let Some(locked) = transaction.run(|connection| {
+        manifest::load_active_schema_migration_in_transaction(connection, requested_shards)
+    })?
+    else {
+        transaction.rollback()?;
+        return finish_completed_by_sql(
+            manifest_connection,
+            requested_shards,
+            schema_coordination,
+            layout,
+            &shards_dir,
+            migration.sql_text(),
+            control.as_ref(),
+        );
+    };
+    ensure_same_migration(&migration, &locked)?;
+    let completed = transaction.run(|connection| {
+        manifest::finalize_schema_migration_in_transaction(connection, requested_shards, &locked)
+    })?;
+    hook(SchemaMigrationCoordinatorPoint::FinalizationPrepared)?;
+    transaction.commit()?;
+    hook(SchemaMigrationCoordinatorPoint::FinalizationCommitted)?;
+    schema_coordination
+        .publish_schema_generation(completed.source_generation(), completed.target_generation())
+}
+
+fn finish_completed_by_sql(
+    manifest_connection: &mut Connection,
+    requested_shards: u16,
+    schema_coordination: &RootSchemaCoordination,
+    layout: &shard::ShardLayout,
+    shards_dir: &Path,
+    sql: &str,
+    control: Option<&Arc<OperationControl>>,
+) -> EngineResult<()> {
+    let completed = match classify_schema_migration(
+        manifest_connection,
+        requested_shards,
+        layout,
+        sql,
+        control,
+    )? {
+        SchemaMigrationClassification::Complete(completed) => completed,
+        SchemaMigrationClassification::Active(_) | SchemaMigrationClassification::Absent => {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "schema migration changed while it was being applied",
+            ));
+        }
+    };
+    validate_schema_migration_prefix(
+        shards_dir,
+        requested_shards,
+        requested_shards,
+        completed.source_generation(),
+        completed.target_generation(),
+        layout,
+        control,
+    )?;
+    schema_coordination
+        .publish_schema_generation(completed.source_generation(), completed.target_generation())
+}
+
+fn finish_completed_schema_migration(
+    storage: &Storage,
+    migration: &SchemaMigration,
+    control: Option<&Arc<OperationControl>>,
+) -> EngineResult<()> {
+    let current = storage.current_schema_generation();
+    if current <= migration.target_generation() {
+        if current != migration.source_generation() && current != migration.target_generation() {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "completed schema migration does not match the loaded catalog generation",
+            ));
+        }
+        validate_schema_migration_prefix(
+            &storage.root.join("shards"),
+            storage.shard_count(),
+            storage.shard_count(),
+            migration.source_generation(),
+            migration.target_generation(),
+            &storage.shard_layout,
+            control,
+        )?;
+        return storage.publish_schema_generation(
+            migration.source_generation(),
+            migration.target_generation(),
+        );
+    }
+
+    // A retained older history row remains idempotent after later migrations.
+    // Validate every shard at the live generation rather than requiring it to
+    // regress to this row's historical target.
+    for shard_id in 0..storage.shard_count() {
+        check_cancelled(control.map(Arc::as_ref))?;
+        match control {
+            None => drop(storage.open_shard(shard_id)?),
+            Some(control) => {
+                let mut connection = storage.open_unconfigured_shard(shard_id)?;
+                run_connection_controlled(&mut connection, Arc::clone(control), |connection| {
+                    storage.validate_unconfigured_shard(connection, shard_id)
+                })?;
+            }
+        }
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn validate_schema_migration_prefix(
+    shards_dir: &Path,
+    shard_count: u16,
+    next_shard: u16,
+    source_generation: u64,
+    target_generation: u64,
+    layout: &shard::ShardLayout,
+    control: Option<&Arc<OperationControl>>,
+) -> EngineResult<Option<shard::SchemaMigrationShardState>> {
+    let Some(control) = control else {
+        return shard::validate_schema_migration_prefix(
+            shards_dir,
+            shard_count,
+            next_shard,
+            source_generation,
+            target_generation,
+            layout,
+        );
+    };
+    shard::validate_schema_migration_prefix_with(
+        shards_dir,
+        shard_count,
+        next_shard,
+        source_generation,
+        target_generation,
+        layout,
+        |path, shard_id| {
+            let mut connection = shard::open_required_file(path)?;
+            run_connection_controlled(&mut connection, Arc::clone(control), |connection| {
+                shard::validate_schema_migration_connection(
+                    connection,
+                    path,
+                    shard_id,
+                    source_generation,
+                    target_generation,
+                    layout,
+                )
+            })
+        },
+    )
+}
+
+fn preflight_one_shard(
+    path: &Path,
+    shard_id: u16,
+    source_generation: u64,
+    target_generation: u64,
+    layout: &shard::ShardLayout,
+    sql: &str,
+    control: Option<&Arc<OperationControl>>,
+) -> EngineResult<shard::SchemaMigrationShardState> {
+    match control {
+        None => shard::preflight_schema_migration(
+            path,
+            shard_id,
+            source_generation,
+            target_generation,
+            layout,
+            sql,
+        ),
+        Some(control) => {
+            let mut connection = shard::open_required_file(path)?;
+            run_connection_controlled(&mut connection, Arc::clone(control), |connection| {
+                shard::preflight_schema_migration_on_connection(
+                    connection,
+                    path,
+                    shard_id,
+                    source_generation,
+                    target_generation,
+                    layout,
+                    sql,
+                )
+            })
+        }
+    }
+}
+
+fn apply_one_shard(
+    path: &Path,
+    shard_id: u16,
+    source_generation: u64,
+    target_generation: u64,
+    layout: &shard::ShardLayout,
+    sql: &str,
+    control: Option<&Arc<OperationControl>>,
+) -> EngineResult<()> {
+    match control {
+        None => shard::apply_schema_migration(
+            path,
+            shard_id,
+            source_generation,
+            target_generation,
+            layout,
+            sql,
+        )
+        .map(|_| ()),
+        Some(control) => {
+            let mut connection = shard::open_required_file(path)?;
+            run_connection_controlled(&mut connection, Arc::clone(control), |connection| {
+                shard::apply_schema_migration_on_connection(
+                    connection,
+                    path,
+                    shard_id,
+                    source_generation,
+                    target_generation,
+                    layout,
+                    sql,
+                )
+                .map(|_| ())
+            })
+        }
+    }
+}
+
+fn run_connection_controlled<T, F>(
+    connection: &mut Connection,
+    control: Arc<OperationControl>,
+    work: F,
+) -> EngineResult<T>
+where
+    F: FnOnce(&mut Connection) -> EngineResult<T>,
+{
+    let _busy_operation = MigrationBusyGuard::install(Arc::clone(&control));
+    connection
+        .busy_handler(Some(cancellable_busy_handler))
+        .map_err(sqlite_error::storage)?;
+    let progress_control = Arc::clone(&control);
+    if let Err(error) =
+        connection.progress_handler(1_000, Some(move || progress_control.should_stop()))
+    {
+        let _ = connection.busy_timeout(CONNECTION_BUSY_TIMEOUT);
+        return Err(sqlite_error::storage(error)
+            .context("failed to install the schema-migration progress hook"));
+    }
+    let interrupt_handle = connection.get_interrupt_handle();
+    if let Err(reason) = control.arm(Arc::new(move || interrupt_handle.interrupt())) {
+        let _ = connection.progress_handler(0, None::<fn() -> bool>);
+        let _ = connection.busy_timeout(CONNECTION_BUSY_TIMEOUT);
+        return Err(reason.error());
+    }
+
+    let outcome = catch_unwind(AssertUnwindSafe(|| work(connection)));
+    let progress_cleanup = connection
+        .progress_handler(0, None::<fn() -> bool>)
+        .map_err(sqlite_error::storage);
+    let busy_cleanup = connection
+        .busy_timeout(CONNECTION_BUSY_TIMEOUT)
+        .map_err(sqlite_error::storage);
+    let reason = control.disarm();
+
+    let result = match outcome {
+        Ok(result) => result,
+        Err(payload) => {
+            let _ = progress_cleanup;
+            let _ = busy_cleanup;
+            resume_unwind(payload)
+        }
+    };
+    match (result, progress_cleanup, busy_cleanup, reason) {
+        (Ok(_), Err(error), _, _) => {
+            Err(error.context("failed to remove the schema-migration progress hook"))
+        }
+        (Ok(_), Ok(()), Err(error), _) => {
+            Err(error.context("failed to restore the schema-migration busy timeout"))
+        }
+        (Ok(value), Ok(()), Ok(()), _) => Ok(value),
+        (Err(_), _, _, Some(reason)) => Err(reason.error()),
+        (Err(error), _, _, None) => Err(error),
+    }
+}
+
+fn ensure_active_matches_catalog(
+    migration: &SchemaMigration,
+    catalog: &CatalogSnapshot,
+    requested_shards: u16,
+) -> EngineResult<()> {
+    if !migration.is_applying()
+        || migration.shard_count() != requested_shards
+        || migration.source_generation() != catalog.logical().schema_generation()
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "active schema migration does not match the loaded catalog",
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_same_migration(
+    expected: &SchemaMigration,
+    observed: &SchemaMigration,
+) -> EngineResult<()> {
+    if expected.source_generation() != observed.source_generation()
+        || expected.target_generation() != observed.target_generation()
+        || expected.migration_id() != observed.migration_id()
+        || expected.sql_text() != observed.sql_text()
+        || expected.shard_count() != observed.shard_count()
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "schema migration identity changed while it was being applied",
+        ));
+    }
+    Ok(())
+}
+
+fn check_cancelled(control: Option<&OperationControl>) -> EngineResult<()> {
+    match control.and_then(OperationControl::reason) {
+        Some(CancellationReason::Cancelled) => Err(CancellationReason::Cancelled.error()),
+        Some(CancellationReason::DeadlineExceeded) => {
+            Err(CancellationReason::DeadlineExceeded.error())
+        }
+        None => Ok(()),
+    }
+}
+
+fn sanitized_shard_error(error: EngineError, phase: &str, shard_id: u16) -> EngineError {
+    EngineError::new(
+        error.kind(),
+        format!("schema migration {phase} failed on shard {shard_id}"),
+    )
+}
+
+fn shard_path(shards_dir: &Path, shard_id: u16) -> PathBuf {
+    shards_dir.join(format!("{shard_id:04}.sqlite"))
+}
+
+fn all_shards(shard_count: u16) -> Vec<u16> {
+    (0..shard_count).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs,
+        panic::{AssertUnwindSafe, catch_unwind},
+        process::Command,
+    };
+
+    use rusqlite::OptionalExtension;
+
+    use super::*;
+    use crate::storage::SchemaGateState;
+
+    const MIGRATION_SQL: &str =
+        "CREATE TABLE migration_marker (id INTEGER PRIMARY KEY, value TEXT NOT NULL)";
+
+    #[derive(Debug, Clone, Copy)]
+    struct ExpectedBoundary {
+        point: SchemaMigrationCoordinatorPoint,
+        manifest_generation: i64,
+        state: i64,
+        next_shard: i64,
+        shard_generations: [i64; 2],
+    }
+
+    const BOUNDARIES: &[ExpectedBoundary] = &[
+        ExpectedBoundary {
+            point: SchemaMigrationCoordinatorPoint::JournalCommitted,
+            manifest_generation: 0,
+            state: 1,
+            next_shard: 0,
+            shard_generations: [0, 0],
+        },
+        ExpectedBoundary {
+            point: SchemaMigrationCoordinatorPoint::ShardCommitted(0),
+            manifest_generation: 0,
+            state: 1,
+            next_shard: 0,
+            shard_generations: [1, 0],
+        },
+        ExpectedBoundary {
+            point: SchemaMigrationCoordinatorPoint::ProgressPrepared(0),
+            manifest_generation: 0,
+            state: 1,
+            next_shard: 0,
+            shard_generations: [1, 0],
+        },
+        ExpectedBoundary {
+            point: SchemaMigrationCoordinatorPoint::ProgressCommitted(0),
+            manifest_generation: 0,
+            state: 1,
+            next_shard: 1,
+            shard_generations: [1, 0],
+        },
+        ExpectedBoundary {
+            point: SchemaMigrationCoordinatorPoint::ShardCommitted(1),
+            manifest_generation: 0,
+            state: 1,
+            next_shard: 1,
+            shard_generations: [1, 1],
+        },
+        ExpectedBoundary {
+            point: SchemaMigrationCoordinatorPoint::ProgressPrepared(1),
+            manifest_generation: 0,
+            state: 1,
+            next_shard: 1,
+            shard_generations: [1, 1],
+        },
+        ExpectedBoundary {
+            point: SchemaMigrationCoordinatorPoint::ProgressCommitted(1),
+            manifest_generation: 0,
+            state: 1,
+            next_shard: 2,
+            shard_generations: [1, 1],
+        },
+        ExpectedBoundary {
+            point: SchemaMigrationCoordinatorPoint::FinalizationPrepared,
+            manifest_generation: 0,
+            state: 1,
+            next_shard: 2,
+            shard_generations: [1, 1],
+        },
+        ExpectedBoundary {
+            point: SchemaMigrationCoordinatorPoint::FinalizationCommitted,
+            manifest_generation: 1,
+            state: 2,
+            next_shard: 2,
+            shard_generations: [1, 1],
+        },
+    ];
+
+    fn run_with_hook<F>(storage: &Storage, hook: F) -> EngineResult<Vec<u16>>
+    where
+        F: FnMut(SchemaMigrationCoordinatorPoint) -> EngineResult<()>,
+    {
+        run_sql_with_hook(storage, MIGRATION_SQL, hook)
+    }
+
+    fn run_sql_with_hook<F>(storage: &Storage, sql: &str, hook: F) -> EngineResult<Vec<u16>>
+    where
+        F: FnMut(SchemaMigrationCoordinatorPoint) -> EngineResult<()>,
+    {
+        let mut guard = storage.begin_schema_migration()?;
+        guard.wait_for_quiescence_blocking();
+        let completed = apply_schema_migration_with_hook(storage, sql, &mut guard, None, hook)?;
+        guard.publish_ready()?;
+        Ok(completed)
+    }
+
+    fn fail_at(
+        expected: SchemaMigrationCoordinatorPoint,
+    ) -> impl FnMut(SchemaMigrationCoordinatorPoint) -> EngineResult<()> {
+        move |observed| {
+            if observed == expected {
+                Err(EngineError::new(
+                    EngineErrorKind::Internal,
+                    "injected coordinator failure",
+                ))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    fn journal_snapshot(root: &Path) -> (i64, i64, i64) {
+        Connection::open(root.join("manifest.sqlite"))
+            .unwrap()
+            .query_row(
+                "SELECT c.schema_generation, m.migration_state, m.next_shard
+                 FROM briskdb_schema_catalog AS c
+                 JOIN briskdb_schema_migrations AS m
+                 WHERE c.singleton = 1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap()
+    }
+
+    fn active_journal_snapshot(root: &Path) -> Option<(i64, i64, i64)> {
+        Connection::open(root.join("manifest.sqlite"))
+            .unwrap()
+            .query_row(
+                "SELECT c.schema_generation, m.migration_state, m.next_shard
+                 FROM briskdb_schema_catalog AS c
+                 JOIN briskdb_schema_migrations AS m
+                 WHERE c.singleton = 1 AND m.migration_state = 1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .optional()
+            .unwrap()
+    }
+
+    fn manifest_generation_and_history(root: &Path, file_name: &str) -> (i64, i64) {
+        Connection::open(root.join(file_name))
+            .unwrap()
+            .query_row(
+                "SELECT c.schema_generation,
+                        (SELECT COUNT(*) FROM briskdb_schema_migrations)
+                 FROM briskdb_schema_catalog AS c
+                 WHERE c.singleton = 1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap()
+    }
+
+    fn shard_generations(root: &Path) -> [i64; 2] {
+        std::array::from_fn(|shard| {
+            Connection::open(root.join("shards").join(format!("{shard:04}.sqlite")))
+                .unwrap()
+                .pragma_query_value(None, "user_version", |row| row.get(0))
+                .unwrap()
+        })
+    }
+
+    fn assert_boundary(root: &Path, expected: ExpectedBoundary) {
+        assert_eq!(
+            journal_snapshot(root),
+            (
+                expected.manifest_generation,
+                expected.state,
+                expected.next_shard,
+            ),
+            "unexpected manifest state at {:?}",
+            expected.point
+        );
+        assert_eq!(
+            shard_generations(root),
+            expected.shard_generations,
+            "unexpected shard prefix at {:?}",
+            expected.point
+        );
+    }
+
+    fn assert_complete(storage: &Storage, root: &Path) {
+        assert_eq!(storage.current_schema_generation(), 1);
+        assert_eq!(journal_snapshot(root), (1, 2, 2));
+        assert_eq!(shard_generations(root), [1, 1]);
+        for shard in 0..2 {
+            assert!(
+                storage
+                    .open_shard(shard)
+                    .unwrap()
+                    .query_row(
+                        "SELECT EXISTS(
+                        SELECT 1 FROM sqlite_schema
+                        WHERE type = 'table' AND name = 'migration_marker'
+                     )",
+                        [],
+                        |row| row.get::<_, bool>(0),
+                    )
+                    .unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn every_coordinator_error_boundary_is_exact_pending_and_idempotently_resumable() {
+        for expected in BOUNDARIES {
+            let temp = tempfile::tempdir().unwrap();
+            let storage = Storage::open(temp.path(), 2).unwrap();
+            let error = run_with_hook(&storage, fail_at(expected.point)).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::Internal);
+            assert_eq!(
+                storage.schema_gate_snapshot().state,
+                SchemaGateState::Pending,
+                "gate was not pending at {:?}",
+                expected.point
+            );
+            assert_boundary(temp.path(), *expected);
+            assert_eq!(
+                storage.enter_schema_operation().unwrap_err().kind(),
+                EngineErrorKind::FailedPrecondition
+            );
+
+            assert_eq!(run_with_hook(&storage, |_| Ok(())).unwrap(), [0, 1]);
+            assert_eq!(storage.schema_gate_snapshot().state, SchemaGateState::Ready);
+            assert_complete(&storage, temp.path());
+            // Exact SQL is the durable idempotency identity.
+            assert_eq!(run_with_hook(&storage, |_| Ok(())).unwrap(), [0, 1]);
+        }
+    }
+
+    #[test]
+    fn every_coordinator_panic_boundary_rolls_back_or_retains_only_durable_progress() {
+        for expected in BOUNDARIES {
+            let temp = tempfile::tempdir().unwrap();
+            let storage = Storage::open(temp.path(), 2).unwrap();
+            let panic = catch_unwind(AssertUnwindSafe(|| {
+                run_with_hook(&storage, |observed| {
+                    if observed == expected.point {
+                        panic!("injected coordinator panic at {observed:?}");
+                    }
+                    Ok(())
+                })
+            }));
+            assert!(panic.is_err(), "hook did not panic at {:?}", expected.point);
+            assert_eq!(
+                storage.schema_gate_snapshot().state,
+                SchemaGateState::Pending
+            );
+            assert_boundary(temp.path(), *expected);
+
+            assert_eq!(run_with_hook(&storage, |_| Ok(())).unwrap(), [0, 1]);
+            assert_complete(&storage, temp.path());
+        }
+    }
+
+    #[test]
+    fn startup_resumes_every_durable_partial_shape_before_returning_ready() {
+        for expected in BOUNDARIES {
+            let temp = tempfile::tempdir().unwrap();
+            let storage = Storage::open(temp.path(), 2).unwrap();
+            run_with_hook(&storage, fail_at(expected.point)).unwrap_err();
+            assert_boundary(temp.path(), *expected);
+            drop(storage);
+
+            let reopened = Storage::open(temp.path(), 2).unwrap();
+            assert_eq!(
+                reopened.schema_gate_snapshot().state,
+                SchemaGateState::Ready
+            );
+            assert_complete(&reopened, temp.path());
+        }
+    }
+
+    #[test]
+    fn cancellation_after_journal_commit_leaves_pending_and_retry_completes() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = Storage::open(temp.path(), 2).unwrap();
+        let control = OperationControl::new(None);
+        let mut guard = storage.begin_schema_migration().unwrap();
+        guard.wait_for_quiescence_blocking();
+        let cancellation = Arc::clone(&control);
+        let error = apply_schema_migration_with_hook(
+            &storage,
+            MIGRATION_SQL,
+            &mut guard,
+            Some(control),
+            move |point| {
+                if point == SchemaMigrationCoordinatorPoint::JournalCommitted {
+                    cancellation.request_cancel(CancellationReason::Cancelled);
+                }
+                Ok(())
+            },
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Cancelled);
+        drop(guard);
+        assert_eq!(
+            storage.schema_gate_snapshot().state,
+            SchemaGateState::Pending
+        );
+        assert_eq!(journal_snapshot(temp.path()), (0, 1, 0));
+        assert_eq!(shard_generations(temp.path()), [0, 0]);
+
+        assert_eq!(run_with_hook(&storage, |_| Ok(())).unwrap(), [0, 1]);
+        assert_complete(&storage, temp.path());
+    }
+
+    #[test]
+    fn an_older_exact_sql_identity_remains_idempotent_after_later_migrations() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = Storage::open(temp.path(), 2).unwrap();
+        assert_eq!(run_with_hook(&storage, |_| Ok(())).unwrap(), [0, 1]);
+
+        let mut second = storage.begin_schema_migration().unwrap();
+        second.wait_for_quiescence_blocking();
+        assert_eq!(
+            apply_schema_migration_with_hook(
+                &storage,
+                "ALTER TABLE migration_marker ADD COLUMN revision INTEGER NOT NULL DEFAULT 0",
+                &mut second,
+                None,
+                |_| Ok(()),
+            )
+            .unwrap(),
+            [0, 1]
+        );
+        second.publish_ready().unwrap();
+        assert_eq!(storage.current_schema_generation(), 2);
+
+        assert_eq!(run_with_hook(&storage, |_| Ok(())).unwrap(), [0, 1]);
+        assert_eq!(storage.current_schema_generation(), 2);
+        for shard in 0..2 {
+            assert_eq!(
+                storage
+                    .open_shard(shard)
+                    .unwrap()
+                    .query_row(
+                        "SELECT COUNT(*) FROM pragma_table_info('migration_marker')",
+                        [],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .unwrap(),
+                3
+            );
+        }
+    }
+
+    #[test]
+    fn manifest_lock_wait_observes_deadline_without_the_fixed_busy_timeout_delay() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = Storage::open(temp.path(), 2).unwrap();
+        let owner = Connection::open(temp.path().join("manifest.sqlite")).unwrap();
+        owner.execute_batch("BEGIN IMMEDIATE").unwrap();
+
+        let control = OperationControl::new(Some(Instant::now() + Duration::from_millis(50)));
+        let mut guard = storage.begin_schema_migration().unwrap();
+        guard.wait_for_quiescence_blocking();
+        let started = Instant::now();
+        let error = apply_schema_migration_with_hook(
+            &storage,
+            MIGRATION_SQL,
+            &mut guard,
+            Some(control),
+            |_| Ok(()),
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DeadlineExceeded);
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "manifest lock ignored the request deadline"
+        );
+        drop(guard);
+        assert_eq!(storage.schema_gate_snapshot().state, SchemaGateState::Ready);
+        assert_eq!(
+            owner
+                .query_row(
+                    "SELECT COUNT(*) FROM briskdb_schema_migrations",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            0
+        );
+
+        owner.execute_batch("ROLLBACK").unwrap();
+        assert_eq!(run_with_hook(&storage, |_| Ok(())).unwrap(), [0, 1]);
+        assert_complete(&storage, temp.path());
+    }
+
+    #[test]
+    fn post_commit_journal_cleanup_failure_keeps_gate_pending_and_retry_heals() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = Storage::open(temp.path(), 2).unwrap();
+        let mut guard = storage.begin_schema_migration().unwrap();
+        guard.wait_for_quiescence_blocking();
+        let mut manifest_connection =
+            open_existing_manifest(&temp.path().join("manifest.sqlite")).unwrap();
+        configure_manifest_connection(&manifest_connection).unwrap();
+        configure_journal_mode(&manifest_connection).unwrap();
+        let control = OperationControl::new(None);
+        FAIL_NEXT_MANIFEST_COMMIT_CLEANUP.with(|fail| fail.set(true));
+
+        let error = begin_schema_migration(
+            &mut manifest_connection,
+            2,
+            &storage.shard_layout,
+            0,
+            MIGRATION_SQL,
+            Some(&control),
+            &mut guard,
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Internal);
+        assert!(manifest_connection.is_autocommit());
+        drop(manifest_connection);
+        drop(guard);
+
+        assert_eq!(
+            storage.schema_gate_snapshot().state,
+            SchemaGateState::Pending
+        );
+        assert_eq!(active_journal_snapshot(temp.path()), Some((0, 1, 0)));
+        assert_eq!(shard_generations(temp.path()), [0, 0]);
+        assert_eq!(run_with_hook(&storage, |_| Ok(())).unwrap(), [0, 1]);
+        assert_eq!(storage.schema_gate_snapshot().state, SchemaGateState::Ready);
+        assert_complete(&storage, temp.path());
+    }
+
+    #[test]
+    fn manifest_history_scan_observes_deadline_and_rolls_back_its_transaction() {
+        const HISTORY_ROWS: i64 = 20_000;
+
+        let temp = tempfile::tempdir().unwrap();
+        let storage = Storage::open(temp.path(), 2).unwrap();
+        let layout = storage.shard_layout;
+        drop(storage);
+        let mut manifest_connection =
+            Connection::open(temp.path().join("manifest.sqlite")).unwrap();
+        configure_manifest_connection(&manifest_connection).unwrap();
+        manifest_connection
+            .execute_batch("BEGIN IMMEDIATE")
+            .unwrap();
+        {
+            let mut insert = manifest_connection
+                .prepare(
+                    "INSERT INTO briskdb_schema_migrations (
+                         target_generation,
+                         source_generation,
+                         migration_id,
+                         digest_version,
+                         sql_text,
+                         shard_count,
+                         migration_state,
+                         next_shard
+                     ) VALUES (?1, ?2, ?3, 1, ?4, 2, 2, 2)",
+                )
+                .unwrap();
+            for target_generation in 1..=HISTORY_ROWS {
+                let sql = format!("SELECT {target_generation}");
+                let migration_id = manifest::schema_migration_id(&sql).unwrap();
+                insert
+                    .execute(rusqlite::params![
+                        target_generation,
+                        target_generation - 1,
+                        migration_id.as_slice(),
+                        sql,
+                    ])
+                    .unwrap();
+            }
+        }
+        manifest_connection
+            .execute(
+                "UPDATE briskdb_schema_catalog SET schema_generation = ?1 WHERE singleton = 1",
+                [HISTORY_ROWS],
+            )
+            .unwrap();
+        manifest_connection.execute_batch("COMMIT").unwrap();
+
+        let control = OperationControl::new(Some(Instant::now() + Duration::from_millis(5)));
+        let started = Instant::now();
+        let error = classify_schema_migration(
+            &mut manifest_connection,
+            2,
+            &layout,
+            "SELECT absent_migration",
+            Some(&control),
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DeadlineExceeded);
+        assert!(started.elapsed() < Duration::from_secs(1));
+        assert!(manifest_connection.is_autocommit());
+        assert_eq!(
+            manifest::classify_schema_migration(
+                &mut manifest_connection,
+                2,
+                "SELECT absent_migration",
+            )
+            .unwrap(),
+            SchemaMigrationClassification::Absent
+        );
+    }
+
+    #[test]
+    fn active_prefix_validation_observes_deadline_on_a_real_shard_lock() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = Storage::open(temp.path(), 2).unwrap();
+        run_with_hook(
+            &storage,
+            fail_at(SchemaMigrationCoordinatorPoint::JournalCommitted),
+        )
+        .unwrap_err();
+        assert_eq!(
+            storage.schema_gate_snapshot().state,
+            SchemaGateState::Pending
+        );
+
+        let blocker = Connection::open(temp.path().join("shards/0000.sqlite")).unwrap();
+        blocker.execute_batch("BEGIN EXCLUSIVE").unwrap();
+        let control = OperationControl::new(Some(Instant::now() + Duration::from_millis(50)));
+        let mut guard = storage.begin_schema_migration().unwrap();
+        guard.wait_for_quiescence_blocking();
+        let started = Instant::now();
+        let error = apply_schema_migration_with_hook(
+            &storage,
+            MIGRATION_SQL,
+            &mut guard,
+            Some(control),
+            |_| Ok(()),
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DeadlineExceeded);
+        assert!(started.elapsed() < Duration::from_secs(1));
+        drop(guard);
+        assert_eq!(
+            storage.schema_gate_snapshot().state,
+            SchemaGateState::Pending
+        );
+
+        blocker.execute_batch("ROLLBACK").unwrap();
+        assert_eq!(run_with_hook(&storage, |_| Ok(())).unwrap(), [0, 1]);
+        assert_complete(&storage, temp.path());
+    }
+
+    #[test]
+    fn same_process_reopen_recovers_finalization_commit_before_publication() {
+        let temp = tempfile::tempdir().unwrap();
+        let original = Storage::open(temp.path(), 2).unwrap();
+        let error = run_with_hook(
+            &original,
+            fail_at(SchemaMigrationCoordinatorPoint::FinalizationCommitted),
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Internal);
+        assert_eq!(original.current_schema_generation(), 0);
+        assert_eq!(
+            original.schema_gate_snapshot().state,
+            SchemaGateState::Pending
+        );
+        assert_boundary(
+            temp.path(),
+            ExpectedBoundary {
+                point: SchemaMigrationCoordinatorPoint::FinalizationCommitted,
+                manifest_generation: 1,
+                state: 2,
+                next_shard: 2,
+                shard_generations: [1, 1],
+            },
+        );
+
+        let reopened = Storage::open(temp.path(), 2).unwrap();
+        assert_eq!(original.current_schema_generation(), 1);
+        assert_eq!(reopened.current_schema_generation(), 1);
+        assert_eq!(
+            original.schema_gate_snapshot().state,
+            SchemaGateState::Ready
+        );
+        for shard_id in 0..2 {
+            drop(original.open_shard(shard_id).unwrap());
+            drop(reopened.open_shard(shard_id).unwrap());
+        }
+    }
+
+    #[test]
+    fn historical_retry_cannot_publish_ready_over_a_different_active_journal() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = Storage::open(temp.path(), 2).unwrap();
+        assert_eq!(run_with_hook(&storage, |_| Ok(())).unwrap(), [0, 1]);
+        let active_sql = "CREATE TABLE second_migration_marker (id INTEGER)";
+        let error = run_sql_with_hook(
+            &storage,
+            active_sql,
+            fail_at(SchemaMigrationCoordinatorPoint::JournalCommitted),
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Internal);
+        assert_eq!(storage.current_schema_generation(), 1);
+        assert_eq!(
+            storage.schema_gate_snapshot().state,
+            SchemaGateState::Pending
+        );
+        assert_eq!(active_journal_snapshot(temp.path()), Some((1, 1, 0)));
+        assert_eq!(shard_generations(temp.path()), [1, 1]);
+
+        let started = Instant::now();
+        let conflict = run_with_hook(&storage, |_| Ok(())).unwrap_err();
+        assert_eq!(conflict.kind(), EngineErrorKind::FailedPrecondition);
+        assert!(started.elapsed() < Duration::from_secs(1));
+        assert_eq!(
+            storage.schema_gate_snapshot().state,
+            SchemaGateState::Pending
+        );
+        assert_eq!(active_journal_snapshot(temp.path()), Some((1, 1, 0)));
+        assert_eq!(shard_generations(temp.path()), [1, 1]);
+
+        assert_eq!(
+            run_sql_with_hook(&storage, active_sql, |_| Ok(())).unwrap(),
+            [0, 1]
+        );
+        assert_eq!(storage.current_schema_generation(), 2);
+        assert_eq!(storage.schema_gate_snapshot().state, SchemaGateState::Ready);
+    }
+
+    #[test]
+    fn absent_migration_rejects_unjournaled_target_generation_shards() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = Storage::open(temp.path(), 2).unwrap();
+        let advanced = Connection::open(temp.path().join("shards/0000.sqlite")).unwrap();
+        advanced
+            .execute_batch(
+                "CREATE TABLE unrelated_schema (id INTEGER);
+                 PRAGMA user_version = 1;",
+            )
+            .unwrap();
+        drop(advanced);
+
+        let error = run_with_hook(&storage, |_| Ok(())).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+        assert_eq!(storage.current_schema_generation(), 0);
+        assert_eq!(storage.schema_gate_snapshot().state, SchemaGateState::Ready);
+        let manifest = Connection::open(temp.path().join("manifest.sqlite")).unwrap();
+        assert_eq!(
+            manifest
+                .query_row(
+                    "SELECT schema_generation FROM briskdb_schema_catalog WHERE singleton = 1",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            manifest
+                .query_row(
+                    "SELECT COUNT(*) FROM briskdb_schema_migrations",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            0
+        );
+        for (shard_id, expected_generation) in [(0, 1), (1, 0)] {
+            let shard = Connection::open(
+                temp.path()
+                    .join("shards")
+                    .join(format!("{shard_id:04}.sqlite")),
+            )
+            .unwrap();
+            assert_eq!(
+                shard
+                    .pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
+                    .unwrap(),
+                expected_generation
+            );
+            assert!(
+                !shard
+                    .query_row(
+                        "SELECT EXISTS(
+                            SELECT 1 FROM sqlite_schema WHERE name = 'migration_marker'
+                         )",
+                        [],
+                        |row| row.get::<_, bool>(0),
+                    )
+                    .unwrap()
+            );
+            assert_eq!(
+                shard
+                    .query_row(
+                        "SELECT EXISTS(
+                            SELECT 1 FROM sqlite_schema WHERE name = 'unrelated_schema'
+                         )",
+                        [],
+                        |row| row.get::<_, bool>(0),
+                    )
+                    .unwrap(),
+                shard_id == 0
+            );
+        }
+    }
+
+    #[test]
+    fn deferred_foreign_key_failure_is_rejected_before_journaling_or_shard_commit() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = Storage::open(temp.path(), 2).unwrap();
+        let baseline_sql = "CREATE TABLE parent (id INTEGER PRIMARY KEY);
+                            CREATE TABLE selector (value INTEGER NOT NULL);";
+        assert_eq!(
+            run_sql_with_hook(&storage, baseline_sql, |_| Ok(())).unwrap(),
+            [0, 1]
+        );
+        storage
+            .open_shard(1)
+            .unwrap()
+            .execute("INSERT INTO selector VALUES (999)", [])
+            .unwrap();
+
+        let deferred_sql = "CREATE TABLE child (
+                                parent_id INTEGER REFERENCES parent(id)
+                                    DEFERRABLE INITIALLY DEFERRED
+                            );
+                            INSERT INTO child SELECT value FROM selector;";
+        let error = run_sql_with_hook(&storage, deferred_sql, |_| Ok(())).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::ForeignKeyViolation);
+        assert_eq!(storage.current_schema_generation(), 1);
+        assert_eq!(storage.schema_gate_snapshot().state, SchemaGateState::Ready);
+        let manifest = Connection::open(temp.path().join("manifest.sqlite")).unwrap();
+        assert_eq!(
+            manifest
+                .query_row(
+                    "SELECT COUNT(*) FROM briskdb_schema_migrations",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            1
+        );
+        assert!(active_journal_snapshot(temp.path()).is_none());
+        assert_eq!(shard_generations(temp.path()), [1, 1]);
+        for shard_id in 0..2 {
+            let shard = storage.open_shard(shard_id).unwrap();
+            assert!(
+                !shard
+                    .query_row(
+                        "SELECT EXISTS(SELECT 1 FROM sqlite_schema WHERE name = 'child')",
+                        [],
+                        |row| row.get::<_, bool>(0),
+                    )
+                    .unwrap()
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn runtime_manifest_symlink_and_cross_layout_replacement_fail_before_mutation() {
+        let first_root = tempfile::tempdir().unwrap();
+        let second_root = tempfile::tempdir().unwrap();
+        let first = Storage::open(first_root.path(), 2).unwrap();
+        let second = Storage::open(second_root.path(), 2).unwrap();
+        let manifest_path = first_root.path().join("manifest.sqlite");
+        let original_manifest_path = first_root.path().join("original-manifest.sqlite");
+        fs::rename(&manifest_path, &original_manifest_path).unwrap();
+        std::os::unix::fs::symlink(second_root.path().join("manifest.sqlite"), &manifest_path)
+            .unwrap();
+
+        let symlink_error = run_with_hook(&first, |_| Ok(())).unwrap_err();
+        assert_eq!(symlink_error.kind(), EngineErrorKind::FailedPrecondition);
+        assert_eq!(first.schema_gate_snapshot().state, SchemaGateState::Ready);
+        assert_eq!(first.current_schema_generation(), 0);
+        assert_eq!(second.current_schema_generation(), 0);
+        assert_eq!(
+            manifest_generation_and_history(first_root.path(), "original-manifest.sqlite"),
+            (0, 0)
+        );
+        assert_eq!(
+            manifest_generation_and_history(second_root.path(), "manifest.sqlite"),
+            (0, 0)
+        );
+
+        fs::remove_file(&manifest_path).unwrap();
+        fs::copy(second_root.path().join("manifest.sqlite"), &manifest_path).unwrap();
+        let replacement_error = run_with_hook(&first, |_| Ok(())).unwrap_err();
+        assert_eq!(replacement_error.kind(), EngineErrorKind::DataCorruption);
+        assert_eq!(first.schema_gate_snapshot().state, SchemaGateState::Ready);
+        assert_eq!(
+            manifest_generation_and_history(first_root.path(), "manifest.sqlite"),
+            (0, 0)
+        );
+        assert_eq!(
+            manifest_generation_and_history(second_root.path(), "manifest.sqlite"),
+            (0, 0)
+        );
+        assert_eq!(shard_generations(first_root.path()), [0, 0]);
+        assert_eq!(shard_generations(second_root.path()), [0, 0]);
+        for root in [first_root.path(), second_root.path()] {
+            for shard_id in 0..2 {
+                assert!(
+                    !Connection::open(root.join("shards").join(format!("{shard_id:04}.sqlite")))
+                        .unwrap()
+                        .query_row(
+                            "SELECT EXISTS(
+                                SELECT 1 FROM sqlite_schema WHERE name = 'migration_marker'
+                             )",
+                            [],
+                            |row| row.get::<_, bool>(0),
+                        )
+                        .unwrap()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn schema_migration_crash_child() {
+        let Ok(root) = std::env::var("BRISKDB_SCHEMA_CRASH_ROOT") else {
+            return;
+        };
+        let crash_point = std::env::var("BRISKDB_SCHEMA_CRASH_POINT").unwrap();
+        let storage = Storage::open(root, 2).unwrap();
+        let mut guard = storage.begin_schema_migration().unwrap();
+        guard.wait_for_quiescence_blocking();
+        let _ =
+            apply_schema_migration_with_hook(&storage, MIGRATION_SQL, &mut guard, None, |point| {
+                if crash_point == point_name(point) {
+                    std::process::abort();
+                }
+                Ok(())
+            });
+        panic!("child did not reach requested crash point {crash_point}");
+    }
+
+    #[test]
+    fn real_process_abort_is_resumed_at_key_durable_boundaries() {
+        for crash_point in [
+            "journal",
+            "shard-0",
+            "progress-0",
+            "finalization-prepared",
+            "finalization-committed",
+        ] {
+            let temp = tempfile::tempdir().unwrap();
+            let status = Command::new(std::env::current_exe().unwrap())
+                .arg("--exact")
+                .arg("storage::migration::tests::schema_migration_crash_child")
+                .arg("--nocapture")
+                .env("BRISKDB_SCHEMA_CRASH_ROOT", temp.path())
+                .env("BRISKDB_SCHEMA_CRASH_POINT", crash_point)
+                .status()
+                .unwrap();
+            assert!(!status.success(), "child did not abort at {crash_point}");
+
+            let reopened = Storage::open(temp.path(), 2).unwrap();
+            assert_complete(&reopened, temp.path());
+        }
+    }
+
+    fn point_name(point: SchemaMigrationCoordinatorPoint) -> &'static str {
+        match point {
+            SchemaMigrationCoordinatorPoint::JournalCommitted => "journal",
+            SchemaMigrationCoordinatorPoint::ShardCommitted(0) => "shard-0",
+            SchemaMigrationCoordinatorPoint::ProgressCommitted(0) => "progress-0",
+            SchemaMigrationCoordinatorPoint::FinalizationPrepared => "finalization-prepared",
+            SchemaMigrationCoordinatorPoint::FinalizationCommitted => "finalization-committed",
+            SchemaMigrationCoordinatorPoint::ShardCommitted(_)
+            | SchemaMigrationCoordinatorPoint::ProgressPrepared(_)
+            | SchemaMigrationCoordinatorPoint::ProgressCommitted(_) => "other",
+        }
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,24 +1,34 @@
 //! SQLite file layout, versioned manifest management, and connection configuration.
 
 mod manifest;
+mod migration;
+mod schema_gate;
 mod shard;
 
 pub(crate) mod pool;
 pub(crate) use pool::{ConnectionOwner, ConnectionPools, PooledConnection};
 
 use std::{
+    collections::HashMap,
     fs,
     path::{Path, PathBuf},
     sync::{
-        Arc,
+        Arc, Mutex, OnceLock, Weak,
         atomic::{AtomicBool, Ordering},
     },
+    time::Instant,
 };
 
 use rusqlite::{
-    Connection,
+    Connection, OpenFlags,
     hooks::{AuthAction, AuthContext, Authorization},
 };
+
+#[cfg(test)]
+pub(crate) use migration::SchemaMigrationCoordinatorPoint;
+#[cfg(test)]
+pub(crate) use schema_gate::{SchemaGateSnapshot, SchemaGateState};
+pub(crate) use schema_gate::{SchemaMigrationGuard, SchemaOperationGuard};
 
 pub use crate::core::Database;
 use crate::{
@@ -28,11 +38,167 @@ use crate::{
 
 pub(crate) const CONNECTION_BUSY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
+#[derive(Debug)]
+struct RootSchemaCoordination {
+    gate: schema_gate::SchemaGate,
+    catalogs: Mutex<Vec<Weak<CatalogSnapshot>>>,
+}
+
+impl RootSchemaCoordination {
+    fn new() -> Self {
+        Self {
+            gate: schema_gate::SchemaGate::new(),
+            catalogs: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn register_catalog(&self, loaded: CatalogSnapshot) -> EngineResult<Arc<CatalogSnapshot>> {
+        let loaded = Arc::new(loaded);
+        let mut catalogs = self.catalogs.lock().map_err(|error| {
+            EngineError::new(
+                EngineErrorKind::Internal,
+                format!("root schema catalog coordination is poisoned: {error}"),
+            )
+        })?;
+        catalogs.retain(|catalog| catalog.strong_count() != 0);
+        catalogs.push(Arc::downgrade(&loaded));
+        Ok(loaded)
+    }
+
+    fn publish_schema_generation(
+        &self,
+        expected_generation: u64,
+        target_generation: u64,
+    ) -> EngineResult<()> {
+        let mut catalogs = self.catalogs.lock().map_err(|error| {
+            EngineError::new(
+                EngineErrorKind::Internal,
+                format!("root schema catalog coordination is poisoned: {error}"),
+            )
+        })?;
+        catalogs.retain(|catalog| catalog.strong_count() != 0);
+        let live = catalogs
+            .iter()
+            .filter_map(Weak::upgrade)
+            .collect::<Vec<_>>();
+
+        if let Some(observed) = live
+            .iter()
+            .map(|catalog| catalog.logical().schema_generation())
+            .find(|generation| {
+                *generation != expected_generation && *generation != target_generation
+            })
+        {
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                format!(
+                    "cannot publish schema generation {target_generation}; a live catalog is at generation {observed}"
+                ),
+            ));
+        }
+
+        for catalog in live {
+            catalog
+                .logical()
+                .publish_schema_generation(expected_generation, target_generation)?;
+        }
+        Ok(())
+    }
+
+    fn reconcile_validated_catalog_generation(
+        &self,
+        validated: &CatalogSnapshot,
+    ) -> EngineResult<()> {
+        let target_generation = validated.logical().schema_generation();
+        let mut catalogs = self.catalogs.lock().map_err(|error| {
+            EngineError::new(
+                EngineErrorKind::Internal,
+                format!("root schema catalog coordination is poisoned: {error}"),
+            )
+        })?;
+        catalogs.retain(|catalog| catalog.strong_count() != 0);
+        let live = catalogs
+            .iter()
+            .filter_map(Weak::upgrade)
+            .collect::<Vec<_>>();
+
+        if live
+            .iter()
+            .all(|catalog| catalog.logical().schema_generation() == target_generation)
+        {
+            return Ok(());
+        }
+        let source_generation = target_generation.checked_sub(1).ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "validated manifest generation conflicts with a live catalog",
+            )
+        })?;
+        if live.iter().any(|catalog| {
+            !matches!(
+                catalog.logical().schema_generation(),
+                generation if generation == source_generation || generation == target_generation
+            )
+        }) {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "validated manifest generation conflicts with a live catalog",
+            ));
+        }
+
+        for catalog in live {
+            catalog
+                .logical()
+                .publish_schema_generation(source_generation, target_generation)?;
+        }
+        Ok(())
+    }
+}
+
+static ROOT_SCHEMA_COORDINATIONS: OnceLock<Mutex<HashMap<PathBuf, Weak<RootSchemaCoordination>>>> =
+    OnceLock::new();
+
+fn root_schema_coordination(root: &Path) -> EngineResult<Arc<RootSchemaCoordination>> {
+    let registry = ROOT_SCHEMA_COORDINATIONS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut registry = registry.lock().map_err(|error| {
+        EngineError::new(
+            EngineErrorKind::Internal,
+            format!("root schema coordination registry is poisoned: {error}"),
+        )
+    })?;
+    registry.retain(|_, coordination| coordination.strong_count() != 0);
+    if let Some(coordination) = registry.get(root).and_then(Weak::upgrade) {
+        return Ok(coordination);
+    }
+    let coordination = Arc::new(RootSchemaCoordination::new());
+    registry.insert(root.to_path_buf(), Arc::downgrade(&coordination));
+    Ok(coordination)
+}
+
+fn begin_startup_coordination(
+    coordination: &RootSchemaCoordination,
+) -> EngineResult<SchemaMigrationGuard> {
+    let started = Instant::now();
+    loop {
+        match coordination.gate.begin_migration() {
+            Ok(guard) => return Ok(guard),
+            Err(error)
+                if error.kind() == EngineErrorKind::Busy
+                    && started.elapsed() < CONNECTION_BUSY_TIMEOUT =>
+            {
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct Storage {
     root: PathBuf,
     catalog: Arc<CatalogSnapshot>,
     shard_layout: shard::ShardLayout,
+    schema_coordination: Arc<RootSchemaCoordination>,
 }
 
 impl Storage {
@@ -43,13 +209,16 @@ impl Storage {
         fs::create_dir_all(&root).map_err(|error| {
             sqlite_error::storage_io(error, format!("failed to create {}", root.display()))
         })?;
+        let root = fs::canonicalize(&root).map_err(|error| {
+            sqlite_error::storage_io(error, format!("failed to resolve {}", root.display()))
+        })?;
+        let schema_coordination = root_schema_coordination(&root)?;
+        let mut startup = begin_startup_coordination(&schema_coordination)?;
+        startup.wait_for_quiescence_blocking();
         let shards_dir = root.join("shards");
         let fresh_layout_allowed = physical_layout_is_empty(&shards_dir)?;
         let manifest_path = root.join("manifest.sqlite");
-        let mut manifest = Connection::open(&manifest_path).map_err(|error| {
-            sqlite_error::storage(error)
-                .context(format!("failed to open {}", manifest_path.display()))
-        })?;
+        let mut manifest = open_manifest_for_startup(&manifest_path)?;
         configure_manifest_connection(&manifest)?;
         let loaded = manifest::load_or_create_manifest_with_fresh_layout(
             &mut manifest,
@@ -57,7 +226,21 @@ impl Storage {
             fresh_layout_allowed,
         )?;
         configure_journal_mode(&manifest)?;
-        let (catalog, shard_layout) = loaded.into_parts();
+        let (catalog, shard_layout, active_migration) = loaded.into_parts_with_migration();
+        let catalog = schema_coordination.register_catalog(catalog)?;
+
+        if let Some(active_migration) = active_migration {
+            startup.mark_pending_on_drop();
+            migration::resume_schema_migration_on_startup(
+                &root,
+                &mut manifest,
+                requested_shards,
+                &catalog,
+                &shard_layout,
+                &schema_coordination,
+                active_migration,
+            )?;
+        }
         let schema_generation = catalog.logical().schema_generation();
 
         let ready_layout = manifest::reconcile_shard_layout(
@@ -76,12 +259,17 @@ impl Storage {
 
         let storage = Self {
             root,
-            catalog: Arc::new(catalog),
+            catalog,
             shard_layout: ready_layout,
+            schema_coordination,
         };
         for shard in 0..storage.shard_count() {
             storage.open_shard(shard)?;
         }
+        storage
+            .schema_coordination
+            .reconcile_validated_catalog_generation(&storage.catalog)?;
+        startup.publish_ready()?;
         Ok(storage)
     }
 
@@ -95,6 +283,51 @@ impl Storage {
 
     pub(crate) fn logical_catalog(&self) -> &Catalog {
         self.catalog.logical()
+    }
+
+    pub(crate) fn current_schema_generation(&self) -> u64 {
+        self.catalog.logical().schema_generation()
+    }
+
+    pub(crate) fn enter_schema_operation(&self) -> EngineResult<SchemaOperationGuard> {
+        self.schema_coordination.gate.try_acquire_operation()
+    }
+
+    pub(crate) fn begin_schema_migration(&self) -> EngineResult<SchemaMigrationGuard> {
+        self.schema_coordination.gate.begin_migration()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn install_schema_migration_test_block(
+        &self,
+        point: SchemaMigrationCoordinatorPoint,
+        started: std::sync::mpsc::Sender<()>,
+        release: std::sync::mpsc::Receiver<()>,
+    ) -> EngineResult<()> {
+        migration::install_schema_migration_test_block(&self.root, point, started, release)
+    }
+
+    fn publish_schema_generation(
+        &self,
+        expected_generation: u64,
+        target_generation: u64,
+    ) -> EngineResult<()> {
+        self.schema_coordination
+            .publish_schema_generation(expected_generation, target_generation)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn schema_gate_snapshot(&self) -> SchemaGateSnapshot {
+        self.schema_coordination.gate.snapshot()
+    }
+
+    pub(crate) fn apply_schema_migration(
+        &self,
+        sql: &str,
+        guard: &mut SchemaMigrationGuard,
+        control: Option<Arc<crate::core::OperationControl>>,
+    ) -> EngineResult<Vec<u16>> {
+        migration::apply_schema_migration(self, sql, guard, control)
     }
 
     fn shard_path(&self, shard: u16) -> PathBuf {
@@ -337,6 +570,105 @@ fn configure_manifest_connection(connection: &Connection) -> EngineResult<()> {
     Ok(())
 }
 
+fn open_manifest_for_startup(path: &Path) -> EngineResult<Connection> {
+    validate_optional_manifest_file(path)?;
+    let flags = OpenFlags::SQLITE_OPEN_READ_WRITE
+        | OpenFlags::SQLITE_OPEN_CREATE
+        | OpenFlags::SQLITE_OPEN_NO_MUTEX
+        | OpenFlags::SQLITE_OPEN_NOFOLLOW
+        | OpenFlags::SQLITE_OPEN_EXRESCODE;
+    let open_path = canonical_manifest_open_path(path)?;
+    let connection = Connection::open_with_flags(open_path, flags).map_err(|error| {
+        sqlite_error::storage(error).context(format!("failed to open {}", path.display()))
+    })?;
+    validate_existing_manifest_file(path)?;
+    Ok(connection)
+}
+
+pub(super) fn open_existing_manifest(path: &Path) -> EngineResult<Connection> {
+    validate_existing_manifest_file(path)?;
+    let flags = OpenFlags::SQLITE_OPEN_READ_WRITE
+        | OpenFlags::SQLITE_OPEN_NO_MUTEX
+        | OpenFlags::SQLITE_OPEN_NOFOLLOW
+        | OpenFlags::SQLITE_OPEN_EXRESCODE;
+    let open_path = canonical_manifest_open_path(path)?;
+    let connection = Connection::open_with_flags(open_path, flags).map_err(|error| {
+        sqlite_error::storage(error).context(format!("failed to open {}", path.display()))
+    })?;
+    validate_existing_manifest_file(path)?;
+    Ok(connection)
+}
+
+fn validate_optional_manifest_file(path: &Path) -> EngineResult<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if !metadata.file_type().is_symlink() && metadata.is_file() => Ok(()),
+        Ok(_) => Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!("manifest {} is not a real file", path.display()),
+        )),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(sqlite_error::storage_io(
+            error,
+            format!("failed to inspect {}", path.display()),
+        )),
+    }
+}
+
+fn validate_existing_manifest_file(path: &Path) -> EngineResult<()> {
+    let metadata = fs::symlink_metadata(path).map_err(|error| {
+        if error.kind() == std::io::ErrorKind::NotFound {
+            EngineError::from_source(
+                EngineErrorKind::DataCorruption,
+                format!("required manifest {} is missing", path.display()),
+                error,
+            )
+        } else {
+            sqlite_error::storage_io(error, format!("failed to inspect {}", path.display()))
+        }
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!("manifest {} is not a real file", path.display()),
+        ));
+    }
+    Ok(())
+}
+
+fn canonical_manifest_open_path(path: &Path) -> EngineResult<PathBuf> {
+    let parent = path.parent().ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!("manifest path {} has no parent directory", path.display()),
+        )
+    })?;
+    let parent_metadata = fs::symlink_metadata(parent).map_err(|error| {
+        sqlite_error::storage_io(
+            error,
+            format!("failed to inspect manifest directory {}", parent.display()),
+        )
+    })?;
+    if parent_metadata.file_type().is_symlink() || !parent_metadata.is_dir() {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!("manifest path {} is not a real directory", parent.display()),
+        ));
+    }
+    let file_name = path.file_name().ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!("manifest path {} has no file name", path.display()),
+        )
+    })?;
+    let canonical_parent = fs::canonicalize(parent).map_err(|error| {
+        sqlite_error::storage_io(
+            error,
+            format!("failed to resolve manifest directory {}", parent.display()),
+        )
+    })?;
+    Ok(canonical_parent.join(file_name))
+}
+
 fn configure_journal_mode(connection: &Connection) -> EngineResult<()> {
     let mode = connection
         .pragma_update_and_check(None, "journal_mode", "WAL", |row| row.get::<_, String>(0))
@@ -503,6 +835,85 @@ mod tests {
                 (layout_id.clone(), shard_id)
             );
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn canonical_and_symlink_roots_share_migration_coordination() {
+        let temp = tempfile::tempdir().unwrap();
+        let original = Storage::open(temp.path(), 2).unwrap();
+        let alias_parent = tempfile::tempdir().unwrap();
+        let alias_path = alias_parent.path().join("database-alias");
+        std::os::unix::fs::symlink(temp.path(), &alias_path).unwrap();
+        let alias = Storage::open(&alias_path, 2).unwrap();
+
+        assert!(Arc::ptr_eq(
+            &original.schema_coordination,
+            &alias.schema_coordination
+        ));
+        let mut migration = alias.begin_schema_migration().unwrap();
+        migration.wait_for_quiescence_blocking();
+        assert_eq!(
+            original.enter_schema_operation().unwrap_err().kind(),
+            EngineErrorKind::Busy
+        );
+        assert_eq!(
+            alias
+                .apply_schema_migration(
+                    "CREATE TABLE canonical_root_marker (id INTEGER)",
+                    &mut migration,
+                    None,
+                )
+                .unwrap(),
+            [0, 1]
+        );
+        migration.publish_ready().unwrap();
+
+        assert_eq!(original.current_schema_generation(), 1);
+        assert_eq!(alias.current_schema_generation(), 1);
+        for shard_id in 0..2 {
+            assert!(
+                original
+                    .open_shard(shard_id)
+                    .unwrap()
+                    .query_row(
+                        "SELECT EXISTS(
+                            SELECT 1 FROM sqlite_schema WHERE name = 'canonical_root_marker'
+                         )",
+                        [],
+                        |row| row.get::<_, bool>(0),
+                    )
+                    .unwrap()
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn startup_rejects_a_symlinked_manifest_without_mutating_its_target() {
+        let target_root = tempfile::tempdir().unwrap();
+        drop(Storage::open(target_root.path(), 2).unwrap());
+        let target_manifest = target_root.path().join("manifest.sqlite");
+        let before = fs::read(&target_manifest).unwrap();
+
+        let victim_root = tempfile::tempdir().unwrap();
+        std::os::unix::fs::symlink(&target_manifest, victim_root.path().join("manifest.sqlite"))
+            .unwrap();
+        let error = Storage::open(victim_root.path(), 2).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert!(!victim_root.path().join("shards").exists());
+        assert_eq!(fs::read(&target_manifest).unwrap(), before);
+        assert_eq!(
+            Connection::open(&target_manifest)
+                .unwrap()
+                .query_row(
+                    "SELECT schema_generation FROM briskdb_schema_catalog WHERE singleton = 1",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            0
+        );
     }
 
     #[test]
@@ -1094,16 +1505,23 @@ mod tests {
     fn every_connection_surface_denies_storage_owned_sql_and_preserves_identity() {
         let temp = tempfile::tempdir().unwrap();
         let storage = Storage::open(temp.path(), 2).unwrap();
+        let mut migration = storage.begin_schema_migration().unwrap();
+        migration.wait_for_quiescence_blocking();
+        storage
+            .apply_schema_migration(
+                "CREATE TABLE application_rows (id INTEGER PRIMARY KEY)",
+                &mut migration,
+                None,
+            )
+            .unwrap();
+        migration.publish_ready().unwrap();
 
         for connection in [
             storage.open_shard(0).unwrap(),
             storage.open_pooled_shard(0).unwrap().0,
         ] {
             connection
-                .execute_batch(
-                    "CREATE TABLE IF NOT EXISTS application_rows (id INTEGER PRIMARY KEY);
-                     INSERT OR IGNORE INTO application_rows VALUES (1);",
-                )
+                .execute_batch("INSERT OR IGNORE INTO application_rows VALUES (1);")
                 .unwrap();
             for statement in [
                 "PRAGMA application_id = 7",
@@ -1114,6 +1532,8 @@ mod tests {
                 "SELECT * FROM briskdb_shard_metadata",
                 "DROP TABLE briskdb_shard_metadata",
                 "CREATE TABLE briskdb_future (id INTEGER)",
+                "CREATE TABLE denied_application_table (id INTEGER)",
+                "DROP TABLE application_rows",
                 "ALTER TABLE application_rows RENAME TO briskdb_future",
             ] {
                 assert!(
@@ -1143,7 +1563,7 @@ mod tests {
         assert_eq!(
             raw.pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
                 .unwrap(),
-            0
+            i64::try_from(storage.current_schema_generation()).unwrap()
         );
         assert_eq!(
             raw.pragma_query_value(None, "journal_mode", |row| row.get::<_, String>(0))
@@ -1157,6 +1577,12 @@ mod tests {
     fn protocol_neutral_database_surfaces_report_storage_denials() {
         let temp = tempfile::tempdir().unwrap();
         let database = Database::open(temp.path(), 2).unwrap();
+        assert_eq!(
+            database
+                .broadcast("CREATE TABLE migration_only (id INTEGER PRIMARY KEY)")
+                .unwrap(),
+            [0, 1]
+        );
 
         let pragma = database
             .execute("tenant", "PRAGMA user_version = 7", &[])
@@ -1166,9 +1592,38 @@ mod tests {
             .query("tenant", "SELECT shard_id FROM briskdb_shard_metadata", &[])
             .unwrap_err();
         assert_eq!(metadata.kind(), EngineErrorKind::PermissionDenied);
+        let routed_ddl = database
+            .execute(
+                "tenant",
+                "CREATE TABLE bypassed_migration (id INTEGER)",
+                &[],
+            )
+            .unwrap_err();
+        assert_eq!(routed_ddl.kind(), EngineErrorKind::PermissionDenied);
         let broadcast = database
             .broadcast("UPDATE briskdb_shard_metadata SET shard_id = 1")
             .unwrap_err();
         assert_eq!(broadcast.kind(), EngineErrorKind::PermissionDenied);
+        for shard_id in 0..2 {
+            let shard = Connection::open(shard_file(temp.path(), shard_id)).unwrap();
+            assert!(
+                shard
+                    .query_row(
+                        "SELECT EXISTS(SELECT 1 FROM sqlite_schema WHERE name = 'migration_only')",
+                        [],
+                        |row| row.get::<_, bool>(0),
+                    )
+                    .unwrap()
+            );
+            assert!(
+                !shard
+                    .query_row(
+                        "SELECT EXISTS(SELECT 1 FROM sqlite_schema WHERE name = 'bypassed_migration')",
+                        [],
+                        |row| row.get::<_, bool>(0),
+                    )
+                    .unwrap()
+            );
+        }
     }
 }

--- a/src/storage/pool.rs
+++ b/src/storage/pool.rs
@@ -187,6 +187,7 @@ impl ConnectionPools {
     }
 
     /// Reserve one slot on every shard in deterministic shard order.
+    #[cfg(test)]
     pub(crate) async fn acquire_all_for_owner(
         &self,
         owner: ConnectionOwner,
@@ -226,6 +227,15 @@ impl ConnectionPools {
         let closed = closing.len();
         drop(closing);
         Ok(closed)
+    }
+
+    /// Retire every idle handle before an application-schema migration starts.
+    ///
+    /// The migration coordinator calls this only after schema-operation
+    /// admission is quiescent, so no checked-out handle can race back into the
+    /// pool while the shard generation changes.
+    pub(crate) fn retire_idle_for_schema_migration(&self) -> EngineResult<usize> {
+        self.close_idle()
     }
 
     #[cfg(test)]
@@ -481,8 +491,18 @@ impl ShardPoolInner {
         owner: ConnectionOwner,
         control: Option<Arc<OperationControl>>,
     ) -> EngineResult<ManagedConnection> {
-        let (reusable, foreign_write_connection) = {
+        let current_schema_generation = self.storage.current_schema_generation();
+        let (reusable, foreign_write_connection, stale_connections) = {
             let mut idle = self.lock_idle()?;
+            let mut stale_connections = Vec::new();
+            let mut index = 0;
+            while index < idle.len() {
+                if idle[index].schema_generation == current_schema_generation {
+                    index += 1;
+                } else {
+                    stale_connections.push(idle.swap_remove(index));
+                }
+            }
             let reusable_index = idle
                 .iter()
                 .position(|connection| connection.write_owner == Some(owner))
@@ -495,17 +515,28 @@ impl ShardPoolInner {
                     idle.iter()
                         .position(|connection| connection.write_owner.is_none())
                 });
-            match reusable_index {
+            let (reusable, foreign_write_connection) = match reusable_index {
                 Some(index) => (Some(idle.swap_remove(index)), None),
                 None => (None, idle.pop()),
-            }
+            };
+            (reusable, foreign_write_connection, stale_connections)
         };
 
+        for connection in stale_connections {
+            self.retire(connection);
+        }
         if let Some(connection) = foreign_write_connection {
             self.retire(connection);
         }
 
         if let Some(connection) = reusable {
+            if connection.schema_generation != self.storage.current_schema_generation() {
+                self.retire(connection);
+                return match control {
+                    Some(control) => self.open_connection_controlled(control),
+                    None => self.open_connection(),
+                };
+            }
             connection.hygiene.wrote.store(false, Ordering::Relaxed);
             #[cfg(test)]
             self.reused.fetch_add(1, Ordering::Relaxed);
@@ -519,14 +550,16 @@ impl ShardPoolInner {
     }
 
     fn open_connection(&self) -> EngineResult<ManagedConnection> {
+        let schema_generation = self.storage.current_schema_generation();
         let (connection, hygiene) = self.storage.open_pooled_shard(self.shard)?;
-        Ok(self.managed_connection(connection, hygiene))
+        Ok(self.managed_connection(connection, hygiene, schema_generation))
     }
 
     fn open_connection_controlled(
         &self,
         control: Arc<OperationControl>,
     ) -> EngineResult<ManagedConnection> {
+        let schema_generation = self.storage.current_schema_generation();
         let mut connection = self.storage.open_unconfigured_shard(self.shard)?;
         configure_connection_controlled(
             &mut connection,
@@ -537,7 +570,7 @@ impl ShardPoolInner {
             self.take_setup_hook(),
         )?;
         let (connection, hygiene) = self.storage.attach_pool_hygiene(connection)?;
-        Ok(self.managed_connection(connection, hygiene))
+        Ok(self.managed_connection(connection, hygiene, schema_generation))
     }
 
     #[cfg(test)]
@@ -568,6 +601,7 @@ impl ShardPoolInner {
         &self,
         connection: Connection,
         hygiene: ConnectionHygiene,
+        schema_generation: u64,
     ) -> ManagedConnection {
         #[cfg(test)]
         let id = self.next_connection_id.fetch_add(1, Ordering::Relaxed);
@@ -578,6 +612,7 @@ impl ShardPoolInner {
             id,
             connection,
             hygiene,
+            schema_generation,
             write_owner: None,
             origin_owner: None,
         }
@@ -590,6 +625,11 @@ impl ShardPoolInner {
     }
 
     fn check_in(&self, mut connection: ManagedConnection, owner: ConnectionOwner, broken: bool) {
+        if connection.schema_generation != self.storage.current_schema_generation() {
+            self.retire(connection);
+            return;
+        }
+
         let panicking = std::thread::panicking();
         let was_in_transaction = !connection.connection.is_autocommit();
         let mut cleanup_failed = false;
@@ -623,6 +663,7 @@ struct ManagedConnection {
     id: u64,
     connection: Connection,
     hygiene: ConnectionHygiene,
+    schema_generation: u64,
     write_owner: Option<ConnectionOwner>,
     origin_owner: Option<ConnectionOwner>,
 }
@@ -847,16 +888,6 @@ impl PooledConnection {
         preparation_failed || probe.requires_fresh_connection()
     }
 
-    pub(crate) fn ensure_owner_local_controlled(
-        &mut self,
-        control: Arc<OperationControl>,
-    ) -> EngineResult<()> {
-        if self.borrowed_from_other_owner {
-            self.replace_with_fresh_controlled(control)?;
-        }
-        Ok(())
-    }
-
     #[cfg(test)]
     fn replace_with_fresh(&mut self) -> EngineResult<()> {
         let previous = self
@@ -1014,6 +1045,45 @@ mod tests {
         (temp, pools)
     }
 
+    fn pools_with_schema(
+        pool_size: usize,
+        queue_capacity: usize,
+        sql: &str,
+    ) -> (tempfile::TempDir, ConnectionPools) {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = Storage::open(temp.path(), 2).unwrap();
+        let mut migration = storage.begin_schema_migration().unwrap();
+        migration.wait_for_quiescence_blocking();
+        storage
+            .apply_schema_migration(sql, &mut migration, None)
+            .unwrap();
+        migration.publish_ready().unwrap();
+        let pools = ConnectionPools::new(storage, pool_size, queue_capacity).unwrap();
+        (temp, pools)
+    }
+
+    fn advance_schema_generation(
+        temp: &tempfile::TempDir,
+        pools: &ConnectionPools,
+        source_generation: u64,
+        target_generation: u64,
+    ) {
+        let target_user_version = i64::try_from(target_generation).unwrap();
+        for shard in 0..pools.shards.len() {
+            let path = temp.path().join(format!("shards/{shard:04}.sqlite"));
+            Connection::open(path)
+                .unwrap()
+                .pragma_update(None, "user_version", target_user_version)
+                .unwrap();
+        }
+        pools.shards[0]
+            .inner
+            .storage
+            .logical_catalog()
+            .publish_schema_generation(source_generation, target_generation)
+            .unwrap();
+    }
+
     async fn wait_for_occupancy(pools: &ConnectionPools, shard: u16, active: usize, queued: usize) {
         timeout(Duration::from_secs(2), async {
             loop {
@@ -1117,6 +1187,69 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn stale_idle_generation_is_retired_before_checkout() {
+        let (temp, pools) = pools(1, 0);
+        let first = pools.acquire(0).await.unwrap().checkout().unwrap();
+        let first_id = first.connection_id();
+        drop(first);
+
+        advance_schema_generation(&temp, &pools, 0, 1);
+
+        let replacement = pools.acquire(0).await.unwrap().checkout().unwrap();
+        assert_ne!(replacement.connection_id(), first_id);
+        drop(replacement);
+
+        let snapshot = pools.snapshot().unwrap().shards[0];
+        assert_eq!(snapshot.opened, 2);
+        assert_eq!(snapshot.checkouts, 2);
+        assert_eq!(snapshot.reused, 0);
+        assert_eq!(snapshot.retired, 1);
+        assert_eq!(snapshot.idle, 1);
+    }
+
+    #[tokio::test]
+    async fn checked_out_connection_from_a_stale_generation_is_retired_on_checkin() {
+        let (temp, pools) = pools(1, 0);
+        let first = pools.acquire(0).await.unwrap().checkout().unwrap();
+        let first_id = first.connection_id();
+
+        advance_schema_generation(&temp, &pools, 0, 1);
+        drop(first);
+
+        let stale = pools.snapshot().unwrap().shards[0];
+        assert_eq!(stale.opened, 1);
+        assert_eq!(stale.retired, 1);
+        assert_eq!(stale.idle, 0);
+
+        let replacement = pools.acquire(0).await.unwrap().checkout().unwrap();
+        assert_ne!(replacement.connection_id(), first_id);
+        drop(replacement);
+
+        let recovered = pools.snapshot().unwrap().shards[0];
+        assert_eq!(recovered.opened, 2);
+        assert_eq!(recovered.retired, 1);
+        assert_eq!(recovered.idle, 1);
+    }
+
+    #[tokio::test]
+    async fn schema_migration_idle_retirement_drains_every_shard() {
+        let (_temp, pools) = pools(1, 0);
+        for shard in 0..2 {
+            drop(pools.acquire(shard).await.unwrap().checkout().unwrap());
+        }
+
+        assert_eq!(pools.retire_idle_for_schema_migration().unwrap(), 2);
+        assert!(
+            pools
+                .snapshot()
+                .unwrap()
+                .shards
+                .iter()
+                .all(|shard| shard.idle == 0)
+        );
+    }
+
+    #[tokio::test]
     async fn lazy_open_preserves_storage_error_classification() {
         let (temp, pools) = pools(1, 0);
         fs::write(
@@ -1135,10 +1268,13 @@ mod tests {
 
     #[tokio::test]
     async fn ordinary_implicit_dml_can_reuse_a_connection_within_one_owner() {
-        let (_temp, pools) = pools(1, 0);
+        let (_temp, pools) = pools_with_schema(
+            1,
+            0,
+            "CREATE TABLE widgets (id INTEGER PRIMARY KEY, value INTEGER)",
+        );
         let mut expected_id = None;
         for sql in [
-            "CREATE TABLE widgets (id INTEGER PRIMARY KEY, value INTEGER)",
             "INSERT INTO widgets (id, value) VALUES (1, 10)",
             "UPDATE widgets SET value = 20 WHERE id = 1",
             "DELETE FROM widgets WHERE id = 1",
@@ -1152,14 +1288,15 @@ mod tests {
 
         let snapshot = pools.snapshot().unwrap().shards[0];
         assert_eq!(snapshot.opened, 1);
-        assert_eq!(snapshot.reused, 3);
+        assert_eq!(snapshot.reused, 2);
         assert_eq!(snapshot.retired, 0);
         assert_eq!(snapshot.idle, 1);
     }
 
     #[tokio::test]
     async fn write_local_sqlite_state_never_crosses_connection_owners() {
-        let (_temp, pools) = pools(1, 0);
+        let (_temp, pools) =
+            pools_with_schema(1, 0, "CREATE TABLE widgets (id INTEGER PRIMARY KEY)");
         let first_owner = ConnectionOwner::new(11);
         let second_owner = ConnectionOwner::new(22);
         let third_owner = ConnectionOwner::new(33);
@@ -1171,10 +1308,7 @@ mod tests {
             .checkout()
             .unwrap();
         first
-            .execute_batch(
-                "CREATE TABLE widgets (id INTEGER PRIMARY KEY);
-                 INSERT INTO widgets (id) VALUES (1);",
-            )
+            .execute_batch("INSERT INTO widgets (id) VALUES (1);")
             .unwrap();
         let first_id = first.connection_id();
         assert_eq!(
@@ -1243,12 +1377,8 @@ mod tests {
 
     #[tokio::test]
     async fn a_foreign_write_moves_to_a_fresh_handle_and_keeps_its_own_counters() {
-        let (_temp, pools) = pools(1, 0);
-        let setup = pools.shards[0].inner.storage.open_shard(0).unwrap();
-        setup
-            .execute_batch("CREATE TABLE widgets (id INTEGER PRIMARY KEY)")
-            .unwrap();
-        drop(setup);
+        let (_temp, pools) =
+            pools_with_schema(1, 0, "CREATE TABLE widgets (id INTEGER PRIMARY KEY)");
 
         let first_owner = ConnectionOwner::new(11);
         let writer = ConnectionOwner::new(22);
@@ -1330,7 +1460,11 @@ mod tests {
 
     #[tokio::test]
     async fn connection_local_sql_on_a_foreign_read_handle_moves_to_a_fresh_connection() {
-        let (_temp, pools) = pools(2, 0);
+        let (_temp, pools) = pools_with_schema(
+            2,
+            0,
+            "CREATE TABLE data_version_marker (id INTEGER PRIMARY KEY)",
+        );
         let first_owner = ConnectionOwner::new(11);
         let writer = ConnectionOwner::new(22);
         let observer = ConnectionOwner::new(33);
@@ -1351,7 +1485,7 @@ mod tests {
             .checkout()
             .unwrap();
         writer_connection
-            .execute_batch("CREATE TABLE data_version_marker (id INTEGER PRIMARY KEY)")
+            .execute_batch("INSERT INTO data_version_marker VALUES (1)")
             .unwrap();
         drop(writer_connection);
         drop(first);
@@ -1595,11 +1729,9 @@ mod tests {
 
     #[tokio::test]
     async fn ordinary_sql_errors_return_a_clean_connection_to_the_pool() {
-        let (_temp, pools) = pools(1, 0);
+        let (_temp, pools) =
+            pools_with_schema(1, 0, "CREATE TABLE widgets (id INTEGER PRIMARY KEY)");
         let connection = pools.acquire(0).await.unwrap().checkout().unwrap();
-        connection
-            .execute_batch("CREATE TABLE widgets (id INTEGER PRIMARY KEY)")
-            .unwrap();
         connection
             .execute("INSERT INTO widgets (id) VALUES (1)", [])
             .unwrap();
@@ -1624,11 +1756,9 @@ mod tests {
 
     #[tokio::test]
     async fn non_autocommit_state_is_rolled_back_before_a_tainted_connection_retires() {
-        let (_temp, pools) = pools(1, 0);
+        let (_temp, pools) =
+            pools_with_schema(1, 0, "CREATE TABLE widgets (id INTEGER PRIMARY KEY)");
         let connection = pools.acquire(0).await.unwrap().checkout().unwrap();
-        connection
-            .execute_batch("CREATE TABLE widgets (id INTEGER PRIMARY KEY)")
-            .unwrap();
         let original_id = connection.connection_id();
         drop(connection);
 

--- a/src/storage/schema_gate.rs
+++ b/src/storage/schema_gate.rs
@@ -1,0 +1,425 @@
+//! In-process admission and quiescence for application-schema migrations.
+
+use std::sync::{Arc, Condvar, Mutex, MutexGuard};
+
+use tokio::sync::Notify;
+
+use crate::core::{EngineError, EngineErrorKind, EngineResult};
+
+/// Current application-schema admission state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SchemaGateState {
+    /// Ordinary operations may be admitted.
+    Ready,
+    /// A migration guard is excluding new ordinary operations while existing
+    /// operations drain or migration work runs.
+    Migrating,
+    /// A durable partial migration must be resumed before ordinary work can run.
+    Pending,
+}
+
+/// One deterministic view of schema admission and current occupancy.
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SchemaGateSnapshot {
+    pub(crate) state: SchemaGateState,
+    pub(crate) active_operations: usize,
+}
+
+#[derive(Debug)]
+struct GateData {
+    state: SchemaGateState,
+    active_operations: usize,
+}
+
+#[derive(Debug)]
+struct SchemaGateInner {
+    data: Mutex<GateData>,
+    blocking_quiesced: Condvar,
+    async_quiesced: Notify,
+}
+
+impl SchemaGateInner {
+    fn lock(&self) -> MutexGuard<'_, GateData> {
+        self.data
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn release_operation(&self) {
+        let quiesced = {
+            let mut data = self.lock();
+            data.active_operations = data
+                .active_operations
+                .checked_sub(1)
+                .expect("a schema operation guard releases exactly one admission");
+            data.active_operations == 0
+        };
+
+        if quiesced {
+            self.blocking_quiesced.notify_all();
+            self.async_quiesced.notify_waiters();
+        }
+    }
+}
+
+/// Shared application-schema admission gate.
+#[derive(Debug, Clone)]
+pub(crate) struct SchemaGate {
+    inner: Arc<SchemaGateInner>,
+}
+
+impl SchemaGate {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Arc::new(SchemaGateInner {
+                data: Mutex::new(GateData {
+                    state: SchemaGateState::Ready,
+                    active_operations: 0,
+                }),
+                blocking_quiesced: Condvar::new(),
+                async_quiesced: Notify::new(),
+            }),
+        }
+    }
+
+    /// Return a coherent snapshot for status and diagnostics.
+    #[cfg(test)]
+    pub(crate) fn snapshot(&self) -> SchemaGateSnapshot {
+        let data = self.inner.lock();
+        SchemaGateSnapshot {
+            state: data.state,
+            active_operations: data.active_operations,
+        }
+    }
+
+    /// Admit one ordinary operation only while the application schema is ready.
+    pub(crate) fn try_acquire_operation(&self) -> EngineResult<SchemaOperationGuard> {
+        let mut data = self.inner.lock();
+        match data.state {
+            SchemaGateState::Ready => {
+                data.active_operations =
+                    data.active_operations.checked_add(1).ok_or_else(|| {
+                        EngineError::new(
+                            EngineErrorKind::Internal,
+                            "application-schema operation count overflowed",
+                        )
+                    })?;
+                Ok(SchemaOperationGuard {
+                    inner: Arc::clone(&self.inner),
+                })
+            }
+            SchemaGateState::Migrating => Err(EngineError::new(
+                EngineErrorKind::Busy,
+                "an application-schema migration is in progress",
+            )),
+            SchemaGateState::Pending => Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "a partial application-schema migration must be resumed",
+            )),
+        }
+    }
+
+    /// Exclude new ordinary work and create the sole migration coordinator.
+    ///
+    /// A ready gate begins new work and therefore restores `Ready` if the
+    /// guard is cancelled before a durable journal is published. A pending
+    /// gate begins recovery and restores `Pending` on cancellation.
+    pub(crate) fn begin_migration(&self) -> EngineResult<SchemaMigrationGuard> {
+        let mut data = self.inner.lock();
+        let restore_state = match data.state {
+            SchemaGateState::Ready => SchemaGateState::Ready,
+            SchemaGateState::Pending => SchemaGateState::Pending,
+            SchemaGateState::Migrating => {
+                return Err(EngineError::new(
+                    EngineErrorKind::Busy,
+                    "an application-schema migration is already in progress",
+                ));
+            }
+        };
+        data.state = SchemaGateState::Migrating;
+        Ok(SchemaMigrationGuard {
+            inner: Arc::clone(&self.inner),
+            restore_state,
+            finished: false,
+        })
+    }
+}
+
+impl Default for SchemaGate {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Owned admission retained for the complete lifetime of one ordinary operation.
+#[derive(Debug)]
+#[must_use = "dropping the guard releases schema-operation admission"]
+pub(crate) struct SchemaOperationGuard {
+    inner: Arc<SchemaGateInner>,
+}
+
+impl Drop for SchemaOperationGuard {
+    fn drop(&mut self) {
+        self.inner.release_operation();
+    }
+}
+
+/// Exclusive coordinator for one new or resumed schema migration.
+#[derive(Debug)]
+#[must_use = "dropping an unfinished migration guard restores safe schema admission state"]
+pub(crate) struct SchemaMigrationGuard {
+    inner: Arc<SchemaGateInner>,
+    restore_state: SchemaGateState,
+    finished: bool,
+}
+
+impl SchemaMigrationGuard {
+    /// Wait asynchronously until every operation admitted before migration has left.
+    pub(crate) async fn wait_for_quiescence(&self) {
+        loop {
+            // Register before checking the count. This closes the gap where
+            // the final operation exits between the check and the await, while
+            // `notify_waiters` also permits more than one diagnostic waiter.
+            let notified = self.inner.async_quiesced.notified();
+            tokio::pin!(notified);
+            let _ = notified.as_mut().enable();
+            if self.inner.lock().active_operations == 0 {
+                return;
+            }
+            notified.await;
+        }
+    }
+
+    /// Wait on a condition variable until every previously admitted operation exits.
+    pub(crate) fn wait_for_quiescence_blocking(&self) {
+        let mut data = self.inner.lock();
+        while data.active_operations != 0 {
+            data = self
+                .inner
+                .blocking_quiesced
+                .wait(data)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
+    }
+
+    /// Make cancellation or unwinding restore `Pending` after the durable
+    /// migration journal has been created.
+    pub(crate) fn mark_pending_on_drop(&mut self) {
+        self.restore_state = SchemaGateState::Pending;
+    }
+
+    /// Publish a successfully completed migration and admit ordinary work again.
+    pub(crate) fn publish_ready(mut self) -> EngineResult<()> {
+        self.publish(SchemaGateState::Ready)
+    }
+
+    /// Publish durable partial progress that only another migration may resume.
+    #[cfg(test)]
+    pub(crate) fn publish_pending(mut self) -> EngineResult<()> {
+        self.publish(SchemaGateState::Pending)
+    }
+
+    fn publish(&mut self, target: SchemaGateState) -> EngineResult<()> {
+        {
+            let mut data = self.inner.lock();
+            if data.state != SchemaGateState::Migrating {
+                return Err(EngineError::new(
+                    EngineErrorKind::Internal,
+                    "application-schema migration guard lost exclusive ownership",
+                ));
+            }
+            if data.active_operations != 0 {
+                return Err(EngineError::new(
+                    EngineErrorKind::Internal,
+                    "application-schema migration was published before operations quiesced",
+                ));
+            }
+            data.state = target;
+        }
+        self.finished = true;
+        Ok(())
+    }
+}
+
+impl Drop for SchemaMigrationGuard {
+    fn drop(&mut self) {
+        if self.finished {
+            return;
+        }
+
+        let mut data = self.inner.lock();
+        if data.state == SchemaGateState::Migrating {
+            data.state = self.restore_state;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Barrier, mpsc};
+
+    use super::*;
+
+    #[test]
+    fn ready_admits_owned_operations_and_drop_releases_exactly_once() {
+        let gate = SchemaGate::new();
+        let first = gate.try_acquire_operation().unwrap();
+        let second = gate.try_acquire_operation().unwrap();
+        assert_eq!(
+            gate.snapshot(),
+            SchemaGateSnapshot {
+                state: SchemaGateState::Ready,
+                active_operations: 2,
+            }
+        );
+
+        drop(first);
+        assert_eq!(gate.snapshot().active_operations, 1);
+        drop(second);
+        assert_eq!(gate.snapshot().active_operations, 0);
+    }
+
+    #[test]
+    fn migrating_is_retryable_busy_and_pending_is_a_failed_precondition() {
+        let gate = SchemaGate::new();
+        let migration = gate.begin_migration().unwrap();
+        let busy = gate.try_acquire_operation().unwrap_err();
+        assert_eq!(busy.kind(), EngineErrorKind::Busy);
+        assert!(busy.is_retryable());
+
+        migration.publish_pending().unwrap();
+        let pending = gate.try_acquire_operation().unwrap_err();
+        assert_eq!(pending.kind(), EngineErrorKind::FailedPrecondition);
+        assert!(!pending.is_retryable());
+    }
+
+    #[test]
+    fn only_one_migration_guard_exists_and_pending_can_be_resumed() {
+        let gate = SchemaGate::new();
+        let migration = gate.begin_migration().unwrap();
+        assert_eq!(
+            gate.begin_migration().unwrap_err().kind(),
+            EngineErrorKind::Busy
+        );
+        migration.publish_pending().unwrap();
+
+        let resumed = gate.begin_migration().unwrap();
+        assert_eq!(gate.snapshot().state, SchemaGateState::Migrating);
+        resumed.publish_ready().unwrap();
+        assert_eq!(gate.snapshot().state, SchemaGateState::Ready);
+    }
+
+    #[test]
+    fn guard_drop_restores_ready_before_durability_and_pending_after_it() {
+        let gate = SchemaGate::new();
+        drop(gate.begin_migration().unwrap());
+        assert_eq!(gate.snapshot().state, SchemaGateState::Ready);
+
+        let mut durable = gate.begin_migration().unwrap();
+        durable.mark_pending_on_drop();
+        drop(durable);
+        assert_eq!(gate.snapshot().state, SchemaGateState::Pending);
+
+        drop(gate.begin_migration().unwrap());
+        assert_eq!(gate.snapshot().state, SchemaGateState::Pending);
+    }
+
+    #[tokio::test]
+    async fn async_quiescence_wait_completes_after_all_owned_operations_drop() {
+        let gate = SchemaGate::new();
+        let first = gate.try_acquire_operation().unwrap();
+        let second = gate.try_acquire_operation().unwrap();
+        let migration = gate.begin_migration().unwrap();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+
+        let waiter = tokio::spawn(async move {
+            let _ = started_tx.send(());
+            migration.wait_for_quiescence().await;
+            migration.publish_ready()
+        });
+        started_rx.await.unwrap();
+        assert_eq!(gate.snapshot().active_operations, 2);
+        drop(first);
+        assert_eq!(gate.snapshot().active_operations, 1);
+        drop(second);
+
+        waiter.await.unwrap().unwrap();
+        assert_eq!(gate.snapshot().state, SchemaGateState::Ready);
+    }
+
+    #[tokio::test]
+    async fn cancelling_an_async_waiter_restores_its_safe_drop_state() {
+        let gate = SchemaGate::new();
+        let operation = gate.try_acquire_operation().unwrap();
+        let migration = gate.begin_migration().unwrap();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let waiter = tokio::spawn(async move {
+            let _ = started_tx.send(());
+            migration.wait_for_quiescence().await;
+            migration.publish_ready()
+        });
+        started_rx.await.unwrap();
+        waiter.abort();
+        assert!(waiter.await.unwrap_err().is_cancelled());
+        assert_eq!(gate.snapshot().state, SchemaGateState::Ready);
+        drop(operation);
+
+        let operation = gate.try_acquire_operation().unwrap();
+        let mut migration = gate.begin_migration().unwrap();
+        migration.mark_pending_on_drop();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let waiter = tokio::spawn(async move {
+            let _ = started_tx.send(());
+            migration.wait_for_quiescence().await;
+            migration.publish_ready()
+        });
+        started_rx.await.unwrap();
+        waiter.abort();
+        assert!(waiter.await.unwrap_err().is_cancelled());
+        assert_eq!(gate.snapshot().state, SchemaGateState::Pending);
+        drop(operation);
+    }
+
+    #[test]
+    fn blocking_quiescence_wait_uses_the_same_operation_count() {
+        let gate = SchemaGate::new();
+        let operation = gate.try_acquire_operation().unwrap();
+        let migration = gate.begin_migration().unwrap();
+        let rendezvous = Arc::new(Barrier::new(2));
+        let thread_rendezvous = Arc::clone(&rendezvous);
+        let (complete_tx, complete_rx) = mpsc::channel();
+
+        let waiter = std::thread::spawn(move || {
+            thread_rendezvous.wait();
+            migration.wait_for_quiescence_blocking();
+            migration.publish_ready().unwrap();
+            complete_tx.send(()).unwrap();
+        });
+        rendezvous.wait();
+        assert!(complete_rx.try_recv().is_err());
+        drop(operation);
+        complete_rx.recv().unwrap();
+        waiter.join().unwrap();
+        assert_eq!(gate.snapshot().state, SchemaGateState::Ready);
+    }
+
+    #[test]
+    fn publishing_before_quiescence_fails_and_drop_restores_the_origin() {
+        let gate = SchemaGate::new();
+        let operation = gate.try_acquire_operation().unwrap();
+        let error = gate.begin_migration().unwrap().publish_ready().unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Internal);
+        assert_eq!(gate.snapshot().state, SchemaGateState::Ready);
+        assert_eq!(gate.snapshot().active_operations, 1);
+        drop(operation);
+    }
+
+    #[test]
+    fn gate_guards_are_send_sync_and_owned() {
+        fn assert_send_sync_static<T: Send + Sync + 'static>() {}
+        assert_send_sync_static::<SchemaGate>();
+        assert_send_sync_static::<SchemaOperationGuard>();
+        assert_send_sync_static::<SchemaMigrationGuard>();
+    }
+}

--- a/src/storage/shard.rs
+++ b/src/storage/shard.rs
@@ -6,7 +6,10 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use rusqlite::{Connection, MAIN_DB, OpenFlags, TransactionBehavior, hooks::AuthAction};
+use rusqlite::{
+    Connection, MAIN_DB, OpenFlags, TransactionBehavior,
+    hooks::{AuthAction, AuthContext, Authorization},
+};
 
 use crate::{
     core::{EngineError, EngineErrorKind, EngineResult},
@@ -117,6 +120,67 @@ struct PreflightShard {
     state: PreflightState,
 }
 
+/// Which side of one journaled schema migration a strictly validated shard is on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SchemaMigrationShardState {
+    Source,
+    Target,
+}
+
+/// Whether this invocation committed a shard migration or observed an earlier commit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SchemaMigrationShardOutcome {
+    Applied,
+    AlreadyApplied,
+}
+
+/// Durable boundaries exposed to storage migration failure-injection tests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SchemaMigrationPoint {
+    SqlApplied,
+    GenerationStamped,
+    Committed,
+}
+
+/// Immutable identity and SQL for one shard's step in a journaled migration.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct SchemaMigrationShard<'a> {
+    path: &'a Path,
+    shard_id: u16,
+    source_generation: u64,
+    target_generation: u64,
+    layout: &'a ShardLayout,
+    sql: &'a str,
+}
+
+impl<'a> SchemaMigrationShard<'a> {
+    pub(super) const fn new(
+        path: &'a Path,
+        shard_id: u16,
+        source_generation: u64,
+        target_generation: u64,
+        layout: &'a ShardLayout,
+        sql: &'a str,
+    ) -> Self {
+        Self {
+            path,
+            shard_id,
+            source_generation,
+            target_generation,
+            layout,
+            sql,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct ReservedSchemaObject {
+    object_type: String,
+    name: String,
+    table_name: String,
+    sql: Option<String>,
+}
+
 /// Preflight every expected file before changing any shard, provision only the
 /// eligible states, then perform one strict no-create validation pass.
 pub(super) fn prepare_layout(
@@ -213,6 +277,529 @@ pub(super) fn validate_open_connection(
     require_writable(connection)?;
     validate_exact_shard(connection, path, shard_id, expected_user_version, layout)?;
     configure_connection_pragmas(connection)
+}
+
+/// Strictly validate a dedicated migration connection while accepting only
+/// the journal's exact source or target application-schema generation.
+///
+/// This does not replace the connection's busy handler or progress callback,
+/// allowing the coordinator to install request cancellation before validation
+/// can wait on a real SQLite lock. The connection must be dedicated to the
+/// migration because the apply path temporarily installs its own authorizer.
+pub(super) fn validate_schema_migration_connection(
+    connection: &Connection,
+    path: &Path,
+    shard_id: u16,
+    source_generation: u64,
+    target_generation: u64,
+    layout: &ShardLayout,
+) -> EngineResult<SchemaMigrationShardState> {
+    validate_shard_id(shard_id)?;
+    let (source_user_version, target_user_version) =
+        validate_schema_migration_inputs(source_generation, target_generation, layout)?;
+    require_writable(connection)?;
+    let state = classify_schema_migration_shard(
+        connection,
+        path,
+        shard_id,
+        source_user_version,
+        target_user_version,
+        layout,
+    )?;
+    configure_connection_pragmas(connection)?;
+    Ok(state)
+}
+
+/// Validate the exact durable prefix described by a migration journal.
+///
+/// Shards before `next_shard` must be at the target generation, the current
+/// shard may be at source or target to cover a commit-before-acknowledgement
+/// crash, and every later shard must remain at source. `None` means the journal
+/// points one past the final shard and every shard validated at target.
+pub(super) fn validate_schema_migration_prefix(
+    shards_dir: &Path,
+    shard_count: u16,
+    next_shard: u16,
+    source_generation: u64,
+    target_generation: u64,
+    layout: &ShardLayout,
+) -> EngineResult<Option<SchemaMigrationShardState>> {
+    validate_schema_migration_prefix_with(
+        shards_dir,
+        shard_count,
+        next_shard,
+        source_generation,
+        target_generation,
+        layout,
+        |path, shard_id| {
+            let connection = open_required_file(path)?;
+            configure_busy_timeout(&connection)?;
+            validate_schema_migration_connection(
+                &connection,
+                path,
+                shard_id,
+                source_generation,
+                target_generation,
+                layout,
+            )
+        },
+    )
+}
+
+/// Validate a migration prefix while delegating each SQLite connection to a
+/// coordinator-provided, optionally cancellation-aware validator.
+pub(super) fn validate_schema_migration_prefix_with<F>(
+    shards_dir: &Path,
+    shard_count: u16,
+    next_shard: u16,
+    source_generation: u64,
+    target_generation: u64,
+    layout: &ShardLayout,
+    mut validate: F,
+) -> EngineResult<Option<SchemaMigrationShardState>>
+where
+    F: FnMut(&Path, u16) -> EngineResult<SchemaMigrationShardState>,
+{
+    validate_inputs(shard_count, source_generation, layout)?;
+    validate_schema_migration_inputs(source_generation, target_generation, layout)?;
+    if next_shard > shard_count {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!("schema migration next shard {next_shard} exceeds shard count {shard_count}"),
+        ));
+    }
+    validate_directory(shards_dir, shard_count, false)?;
+
+    let mut current = None;
+    for shard_id in 0..shard_count {
+        let path = shard_path(shards_dir, shard_id);
+        let state = validate(&path, shard_id)?;
+        let expected = if shard_id < next_shard {
+            SchemaMigrationShardState::Target
+        } else if shard_id > next_shard {
+            SchemaMigrationShardState::Source
+        } else {
+            current = Some(state);
+            continue;
+        };
+        if state != expected {
+            let expected_name = match expected {
+                SchemaMigrationShardState::Source => "source",
+                SchemaMigrationShardState::Target => "target",
+            };
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!(
+                    "schema migration shard {shard_id} is not at its journaled {expected_name} generation"
+                ),
+            ));
+        }
+    }
+    Ok(current)
+}
+
+/// Execute a migration batch in an immediate transaction and always roll it
+/// back. A target-generation shard is strictly validated and skipped.
+pub(super) fn preflight_schema_migration(
+    path: &Path,
+    shard_id: u16,
+    source_generation: u64,
+    target_generation: u64,
+    layout: &ShardLayout,
+    sql: &str,
+) -> EngineResult<SchemaMigrationShardState> {
+    let mut connection = open_required_file(path)?;
+    configure_busy_timeout(&connection)?;
+    preflight_schema_migration_on_connection(
+        &mut connection,
+        path,
+        shard_id,
+        source_generation,
+        target_generation,
+        layout,
+        sql,
+    )
+}
+
+/// Connection-level preflight for a coordinator-owned, cancellation-aware handle.
+pub(super) fn preflight_schema_migration_on_connection(
+    connection: &mut Connection,
+    path: &Path,
+    shard_id: u16,
+    source_generation: u64,
+    target_generation: u64,
+    layout: &ShardLayout,
+    sql: &str,
+) -> EngineResult<SchemaMigrationShardState> {
+    let initial = validate_schema_migration_connection(
+        connection,
+        path,
+        shard_id,
+        source_generation,
+        target_generation,
+        layout,
+    )?;
+    if initial == SchemaMigrationShardState::Target {
+        return Ok(initial);
+    }
+
+    let (source_user_version, target_user_version) =
+        validate_schema_migration_inputs(source_generation, target_generation, layout)?;
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    let locked = classify_schema_migration_shard(
+        &transaction,
+        path,
+        shard_id,
+        source_user_version,
+        target_user_version,
+        layout,
+    )?;
+    if locked == SchemaMigrationShardState::Target {
+        transaction.rollback().map_err(sqlite_error::storage)?;
+        return validate_schema_migration_connection(
+            connection,
+            path,
+            shard_id,
+            source_generation,
+            target_generation,
+            layout,
+        );
+    }
+
+    let reserved_before = reserved_schema_snapshot(&transaction)?;
+    execute_schema_migration_batch(&transaction, sql)?;
+    ensure_reserved_schema_unchanged(&reserved_before, &transaction)?;
+    ensure_no_foreign_key_violations(&transaction)?;
+    transaction.rollback().map_err(sqlite_error::storage)?;
+
+    let state = validate_schema_migration_connection(
+        connection,
+        path,
+        shard_id,
+        source_generation,
+        target_generation,
+        layout,
+    )?;
+    if state != SchemaMigrationShardState::Source {
+        return Err(EngineError::new(
+            EngineErrorKind::Internal,
+            format!("schema migration preflight changed shard {shard_id} generation"),
+        ));
+    }
+    Ok(state)
+}
+
+/// Atomically apply one journaled batch and its target generation, or strictly
+/// validate and skip a shard already committed at the target generation.
+pub(super) fn apply_schema_migration(
+    path: &Path,
+    shard_id: u16,
+    source_generation: u64,
+    target_generation: u64,
+    layout: &ShardLayout,
+    sql: &str,
+) -> EngineResult<SchemaMigrationShardOutcome> {
+    let mut connection = open_required_file(path)?;
+    configure_busy_timeout(&connection)?;
+    apply_schema_migration_on_connection(
+        &mut connection,
+        path,
+        shard_id,
+        source_generation,
+        target_generation,
+        layout,
+        sql,
+    )
+}
+
+/// Connection-level apply for a coordinator-owned, cancellation-aware handle.
+pub(super) fn apply_schema_migration_on_connection(
+    connection: &mut Connection,
+    path: &Path,
+    shard_id: u16,
+    source_generation: u64,
+    target_generation: u64,
+    layout: &ShardLayout,
+    sql: &str,
+) -> EngineResult<SchemaMigrationShardOutcome> {
+    let migration = SchemaMigrationShard::new(
+        path,
+        shard_id,
+        source_generation,
+        target_generation,
+        layout,
+        sql,
+    );
+    apply_schema_migration_on_connection_inner(connection, migration, |_| Ok(()))
+}
+
+/// Test seam for injecting errors, panics, and process termination at the
+/// shard transaction's persistence boundaries.
+#[cfg(test)]
+pub(super) fn apply_schema_migration_on_connection_with_hook<F>(
+    connection: &mut Connection,
+    migration: SchemaMigrationShard<'_>,
+    hook: F,
+) -> EngineResult<SchemaMigrationShardOutcome>
+where
+    F: FnMut(SchemaMigrationPoint) -> EngineResult<()>,
+{
+    apply_schema_migration_on_connection_inner(connection, migration, hook)
+}
+
+fn apply_schema_migration_on_connection_inner<F>(
+    connection: &mut Connection,
+    migration: SchemaMigrationShard<'_>,
+    mut hook: F,
+) -> EngineResult<SchemaMigrationShardOutcome>
+where
+    F: FnMut(SchemaMigrationPoint) -> EngineResult<()>,
+{
+    let SchemaMigrationShard {
+        path,
+        shard_id,
+        source_generation,
+        target_generation,
+        layout,
+        sql,
+    } = migration;
+    let initial = validate_schema_migration_connection(
+        connection,
+        path,
+        shard_id,
+        source_generation,
+        target_generation,
+        layout,
+    )?;
+    if initial == SchemaMigrationShardState::Target {
+        return Ok(SchemaMigrationShardOutcome::AlreadyApplied);
+    }
+
+    let (source_user_version, target_user_version) =
+        validate_schema_migration_inputs(source_generation, target_generation, layout)?;
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    let locked = classify_schema_migration_shard(
+        &transaction,
+        path,
+        shard_id,
+        source_user_version,
+        target_user_version,
+        layout,
+    )?;
+    if locked == SchemaMigrationShardState::Target {
+        transaction.rollback().map_err(sqlite_error::storage)?;
+        validate_schema_migration_connection(
+            connection,
+            path,
+            shard_id,
+            source_generation,
+            target_generation,
+            layout,
+        )?;
+        return Ok(SchemaMigrationShardOutcome::AlreadyApplied);
+    }
+
+    let reserved_before = reserved_schema_snapshot(&transaction)?;
+    execute_schema_migration_batch(&transaction, sql)?;
+    hook(SchemaMigrationPoint::SqlApplied)?;
+    ensure_reserved_schema_unchanged(&reserved_before, &transaction)?;
+
+    transaction
+        .pragma_update(None, "user_version", target_user_version)
+        .map_err(sqlite_error::storage)?;
+    hook(SchemaMigrationPoint::GenerationStamped)?;
+    if classify_schema_migration_shard(
+        &transaction,
+        path,
+        shard_id,
+        source_user_version,
+        target_user_version,
+        layout,
+    )? != SchemaMigrationShardState::Target
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::Internal,
+            format!("schema migration did not stamp shard {shard_id} target generation"),
+        ));
+    }
+
+    transaction.commit().map_err(sqlite_error::storage)?;
+    hook(SchemaMigrationPoint::Committed)?;
+    if validate_schema_migration_connection(
+        connection,
+        path,
+        shard_id,
+        source_generation,
+        target_generation,
+        layout,
+    )? != SchemaMigrationShardState::Target
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::Internal,
+            format!("committed schema migration did not persist on shard {shard_id}"),
+        ));
+    }
+    Ok(SchemaMigrationShardOutcome::Applied)
+}
+
+fn validate_schema_migration_inputs(
+    source_generation: u64,
+    target_generation: u64,
+    layout: &ShardLayout,
+) -> EngineResult<(i64, i64)> {
+    let expected_target = source_generation.checked_add(1).ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "schema migration source generation cannot be incremented",
+        )
+    })?;
+    if target_generation != expected_target {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "schema migration target must immediately follow its source generation",
+        ));
+    }
+    if layout.state() != ShardLayoutState::Ready
+        || layout.expected_application_id() != SHARD_APPLICATION_ID
+        || layout.metadata_version() != SHARD_METADATA_VERSION
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "schema migration requires a ready supported shard layout",
+        ));
+    }
+    Ok((
+        expected_user_version(source_generation)?,
+        expected_user_version(target_generation)?,
+    ))
+}
+
+fn classify_schema_migration_shard(
+    connection: &Connection,
+    path: &Path,
+    shard_id: u16,
+    source_user_version: i64,
+    target_user_version: i64,
+    layout: &ShardLayout,
+) -> EngineResult<SchemaMigrationShardState> {
+    let (application_id, user_version) = read_identity(connection)?;
+    if application_id != layout.expected_application_id() {
+        return if application_id == 0 {
+            Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!("schema-migration shard {shard_id} is missing its BriskDB application ID"),
+            ))
+        } else {
+            Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "schema-migration shard {shard_id} has foreign application identifier {application_id:#010x}"
+                ),
+            ))
+        };
+    }
+    let state = if user_version == source_user_version {
+        SchemaMigrationShardState::Source
+    } else if user_version == target_user_version {
+        SchemaMigrationShardState::Target
+    } else if user_version > target_user_version {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!(
+                "shard {shard_id} schema generation {user_version} is newer than migration target {target_user_version}"
+            ),
+        ));
+    } else {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!(
+                "shard {shard_id} schema generation {user_version} is neither migration source {source_user_version} nor target {target_user_version}"
+            ),
+        ));
+    };
+    require_wal(connection, path)?;
+    validate_metadata(connection, shard_id, layout.layout_id())?;
+    Ok(state)
+}
+
+fn execute_schema_migration_batch(connection: &Connection, sql: &str) -> EngineResult<()> {
+    connection
+        .authorizer(Some(|context: AuthContext<'_>| {
+            if denies_schema_migration_action(context) {
+                Authorization::Deny
+            } else {
+                Authorization::Allow
+            }
+        }))
+        .map_err(sqlite_error::storage)?;
+    let executed = connection
+        .execute_batch(sql)
+        .map_err(sqlite_error::statement);
+    let cleared = connection
+        .authorizer(None::<fn(AuthContext<'_>) -> Authorization>)
+        .map_err(sqlite_error::storage);
+    cleared?;
+    executed
+}
+
+fn reserved_schema_snapshot(connection: &Connection) -> EngineResult<Vec<ReservedSchemaObject>> {
+    let mut statement = connection
+        .prepare(
+            "SELECT type, name, tbl_name, sql
+             FROM sqlite_schema
+             ORDER BY type, name, tbl_name",
+        )
+        .map_err(sqlite_error::storage)?;
+    let rows = statement
+        .query_map([], |row| {
+            Ok(ReservedSchemaObject {
+                object_type: row.get(0)?,
+                name: row.get(1)?,
+                table_name: row.get(2)?,
+                sql: row.get(3)?,
+            })
+        })
+        .map_err(sqlite_error::storage)?;
+    let mut reserved = Vec::new();
+    for row in rows {
+        let row = row.map_err(sqlite_error::storage)?;
+        if is_reserved_name(&row.name) || is_reserved_name(&row.table_name) {
+            reserved.push(row);
+        }
+    }
+    Ok(reserved)
+}
+
+fn ensure_reserved_schema_unchanged(
+    before: &[ReservedSchemaObject],
+    connection: &Connection,
+) -> EngineResult<()> {
+    if reserved_schema_snapshot(connection)? == before {
+        Ok(())
+    } else {
+        Err(EngineError::new(
+            EngineErrorKind::PermissionDenied,
+            "schema migration attempted to change the reserved BriskDB namespace",
+        ))
+    }
+}
+
+fn ensure_no_foreign_key_violations(connection: &Connection) -> EngineResult<()> {
+    let mut statement = connection
+        .prepare("PRAGMA main.foreign_key_check")
+        .map_err(sqlite_error::storage)?;
+    let mut rows = statement.query([]).map_err(sqlite_error::storage)?;
+    if rows.next().map_err(sqlite_error::storage)?.is_some() {
+        return Err(EngineError::new(
+            EngineErrorKind::ForeignKeyViolation,
+            "schema migration preflight found a foreign-key violation",
+        ));
+    }
+    Ok(())
 }
 
 fn preflight_all(
@@ -1040,6 +1627,83 @@ fn shard_read_error(error: rusqlite::Error, diagnostic: &'static str) -> EngineE
     }
 }
 
+/// The migration connection is the only SQL surface allowed to change the
+/// persistent application schema. Keep it inside `main`, prevent the batch
+/// from escaping BriskDB's transaction, and protect every storage-owned name
+/// and control. ALTER destinations are validated by comparing the reserved
+/// schema before and after the batch because SQLite reports only its source.
+fn denies_schema_migration_action(context: AuthContext<'_>) -> bool {
+    if context
+        .database_name
+        .is_some_and(|database| !database.eq_ignore_ascii_case("main"))
+    {
+        return true;
+    }
+
+    match context.action {
+        AuthAction::Unknown { .. }
+        | AuthAction::Transaction { .. }
+        | AuthAction::Savepoint { .. }
+        | AuthAction::Attach { .. }
+        | AuthAction::Detach { .. }
+        | AuthAction::CreateTempIndex { .. }
+        | AuthAction::CreateTempTable { .. }
+        | AuthAction::CreateTempTrigger { .. }
+        | AuthAction::CreateTempView { .. }
+        | AuthAction::DropTempIndex { .. }
+        | AuthAction::DropTempTable { .. }
+        | AuthAction::DropTempTrigger { .. }
+        | AuthAction::DropTempView { .. }
+        | AuthAction::CreateVtable { .. }
+        | AuthAction::DropVtable { .. } => true,
+        AuthAction::Pragma {
+            pragma_name,
+            pragma_value,
+        } => pragma_value.is_some() || matches_persistent_pragma(pragma_name),
+        AuthAction::Insert { table_name } | AuthAction::Delete { table_name } => {
+            is_reserved_name(table_name)
+        }
+        AuthAction::Update {
+            table_name,
+            column_name: _,
+        } => is_reserved_name(table_name),
+        AuthAction::Read {
+            table_name,
+            column_name: _,
+        } => is_metadata_table(table_name),
+        AuthAction::CreateTable { table_name } | AuthAction::DropTable { table_name } => {
+            is_reserved_name(table_name)
+        }
+        AuthAction::CreateIndex {
+            index_name,
+            table_name,
+        }
+        | AuthAction::DropIndex {
+            index_name,
+            table_name,
+        } => is_reserved_name(index_name) || is_reserved_name(table_name),
+        AuthAction::CreateTrigger {
+            trigger_name,
+            table_name,
+        }
+        | AuthAction::DropTrigger {
+            trigger_name,
+            table_name,
+        } => is_reserved_name(trigger_name) || is_reserved_name(table_name),
+        AuthAction::CreateView { view_name } | AuthAction::DropView { view_name } => {
+            is_reserved_name(view_name)
+        }
+        AuthAction::AlterTable {
+            database_name,
+            table_name,
+        } => !database_name.eq_ignore_ascii_case("main") || is_reserved_name(table_name),
+        AuthAction::Reindex { index_name } => is_reserved_name(index_name),
+        AuthAction::Analyze { table_name } => is_reserved_name(table_name),
+        AuthAction::Select | AuthAction::Function { .. } | AuthAction::Recursive => false,
+        _ => false,
+    }
+}
+
 /// Return whether a client statement action would mutate storage-owned shard
 /// identity, durability configuration, or the reserved metadata namespace.
 pub(super) fn denies_client_action(action: AuthAction<'_>) -> bool {
@@ -1048,13 +1712,9 @@ pub(super) fn denies_client_action(action: AuthAction<'_>) -> bool {
             pragma_name,
             pragma_value: Some(_),
         } => matches_persistent_pragma(pragma_name),
-        AuthAction::Insert { table_name }
-        | AuthAction::Delete { table_name }
-        | AuthAction::DropTable { table_name }
-        | AuthAction::DropVtable {
-            table_name,
-            module_name: _,
-        } => is_metadata_table(table_name),
+        AuthAction::Insert { table_name } | AuthAction::Delete { table_name } => {
+            is_metadata_table(table_name)
+        }
         AuthAction::Update {
             table_name,
             column_name: _,
@@ -1063,55 +1723,40 @@ pub(super) fn denies_client_action(action: AuthAction<'_>) -> bool {
             table_name,
             column_name: _,
         } => is_metadata_table(table_name),
-        // SQLite's authorizer reports the source table for ALTER TABLE but
-        // does not expose a RENAME TO destination. Deny the whole operation
-        // so a client cannot move an application table into the reserved
-        // namespace without the authorizer seeing the new name.
-        AuthAction::AlterTable {
-            database_name: _,
-            table_name: _,
-        } => true,
-        AuthAction::CreateTable { table_name }
-        | AuthAction::CreateTempTable { table_name }
-        | AuthAction::CreateVtable {
-            table_name,
-            module_name: _,
-        } => is_reserved_name(table_name),
-        AuthAction::CreateIndex {
-            index_name,
-            table_name,
-        }
-        | AuthAction::CreateTempIndex {
+        // Every persistent application-schema change must go through the
+        // journaled migration connection. Temp objects remain connection-local
+        // and are retired by the pool's hygiene boundary.
+        AuthAction::AlterTable { .. }
+        | AuthAction::CreateTable { .. }
+        | AuthAction::CreateIndex { .. }
+        | AuthAction::CreateTrigger { .. }
+        | AuthAction::CreateView { .. }
+        | AuthAction::CreateVtable { .. }
+        | AuthAction::DropTable { .. }
+        | AuthAction::DropIndex { .. }
+        | AuthAction::DropTrigger { .. }
+        | AuthAction::DropView { .. }
+        | AuthAction::DropVtable { .. } => true,
+        AuthAction::CreateTempTable { table_name } => is_reserved_name(table_name),
+        AuthAction::CreateTempIndex {
             index_name,
             table_name,
         } => is_reserved_name(index_name) || is_metadata_table(table_name),
-        AuthAction::CreateTrigger {
-            trigger_name,
-            table_name,
-        }
-        | AuthAction::CreateTempTrigger {
+        AuthAction::CreateTempTrigger {
             trigger_name,
             table_name,
         } => is_reserved_name(trigger_name) || is_metadata_table(table_name),
-        AuthAction::CreateView { view_name } | AuthAction::CreateTempView { view_name } => {
-            is_reserved_name(view_name)
-        }
-        AuthAction::DropIndex {
-            index_name,
-            table_name,
-        }
-        | AuthAction::DropTempIndex {
+        AuthAction::CreateTempView { view_name } => is_reserved_name(view_name),
+        AuthAction::DropTempIndex {
             index_name,
             table_name,
         } => is_reserved_name(index_name) || is_metadata_table(table_name),
-        AuthAction::DropTrigger {
-            trigger_name,
-            table_name,
-        }
-        | AuthAction::DropTempTrigger {
+        AuthAction::DropTempTrigger {
             trigger_name,
             table_name,
         } => is_reserved_name(trigger_name) || is_metadata_table(table_name),
+        AuthAction::DropTempTable { table_name } => is_reserved_name(table_name),
+        AuthAction::DropTempView { view_name } => is_reserved_name(view_name),
         AuthAction::Reindex { index_name } => is_reserved_name(index_name),
         AuthAction::Analyze { table_name } => is_metadata_table(table_name),
         _ => false,
@@ -1135,15 +1780,18 @@ fn is_metadata_table(name: &str) -> bool {
 }
 
 fn is_reserved_name(name: &str) -> bool {
-    name.as_bytes()
-        .get(.."briskdb_".len())
-        .is_some_and(|prefix| prefix.eq_ignore_ascii_case(b"briskdb_"))
+    name.eq_ignore_ascii_case("briskdb")
+        || name
+            .as_bytes()
+            .get(.."briskdb_".len())
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case(b"briskdb_"))
 }
 
 #[cfg(test)]
 mod tests {
     use std::{
         panic::{AssertUnwindSafe, catch_unwind},
+        process::Command,
         sync::Arc,
         thread,
     };
@@ -1153,6 +1801,9 @@ mod tests {
     use super::*;
 
     const LAYOUT_ID: [u8; 16] = *b"brisk-layout-001";
+    const SHARD_CRASH_SQL: &str = "\
+        CREATE TABLE shard_crash_marker (id INTEGER PRIMARY KEY, value TEXT NOT NULL);\
+        INSERT INTO shard_crash_marker (id, value) VALUES (1, 'persisted');";
 
     fn layout(state: ShardLayoutState) -> ShardLayout {
         ShardLayout::from_validated_parts(
@@ -1179,6 +1830,24 @@ mod tests {
     fn has_metadata(path: &Path) -> bool {
         let connection = Connection::open(path).unwrap();
         has_metadata_object(&connection).unwrap()
+    }
+
+    fn create_ready_layout(shard_count: u16) -> (tempfile::TempDir, PathBuf, ShardLayout) {
+        let temp = tempfile::tempdir().unwrap();
+        let shards = temp.path().join("shards");
+        prepare_layout(&shards, shard_count, 0, &layout(ShardLayoutState::Creating)).unwrap();
+        (temp, shards, layout(ShardLayoutState::Ready))
+    }
+
+    fn schema_object_exists(path: &Path, name: &str) -> bool {
+        Connection::open(path)
+            .unwrap()
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM sqlite_schema WHERE name = ?1)",
+                [name],
+                |row| row.get(0),
+            )
+            .unwrap()
     }
 
     #[test]
@@ -1582,6 +2251,495 @@ mod tests {
     }
 
     #[test]
+    fn migration_preflight_rolls_back_and_apply_commits_sql_with_generation_once() {
+        let (_temp, shards, ready) = create_ready_layout(2);
+        let path = shard_path(&shards, 0);
+        let sql = "CREATE TABLE migrated_widgets (
+                       id INTEGER PRIMARY KEY,
+                       value TEXT NOT NULL
+                   );
+                   INSERT INTO migrated_widgets (id, value) VALUES (1, 'once');";
+
+        assert_eq!(
+            preflight_schema_migration(&path, 0, 0, 1, &ready, sql).unwrap(),
+            SchemaMigrationShardState::Source
+        );
+        assert_eq!(identity(&path), (SHARD_APPLICATION_ID, 0));
+        assert!(!schema_object_exists(&path, "migrated_widgets"));
+
+        assert_eq!(
+            apply_schema_migration(&path, 0, 0, 1, &ready, sql).unwrap(),
+            SchemaMigrationShardOutcome::Applied
+        );
+        assert_eq!(identity(&path), (SHARD_APPLICATION_ID, 1));
+        assert_eq!(
+            Connection::open(&path)
+                .unwrap()
+                .query_row("SELECT value FROM migrated_widgets", [], |row| {
+                    row.get::<_, String>(0)
+                })
+                .unwrap(),
+            "once"
+        );
+
+        // The original SQL is intentionally not idempotent. A retry must
+        // recognize the target generation and skip it rather than execute it.
+        assert_eq!(
+            preflight_schema_migration(&path, 0, 0, 1, &ready, sql).unwrap(),
+            SchemaMigrationShardState::Target
+        );
+        assert_eq!(
+            apply_schema_migration(&path, 0, 0, 1, &ready, sql).unwrap(),
+            SchemaMigrationShardOutcome::AlreadyApplied
+        );
+        assert_eq!(
+            Connection::open(&path)
+                .unwrap()
+                .query_row("SELECT COUNT(*) FROM migrated_widgets", [], |row| {
+                    row.get::<_, i64>(0)
+                })
+                .unwrap(),
+            1
+        );
+        open_existing(&path, 0, 1, &ready).unwrap();
+    }
+
+    #[test]
+    fn migration_batch_failure_rolls_back_earlier_statements_and_generation() {
+        for preflight_only in [true, false] {
+            let (_temp, shards, ready) = create_ready_layout(2);
+            let path = shard_path(&shards, 0);
+            let sql = "CREATE TABLE must_rollback (id INTEGER);
+                       INSERT INTO missing_table VALUES (1);";
+            let error = if preflight_only {
+                preflight_schema_migration(&path, 0, 0, 1, &ready, sql).unwrap_err()
+            } else {
+                apply_schema_migration(&path, 0, 0, 1, &ready, sql).unwrap_err()
+            };
+            assert_eq!(error.kind(), EngineErrorKind::InvalidQuery);
+            assert_eq!(identity(&path), (SHARD_APPLICATION_ID, 0));
+            assert!(!schema_object_exists(&path, "must_rollback"));
+            open_existing(&path, 0, 0, &ready).unwrap();
+        }
+    }
+
+    #[test]
+    fn migration_allows_main_ddl_dml_and_alter_without_touching_reserved_schema() {
+        let (_temp, shards, ready) = create_ready_layout(2);
+        let path = shard_path(&shards, 0);
+        Connection::open(&path)
+            .unwrap()
+            .execute_batch(
+                "CREATE TABLE widgets (
+                     id INTEGER PRIMARY KEY,
+                     value TEXT NOT NULL
+                 );",
+            )
+            .unwrap();
+        let sql = "ALTER TABLE widgets ADD COLUMN note TEXT;
+                   INSERT INTO widgets (id, value, note) VALUES (1, 'first', 'created');
+                   UPDATE widgets SET value = upper(value) WHERE id = 1;
+                   CREATE INDEX widgets_value_idx ON widgets (value);
+                   CREATE VIEW widget_notes AS SELECT id, note FROM widgets;
+                   CREATE TRIGGER widgets_note_default
+                   AFTER INSERT ON widgets WHEN NEW.note IS NULL
+                   BEGIN
+                       UPDATE widgets SET note = 'default' WHERE id = NEW.id;
+                   END;";
+
+        assert_eq!(
+            apply_schema_migration(&path, 0, 0, 1, &ready, sql).unwrap(),
+            SchemaMigrationShardOutcome::Applied
+        );
+        let connection = Connection::open(&path).unwrap();
+        assert_eq!(
+            connection
+                .query_row("SELECT value, note FROM widgets", [], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                })
+                .unwrap(),
+            ("FIRST".to_owned(), "created".to_owned())
+        );
+        validate_metadata(&connection, 0, LAYOUT_ID).unwrap();
+    }
+
+    #[test]
+    fn migration_authorizer_denies_escape_and_reserved_surfaces() {
+        let denied = [
+            "SAVEPOINT escaped",
+            "ATTACH DATABASE ':memory:' AS auxiliary",
+            "CREATE TEMP TABLE temporary_escape (id INTEGER)",
+            "CREATE VIRTUAL TABLE virtual_escape USING fts5(value)",
+            "PRAGMA user_version = 7",
+            "CREATE TABLE briskdb (id INTEGER)",
+            "CREATE TABLE BRISKDB (id INTEGER)",
+            "CREATE TABLE briskdb_private (id INTEGER)",
+            "SELECT * FROM briskdb_shard_metadata",
+        ];
+        for sql in denied {
+            let (_temp, shards, ready) = create_ready_layout(2);
+            let path = shard_path(&shards, 0);
+            let error = preflight_schema_migration(&path, 0, 0, 1, &ready, sql).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::PermissionDenied, "{sql}");
+            assert_eq!(identity(&path), (SHARD_APPLICATION_ID, 0));
+            validate_metadata(&Connection::open(&path).unwrap(), 0, LAYOUT_ID).unwrap();
+        }
+    }
+
+    #[test]
+    fn migration_postcheck_catches_an_alter_destination_in_reserved_namespace() {
+        let (_temp, shards, ready) = create_ready_layout(2);
+        let path = shard_path(&shards, 0);
+        Connection::open(&path)
+            .unwrap()
+            .execute_batch("CREATE TABLE widgets (id INTEGER PRIMARY KEY);")
+            .unwrap();
+
+        for destination in ["briskdb", "BRISKDB", "briskdb_hidden"] {
+            let sql = format!("ALTER TABLE widgets RENAME TO {destination}");
+            let error = preflight_schema_migration(&path, 0, 0, 1, &ready, &sql).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::PermissionDenied);
+            assert!(schema_object_exists(&path, "widgets"));
+            assert!(!schema_object_exists(&path, destination));
+            assert_eq!(identity(&path), (SHARD_APPLICATION_ID, 0));
+        }
+    }
+
+    #[test]
+    fn migration_error_hooks_prove_every_transaction_persistence_boundary() {
+        for point in [
+            SchemaMigrationPoint::SqlApplied,
+            SchemaMigrationPoint::GenerationStamped,
+            SchemaMigrationPoint::Committed,
+        ] {
+            let (_temp, shards, ready) = create_ready_layout(2);
+            let path = shard_path(&shards, 0);
+            let mut connection = open_required_file(&path).unwrap();
+            configure_busy_timeout(&connection).unwrap();
+            let error = apply_schema_migration_on_connection_with_hook(
+                &mut connection,
+                SchemaMigrationShard::new(
+                    &path,
+                    0,
+                    0,
+                    1,
+                    &ready,
+                    "CREATE TABLE error_boundary (id INTEGER)",
+                ),
+                |seen| {
+                    if seen == point {
+                        Err(EngineError::new(
+                            EngineErrorKind::Internal,
+                            "injected migration boundary error",
+                        ))
+                    } else {
+                        Ok(())
+                    }
+                },
+            )
+            .unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::Internal);
+            drop(connection);
+
+            let committed = point == SchemaMigrationPoint::Committed;
+            assert_eq!(
+                identity(&path),
+                (SHARD_APPLICATION_ID, i64::from(committed))
+            );
+            assert_eq!(schema_object_exists(&path, "error_boundary"), committed);
+            assert_eq!(
+                apply_schema_migration(
+                    &path,
+                    0,
+                    0,
+                    1,
+                    &ready,
+                    "CREATE TABLE error_boundary (id INTEGER)",
+                )
+                .unwrap(),
+                if committed {
+                    SchemaMigrationShardOutcome::AlreadyApplied
+                } else {
+                    SchemaMigrationShardOutcome::Applied
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn migration_panics_prove_every_transaction_persistence_boundary() {
+        for point in [
+            SchemaMigrationPoint::SqlApplied,
+            SchemaMigrationPoint::GenerationStamped,
+            SchemaMigrationPoint::Committed,
+        ] {
+            let (_temp, shards, ready) = create_ready_layout(2);
+            let path = shard_path(&shards, 0);
+            let panic = catch_unwind(AssertUnwindSafe(|| {
+                let mut connection = open_required_file(&path).unwrap();
+                configure_busy_timeout(&connection).unwrap();
+                let _ = apply_schema_migration_on_connection_with_hook(
+                    &mut connection,
+                    SchemaMigrationShard::new(
+                        &path,
+                        0,
+                        0,
+                        1,
+                        &ready,
+                        "CREATE TABLE panic_boundary (id INTEGER)",
+                    ),
+                    |seen| {
+                        if seen == point {
+                            panic!("injected migration boundary panic");
+                        }
+                        Ok(())
+                    },
+                );
+            }));
+            assert!(panic.is_err());
+
+            let committed = point == SchemaMigrationPoint::Committed;
+            assert_eq!(
+                identity(&path),
+                (SHARD_APPLICATION_ID, i64::from(committed))
+            );
+            assert_eq!(schema_object_exists(&path, "panic_boundary"), committed);
+            assert_eq!(
+                apply_schema_migration(
+                    &path,
+                    0,
+                    0,
+                    1,
+                    &ready,
+                    "CREATE TABLE panic_boundary (id INTEGER)",
+                )
+                .unwrap(),
+                if committed {
+                    SchemaMigrationShardOutcome::AlreadyApplied
+                } else {
+                    SchemaMigrationShardOutcome::Applied
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn schema_migration_shard_crash_child() {
+        let Ok(path) = std::env::var("BRISKDB_SHARD_CRASH_PATH") else {
+            return;
+        };
+        let crash_point = std::env::var("BRISKDB_SHARD_CRASH_POINT").unwrap();
+        let ready = layout(ShardLayoutState::Ready);
+        let mut connection = open_required_file(Path::new(&path)).unwrap();
+        configure_busy_timeout(&connection).unwrap();
+        let result = apply_schema_migration_on_connection_with_hook(
+            &mut connection,
+            SchemaMigrationShard::new(Path::new(&path), 0, 0, 1, &ready, SHARD_CRASH_SQL),
+            |point| {
+                let point_name = match point {
+                    SchemaMigrationPoint::SqlApplied => "sql-applied",
+                    SchemaMigrationPoint::GenerationStamped => "generation-stamped",
+                    SchemaMigrationPoint::Committed => "committed",
+                };
+                if crash_point == point_name {
+                    std::process::abort();
+                }
+                Ok(())
+            },
+        );
+        panic!("child did not reach requested crash point {crash_point}: {result:?}");
+    }
+
+    #[test]
+    fn real_process_abort_before_shard_commit_rolls_back_sql_and_generation() {
+        for crash_point in ["sql-applied", "generation-stamped"] {
+            let (_temp, shards, ready) = create_ready_layout(2);
+            let path = shard_path(&shards, 0);
+            let status = Command::new(std::env::current_exe().unwrap())
+                .arg("--exact")
+                .arg("storage::shard::tests::schema_migration_shard_crash_child")
+                .arg("--nocapture")
+                .env("BRISKDB_SHARD_CRASH_PATH", &path)
+                .env("BRISKDB_SHARD_CRASH_POINT", crash_point)
+                .status()
+                .unwrap();
+            assert!(!status.success(), "child did not abort at {crash_point}");
+
+            assert_eq!(identity(&path), (SHARD_APPLICATION_ID, 0));
+            assert!(!schema_object_exists(&path, "shard_crash_marker"));
+            assert_eq!(
+                apply_schema_migration(&path, 0, 0, 1, &ready, SHARD_CRASH_SQL).unwrap(),
+                SchemaMigrationShardOutcome::Applied
+            );
+            assert_eq!(identity(&path), (SHARD_APPLICATION_ID, 1));
+            assert!(schema_object_exists(&path, "shard_crash_marker"));
+            assert_eq!(
+                Connection::open(&path)
+                    .unwrap()
+                    .query_row(
+                        "SELECT value FROM shard_crash_marker WHERE id = 1",
+                        [],
+                        |row| row.get::<_, String>(0),
+                    )
+                    .unwrap(),
+                "persisted"
+            );
+        }
+    }
+
+    #[test]
+    fn migration_prefix_allows_only_the_single_commit_before_acknowledgement_slot() {
+        let (_temp, shards, ready) = create_ready_layout(4);
+        let sql = "CREATE TABLE prefix_marker (id INTEGER)";
+        assert_eq!(
+            validate_schema_migration_prefix(&shards, 4, 0, 0, 1, &ready).unwrap(),
+            Some(SchemaMigrationShardState::Source)
+        );
+
+        apply_schema_migration(&shard_path(&shards, 0), 0, 0, 1, &ready, sql).unwrap();
+        assert_eq!(
+            validate_schema_migration_prefix(&shards, 4, 0, 0, 1, &ready).unwrap(),
+            Some(SchemaMigrationShardState::Target)
+        );
+        assert_eq!(
+            validate_schema_migration_prefix(&shards, 4, 1, 0, 1, &ready).unwrap(),
+            Some(SchemaMigrationShardState::Source)
+        );
+
+        apply_schema_migration(&shard_path(&shards, 2), 2, 0, 1, &ready, sql).unwrap();
+        assert_eq!(
+            validate_schema_migration_prefix(&shards, 4, 1, 0, 1, &ready)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::DataCorruption
+        );
+
+        let (_temp, shards, ready) = create_ready_layout(2);
+        for shard_id in 0..2 {
+            apply_schema_migration(&shard_path(&shards, shard_id), shard_id, 0, 1, &ready, sql)
+                .unwrap();
+        }
+        assert_eq!(
+            validate_schema_migration_prefix(&shards, 2, 2, 0, 1, &ready).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn migration_prefix_regression_is_corruption_and_future_generation_is_newer() {
+        let (_temp, shards, ready) = create_ready_layout(2);
+        let first = shard_path(&shards, 0);
+        apply_schema_migration(
+            &first,
+            0,
+            0,
+            1,
+            &ready,
+            "CREATE TABLE regression_marker (id INTEGER)",
+        )
+        .unwrap();
+        Connection::open(&first)
+            .unwrap()
+            .pragma_update(None, "user_version", 0)
+            .unwrap();
+        assert_eq!(
+            validate_schema_migration_prefix(&shards, 2, 1, 0, 1, &ready)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::DataCorruption
+        );
+
+        Connection::open(&first)
+            .unwrap()
+            .pragma_update(None, "user_version", 2)
+            .unwrap();
+        assert_eq!(
+            validate_schema_migration_prefix(&shards, 2, 0, 0, 1, &ready)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+    }
+
+    #[test]
+    fn migration_validation_rejects_nonadjacent_overflow_and_nonready_inputs() {
+        let (_temp, shards, ready) = create_ready_layout(2);
+        let path = shard_path(&shards, 0);
+        for (source, target, layout, expected) in [
+            (0, 2, ready, EngineErrorKind::FailedPrecondition),
+            (u64::MAX, 0, ready, EngineErrorKind::FailedPrecondition),
+            (
+                0,
+                1,
+                layout(ShardLayoutState::Adopting),
+                EngineErrorKind::DataCorruption,
+            ),
+        ] {
+            assert_eq!(
+                validate_schema_migration_connection(
+                    &Connection::open(&path).unwrap(),
+                    &path,
+                    0,
+                    source,
+                    target,
+                    &layout,
+                )
+                .unwrap_err()
+                .kind(),
+                expected
+            );
+        }
+        assert_eq!(
+            validate_schema_migration_connection(
+                &Connection::open(&path).unwrap(),
+                &path,
+                0,
+                i32::MAX as u64,
+                i32::MAX as u64 + 1,
+                &ready,
+            )
+            .unwrap_err()
+            .kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+    }
+
+    #[test]
+    fn connection_level_migration_keeps_the_callers_progress_handler() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let (_temp, shards, ready) = create_ready_layout(2);
+        let path = shard_path(&shards, 0);
+        let mut connection = open_required_file(&path).unwrap();
+        configure_busy_timeout(&connection).unwrap();
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let callback_cancelled = Arc::clone(&cancelled);
+        connection
+            .progress_handler(1, Some(move || callback_cancelled.load(Ordering::Relaxed)))
+            .unwrap();
+        assert_eq!(
+            validate_schema_migration_connection(&connection, &path, 0, 0, 1, &ready).unwrap(),
+            SchemaMigrationShardState::Source
+        );
+
+        cancelled.store(true, Ordering::Relaxed);
+        let error = apply_schema_migration_on_connection(
+            &mut connection,
+            &path,
+            0,
+            0,
+            1,
+            &ready,
+            "CREATE TABLE cancellation_marker (id INTEGER)",
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Cancelled);
+        drop(connection);
+        assert_eq!(identity(&path), (SHARD_APPLICATION_ID, 0));
+        assert!(!schema_object_exists(&path, "cancellation_marker"));
+    }
+
+    #[test]
     fn strict_existing_opens_are_deterministic_in_parallel() {
         let temp = tempfile::tempdir().unwrap();
         let shards = temp.path().join("shards");
@@ -1609,7 +2767,7 @@ mod tests {
     }
 
     #[test]
-    fn protected_client_actions_are_exact_and_application_reads_remain_allowed() {
+    fn client_authorizer_denies_every_persistent_ddl_and_allows_application_dml() {
         for pragma in [
             "application_id",
             "USER_VERSION",
@@ -1639,6 +2797,39 @@ mod tests {
         assert!(denies_client_action(AuthAction::CreateTable {
             table_name: "briskdb_future",
         }));
+        assert!(denies_client_action(AuthAction::CreateTable {
+            table_name: "widgets",
+        }));
+        assert!(denies_client_action(AuthAction::CreateIndex {
+            index_name: "widgets_idx",
+            table_name: "widgets",
+        }));
+        assert!(denies_client_action(AuthAction::CreateTrigger {
+            trigger_name: "widgets_trigger",
+            table_name: "widgets",
+        }));
+        assert!(denies_client_action(AuthAction::CreateView {
+            view_name: "widget_view",
+        }));
+        assert!(denies_client_action(AuthAction::CreateVtable {
+            table_name: "widget_search",
+            module_name: "fts5",
+        }));
+        assert!(denies_client_action(AuthAction::DropIndex {
+            index_name: "widgets_idx",
+            table_name: "widgets",
+        }));
+        assert!(denies_client_action(AuthAction::DropTrigger {
+            trigger_name: "widgets_trigger",
+            table_name: "widgets",
+        }));
+        assert!(denies_client_action(AuthAction::DropView {
+            view_name: "widget_view",
+        }));
+        assert!(denies_client_action(AuthAction::DropVtable {
+            table_name: "widget_search",
+            module_name: "fts5",
+        }));
         assert!(denies_client_action(AuthAction::AlterTable {
             database_name: "main",
             table_name: "widgets",
@@ -1651,8 +2842,120 @@ mod tests {
             table_name: "widgets",
             column_name: "value",
         }));
+        assert!(!denies_client_action(AuthAction::Insert {
+            table_name: "widgets",
+        }));
+        assert!(!denies_client_action(AuthAction::Update {
+            table_name: "widgets",
+            column_name: "value",
+        }));
+        assert!(!denies_client_action(AuthAction::Delete {
+            table_name: "widgets",
+        }));
+        assert!(!denies_client_action(AuthAction::CreateTempTable {
+            table_name: "temporary_widgets",
+        }));
         assert!(!denies_client_action(AuthAction::Transaction {
             operation: TransactionOperation::Begin,
         }));
+    }
+
+    #[test]
+    fn migration_authorizer_action_matrix_is_fail_closed() {
+        let context = |action, database_name| AuthContext {
+            action,
+            database_name,
+            accessor: None,
+        };
+        assert!(!denies_schema_migration_action(context(
+            AuthAction::CreateTable {
+                table_name: "widgets",
+            },
+            Some("main"),
+        )));
+        assert!(!denies_schema_migration_action(context(
+            AuthAction::AlterTable {
+                database_name: "main",
+                table_name: "widgets",
+            },
+            Some("main"),
+        )));
+        assert!(!denies_schema_migration_action(context(
+            AuthAction::Insert {
+                table_name: "widgets",
+            },
+            Some("main"),
+        )));
+        for table_name in ["briskdb", "BRISKDB", "briskdb_private"] {
+            assert!(denies_schema_migration_action(context(
+                AuthAction::CreateTable { table_name },
+                Some("main"),
+            )));
+        }
+        assert!(denies_schema_migration_action(context(
+            AuthAction::Read {
+                table_name: SHARD_METADATA_TABLE,
+                column_name: "shard_id",
+            },
+            Some("main"),
+        )));
+        assert!(denies_schema_migration_action(context(
+            AuthAction::Pragma {
+                pragma_name: "user_version",
+                pragma_value: None,
+            },
+            None,
+        )));
+        assert!(denies_schema_migration_action(context(
+            AuthAction::Pragma {
+                pragma_name: "cache_size",
+                pragma_value: Some("20"),
+            },
+            None,
+        )));
+        assert!(denies_schema_migration_action(context(
+            AuthAction::Transaction {
+                operation: TransactionOperation::Begin,
+            },
+            None,
+        )));
+        assert!(denies_schema_migration_action(context(
+            AuthAction::Savepoint {
+                operation: TransactionOperation::Begin,
+                savepoint_name: "escaped",
+            },
+            None,
+        )));
+        assert!(denies_schema_migration_action(context(
+            AuthAction::Attach {
+                filename: "other.sqlite",
+            },
+            None,
+        )));
+        assert!(denies_schema_migration_action(context(
+            AuthAction::CreateTempTable {
+                table_name: "temporary_widgets",
+            },
+            Some("temp"),
+        )));
+        assert!(denies_schema_migration_action(context(
+            AuthAction::CreateVtable {
+                table_name: "widget_search",
+                module_name: "fts5",
+            },
+            Some("main"),
+        )));
+        assert!(denies_schema_migration_action(context(
+            AuthAction::Select,
+            Some("auxiliary"),
+        )));
+        assert!(denies_schema_migration_action(context(
+            AuthAction::Unknown {
+                code: -1,
+                arg1: None,
+                arg2: None,
+            },
+            None,
+        )));
     }
 }


### PR DESCRIPTION
## Summary

- replace best-effort broadcast with a durable manifest-v6 migration journal
- preflight every shard, apply an ascending crash-resumable prefix, and recover active work at startup
- add shared schema admission, live catalog generation publication, and generation-aware pool retirement
- deny persistent DDL outside the migration path and harden manifest/shard file identity checks
- document migration identity, storage format, cancellation, recovery, and compatibility contracts

## Verification

- cargo fmt --all -- --check
- git diff --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-targets --all-features --no-fail-fast
- cargo +1.85.0 test --locked --all-targets --all-features --no-fail-fast
- cargo +1.85.0 test --locked --doc --all-features
- engine cleanup and stuck-body lifecycle regressions each pass 100 repeated focused runs
- three independent exact-head audits report no blocker or medium finding
- protected GitHub CI passes on stable and Rust 1.85

Closes #17