### PR TITLE
Add integrity checks and degraded states

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ minimum supported Rust version (MSRV) and the latest stable toolchain.
   recreated after initialization
 - Routed execute and query endpoints
 - A crash-resumable, journaled schema-migration endpoint for every shard
+- A checksummed manifest, generation-bound shard-schema fingerprints, and
+  fail-closed `Verifying`/`Ready`/`Migrating`/`Degraded` storage states
 - Full SQLite synchronous durability and a five-second busy timeout
 - Reproducible point-read, point-write, and four-shard write benchmarks
 
@@ -195,8 +197,8 @@ retained permanently for recovery and idempotency, so migration batches must
 not contain passwords, tokens, or other sensitive literals.
 
 The initial shard count is immutable, so resharding will require an explicit
-migration workflow. Opening upgrades exact version-1 through version-5
-manifests to version 6 through ordered, resumable steps.
+migration workflow. Opening upgrades exact version-1 through version-6
+manifests to version 7 through ordered, resumable steps.
 Version 3 introduced the versioned, generation-stamped 4,096-bucket routing
 map. Version 4 adds schema generation 0 and immutable logical metadata with
 default database ID 1 named `default`; identifier encoding version 1 accepts
@@ -220,8 +222,21 @@ application-schema generations from 0 through 2,147,483,647. A fresh migration
 advances exactly one generation. After manifest load or upgrade, startup resumes
 any active schema migration before ordinary physical-layout reconciliation and
 final strict shard validation, then returns an engine. Completed journal rows
-remain as the exact generation history; schema equivalence checks, checksums,
-and explicit degraded states remain issue #18.
+remain as the exact generation history.
+
+Version 7 adds a semantic BLAKE3 manifest root, generation-bound persistent
+schema fingerprints, SQLite integrity checks, and explicit durable database
+states. A v6 migration already in progress is completed under v6 rules before
+the upgrade establishes its first trusted schema consensus. New migrations
+preserve source and target fingerprints so restart recovery accepts only the
+exact journal prefix. Detected corruption makes the shared schema gate fail
+closed to new work with `DataCorruption`. When the trusted manifest is
+writable, BriskDB makes a best-effort transition to terminal `Degraded` so a
+restart also refuses service. Recovery requires stopping BriskDB and restoring
+the complete manifest-and-shard set from one consistent known-good copy rather
+than rewriting checksum values. These unkeyed
+checksums are corruption detectors, not authentication, and they do not cover
+application row values or provide a continuous whole-data scan.
 
 The v3-to-v4 step deliberately leaves the table catalog empty: it neither
 infers nor adopts tables already present in physical shard files. The v4-to-v5
@@ -246,8 +261,8 @@ same canonical data directory share schema coordination. Separate BriskDB
 server processes must not use the same data directory.
 
 Near-term work includes authentication, richer migration administration and
-status APIs in issue #53, schema checksums and degraded-state handling in issue
-#18, scatter/gather reads, observability, and backup tooling.
+status APIs in issue #53, scatter/gather reads, observability, and backup
+tooling.
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -192,7 +192,7 @@ existing tests pass through the shared engine.
   application ID/user version, and matches the cataloged schema generation.
 - [x] Implement a crash-resumable schema migration journal instead of the
   previous unjournaled broadcast behavior.
-- [ ] Add checksums/integrity checks and explicit states for degraded or
+- [x] Add checksums/integrity checks and explicit states for degraded or
   partially migrated databases.
 
 Exit criterion: restarts and upgrades cannot silently change routing, and an

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -119,6 +119,18 @@ history is contiguous and retained permanently; at most one active row may
 target the generation immediately after the committed catalog. Exact SQL is
 therefore operational metadata that may reveal sensitive literals.
 
+Version 7 adds the `briskdb_integrity` singleton. It stores a canonical BLAKE3
+semantic root over authoritative manifest values, a generation-bound BLAKE3
+fingerprint for the committed application schema, an optional migration-target
+fingerprint, and one of four durable states: `Verifying`, `Ready`, `Migrating`,
+or `Degraded`. Manifest mutations reseal the semantic root inside their own
+transaction. Startup establishes the first fingerprint or requires the existing
+trusted value, and every later shard connection verifies it. A migration stores
+source and target fingerprints before its first shard commit and verifies the
+exact journal prefix during recovery. The full input encodings and state
+invariants are frozen in the
+[manifest storage format](STORAGE_FORMAT.md).
+
 Each manifest version retains an intentionally incompatible
 `briskdb_metadata` definition and row as a downgrade fence. The v3-to-v4
 migration remains manifest-atomic. The v4-to-v5 step first validates the v4
@@ -132,8 +144,10 @@ safe.
 
 The v5-to-v6 step is manifest-only: it preserves layout state, routing, logical
 metadata, and data while rebuilding the schema-generation constraint, creating
-an empty journal, and fencing v5 readers. There is no automatic downgrade; an
-older binary requires a pre-v6 backup.
+an empty journal, and fencing v5 readers. The v6-to-v7 step is also
+manifest-only and begins in `Verifying`; it cannot manufacture a historical
+checksum that v6 never stored. There is no automatic downgrade; an older binary
+requires a backup from before the newer format.
 
 Startup first canonicalizes the data-directory path and joins the process-wide
 root coordination keyed by that path. It acquires the shared schema gate before
@@ -141,13 +155,15 @@ loading the manifest, so independent `Storage`, `Database`, and `Engine` handles
 in one process serialize startup and migration against ordinary admission and
 share catalog-generation publication.
 
-Manifest loading acquires `BEGIN IMMEDIATE` before making a format migration or
-layout-state decision. Numbered manifest-only steps rewrite schema/data, stamp
-and read back their target identity/version, validate the destination, and
-commit in their own transaction. If the resulting v6 manifest contains an
-`Applying` schema migration, startup validates and resumes it immediately. A
-journal can exist only with a durable `Ready` layout, and recovery publishes its
-target generation before ordinary layout reconciliation or final shard opens.
+Each manifest connection enables and reads back SQLite cell-size checks and
+requires a full manifest integrity check before parsing control-plane state.
+Manifest loading then acquires `BEGIN IMMEDIATE` before making a format
+migration or layout-state decision. Numbered manifest-only steps rewrite
+schema/data, stamp and read back their target identity/version, validate the
+destination, and commit in their own transaction. An `Applying` v6 migration is
+finished under v6 rules before v7 establishes checksum authority. An active v7
+migration is resumed only after every shard matches the preserved source or
+target fingerprint for its exact journal-prefix position.
 
 Layout reconciliation then acquires a new immediate manifest transaction,
 re-reads and validates the layout state under that write lock, and holds the
@@ -157,7 +173,11 @@ from a stale `Creating` observation. Only a locked, durable `Creating` state
 permits missing canonical shard files to be created and WAL to be enabled. The
 final strict shard opens and catalog reconciliation complete before the startup
 guard publishes `Ready`; ordinary work is never served against a persisted
-mixed-generation prefix.
+mixed-generation prefix. A first v7 open treats the consensus across all strict
+generation-bound shard-schema fingerprints as its trust-on-first-upgrade
+baseline. Later opens require that existing trusted fingerprint. A durable
+`Degraded` state is terminal; recovery replaces the complete manifest and
+shard set from one known-good consistent copy rather than rebaselining it.
 
 `Adopting` recognizes only existing legacy shard files with exact zero
 application-ID/user-version headers and an existing WAL mode. It writes current
@@ -166,8 +186,10 @@ runtime connection opens use read-write, no-create, no-follow SQLite flags and
 require the exact path, layout ID, shard ID, application ID, metadata encoding,
 schema generation, and WAL mode. Missing, extra canonical, foreign, non-WAL,
 and wrong-generation files fail closed, as do swapped files and files cloned
-into a wrong slot or layout. WAL and shared-memory sidecars are transient and
-are not required layout members.
+into a wrong slot or layout. Every shard open also enables cell-size checks,
+checks the BriskDB metadata table with SQLite's table-scoped integrity check,
+and verifies the persistent application-schema fingerprint. WAL and
+shared-memory sidecars are transient and are not required layout members.
 
 This is an internal storage-open concern, is unreachable from client SQL, and
 is atomic only within `manifest.sqlite`. Validation returns routing and logical
@@ -180,8 +202,10 @@ The logical catalog remains advisory: there is no catalog mutation API,
 planner integration, or schema enforcement yet. Fresh manifests and upgrades
 originating before v4 contain no table rows; a v4-to-v5 upgrade retains every
 validated v4 logical-catalog row. Schema migration does not inspect, infer, or
-mutate `briskdb_tables`, nor does it prove physical schema equivalence. Existing
-tables remain reachable through the explicit-key execute/query surfaces. Core
+mutate `briskdb_tables`; instead, v7 independently requires the exact
+`sqlite_schema` fingerprint to agree across shards without claiming the
+advisory catalog describes it. Existing tables remain reachable through the
+explicit-key execute/query surfaces. Core
 routing still hashes the exact caller-provided key bytes, derives a versioned
 virtual bucket, and reads the final physical shard from the snapshot without
 querying SQLite. The generation-1 ranges reproduce prior modulo placement for
@@ -205,8 +229,12 @@ objects, and reserved-state access. Because SQLite does not reveal an
 compares the reserved schema before and after the batch. The exact format,
 numeric codes, downgrade policy, recovery cases, and tests are documented in
 [manifest storage format](STORAGE_FORMAT.md).
-Schema checksums and explicit degraded states remain issue #18; richer
-migration administration and status surfaces remain issue #53.
+Integrity failure marks the canonical-root admission gate sticky `Degraded`;
+ordinary operations, status calls, and migrations then fail with
+`DataCorruption`, and a trusted manifest records that terminal state when
+possible. BriskDB exposes no repair, rebaseline, or detailed integrity status
+API here; richer migration administration and status surfaces remain issue
+#53.
 
 ## Session and asynchronous engine boundary
 

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -70,6 +70,15 @@ returns an engine. `Cancelled` and `DeadlineExceeded` themselves remain
 non-retryable classifications even though an operator may deliberately submit
 the exact migration again.
 
+If an integrity check fails, the gate for every in-process handle sharing that
+canonical root becomes sticky `Degraded`. Ordinary execute/query work, status,
+and schema migration then return non-retryable `DataCorruption` (HTTP 500); an
+outstanding migration guard cannot restore admission when it drops. There is no
+public repair or rebaseline operation, and startup never clears a persisted
+`Degraded` marker from the same manifest. Service can return only after an
+operator restores the complete manifest-and-shard set from one consistent,
+known-good copy.
+
 An explicit cancellation is `Cancelled`; expiration of an absolute request
 deadline is `DeadlineExceeded`, even though PostgreSQL represents both with
 SQLSTATE `57014`. MySQL distinguishes them with errors 1317 and 3024. If a
@@ -141,6 +150,19 @@ than the coordinator can safely interpret is `FailedPrecondition`. Lock
 contention during preflight, apply, progress, or startup recovery remains
 retryable `Busy`.
 
+Manifest v7 adds the same classification to integrity state. An unsupported
+manifest-root or shard-schema digest encoding version is
+`FailedPrecondition`; this binary will not reinterpret or rewrite it. A
+recognized encoding with a semantic-root mismatch, malformed checksum blob,
+invalid durable-state/checksum/journal combination, failed SQLite manifest or
+shard-metadata integrity check, inconsistent shard-schema consensus, or source
+or target fingerprint in the wrong migration-prefix position is
+`DataCorruption`. BriskDB persists `Degraded` only when it can first validate
+the existing manifest root, and that emergency write is best-effort because
+lock, disk, or process failure can prevent it. The in-process gate remains
+sticky even if persistence fails; a restart is never a supported repair. An
+altered manifest payload is never blessed while handling its mismatch.
+
 For submitted migration input, an empty batch, a batch over 65,536 UTF-8 bytes,
 or a NUL byte is `InvalidArgument`. SQLite syntax or statement-shape failures
 retain the normal SQL classification, and attempts to reach the reserved
@@ -163,9 +185,10 @@ BriskDB-owned metadata or mutation of a storage-control PRAGMA is
 serialized directly by an adapter.
 
 The earlier taxonomy change affected reporting only. Manifest v5 later added
-identity metadata to shard files; manifest v6 adds retained, crash-resumable
-application-schema history. Both preserve legacy application tables, rows,
-routing, SQL results, and wire configuration during format upgrade.
+identity metadata to shard files, manifest v6 added retained crash-resumable
+application-schema history, and manifest v7 added semantic and schema
+fingerprints plus explicit integrity state. Their format upgrades preserve
+legacy application tables, rows, routing, SQL results, and wire configuration.
 
 This is a pre-1.0 Rust API migration: public `Database` operations now return
 `EngineResult<T>` instead of `anyhow::Result<T>`. The `?` operator still

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -143,8 +143,9 @@ exact SQL remain in the manifest, so callers must not include credentials or
 other sensitive literals. A byte-identical retry of completed SQL is
 idempotent and does not advance the schema generation again.
 The migration does not infer or update advisory `briskdb_tables` rows. Richer
-migration/history APIs remain issue #53, and schema-equivalence checks,
-checksums, and explicit degraded states remain issue #18.
+migration/history APIs remain issue #53. Manifest v7 independently requires a
+generation-bound persistent-schema fingerprint to agree across every shard; it
+does not claim the advisory catalog describes that schema.
 
 The schema gate admits no new routed work after migration begins and waits for
 previously admitted operations to drain. During active preflight or apply,
@@ -370,9 +371,9 @@ underlying execution semantics.
   prefix selects one of 4,096 virtual buckets through the versioned
   compatibility algorithm.
 - The final physical shard is read from the validated, generation-stamped
-  bucket map retained in manifest version 6. Routing generation 1 preserves
+  bucket map retained in manifest version 7. Routing generation 1 preserves
   the earlier modulo placement for every supported shard count.
-- Manifest version 6 retains the read-only logical catalog introduced in v4,
+- Manifest version 7 retains the read-only logical catalog introduced in v4,
   with a journaled schema generation from 0 through 2,147,483,647 and default
   database ID 1 named `default`. Its optional table rows can describe sharded,
   global, or catalog placement and a sharded table's `Int64`, text, or binary
@@ -391,7 +392,9 @@ underlying execution semantics.
 - Unique constraints and transactions are local to one SQLite shard.
 - Schema migration preflights every shard, then commits an ascending prefix
   under a retained journal. Each shard is atomic; the shard set is not one
-  transaction, and startup resumes a partial prefix before serving work.
+  transaction. The manifest preserves committed-source and target schema
+  fingerprints, and startup resumes only an exact checksummed prefix before
+  serving work.
 
 ### Planned stable contract
 
@@ -429,7 +432,9 @@ identity metadata. Version 6 adds the application-schema journal. A migration
 batch and generation are atomic within each shard, and final journal state plus
 catalog generation are atomic within the manifest, but no transaction spans
 those files. Ascending-prefix validation and replay provide recovery rather
-than cross-file atomicity.
+than cross-file atomicity. Version 7 adds the semantic manifest root, explicit
+integrity states, and generation-bound shard-schema fingerprints; journal,
+state, checksum, and catalog changes reseal atomically within the manifest.
 See the [manifest storage-format contract](STORAGE_FORMAT.md).
 
 Scatter reads will combine committed results from multiple SQLite files. They

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -11,24 +11,23 @@ permitted; later migration opens never create a missing replacement, use
 SQLite's no-follow mode, and revalidate the freshly opened layout identity
 inside the same manifest transaction before changing journal state.
 
-## Current format: version 6
+## Current format: version 7
 
 SQLite header fields identify the file and its format:
 
 | Header field | Value | Meaning |
 | --- | --- | --- |
 | `PRAGMA application_id` | `0x42524442` (`BRDB`) | Permanent BriskDB manifest-family marker |
-| `PRAGMA user_version` | `6` | Authoritative manifest schema version |
+| `PRAGMA user_version` | `7` | Authoritative manifest schema version |
 
 The application ID prevents an accidental foreign SQLite file from being
 adopted as a manifest. It is not authentication or tamper protection: a process
-that can write the data directory can forge it. Checksums and explicit degraded
-states remain issue #18.
+that can write the data directory can forge it and the unkeyed checksums
+described below.
 
-Version 6 has ten strict manifest tables. It retains the v5 routing, logical
-catalog, and physical-layout tables; rebuilds the schema-catalog singleton to
-allow journaled generations; replaces the downgrade fence; and adds the
-application-schema migration journal.
+Version 7 has eleven strict manifest tables. It retains the v6 routing, logical
+catalog, physical-layout, and application-schema migration tables; replaces the
+downgrade fence; and adds one integrity singleton.
 
 ```sql
 CREATE TABLE briskdb_manifest (
@@ -38,7 +37,7 @@ CREATE TABLE briskdb_manifest (
 
 CREATE TABLE briskdb_metadata (
     requires_manifest_version INTEGER NOT NULL
-        CHECK (requires_manifest_version >= 6)
+        CHECK (requires_manifest_version >= 7)
 ) STRICT;
 
 CREATE TABLE briskdb_routing (
@@ -160,26 +159,69 @@ CREATE TABLE briskdb_schema_migrations (
     next_shard INTEGER NOT NULL CHECK (next_shard BETWEEN 0 AND shard_count),
     CHECK (migration_state = 1 OR next_shard = shard_count)
 ) STRICT;
+
+CREATE TABLE briskdb_integrity (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    manifest_digest_version INTEGER NOT NULL CHECK (manifest_digest_version > 0),
+    manifest_digest BLOB NOT NULL
+        CHECK (typeof(manifest_digest) = 'blob' AND length(manifest_digest) = 32),
+    schema_digest_version INTEGER NOT NULL CHECK (schema_digest_version > 0),
+    database_state INTEGER NOT NULL CHECK (database_state IN (1, 2, 3, 4)),
+    committed_schema_digest BLOB
+        CHECK (
+            committed_schema_digest IS NULL
+            OR (
+                typeof(committed_schema_digest) = 'blob'
+                AND length(committed_schema_digest) = 32
+            )
+        ),
+    target_schema_digest BLOB
+        CHECK (
+            target_schema_digest IS NULL
+            OR (
+                typeof(target_schema_digest) = 'blob'
+                AND length(target_schema_digest) = 32
+            )
+        ),
+    CHECK (
+        (database_state = 1 AND target_schema_digest IS NULL)
+        OR (
+            database_state = 2
+            AND committed_schema_digest IS NOT NULL
+            AND target_schema_digest IS NULL
+        )
+        OR (
+            database_state = 3
+            AND committed_schema_digest IS NOT NULL
+            AND target_schema_digest IS NOT NULL
+        )
+        OR database_state = 4
+    )
+) STRICT;
 ```
 
-The manifest, metadata, routing, schema-catalog, and shard-layout tables each
-contain exactly one row. The v6 downgrade-fence row is exactly `6`.
+The manifest, metadata, routing, schema-catalog, shard-layout, and integrity
+tables each contain exactly one row. The v7 downgrade-fence row is exactly `7`.
+The two integrity-version columns deliberately accept any positive integer so
+a future digest encoding can remain structurally readable long enough for an
+older binary to reject it as `FailedPrecondition`; v7 writers emit only `1`.
+Zero or negative versions are malformed and are `DataCorruption`.
 `briskdb_manifest.shard_count` is immutable and is the initial routing modulus;
 it is also the live physical-shard count. Physical IDs are exactly
 `0..shard_count - 1`. Filenames remain derived by trusted code as
 `shards/{shard_id:04}.sqlite` and are never read from catalog-controlled paths.
-Version 6 supports only the `active` physical-shard lifecycle state. Adding
+Version 7 supports only the `active` physical-shard lifecycle state. Adding
 provisioning, draining, or retirement states to the routing catalog requires a
 later format and state-machine change. The separate shard-layout state governs
 only startup identity reconciliation.
 
 ### Logical catalog
 
-Every fresh or upgraded v6 manifest contains logical database ID `1` named
-`default`. A fresh or v5-upgraded manifest begins at application-schema
+Every fresh or upgraded v7 manifest contains logical database ID `1` named
+`default`. A fresh or pre-v6 upgrade begins at application-schema
 generation `0`; each completed journal row advances it by exactly one, through
 a maximum of `2,147,483,647`. The schema-catalog singleton also contains
-identifier encoding version `1` and default database ID `1`. Version 6 permits
+identifier encoding version `1` and default database ID `1`. Version 7 permits
 at most 64 logical databases and 4,096 table rows. Database and table IDs are
 positive; table names are unique within their owning database, and every table
 references an existing database.
@@ -210,17 +252,18 @@ Table placement and shard-key type use stable numeric codes:
 are key-routed. `Global` describes small replicated lookup data. `Catalog`
 describes manifest-owned metadata rather than a user shard table.
 
-The loaded `Catalog` is read-only to callers and remains advisory in version 6:
+The loaded `Catalog` is read-only to callers and remains advisory in version 7:
 there is no table-catalog mutation API, planner integration, or enforcement
 against physical shard schemas. The engine publishes a newly committed schema
 generation into its shared catalog snapshot only after every shard has reached
 that generation. Fresh initialization and every v1/v2/v3 upgrade leave
 `briskdb_tables` empty; a v4-to-v5 upgrade retains every validated v4 catalog
-row. Schema migration does not inspect, infer, or mutate `briskdb_tables`, and
-it does not compare the journaled SQL with physical schema equivalence. Tables
-that are absent from the advisory catalog remain usable through the existing
-explicit-key execute/query API. Version-5 adoption preserves existing tables
-and rows while adding only BriskDB-owned shard identity metadata.
+row. Schema migration does not inspect, infer, or mutate `briskdb_tables` from
+the journaled SQL; the physical-schema fingerprint independently establishes
+exact consensus across shards. Tables that are absent from the advisory catalog
+remain usable through the existing explicit-key execute/query API. Version-5
+adoption preserves existing tables and rows while adding only BriskDB-owned
+shard identity metadata.
 
 ### Application-schema migration journal
 
@@ -247,15 +290,124 @@ additional `Applying` row may exist, and it must target
 `schema_generation + 1`. Its stored source generation, shard count, SQL text,
 digest, state, and progress are validated on every manifest open. Any journal
 history requires the physical layout to be `Ready`; `Creating` and `Adopting`
-manifests have an empty journal. Fresh v6 initialization and v5-to-v6 upgrade
-also create an empty journal at generation 0.
+manifests have an empty journal. Fresh v7 initialization and pre-v6 upgrades
+begin with an empty journal at generation 0.
 
 The retained journal proves which exact batches BriskDB coordinated; it does
-not prove that a shard schema is equivalent to another schema or that its file
-contents are untampered. Checksums, schema-equivalence checks, and explicit
-degraded states remain issue #18. Richer migration submission, history, and
-status APIs remain issue #53; the current public entry point retains the
-`broadcast` name and response shape.
+not authenticate the files or cryptographically cover application rows. Version
+7 separately requires every shard's persistent application-schema fingerprint
+to match the trusted source or target fingerprint for its position in an active
+migration. Richer migration submission, history, and status APIs remain issue
+#53; the current public entry point retains the `broadcast` name and response
+shape.
+
+### Integrity metadata and durable database states
+
+`briskdb_integrity` contains the supported digest versions, a semantic manifest
+root, the durable database state, the trusted committed application-schema
+fingerprint, and an optional migration target fingerprint. Its numeric states
+are distinct from the v5 physical-layout states:
+
+| Code | State | Required checksum and journal shape | Admission contract |
+| --- | --- | --- | --- |
+| `1` | `Verifying` | No active migration and no target fingerprint; the committed fingerprint may be absent during first bootstrap | Startup must verify one shard-schema consensus and seal it before serving work |
+| `2` | `Ready` | One committed fingerprint, no target fingerprint, no active migration, physical layout `Ready` | Ordinary operations may run |
+| `3` | `Migrating` | Committed source and target fingerprints plus exactly one `Applying` journal row, physical layout `Ready` | Only the migration coordinator may advance the validated prefix |
+| `4` | `Degraded` | Preserves whatever trusted committed/target fingerprints and active journal existed when validation failed | Terminal fail-closed state; startup and all new work return non-retryable `DataCorruption` until the complete database is restored from a known-good copy |
+
+`Pending` is an in-process admission state used after durable partial progress;
+it is not a fifth manifest state. A state transition, its checksum fields, the
+corresponding journal/catalog mutation, and the refreshed semantic root commit
+in one `manifest.sqlite` transaction. A failed validation marks the canonical
+root's shared in-process gate `Degraded` immediately. BriskDB also persists
+`Degraded` on a best-effort basis when the existing manifest root can first be
+validated; it never reseals altered manifest payload as part of handling a root
+mismatch. If that emergency write cannot commit because of lock contention,
+read-only media, a full disk, I/O failure, or process loss, the current process
+still remains fail-closed but the manifest may retain its prior state. Because
+startup does not yet scan every application-data page, operators must not use a
+restart as repair after any reported `DataCorruption`; whole-shard corruption
+drills and failure handling remain issue #68. Those storage failures retain
+their own error kinds and do not themselves justify rebaselining data.
+
+Manifest digest version 1 is a full 32-byte, unkeyed BLAKE3 digest. The stream
+begins with `briskdb.manifest.semantic-root.v1` plus its terminating NUL. It
+then encodes the length-prefixed name `application_id` and its tagged integer,
+followed by the length-prefixed name `user_version` and its tagged integer.
+These tables and columns follow in fixed order:
+
+| Table | Canonical columns |
+| --- | --- |
+| `briskdb_manifest` | `singleton`, `shard_count` |
+| `briskdb_metadata` | `requires_manifest_version` |
+| `briskdb_routing` | `singleton`, `hash_version`, `key_encoding_version`, `bucket_algorithm_version`, `virtual_bucket_count`, `map_generation` |
+| `briskdb_physical_shards` | `shard_id`, `lifecycle_state` |
+| `briskdb_virtual_buckets` | `bucket_id`, `physical_shard_id` |
+| `briskdb_logical_databases` | `database_id`, `database_name` |
+| `briskdb_schema_catalog` | `singleton`, `identifier_encoding_version`, `schema_generation`, `default_database_id` |
+| `briskdb_tables` | `table_id`, `database_id`, `table_name`, `placement`, `shard_key_column`, `shard_key_type` |
+| `briskdb_shard_layout` | `singleton`, `layout_id`, `shard_application_id`, `shard_metadata_version`, `layout_state` |
+| `briskdb_schema_migrations` | `target_generation`, `source_generation`, `migration_id`, `digest_version`, `sql_text`, `shard_count`, `migration_state`, `next_shard` |
+| `briskdb_integrity` | `singleton`, `manifest_digest_version`, `schema_digest_version`, `database_state`, `committed_schema_digest`, `target_schema_digest` |
+
+Rows use ascending primary-key or singleton order; the metadata fence uses
+`rowid` order. The encoding includes table and column names with unsigned
+64-bit little-endian byte lengths. Each table starts with `0x10`, then its name,
+unsigned 64-bit little-endian column count, and column names. Each row starts
+with `0x11`; `0x12` ends a table and `0xff` ends the stream. Values are tagged
+by SQLite storage class: `0` is null with no payload, `1` is a signed 64-bit
+little-endian integer, and `2`/`3` are text/blob followed by their byte length
+and exact bytes. A real value is invalid for this manifest. The stored
+`manifest_digest` column itself is the sole omitted field, avoiding
+self-reference; its version, database state, and schema digest fields are
+covered. Frozen SQL definitions, STRICT flags, indexes, and foreign keys are
+validated separately rather than encoded as semantic rows.
+
+Every BriskDB-owned v7 manifest mutation recalculates the root after its row
+changes and before the same transaction commits. Progress acknowledgement,
+migration publication/finalization, layout publication, state changes, and
+catalog changes therefore cannot commit with a stale root through supported
+code. Hashing semantic values instead of the raw SQLite file makes the root
+stable across WAL checkpoints, page relocation, and `VACUUM`; it deliberately
+does not cover SQLite page bytes, rollback journals, WAL, or shared memory.
+
+The frozen four-shard v7 fixture with layout ID
+`000102030405060708090a0b0c0d0e0f`, committed schema fingerprint `5a` repeated
+32 times, and the catalog rows in
+`manifest_semantic_digest_v1_has_a_frozen_golden_vector` hashes to
+`579d8a7854a9a7aa3add69dbb8c413b2851db74edce19ad6def22ab94f029ed1`.
+The adjacent reverse-insertion fixture must produce the same root.
+
+Schema digest version 1 is also a full 32-byte, unkeyed BLAKE3 digest. It begins
+with `briskdb.shard.application-schema.v1` plus its terminating NUL, the
+unsigned 32-bit little-endian digest version, and the unsigned 64-bit
+little-endian application-schema generation. BriskDB then streams
+`type`, `name`, `tbl_name`, and nullable `sql` from `main.sqlite_schema`, sorted
+by those four fields with binary collation. Each object starts with `1`; every
+text field uses an unsigned 64-bit little-endian byte length and exact UTF-8
+bytes; nullable SQL uses `1` for present and `0` for absent; and `0` ends the
+object stream. The generation binding means identical DDL at two generations
+has different fingerprints.
+
+SQLite-owned objects whose names begin with `sqlite_` (case-insensitive) and
+the one exact `briskdb_shard_metadata` table are excluded. Any other reserved
+object is corruption. The fingerprint includes persistent application tables,
+indexes, views, and triggers exactly as SQLite records them. It excludes
+`rootpage`, application row values, shard ID and layout metadata, file headers,
+page layout, WAL state, and temporary schema objects. Thus it is stable across
+row DML, checkpoint, reopen, and `VACUUM`, while differing for any persistent
+application-schema change or generation change.
+
+Every manifest connection first enables and reads back
+`PRAGMA cell_size_check=ON`, then requires `PRAGMA main.integrity_check(1)` to
+return exactly one `ok` row before manifest parsing or migration. Strict
+manifest validation separately runs the foreign-key check because SQLite's
+integrity check does not report foreign-key violations. Every BriskDB-opened
+shard connection likewise enables and reads back `cell_size_check`. Strict
+shard identity validation requires
+`PRAGMA main.integrity_check('briskdb_shard_metadata')` to return exactly one
+`ok` row. That shard check is intentionally scoped to the storage-owned
+metadata table; startup does not claim a whole-shard application-data scan.
 
 ### Physical shard layout
 
@@ -342,7 +494,7 @@ The routing singleton contains exactly these generation-1 values:
 | `key_encoding_version` | `1` | Exact caller-supplied bytes; string shard keys contribute their UTF-8 bytes, with no Unicode normalization |
 | `bucket_algorithm_version` | `1` | Compatibility-preserving range algorithm below |
 | `virtual_bucket_count` | `4096` | Fixed virtual bucket space `0..4095` |
-| `map_generation` | `1` | Initial committed bucket map and the only generation version 6 can interpret |
+| `map_generation` | `1` | Initial committed bucket map and the only generation version 7 can interpret |
 
 Every bucket ID exists exactly once and references an active physical shard.
 Every physical shard owns at least one bucket. The generation-1 map partitions
@@ -371,7 +523,7 @@ vectors freeze the exact key bytes, BLAKE3 prefix, little-endian hash integer,
 bucket ID, and persisted physical shard.
 
 `map_generation` is separate from manifest `user_version` and from
-`schema_generation`. Version 6 accepts only routing generation 1 and validates
+`schema_generation`. Version 7 accepts only routing generation 1 and validates
 its exact deterministic assignment; no public map-mutation operation exists
 yet. A future format that can commit a changed map must bump `user_version` and
 its downgrade fence as well as `map_generation`. That requirement makes this
@@ -382,12 +534,37 @@ At each open, BriskDB validates the exact objects, columns, strict flags, frozen
 schema SQL, singleton rows, logical identifiers and limits, metadata codes,
 supported algorithm values, contiguous physical and bucket IDs, active
 lifecycle states, assignments, coverage, and foreign keys. A recognized
-version-6 manifest that violates any invariant is `DataCorruption` and is
+version-7 manifest that violates any invariant is `DataCorruption` and is
 rejected before shard connections are opened. The same locked transaction
 returns routing and logical rows as one coherent shared snapshot. Request
 routing performs no manifest query and cannot fall back to modulo after a failed
 validation; only successful migration finalization publishes a newer logical
 schema generation into the snapshot.
+
+## Previous version 6
+
+Version 6 has the first ten current tables and no `briskdb_integrity` table.
+Its exact downgrade fence requires manifest version 6, contains exactly `6`,
+and `PRAGMA user_version` is `6`. It introduced the retained application-schema
+migration journal but had no trusted manifest or shard-schema checksum and no
+durable database integrity state.
+
+A v7 opener first performs full v6 structural validation. If v6 has an
+`Applying` journal row, startup completes that exact ascending source/target
+prefix under the frozen v6 recovery rules while the manifest is still version
+6. Only after the row is `Complete` and its target generation is committed may
+the manifest-only v6-to-v7 transaction replace the downgrade fence, add the
+integrity singleton in `Verifying`, and stamp version 7. A crash before that
+upgrade remains recoverable by v6 rules; a crash after it restarts from the
+durable v7 `Verifying` state.
+
+Because v6 stored no application-schema checksum, this first v7 open is an
+explicit trust-on-first-upgrade boundary. BriskDB strictly validates every
+shard and requires all generation-bound schema fingerprints to agree, then
+stores that consensus as the first trusted committed fingerprint and moves to
+`Ready` atomically. Divergent shards fail closed; matching fingerprints prove
+consensus at upgrade time, not that the pre-v7 schema has an authenticated
+history.
 
 ## Previous version 5
 
@@ -402,15 +579,16 @@ CREATE TABLE briskdb_metadata (
 ) STRICT;
 ```
 
-The fence contains exactly `5`, and `PRAGMA user_version` is `5`. A v6 opener
-fully validates the v5 manifest, then atomically rebuilds only the
+The fence contains exactly `5`, and `PRAGMA user_version` is `5`. A current
+opener fully validates the v5 manifest, then atomically rebuilds only the
 schema-catalog table, creates the empty migration journal, replaces the fence,
 and stamps manifest version 6. It preserves the layout ID and state, routing,
 logical databases, table-catalog rows, and every application table and row.
-After that manifest-only step, an unfinished v5 `Creating` or `Adopting` layout
-is reconciled exactly as before. That upgrade creates no active migration. In a
-later v6 open, an active journal can exist only beside a durable `Ready` layout
-and is resumed before ordinary layout reconciliation and final shard opens.
+The next manifest-only step establishes v7 `Verifying`. An unfinished v5
+`Creating` or `Adopting` layout is then reconciled exactly as before. These
+upgrades create no active migration. An active journal found in an already
+existing v6 manifest can exist only beside a durable `Ready` layout and is
+finished under v6 rules before the v7 step.
 
 ## Previous version 4
 
@@ -474,8 +652,8 @@ CREATE TABLE briskdb_metadata (
 ```
 
 The fence contains exactly `2`. A current opener validates this complete format
-before applying the numbered v2-to-v3, v3-to-v4, v4-to-v5, and v5-to-v6
-transactions.
+before applying the numbered v2-to-v3, v3-to-v4, v4-to-v5, v5-to-v6, and
+v6-to-v7 transactions.
 
 ## Legacy version 1
 
@@ -512,27 +690,36 @@ returning:
    generation.
 2. Determine whether fresh layout creation is allowed, validate the canonical
    parent and regular final file, then open the manifest with no symbolic-link
-   following, a finite busy timeout, `synchronous=FULL`, and foreign keys
-   enabled.
-3. Acquire `BEGIN IMMEDIATE`, then read identity, version, schema, and stored
-   configuration under that write lock.
-4. Reject a foreign file, a newer version, a requested shard-count mismatch, or
-   an invalid recognized schema before changing it.
+   following and a finite busy timeout. Enable and read back
+   `cell_size_check`, require a clean full manifest `integrity_check`, then
+   configure `synchronous=FULL` and foreign keys before interpreting manifest
+   state.
+3. If the file is version 6 with one `Applying` migration, validate and finish
+   its exact source/target prefix under v6 rules while it is still version 6.
+   Do not establish v7 checksum authority over a partial v6 migration.
+4. Acquire `BEGIN IMMEDIATE`, then read identity, version, exact schema,
+   invariant rows, foreign keys, and the semantic root under that write lock.
+   Reject a foreign file, a newer version, a requested shard-count mismatch, a
+   stale root, or another invalid recognized state before changing it.
 5. Apply each compile-time registered manifest migration with static SQL and
    bound data. The destination application ID and `user_version` are the final
    mutations; validate the complete destination and commit one numbered step at
-   a time.
+   a time. The v6-to-v7 transaction adds an integrity row in `Verifying`; older
+   formats therefore cannot be mistaken for checksummed data.
 6. Fresh initialization is allowed only beside an otherwise empty physical
-   layout and commits v6 state `Creating` with generation 0 and an empty
-   migration journal. An existing v1/v2/v3 manifest first advances through v4;
-   the v4-to-v5 transaction commits a random 16-byte layout ID and state
-   `Adopting` before any shard file changes. The v5-to-v6 manifest-only step
-   preserves that state and creates an empty journal.
-7. If the validated v6 manifest contains one `Applying` schema migration, mark
-   startup as pending on interruption, validate its exact source/target shard
-   prefix, and resume it in ascending order. Its layout is necessarily already
-   durable `Ready`. The final migration transaction publishes `Complete` and
-   the target catalog generation before ordinary layout reconciliation begins.
+   layout and commits v7 physical state `Creating`, integrity state
+   `Verifying`, generation 0, and an empty migration journal. An existing
+   v1/v2/v3 manifest first advances through v4; the v4-to-v5 transaction commits
+   a random 16-byte layout ID and physical state `Adopting` before any shard
+   file changes. The v5-to-v6 step creates the journal, and v6-to-v7 establishes
+   the unsealed integrity row.
+7. If the validated integrity state is `Degraded`, fail startup without
+   changing it. Otherwise, if a validated v7 manifest contains one `Applying`
+   migration, require state `Migrating`, validate every shard against the
+   trusted source/target fingerprint for its exact journal-prefix position,
+   and resume it in ascending order. The final transaction publishes the
+   target catalog generation, target fingerprint, `Complete`, `Ready`, and a
+   refreshed root before ordinary layout reconciliation continues.
 8. Acquire a new `BEGIN IMMEDIATE`, re-read and validate the committed layout
    identity and state, and reconcile every expected physical ID in ascending
    order while retaining the lock. Only `Creating` may create a missing file
@@ -542,14 +729,19 @@ returning:
    shard filenames, strictly revalidate every expected file, publish `Ready`
    only after full validation, and commit.
 9. Open every shard once more with read-write, no-create, no-follow flags;
-   apply connection-local durability and foreign-key settings only after
-   identity, generation, and WAL validation. Reconcile the validated catalog
-   generation with other live handles for the canonical root, publish the
-   startup gate `Ready`, and only then return `Storage`, `Database`, or `Engine`.
+   enable cell-size checking; and validate identity, generation, WAL, the
+   metadata-table integrity check, and the generation-bound application-schema
+   fingerprint. `Verifying` requires one consensus across all shards. `Ready`
+   requires the existing trusted fingerprint.
+10. In one manifest transaction, seal a first consensus as the committed
+    fingerprint, transition `Verifying` to `Ready`, and refresh the root.
+    Reconcile the catalog generation with other live handles for the canonical
+    root, publish the startup gate `Ready`, and only then return `Storage`,
+    `Database`, or `Engine`.
 
 SQLite transactional DDL keeps each numbered manifest step atomic within
-`manifest.sqlite`. A version-1 upgrade commits versions 2, 3, 4, 5, and then 6;
-a version-2 upgrade begins at 3, and so on. The v3-to-v4 step still creates the
+`manifest.sqlite`. A version-1 upgrade commits versions 2, 3, 4, 5, 6, and then
+7; a version-2 upgrade begins at 3, and so on. The v3-to-v4 step still creates the
 logical catalog, inserts database ID 1 named `default` plus the
 schema-generation-0 singleton, and leaves the table catalog empty.
 
@@ -566,39 +758,45 @@ The adoption path changes no application table or row and does not derive
 identity from application schema. A legacy shard with a nonzero header, a
 non-WAL mode, or a missing file is rejected without being repaired or replaced.
 The v5-to-v6 step does not change any shard because a valid v5 database is at
-schema generation 0 and has no journal history. Matching a shard generation
-validates only the declared generation; `briskdb_tables` remains advisory and
-is not checked against physical DDL.
+schema generation 0 and has no journal history. The v6-to-v7 step also changes
+no shard; it establishes a first fingerprint only after later cross-file
+consensus verification. `briskdb_tables` remains advisory and is not inferred
+from physical DDL.
 
 A new application-schema migration follows a separate durable protocol:
 
 1. Acquire the sole in-process schema-migration gate, stop admitting ordinary
    operations, and wait for operations already admitted to finish.
-2. Validate the SQL identity and limits, then execute the complete batch inside
-   a rollback-only immediate transaction on every shard at the source
-   generation. The preflight also runs `PRAGMA main.foreign_key_check` after
-   the batch so deferred violations cannot survive until a real commit. If any
-   preflight fails or the request is cancelled, no journal or shard change is
-   retained and ordinary work becomes ready again.
-3. Append one `Applying` journal row at target generation
-   `source_generation + 1` with `next_shard = 0`.
+2. Validate the SQL identity and limits. Require every shard's source schema to
+   match the committed fingerprint, then execute the complete batch inside a
+   rollback-only immediate transaction on every shard. Each preflight computes
+   the generation-bound target fingerprint and runs
+   `PRAGMA main.foreign_key_check`; every shard must produce the same target.
+   If any preflight fails or the request is cancelled, no journal or shard
+   change is retained and ordinary work becomes ready again.
+3. In one manifest transaction, append one `Applying` journal row at target
+   generation `source_generation + 1` with `next_shard = 0`, store the target
+   fingerprint, transition `Ready` to `Migrating`, and refresh the manifest
+   root.
 4. For each shard in ascending physical-ID order, execute the complete SQL
-   batch and stamp its target `user_version` in the same immediate SQLite
-   transaction. After that shard commit, advance the journal prefix by one in
-   a separate manifest transaction.
-5. Strictly validate every shard at the target generation, then atomically mark
-   the journal row `Complete` and advance the schema-catalog generation in one
-   final manifest transaction. Publish the new in-memory generation and admit
-   ordinary work again.
+   batch, stamp its target `user_version`, and require the target fingerprint in
+   the same immediate SQLite transaction. After that shard commits, advance the
+   journal prefix and refresh the root in one manifest transaction.
+5. Strictly validate every shard at the target generation and fingerprint.
+   Then, in one final manifest transaction, mark the journal row `Complete`,
+   advance the schema-catalog generation, promote the target fingerprint to
+   committed, clear the target, transition to `Ready`, and refresh the root.
+   Publish the new in-memory generation and admit ordinary work again.
 
 There is deliberately no transaction spanning shard files and the manifest.
 A crash after a shard commit but before its journal acknowledgement leaves the
 durable prefix one position behind. Recovery permits exactly that one
-already-target shard at the boundary, revalidates it, and advances without
-executing the batch twice. Any other hole, regression, or out-of-range shard
-generation is rejected. A byte-identical public retry resumes an active row or
-validates and returns an already completed row without creating another
-generation.
+already-target shard at the boundary, requires its target fingerprint, and
+advances without executing the batch twice. Every earlier shard must match the
+target generation and fingerprint; every later shard must match the source.
+Any other hole, regression, generation, or checksum mismatch is corruption and
+fails closed. A byte-identical public retry resumes an active row or validates
+and returns an already completed row without creating another generation.
 
 The controlled migration path installs cancellation-aware busy, progress, and
 interrupt hooks. Cancellation or deadline expiration rolls back the currently
@@ -610,6 +808,15 @@ is actively preflighting or applying, new ordinary work and another migration
 coordinator receive retryable `Busy`. If SQLite attempts a manifest `COMMIT`
 but reports an ambiguous cleanup or I/O failure, admission remains `Pending`
 until recovery validates whether that boundary became durable.
+
+If checksum or structural validation fails, the canonical-root gate becomes
+sticky `Degraded`, so a migration guard's later drop cannot reopen admission.
+When the semantic manifest root was still trustworthy, BriskDB records durable
+state `Degraded` without discarding its committed/target fingerprints or active
+journal. That state is terminal for v7: startup never clears it or chooses a
+new baseline. This is deliberately conservative because a runtime SQLite
+corruption result can originate in application-row pages that the schema
+fingerprint does not cover, while whole-shard scans are deferred.
 
 Tests prove retry after injected errors and Rust panic unwinding at cross-file
 persistence boundaries. Targeted subprocess-abort tests also prove migration
@@ -623,13 +830,12 @@ later storage-hardening certification.
 
 ## Compatibility and operations
 
-- Version 1 upgrades through versions 2, 3, 4, and 5 to version 6; version 2
-  begins at version 3, version 3 begins at version 4, version 4 begins at
-  version 5, and version 5 upgrades directly to version 6. Opening is therefore
-  potentially mutating.
+- Version 1 upgrades through versions 2, 3, 4, 5, 6, and 7; later versions
+  begin at the next numbered transaction. Opening is therefore potentially
+  mutating. An active v6 journal is completed before its v7 transaction.
 - There is no automatic downgrade. Older readers are fenced by the incompatible
-  metadata schema and authoritative header; in particular, a version-5 reader
-  rejects `user_version = 6` before it can ignore the migration journal.
+  metadata schema and authoritative header; in particular, a version-6 reader
+  rejects `user_version = 7` before it can ignore integrity state.
 - A manifest with the BriskDB application ID and a `user_version` newer than the
   binary supports fails with non-retryable `FailedPrecondition`; it is not
   downgraded or switched to WAL, and shard files are not opened.
@@ -642,7 +848,7 @@ later storage-hardening certification.
   are not canonical shard files and need not exist after a clean close.
 - The layout ID and application IDs detect accidental wrong-file placement;
   they are forgeable by anyone who can modify the directory and are not a
-  security or checksum mechanism.
+  security mechanism.
 - BriskDB owns the shard identity table and the persistent `application_id`,
   `user_version`, and `journal_mode` settings. Client SQL access to the identity
   table and mutation of those settings is denied. `user_version` is the
@@ -650,29 +856,46 @@ later storage-hardening certification.
 - SQLite lock contention remains retryable `Busy`; permission, read-only, full,
   and I/O failures retain the storage error taxonomy.
 
-Do not edit the header, tables, or rows manually. Until the checksum milestone,
-a coordinated manual edit that still satisfies every structural invariant
-cannot be distinguished from an intentional catalog update. The current
-deployment boundary remains local storage and one BriskDB process per data
-directory. Independent handles inside that process share a gate and live
-catalog coordination keyed by the canonical root. A formal backup/restore
-workflow is not implemented; recovery from a missing, swapped, or otherwise
-incompatible shard—including one cloned into the wrong slot or from another
-layout—requires the correct complete layout or a known-good copy made while
-BriskDB was stopped. Recovery to an older binary likewise requires a pre-v6
-backup. Separate server processes against one data directory are unsupported
-even though SQLite and the manifest use file locks; the in-process coordination
-is intentionally not a distributed lock.
+The checksums are corruption detectors, not authentication. Both use unkeyed
+BLAKE3 and are writable by anyone who can modify the data directory. The
+manifest root covers canonical control-plane values, not raw SQLite pages. The
+shard fingerprint covers persistent application-schema definitions, not
+application row values. The SQLite integrity and cell checks describe what was
+read at validation time; they are not continuous monitoring, and startup's
+table-scoped shard check is not a whole-data integrity scan. Whole-shard data
+scans, authenticated storage, online repair, and backup orchestration remain
+outside this format milestone.
+
+Do not edit headers, manifest rows, integrity state, or checksum values
+manually. There is no supported command that rebaselines a damaged database.
+For a degraded or rejected root, stop every BriskDB process using it, preserve
+the complete current directory for diagnosis, and restore the exact known-good
+manifest and shard contents from a consistent copy made while BriskDB was
+stopped. Do not copy an individual shard from another layout, mix backup times,
+or rewrite a checksum to match observed contents. The restored set must include
+the known-good manifest, rather than the terminal `Degraded` manifest from the
+failed root. A corrupt semantic root likewise must be restored, because
+BriskDB will not sign altered manifest payload while reporting the failure.
+
+The current deployment boundary remains local storage and one BriskDB process
+per data directory. Independent handles inside that process share a gate,
+schema fingerprints, and live catalog coordination keyed by the canonical
+root. A formal backup/restore workflow is not implemented. Recovery to an older
+binary requires a pre-v7 backup. Separate server processes against one data
+directory are unsupported even though SQLite and the manifest use file locks;
+the in-process coordination is intentionally not a distributed lock.
 
 ## Verification contract
 
-Tests cover fresh creation and every v1/v2/v3/v4/v5-to-v6 upgrade, every
-manifest layout state, the exact shard header and metadata row, dynamic schema
-generations, retained migration history, and no-op ready reopen. Failure
+Tests cover fresh creation and every v1/v2/v3/v4/v5/v6-to-v7 upgrade, every
+manifest layout and integrity state, the exact shard header and metadata row,
+dynamic schema generations, retained migration history, checksum golden
+vectors, and no-op ready reopen. Failure
 coverage includes missing and extra canonical files, foreign headers, non-WAL
 mode, malformed metadata or journal rows, cross-layout shard clones, shard
-swaps, symlinks, wrong generations, client attempts to reach storage-owned
-state, and runtime pool replacement opens. Injection around each manifest,
+swaps, symlinks, wrong generations, manifest-root and shard-schema mismatches,
+client attempts to reach storage-owned state, and runtime pool replacement
+opens. Injection around each manifest,
 layout, shard-migration, journal-progress, and finalization persistence boundary
 proves resumability and prevents a ready layout or completed generation from
 being published before full strict revalidation. Concurrent openers exercise
@@ -685,7 +908,9 @@ cover every algorithm state for every supported shard count, prove the final
 map lookup with a synthetic reassignment, and exercise parallel and reopen
 stability. Schema-migration tests cover exact identity and input limits,
 byte-identical retry, preflight rollback, per-shard atomicity, gate states,
-cancellation, panic, and targeted process abort at durable boundaries.
+cancellation, panic, target-fingerprint consensus, checksummed prefix recovery,
+sticky degradation, exact restoration, and targeted process abort at durable
+boundaries.
 Arbitrary process termination and filesystem faults remain part of the later
 storage-hardening suite. Every new manifest-format migration must extend the
 registry, destination validator, format documentation, and the same

--- a/docs/SUPPORTED_PLATFORMS.md
+++ b/docs/SUPPORTED_PLATFORMS.md
@@ -86,13 +86,15 @@ Startup and runtime migration opens disable symbolic-link following; a runtime
 open will not create a missing manifest and rechecks the opened layout identity
 before journal mutation.
 
-Manifest v6 retains each migration's exact SQL text for idempotency and startup
-recovery. Treat the data directory accordingly and do not include credentials,
-tokens, or other sensitive literals in migration SQL.
+Manifest v7 retains the v6 journal's exact migration SQL for idempotency and
+startup recovery. Treat the data directory accordingly and do not include
+credentials, tokens, or other sensitive literals in migration SQL.
 
 Manifest and shard application IDs plus the random 16-byte layout ID guard
-against accidental wrong-file placement. They are not authentication, checksums,
-or protection from a process that can write the data directory. Targeted
+against accidental wrong-file placement. They are not authentication or
+protection from a process that can write the data directory. The v7 semantic
+and schema checksums are likewise unkeyed corruption detectors, not
+authentication, and do not checksum application row values. Targeted
 subprocess-abort tests cover schema-journal persistence boundaries, but
 arbitrary process-kill timing, power-loss, and filesystem-fault certification
 remain later hardening work.

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -428,7 +428,12 @@ impl Engine {
         context: RequestContext,
     ) -> EngineResult<EngineStatus> {
         let mut operation = self.operation(context)?;
+        let schema_operation = match self.inner.database.storage.enter_schema_operation() {
+            Ok(guard) => guard,
+            Err(error) => return operation.finish(Err(error)),
+        };
         let result = async {
+            let _schema_operation = schema_operation;
             let _guard = operation.wait_pending(self.ready_session(session)).await?;
             operation.check_before_start()?;
             let result_limits = self.inner.options.result_limits();
@@ -658,6 +663,7 @@ impl Engine {
         let lease = operation.take_lease();
         let control = Arc::clone(&operation.control);
         let worker_control = Arc::clone(&control);
+        let storage = self.inner.database.storage.clone();
         let join = worker.spawn(move || {
             let _lease = lease;
             let _session = session;
@@ -669,6 +675,15 @@ impl Engine {
                     retire_if_broken(&mut connection, &result);
                     result
                 });
+            if result
+                .as_ref()
+                .is_err_and(|error| error.kind() == EngineErrorKind::DataCorruption)
+            {
+                // Query execution can surface corruption outside the schema
+                // fingerprint's coverage. Persist terminal Degraded state so a
+                // restart cannot reopen admission without a complete restore.
+                storage.record_schema_degraded();
+            }
             worker_control.complete(result)
         });
         operation.wait_started(join).await
@@ -739,6 +754,37 @@ impl Engine {
                 schema_operation,
                 guard,
                 move |_, _| panic!("intentional blocking worker panic"),
+            )
+            .await;
+        operation.finish_started(result)
+    }
+
+    #[cfg(test)]
+    async fn data_corruption_worker_for_test(
+        &self,
+        session: &Session,
+        shard: u16,
+    ) -> EngineResult<()> {
+        let mut operation = self.operation(RequestContext::new())?;
+        let schema_operation = self.inner.database.storage.enter_schema_operation()?;
+        let guard = match operation.wait_pending(self.ready_session(session)).await {
+            Ok(guard) => guard,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let owner = ConnectionOwner::new(session.id().get());
+        let result = self
+            .run_on_shard(
+                &mut operation,
+                shard,
+                owner,
+                schema_operation,
+                guard,
+                move |_, _| {
+                    Err(EngineError::new(
+                        EngineErrorKind::DataCorruption,
+                        "injected SQLite data corruption",
+                    ))
+                },
             )
             .await;
         operation.finish_started(result)
@@ -954,6 +1000,124 @@ mod tests {
         assert_eq!(status.connections_per_shard(), 4);
         assert_eq!(status.queue_capacity_per_shard(), 32);
         assert_eq!(session.state().await, SessionState::Ready);
+    }
+
+    #[tokio::test]
+    async fn status_obeys_migrating_and_degraded_schema_admission_before_session_waits() {
+        let (_temp, engine) = engine_with_options(2, 1, 1);
+        let session = Arc::new(engine.session());
+        let (holder_started_tx, holder_started_rx) = oneshot::channel();
+        let (holder_release_tx, holder_release_rx) = mpsc::channel();
+        let holder_engine = engine.clone();
+        let holder_session = Arc::clone(&session);
+        let holder = tokio::spawn(async move {
+            holder_engine
+                .hold_session_for_test(&holder_session, 0, holder_started_tx, holder_release_rx)
+                .await
+        });
+        timeout(Duration::from_secs(2), holder_started_rx)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let migration = engine
+            .inner
+            .database
+            .storage
+            .begin_schema_migration()
+            .unwrap();
+        assert_eq!(
+            engine.inner.database.storage.schema_gate_snapshot(),
+            crate::storage::SchemaGateSnapshot {
+                state: crate::storage::SchemaGateState::Migrating,
+                active_operations: 1,
+            }
+        );
+        let busy = timeout(Duration::from_secs(2), engine.status(&session))
+            .await
+            .expect("schema admission should reject status before its busy session is awaited")
+            .unwrap_err();
+        assert_eq!(busy.kind(), EngineErrorKind::Busy);
+        assert!(busy.is_retryable());
+        assert_eq!(engine.active_operations_for_test(), 1);
+
+        drop(migration);
+        holder_release_tx.send(()).unwrap();
+        holder.await.unwrap().unwrap();
+        assert_eq!(engine.status(&session).await.unwrap().shard_count(), 2);
+
+        engine.inner.database.storage.mark_schema_degraded();
+        let corruption = engine.status(&session).await.unwrap_err();
+        assert_eq!(corruption.kind(), EngineErrorKind::DataCorruption);
+        assert!(!corruption.is_retryable());
+        assert_eq!(session.state().await, SessionState::Ready);
+        assert_eq!(engine.active_operations_for_test(), 0);
+        assert_eq!(
+            engine.inner.database.storage.schema_gate_snapshot(),
+            crate::storage::SchemaGateSnapshot {
+                state: crate::storage::SchemaGateState::Degraded,
+                active_operations: 0,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn worker_data_corruption_persists_sticky_fail_closed_admission() {
+        let (temp, engine) = engine_with_options(2, 1, 1);
+        let session = engine.session();
+        session.set_routing_key("corrupt-worker").await.unwrap();
+
+        let detected = engine
+            .data_corruption_worker_for_test(&session, 0)
+            .await
+            .unwrap_err();
+        assert_eq!(detected.kind(), EngineErrorKind::DataCorruption);
+        assert_eq!(detected.to_string(), "injected SQLite data corruption");
+        assert_eq!(engine.active_operations_for_test(), 0);
+        assert_eq!(
+            engine.inner.database.storage.schema_gate_snapshot(),
+            crate::storage::SchemaGateSnapshot {
+                state: crate::storage::SchemaGateState::Degraded,
+                active_operations: 0,
+            }
+        );
+
+        for error in [
+            engine.status(&session).await.unwrap_err(),
+            engine
+                .execute(
+                    &session,
+                    Statement::new("CREATE TABLE denied(id INTEGER)", vec![]),
+                )
+                .await
+                .unwrap_err(),
+            engine
+                .broadcast(
+                    &session,
+                    "CREATE TABLE denied_everywhere(id INTEGER)".into(),
+                )
+                .await
+                .unwrap_err(),
+        ] {
+            assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+            assert!(!error.is_retryable());
+        }
+
+        let manifest = rusqlite::Connection::open(temp.path().join("manifest.sqlite")).unwrap();
+        let state: i64 = manifest
+            .query_row(
+                "SELECT database_state FROM briskdb_integrity WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(state, 4, "runtime corruption must persist Degraded");
+
+        drop(manifest);
+        drop(session);
+        drop(engine);
+        let restart = Database::open(temp.path(), 2).unwrap_err();
+        assert_eq!(restart.kind(), EngineErrorKind::DataCorruption);
     }
 
     #[tokio::test]

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -92,7 +92,9 @@ impl Database {
         let _schema_operation = self.storage.enter_schema_operation()?;
         let shard = self.shard_for_key(shard_key.as_bytes());
         let connection = self.storage.open_shard(shard)?;
-        let value = sql::execute(&connection, statement, params)?;
+        let value =
+            self.storage
+                .fail_closed_on_corruption(sql::execute(&connection, statement, params))?;
         Ok(Routed { shard, value })
     }
 
@@ -105,7 +107,9 @@ impl Database {
         let _schema_operation = self.storage.enter_schema_operation()?;
         let shard = self.shard_for_key(shard_key.as_bytes());
         let connection = self.storage.open_shard(shard)?;
-        let value = sql::query(&connection, statement, params)?;
+        let value =
+            self.storage
+                .fail_closed_on_corruption(sql::query(&connection, statement, params))?;
         Ok(Routed { shard, value })
     }
 
@@ -140,7 +144,53 @@ impl Database {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        fs::OpenOptions,
+        io::{Seek, SeekFrom, Write},
+        sync::{Arc, mpsc},
+        thread,
+        time::Duration,
+    };
+
     use super::*;
+
+    fn routing_key_for_shard(database: &Database, expected: u16) -> String {
+        (0_u64..)
+            .map(|value| format!("sync-corruption-{value}"))
+            .find(|key| database.shard_for_key(key.as_bytes()) == expected)
+            .expect("the finite shard layout has a routing key")
+    }
+
+    fn corrupt_application_table_root(root: &Path, shard: u16, table: &str) {
+        let path = root.join(format!("shards/{shard:04}.sqlite"));
+        let connection = rusqlite::Connection::open(&path).unwrap();
+        let page_size = u64::try_from(
+            connection
+                .pragma_query_value(None, "page_size", |row| row.get::<_, i64>(0))
+                .unwrap(),
+        )
+        .unwrap();
+        let root_page = u64::try_from(
+            connection
+                .query_row(
+                    "SELECT rootpage FROM sqlite_schema WHERE type = 'table' AND name = ?1",
+                    [table],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+        )
+        .unwrap();
+        connection
+            .query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |_| Ok(()))
+            .unwrap();
+        drop(connection);
+
+        let mut file = OpenOptions::new().write(true).open(path).unwrap();
+        file.seek(SeekFrom::Start((root_page - 1) * page_size))
+            .unwrap();
+        file.write_all(&[0]).unwrap();
+        file.sync_all().unwrap();
+    }
 
     #[test]
     fn routing_is_stable() {
@@ -328,6 +378,167 @@ mod tests {
         assert_eq!(
             Database::open(temp.path(), 1).unwrap_err().kind(),
             EngineErrorKind::InvalidArgument
+        );
+    }
+
+    #[test]
+    fn synchronous_query_and_execute_corruption_persist_terminal_degraded_state() {
+        for operation in ["query", "execute"] {
+            let temp = tempfile::tempdir().unwrap();
+            let database = Database::open(temp.path(), 2).unwrap();
+            database
+                .broadcast(
+                    "CREATE TABLE corrupt_application_page (
+                         id INTEGER PRIMARY KEY,
+                         value TEXT NOT NULL
+                     )",
+                )
+                .unwrap();
+            let routing_key = routing_key_for_shard(&database, 0);
+            database
+                .execute(
+                    &routing_key,
+                    "INSERT INTO corrupt_application_page(value) VALUES (?1)",
+                    &[Value::from("before-corruption")],
+                )
+                .unwrap();
+            corrupt_application_table_root(temp.path(), 0, "corrupt_application_page");
+
+            let error = match operation {
+                "query" => database
+                    .query(
+                        &routing_key,
+                        "SELECT value FROM corrupt_application_page",
+                        &[],
+                    )
+                    .map(|_| ()),
+                "execute" => database
+                    .execute(
+                        &routing_key,
+                        "INSERT INTO corrupt_application_page(value) VALUES (?1)",
+                        &[Value::from("after-corruption")],
+                    )
+                    .map(|_| ()),
+                _ => unreachable!(),
+            }
+            .unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::DataCorruption, "{operation}");
+            assert_eq!(
+                database
+                    .query(&routing_key, "SELECT 1", &[])
+                    .unwrap_err()
+                    .kind(),
+                EngineErrorKind::DataCorruption,
+                "{operation} must leave shared admission fail-closed"
+            );
+
+            let manifest = rusqlite::Connection::open(temp.path().join("manifest.sqlite")).unwrap();
+            assert_eq!(
+                manifest
+                    .query_row(
+                        "SELECT database_state FROM briskdb_integrity WHERE singleton = 1",
+                        [],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .unwrap(),
+                4,
+                "{operation} must persist Degraded"
+            );
+            drop(manifest);
+            drop(database);
+            assert_eq!(
+                Database::open(temp.path(), 2).unwrap_err().kind(),
+                EngineErrorKind::DataCorruption,
+                "{operation} restart must remain fail-closed"
+            );
+        }
+    }
+
+    #[test]
+    fn public_broadcast_corruption_preserves_checksummed_journal_in_terminal_degraded() {
+        const SQL: &str = "CREATE TABLE durable_migration(id INTEGER PRIMARY KEY)";
+
+        let temp = tempfile::tempdir().unwrap();
+        let database = Arc::new(Database::open(temp.path(), 2).unwrap());
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        database
+            .storage
+            .install_schema_migration_test_block(
+                crate::storage::SchemaMigrationCoordinatorPoint::JournalCommitted,
+                started_tx,
+                release_rx,
+            )
+            .unwrap();
+
+        let worker_database = Arc::clone(&database);
+        let worker = thread::spawn(move || worker_database.broadcast(SQL));
+        started_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("migration should commit its journal before shard application");
+
+        let manifest_path = temp.path().join("manifest.sqlite");
+        let manifest = rusqlite::Connection::open(&manifest_path).unwrap();
+        let trusted_digests: (Vec<u8>, Vec<u8>) = manifest
+            .query_row(
+                "SELECT committed_schema_digest, target_schema_digest
+                 FROM briskdb_integrity WHERE singleton = 1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(trusted_digests.0.len(), 32);
+        assert_eq!(trusted_digests.1.len(), 32);
+        drop(manifest);
+
+        rusqlite::Connection::open(temp.path().join("shards/0000.sqlite"))
+            .unwrap()
+            .execute_batch("CREATE TABLE injected_migration_drift(value TEXT)")
+            .unwrap();
+        release_tx.send(()).unwrap();
+        let error = worker.join().unwrap().unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+
+        let manifest = rusqlite::Connection::open(&manifest_path).unwrap();
+        let persisted: (i64, Vec<u8>, Vec<u8>, i64, i64) = manifest
+            .query_row(
+                "SELECT i.database_state,
+                        i.committed_schema_digest,
+                        i.target_schema_digest,
+                        m.migration_state,
+                        m.next_shard
+                 FROM briskdb_integrity AS i
+                 JOIN briskdb_schema_migrations AS m
+                   ON m.migration_state = 1
+                 WHERE i.singleton = 1",
+                [],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                    ))
+                },
+            )
+            .unwrap();
+        assert_eq!(persisted.0, 4);
+        assert_eq!((persisted.1, persisted.2), trusted_digests);
+        assert_eq!((persisted.3, persisted.4), (1, 0));
+        drop(manifest);
+
+        assert_eq!(
+            database
+                .query("blocked", "SELECT 1", &[])
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::DataCorruption
+        );
+        drop(database);
+        assert_eq!(
+            Database::open(temp.path(), 2).unwrap_err().kind(),
+            EngineErrorKind::DataCorruption
         );
     }
 

--- a/src/protocol/http.rs
+++ b/src/protocol/http.rs
@@ -397,6 +397,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn detected_schema_drift_makes_health_fail_closed_with_a_redacted_problem() {
+        let temp = tempfile::tempdir().unwrap();
+        let database = Arc::new(Database::open(temp.path(), 2).unwrap());
+        let application = engine_router(database);
+        for shard_id in 0..2 {
+            rusqlite::Connection::open(temp.path().join(format!("shards/{shard_id:04}.sqlite")))
+                .unwrap()
+                .execute_batch("CREATE TABLE secret_drift(value TEXT)")
+                .unwrap();
+        }
+
+        let expected = json!({
+            "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#data-corruption",
+            "title": "Data corruption",
+            "status": 500,
+            "detail": "Stored data failed an integrity check.",
+            "code": "data_corruption"
+        });
+        assert_eq!(
+            request_json(
+                &application,
+                Method::POST,
+                "/v1/query",
+                Some(json!({
+                    "shard_key": "detect-drift",
+                    "sql": "SELECT 1",
+                    "params": []
+                })),
+            )
+            .await,
+            (StatusCode::INTERNAL_SERVER_ERROR, expected.clone())
+        );
+        let (status, body) = request_json(&application, Method::GET, "/health", None).await;
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(body, expected);
+        let serialized = body.to_string();
+        assert!(!serialized.contains("secret_drift"));
+        assert!(!serialized.contains(temp.path().to_string_lossy().as_ref()));
+    }
+
+    #[tokio::test]
     async fn legacy_database_router_is_a_behavior_preserving_engine_wrapper() {
         let temp = tempfile::tempdir().unwrap();
         let application = router(Arc::new(Database::open(temp.path(), 4).unwrap()));

--- a/src/storage/manifest.rs
+++ b/src/storage/manifest.rs
@@ -1,6 +1,6 @@
 //! Version detection and transactional upgrades for `manifest.sqlite`.
 
-use rusqlite::{Connection, Transaction, TransactionBehavior};
+use rusqlite::{Connection, Transaction, TransactionBehavior, types::ValueRef};
 
 use crate::{
     core::{
@@ -24,7 +24,8 @@ const V3_SCHEMA_VERSION: u32 = 3;
 const V4_SCHEMA_VERSION: u32 = 4;
 const V5_SCHEMA_VERSION: u32 = 5;
 const V6_SCHEMA_VERSION: u32 = 6;
-pub(super) const CURRENT_SCHEMA_VERSION: u32 = V6_SCHEMA_VERSION;
+const V7_SCHEMA_VERSION: u32 = 7;
+pub(super) const CURRENT_SCHEMA_VERSION: u32 = V7_SCHEMA_VERSION;
 const MAX_TABLE_SQL_BYTES: i64 = 4_096;
 
 pub(super) const MAX_SCHEMA_MIGRATION_SQL_BYTES: usize = 65_536;
@@ -32,6 +33,14 @@ pub(super) const MAX_SCHEMA_GENERATION: u64 = i32::MAX as u64;
 const SCHEMA_MIGRATION_DIGEST_VERSION: u32 = 1;
 const SCHEMA_MIGRATION_APPLYING: i64 = 1;
 const SCHEMA_MIGRATION_COMPLETE: i64 = 2;
+const MANIFEST_DIGEST_VERSION: u32 = 1;
+pub(super) const SCHEMA_DIGEST_VERSION: u32 = 1;
+const MANIFEST_DIGEST_DOMAIN: &[u8] = b"briskdb.manifest.semantic-root.v1\0";
+
+const DATABASE_STATE_VERIFYING: i64 = 1;
+const DATABASE_STATE_READY: i64 = 2;
+const DATABASE_STATE_MIGRATING: i64 = 3;
+const DATABASE_STATE_DEGRADED: i64 = 4;
 
 const INITIAL_SCHEMA_GENERATION: u64 = 0;
 const SHARDED_PLACEMENT: i64 = 1;
@@ -70,6 +79,10 @@ const V5_DOWNGRADE_FENCE_SQL: &str = "CREATE TABLE briskdb_metadata (
 const V6_DOWNGRADE_FENCE_SQL: &str = "CREATE TABLE briskdb_metadata (
     requires_manifest_version INTEGER NOT NULL
         CHECK (requires_manifest_version >= 6)
+) STRICT";
+const V7_DOWNGRADE_FENCE_SQL: &str = "CREATE TABLE briskdb_metadata (
+    requires_manifest_version INTEGER NOT NULL
+        CHECK (requires_manifest_version >= 7)
 ) STRICT";
 const V3_ROUTING_TABLE_SQL: &str = "CREATE TABLE briskdb_routing (
     singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
@@ -191,6 +204,44 @@ const V6_SCHEMA_MIGRATIONS_TABLE_SQL: &str = "CREATE TABLE briskdb_schema_migrat
     next_shard INTEGER NOT NULL CHECK (next_shard BETWEEN 0 AND shard_count),
     CHECK (migration_state = 1 OR next_shard = shard_count)
 ) STRICT";
+const V7_INTEGRITY_TABLE_SQL: &str = "CREATE TABLE briskdb_integrity (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    manifest_digest_version INTEGER NOT NULL CHECK (manifest_digest_version > 0),
+    manifest_digest BLOB NOT NULL
+        CHECK (typeof(manifest_digest) = 'blob' AND length(manifest_digest) = 32),
+    schema_digest_version INTEGER NOT NULL CHECK (schema_digest_version > 0),
+    database_state INTEGER NOT NULL CHECK (database_state IN (1, 2, 3, 4)),
+    committed_schema_digest BLOB
+        CHECK (
+            committed_schema_digest IS NULL
+            OR (
+                typeof(committed_schema_digest) = 'blob'
+                AND length(committed_schema_digest) = 32
+            )
+        ),
+    target_schema_digest BLOB
+        CHECK (
+            target_schema_digest IS NULL
+            OR (
+                typeof(target_schema_digest) = 'blob'
+                AND length(target_schema_digest) = 32
+            )
+        ),
+    CHECK (
+        (database_state = 1 AND target_schema_digest IS NULL)
+        OR (
+            database_state = 2
+            AND committed_schema_digest IS NOT NULL
+            AND target_schema_digest IS NULL
+        )
+        OR (
+            database_state = 3
+            AND committed_schema_digest IS NOT NULL
+            AND target_schema_digest IS NOT NULL
+        )
+        OR database_state = 4
+    )
+) STRICT";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct RoutingConfiguration {
@@ -205,6 +256,61 @@ struct SchemaCatalogConfiguration {
     identifier_encoding_version: u32,
     schema_generation: u64,
     default_database_id: u64,
+}
+
+/// Durable integrity/readiness state stored in the v7 manifest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum DatabaseIntegrityState {
+    Verifying,
+    Ready,
+    Migrating,
+    Degraded,
+}
+
+impl DatabaseIntegrityState {
+    const fn code(self) -> i64 {
+        match self {
+            Self::Verifying => DATABASE_STATE_VERIFYING,
+            Self::Ready => DATABASE_STATE_READY,
+            Self::Migrating => DATABASE_STATE_MIGRATING,
+            Self::Degraded => DATABASE_STATE_DEGRADED,
+        }
+    }
+
+    fn from_code(code: i64) -> EngineResult<Self> {
+        match code {
+            DATABASE_STATE_VERIFYING => Ok(Self::Verifying),
+            DATABASE_STATE_READY => Ok(Self::Ready),
+            DATABASE_STATE_MIGRATING => Ok(Self::Migrating),
+            DATABASE_STATE_DEGRADED => Ok(Self::Degraded),
+            _ => Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "manifest contains an unsupported database integrity state",
+            )),
+        }
+    }
+}
+
+/// Fully validated v7 checksum metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct ManifestIntegrity {
+    state: DatabaseIntegrityState,
+    committed_schema_digest: Option<[u8; 32]>,
+    target_schema_digest: Option<[u8; 32]>,
+}
+
+impl ManifestIntegrity {
+    pub(super) const fn state(self) -> DatabaseIntegrityState {
+        self.state
+    }
+
+    pub(super) const fn committed_schema_digest(self) -> Option<[u8; 32]> {
+        self.committed_schema_digest
+    }
+
+    pub(super) const fn target_schema_digest(self) -> Option<[u8; 32]> {
+        self.target_schema_digest
+    }
 }
 
 /// One fully validated application-schema migration journal row.
@@ -296,6 +402,7 @@ struct ManifestSnapshot {
     logical_catalog: Option<Catalog>,
     shard_layout: Option<ShardLayout>,
     active_migration: Option<SchemaMigration>,
+    integrity: Option<ManifestIntegrity>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -303,6 +410,20 @@ pub(super) struct LoadedManifest {
     catalog: CatalogSnapshot,
     shard_layout: ShardLayout,
     active_migration: Option<SchemaMigration>,
+    integrity: ManifestIntegrity,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct V6ActiveMigration {
+    catalog: CatalogSnapshot,
+    shard_layout: ShardLayout,
+    migration: SchemaMigration,
+}
+
+impl V6ActiveMigration {
+    pub(super) fn into_parts(self) -> (CatalogSnapshot, ShardLayout, SchemaMigration) {
+        (self.catalog, self.shard_layout, self.migration)
+    }
 }
 
 impl LoadedManifest {
@@ -318,8 +439,18 @@ impl LoadedManifest {
 
     pub(super) fn into_parts_with_migration(
         self,
-    ) -> (CatalogSnapshot, ShardLayout, Option<SchemaMigration>) {
-        (self.catalog, self.shard_layout, self.active_migration)
+    ) -> (
+        CatalogSnapshot,
+        ShardLayout,
+        Option<SchemaMigration>,
+        ManifestIntegrity,
+    ) {
+        (
+            self.catalog,
+            self.shard_layout,
+            self.active_migration,
+            self.integrity,
+        )
     }
 }
 
@@ -359,6 +490,13 @@ const MIGRATIONS: &[Migration] = &[
         apply: migrate_v5_to_v6,
         validate: validate_v6,
     },
+    Migration {
+        from: V6_SCHEMA_VERSION,
+        to: V7_SCHEMA_VERSION,
+        name: "checksummed_integrity_state",
+        apply: migrate_v6_to_v7,
+        validate: validate_v7,
+    },
 ];
 
 #[derive(Clone, Copy)]
@@ -371,6 +509,15 @@ struct MigrationPlan<'a> {
 
 const CURRENT_PLAN: MigrationPlan<'static> = MigrationPlan {
     current_version: CURRENT_SCHEMA_VERSION,
+    migrations: MIGRATIONS,
+    initialize_current: create_v7_schema,
+    initialize_interrupted_legacy: migrate_interrupted_legacy_to_v7,
+};
+
+// Startup uses this frozen plan only to finish an already-active v6 journal
+// before the v7 checksum bootstrap. It must never initialize or upgrade data.
+const V6_PLAN: MigrationPlan<'static> = MigrationPlan {
+    current_version: V6_SCHEMA_VERSION,
     migrations: MIGRATIONS,
     initialize_current: create_v6_schema,
     initialize_interrupted_legacy: migrate_interrupted_legacy_to_v6,
@@ -452,11 +599,64 @@ pub(super) fn load_or_create_manifest_with_fresh_layout(
             "current manifest validation did not produce a physical shard layout",
         )
     })?;
+    let integrity = snapshot.integrity.ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::Internal,
+            "current manifest validation did not produce integrity metadata",
+        )
+    })?;
     Ok(LoadedManifest {
         catalog: CatalogSnapshot::from_validated_parts(routing, logical),
         shard_layout,
         active_migration: snapshot.active_migration,
+        integrity,
     })
+}
+
+/// Return an active v6 journal without upgrading it. Startup completes this
+/// recovery under the v6 rules before establishing v7 checksum authority.
+pub(super) fn load_v6_active_migration(
+    connection: &Connection,
+    requested_shards: u16,
+) -> EngineResult<Option<V6ActiveMigration>> {
+    let (application_id, version) = read_identity(connection)?;
+    if application_id != MANIFEST_APPLICATION_ID || version != i64::from(V6_SCHEMA_VERSION) {
+        return Ok(None);
+    }
+    let ManifestState::Versioned { version, snapshot } =
+        inspect_with_plan(connection, requested_shards, V6_PLAN)?
+    else {
+        return Ok(None);
+    };
+    if version != V6_SCHEMA_VERSION {
+        return Ok(None);
+    }
+    let Some(migration) = snapshot.active_migration else {
+        return Ok(None);
+    };
+    let routing = snapshot.routing_catalog.ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::Internal,
+            "v6 recovery validation omitted its routing catalog",
+        )
+    })?;
+    let logical = snapshot.logical_catalog.ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::Internal,
+            "v6 recovery validation omitted its logical catalog",
+        )
+    })?;
+    let shard_layout = snapshot.shard_layout.ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::Internal,
+            "v6 recovery validation omitted its physical shard layout",
+        )
+    })?;
+    Ok(Some(V6ActiveMigration {
+        catalog: CatalogSnapshot::from_validated_parts(routing, logical),
+        shard_layout,
+        migration,
+    }))
 }
 
 #[cfg(test)]
@@ -546,6 +746,157 @@ pub(super) fn ensure_schema_migration_layout(
     Ok(())
 }
 
+pub(super) fn current_integrity(
+    connection: &Connection,
+    requested_shards: u16,
+) -> EngineResult<ManifestIntegrity> {
+    current_manifest_snapshot(connection, requested_shards)?
+        .integrity
+        .ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "database manifest predates integrity metadata",
+            )
+        })
+}
+
+pub(super) fn current_integrity_optional(
+    connection: &Connection,
+    requested_shards: u16,
+) -> EngineResult<Option<ManifestIntegrity>> {
+    Ok(current_manifest_snapshot(connection, requested_shards)?.integrity)
+}
+
+/// Seal a freshly verified v7 schema baseline or validate an already-ready
+/// database. Terminal `Degraded` state is never cleared here.
+pub(super) fn seal_verified_schema(
+    connection: &mut Connection,
+    requested_shards: u16,
+    observed_digest: [u8; 32],
+) -> EngineResult<ManifestIntegrity> {
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    let snapshot = current_manifest_snapshot(&transaction, requested_shards)?;
+    if snapshot.active_migration.is_some() {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "an active schema migration cannot be published as ready",
+        ));
+    }
+    let integrity = snapshot.integrity.ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "database manifest predates integrity metadata",
+        )
+    })?;
+    match integrity.state {
+        DatabaseIntegrityState::Verifying => {
+            if integrity
+                .committed_schema_digest
+                .is_some_and(|expected| expected != observed_digest)
+            {
+                return Err(EngineError::new(
+                    EngineErrorKind::DataCorruption,
+                    "verified application schema does not match the trusted checksum",
+                ));
+            }
+            transaction
+                .execute(
+                    "UPDATE briskdb_integrity
+                     SET database_state = ?1, committed_schema_digest = ?2
+                     WHERE singleton = 1 AND database_state = ?3",
+                    rusqlite::params![
+                        DATABASE_STATE_READY,
+                        observed_digest.as_slice(),
+                        DATABASE_STATE_VERIFYING,
+                    ],
+                )
+                .map_err(sqlite_error::storage)?;
+            refresh_manifest_digest(&transaction)?;
+        }
+        DatabaseIntegrityState::Ready => {
+            if integrity.committed_schema_digest != Some(observed_digest) {
+                return Err(EngineError::new(
+                    EngineErrorKind::DataCorruption,
+                    "application schema checksum does not match the manifest",
+                ));
+            }
+        }
+        DatabaseIntegrityState::Degraded => {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "degraded database requires a complete known-good restore",
+            ));
+        }
+        DatabaseIntegrityState::Migrating => {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "an active schema migration cannot be published as ready",
+            ));
+        }
+    }
+    let sealed = current_integrity(&transaction, requested_shards)?;
+    transaction.commit().map_err(sqlite_error::storage)?;
+    Ok(sealed)
+}
+
+/// Persist the fail-closed state only after the current semantic root and the
+/// caller's exact shard layout have been validated. A corrupt or replaced
+/// manifest therefore never signs its own altered data.
+pub(super) fn mark_degraded(
+    connection: &mut Connection,
+    requested_shards: u16,
+    expected_layout: &ShardLayout,
+) -> EngineResult<()> {
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    let snapshot = current_manifest_snapshot(&transaction, requested_shards)?;
+    let observed_layout = snapshot.shard_layout.ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "manifest degradation requires a validated shard-layout identity",
+        )
+    })?;
+    if observed_layout != *expected_layout {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "manifest shard-layout identity changed before degradation could be recorded",
+        ));
+    }
+    let integrity = snapshot.integrity.ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "database manifest predates integrity metadata",
+        )
+    })?;
+    if integrity.state != DatabaseIntegrityState::Degraded {
+        let changed = transaction
+            .execute(
+                "UPDATE briskdb_integrity SET database_state = ?1
+                 WHERE singleton = 1 AND database_state = ?2",
+                rusqlite::params![DATABASE_STATE_DEGRADED, integrity.state.code()],
+            )
+            .map_err(sqlite_error::storage)?;
+        if changed != 1 {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "database integrity state changed before degradation was recorded",
+            ));
+        }
+        refresh_manifest_digest(&transaction)?;
+        let persisted = current_integrity(&transaction, requested_shards)?;
+        if persisted.state != DatabaseIntegrityState::Degraded {
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                "database degradation state did not persist",
+            ));
+        }
+    }
+    transaction.commit().map_err(sqlite_error::storage)
+}
+
 /// Atomically append a new active journal row after the caller has preflighted
 /// every shard at `expected_source_generation`.
 ///
@@ -571,11 +922,45 @@ pub(super) fn begin_schema_migration(
     Ok(migration)
 }
 
+#[cfg(test)]
 pub(super) fn begin_schema_migration_in_transaction(
     transaction: &Connection,
     requested_shards: u16,
     expected_source_generation: u64,
     sql: &str,
+) -> EngineResult<SchemaMigration> {
+    begin_schema_migration_with_digests_inner(
+        transaction,
+        requested_shards,
+        expected_source_generation,
+        sql,
+        None,
+    )
+}
+
+pub(super) fn begin_schema_migration_with_digests_in_transaction(
+    transaction: &Connection,
+    requested_shards: u16,
+    expected_source_generation: u64,
+    sql: &str,
+    expected_source_digest: [u8; 32],
+    target_digest: [u8; 32],
+) -> EngineResult<SchemaMigration> {
+    begin_schema_migration_with_digests_inner(
+        transaction,
+        requested_shards,
+        expected_source_generation,
+        sql,
+        Some((expected_source_digest, target_digest)),
+    )
+}
+
+fn begin_schema_migration_with_digests_inner(
+    transaction: &Connection,
+    requested_shards: u16,
+    expected_source_generation: u64,
+    sql: &str,
+    schema_digests: Option<([u8; 32], [u8; 32])>,
 ) -> EngineResult<SchemaMigration> {
     let migration_id = schema_migration_id(sql)?;
     let snapshot = current_manifest_snapshot(transaction, requested_shards)?;
@@ -647,6 +1032,30 @@ pub(super) fn begin_schema_migration_in_transaction(
             "schema migration generation is exhausted",
         ));
     }
+    let target_schema_digest = if let Some(integrity) = snapshot.integrity {
+        if integrity.state != DatabaseIntegrityState::Ready {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "schema migration requires a checksum-verified ready database",
+            ));
+        }
+        let committed = integrity.committed_schema_digest.ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "ready manifest is missing its committed application-schema checksum",
+            )
+        })?;
+        let (expected, target) = schema_digests.unwrap_or((committed, committed));
+        if expected != committed {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "schema migration source checksum does not match the manifest",
+            ));
+        }
+        Some(target)
+    } else {
+        None
+    };
     transaction
         .execute(
             "INSERT INTO briskdb_schema_migrations (
@@ -670,6 +1079,27 @@ pub(super) fn begin_schema_migration_in_transaction(
             ],
         )
         .map_err(sqlite_error::storage)?;
+    if let Some(target_schema_digest) = target_schema_digest {
+        let changed = transaction
+            .execute(
+                "UPDATE briskdb_integrity
+                 SET database_state = ?1, target_schema_digest = ?2
+                 WHERE singleton = 1 AND database_state = ?3",
+                rusqlite::params![
+                    DATABASE_STATE_MIGRATING,
+                    target_schema_digest.as_slice(),
+                    DATABASE_STATE_READY,
+                ],
+            )
+            .map_err(sqlite_error::storage)?;
+        if changed != 1 {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "database integrity state changed before migration publication",
+            ));
+        }
+        refresh_manifest_digest(transaction)?;
+    }
     let validated = current_manifest_snapshot(transaction, requested_shards)?
         .active_migration
         .ok_or_else(|| {
@@ -760,6 +1190,7 @@ pub(super) fn advance_schema_migration_in_transaction(
             ],
         )
         .map_err(sqlite_error::storage)?;
+    refresh_manifest_digest_if_v7(transaction)?;
     let advanced = current_manifest_snapshot(transaction, requested_shards)?
         .active_migration
         .ok_or_else(|| {
@@ -845,6 +1276,27 @@ pub(super) fn finalize_schema_migration_in_transaction(
             ],
         )
         .map_err(sqlite_error::storage)?;
+    if snapshot.integrity.is_some() {
+        let changed = transaction
+            .execute(
+                "UPDATE briskdb_integrity
+                 SET committed_schema_digest = target_schema_digest,
+                     target_schema_digest = NULL,
+                     database_state = ?1
+                 WHERE singleton = 1
+                   AND database_state = ?2
+                   AND target_schema_digest IS NOT NULL",
+                rusqlite::params![DATABASE_STATE_READY, DATABASE_STATE_MIGRATING],
+            )
+            .map_err(sqlite_error::storage)?;
+        if changed != 1 {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "schema migration finalization found inconsistent integrity metadata",
+            ));
+        }
+        refresh_manifest_digest(transaction)?;
+    }
     let finalized_snapshot = current_manifest_snapshot(transaction, requested_shards)?;
     if finalized_snapshot.active_migration.is_some()
         || finalized_snapshot
@@ -883,7 +1335,9 @@ fn current_manifest_snapshot(
     requested_shards: u16,
 ) -> EngineResult<ManifestSnapshot> {
     match inspect_with_plan(connection, requested_shards, CURRENT_PLAN)? {
-        ManifestState::Versioned { version, snapshot } if version == CURRENT_SCHEMA_VERSION => {
+        ManifestState::Versioned { version, snapshot }
+            if version == CURRENT_SCHEMA_VERSION || version == V6_SCHEMA_VERSION =>
+        {
             Ok(*snapshot)
         }
         _ => Err(EngineError::new(
@@ -1028,6 +1482,7 @@ where
                 ],
             )
             .map_err(sqlite_error::storage)?;
+        refresh_manifest_digest_if_v7(&transaction)?;
 
         let ready = match inspect_with_plan(&transaction, requested_shards, CURRENT_PLAN)? {
             ManifestState::Versioned { version, snapshot } if version == CURRENT_SCHEMA_VERSION => {
@@ -1215,6 +1670,9 @@ where
     })?;
 
     set_identity(&transaction, change.to)?;
+    if change.to == V7_SCHEMA_VERSION {
+        refresh_manifest_digest(&transaction)?;
+    }
     hook(MigrationPoint {
         from: change.from,
         to: change.to,
@@ -1289,6 +1747,11 @@ fn create_v6_schema(transaction: &Transaction<'_>, shard_count: u16) -> EngineRe
     migrate_v5_to_v6(transaction, shard_count)
 }
 
+fn create_v7_schema(transaction: &Transaction<'_>, shard_count: u16) -> EngineResult<()> {
+    create_v6_schema(transaction, shard_count)?;
+    migrate_v6_to_v7(transaction, shard_count)
+}
+
 fn migrate_interrupted_legacy_to_v6(
     transaction: &Transaction<'_>,
     shard_count: u16,
@@ -1297,6 +1760,16 @@ fn migrate_interrupted_legacy_to_v6(
         .execute_batch("DROP TABLE briskdb_metadata;")
         .map_err(sqlite_error::storage)?;
     create_v6_schema(transaction, shard_count)
+}
+
+fn migrate_interrupted_legacy_to_v7(
+    transaction: &Transaction<'_>,
+    shard_count: u16,
+) -> EngineResult<()> {
+    transaction
+        .execute_batch("DROP TABLE briskdb_metadata;")
+        .map_err(sqlite_error::storage)?;
+    create_v7_schema(transaction, shard_count)
 }
 
 #[cfg(test)]
@@ -1518,6 +1991,43 @@ fn migrate_v5_to_v6(transaction: &Transaction<'_>, _shard_count: u16) -> EngineR
         .map_err(sqlite_error::storage)?;
     transaction
         .execute_batch(V6_SCHEMA_MIGRATIONS_TABLE_SQL)
+        .map_err(sqlite_error::storage)?;
+    Ok(())
+}
+
+fn migrate_v6_to_v7(transaction: &Transaction<'_>, _shard_count: u16) -> EngineResult<()> {
+    transaction
+        .execute_batch("DROP TABLE briskdb_metadata;")
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch(V7_DOWNGRADE_FENCE_SQL)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "INSERT INTO briskdb_metadata (requires_manifest_version) VALUES (?1)",
+            [V7_SCHEMA_VERSION],
+        )
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch(V7_INTEGRITY_TABLE_SQL)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "INSERT INTO briskdb_integrity (
+                singleton,
+                manifest_digest_version,
+                manifest_digest,
+                schema_digest_version,
+                database_state,
+                committed_schema_digest,
+                target_schema_digest
+             ) VALUES (1, ?1, zeroblob(32), ?2, ?3, NULL, NULL)",
+            rusqlite::params![
+                MANIFEST_DIGEST_VERSION,
+                SCHEMA_DIGEST_VERSION,
+                DATABASE_STATE_VERIFYING,
+            ],
+        )
         .map_err(sqlite_error::storage)?;
     Ok(())
 }
@@ -1799,6 +2309,18 @@ fn v6_objects() -> Vec<SchemaObject> {
     objects
 }
 
+fn v7_objects() -> Vec<SchemaObject> {
+    let mut objects = v6_objects();
+    objects.push(SchemaObject {
+        object_type: "table".to_owned(),
+        name: "briskdb_integrity".to_owned(),
+    });
+    objects.sort_by(|left, right| {
+        (&left.object_type, &left.name).cmp(&(&right.object_type, &right.name))
+    });
+    objects
+}
+
 fn schema_objects(connection: &Connection) -> EngineResult<Vec<SchemaObject>> {
     let mut statement = connection
         .prepare(
@@ -1903,6 +2425,10 @@ fn validate_table(
         "briskdb_schema_migrations" => {
             "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden
              FROM pragma_table_xinfo('briskdb_schema_migrations') LIMIT ?1"
+        }
+        "briskdb_integrity" => {
+            "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden
+             FROM pragma_table_xinfo('briskdb_integrity') LIMIT ?1"
         }
         _ => {
             return Err(EngineError::new(
@@ -2092,6 +2618,7 @@ fn validate_v2(
         logical_catalog: None,
         shard_layout: None,
         active_migration: None,
+        integrity: None,
     })
 }
 
@@ -2120,6 +2647,7 @@ fn validate_v3(
         logical_catalog: None,
         shard_layout: None,
         active_migration: None,
+        integrity: None,
     })
 }
 
@@ -2359,6 +2887,453 @@ fn validate_v6(
     Ok(snapshot)
 }
 
+fn validate_v7(
+    connection: &Connection,
+    requested_shards: u16,
+    objects: &[SchemaObject],
+) -> EngineResult<ManifestSnapshot> {
+    let mut snapshot = validate_catalog_manifest(
+        connection,
+        requested_shards,
+        objects,
+        CatalogManifestDefinition {
+            version: V7_SCHEMA_VERSION,
+            downgrade_fence_sql: V7_DOWNGRADE_FENCE_SQL,
+            expected_objects: &v7_objects(),
+            schema_catalog_sql: V6_SCHEMA_CATALOG_TABLE_SQL,
+            generation_policy: SchemaGenerationPolicy::Journaled,
+        },
+    )?;
+    validate_table(
+        connection,
+        "briskdb_shard_layout",
+        &[
+            TableColumn::expected(0, "singleton", "INTEGER", false, 1),
+            TableColumn::expected(1, "layout_id", "BLOB", true, 0),
+            TableColumn::expected(2, "shard_application_id", "INTEGER", true, 0),
+            TableColumn::expected(3, "shard_metadata_version", "INTEGER", true, 0),
+            TableColumn::expected(4, "layout_state", "INTEGER", true, 0),
+        ],
+        true,
+    )?;
+    validate_table_sql(
+        connection,
+        "briskdb_shard_layout",
+        V5_SHARD_LAYOUT_TABLE_SQL,
+    )?;
+    let layout = validate_shard_layout(connection)?;
+
+    validate_table(
+        connection,
+        "briskdb_schema_migrations",
+        &[
+            TableColumn::expected(0, "target_generation", "INTEGER", false, 1),
+            TableColumn::expected(1, "source_generation", "INTEGER", true, 0),
+            TableColumn::expected(2, "migration_id", "BLOB", true, 0),
+            TableColumn::expected(3, "digest_version", "INTEGER", true, 0),
+            TableColumn::expected(4, "sql_text", "TEXT", true, 0),
+            TableColumn::expected(5, "shard_count", "INTEGER", true, 0),
+            TableColumn::expected(6, "migration_state", "INTEGER", true, 0),
+            TableColumn::expected(7, "next_shard", "INTEGER", true, 0),
+        ],
+        true,
+    )?;
+    validate_table_sql(
+        connection,
+        "briskdb_schema_migrations",
+        V6_SCHEMA_MIGRATIONS_TABLE_SQL,
+    )?;
+    validate_table(
+        connection,
+        "briskdb_integrity",
+        &[
+            TableColumn::expected(0, "singleton", "INTEGER", false, 1),
+            TableColumn::expected(1, "manifest_digest_version", "INTEGER", true, 0),
+            TableColumn::expected(2, "manifest_digest", "BLOB", true, 0),
+            TableColumn::expected(3, "schema_digest_version", "INTEGER", true, 0),
+            TableColumn::expected(4, "database_state", "INTEGER", true, 0),
+            TableColumn::expected(5, "committed_schema_digest", "BLOB", false, 0),
+            TableColumn::expected(6, "target_schema_digest", "BLOB", false, 0),
+        ],
+        true,
+    )?;
+    validate_table_sql(connection, "briskdb_integrity", V7_INTEGRITY_TABLE_SQL)?;
+
+    let catalog_generation = snapshot
+        .logical_catalog
+        .as_ref()
+        .ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::Internal,
+                "current manifest validation omitted its logical catalog",
+            )
+        })?
+        .schema_generation();
+    let active =
+        validate_schema_migration_history(connection, snapshot.shard_count, catalog_generation)?;
+    let integrity = validate_manifest_integrity(connection, &layout, active.as_ref())?;
+    snapshot.shard_layout = Some(layout);
+    snapshot.active_migration = active;
+    snapshot.integrity = Some(integrity);
+    Ok(snapshot)
+}
+
+struct ManifestDigestQuery {
+    table: &'static str,
+    columns: &'static [&'static str],
+    sql: &'static str,
+}
+
+const MANIFEST_DIGEST_QUERIES: &[ManifestDigestQuery] = &[
+    ManifestDigestQuery {
+        table: "briskdb_manifest",
+        columns: &["singleton", "shard_count"],
+        sql: "SELECT singleton, shard_count FROM briskdb_manifest ORDER BY singleton",
+    },
+    ManifestDigestQuery {
+        table: "briskdb_metadata",
+        columns: &["requires_manifest_version"],
+        sql: "SELECT requires_manifest_version FROM briskdb_metadata ORDER BY rowid",
+    },
+    ManifestDigestQuery {
+        table: "briskdb_routing",
+        columns: &[
+            "singleton",
+            "hash_version",
+            "key_encoding_version",
+            "bucket_algorithm_version",
+            "virtual_bucket_count",
+            "map_generation",
+        ],
+        sql: "SELECT singleton, hash_version, key_encoding_version, bucket_algorithm_version, virtual_bucket_count, map_generation FROM briskdb_routing ORDER BY singleton",
+    },
+    ManifestDigestQuery {
+        table: "briskdb_physical_shards",
+        columns: &["shard_id", "lifecycle_state"],
+        sql: "SELECT shard_id, lifecycle_state FROM briskdb_physical_shards ORDER BY shard_id",
+    },
+    ManifestDigestQuery {
+        table: "briskdb_virtual_buckets",
+        columns: &["bucket_id", "physical_shard_id"],
+        sql: "SELECT bucket_id, physical_shard_id FROM briskdb_virtual_buckets ORDER BY bucket_id",
+    },
+    ManifestDigestQuery {
+        table: "briskdb_logical_databases",
+        columns: &["database_id", "database_name"],
+        sql: "SELECT database_id, database_name FROM briskdb_logical_databases ORDER BY database_id",
+    },
+    ManifestDigestQuery {
+        table: "briskdb_schema_catalog",
+        columns: &[
+            "singleton",
+            "identifier_encoding_version",
+            "schema_generation",
+            "default_database_id",
+        ],
+        sql: "SELECT singleton, identifier_encoding_version, schema_generation, default_database_id FROM briskdb_schema_catalog ORDER BY singleton",
+    },
+    ManifestDigestQuery {
+        table: "briskdb_tables",
+        columns: &[
+            "table_id",
+            "database_id",
+            "table_name",
+            "placement",
+            "shard_key_column",
+            "shard_key_type",
+        ],
+        sql: "SELECT table_id, database_id, table_name, placement, shard_key_column, shard_key_type FROM briskdb_tables ORDER BY table_id",
+    },
+    ManifestDigestQuery {
+        table: "briskdb_shard_layout",
+        columns: &[
+            "singleton",
+            "layout_id",
+            "shard_application_id",
+            "shard_metadata_version",
+            "layout_state",
+        ],
+        sql: "SELECT singleton, layout_id, shard_application_id, shard_metadata_version, layout_state FROM briskdb_shard_layout ORDER BY singleton",
+    },
+    ManifestDigestQuery {
+        table: "briskdb_schema_migrations",
+        columns: &[
+            "target_generation",
+            "source_generation",
+            "migration_id",
+            "digest_version",
+            "sql_text",
+            "shard_count",
+            "migration_state",
+            "next_shard",
+        ],
+        sql: "SELECT target_generation, source_generation, migration_id, digest_version, sql_text, shard_count, migration_state, next_shard FROM briskdb_schema_migrations ORDER BY target_generation",
+    },
+    ManifestDigestQuery {
+        table: "briskdb_integrity",
+        columns: &[
+            "singleton",
+            "manifest_digest_version",
+            "schema_digest_version",
+            "database_state",
+            "committed_schema_digest",
+            "target_schema_digest",
+        ],
+        sql: "SELECT singleton, manifest_digest_version, schema_digest_version, database_state, committed_schema_digest, target_schema_digest FROM briskdb_integrity ORDER BY singleton",
+    },
+];
+
+fn manifest_semantic_digest(connection: &Connection) -> EngineResult<[u8; 32]> {
+    let (application_id, user_version) = read_identity(connection)?;
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(MANIFEST_DIGEST_DOMAIN);
+    hash_manifest_name(&mut hasher, b"application_id");
+    hash_manifest_value(&mut hasher, ValueRef::Integer(application_id))?;
+    hash_manifest_name(&mut hasher, b"user_version");
+    hash_manifest_value(&mut hasher, ValueRef::Integer(user_version))?;
+
+    for query in MANIFEST_DIGEST_QUERIES {
+        hasher.update(&[0x10]);
+        hash_manifest_name(&mut hasher, query.table.as_bytes());
+        hasher.update(
+            &u64::try_from(query.columns.len())
+                .expect("manifest digest column count fits u64")
+                .to_le_bytes(),
+        );
+        for column in query.columns {
+            hash_manifest_name(&mut hasher, column.as_bytes());
+        }
+        let mut statement = connection.prepare(query.sql).map_err(|error| {
+            manifest_read_error(error, "failed to prepare manifest semantic checksum")
+        })?;
+        let column_count = query.columns.len();
+        let mut rows = statement.query([]).map_err(|error| {
+            manifest_read_error(error, "failed to read manifest semantic checksum")
+        })?;
+        while let Some(row) = rows.next().map_err(|error| {
+            manifest_read_error(error, "failed to read manifest semantic checksum")
+        })? {
+            hasher.update(&[0x11]);
+            for index in 0..column_count {
+                let value = row.get_ref(index).map_err(|error| {
+                    manifest_read_error(error, "failed to decode manifest semantic checksum")
+                })?;
+                hash_manifest_value(&mut hasher, value)?;
+            }
+        }
+        hasher.update(&[0x12]);
+    }
+    hasher.update(&[0xff]);
+    Ok(*hasher.finalize().as_bytes())
+}
+
+fn hash_manifest_name(hasher: &mut blake3::Hasher, value: &[u8]) {
+    hasher.update(
+        &u64::try_from(value.len())
+            .expect("manifest digest field length fits u64")
+            .to_le_bytes(),
+    );
+    hasher.update(value);
+}
+
+fn hash_manifest_value(hasher: &mut blake3::Hasher, value: ValueRef<'_>) -> EngineResult<()> {
+    match value {
+        ValueRef::Null => {
+            hasher.update(&[0]);
+        }
+        ValueRef::Integer(value) => {
+            hasher.update(&[1]);
+            hasher.update(&value.to_le_bytes());
+        }
+        ValueRef::Text(value) => {
+            hasher.update(&[2]);
+            hash_manifest_name(hasher, value);
+        }
+        ValueRef::Blob(value) => {
+            hasher.update(&[3]);
+            hash_manifest_name(hasher, value);
+        }
+        ValueRef::Real(_) => {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "manifest semantic checksum encountered an unsupported value type",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn refresh_manifest_digest(connection: &Connection) -> EngineResult<[u8; 32]> {
+    let digest = manifest_semantic_digest(connection)?;
+    let changed = connection
+        .execute(
+            "UPDATE briskdb_integrity SET manifest_digest = ?1 WHERE singleton = 1",
+            [digest.as_slice()],
+        )
+        .map_err(sqlite_error::storage)?;
+    if changed != 1 {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "manifest integrity metadata is missing its singleton row",
+        ));
+    }
+    Ok(digest)
+}
+
+fn refresh_manifest_digest_if_v7(connection: &Connection) -> EngineResult<()> {
+    let (application_id, version) = read_identity(connection)?;
+    if application_id == MANIFEST_APPLICATION_ID && version == i64::from(V7_SCHEMA_VERSION) {
+        let _ = refresh_manifest_digest(connection)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+pub(super) fn reseal_manifest_for_test(connection: &Connection) -> EngineResult<[u8; 32]> {
+    refresh_manifest_digest(connection)
+}
+
+fn validate_manifest_integrity(
+    connection: &Connection,
+    layout: &ShardLayout,
+    active_migration: Option<&SchemaMigration>,
+) -> EngineResult<ManifestIntegrity> {
+    let rows = connection
+        .prepare(
+            "SELECT singleton,
+                    manifest_digest_version,
+                    manifest_digest,
+                    schema_digest_version,
+                    database_state,
+                    committed_schema_digest,
+                    target_schema_digest
+             FROM briskdb_integrity
+             ORDER BY singleton
+             LIMIT 3",
+        )
+        .and_then(|mut statement| {
+            statement
+                .query_map([], |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, Vec<u8>>(2)?,
+                        row.get::<_, i64>(3)?,
+                        row.get::<_, i64>(4)?,
+                        row.get::<_, Option<Vec<u8>>>(5)?,
+                        row.get::<_, Option<Vec<u8>>>(6)?,
+                    ))
+                })?
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .map_err(|error| {
+            manifest_read_error(error, "failed to read manifest integrity metadata")
+        })?;
+    if rows.len() != 1 || rows[0].0 != 1 {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "manifest integrity metadata must contain exactly its singleton row",
+        ));
+    }
+    let (_, manifest_version, stored_root, schema_version, state_code, committed, target) =
+        &rows[0];
+    if *manifest_version <= 0 {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "manifest checksum version must be positive",
+        ));
+    }
+    if *manifest_version > i64::from(MANIFEST_DIGEST_VERSION) {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "manifest checksum version is newer than this BriskDB build supports",
+        ));
+    }
+    if *schema_version <= 0 {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "application-schema checksum version must be positive",
+        ));
+    }
+    if *schema_version > i64::from(SCHEMA_DIGEST_VERSION) {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "application-schema checksum version is newer than this BriskDB build supports",
+        ));
+    }
+    let stored_root = digest_from_blob(stored_root, "manifest semantic checksum")?;
+    let committed = committed
+        .as_deref()
+        .map(|digest| digest_from_blob(digest, "committed application-schema checksum"))
+        .transpose()?;
+    let target = target
+        .as_deref()
+        .map(|digest| digest_from_blob(digest, "target application-schema checksum"))
+        .transpose()?;
+    if manifest_semantic_digest(connection)? != stored_root {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "manifest semantic checksum does not match its authoritative contents",
+        ));
+    }
+    let state = DatabaseIntegrityState::from_code(*state_code)?;
+    match state {
+        DatabaseIntegrityState::Verifying => {
+            if active_migration.is_some() || target.is_some() {
+                return Err(invalid_integrity_state());
+            }
+        }
+        DatabaseIntegrityState::Ready => {
+            if layout.state() != ShardLayoutState::Ready
+                || active_migration.is_some()
+                || committed.is_none()
+                || target.is_some()
+            {
+                return Err(invalid_integrity_state());
+            }
+        }
+        DatabaseIntegrityState::Migrating => {
+            if layout.state() != ShardLayoutState::Ready
+                || active_migration.is_none()
+                || committed.is_none()
+                || target.is_none()
+            {
+                return Err(invalid_integrity_state());
+            }
+        }
+        DatabaseIntegrityState::Degraded => {
+            if active_migration.is_some() {
+                if committed.is_none() || target.is_none() {
+                    return Err(invalid_integrity_state());
+                }
+            } else if target.is_some() {
+                return Err(invalid_integrity_state());
+            }
+        }
+    }
+    Ok(ManifestIntegrity {
+        state,
+        committed_schema_digest: committed,
+        target_schema_digest: target,
+    })
+}
+
+fn digest_from_blob(value: &[u8], description: &'static str) -> EngineResult<[u8; 32]> {
+    value.try_into().map_err(|_| {
+        EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!("{description} is not exactly 32 bytes"),
+        )
+    })
+}
+
+fn invalid_integrity_state() -> EngineError {
+    EngineError::new(
+        EngineErrorKind::DataCorruption,
+        "manifest integrity state is inconsistent with durable database metadata",
+    )
+}
+
 #[derive(Debug, Clone, Copy)]
 enum SchemaGenerationPolicy {
     InitialOnly,
@@ -2460,6 +3435,7 @@ fn validate_catalog_manifest(
         )),
         shard_layout: None,
         active_migration: None,
+        integrity: None,
     })
 }
 
@@ -3479,6 +4455,7 @@ mod tests {
         if creating.state() != ShardLayoutState::Ready {
             mark_shard_layout_ready(connection, shards, &creating).unwrap();
         }
+        seal_verified_schema(connection, shards, [0x5a; 32]).unwrap();
     }
 
     fn complete_manifest_migration(
@@ -3624,6 +4601,17 @@ mod tests {
             .unwrap()
     }
 
+    fn stored_manifest_digest(connection: &Connection) -> [u8; 32] {
+        let digest = connection
+            .query_row(
+                "SELECT manifest_digest FROM briskdb_integrity WHERE singleton = 1",
+                [],
+                |row| row.get::<_, Vec<u8>>(0),
+            )
+            .unwrap();
+        digest.try_into().unwrap()
+    }
+
     fn insert_valid_table_catalog(connection: &Connection) {
         connection
             .execute_batch(
@@ -3635,6 +4623,7 @@ mod tests {
                  INSERT INTO briskdb_tables VALUES (55, 9, 'counters', 1, 'counter_id', 1);",
             )
             .unwrap();
+        refresh_manifest_digest_if_v7(connection).unwrap();
     }
 
     fn assert_generation_one_catalog(connection: &Connection, shard_count: u16) {
@@ -3642,7 +4631,7 @@ mod tests {
             identity(connection),
             (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
         );
-        assert_eq!(schema_objects(connection).unwrap(), v6_objects());
+        assert_eq!(schema_objects(connection).unwrap(), v7_objects());
         assert_eq!(
             connection
                 .query_row(
@@ -3651,7 +4640,7 @@ mod tests {
                     |row| row.get::<_, i64>(0),
                 )
                 .unwrap(),
-            i64::from(V6_SCHEMA_VERSION)
+            i64::from(V7_SCHEMA_VERSION)
         );
         assert_eq!(
             routing_configuration(connection),
@@ -3796,7 +4785,7 @@ mod tests {
             .unwrap(),
             4
         );
-        assert_eq!(resumed_steps, [(2, 3), (3, 4), (4, 5), (5, 6)]);
+        assert_eq!(resumed_steps, [(2, 3), (3, 4), (4, 5), (5, 6), (6, 7)]);
         assert_generation_one_catalog(&connection, 4);
         assert_eq!(quick_check(&connection), "ok");
     }
@@ -3821,6 +4810,292 @@ mod tests {
             .pragma_query_value(None, "data_version", |row| row.get(0))
             .unwrap();
         assert_eq!(before, after, "a current-version reopen must not write");
+    }
+
+    #[test]
+    fn v7_integrity_root_is_deterministic_across_reopen_checkpoint_and_vacuum() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("manifest.sqlite");
+        let mut connection = Connection::open(&path).unwrap();
+        create_ready_current_manifest(&mut connection, 4);
+        connection
+            .pragma_update(None, "journal_mode", "WAL")
+            .unwrap();
+        let expected = stored_manifest_digest(&connection);
+        assert_eq!(manifest_semantic_digest(&connection).unwrap(), expected);
+
+        connection
+            .execute_batch("PRAGMA wal_checkpoint(TRUNCATE); VACUUM;")
+            .unwrap();
+        assert_eq!(manifest_semantic_digest(&connection).unwrap(), expected);
+        drop(connection);
+
+        let mut reopened = Connection::open(&path).unwrap();
+        let loaded = load_or_create_manifest(&mut reopened, 4).unwrap();
+        assert_eq!(loaded.integrity.state(), DatabaseIntegrityState::Ready);
+        assert_eq!(stored_manifest_digest(&reopened), expected);
+        assert_eq!(manifest_semantic_digest(&reopened).unwrap(), expected);
+    }
+
+    #[test]
+    fn manifest_semantic_digest_v1_has_a_frozen_golden_vector() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        create_ready_current_manifest(&mut connection, 4);
+        connection
+            .execute(
+                "UPDATE briskdb_shard_layout
+                 SET layout_id = x'000102030405060708090a0b0c0d0e0f'
+                 WHERE singleton = 1",
+                [],
+            )
+            .unwrap();
+        insert_valid_table_catalog(&connection);
+        let digest = refresh_manifest_digest(&connection).unwrap();
+        assert_eq!(
+            digest,
+            [
+                0x57, 0x9d, 0x8a, 0x78, 0x54, 0xa9, 0xa7, 0xaa, 0x3a, 0xdd, 0x69, 0xdb, 0xb8, 0xc4,
+                0x13, 0xb2, 0x85, 0x1d, 0xb7, 0x4e, 0xdc, 0xe1, 0x9a, 0xd6, 0xde, 0xf2, 0x2a, 0xb9,
+                0x4f, 0x02, 0x9e, 0xd1,
+            ]
+        );
+        assert_eq!(manifest_semantic_digest(&connection).unwrap(), digest);
+    }
+
+    #[test]
+    fn manifest_semantic_digest_orders_catalog_rows_by_frozen_keys() {
+        let mut forward = Connection::open_in_memory().unwrap();
+        let mut reverse = Connection::open_in_memory().unwrap();
+        for connection in [&mut forward, &mut reverse] {
+            create_ready_current_manifest(connection, 4);
+            connection
+                .execute(
+                    "UPDATE briskdb_shard_layout
+                     SET layout_id = x'000102030405060708090a0b0c0d0e0f'
+                     WHERE singleton = 1",
+                    [],
+                )
+                .unwrap();
+        }
+        insert_valid_table_catalog(&forward);
+        reverse
+            .execute_batch(
+                "INSERT INTO briskdb_logical_databases VALUES (9, 'tenant');
+                 INSERT INTO briskdb_tables VALUES (55, 9, 'counters', 1, 'counter_id', 1);
+                 INSERT INTO briskdb_tables VALUES (34, 9, 'binary_keys', 1, 'key_bytes', 3);
+                 INSERT INTO briskdb_tables VALUES (21, 9, 'audit_log', 3, NULL, NULL);
+                 INSERT INTO briskdb_tables VALUES (8, 1, 'countries', 2, NULL, NULL);
+                 INSERT INTO briskdb_tables VALUES (3, 1, 'accounts', 1, 'tenant_id', 2);",
+            )
+            .unwrap();
+
+        assert_eq!(
+            refresh_manifest_digest(&forward).unwrap(),
+            refresh_manifest_digest(&reverse).unwrap()
+        );
+    }
+
+    #[test]
+    fn semantic_root_covers_every_authoritative_manifest_table_and_integrity_state() {
+        let mutations = [
+            "UPDATE briskdb_manifest SET singleton = 2 WHERE singleton = 1",
+            "UPDATE briskdb_metadata SET requires_manifest_version = 8",
+            "UPDATE briskdb_routing SET hash_version = 2 WHERE singleton = 1",
+            "UPDATE briskdb_physical_shards SET lifecycle_state = 'retired' WHERE shard_id = 0",
+            "UPDATE briskdb_virtual_buckets SET physical_shard_id = 1 WHERE bucket_id = 0",
+            "UPDATE briskdb_logical_databases SET database_name = 'primary' WHERE database_id = 1",
+            "UPDATE briskdb_schema_catalog SET identifier_encoding_version = 2 WHERE singleton = 1",
+            "INSERT INTO briskdb_tables VALUES (1, 1, 'widgets', 2, NULL, NULL)",
+            "UPDATE briskdb_shard_layout SET layout_id = randomblob(16) WHERE singleton = 1",
+            "INSERT INTO briskdb_schema_migrations VALUES (1, 0, randomblob(32), 1, 'SELECT 1', 4, 2, 4)",
+            "UPDATE briskdb_integrity SET database_state = 4 WHERE singleton = 1",
+            "UPDATE briskdb_integrity SET committed_schema_digest = randomblob(32) WHERE singleton = 1",
+        ];
+
+        for mutation in mutations {
+            let mut connection = Connection::open_in_memory().unwrap();
+            create_ready_current_manifest(&mut connection, 4);
+            let trusted = stored_manifest_digest(&connection);
+            connection
+                .execute_batch(
+                    "PRAGMA foreign_keys = OFF;
+                     PRAGMA ignore_check_constraints = ON;",
+                )
+                .unwrap();
+            connection.execute_batch(mutation).unwrap();
+            connection
+                .execute_batch("PRAGMA ignore_check_constraints = OFF;")
+                .unwrap();
+
+            assert_ne!(
+                manifest_semantic_digest(&connection).unwrap(),
+                trusted,
+                "{mutation}"
+            );
+            assert_eq!(stored_manifest_digest(&connection), trusted, "{mutation}");
+            assert_eq!(
+                load_or_create_manifest(&mut connection, 4)
+                    .unwrap_err()
+                    .kind(),
+                EngineErrorKind::DataCorruption,
+                "{mutation}"
+            );
+            assert_eq!(stored_manifest_digest(&connection), trusted, "{mutation}");
+        }
+    }
+
+    #[test]
+    fn integrity_versions_lengths_and_forged_state_invariants_fail_closed() {
+        for version_column in ["manifest_digest_version", "schema_digest_version"] {
+            let mut unsupported = Connection::open_in_memory().unwrap();
+            create_ready_current_manifest(&mut unsupported, 4);
+            unsupported
+                .execute(
+                    &format!(
+                        "UPDATE briskdb_integrity SET {version_column} = 2 WHERE singleton = 1"
+                    ),
+                    [],
+                )
+                .unwrap();
+            refresh_manifest_digest(&unsupported).unwrap();
+            assert_eq!(
+                load_or_create_manifest(&mut unsupported, 4)
+                    .unwrap_err()
+                    .kind(),
+                EngineErrorKind::FailedPrecondition,
+                "{version_column}"
+            );
+
+            let mut invalid = Connection::open_in_memory().unwrap();
+            create_ready_current_manifest(&mut invalid, 4);
+            invalid
+                .pragma_update(None, "ignore_check_constraints", "ON")
+                .unwrap();
+            invalid
+                .execute(
+                    &format!(
+                        "UPDATE briskdb_integrity SET {version_column} = 0 WHERE singleton = 1"
+                    ),
+                    [],
+                )
+                .unwrap();
+            refresh_manifest_digest(&invalid).unwrap();
+            invalid
+                .pragma_update(None, "ignore_check_constraints", "OFF")
+                .unwrap();
+            assert_eq!(
+                load_or_create_manifest(&mut invalid, 4).unwrap_err().kind(),
+                EngineErrorKind::DataCorruption,
+                "{version_column}"
+            );
+        }
+
+        let mut malformed = Connection::open_in_memory().unwrap();
+        create_ready_current_manifest(&mut malformed, 4);
+        malformed
+            .pragma_update(None, "ignore_check_constraints", "ON")
+            .unwrap();
+        malformed
+            .execute(
+                "UPDATE briskdb_integrity SET committed_schema_digest = x'01' WHERE singleton = 1",
+                [],
+            )
+            .unwrap();
+        malformed
+            .pragma_update(None, "ignore_check_constraints", "OFF")
+            .unwrap();
+        assert_eq!(
+            load_or_create_manifest(&mut malformed, 4)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::DataCorruption
+        );
+
+        let mut forged = Connection::open_in_memory().unwrap();
+        load_or_create_manifest(&mut forged, 4).unwrap();
+        forged
+            .pragma_update(None, "ignore_check_constraints", "ON")
+            .unwrap();
+        forged
+            .execute(
+                "UPDATE briskdb_integrity
+                 SET database_state = 2, committed_schema_digest = NULL
+                 WHERE singleton = 1",
+                [],
+            )
+            .unwrap();
+        refresh_manifest_digest(&forged).unwrap();
+        forged
+            .pragma_update(None, "ignore_check_constraints", "OFF")
+            .unwrap();
+        assert_eq!(
+            load_or_create_manifest(&mut forged, 4).unwrap_err().kind(),
+            EngineErrorKind::DataCorruption
+        );
+    }
+
+    #[test]
+    fn migration_and_degraded_transitions_reseal_without_rebaselining() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        create_ready_current_manifest(&mut connection, 4);
+        let ready_root = stored_manifest_digest(&connection);
+
+        let mut migration =
+            begin_schema_migration(&mut connection, 4, 0, "CREATE TABLE widgets(id INTEGER)")
+                .unwrap();
+        let journal_root = stored_manifest_digest(&connection);
+        assert_ne!(journal_root, ready_root);
+        assert_eq!(
+            current_integrity(&connection, 4).unwrap().state(),
+            DatabaseIntegrityState::Migrating
+        );
+
+        migration = advance_schema_migration(&mut connection, 4, &migration, 1).unwrap();
+        let progress_root = stored_manifest_digest(&connection);
+        assert_ne!(progress_root, journal_root);
+        while migration.next_shard() < migration.shard_count() {
+            let next = migration.next_shard() + 1;
+            migration = advance_schema_migration(&mut connection, 4, &migration, next).unwrap();
+        }
+        finalize_schema_migration(&mut connection, 4, &migration).unwrap();
+        let completed_root = stored_manifest_digest(&connection);
+        assert_ne!(completed_root, progress_root);
+        assert_eq!(
+            manifest_semantic_digest(&connection).unwrap(),
+            completed_root
+        );
+        assert_eq!(
+            current_integrity(&connection, 4).unwrap().state(),
+            DatabaseIntegrityState::Ready
+        );
+
+        let layout = current_manifest_snapshot(&connection, 4)
+            .unwrap()
+            .shard_layout
+            .unwrap();
+        mark_degraded(&mut connection, 4, &layout).unwrap();
+        let degraded = current_integrity(&connection, 4).unwrap();
+        assert_eq!(degraded.state(), DatabaseIntegrityState::Degraded);
+        assert_eq!(
+            seal_verified_schema(&mut connection, 4, [0x11; 32])
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::DataCorruption
+        );
+        assert_eq!(
+            current_integrity(&connection, 4).unwrap().state(),
+            DatabaseIntegrityState::Degraded
+        );
+        assert_eq!(
+            seal_verified_schema(
+                &mut connection,
+                4,
+                degraded.committed_schema_digest().unwrap(),
+            )
+            .unwrap_err()
+            .kind(),
+            EngineErrorKind::DataCorruption
+        );
     }
 
     #[test]
@@ -3893,9 +5168,9 @@ mod tests {
         assert_eq!(catalog.logical().tables().len(), 5);
         assert_eq!(
             identity(&connection),
-            (MANIFEST_APPLICATION_ID, i64::from(V6_SCHEMA_VERSION))
+            (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
         );
-        assert_eq!(schema_objects(&connection).unwrap(), v6_objects());
+        assert_eq!(schema_objects(&connection).unwrap(), v7_objects());
         assert_eq!(
             shard_layout_row(&connection).3,
             ShardLayoutState::Adopting.code()
@@ -3914,16 +5189,26 @@ mod tests {
 
         let loaded = load_or_create_manifest(&mut connection, 4).unwrap();
         assert!(loaded.active_migration().is_none());
-        let (catalog, layout, active) = loaded.into_parts_with_migration();
+        let (catalog, layout, active, integrity) = loaded.into_parts_with_migration();
 
-        assert_eq!(identity(&connection), (MANIFEST_APPLICATION_ID, 6));
-        assert_eq!(schema_objects(&connection).unwrap(), v6_objects());
+        assert_eq!(
+            identity(&connection),
+            (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
+        );
+        assert_eq!(schema_objects(&connection).unwrap(), v7_objects());
         assert_eq!(layout.state(), ShardLayoutState::Ready);
         assert_eq!(shard_layout_row(&connection), layout_before);
         assert_eq!(catalog.logical().schema_generation(), 0);
         assert_eq!(logical_databases(&connection), databases_before);
         assert_eq!(table_metadata_rows(&connection), tables_before);
         assert!(active.is_none());
+        assert_eq!(integrity.state(), DatabaseIntegrityState::Verifying);
+        assert_eq!(integrity.committed_schema_digest(), None);
+        assert_eq!(integrity.target_schema_digest(), None);
+        assert_eq!(
+            manifest_semantic_digest(&connection).unwrap(),
+            stored_manifest_digest(&connection)
+        );
         assert_eq!(
             connection
                 .query_row(
@@ -3935,6 +5220,40 @@ mod tests {
             0
         );
         assert_eq!(quick_check(&connection), "ok");
+    }
+
+    #[test]
+    fn version_six_upgrade_enters_verifying_without_changing_catalog_or_history() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        create_v5_manifest(&mut connection, 4);
+        insert_valid_table_catalog(&connection);
+        let mut no_hook = |_| Ok(());
+        let v6 = load_or_create_snapshot_with_plan(&mut connection, 4, V6_PLAN, true, &mut no_hook)
+            .unwrap();
+        assert_eq!(identity(&connection), (MANIFEST_APPLICATION_ID, 6));
+        let databases_before = logical_databases(&connection);
+        let tables_before = table_metadata_rows(&connection);
+        assert!(v6.active_migration.is_none());
+
+        let loaded = load_or_create_manifest(&mut connection, 4).unwrap();
+        assert_eq!(loaded.integrity.state(), DatabaseIntegrityState::Verifying);
+        assert_eq!(loaded.integrity.committed_schema_digest(), None);
+        assert_eq!(logical_databases(&connection), databases_before);
+        assert_eq!(table_metadata_rows(&connection), tables_before);
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT COUNT(*) FROM briskdb_schema_migrations",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            manifest_semantic_digest(&connection).unwrap(),
+            stored_manifest_digest(&connection)
+        );
     }
 
     #[test]
@@ -3965,8 +5284,11 @@ mod tests {
             assert_eq!(quick_check(&connection), "ok");
 
             load_or_create_manifest(&mut connection, 4).unwrap();
-            assert_eq!(identity(&connection), (MANIFEST_APPLICATION_ID, 6));
-            assert_eq!(schema_objects(&connection).unwrap(), v6_objects());
+            assert_eq!(
+                identity(&connection),
+                (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
+            );
+            assert_eq!(schema_objects(&connection).unwrap(), v7_objects());
         }
 
         let mut connection = Connection::open_in_memory().unwrap();
@@ -3985,7 +5307,10 @@ mod tests {
         assert_eq!(identity(&connection), (MANIFEST_APPLICATION_ID, 5));
         assert_eq!(schema_objects(&connection).unwrap(), v5_objects());
         load_or_create_manifest(&mut connection, 4).unwrap();
-        assert_eq!(identity(&connection), (MANIFEST_APPLICATION_ID, 6));
+        assert_eq!(
+            identity(&connection),
+            (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
+        );
     }
 
     #[test]
@@ -5462,7 +6787,7 @@ mod tests {
     }
 
     #[test]
-    fn version_five_reader_rejects_version_six_without_mutating_it() {
+    fn version_five_reader_rejects_current_manifest_without_mutating_it() {
         const OLD_MIGRATIONS: &[Migration] = &[
             Migration {
                 from: LEGACY_SCHEMA_VERSION,
@@ -5518,8 +6843,25 @@ mod tests {
                     |row| row.get::<_, i64>(0),
                 )
                 .unwrap(),
-            i64::from(V6_SCHEMA_VERSION)
+            i64::from(CURRENT_SCHEMA_VERSION)
         );
+    }
+
+    #[test]
+    fn version_six_reader_rejects_version_seven_without_mutating_it() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        create_ready_current_manifest(&mut connection, 4);
+        let identity_before = identity(&connection);
+        let objects_before = schema_objects(&connection).unwrap();
+        let root_before = stored_manifest_digest(&connection);
+
+        let error = inspect_with_plan(&connection, 4, V6_PLAN).unwrap_err();
+
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert_eq!(identity(&connection), identity_before);
+        assert_eq!(schema_objects(&connection).unwrap(), objects_before);
+        assert_eq!(stored_manifest_digest(&connection), root_before);
+        assert_eq!(manifest_semantic_digest(&connection).unwrap(), root_before);
     }
 
     #[test]
@@ -5731,6 +7073,7 @@ mod tests {
             drop(insert);
             transaction.commit().unwrap();
         }
+        refresh_manifest_digest(&databases).unwrap();
         assert_eq!(
             load_or_create_catalog(&mut databases, 4)
                 .unwrap()
@@ -5781,6 +7124,7 @@ mod tests {
             drop(insert);
             transaction.commit().unwrap();
         }
+        refresh_manifest_digest(&tables).unwrap();
         assert_eq!(
             load_or_create_catalog(&mut tables, 4)
                 .unwrap()

--- a/src/storage/migration.rs
+++ b/src/storage/migration.rs
@@ -28,7 +28,8 @@ use crate::{
 
 use super::{
     CONNECTION_BUSY_TIMEOUT, RootSchemaCoordination, SchemaMigrationGuard, Storage,
-    configure_journal_mode, configure_manifest_connection, manifest,
+    configure_journal_mode, configure_manifest_connection,
+    configure_manifest_connection_after_busy_setup, manifest,
     manifest::{SchemaMigration, SchemaMigrationClassification},
     open_existing_manifest, shard,
 };
@@ -42,6 +43,7 @@ thread_local! {
 #[cfg(test)]
 thread_local! {
     static FAIL_NEXT_MANIFEST_COMMIT_CLEANUP: Cell<bool> = const { Cell::new(false) };
+    static CANCEL_AFTER_CONTROLLED_CORRUPTION: Cell<bool> = const { Cell::new(false) };
 }
 
 struct MigrationBusyOperation {
@@ -230,15 +232,20 @@ pub(super) fn apply_schema_migration(
     control: Option<Arc<OperationControl>>,
 ) -> EngineResult<Vec<u16>> {
     #[cfg(test)]
-    {
+    let result = {
         apply_schema_migration_with_hook(storage, sql, guard, control, |point| {
             run_schema_migration_test_block(&storage.root, point)
         })
-    }
+    };
     #[cfg(not(test))]
+    let result = { apply_schema_migration_with_hook(storage, sql, guard, control, |_| Ok(())) };
+    if result
+        .as_ref()
+        .is_err_and(|error| error.kind() == EngineErrorKind::DataCorruption)
     {
-        apply_schema_migration_with_hook(storage, sql, guard, control, |_| Ok(()))
+        storage.record_schema_degraded();
     }
+    result
 }
 
 fn apply_schema_migration_with_hook<F>(
@@ -257,8 +264,20 @@ where
 
     let manifest_path = storage.root.join("manifest.sqlite");
     let mut manifest_connection = open_existing_manifest(&manifest_path)?;
-    configure_manifest_connection(&manifest_connection)?;
-    configure_journal_mode(&manifest_connection)?;
+    match control.as_ref() {
+        Some(control) => run_connection_controlled(
+            &mut manifest_connection,
+            Arc::clone(control),
+            |connection| {
+                configure_manifest_connection_after_busy_setup(connection)?;
+                configure_journal_mode(connection)
+            },
+        )?,
+        None => {
+            configure_manifest_connection(&manifest_connection)?;
+            configure_journal_mode(&manifest_connection)?;
+        }
+    }
 
     match classify_schema_migration(
         &mut manifest_connection,
@@ -268,10 +287,30 @@ where
         control.as_ref(),
     )? {
         SchemaMigrationClassification::Complete(migration) => {
+            if let Some(integrity) = current_integrity_optional_controlled(
+                &mut manifest_connection,
+                storage.shard_count(),
+                control.as_ref(),
+            )? {
+                storage.schema_coordination.publish_schema_digests(
+                    integrity.committed_schema_digest(),
+                    integrity.target_schema_digest(),
+                )?;
+            }
             finish_completed_schema_migration(storage, &migration, control.as_ref())?;
             return Ok(all_shards(storage.shard_count()));
         }
         SchemaMigrationClassification::Active(migration) => {
+            if let Some(integrity) = current_integrity_optional_controlled(
+                &mut manifest_connection,
+                storage.shard_count(),
+                control.as_ref(),
+            )? {
+                storage.schema_coordination.publish_schema_digests(
+                    integrity.committed_schema_digest(),
+                    integrity.target_schema_digest(),
+                )?;
+            }
             guard.mark_pending_on_drop();
             resume_active_schema_migration(
                 SchemaMigrationCoordinator {
@@ -299,17 +338,22 @@ where
         )
     })?;
     let shards_dir = storage.root.join("shards");
+    let source_digest = storage.schema_coordination.committed_schema_digest()?;
+    let mut target_digest = None;
     for shard_id in 0..storage.shard_count() {
         check_cancelled(control.as_deref())?;
         let path = shard_path(&shards_dir, shard_id);
-        let state = preflight_one_shard(
-            &path,
-            shard_id,
-            source_generation,
-            target_generation,
-            &storage.shard_layout,
-            sql,
-            control.as_ref(),
+        let (state, observed_target_digest) = preflight_one_shard(
+            ShardMigrationRequest {
+                path: &path,
+                shard_id,
+                source_generation,
+                target_generation,
+                layout: &storage.shard_layout,
+                sql,
+                control: control.as_ref(),
+            },
+            &source_digest,
         )
         .map_err(|error| sanitized_shard_error(error, "preflight", shard_id))?;
         if state != shard::SchemaMigrationShardState::Source {
@@ -320,18 +364,38 @@ where
                 ),
             ));
         }
+        if target_digest.is_some_and(|expected| expected != observed_target_digest) {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "schema migration produced inconsistent target fingerprints across shards",
+            ));
+        }
+        target_digest = Some(observed_target_digest);
     }
     check_cancelled(control.as_deref())?;
+    let target_digest = target_digest.ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::Internal,
+            "schema migration preflight did not inspect any shards",
+        )
+    })?;
 
     let migration = begin_schema_migration(
         &mut manifest_connection,
-        storage.shard_count(),
-        &storage.shard_layout,
-        source_generation,
-        sql,
-        control.as_ref(),
+        BeginSchemaMigrationRequest {
+            requested_shards: storage.shard_count(),
+            layout: &storage.shard_layout,
+            source_generation,
+            sql,
+            source_digest,
+            target_digest,
+            control: control.as_ref(),
+        },
         guard,
     )?;
+    storage
+        .schema_coordination
+        .publish_schema_digests(Some(source_digest), Some(target_digest))?;
     if migration.is_complete() {
         finish_completed_schema_migration(storage, &migration, control.as_ref())?;
         return Ok(all_shards(storage.shard_count()));
@@ -369,23 +433,53 @@ fn classify_schema_migration(
     Ok(classification)
 }
 
-fn begin_schema_migration(
+fn current_integrity_optional_controlled(
     connection: &mut Connection,
     requested_shards: u16,
-    layout: &shard::ShardLayout,
-    source_generation: u64,
-    sql: &str,
     control: Option<&Arc<OperationControl>>,
+) -> EngineResult<Option<manifest::ManifestIntegrity>> {
+    match control {
+        Some(control) => run_connection_controlled(connection, Arc::clone(control), |connection| {
+            manifest::current_integrity_optional(connection, requested_shards)
+        }),
+        None => manifest::current_integrity_optional(connection, requested_shards),
+    }
+}
+
+struct BeginSchemaMigrationRequest<'a> {
+    requested_shards: u16,
+    layout: &'a shard::ShardLayout,
+    source_generation: u64,
+    sql: &'a str,
+    source_digest: [u8; 32],
+    target_digest: [u8; 32],
+    control: Option<&'a Arc<OperationControl>>,
+}
+
+fn begin_schema_migration(
+    connection: &mut Connection,
+    request: BeginSchemaMigrationRequest<'_>,
     guard: &mut SchemaMigrationGuard,
 ) -> EngineResult<SchemaMigration> {
+    let BeginSchemaMigrationRequest {
+        requested_shards,
+        layout,
+        source_generation,
+        sql,
+        source_digest,
+        target_digest,
+        control,
+    } = request;
     let mut transaction = ManifestTransaction::begin(connection, control)?;
     let migration = transaction.run(|connection| {
         manifest::ensure_schema_migration_layout(connection, requested_shards, layout)?;
-        manifest::begin_schema_migration_in_transaction(
+        manifest::begin_schema_migration_with_digests_in_transaction(
             connection,
             requested_shards,
             source_generation,
             sql,
+            source_digest,
+            target_digest,
         )
     })?;
     transaction.commit_with_durability_boundary(|| guard.mark_pending_on_drop())?;
@@ -511,15 +605,61 @@ where
     } = coordinator;
     ensure_active_matches_catalog(&migration, catalog, requested_shards)?;
     let shards_dir = root.join("shards");
-    validate_schema_migration_prefix(
-        &shards_dir,
+    let integrity = current_integrity_optional_controlled(
+        manifest_connection,
         requested_shards,
-        migration.next_shard(),
-        migration.source_generation(),
-        migration.target_generation(),
-        layout,
         control.as_ref(),
     )?;
+    let schema_digests = if let Some(integrity) = integrity {
+        if integrity.state() != manifest::DatabaseIntegrityState::Migrating {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "active schema migration is not in its durable migrating state",
+            ));
+        }
+        let source = integrity.committed_schema_digest().ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "active schema migration is missing its source fingerprint",
+            )
+        })?;
+        let target = integrity.target_schema_digest().ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "active schema migration is missing its target fingerprint",
+            )
+        })?;
+        schema_coordination.publish_schema_digests(Some(source), Some(target))?;
+        let target = schema_coordination.target_schema_digest()?.ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::Internal,
+                "root coordination did not publish the migration target fingerprint",
+            )
+        })?;
+        validate_schema_migration_prefix_with_digests(
+            &shards_dir,
+            requested_shards,
+            migration.next_shard(),
+            migration.source_generation(),
+            migration.target_generation(),
+            layout,
+            &source,
+            &target,
+            control.as_ref(),
+        )?;
+        Some((source, target))
+    } else {
+        validate_schema_migration_prefix(
+            &shards_dir,
+            requested_shards,
+            migration.next_shard(),
+            migration.source_generation(),
+            migration.target_generation(),
+            layout,
+            control.as_ref(),
+        )?;
+        None
+    };
 
     while migration.next_shard() < requested_shards {
         check_cancelled(control.as_deref())?;
@@ -549,13 +689,16 @@ where
         let shard_id = migration.next_shard();
         let path = shard_path(&shards_dir, shard_id);
         apply_one_shard(
-            &path,
-            shard_id,
-            migration.source_generation(),
-            migration.target_generation(),
-            layout,
-            migration.sql_text(),
-            control.as_ref(),
+            ShardMigrationRequest {
+                path: &path,
+                shard_id,
+                source_generation: migration.source_generation(),
+                target_generation: migration.target_generation(),
+                layout,
+                sql: migration.sql_text(),
+                control: control.as_ref(),
+            },
+            schema_digests.as_ref().map(|(_, target)| target),
         )
         .map_err(|error| sanitized_shard_error(error, "apply", shard_id))?;
         hook(SchemaMigrationCoordinatorPoint::ShardCommitted(shard_id))?;
@@ -576,15 +719,29 @@ where
     }
 
     check_cancelled(control.as_deref())?;
-    validate_schema_migration_prefix(
-        &shards_dir,
-        requested_shards,
-        requested_shards,
-        migration.source_generation(),
-        migration.target_generation(),
-        layout,
-        control.as_ref(),
-    )?;
+    if let Some((source_digest, target_digest)) = schema_digests.as_ref() {
+        validate_schema_migration_prefix_with_digests(
+            &shards_dir,
+            requested_shards,
+            requested_shards,
+            migration.source_generation(),
+            migration.target_generation(),
+            layout,
+            source_digest,
+            target_digest,
+            control.as_ref(),
+        )?;
+    } else {
+        validate_schema_migration_prefix(
+            &shards_dir,
+            requested_shards,
+            requested_shards,
+            migration.source_generation(),
+            migration.target_generation(),
+            layout,
+            control.as_ref(),
+        )?;
+    }
 
     let mut transaction = ManifestTransaction::begin(manifest_connection, control.as_ref())?;
     let Some(locked) = transaction.run(|connection| {
@@ -610,7 +767,11 @@ where
     transaction.commit()?;
     hook(SchemaMigrationCoordinatorPoint::FinalizationCommitted)?;
     schema_coordination
-        .publish_schema_generation(completed.source_generation(), completed.target_generation())
+        .publish_schema_generation(completed.source_generation(), completed.target_generation())?;
+    if let Some((_, target_digest)) = schema_digests {
+        schema_coordination.publish_schema_digests(Some(target_digest), None)?;
+    }
+    Ok(())
 }
 
 fn finish_completed_by_sql(
@@ -637,15 +798,38 @@ fn finish_completed_by_sql(
             ));
         }
     };
-    validate_schema_migration_prefix(
-        shards_dir,
-        requested_shards,
-        requested_shards,
-        completed.source_generation(),
-        completed.target_generation(),
-        layout,
-        control,
-    )?;
+    if let Some(integrity) =
+        current_integrity_optional_controlled(manifest_connection, requested_shards, control)?
+    {
+        let target_digest = integrity.committed_schema_digest().ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "completed schema migration is missing its committed fingerprint",
+            )
+        })?;
+        validate_schema_migration_prefix_with_digests(
+            shards_dir,
+            requested_shards,
+            requested_shards,
+            completed.source_generation(),
+            completed.target_generation(),
+            layout,
+            &target_digest,
+            &target_digest,
+            control,
+        )?;
+        schema_coordination.publish_schema_digests(Some(target_digest), None)?;
+    } else {
+        validate_schema_migration_prefix(
+            shards_dir,
+            requested_shards,
+            requested_shards,
+            completed.source_generation(),
+            completed.target_generation(),
+            layout,
+            control,
+        )?;
+    }
     schema_coordination
         .publish_schema_generation(completed.source_generation(), completed.target_generation())
 }
@@ -663,13 +847,16 @@ fn finish_completed_schema_migration(
                 "completed schema migration does not match the loaded catalog generation",
             ));
         }
-        validate_schema_migration_prefix(
+        let target_digest = storage.schema_coordination.committed_schema_digest()?;
+        validate_schema_migration_prefix_with_digests(
             &storage.root.join("shards"),
             storage.shard_count(),
             storage.shard_count(),
             migration.source_generation(),
             migration.target_generation(),
             &storage.shard_layout,
+            &target_digest,
+            &target_digest,
             control,
         )?;
         return storage.publish_schema_generation(
@@ -739,28 +926,119 @@ fn validate_schema_migration_prefix(
     )
 }
 
-fn preflight_one_shard(
-    path: &Path,
-    shard_id: u16,
+#[allow(clippy::too_many_arguments)]
+fn validate_schema_migration_prefix_with_digests(
+    shards_dir: &Path,
+    shard_count: u16,
+    next_shard: u16,
     source_generation: u64,
     target_generation: u64,
     layout: &shard::ShardLayout,
-    sql: &str,
+    source_digest: &[u8; 32],
+    target_digest: &[u8; 32],
     control: Option<&Arc<OperationControl>>,
-) -> EngineResult<shard::SchemaMigrationShardState> {
+) -> EngineResult<Option<shard::SchemaMigrationShardState>> {
+    shard::validate_schema_migration_prefix_with(
+        shards_dir,
+        shard_count,
+        next_shard,
+        source_generation,
+        target_generation,
+        layout,
+        |path, shard_id| {
+            let mut connection = shard::open_required_file(path)?;
+            let validate = |connection: &mut Connection| {
+                let state = shard::validate_schema_migration_connection(
+                    connection,
+                    path,
+                    shard_id,
+                    source_generation,
+                    target_generation,
+                    layout,
+                )?;
+                let (generation, expected) = match state {
+                    shard::SchemaMigrationShardState::Source => (source_generation, source_digest),
+                    shard::SchemaMigrationShardState::Target => (target_generation, target_digest),
+                };
+                shard::verify_schema_digest(connection, generation, expected)?;
+                Ok(state)
+            };
+            match control {
+                Some(control) => {
+                    run_connection_controlled(&mut connection, Arc::clone(control), validate)
+                }
+                None => {
+                    connection
+                        .busy_timeout(CONNECTION_BUSY_TIMEOUT)
+                        .map_err(sqlite_error::storage)?;
+                    validate(&mut connection)
+                }
+            }
+        },
+    )
+}
+
+struct ShardMigrationRequest<'a> {
+    path: &'a Path,
+    shard_id: u16,
+    source_generation: u64,
+    target_generation: u64,
+    layout: &'a shard::ShardLayout,
+    sql: &'a str,
+    control: Option<&'a Arc<OperationControl>>,
+}
+
+fn preflight_one_shard(
+    request: ShardMigrationRequest<'_>,
+    expected_source_digest: &[u8; 32],
+) -> EngineResult<(shard::SchemaMigrationShardState, [u8; 32])> {
+    let ShardMigrationRequest {
+        path,
+        shard_id,
+        source_generation,
+        target_generation,
+        layout,
+        sql,
+        control,
+    } = request;
     match control {
-        None => shard::preflight_schema_migration(
-            path,
-            shard_id,
-            source_generation,
-            target_generation,
-            layout,
-            sql,
-        ),
+        None => {
+            let mut connection = shard::open_required_file(path)?;
+            connection
+                .busy_timeout(CONNECTION_BUSY_TIMEOUT)
+                .map_err(sqlite_error::storage)?;
+            shard::validate_schema_migration_connection(
+                &connection,
+                path,
+                shard_id,
+                source_generation,
+                target_generation,
+                layout,
+            )?;
+            shard::verify_schema_digest(&connection, source_generation, expected_source_digest)?;
+            shard::preflight_schema_migration_on_connection_with_digest(
+                &mut connection,
+                path,
+                shard_id,
+                source_generation,
+                target_generation,
+                layout,
+                sql,
+            )
+        }
         Some(control) => {
             let mut connection = shard::open_required_file(path)?;
             run_connection_controlled(&mut connection, Arc::clone(control), |connection| {
-                shard::preflight_schema_migration_on_connection(
+                shard::validate_schema_migration_connection(
+                    connection,
+                    path,
+                    shard_id,
+                    source_generation,
+                    target_generation,
+                    layout,
+                )?;
+                shard::verify_schema_digest(connection, source_generation, expected_source_digest)?;
+                shard::preflight_schema_migration_on_connection_with_digest(
                     connection,
                     path,
                     shard_id,
@@ -775,37 +1053,66 @@ fn preflight_one_shard(
 }
 
 fn apply_one_shard(
-    path: &Path,
-    shard_id: u16,
-    source_generation: u64,
-    target_generation: u64,
-    layout: &shard::ShardLayout,
-    sql: &str,
-    control: Option<&Arc<OperationControl>>,
+    request: ShardMigrationRequest<'_>,
+    expected_target_digest: Option<&[u8; 32]>,
 ) -> EngineResult<()> {
+    let ShardMigrationRequest {
+        path,
+        shard_id,
+        source_generation,
+        target_generation,
+        layout,
+        sql,
+        control,
+    } = request;
     match control {
-        None => shard::apply_schema_migration(
-            path,
-            shard_id,
-            source_generation,
-            target_generation,
-            layout,
-            sql,
-        )
-        .map(|_| ()),
+        None => match expected_target_digest {
+            Some(expected) => shard::apply_schema_migration_with_digest(
+                path,
+                shard_id,
+                source_generation,
+                target_generation,
+                layout,
+                sql,
+                expected,
+            )
+            .map(|_| ()),
+            None => shard::apply_schema_migration(
+                path,
+                shard_id,
+                source_generation,
+                target_generation,
+                layout,
+                sql,
+            )
+            .map(|_| ()),
+        },
         Some(control) => {
             let mut connection = shard::open_required_file(path)?;
             run_connection_controlled(&mut connection, Arc::clone(control), |connection| {
-                shard::apply_schema_migration_on_connection(
-                    connection,
-                    path,
-                    shard_id,
-                    source_generation,
-                    target_generation,
-                    layout,
-                    sql,
-                )
-                .map(|_| ())
+                match expected_target_digest {
+                    Some(expected) => shard::apply_schema_migration_on_connection_with_digest(
+                        connection,
+                        path,
+                        shard_id,
+                        source_generation,
+                        target_generation,
+                        layout,
+                        sql,
+                        expected,
+                    )
+                    .map(|_| ()),
+                    None => shard::apply_schema_migration_on_connection(
+                        connection,
+                        path,
+                        shard_id,
+                        source_generation,
+                        target_generation,
+                        layout,
+                        sql,
+                    )
+                    .map(|_| ()),
+                }
             })
         }
     }
@@ -839,6 +1146,14 @@ where
     }
 
     let outcome = catch_unwind(AssertUnwindSafe(|| work(connection)));
+    #[cfg(test)]
+    if matches!(
+        &outcome,
+        Ok(Err(error)) if error.kind() == EngineErrorKind::DataCorruption
+    ) && CANCEL_AFTER_CONTROLLED_CORRUPTION.with(|cancel| cancel.replace(false))
+    {
+        control.request_cancel(CancellationReason::Cancelled);
+    }
     let progress_cleanup = connection
         .progress_handler(0, None::<fn() -> bool>)
         .map_err(sqlite_error::storage);
@@ -863,6 +1178,7 @@ where
             Err(error.context("failed to restore the schema-migration busy timeout"))
         }
         (Ok(value), Ok(()), Ok(()), _) => Ok(value),
+        (Err(error), _, _, _) if error.kind() == EngineErrorKind::DataCorruption => Err(error),
         (Err(_), _, _, Some(reason)) => Err(reason.error()),
         (Err(error), _, _, None) => Err(error),
     }
@@ -1081,6 +1397,60 @@ mod tests {
             .unwrap()
     }
 
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct MigratingManifestSnapshot {
+        catalog_generation: i64,
+        target_generation: i64,
+        source_generation: i64,
+        migration_id: Vec<u8>,
+        digest_version: i64,
+        sql_text: String,
+        shard_count: i64,
+        migration_state: i64,
+        next_shard: i64,
+        committed_schema_digest: Vec<u8>,
+        target_schema_digest: Vec<u8>,
+    }
+
+    fn migrating_manifest_snapshot(root: &Path) -> MigratingManifestSnapshot {
+        Connection::open(root.join("manifest.sqlite"))
+            .unwrap()
+            .query_row(
+                "SELECT c.schema_generation,
+                        m.target_generation,
+                        m.source_generation,
+                        m.migration_id,
+                        m.digest_version,
+                        m.sql_text,
+                        m.shard_count,
+                        m.migration_state,
+                        m.next_shard,
+                        i.committed_schema_digest,
+                        i.target_schema_digest
+                 FROM briskdb_schema_catalog AS c
+                 JOIN briskdb_schema_migrations AS m ON m.migration_state = 1
+                 JOIN briskdb_integrity AS i ON i.singleton = 1
+                 WHERE c.singleton = 1",
+                [],
+                |row| {
+                    Ok(MigratingManifestSnapshot {
+                        catalog_generation: row.get(0)?,
+                        target_generation: row.get(1)?,
+                        source_generation: row.get(2)?,
+                        migration_id: row.get(3)?,
+                        digest_version: row.get(4)?,
+                        sql_text: row.get(5)?,
+                        shard_count: row.get(6)?,
+                        migration_state: row.get(7)?,
+                        next_shard: row.get(8)?,
+                        committed_schema_digest: row.get(9)?,
+                        target_schema_digest: row.get(10)?,
+                    })
+                },
+            )
+            .unwrap()
+    }
+
     fn manifest_generation_and_history(root: &Path, file_name: &str) -> (i64, i64) {
         Connection::open(root.join(file_name))
             .unwrap()
@@ -1143,6 +1513,130 @@ mod tests {
                     .unwrap()
             );
         }
+    }
+
+    fn assert_file_backed_migrating_startup_rejects_schema_tamper(
+        tampered_shard: u16,
+        drift_table: &str,
+    ) {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = Storage::open(temp.path(), 2).unwrap();
+        let failure = run_with_hook(
+            &storage,
+            fail_at(SchemaMigrationCoordinatorPoint::ShardCommitted(0)),
+        )
+        .unwrap_err();
+        assert_eq!(failure.kind(), EngineErrorKind::Internal);
+        assert_eq!(
+            storage.schema_gate_snapshot().state,
+            SchemaGateState::Pending
+        );
+        assert_eq!(active_journal_snapshot(temp.path()), Some((0, 1, 0)));
+        assert_eq!(shard_generations(temp.path()), [1, 0]);
+
+        let trusted = migrating_manifest_snapshot(temp.path());
+        assert_eq!(trusted.catalog_generation, 0);
+        assert_eq!(
+            (trusted.source_generation, trusted.target_generation),
+            (0, 1)
+        );
+        assert_eq!((trusted.migration_state, trusted.next_shard), (1, 0));
+        assert_eq!(trusted.committed_schema_digest.len(), 32);
+        assert_eq!(trusted.target_schema_digest.len(), 32);
+        assert_eq!(
+            Connection::open(temp.path().join("manifest.sqlite"))
+                .unwrap()
+                .query_row(
+                    "SELECT database_state FROM briskdb_integrity WHERE singleton = 1",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            3
+        );
+        drop(storage);
+
+        Connection::open(
+            temp.path()
+                .join("shards")
+                .join(format!("{tampered_shard:04}.sqlite")),
+        )
+        .unwrap()
+        .execute_batch(&format!(
+            "CREATE TABLE {drift_table}(id INTEGER PRIMARY KEY)"
+        ))
+        .unwrap();
+
+        let error = Storage::open(temp.path(), 2).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+        assert_eq!(
+            migrating_manifest_snapshot(temp.path()),
+            trusted,
+            "startup must preserve the complete active journal and both trusted digests"
+        );
+        assert_eq!(active_journal_snapshot(temp.path()), Some((0, 1, 0)));
+        assert_eq!(
+            shard_generations(temp.path()),
+            [1, 0],
+            "startup must not acknowledge or apply another shard"
+        );
+
+        let manifest_path = temp.path().join("manifest.sqlite");
+        let manifest_connection = Connection::open(&manifest_path).unwrap();
+        configure_manifest_connection(&manifest_connection).unwrap();
+        let degraded = manifest::current_integrity(&manifest_connection, 2).unwrap();
+        assert_eq!(degraded.state(), manifest::DatabaseIntegrityState::Degraded);
+        assert_eq!(
+            degraded.committed_schema_digest().unwrap().as_slice(),
+            trusted.committed_schema_digest.as_slice()
+        );
+        assert_eq!(
+            degraded.target_schema_digest().unwrap().as_slice(),
+            trusted.target_schema_digest.as_slice()
+        );
+        drop(manifest_connection);
+
+        for shard_id in 0..2 {
+            let connection = Connection::open(
+                temp.path()
+                    .join("shards")
+                    .join(format!("{shard_id:04}.sqlite")),
+            )
+            .unwrap();
+            assert_eq!(
+                connection
+                    .query_row(
+                        "SELECT EXISTS(
+                            SELECT 1 FROM sqlite_schema
+                            WHERE type = 'table' AND name = 'migration_marker'
+                         )",
+                        [],
+                        |row| row.get::<_, bool>(0),
+                    )
+                    .unwrap(),
+                shard_id == 0,
+                "startup advanced the commit-before-ack migration prefix"
+            );
+            assert_eq!(
+                connection
+                    .query_row(
+                        "SELECT EXISTS(
+                            SELECT 1 FROM sqlite_schema
+                            WHERE type = 'table' AND name = ?1
+                         )",
+                        [drift_table],
+                        |row| row.get::<_, bool>(0),
+                    )
+                    .unwrap(),
+                shard_id == tampered_shard,
+                "startup changed the injected schema drift"
+            );
+        }
+
+        let terminal = Storage::open(temp.path(), 2).unwrap_err();
+        assert_eq!(terminal.kind(), EngineErrorKind::DataCorruption);
+        assert_eq!(migrating_manifest_snapshot(temp.path()), trusted);
+        assert_eq!(shard_generations(temp.path()), [1, 0]);
     }
 
     #[test]
@@ -1216,6 +1710,22 @@ mod tests {
     }
 
     #[test]
+    fn file_backed_migrating_startup_degrades_without_advancing_on_source_schema_tamper() {
+        assert_file_backed_migrating_startup_rejects_schema_tamper(
+            1,
+            "injected_source_schema_drift",
+        );
+    }
+
+    #[test]
+    fn file_backed_migrating_startup_degrades_without_advancing_on_target_schema_tamper() {
+        assert_file_backed_migrating_startup_rejects_schema_tamper(
+            0,
+            "injected_target_schema_drift",
+        );
+    }
+
+    #[test]
     fn cancellation_after_journal_commit_leaves_pending_and_retry_completes() {
         let temp = tempfile::tempdir().unwrap();
         let storage = Storage::open(temp.path(), 2).unwrap();
@@ -1247,6 +1757,62 @@ mod tests {
 
         assert_eq!(run_with_hook(&storage, |_| Ok(())).unwrap(), [0, 1]);
         assert_complete(&storage, temp.path());
+    }
+
+    #[test]
+    fn cancellation_cannot_mask_corruption_before_terminal_degradation_is_recorded() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = Storage::open(temp.path(), 2).unwrap();
+        Connection::open(temp.path().join("shards/0000.sqlite"))
+            .unwrap()
+            .execute_batch("CREATE TABLE injected_checksum_drift(value TEXT)")
+            .unwrap();
+
+        CANCEL_AFTER_CONTROLLED_CORRUPTION.with(|cancel| cancel.set(true));
+        let control = OperationControl::new(None);
+        let mut guard = storage.begin_schema_migration().unwrap();
+        guard.wait_for_quiescence_blocking();
+        let result = apply_schema_migration(
+            &storage,
+            MIGRATION_SQL,
+            &mut guard,
+            Some(Arc::clone(&control)),
+        );
+        assert_eq!(
+            result.as_ref().unwrap_err().kind(),
+            EngineErrorKind::DataCorruption,
+            "the storage wrapper must observe corruption before client cancellation mapping"
+        );
+        drop(guard);
+        assert_eq!(
+            storage.schema_gate_snapshot().state,
+            SchemaGateState::Degraded
+        );
+        assert_eq!(
+            control.complete(result).unwrap_err().kind(),
+            EngineErrorKind::Cancelled,
+            "the outer request boundary may still report the accepted cancellation"
+        );
+
+        let manifest_connection = Connection::open(temp.path().join("manifest.sqlite")).unwrap();
+        configure_manifest_connection(&manifest_connection).unwrap();
+        assert_eq!(
+            manifest::current_integrity(&manifest_connection, 2)
+                .unwrap()
+                .state(),
+            manifest::DatabaseIntegrityState::Degraded
+        );
+        assert_eq!(
+            manifest_connection
+                .query_row(
+                    "SELECT COUNT(*) FROM briskdb_schema_migrations",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            0,
+            "preflight corruption must not publish a migration journal"
+        );
     }
 
     #[test]
@@ -1294,7 +1860,13 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let storage = Storage::open(temp.path(), 2).unwrap();
         let owner = Connection::open(temp.path().join("manifest.sqlite")).unwrap();
-        owner.execute_batch("BEGIN IMMEDIATE").unwrap();
+        owner
+            .execute_batch(
+                "PRAGMA wal_checkpoint(TRUNCATE);
+                 PRAGMA journal_mode = DELETE;
+                 BEGIN EXCLUSIVE;",
+            )
+            .unwrap();
 
         let control = OperationControl::new(Some(Instant::now() + Duration::from_millis(50)));
         let mut guard = storage.begin_schema_migration().unwrap();
@@ -1343,14 +1915,31 @@ mod tests {
         configure_journal_mode(&manifest_connection).unwrap();
         let control = OperationControl::new(None);
         FAIL_NEXT_MANIFEST_COMMIT_CLEANUP.with(|fail| fail.set(true));
+        let source_digest = storage
+            .schema_coordination
+            .committed_schema_digest()
+            .unwrap();
+        let (_, target_digest) = shard::preflight_schema_migration_with_digest(
+            &temp.path().join("shards/0000.sqlite"),
+            0,
+            0,
+            1,
+            &storage.shard_layout,
+            MIGRATION_SQL,
+        )
+        .unwrap();
 
         let error = begin_schema_migration(
             &mut manifest_connection,
-            2,
-            &storage.shard_layout,
-            0,
-            MIGRATION_SQL,
-            Some(&control),
+            BeginSchemaMigrationRequest {
+                requested_shards: 2,
+                layout: &storage.shard_layout,
+                source_generation: 0,
+                sql: MIGRATION_SQL,
+                source_digest,
+                target_digest,
+                control: Some(&control),
+            },
             &mut guard,
         )
         .unwrap_err();
@@ -1377,7 +1966,6 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let storage = Storage::open(temp.path(), 2).unwrap();
         let layout = storage.shard_layout;
-        drop(storage);
         let mut manifest_connection =
             Connection::open(temp.path().join("manifest.sqlite")).unwrap();
         configure_manifest_connection(&manifest_connection).unwrap();
@@ -1419,6 +2007,7 @@ mod tests {
             )
             .unwrap();
         manifest_connection.execute_batch("COMMIT").unwrap();
+        manifest::reseal_manifest_for_test(&manifest_connection).unwrap();
 
         let control = OperationControl::new(Some(Instant::now() + Duration::from_millis(5)));
         let started = Instant::now();
@@ -1433,6 +2022,37 @@ mod tests {
         assert_eq!(error.kind(), EngineErrorKind::DeadlineExceeded);
         assert!(started.elapsed() < Duration::from_secs(1));
         assert!(manifest_connection.is_autocommit());
+
+        let integrity_control =
+            OperationControl::new(Some(Instant::now() + Duration::from_millis(5)));
+        let integrity_started = Instant::now();
+        let integrity_error = current_integrity_optional_controlled(
+            &mut manifest_connection,
+            2,
+            Some(&integrity_control),
+        )
+        .unwrap_err();
+        assert_eq!(integrity_error.kind(), EngineErrorKind::DeadlineExceeded);
+        assert!(integrity_started.elapsed() < Duration::from_secs(1));
+        assert!(manifest_connection.is_autocommit());
+
+        let public_control = OperationControl::new(Some(Instant::now() + Duration::from_millis(5)));
+        let mut guard = storage.begin_schema_migration().unwrap();
+        guard.wait_for_quiescence_blocking();
+        let public_started = Instant::now();
+        let public_error = apply_schema_migration_with_hook(
+            &storage,
+            "SELECT absent_migration",
+            &mut guard,
+            Some(public_control),
+            |_| Ok(()),
+        )
+        .unwrap_err();
+        assert_eq!(public_error.kind(), EngineErrorKind::DeadlineExceeded);
+        assert!(public_started.elapsed() < Duration::from_secs(1));
+        drop(guard);
+        assert_eq!(storage.schema_gate_snapshot().state, SchemaGateState::Ready);
+
         assert_eq!(
             manifest::classify_schema_migration(
                 &mut manifest_connection,
@@ -1722,9 +2342,39 @@ mod tests {
 
         fs::remove_file(&manifest_path).unwrap();
         fs::copy(second_root.path().join("manifest.sqlite"), &manifest_path).unwrap();
-        let replacement_error = run_with_hook(&first, |_| Ok(())).unwrap_err();
+        let replacement_integrity_before: (i64, Vec<u8>) = Connection::open(&manifest_path)
+            .unwrap()
+            .query_row(
+                "SELECT database_state, manifest_digest
+                 FROM briskdb_integrity WHERE singleton = 1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        let mut guard = first.begin_schema_migration().unwrap();
+        guard.wait_for_quiescence_blocking();
+        let replacement_error = first
+            .apply_schema_migration(MIGRATION_SQL, &mut guard, None)
+            .unwrap_err();
         assert_eq!(replacement_error.kind(), EngineErrorKind::DataCorruption);
-        assert_eq!(first.schema_gate_snapshot().state, SchemaGateState::Ready);
+        drop(guard);
+        assert_eq!(
+            first.schema_gate_snapshot().state,
+            SchemaGateState::Degraded
+        );
+        assert_eq!(
+            Connection::open(&manifest_path)
+                .unwrap()
+                .query_row(
+                    "SELECT database_state, manifest_digest
+                     FROM briskdb_integrity WHERE singleton = 1",
+                    [],
+                    |row| Ok((row.get::<_, i64>(0)?, row.get::<_, Vec<u8>>(1)?)),
+                )
+                .unwrap(),
+            replacement_integrity_before,
+            "a rejected foreign manifest must not be marked or resealed"
+        );
         assert_eq!(
             manifest_generation_and_history(first_root.path(), "manifest.sqlite"),
             (0, 0)

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -42,6 +42,13 @@ pub(crate) const CONNECTION_BUSY_TIMEOUT: std::time::Duration = std::time::Durat
 struct RootSchemaCoordination {
     gate: schema_gate::SchemaGate,
     catalogs: Mutex<Vec<Weak<CatalogSnapshot>>>,
+    schema_digests: Mutex<RuntimeSchemaDigests>,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct RuntimeSchemaDigests {
+    committed: Option<[u8; 32]>,
+    target: Option<[u8; 32]>,
 }
 
 impl RootSchemaCoordination {
@@ -49,7 +56,58 @@ impl RootSchemaCoordination {
         Self {
             gate: schema_gate::SchemaGate::new(),
             catalogs: Mutex::new(Vec::new()),
+            schema_digests: Mutex::new(RuntimeSchemaDigests::default()),
         }
+    }
+
+    fn mark_degraded(&self) {
+        self.gate.mark_degraded();
+    }
+
+    fn publish_schema_digests(
+        &self,
+        committed: Option<[u8; 32]>,
+        target: Option<[u8; 32]>,
+    ) -> EngineResult<()> {
+        let mut digests = self.schema_digests.lock().map_err(|error| {
+            EngineError::new(
+                EngineErrorKind::Internal,
+                format!("root schema checksum coordination is poisoned: {error}"),
+            )
+        })?;
+        *digests = RuntimeSchemaDigests { committed, target };
+        Ok(())
+    }
+
+    fn committed_schema_digest(&self) -> EngineResult<[u8; 32]> {
+        self.schema_digests
+            .lock()
+            .map_err(|error| {
+                EngineError::new(
+                    EngineErrorKind::Internal,
+                    format!("root schema checksum coordination is poisoned: {error}"),
+                )
+            })?
+            .committed
+            .ok_or_else(|| {
+                EngineError::new(
+                    EngineErrorKind::FailedPrecondition,
+                    "application schema has not completed integrity verification",
+                )
+            })
+    }
+
+    fn target_schema_digest(&self) -> EngineResult<Option<[u8; 32]>> {
+        Ok(self
+            .schema_digests
+            .lock()
+            .map_err(|error| {
+                EngineError::new(
+                    EngineErrorKind::Internal,
+                    format!("root schema checksum coordination is poisoned: {error}"),
+                )
+            })?
+            .target)
     }
 
     fn register_catalog(&self, loaded: CatalogSnapshot) -> EngineResult<Arc<CatalogSnapshot>> {
@@ -193,6 +251,66 @@ fn begin_startup_coordination(
     }
 }
 
+fn validate_schema_migration_checksum_prefix(
+    shards_dir: &Path,
+    shard_count: u16,
+    layout: &shard::ShardLayout,
+    migration: &manifest::SchemaMigration,
+    integrity: manifest::ManifestIntegrity,
+) -> EngineResult<()> {
+    if integrity.state() != manifest::DatabaseIntegrityState::Migrating {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "active schema migration has an inconsistent database integrity state",
+        ));
+    }
+    let source_digest = integrity.committed_schema_digest().ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "active schema migration is missing its source checksum",
+        )
+    })?;
+    let target_digest = integrity.target_schema_digest().ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "active schema migration is missing its target checksum",
+        )
+    })?;
+    shard::validate_schema_migration_prefix_with(
+        shards_dir,
+        shard_count,
+        migration.next_shard(),
+        migration.source_generation(),
+        migration.target_generation(),
+        layout,
+        |path, shard_id| {
+            let connection = shard::open_required_file(path)?;
+            connection
+                .busy_timeout(CONNECTION_BUSY_TIMEOUT)
+                .map_err(sqlite_error::storage)?;
+            let state = shard::validate_schema_migration_connection(
+                &connection,
+                path,
+                shard_id,
+                migration.source_generation(),
+                migration.target_generation(),
+                layout,
+            )?;
+            let (generation, expected) = match state {
+                shard::SchemaMigrationShardState::Source => {
+                    (migration.source_generation(), &source_digest)
+                }
+                shard::SchemaMigrationShardState::Target => {
+                    (migration.target_generation(), &target_digest)
+                }
+            };
+            shard::verify_schema_digest(&connection, generation, expected)?;
+            Ok(state)
+        },
+    )?;
+    Ok(())
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct Storage {
     root: PathBuf,
@@ -219,31 +337,104 @@ impl Storage {
         let fresh_layout_allowed = physical_layout_is_empty(&shards_dir)?;
         let manifest_path = root.join("manifest.sqlite");
         let mut manifest = open_manifest_for_startup(&manifest_path)?;
-        configure_manifest_connection(&manifest)?;
-        let loaded = manifest::load_or_create_manifest_with_fresh_layout(
-            &mut manifest,
-            requested_shards,
-            fresh_layout_allowed,
-        )?;
-        configure_journal_mode(&manifest)?;
-        let (catalog, shard_layout, active_migration) = loaded.into_parts_with_migration();
-        let catalog = schema_coordination.register_catalog(catalog)?;
-
-        if let Some(active_migration) = active_migration {
+        if let Err(error) = configure_manifest_connection(&manifest) {
+            if error.kind() == EngineErrorKind::DataCorruption {
+                schema_coordination.mark_degraded();
+            }
+            return Err(error);
+        }
+        let v6_active = match manifest::load_v6_active_migration(&manifest, requested_shards) {
+            Ok(active) => active,
+            Err(error) => {
+                if error.kind() == EngineErrorKind::DataCorruption {
+                    schema_coordination.mark_degraded();
+                }
+                return Err(error);
+            }
+        };
+        if let Some(v6_active) = v6_active {
+            configure_journal_mode(&manifest)?;
+            let (v6_catalog, v6_layout, active_migration) = v6_active.into_parts();
+            let v6_catalog = schema_coordination.register_catalog(v6_catalog)?;
             startup.mark_pending_on_drop();
-            migration::resume_schema_migration_on_startup(
+            if let Err(error) = migration::resume_schema_migration_on_startup(
                 &root,
                 &mut manifest,
                 requested_shards,
-                &catalog,
-                &shard_layout,
+                &v6_catalog,
+                &v6_layout,
                 &schema_coordination,
                 active_migration,
-            )?;
+            ) {
+                if error.kind() == EngineErrorKind::DataCorruption {
+                    schema_coordination.mark_degraded();
+                }
+                return Err(error);
+            }
+        }
+
+        let loaded = match manifest::load_or_create_manifest_with_fresh_layout(
+            &mut manifest,
+            requested_shards,
+            fresh_layout_allowed,
+        ) {
+            Ok(loaded) => loaded,
+            Err(error) => {
+                if error.kind() == EngineErrorKind::DataCorruption {
+                    schema_coordination.mark_degraded();
+                }
+                return Err(error);
+            }
+        };
+        let (catalog, shard_layout, active_migration, mut integrity) =
+            loaded.into_parts_with_migration();
+        let catalog = schema_coordination.register_catalog(catalog)?;
+        schema_coordination.publish_schema_digests(
+            integrity.committed_schema_digest(),
+            integrity.target_schema_digest(),
+        )?;
+
+        if integrity.state() == manifest::DatabaseIntegrityState::Degraded {
+            schema_coordination.mark_degraded();
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "database is persistently degraded and requires a complete known-good restore",
+            ));
+        }
+        configure_journal_mode(&manifest)?;
+
+        if let Some(active_migration) = active_migration {
+            startup.mark_pending_on_drop();
+            let recovery = (|| {
+                validate_schema_migration_checksum_prefix(
+                    &root.join("shards"),
+                    requested_shards,
+                    &shard_layout,
+                    &active_migration,
+                    integrity,
+                )?;
+                migration::resume_schema_migration_on_startup(
+                    &root,
+                    &mut manifest,
+                    requested_shards,
+                    &catalog,
+                    &shard_layout,
+                    &schema_coordination,
+                    active_migration,
+                )
+            })();
+            if let Err(error) = recovery {
+                if error.kind() == EngineErrorKind::DataCorruption {
+                    schema_coordination.mark_degraded();
+                    let _ = manifest::mark_degraded(&mut manifest, requested_shards, &shard_layout);
+                }
+                return Err(error);
+            }
+            integrity = manifest::current_integrity(&manifest, requested_shards)?;
         }
         let schema_generation = catalog.logical().schema_generation();
 
-        let ready_layout = manifest::reconcile_shard_layout(
+        let ready_layout = match manifest::reconcile_shard_layout(
             &mut manifest,
             requested_shards,
             &shard_layout,
@@ -255,7 +446,16 @@ impl Storage {
                     locked_layout,
                 )
             },
-        )?;
+        ) {
+            Ok(layout) => layout,
+            Err(error) => {
+                if error.kind() == EngineErrorKind::DataCorruption {
+                    schema_coordination.mark_degraded();
+                    let _ = manifest::mark_degraded(&mut manifest, requested_shards, &shard_layout);
+                }
+                return Err(error);
+            }
+        };
 
         let storage = Self {
             root,
@@ -263,9 +463,43 @@ impl Storage {
             shard_layout: ready_layout,
             schema_coordination,
         };
-        for shard in 0..storage.shard_count() {
-            storage.open_shard(shard)?;
-        }
+        let verification = storage.verify_current_schema_consensus(integrity);
+        let observed_digest = match verification {
+            Ok(digest) => digest,
+            Err(error) => {
+                if error.kind() == EngineErrorKind::DataCorruption {
+                    storage.mark_schema_degraded();
+                    let _ = manifest::mark_degraded(
+                        &mut manifest,
+                        requested_shards,
+                        &storage.shard_layout,
+                    );
+                }
+                return Err(error);
+            }
+        };
+        let sealed = match manifest::seal_verified_schema(
+            &mut manifest,
+            requested_shards,
+            observed_digest,
+        ) {
+            Ok(sealed) => sealed,
+            Err(error) => {
+                if error.kind() == EngineErrorKind::DataCorruption {
+                    storage.mark_schema_degraded();
+                    let _ = manifest::mark_degraded(
+                        &mut manifest,
+                        requested_shards,
+                        &storage.shard_layout,
+                    );
+                }
+                return Err(error);
+            }
+        };
+        storage.schema_coordination.publish_schema_digests(
+            sealed.committed_schema_digest(),
+            sealed.target_schema_digest(),
+        )?;
         storage
             .schema_coordination
             .reconcile_validated_catalog_generation(&storage.catalog)?;
@@ -295,6 +529,41 @@ impl Storage {
 
     pub(crate) fn begin_schema_migration(&self) -> EngineResult<SchemaMigrationGuard> {
         self.schema_coordination.gate.begin_migration()
+    }
+
+    pub(crate) fn mark_schema_degraded(&self) {
+        self.schema_coordination.mark_degraded();
+    }
+
+    /// Fail closed immediately and make one zero-busy-wait best-effort attempt
+    /// to persist terminal `Degraded` state in an already-trusted manifest.
+    pub(crate) fn record_schema_degraded(&self) {
+        self.mark_schema_degraded();
+        if let Ok(mut manifest_connection) =
+            open_existing_manifest(&self.root.join("manifest.sqlite"))
+        {
+            let configured = manifest_connection
+                .busy_timeout(std::time::Duration::ZERO)
+                .map_err(sqlite_error::storage)
+                .and_then(|_| configure_manifest_connection_after_busy_setup(&manifest_connection));
+            if configured.is_ok() {
+                let _ = manifest::mark_degraded(
+                    &mut manifest_connection,
+                    self.catalog.routing().shard_count(),
+                    &self.shard_layout,
+                );
+            }
+        }
+    }
+
+    pub(crate) fn fail_closed_on_corruption<T>(&self, result: EngineResult<T>) -> EngineResult<T> {
+        if result
+            .as_ref()
+            .is_err_and(|error| error.kind() == EngineErrorKind::DataCorruption)
+        {
+            self.record_schema_degraded();
+        }
+        result
     }
 
     #[cfg(test)]
@@ -335,16 +604,67 @@ impl Storage {
     }
 
     pub(crate) fn open_shard(&self, shard: u16) -> EngineResult<Connection> {
-        self.ensure_shard_in_range(shard)?;
-        let path = self.shard_path(shard);
-        let connection = shard::open_existing(
-            &path,
-            shard,
-            self.catalog.logical().schema_generation(),
-            &self.shard_layout,
-        )?;
-        attach_storage_authorizer(&connection)?;
-        Ok(connection)
+        let result = (|| {
+            self.ensure_shard_in_range(shard)?;
+            let path = self.shard_path(shard);
+            let connection = shard::open_existing(
+                &path,
+                shard,
+                self.catalog.logical().schema_generation(),
+                &self.shard_layout,
+            )?;
+            let expected_digest = self.schema_coordination.committed_schema_digest()?;
+            shard::verify_schema_digest(
+                &connection,
+                self.catalog.logical().schema_generation(),
+                &expected_digest,
+            )?;
+            attach_storage_authorizer(&connection)?;
+            Ok(connection)
+        })();
+        self.fail_closed_on_corruption(result)
+    }
+
+    fn verify_current_schema_consensus(
+        &self,
+        integrity: manifest::ManifestIntegrity,
+    ) -> EngineResult<[u8; 32]> {
+        if matches!(
+            integrity.state(),
+            manifest::DatabaseIntegrityState::Migrating
+        ) {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "database remained in migrating state after startup recovery",
+            ));
+        }
+        let generation = self.catalog.logical().schema_generation();
+        let trusted = integrity.committed_schema_digest();
+        let mut consensus = None;
+        for shard_id in 0..self.shard_count() {
+            let path = self.shard_path(shard_id);
+            let connection = shard::open_existing(&path, shard_id, generation, &self.shard_layout)?;
+            let observed = shard::calculate_schema_digest(&connection, generation)?;
+            if trusted.is_some_and(|expected| expected != observed) {
+                return Err(EngineError::new(
+                    EngineErrorKind::DataCorruption,
+                    "a shard application schema does not match the trusted checksum",
+                ));
+            }
+            if consensus.is_some_and(|expected| expected != observed) {
+                return Err(EngineError::new(
+                    EngineErrorKind::DataCorruption,
+                    "shard application schemas do not have one consistent fingerprint",
+                ));
+            }
+            consensus = Some(observed);
+        }
+        consensus.ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::Internal,
+                "schema verification requires at least one configured shard",
+            )
+        })
     }
 
     fn open_unconfigured_shard(&self, shard: u16) -> EngineResult<Connection> {
@@ -353,14 +673,23 @@ impl Storage {
     }
 
     fn validate_unconfigured_shard(&self, connection: &Connection, shard: u16) -> EngineResult<()> {
-        self.ensure_shard_in_range(shard)?;
-        shard::validate_open_connection(
-            connection,
-            &self.shard_path(shard),
-            shard,
-            self.catalog.logical().schema_generation(),
-            &self.shard_layout,
-        )
+        let result = (|| {
+            self.ensure_shard_in_range(shard)?;
+            shard::validate_open_connection(
+                connection,
+                &self.shard_path(shard),
+                shard,
+                self.catalog.logical().schema_generation(),
+                &self.shard_layout,
+            )?;
+            let expected_digest = self.schema_coordination.committed_schema_digest()?;
+            shard::verify_schema_digest(
+                connection,
+                self.catalog.logical().schema_generation(),
+                &expected_digest,
+            )
+        })();
+        self.fail_closed_on_corruption(result)
     }
 
     fn ensure_shard_in_range(&self, shard: u16) -> EngineResult<()> {
@@ -561,6 +890,23 @@ fn configure_manifest_connection(connection: &Connection) -> EngineResult<()> {
     connection
         .busy_timeout(CONNECTION_BUSY_TIMEOUT)
         .map_err(sqlite_error::storage)?;
+    configure_manifest_connection_after_busy_setup(connection)
+}
+
+fn configure_manifest_connection_after_busy_setup(connection: &Connection) -> EngineResult<()> {
+    connection
+        .pragma_update(None, "cell_size_check", "ON")
+        .map_err(sqlite_error::storage)?;
+    let cell_size_check = connection
+        .pragma_query_value(None, "cell_size_check", |row| row.get::<_, i64>(0))
+        .map_err(sqlite_error::storage)?;
+    if cell_size_check != 1 {
+        return Err(EngineError::new(
+            EngineErrorKind::Internal,
+            "SQLite did not enable manifest b-tree cell-size checking",
+        ));
+    }
+    validate_manifest_integrity_check(connection)?;
     connection
         .pragma_update(None, "synchronous", "FULL")
         .map_err(sqlite_error::storage)?;
@@ -568,6 +914,25 @@ fn configure_manifest_connection(connection: &Connection) -> EngineResult<()> {
         .pragma_update(None, "foreign_keys", "ON")
         .map_err(sqlite_error::storage)?;
     Ok(())
+}
+
+fn validate_manifest_integrity_check(connection: &Connection) -> EngineResult<()> {
+    let mut statement = connection
+        .prepare("PRAGMA main.integrity_check(1)")
+        .map_err(sqlite_error::storage)?;
+    let rows = statement
+        .query_map([], |row| row.get::<_, String>(0))
+        .map_err(sqlite_error::storage)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(sqlite_error::storage)?;
+    if rows == ["ok"] {
+        Ok(())
+    } else {
+        Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "SQLite manifest integrity verification failed",
+        ))
+    }
 }
 
 fn open_manifest_for_startup(path: &Path) -> EngineResult<Connection> {
@@ -694,6 +1059,24 @@ mod tests {
 
     fn shard_file(root: &Path, shard: u16) -> PathBuf {
         root.join("shards").join(format!("{shard:04}.sqlite"))
+    }
+
+    #[test]
+    fn manifest_configuration_enables_and_reads_back_cell_size_checks() {
+        let connection = Connection::open_in_memory().unwrap();
+        assert_eq!(
+            connection
+                .pragma_query_value(None, "cell_size_check", |row| row.get::<_, i64>(0))
+                .unwrap(),
+            0
+        );
+        configure_manifest_connection(&connection).unwrap();
+        assert_eq!(
+            connection
+                .pragma_query_value(None, "cell_size_check", |row| row.get::<_, i64>(0))
+                .unwrap(),
+            1
+        );
     }
 
     fn manifest_layout_row(root: &Path) -> (Vec<u8>, i64, i64, i64) {
@@ -886,6 +1269,498 @@ mod tests {
                     .unwrap()
             );
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn canonical_and_symlink_roots_share_sticky_degraded_admission() {
+        let temp = tempfile::tempdir().unwrap();
+        let original = Storage::open(temp.path(), 2).unwrap();
+        let alias_parent = tempfile::tempdir().unwrap();
+        let alias_path = alias_parent.path().join("database-alias");
+        std::os::unix::fs::symlink(temp.path(), &alias_path).unwrap();
+        let alias = Storage::open(&alias_path, 2).unwrap();
+
+        alias.mark_schema_degraded();
+
+        for storage in [&original, &alias] {
+            assert_eq!(
+                storage.schema_gate_snapshot(),
+                SchemaGateSnapshot {
+                    state: SchemaGateState::Degraded,
+                    active_operations: 0,
+                }
+            );
+            assert_eq!(
+                storage.enter_schema_operation().unwrap_err().kind(),
+                EngineErrorKind::DataCorruption
+            );
+            assert_eq!(
+                storage.begin_schema_migration().unwrap_err().kind(),
+                EngineErrorKind::DataCorruption
+            );
+        }
+
+        assert_eq!(
+            Storage::open(temp.path(), 2).unwrap_err().kind(),
+            EngineErrorKind::DataCorruption
+        );
+    }
+
+    #[test]
+    fn runtime_schema_drift_is_sticky_and_persisted_until_a_complete_restore() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = Storage::open(temp.path(), 2).unwrap();
+        let shard_path = temp.path().join("shards/0000.sqlite");
+        Connection::open(&shard_path)
+            .unwrap()
+            .execute_batch("CREATE TABLE unexpected_drift(id INTEGER PRIMARY KEY)")
+            .unwrap();
+
+        let detected = storage.open_shard(0).unwrap_err();
+        assert_eq!(detected.kind(), EngineErrorKind::DataCorruption);
+        assert_eq!(
+            storage.schema_gate_snapshot().state,
+            SchemaGateState::Degraded
+        );
+        assert_eq!(
+            storage.enter_schema_operation().unwrap_err().kind(),
+            EngineErrorKind::DataCorruption
+        );
+        assert_eq!(
+            Connection::open(temp.path().join("manifest.sqlite"))
+                .unwrap()
+                .query_row(
+                    "SELECT database_state FROM briskdb_integrity WHERE singleton = 1",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            4
+        );
+
+        Connection::open(&shard_path)
+            .unwrap()
+            .execute_batch("DROP TABLE unexpected_drift")
+            .unwrap();
+        assert_eq!(
+            storage.enter_schema_operation().unwrap_err().kind(),
+            EngineErrorKind::DataCorruption,
+            "repair without releasing the live canonical-root coordination must stay degraded"
+        );
+        drop(storage);
+
+        let restart = Storage::open(temp.path(), 2).unwrap_err();
+        assert_eq!(restart.kind(), EngineErrorKind::DataCorruption);
+        assert_eq!(
+            Connection::open(temp.path().join("manifest.sqlite"))
+                .unwrap()
+                .query_row(
+                    "SELECT database_state FROM briskdb_integrity WHERE singleton = 1",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            4
+        );
+    }
+
+    #[test]
+    fn terminal_degraded_startup_does_not_change_manifest_journal_mode_or_bytes() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = Storage::open(temp.path(), 2).unwrap();
+        let layout = storage.shard_layout;
+        drop(storage);
+        let manifest_path = temp.path().join("manifest.sqlite");
+        let mut manifest_connection = Connection::open(&manifest_path).unwrap();
+        configure_manifest_connection(&manifest_connection).unwrap();
+        manifest::mark_degraded(&mut manifest_connection, 2, &layout).unwrap();
+        manifest_connection
+            .query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |_| Ok(()))
+            .unwrap();
+        assert_eq!(
+            manifest_connection
+                .pragma_update_and_check(None, "journal_mode", "DELETE", |row| {
+                    row.get::<_, String>(0)
+                })
+                .unwrap()
+                .to_ascii_lowercase(),
+            "delete"
+        );
+        drop(manifest_connection);
+        let before = fs::read(&manifest_path).unwrap();
+
+        let error = Storage::open(temp.path(), 2).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+        assert_eq!(fs::read(&manifest_path).unwrap(), before);
+        let observed_mode = Connection::open(&manifest_path)
+            .unwrap()
+            .pragma_query_value(None, "journal_mode", |row| row.get::<_, String>(0))
+            .unwrap();
+        assert_eq!(observed_mode.to_ascii_lowercase(), "delete");
+        assert!(!temp.path().join("manifest.sqlite-wal").exists());
+    }
+
+    #[test]
+    fn failed_emergency_marker_write_still_leaves_live_admission_degraded() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = Storage::open(temp.path(), 2).unwrap();
+        let manifest_path = temp.path().join("manifest.sqlite");
+        let owner = Connection::open(&manifest_path).unwrap();
+        owner
+            .execute_batch(
+                "PRAGMA wal_checkpoint(TRUNCATE);
+                 PRAGMA journal_mode = DELETE;
+                 BEGIN EXCLUSIVE;",
+            )
+            .unwrap();
+
+        let started = Instant::now();
+        storage.record_schema_degraded();
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(1),
+            "best-effort degradation persistence must not inherit the normal busy timeout"
+        );
+        assert_eq!(
+            storage.enter_schema_operation().unwrap_err().kind(),
+            EngineErrorKind::DataCorruption
+        );
+        owner.execute_batch("ROLLBACK").unwrap();
+        assert_eq!(
+            Connection::open(manifest_path)
+                .unwrap()
+                .query_row(
+                    "SELECT database_state FROM briskdb_integrity WHERE singleton = 1",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            2,
+            "the blocked emergency write must not claim it committed Degraded"
+        );
+    }
+
+    #[test]
+    fn identical_offline_schema_drift_on_every_shard_is_not_rebaselined() {
+        let temp = tempfile::tempdir().unwrap();
+        drop(Storage::open(temp.path(), 2).unwrap());
+        for shard_id in 0..2 {
+            Connection::open(temp.path().join(format!("shards/{shard_id:04}.sqlite")))
+                .unwrap()
+                .execute_batch("CREATE TABLE coordinated_drift(id INTEGER PRIMARY KEY)")
+                .unwrap();
+        }
+
+        let error = Storage::open(temp.path(), 2).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+        assert_eq!(
+            Connection::open(temp.path().join("manifest.sqlite"))
+                .unwrap()
+                .query_row(
+                    "SELECT database_state FROM briskdb_integrity WHERE singleton = 1",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            4
+        );
+    }
+
+    #[test]
+    fn a_manifest_root_mismatch_degrades_live_aliases_without_signing_the_mutation() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = Storage::open(temp.path(), 2).unwrap();
+        let manifest_path = temp.path().join("manifest.sqlite");
+        let manifest = Connection::open(&manifest_path).unwrap();
+        let trusted_root: Vec<u8> = manifest
+            .query_row(
+                "SELECT manifest_digest FROM briskdb_integrity WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        manifest
+            .execute(
+                "UPDATE briskdb_virtual_buckets
+                 SET physical_shard_id = 1 - physical_shard_id
+                 WHERE bucket_id = 0",
+                [],
+            )
+            .unwrap();
+        drop(manifest);
+
+        let error = Storage::open(temp.path(), 2).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+        assert_eq!(
+            storage.enter_schema_operation().unwrap_err().kind(),
+            EngineErrorKind::DataCorruption
+        );
+        let manifest = Connection::open(manifest_path).unwrap();
+        assert_eq!(
+            manifest
+                .query_row(
+                    "SELECT manifest_digest FROM briskdb_integrity WHERE singleton = 1",
+                    [],
+                    |row| row.get::<_, Vec<u8>>(0),
+                )
+                .unwrap(),
+            trusted_root
+        );
+        assert_eq!(
+            manifest
+                .query_row(
+                    "SELECT database_state FROM briskdb_integrity WHERE singleton = 1",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            2,
+            "an untrusted manifest must never write or reseal its own degraded marker"
+        );
+    }
+
+    #[test]
+    fn every_v6_active_prefix_finishes_before_v7_checksum_bootstrap() {
+        const SQL: &str = "CREATE TABLE recovered_v6(id INTEGER PRIMARY KEY)";
+        for (target_shards, acknowledged) in [(0_u16, 0_u16), (1, 0), (1, 1), (2, 1), (2, 2)] {
+            let temp = tempfile::tempdir().unwrap();
+            let storage = Storage::open(temp.path(), 2).unwrap();
+            let layout = storage.shard_layout;
+            drop(storage);
+
+            let manifest_path = temp.path().join("manifest.sqlite");
+            let mut manifest = Connection::open(&manifest_path).unwrap();
+            manifest
+                .execute_batch(
+                    "BEGIN IMMEDIATE;
+                     DROP TABLE briskdb_integrity;
+                     DROP TABLE briskdb_metadata;
+                     CREATE TABLE briskdb_metadata (
+                         requires_manifest_version INTEGER NOT NULL
+                             CHECK (requires_manifest_version >= 6)
+                     ) STRICT;
+                     INSERT INTO briskdb_metadata VALUES (6);
+                     PRAGMA user_version = 6;
+                     COMMIT;",
+                )
+                .unwrap();
+            let mut migration = manifest::begin_schema_migration(&mut manifest, 2, 0, SQL).unwrap();
+            for shard_id in 0..target_shards {
+                shard::apply_schema_migration(
+                    &temp.path().join(format!("shards/{shard_id:04}.sqlite")),
+                    shard_id,
+                    0,
+                    1,
+                    &layout,
+                    SQL,
+                )
+                .unwrap();
+            }
+            while migration.next_shard() < acknowledged {
+                let next = migration.next_shard() + 1;
+                migration =
+                    manifest::advance_schema_migration(&mut manifest, 2, &migration, next).unwrap();
+            }
+            drop(manifest);
+
+            let recovered = Storage::open(temp.path(), 2).unwrap();
+            assert_eq!(recovered.current_schema_generation(), 1);
+            for shard_id in 0..2 {
+                let connection = recovered.open_shard(shard_id).unwrap();
+                assert_eq!(
+                    connection
+                        .query_row(
+                            "SELECT COUNT(*) FROM sqlite_schema
+                             WHERE type = 'table' AND name = 'recovered_v6'",
+                            [],
+                            |row| row.get::<_, i64>(0),
+                        )
+                        .unwrap(),
+                    1
+                );
+            }
+            let manifest = Connection::open(manifest_path).unwrap();
+            assert_eq!(
+                manifest
+                    .pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
+                    .unwrap(),
+                i64::from(manifest::CURRENT_SCHEMA_VERSION)
+            );
+            assert_eq!(
+                manifest
+                    .query_row(
+                        "SELECT database_state,
+                                length(committed_schema_digest),
+                                target_schema_digest IS NULL
+                         FROM briskdb_integrity",
+                        [],
+                        |row| {
+                            Ok((
+                                row.get::<_, i64>(0)?,
+                                row.get::<_, i64>(1)?,
+                                row.get::<_, bool>(2)?,
+                            ))
+                        },
+                    )
+                    .unwrap(),
+                (2, 32, true),
+                "shape targets={target_shards} acknowledged={acknowledged}"
+            );
+        }
+    }
+
+    #[test]
+    fn file_backed_v7_verifying_interruption_reopens_to_ready_without_metadata_or_schema_drift() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = Storage::open(temp.path(), 2).unwrap();
+        let catalog_before = storage.catalog.as_ref().clone();
+        let layout_before = storage.shard_layout;
+        let schema_generation = storage.current_schema_generation();
+        let schema_digests_before: [[u8; 32]; 2] = std::array::from_fn(|shard_id| {
+            let connection = storage
+                .open_shard(u16::try_from(shard_id).unwrap())
+                .unwrap();
+            shard::calculate_schema_digest(&connection, schema_generation).unwrap()
+        });
+        assert_eq!(schema_digests_before[0], schema_digests_before[1]);
+        drop(storage);
+
+        let manifest_path = temp.path().join("manifest.sqlite");
+        Connection::open(&manifest_path)
+            .unwrap()
+            .execute_batch(
+                "BEGIN IMMEDIATE;
+                 DROP TABLE briskdb_integrity;
+                 DROP TABLE briskdb_metadata;
+                 CREATE TABLE briskdb_metadata (
+                     requires_manifest_version INTEGER NOT NULL
+                         CHECK (requires_manifest_version >= 6)
+                 ) STRICT;
+                 INSERT INTO briskdb_metadata VALUES (6);
+                 PRAGMA user_version = 6;
+                 COMMIT;",
+            )
+            .unwrap();
+
+        let mut manifest_connection = Connection::open(&manifest_path).unwrap();
+        configure_manifest_connection(&manifest_connection).unwrap();
+        let verifying =
+            manifest::load_or_create_manifest_with_fresh_layout(&mut manifest_connection, 2, false)
+                .unwrap();
+        assert!(manifest_connection.is_autocommit());
+        let (verifying_catalog, verifying_layout, active_migration, verifying_integrity) =
+            verifying.into_parts_with_migration();
+        assert_eq!(
+            verifying_catalog, catalog_before,
+            "the committed v7 Verifying upgrade changed catalog or routing metadata"
+        );
+        assert_eq!(verifying_layout, layout_before);
+        assert!(active_migration.is_none());
+        assert_eq!(
+            verifying_integrity.state(),
+            manifest::DatabaseIntegrityState::Verifying
+        );
+        assert_eq!(verifying_integrity.committed_schema_digest(), None);
+        assert_eq!(verifying_integrity.target_schema_digest(), None);
+        assert_eq!(
+            manifest::current_integrity(&manifest_connection, 2)
+                .unwrap()
+                .state(),
+            manifest::DatabaseIntegrityState::Verifying,
+            "the file-backed v7 upgrade must be durably valid before restart verification"
+        );
+        drop(manifest_connection);
+
+        let reopened = Storage::open(temp.path(), 2).unwrap();
+        assert_eq!(
+            reopened.catalog.as_ref(),
+            &catalog_before,
+            "restart verification changed catalog or routing metadata"
+        );
+        assert_eq!(reopened.shard_layout, layout_before);
+        assert_eq!(reopened.current_schema_generation(), schema_generation);
+        let schema_digests_after: [[u8; 32]; 2] = std::array::from_fn(|shard_id| {
+            let connection = reopened
+                .open_shard(u16::try_from(shard_id).unwrap())
+                .unwrap();
+            shard::calculate_schema_digest(&connection, schema_generation).unwrap()
+        });
+        assert_eq!(
+            schema_digests_after, schema_digests_before,
+            "restart verification changed an application schema"
+        );
+
+        let manifest_connection = Connection::open(manifest_path).unwrap();
+        configure_manifest_connection(&manifest_connection).unwrap();
+        let ready = manifest::current_integrity(&manifest_connection, 2).unwrap();
+        assert_eq!(ready.state(), manifest::DatabaseIntegrityState::Ready);
+        assert_eq!(
+            ready.committed_schema_digest(),
+            Some(schema_digests_before[0])
+        );
+        assert_eq!(ready.target_schema_digest(), None);
+        assert_eq!(
+            manifest_connection
+                .query_row(
+                    "SELECT COUNT(*) FROM briskdb_schema_migrations",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn divergent_v6_bootstrap_persists_terminal_degraded_without_a_new_baseline() {
+        let temp = tempfile::tempdir().unwrap();
+        drop(Storage::open(temp.path(), 2).unwrap());
+
+        let manifest_path = temp.path().join("manifest.sqlite");
+        Connection::open(&manifest_path)
+            .unwrap()
+            .execute_batch(
+                "BEGIN IMMEDIATE;
+                 DROP TABLE briskdb_integrity;
+                 DROP TABLE briskdb_metadata;
+                 CREATE TABLE briskdb_metadata (
+                     requires_manifest_version INTEGER NOT NULL
+                         CHECK (requires_manifest_version >= 6)
+                 ) STRICT;
+                 INSERT INTO briskdb_metadata VALUES (6);
+                 PRAGMA user_version = 6;
+                 COMMIT;",
+            )
+            .unwrap();
+        Connection::open(temp.path().join("shards/0000.sqlite"))
+            .unwrap()
+            .execute_batch("CREATE TABLE divergent_bootstrap(id INTEGER PRIMARY KEY)")
+            .unwrap();
+
+        let first = Storage::open(temp.path(), 2).unwrap_err();
+        assert_eq!(first.kind(), EngineErrorKind::DataCorruption);
+        let mut manifest_connection = Connection::open(&manifest_path).unwrap();
+        configure_manifest_connection(&manifest_connection).unwrap();
+        let degraded = manifest::current_integrity(&manifest_connection, 2).unwrap();
+        assert_eq!(degraded.state(), manifest::DatabaseIntegrityState::Degraded);
+        assert_eq!(degraded.committed_schema_digest(), None);
+        drop(manifest_connection);
+
+        Connection::open(temp.path().join("shards/0001.sqlite"))
+            .unwrap()
+            .execute_batch("CREATE TABLE divergent_bootstrap(id INTEGER PRIMARY KEY)")
+            .unwrap();
+        let second = Storage::open(temp.path(), 2).unwrap_err();
+        assert_eq!(second.kind(), EngineErrorKind::DataCorruption);
+
+        manifest_connection = Connection::open(manifest_path).unwrap();
+        configure_manifest_connection(&manifest_connection).unwrap();
+        let still_degraded = manifest::current_integrity(&manifest_connection, 2).unwrap();
+        assert_eq!(
+            still_degraded.state(),
+            manifest::DatabaseIntegrityState::Degraded
+        );
+        assert_eq!(still_degraded.committed_schema_digest(), None);
     }
 
     #[cfg(unix)]
@@ -1319,7 +2194,8 @@ mod tests {
             assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
             assert_eq!(
                 error.to_string(),
-                format!("manifest shard count {invalid} is outside the supported range")
+                "SQLite manifest integrity verification failed",
+                "invalid shard count {invalid}"
             );
         }
     }

--- a/src/storage/pool.rs
+++ b/src/storage/pool.rs
@@ -1069,18 +1069,27 @@ mod tests {
         target_generation: u64,
     ) {
         let target_user_version = i64::try_from(target_generation).unwrap();
+        let mut target_digest = None;
         for shard in 0..pools.shards.len() {
             let path = temp.path().join(format!("shards/{shard:04}.sqlite"));
-            Connection::open(path)
-                .unwrap()
+            let connection = Connection::open(path).unwrap();
+            connection
                 .pragma_update(None, "user_version", target_user_version)
                 .unwrap();
+            let observed =
+                crate::storage::shard::calculate_schema_digest(&connection, target_generation)
+                    .unwrap();
+            assert!(target_digest.is_none_or(|expected| expected == observed));
+            target_digest = Some(observed);
         }
-        pools.shards[0]
-            .inner
-            .storage
+        let storage = &pools.shards[0].inner.storage;
+        storage
             .logical_catalog()
             .publish_schema_generation(source_generation, target_generation)
+            .unwrap();
+        storage
+            .schema_coordination
+            .publish_schema_digests(target_digest, None)
             .unwrap();
     }
 

--- a/src/storage/schema_gate.rs
+++ b/src/storage/schema_gate.rs
@@ -16,6 +16,15 @@ pub(crate) enum SchemaGateState {
     Migrating,
     /// A durable partial migration must be resumed before ordinary work can run.
     Pending,
+    /// Integrity validation failed and no further work may be admitted.
+    Degraded,
+}
+
+fn degraded_error() -> EngineError {
+    EngineError::new(
+        EngineErrorKind::DataCorruption,
+        "database integrity verification failed",
+    )
 }
 
 /// One deterministic view of schema admission and current occupancy.
@@ -117,7 +126,17 @@ impl SchemaGate {
                 EngineErrorKind::FailedPrecondition,
                 "a partial application-schema migration must be resumed",
             )),
+            SchemaGateState::Degraded => Err(degraded_error()),
         }
+    }
+
+    /// Permanently reject new work after integrity validation fails.
+    ///
+    /// Operations admitted before degradation retain their guards and may
+    /// drain normally. The degraded state is otherwise sticky for this gate,
+    /// including across outstanding migration-guard publication and drop.
+    pub(crate) fn mark_degraded(&self) {
+        self.inner.lock().state = SchemaGateState::Degraded;
     }
 
     /// Exclude new ordinary work and create the sole migration coordinator.
@@ -136,6 +155,7 @@ impl SchemaGate {
                     "an application-schema migration is already in progress",
                 ));
             }
+            SchemaGateState::Degraded => return Err(degraded_error()),
         };
         data.state = SchemaGateState::Migrating;
         Ok(SchemaMigrationGuard {
@@ -223,11 +243,15 @@ impl SchemaMigrationGuard {
     fn publish(&mut self, target: SchemaGateState) -> EngineResult<()> {
         {
             let mut data = self.inner.lock();
-            if data.state != SchemaGateState::Migrating {
-                return Err(EngineError::new(
-                    EngineErrorKind::Internal,
-                    "application-schema migration guard lost exclusive ownership",
-                ));
+            match data.state {
+                SchemaGateState::Migrating => {}
+                SchemaGateState::Degraded => return Err(degraded_error()),
+                SchemaGateState::Ready | SchemaGateState::Pending => {
+                    return Err(EngineError::new(
+                        EngineErrorKind::Internal,
+                        "application-schema migration guard lost exclusive ownership",
+                    ));
+                }
             }
             if data.active_operations != 0 {
                 return Err(EngineError::new(
@@ -295,6 +319,48 @@ mod tests {
     }
 
     #[test]
+    fn degraded_rejects_operations_and_migrations_without_losing_occupancy() {
+        let gate = SchemaGate::new();
+        let admitted = gate.try_acquire_operation().unwrap();
+
+        gate.mark_degraded();
+        assert_eq!(
+            gate.snapshot(),
+            SchemaGateSnapshot {
+                state: SchemaGateState::Degraded,
+                active_operations: 1,
+            }
+        );
+        for error in [
+            gate.try_acquire_operation().unwrap_err(),
+            gate.begin_migration().unwrap_err(),
+        ] {
+            assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+            assert_eq!(error.to_string(), "database integrity verification failed");
+            assert!(!error.is_retryable());
+        }
+
+        gate.mark_degraded();
+        drop(admitted);
+        assert_eq!(
+            gate.snapshot(),
+            SchemaGateSnapshot {
+                state: SchemaGateState::Degraded,
+                active_operations: 0,
+            }
+        );
+
+        let pending_gate = SchemaGate::new();
+        pending_gate
+            .begin_migration()
+            .unwrap()
+            .publish_pending()
+            .unwrap();
+        pending_gate.mark_degraded();
+        assert_eq!(pending_gate.snapshot().state, SchemaGateState::Degraded);
+    }
+
+    #[test]
     fn only_one_migration_guard_exists_and_pending_can_be_resumed() {
         let gate = SchemaGate::new();
         let migration = gate.begin_migration().unwrap();
@@ -323,6 +389,61 @@ mod tests {
 
         drop(gate.begin_migration().unwrap());
         assert_eq!(gate.snapshot().state, SchemaGateState::Pending);
+    }
+
+    #[test]
+    fn degradation_wins_over_migration_guard_drop_and_publication() {
+        let gate = SchemaGate::new();
+        let migration = gate.begin_migration().unwrap();
+        gate.mark_degraded();
+        drop(migration);
+        assert_eq!(gate.snapshot().state, SchemaGateState::Degraded);
+
+        let ready_publish_gate = SchemaGate::new();
+        let migration = ready_publish_gate.begin_migration().unwrap();
+        ready_publish_gate.mark_degraded();
+        let error = migration.publish_ready().unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+        assert_eq!(
+            ready_publish_gate.snapshot().state,
+            SchemaGateState::Degraded
+        );
+
+        let pending_publish_gate = SchemaGate::new();
+        let migration = pending_publish_gate.begin_migration().unwrap();
+        pending_publish_gate.mark_degraded();
+        let error = migration.publish_pending().unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+        assert_eq!(
+            pending_publish_gate.snapshot().state,
+            SchemaGateState::Degraded
+        );
+    }
+
+    #[test]
+    fn concurrent_degradation_and_guard_drop_always_leave_the_gate_degraded() {
+        for _ in 0..128 {
+            let gate = SchemaGate::new();
+            let migration = gate.begin_migration().unwrap();
+            let rendezvous = Arc::new(Barrier::new(3));
+
+            let marker_gate = gate.clone();
+            let marker_rendezvous = Arc::clone(&rendezvous);
+            let marker = std::thread::spawn(move || {
+                marker_rendezvous.wait();
+                marker_gate.mark_degraded();
+            });
+            let drop_rendezvous = Arc::clone(&rendezvous);
+            let dropper = std::thread::spawn(move || {
+                drop_rendezvous.wait();
+                drop(migration);
+            });
+
+            rendezvous.wait();
+            marker.join().unwrap();
+            dropper.join().unwrap();
+            assert_eq!(gate.snapshot().state, SchemaGateState::Degraded);
+        }
     }
 
     #[tokio::test]

--- a/src/storage/shard.rs
+++ b/src/storage/shard.rs
@@ -22,8 +22,11 @@ use super::CONNECTION_BUSY_TIMEOUT;
 pub(super) const SHARD_APPLICATION_ID: i64 = 0x4252_5348;
 /// Version of the storage-owned shard metadata table.
 pub(super) const SHARD_METADATA_VERSION: u32 = 1;
+/// Version of the canonical application-schema fingerprint encoding.
+pub(super) const SHARD_SCHEMA_DIGEST_VERSION: u32 = 1;
 
 const SHARD_METADATA_TABLE: &str = "briskdb_shard_metadata";
+const SHARD_SCHEMA_DIGEST_DOMAIN: &[u8] = b"briskdb.shard.application-schema.v1\0";
 const MAX_SHARDS: u16 = 64;
 const MAX_DIRECTORY_ENTRIES: usize = 512;
 const MAX_SCHEMA_SQL_BYTES: usize = 4_096;
@@ -133,6 +136,9 @@ pub(super) enum SchemaMigrationShardOutcome {
     Applied,
     AlreadyApplied,
 }
+
+/// Canonical BLAKE3 fingerprint of one generation's persistent application schema.
+pub(super) type SchemaDigest = [u8; 32];
 
 /// Durable boundaries exposed to storage migration failure-injection tests.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -272,11 +278,111 @@ pub(super) fn validate_open_connection(
     schema_generation: u64,
     layout: &ShardLayout,
 ) -> EngineResult<()> {
+    configure_cell_size_check(connection)?;
     validate_shard_id(shard_id)?;
     let expected_user_version = expected_user_version(schema_generation)?;
     require_writable(connection)?;
     validate_exact_shard(connection, path, shard_id, expected_user_version, layout)?;
     configure_connection_pragmas(connection)
+}
+
+/// Calculate the canonical fingerprint of the persistent application schema.
+///
+/// The encoding is domain-separated and generation-bound. Rows are streamed in
+/// binary order from `main.sqlite_schema`; SQLite-owned `sqlite_*` objects and
+/// the one storage-owned shard-metadata table are omitted. Every text field is
+/// length-prefixed, including the nullable SQL field, so no tuple ambiguity is
+/// possible. Application data, root pages, shard identity, and WAL state do not
+/// participate in the fingerprint.
+pub(super) fn calculate_schema_digest(
+    connection: &Connection,
+    schema_generation: u64,
+) -> EngineResult<SchemaDigest> {
+    configure_cell_size_check(connection)?;
+    expected_user_version(schema_generation)?;
+
+    let mut statement = connection
+        .prepare(
+            "SELECT type, name, tbl_name, sql
+             FROM main.sqlite_schema
+             ORDER BY
+                 type COLLATE BINARY,
+                 name COLLATE BINARY,
+                 tbl_name COLLATE BINARY,
+                 sql COLLATE BINARY",
+        )
+        .map_err(|error| shard_read_error(error, "failed to inspect shard application schema"))?;
+    let mut rows = statement
+        .query([])
+        .map_err(|error| shard_read_error(error, "failed to inspect shard application schema"))?;
+
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(SHARD_SCHEMA_DIGEST_DOMAIN);
+    hasher.update(&SHARD_SCHEMA_DIGEST_VERSION.to_le_bytes());
+    hasher.update(&schema_generation.to_le_bytes());
+
+    while let Some(row) = rows
+        .next()
+        .map_err(|error| shard_read_error(error, "failed to read shard application schema"))?
+    {
+        let object_type = row
+            .get::<_, String>(0)
+            .map_err(|error| shard_read_error(error, "failed to read shard application schema"))?;
+        let name = row
+            .get::<_, String>(1)
+            .map_err(|error| shard_read_error(error, "failed to read shard application schema"))?;
+        let table_name = row
+            .get::<_, String>(2)
+            .map_err(|error| shard_read_error(error, "failed to read shard application schema"))?;
+        let sql = row
+            .get::<_, Option<String>>(3)
+            .map_err(|error| shard_read_error(error, "failed to read shard application schema"))?;
+
+        if is_sqlite_schema_name(&name) {
+            continue;
+        }
+        if is_exact_metadata_schema_object(&object_type, &name, &table_name, sql.as_deref()) {
+            continue;
+        }
+        if is_reserved_name(&name) || is_reserved_name(&table_name) {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "shard application schema contains an unexpected reserved object",
+            ));
+        }
+
+        hasher.update(&[1]);
+        hash_schema_text(&mut hasher, &object_type)?;
+        hash_schema_text(&mut hasher, &name)?;
+        hash_schema_text(&mut hasher, &table_name)?;
+        match sql {
+            Some(sql) => {
+                hasher.update(&[1]);
+                hash_schema_text(&mut hasher, &sql)?;
+            }
+            None => {
+                hasher.update(&[0]);
+            }
+        }
+    }
+    hasher.update(&[0]);
+    Ok(*hasher.finalize().as_bytes())
+}
+
+/// Require the current persistent application schema to match a trusted digest.
+pub(super) fn verify_schema_digest(
+    connection: &Connection,
+    schema_generation: u64,
+    expected: &SchemaDigest,
+) -> EngineResult<()> {
+    if calculate_schema_digest(connection, schema_generation)? == *expected {
+        Ok(())
+    } else {
+        Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "shard application schema does not match its trusted fingerprint",
+        ))
+    }
 }
 
 /// Strictly validate a dedicated migration connection while accepting only
@@ -294,6 +400,7 @@ pub(super) fn validate_schema_migration_connection(
     target_generation: u64,
     layout: &ShardLayout,
 ) -> EngineResult<SchemaMigrationShardState> {
+    configure_cell_size_check(connection)?;
     validate_shard_id(shard_id)?;
     let (source_user_version, target_user_version) =
         validate_schema_migration_inputs(source_generation, target_generation, layout)?;
@@ -400,6 +507,7 @@ where
 
 /// Execute a migration batch in an immediate transaction and always roll it
 /// back. A target-generation shard is strictly validated and skipped.
+#[cfg(test)]
 pub(super) fn preflight_schema_migration(
     path: &Path,
     shard_id: u16,
@@ -408,9 +516,30 @@ pub(super) fn preflight_schema_migration(
     layout: &ShardLayout,
     sql: &str,
 ) -> EngineResult<SchemaMigrationShardState> {
+    preflight_schema_migration_with_digest(
+        path,
+        shard_id,
+        source_generation,
+        target_generation,
+        layout,
+        sql,
+    )
+    .map(|(state, _)| state)
+}
+
+/// Preflight a migration and return its generation-bound target-schema digest.
+#[cfg(test)]
+pub(super) fn preflight_schema_migration_with_digest(
+    path: &Path,
+    shard_id: u16,
+    source_generation: u64,
+    target_generation: u64,
+    layout: &ShardLayout,
+    sql: &str,
+) -> EngineResult<(SchemaMigrationShardState, SchemaDigest)> {
     let mut connection = open_required_file(path)?;
     configure_busy_timeout(&connection)?;
-    preflight_schema_migration_on_connection(
+    preflight_schema_migration_on_connection_with_digest(
         &mut connection,
         path,
         shard_id,
@@ -421,8 +550,8 @@ pub(super) fn preflight_schema_migration(
     )
 }
 
-/// Connection-level preflight for a coordinator-owned, cancellation-aware handle.
-pub(super) fn preflight_schema_migration_on_connection(
+/// Connection-level digesting preflight for a cancellation-aware coordinator.
+pub(super) fn preflight_schema_migration_on_connection_with_digest(
     connection: &mut Connection,
     path: &Path,
     shard_id: u16,
@@ -430,7 +559,7 @@ pub(super) fn preflight_schema_migration_on_connection(
     target_generation: u64,
     layout: &ShardLayout,
     sql: &str,
-) -> EngineResult<SchemaMigrationShardState> {
+) -> EngineResult<(SchemaMigrationShardState, SchemaDigest)> {
     let initial = validate_schema_migration_connection(
         connection,
         path,
@@ -440,7 +569,8 @@ pub(super) fn preflight_schema_migration_on_connection(
         layout,
     )?;
     if initial == SchemaMigrationShardState::Target {
-        return Ok(initial);
+        let digest = calculate_schema_digest(connection, target_generation)?;
+        return Ok((initial, digest));
     }
 
     let (source_user_version, target_user_version) =
@@ -458,20 +588,23 @@ pub(super) fn preflight_schema_migration_on_connection(
     )?;
     if locked == SchemaMigrationShardState::Target {
         transaction.rollback().map_err(sqlite_error::storage)?;
-        return validate_schema_migration_connection(
+        let state = validate_schema_migration_connection(
             connection,
             path,
             shard_id,
             source_generation,
             target_generation,
             layout,
-        );
+        )?;
+        let digest = calculate_schema_digest(connection, target_generation)?;
+        return Ok((state, digest));
     }
 
     let reserved_before = reserved_schema_snapshot(&transaction)?;
     execute_schema_migration_batch(&transaction, sql)?;
     ensure_reserved_schema_unchanged(&reserved_before, &transaction)?;
     ensure_no_foreign_key_violations(&transaction)?;
+    let target_digest = calculate_schema_digest(&transaction, target_generation)?;
     transaction.rollback().map_err(sqlite_error::storage)?;
 
     let state = validate_schema_migration_connection(
@@ -488,7 +621,7 @@ pub(super) fn preflight_schema_migration_on_connection(
             format!("schema migration preflight changed shard {shard_id} generation"),
         ));
     }
-    Ok(state)
+    Ok((state, target_digest))
 }
 
 /// Atomically apply one journaled batch and its target generation, or strictly
@@ -514,6 +647,30 @@ pub(super) fn apply_schema_migration(
     )
 }
 
+/// Apply one migration while requiring its exact trusted target fingerprint.
+pub(super) fn apply_schema_migration_with_digest(
+    path: &Path,
+    shard_id: u16,
+    source_generation: u64,
+    target_generation: u64,
+    layout: &ShardLayout,
+    sql: &str,
+    expected_target_digest: &SchemaDigest,
+) -> EngineResult<SchemaMigrationShardOutcome> {
+    let mut connection = open_required_file(path)?;
+    configure_busy_timeout(&connection)?;
+    apply_schema_migration_on_connection_with_digest(
+        &mut connection,
+        path,
+        shard_id,
+        source_generation,
+        target_generation,
+        layout,
+        sql,
+        expected_target_digest,
+    )
+}
+
 /// Connection-level apply for a coordinator-owned, cancellation-aware handle.
 pub(super) fn apply_schema_migration_on_connection(
     connection: &mut Connection,
@@ -532,7 +689,35 @@ pub(super) fn apply_schema_migration_on_connection(
         layout,
         sql,
     );
-    apply_schema_migration_on_connection_inner(connection, migration, |_| Ok(()))
+    apply_schema_migration_on_connection_inner(connection, migration, None, |_| Ok(()))
+}
+
+/// Connection-level digest-verifying apply for a cancellation-aware coordinator.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn apply_schema_migration_on_connection_with_digest(
+    connection: &mut Connection,
+    path: &Path,
+    shard_id: u16,
+    source_generation: u64,
+    target_generation: u64,
+    layout: &ShardLayout,
+    sql: &str,
+    expected_target_digest: &SchemaDigest,
+) -> EngineResult<SchemaMigrationShardOutcome> {
+    let migration = SchemaMigrationShard::new(
+        path,
+        shard_id,
+        source_generation,
+        target_generation,
+        layout,
+        sql,
+    );
+    apply_schema_migration_on_connection_inner(
+        connection,
+        migration,
+        Some(expected_target_digest),
+        |_| Ok(()),
+    )
 }
 
 /// Test seam for injecting errors, panics, and process termination at the
@@ -546,12 +731,13 @@ pub(super) fn apply_schema_migration_on_connection_with_hook<F>(
 where
     F: FnMut(SchemaMigrationPoint) -> EngineResult<()>,
 {
-    apply_schema_migration_on_connection_inner(connection, migration, hook)
+    apply_schema_migration_on_connection_inner(connection, migration, None, hook)
 }
 
 fn apply_schema_migration_on_connection_inner<F>(
     connection: &mut Connection,
     migration: SchemaMigrationShard<'_>,
+    expected_target_digest: Option<&SchemaDigest>,
     mut hook: F,
 ) -> EngineResult<SchemaMigrationShardOutcome>
 where
@@ -574,6 +760,9 @@ where
         layout,
     )?;
     if initial == SchemaMigrationShardState::Target {
+        if let Some(expected) = expected_target_digest {
+            verify_schema_digest(connection, target_generation, expected)?;
+        }
         return Ok(SchemaMigrationShardOutcome::AlreadyApplied);
     }
 
@@ -600,6 +789,9 @@ where
             target_generation,
             layout,
         )?;
+        if let Some(expected) = expected_target_digest {
+            verify_schema_digest(connection, target_generation, expected)?;
+        }
         return Ok(SchemaMigrationShardOutcome::AlreadyApplied);
     }
 
@@ -626,6 +818,9 @@ where
             format!("schema migration did not stamp shard {shard_id} target generation"),
         ));
     }
+    if let Some(expected) = expected_target_digest {
+        verify_schema_digest(&transaction, target_generation, expected)?;
+    }
 
     transaction.commit().map_err(sqlite_error::storage)?;
     hook(SchemaMigrationPoint::Committed)?;
@@ -642,6 +837,9 @@ where
             EngineErrorKind::Internal,
             format!("committed schema migration did not persist on shard {shard_id}"),
         ));
+    }
+    if let Some(expected) = expected_target_digest {
+        verify_schema_digest(connection, target_generation, expected)?;
     }
     Ok(SchemaMigrationShardOutcome::Applied)
 }
@@ -1076,9 +1274,11 @@ fn open_existing_connection(path: &Path) -> EngineResult<Connection> {
         | OpenFlags::SQLITE_OPEN_NOFOLLOW
         | OpenFlags::SQLITE_OPEN_EXRESCODE;
     let open_path = canonical_open_path(path)?;
-    Connection::open_with_flags(open_path, flags).map_err(|error| {
+    let connection = Connection::open_with_flags(open_path, flags).map_err(|error| {
         sqlite_error::storage(error).context(format!("failed to open shard {}", path.display()))
-    })
+    })?;
+    configure_cell_size_check(&connection)?;
+    Ok(connection)
 }
 
 fn open_creating_connection(path: &Path) -> EngineResult<Connection> {
@@ -1088,9 +1288,11 @@ fn open_creating_connection(path: &Path) -> EngineResult<Connection> {
         | OpenFlags::SQLITE_OPEN_NOFOLLOW
         | OpenFlags::SQLITE_OPEN_EXRESCODE;
     let open_path = canonical_open_path(path)?;
-    Connection::open_with_flags(open_path, flags).map_err(|error| {
+    let connection = Connection::open_with_flags(open_path, flags).map_err(|error| {
         sqlite_error::storage(error).context(format!("failed to create shard {}", path.display()))
-    })
+    })?;
+    configure_cell_size_check(&connection)?;
+    Ok(connection)
 }
 
 // SQLite's NOFOLLOW flag rejects a path containing any symlink component. On
@@ -1145,6 +1347,23 @@ fn configure_busy_timeout(connection: &Connection) -> EngineResult<()> {
     connection
         .busy_timeout(CONNECTION_BUSY_TIMEOUT)
         .map_err(sqlite_error::storage)
+}
+
+fn configure_cell_size_check(connection: &Connection) -> EngineResult<()> {
+    connection
+        .pragma_update(None, "cell_size_check", "ON")
+        .map_err(sqlite_error::storage)?;
+    let enabled = connection
+        .pragma_query_value(None, "cell_size_check", |row| row.get::<_, i64>(0))
+        .map_err(sqlite_error::storage)?;
+    if enabled == 1 {
+        Ok(())
+    } else {
+        Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "SQLite did not enable required shard cell-size checks",
+        ))
+    }
 }
 
 fn require_writable(connection: &Connection) -> EngineResult<()> {
@@ -1595,11 +1814,79 @@ fn validate_metadata(
             ),
         ));
     }
-    Ok(())
+    validate_metadata_integrity(connection)
+}
+
+fn validate_metadata_integrity(connection: &Connection) -> EngineResult<()> {
+    let mut statement = connection
+        .prepare("PRAGMA main.integrity_check('briskdb_shard_metadata')")
+        .map_err(|error| shard_read_error(error, "failed to check shard metadata integrity"))?;
+    let mut rows = statement
+        .query([])
+        .map_err(|error| shard_read_error(error, "failed to check shard metadata integrity"))?;
+    let first = rows
+        .next()
+        .map_err(|error| shard_read_error(error, "failed to check shard metadata integrity"))?
+        .map(|row| row.get::<_, String>(0))
+        .transpose()
+        .map_err(|error| shard_read_error(error, "failed to check shard metadata integrity"))?;
+    let has_additional = rows
+        .next()
+        .map_err(|error| shard_read_error(error, "failed to check shard metadata integrity"))?
+        .is_some();
+    require_single_ok_integrity_result(first.as_deref(), has_additional)
+}
+
+fn require_single_ok_integrity_result(
+    first: Option<&str>,
+    has_additional: bool,
+) -> EngineResult<()> {
+    if first == Some("ok") && !has_additional {
+        Ok(())
+    } else {
+        Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "shard metadata integrity check failed",
+        ))
+    }
 }
 
 fn normalize_schema_sql(sql: &str) -> String {
     sql.split_ascii_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn hash_schema_text(hasher: &mut blake3::Hasher, value: &str) -> EngineResult<()> {
+    let length = u64::try_from(value.len()).map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::LimitExceeded,
+            "shard schema field length exceeds its canonical encoding",
+            error,
+        )
+    })?;
+    hasher.update(&length.to_le_bytes());
+    hasher.update(value.as_bytes());
+    Ok(())
+}
+
+fn is_sqlite_schema_name(name: &str) -> bool {
+    name.as_bytes()
+        .get(.."sqlite_".len())
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case(b"sqlite_"))
+}
+
+fn is_exact_metadata_schema_object(
+    object_type: &str,
+    name: &str,
+    table_name: &str,
+    sql: Option<&str>,
+) -> bool {
+    object_type == "table"
+        && name == SHARD_METADATA_TABLE
+        && table_name == SHARD_METADATA_TABLE
+        && sql.is_some_and(|sql| {
+            sql.len() <= MAX_SCHEMA_SQL_BYTES
+                && normalize_schema_sql(sql) == normalize_schema_sql(SHARD_METADATA_TABLE_SQL)
+        })
 }
 
 fn missing_shard(path: &Path, shard_id: u16) -> EngineError {
@@ -1848,6 +2135,278 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap()
+    }
+
+    fn schema_fixture(schema: &str) -> Connection {
+        let connection = Connection::open_in_memory().unwrap();
+        connection.execute_batch(SHARD_METADATA_TABLE_SQL).unwrap();
+        connection.execute_batch(schema).unwrap();
+        connection
+    }
+
+    fn cell_size_check(connection: &Connection) -> i64 {
+        connection
+            .pragma_query_value(None, "cell_size_check", |row| row.get(0))
+            .unwrap()
+    }
+
+    #[test]
+    fn internal_shard_opens_enable_and_read_back_cell_size_checks() {
+        let temp = tempfile::tempdir().unwrap();
+        let creating_path = temp.path().join("creating.sqlite");
+        let creating = open_creating_connection(&creating_path).unwrap();
+        assert_eq!(cell_size_check(&creating), 1);
+        drop(creating);
+
+        let (_temp, shards, ready) = create_ready_layout(2);
+        let path = shard_path(&shards, 0);
+        let required = open_required_file(&path).unwrap();
+        assert_eq!(cell_size_check(&required), 1);
+        drop(required);
+
+        let borrowed = Connection::open(&path).unwrap();
+        borrowed
+            .pragma_update(None, "cell_size_check", "OFF")
+            .unwrap();
+        assert_eq!(cell_size_check(&borrowed), 0);
+        validate_open_connection(&borrowed, &path, 0, 0, &ready).unwrap();
+        assert_eq!(cell_size_check(&borrowed), 1);
+
+        let migration = Connection::open(&path).unwrap();
+        migration
+            .pragma_update(None, "cell_size_check", "OFF")
+            .unwrap();
+        assert_eq!(cell_size_check(&migration), 0);
+        validate_schema_migration_connection(&migration, &path, 0, 0, 1, &ready).unwrap();
+        assert_eq!(cell_size_check(&migration), 1);
+    }
+
+    #[test]
+    fn metadata_integrity_requires_exactly_one_ok_row_and_maps_failures_to_corruption() {
+        assert!(require_single_ok_integrity_result(Some("ok"), false).is_ok());
+        for (first, additional) in [
+            (None, false),
+            (Some(""), false),
+            (Some("malformed"), false),
+            (Some("ok"), true),
+        ] {
+            assert_eq!(
+                require_single_ok_integrity_result(first, additional)
+                    .unwrap_err()
+                    .kind(),
+                EngineErrorKind::DataCorruption
+            );
+        }
+
+        let (_temp, shards, _) = create_ready_layout(2);
+        validate_metadata_integrity(&Connection::open(shard_path(&shards, 0)).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn schema_digest_has_a_frozen_golden_vector() {
+        let connection = schema_fixture(
+            "CREATE TABLE widgets (
+                 id INTEGER PRIMARY KEY,
+                 value TEXT NOT NULL
+             ) STRICT;
+             CREATE INDEX widgets_value_idx ON widgets (value);",
+        );
+        let digest = calculate_schema_digest(&connection, 7).unwrap();
+        assert_eq!(
+            blake3::Hash::from_bytes(digest).to_hex().as_str(),
+            "5199ef8f79db275ed5b2ff06ef85c2138f6ddf714b0843300356b9efcfb078aa"
+        );
+    }
+
+    #[test]
+    fn schema_digest_ignores_shard_identity_rows_and_application_data() {
+        let (_temp, shards, _) = create_ready_layout(2);
+        let mut digests = Vec::new();
+        for shard_id in 0..2 {
+            let connection = Connection::open(shard_path(&shards, shard_id)).unwrap();
+            connection
+                .execute_batch(
+                    "CREATE TABLE widgets (
+                         id INTEGER PRIMARY KEY AUTOINCREMENT,
+                         value TEXT NOT NULL
+                     ) STRICT;
+                     CREATE INDEX widgets_value_idx ON widgets (value);",
+                )
+                .unwrap();
+            connection
+                .execute(
+                    "INSERT INTO widgets (value) VALUES (?1)",
+                    [format!("shard-{shard_id}")],
+                )
+                .unwrap();
+            digests.push(calculate_schema_digest(&connection, 0).unwrap());
+        }
+        assert_eq!(digests[0], digests[1]);
+
+        let first = Connection::open(shard_path(&shards, 0)).unwrap();
+        verify_schema_digest(&first, 0, &digests[0]).unwrap();
+        let wrong = [0x5a; 32];
+        assert_eq!(
+            verify_schema_digest(&first, 0, &wrong).unwrap_err().kind(),
+            EngineErrorKind::DataCorruption
+        );
+    }
+
+    #[test]
+    fn schema_digest_is_stable_across_dml_checkpoint_and_vacuum() {
+        let (_temp, shards, _) = create_ready_layout(2);
+        let path = shard_path(&shards, 0);
+        let connection = Connection::open(&path).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE events (
+                     id INTEGER PRIMARY KEY AUTOINCREMENT,
+                     value TEXT NOT NULL
+                 ) STRICT;
+                 CREATE INDEX events_value_idx ON events (value);",
+            )
+            .unwrap();
+        let baseline = calculate_schema_digest(&connection, 0).unwrap();
+
+        connection
+            .execute_batch(
+                "INSERT INTO events (value) VALUES ('one'), ('two'), ('three');
+                 UPDATE events SET value = upper(value) WHERE id = 2;
+                 DELETE FROM events WHERE id = 1;",
+            )
+            .unwrap();
+        assert_eq!(calculate_schema_digest(&connection, 0).unwrap(), baseline);
+
+        connection
+            .query_row("PRAGMA main.wal_checkpoint(TRUNCATE)", [], |_| Ok(()))
+            .unwrap();
+        assert_eq!(calculate_schema_digest(&connection, 0).unwrap(), baseline);
+
+        connection.execute_batch("VACUUM main").unwrap();
+        assert_eq!(calculate_schema_digest(&connection, 0).unwrap(), baseline);
+    }
+
+    #[test]
+    fn every_persistent_application_object_changes_the_schema_digest() {
+        let connection = schema_fixture("");
+        let mut seen = HashSet::new();
+        assert!(seen.insert(calculate_schema_digest(&connection, 0).unwrap()));
+
+        for sql in [
+            "CREATE TABLE widgets (id INTEGER PRIMARY KEY, value TEXT NOT NULL) STRICT;",
+            "CREATE INDEX widgets_value_idx ON widgets (value);",
+            "CREATE VIEW widget_values AS SELECT id, value FROM widgets;",
+            "CREATE TRIGGER widgets_after_insert AFTER INSERT ON widgets BEGIN UPDATE widgets SET value = upper(value) WHERE id = NEW.id; END;",
+        ] {
+            connection.execute_batch(sql).unwrap();
+            assert!(seen.insert(calculate_schema_digest(&connection, 0).unwrap()));
+        }
+        assert_eq!(seen.len(), 5);
+    }
+
+    #[test]
+    fn schema_digest_order_is_binary_and_independent_of_creation_order() {
+        let first = schema_fixture(
+            "CREATE TABLE alpha (id INTEGER PRIMARY KEY, value TEXT) STRICT;
+             CREATE TABLE beta (id INTEGER PRIMARY KEY, value TEXT) STRICT;
+             CREATE INDEX alpha_value_idx ON alpha (value);
+             CREATE INDEX beta_value_idx ON beta (value);",
+        );
+        let second = schema_fixture(
+            "CREATE TABLE beta (id INTEGER PRIMARY KEY, value TEXT) STRICT;
+             CREATE TABLE alpha (id INTEGER PRIMARY KEY, value TEXT) STRICT;
+             CREATE INDEX beta_value_idx ON beta (value);
+             CREATE INDEX alpha_value_idx ON alpha (value);",
+        );
+        assert_eq!(
+            calculate_schema_digest(&first, 4).unwrap(),
+            calculate_schema_digest(&second, 4).unwrap()
+        );
+    }
+
+    #[test]
+    fn schema_digest_is_generation_bound_and_rejects_unencodable_generations() {
+        let connection = schema_fixture("CREATE TABLE widgets (id INTEGER PRIMARY KEY) STRICT;");
+        assert_ne!(
+            calculate_schema_digest(&connection, 0).unwrap(),
+            calculate_schema_digest(&connection, 1).unwrap()
+        );
+        assert_eq!(
+            calculate_schema_digest(&connection, i32::MAX as u64 + 1)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+    }
+
+    #[test]
+    fn schema_digest_rejects_unexpected_or_incompatible_reserved_objects() {
+        for schema in [
+            "CREATE TABLE briskdb_private (id INTEGER);",
+            "CREATE INDEX metadata_tamper_idx ON briskdb_shard_metadata (shard_id);",
+        ] {
+            let connection = schema_fixture(schema);
+            assert_eq!(
+                calculate_schema_digest(&connection, 0).unwrap_err().kind(),
+                EngineErrorKind::DataCorruption,
+                "{schema}"
+            );
+        }
+
+        let connection = Connection::open_in_memory().unwrap();
+        connection
+            .execute_batch("CREATE TABLE briskdb_shard_metadata (singleton INTEGER);")
+            .unwrap();
+        assert_eq!(
+            calculate_schema_digest(&connection, 0).unwrap_err().kind(),
+            EngineErrorKind::DataCorruption
+        );
+    }
+
+    #[test]
+    fn migration_preflight_fingerprints_rollback_target_and_apply_verifies_before_commit() {
+        let (_temp, shards, ready) = create_ready_layout(2);
+        let sql = "CREATE TABLE migrated_widgets (
+                       id INTEGER PRIMARY KEY,
+                       value TEXT NOT NULL
+                   ) STRICT";
+        let mut target = None;
+        for shard_id in 0..2 {
+            let path = shard_path(&shards, shard_id);
+            let (state, digest) =
+                preflight_schema_migration_with_digest(&path, shard_id, 0, 1, &ready, sql).unwrap();
+            assert_eq!(state, SchemaMigrationShardState::Source);
+            assert!(!schema_object_exists(&path, "migrated_widgets"));
+            assert_eq!(identity(&path), (SHARD_APPLICATION_ID, 0));
+            if let Some(expected) = target {
+                assert_eq!(digest, expected);
+            } else {
+                target = Some(digest);
+            }
+        }
+        let target = target.unwrap();
+
+        let first = shard_path(&shards, 0);
+        assert_eq!(
+            apply_schema_migration_with_digest(&first, 0, 0, 1, &ready, sql, &target).unwrap(),
+            SchemaMigrationShardOutcome::Applied
+        );
+        verify_schema_digest(&Connection::open(&first).unwrap(), 1, &target).unwrap();
+        assert_eq!(
+            apply_schema_migration_with_digest(&first, 0, 0, 1, &ready, sql, &target).unwrap(),
+            SchemaMigrationShardOutcome::AlreadyApplied
+        );
+
+        let second = shard_path(&shards, 1);
+        let wrong = [0x5a; 32];
+        assert_eq!(
+            apply_schema_migration_with_digest(&second, 1, 0, 1, &ready, sql, &wrong)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::DataCorruption
+        );
+        assert_eq!(identity(&second), (SHARD_APPLICATION_ID, 0));
+        assert!(!schema_object_exists(&second, "migrated_widgets"));
     }
 
     #[test]

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -18,6 +18,13 @@ fn insert_catalog_fixture(root: &Path) {
         .execute_batch(
             "PRAGMA foreign_keys = ON;
              BEGIN IMMEDIATE;
+             DROP TABLE briskdb_integrity;
+             DROP TABLE briskdb_metadata;
+             CREATE TABLE briskdb_metadata (
+                 requires_manifest_version INTEGER NOT NULL
+                     CHECK (requires_manifest_version >= 6)
+             ) STRICT;
+             INSERT INTO briskdb_metadata VALUES (6);
              INSERT INTO briskdb_logical_databases (database_id, database_name)
              VALUES (9, 'tenant');
              INSERT INTO briskdb_tables (
@@ -31,6 +38,7 @@ fn insert_catalog_fixture(root: &Path) {
                 (20, 1, 'countries', 2, NULL, NULL),
                 (30, 9, 'accounts', 1, 'tenant_id', 2),
                 (40, 9, 'internal_catalog', 3, NULL, NULL);
+             PRAGMA user_version = 6;
              COMMIT;",
         )
         .unwrap();


### PR DESCRIPTION
## Summary

- introduce manifest schema v7 with a deterministic BLAKE3 semantic root, generation-bound shard schema digests, and explicit Verifying, Ready, Migrating, and terminal Degraded states
- reseal every sanctioned manifest mutation atomically, validate migration prefixes by trusted source/target digests, and resume v6/v7 interrupted upgrades without selecting a new baseline
- fail closed across synchronous, asynchronous, migration, startup, and HTTP paths while preserving redacted protocol-neutral error behavior
- document the storage-format, compatibility, recovery, and operational boundaries and complete the Phase 2 roadmap item

## Tests

- [x] Unit tests were added or updated for behavior-changing code.
- [x] Boundary/integration tests were added where the change crosses SQLite,
      HTTP, protocol, filesystem, or process boundaries.
- [x] A regression test accompanies each bug fix.
- [ ] No automated test is applicable; the explanation is included above.
- [x] `cargo fmt --check` passes.
- [x] `cargo test` passes.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes.

Exact local release gate:

- `cargo fmt --all --check`
- `git diff --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features`
- `cargo test --locked --doc --all-features`
- `cargo +1.85.0 test --locked --all-targets --all-features`
- `cargo +1.85.0 test --locked --doc --all-features`

The library suite contains 355 passing tests, including deterministic golden vectors, manifest mutation coverage, schema drift/corruption cases, cancellation races, migration crash boundaries, file-backed restart recovery, public API behavior, and HTTP redaction.

## Compatibility and operations

- [x] Public behavior and compatibility documentation were updated where needed.
- [x] Storage-format, migration, security, and recovery effects were considered.

The v7 format is downgrade-fenced. Persisted Degraded is terminal and requires restoring a complete, consistent known-good database set. Emergency marker persistence remains best effort when storage is locked, read-only, full, unavailable, or the process fails; the live gate still fails closed.

Closes #18