### PR TITLE
Add dialect-explicit SQL parser facade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c269894b6fe5e9d7ada0cf69b5bf847ff35bc25fc271f08e1d080fce80339a"
+dependencies = [
+ "object",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,9 +189,11 @@ dependencies = [
  "criterion",
  "hyper",
  "hyper-util",
+ "psm",
  "rusqlite",
  "serde",
  "serde_json",
+ "sqlparser",
  "tempfile",
  "tokio",
  "tower",
@@ -695,6 +706,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -763,6 +783,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d11f2fedc3b7dafdc2851bc52f277377c5473d378859be234bc7ebb593144d01"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,6 +806,26 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "recursive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0786a43debb760f491b1bc0269fe5e84155353c67482b9e60d0cfb596054b43e"
+dependencies = [
+ "recursive-proc-macro-impl",
+ "stacker",
+]
+
+[[package]]
+name = "recursive-proc-macro-impl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1003,6 +1053,28 @@ dependencies = [
  "js-sys",
  "rsqlite-vfs",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "sqlparser"
+version = "0.62.0"
+source = "git+https://github.com/apache/datafusion-sqlparser-rs?rev=33521a534eae72188e06ce0ce4836d19c7f3458a#33521a534eae72188e06ce0ce4836d19c7f3458a"
+dependencies = [
+ "log",
+ "recursive",
+]
+
+[[package]]
+name = "stacker"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707f49d46706bacf8a2b00d51dace3f9de527c13eec3778f570c411f89e69967"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ rust-version = "1.85"
 description = "A small, fast, sharded SQLite server"
 license = "MIT"
 repository = "https://github.com/schapman1974/briskdb"
+# Cargo packaging removes Git source pins from dependencies. Keep registry
+# publishing disabled while the exact post-0.62 parser snapshot is required.
+publish = false
 
 [dependencies]
 anyhow = "1.0"
@@ -17,6 +20,14 @@ hyper-util = { version = "0.1.20", features = ["service", "tokio"] }
 rusqlite = { version = "0.39.0", features = ["bundled", "hooks"] }
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0"
+# The exact upstream revision contains the post-0.62.0 `parse_interval`
+# recursion fix. This must remain a direct source pin so downstream BriskDB
+# consumers inherit it; a root-only `[patch]` would not propagate.
+sqlparser = { version = "=0.62.0", git = "https://github.com/apache/datafusion-sqlparser-rs", rev = "33521a534eae72188e06ce0ce4836d19c7f3458a", default-features = false, features = ["std", "recursive-protection"] }
+# `recursive` admits newer `psm` releases whose build dependencies require
+# Rust 1.88. The direct exact constraint preserves BriskDB's Rust 1.85 MSRV for
+# both this repository and downstream consumers until that graph is corrected.
+psm = "=0.1.28"
 tokio = { version = "1.53.1", features = ["full"] }
 tower = { version = "0.5", features = ["util"] }
 tracing = "0.1"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ boundaries and dependency direction.
 
 The [SQL compatibility contract](docs/SQL_COMPATIBILITY.md) distinguishes the
 current SQLite pass-through API from planned PostgreSQL and MySQL compatibility.
+The [SQL parser decision record](docs/SQL_PARSER.md) defines the shared,
+dialect-explicit syntax boundary and its resource and dependency limits.
 The [error contract](docs/ERRORS.md) defines stable engine error kinds, safe
 HTTP problem details, and the mappings reserved for future PostgreSQL and MySQL
 adapters.
@@ -40,6 +42,8 @@ minimum supported Rust version (MSRV) and the latest stable toolchain.
 - Finite per-query row/logical-byte budgets with no partial results
 - Explicit graceful drain, forced cancellation, and blocking handle cleanup
 - Protocol-neutral typed values, ordered columns, positional rows, and results
+- A bounded SQL AST parser for explicit SQLite, PostgreSQL, and MySQL dialects,
+  isolated from the current raw SQLite HTTP execution path
 - A transactionally versioned `manifest.sqlite` with durable 4,096-bucket
   routing plus logical-database and table metadata
 - Identity-bound, WAL-enabled SQLite shard files that are never silently

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -200,7 +200,7 @@ interrupted schema migration can be diagnosed and resumed.
 
 ### 3. SQL frontend and query planner
 
-- [ ] Parse SQL into an AST using a maintained parser after a focused parser
+- [x] Parse SQL into an AST using a maintained parser after a focused parser
   spike; do not route by regular expression.
 - [ ] Define the first common SQL subset: `CREATE TABLE`, indexes, `SELECT`,
   `INSERT`, `UPDATE`, `DELETE`, `BEGIN`, `COMMIT`, and `ROLLBACK`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,7 +23,7 @@ server ---------> protocol::http
 | --- | --- | --- |
 | `core` | Protocol-neutral `Engine`, `Session`, statements, values, results, errors, and read-only logical catalog; stable key routing; bounded per-shard admission and connection pools; routed execute/query and journaled schema migration | JSON/HTTP types, listeners, or Axum handlers |
 | `storage` | Versioned routing/logical manifest, shard layout, migration journal and recovery, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
-| `sql` | SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, routing, filesystem layout, or protocol responses |
+| `sql` | Dialect-explicit SQL syntax parsing behind BriskDB-owned opaque types; exact source retention; SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, routing, filesystem layout, protocol responses, or independent support policy |
 | `protocol::http` | HTTP request extraction plus JSON/BriskDB value and RFC 9457 problem-detail encoding | BLAKE3 routing, shard files, or rusqlite calls |
 | `protocol::error` | Exhaustive HTTP, PostgreSQL, and MySQL mappings from stable engine error kinds | SQLite errors, routing decisions, or wire-protocol session state |
 | `server` | Process configuration, database assembly, listener binding, and tracked Axum HTTP/1 connection lifecycle | SQL parsing or storage implementation details |
@@ -80,6 +80,33 @@ request controls, and explicit shutdown lifecycle are now in place. The
 synchronous `Database` API remains available as a Rust compatibility surface;
 existing engine and server entry points retain their signatures and delegate to
 the controlled defaults.
+
+## SQL parser boundary
+
+The SQL module owns a single parser entry point with explicit SQLite,
+PostgreSQL, and MySQL dialect selection. It retains exact source text and wraps
+the selected parser's ordered AST without exposing dependency-owned AST types
+to protocols or the engine's public request model. There is no generic dialect,
+autodetection, or fallback parse. This makes a frontend's dialect choice
+deterministic and keeps the dependency replaceable.
+
+Parsing is syntax recognition, not support validation or planning. The parser
+has no session, parameter, catalog, storage, or routing access. The later common
+subset, normalization, and planner layers will consume structural syntax
+through BriskDB-owned interfaces; shard-key inference must not inspect raw or
+formatted SQL with regular expressions. Exact input remains authoritative
+because AST formatting is lossy and is never executed.
+
+Inputs are bounded to 65,536 UTF-8 bytes, 256 statements, and recursion depth
+32. The dependency's recursive-protection feature remains enabled. Parse and
+limit failures use protocol-neutral engine error kinds, whose diagnostics stay
+internal. The full dependency, error, testing, and non-goal contract is in the
+[SQL parser decision record](SQL_PARSER.md).
+
+The current HTTP execute/query and migration paths deliberately remain raw
+SQLite pass-through. Connecting this parser to execution would define
+common-subset and strict-mode behavior owned by later roadmap issues, so issue
+#19 changes no HTTP shape, SQL acceptance, routing, or storage behavior.
 
 ## Manifest storage boundary
 

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -130,6 +130,13 @@ human-readable message to distinguish error kinds. Constraint subtypes use
 extended result codes; an unrecognized constraint remains
 `ConstraintViolation` rather than being guessed from text.
 
+The SQL parser facade classifies tokenization and syntax failures as
+`InvalidQuery`. Exceeding its configured SQL-input, statement-count, or
+recursion limit is `LimitExceeded`. The upstream parser message, source
+location, and submitted SQL remain trusted diagnostics only. Protocol adapters
+serialize the fixed mapping for the BriskDB error kind and never expose those
+diagnostics to a client.
+
 The core contains no HTTP, PostgreSQL, or MySQL response types. Conversely,
 protocol adapters do not inspect SQLite errors. This lets every frontend share
 one error identity while retaining its own response encoding.

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -16,10 +16,11 @@ document defines the SQL and behavioral contract separately from connectivity.
 - **Unsupported** means BriskDB rejects the behavior or makes no compatibility
   promise for it.
 
-The stable parser and protocol adapters will fail explicitly for unsupported
+The syntax parser is now available behind a BriskDB-owned boundary. Later
+subset validation and protocol adapters will fail explicitly for unsupported
 syntax and must not silently reinterpret a statement with materially different
-semantics. The current experimental HTTP interface is a raw SQLite pass-through
-and can still execute uncontracted SQLite syntax; that behavior is not a
+semantics. The current experimental HTTP interface is still a raw SQLite
+pass-through and can execute uncontracted SQLite syntax; that behavior is not a
 compatibility promise.
 
 ## Compatibility layers
@@ -40,8 +41,11 @@ than claiming to be a drop-in PostgreSQL or MySQL replacement.
 ## Current implementation
 
 Only the experimental HTTP interface is implemented today. There is no
-PostgreSQL or MySQL listener yet, and there is no SQL parser or dialect
-translation layer. HTTP requests send SQLite SQL directly to `rusqlite`.
+PostgreSQL or MySQL listener or dialect translation layer yet. A bounded syntax
+parser can produce an opaque AST for an explicitly selected SQLite,
+PostgreSQL, or MySQL dialect, but it does not validate the supported subset,
+plan, route, or execute a statement. HTTP requests still send SQLite SQL
+directly to `rusqlite`; they do not pass through the parser.
 
 | Interface | Status | SQL accepted | Routing |
 | --- | --- | --- | --- |
@@ -240,6 +244,29 @@ They do not make either wire-protocol listener available. See the complete
 
 ## SQL surface
 
+### Implemented syntax boundary
+
+BriskDB uses an exact post-0.62 upstream `sqlparser` snapshot behind its own
+dialect and parsed-batch types. The pinned snapshot contains corrected
+`parse_interval` recursion accounting plus other reviewed upstream changes
+after the `v0.62.0` tag. Callers select SQLite, PostgreSQL, or MySQL explicitly;
+generic parsing, dialect autodetection, and fallback parsing are not available.
+Exact SQL is retained because formatting an AST is not source preserving and
+formatted AST text is never sent to SQLite.
+
+Parsing establishes only that one dialect recognizes the syntax. It does not
+make a statement part of BriskDB's supported common subset or establish that
+its behavior matches SQLite. Inputs are bounded to 65,536 UTF-8 bytes, 256
+statements, and recursion depth 32. The parser can represent an ordered batch,
+but the current execution surfaces retain their existing endpoint-specific
+single-statement and migration rules; later classification will decide which
+multi-statement combinations are safe.
+
+The parser has no routing or storage access. Future shard inference and
+statement classification consume structural syntax, never regular-expression
+matches over raw or formatted SQL. See the [SQL parser decision
+record](SQL_PARSER.md) for the dependency, error, MSRV, and non-goal contract.
+
 ### Implemented pass-through surface
 
 The following operations work when expressed in syntax accepted by the bundled
@@ -282,9 +309,11 @@ The first driver-capable SQL subset will include:
 - `BEGIN`, `COMMIT`, and `ROLLBACK` for transactions pinned to one shard; and
 - protocol-neutral prepare, bind, describe, execute, and close operations.
 
-The parser and planner will classify statements before execution. Writes with
-no provable shard, writes with conflicting shard keys, unsafe multi-statement
-requests, and cross-shard transactions will be rejected before changing data.
+The implemented parser supplies structured syntax without deciding support or
+routing. Later subset validation and planning will classify statements before
+execution. Writes with no provable shard, writes with conflicting shard keys,
+unsafe multi-statement requests, and cross-shard transactions will be rejected
+before changing data.
 
 ## PostgreSQL differences
 

--- a/docs/SQL_PARSER.md
+++ b/docs/SQL_PARSER.md
@@ -1,0 +1,159 @@
+# SQL parser decision record
+
+Status: accepted for roadmap issue #19
+
+BriskDB needs one syntax boundary that PostgreSQL, MySQL, HTTP, and future
+frontends can share without making a protocol adapter understand SQLite or
+invent its own routing rules. This record selects the parser dependency and
+defines that boundary. It does not define the supported BriskDB SQL subset or
+put the parser in the current HTTP execution path.
+
+## Decision
+
+BriskDB uses the `sqlparser` package at version `0.62.0` from the exact
+post-release upstream snapshot
+[`33521a534eae72188e06ce0ce4836d19c7f3458a`](https://github.com/apache/datafusion-sqlparser-rs/commit/33521a534eae72188e06ce0ce4836d19c7f3458a).
+That commit contains the required recursion-accounting correction as well as
+other upstream work after the `v0.62.0` tag; BriskDB reviews and tests the pinned
+snapshot as a whole rather than describing it as a one-change patch. The spike
+selected the library because it is maintained, written in Rust, produces a
+structured AST, and provides explicit SQLite, PostgreSQL, and MySQL dialect
+implementations. The dependency is Apache-2.0 licensed; BriskDB continues to
+use its own types and entry point so a later parser replacement does not require
+protocol or engine APIs to expose `sqlparser` types.
+
+Callers must select exactly one BriskDB dialect:
+
+- SQLite
+- PostgreSQL
+- MySQL
+
+There is no generic production dialect, dialect autodetection, or retry under a
+different dialect after a parse error. Those behaviors can accept an ambiguous
+statement differently depending on fallback order and would make protocol
+behavior hard to reproduce. A PostgreSQL adapter will select PostgreSQL, a
+MySQL adapter will select MySQL, and a strict SQLite surface will select
+SQLite.
+
+The SQL module retains the exact input text alongside an ordered parsed batch.
+The upstream AST stays opaque outside BriskDB's SQL boundary. Later validators,
+normalizers, and planners can inspect it through BriskDB-owned interfaces, but
+protocol adapters must not depend on `sqlparser` AST types.
+
+`sqlparser`'s formatter is not a source-preserving serializer: it can normalize
+comments, whitespace, quoting, and keyword presentation. BriskDB therefore
+never executes an AST's `Display` output and does not use that output as a
+migration identity. Execution and byte-identity operations retain their exact
+original SQL unless a later, documented translation produces separate SQL.
+
+## Syntax-only contract
+
+Successful parsing means only that the selected parser dialect recognizes the
+input as syntax. It does not mean that BriskDB supports the statement, that the
+statement has valid catalog references or types, that it can be routed, or that
+executing it on SQLite would preserve the source dialect's semantics.
+
+In particular, this layer does not:
+
+- define or enforce the common SQL subset (issue #20);
+- normalize placeholders (issue #21);
+- infer shard keys or inspect bound values (issue #22);
+- plan prepared statements at bind time (issue #23);
+- reject conflicting keys or unroutable writes (issue #24);
+- translate types or syntax, or choose strict SQLite mode (issue #25);
+- implement prepare/bind/describe/execute state or caches (issue #26); or
+- classify statement behavior or reject unsafe multi-statement combinations
+  (issue #27).
+
+The parser may return several statements in source order. The 256-statement
+limit below is a resource bound, not permission to execute a batch. Whether a
+particular surface accepts one statement or a safe combination remains issue
+#27. Likewise, later subset validation must return an explicit unsupported
+error instead of treating parser acceptance as product support.
+
+The existing HTTP execute, query, and migration paths remain raw SQLite
+pass-through surfaces with their existing authorizer and endpoint-specific
+rules. They do not call this parser yet. Gating them now would silently replace
+SQLite's accepted syntax with `sqlparser`'s coverage before strict-mode and
+common-subset policy is defined.
+
+## Resource and error boundaries
+
+Parsing untrusted text is bounded before it can become planner or execution
+work:
+
+| Limit | Value | Classification |
+| --- | ---: | --- |
+| SQL input size | 65,536 UTF-8 bytes | `LimitExceeded` |
+| Statements in one parsed batch | 256 | `LimitExceeded` |
+| Parser recursion depth | 32 | `LimitExceeded` |
+
+Empty, whitespace-only, and comment-only input successfully produces an empty
+AST; whether a later request surface permits that is classification policy for
+issue #27. NUL input, malformed tokens, incomplete syntax, and other parse
+failures are `InvalidQuery`. A syntactically valid statement that is outside
+BriskDB's eventual common subset is not a parse failure; subset validation will
+classify it later. Public protocol errors continue to use the fixed safe text
+for the error kind and must not serialize SQL text, parser diagnostics, source
+locations, or internal error chains.
+
+The parser is stateless and has no catalog, storage, session, parameters,
+filesystem, or routing access. Routing will consume structural AST information
+through the later BriskDB planner. It must never search SQL text or formatted
+AST text with regular expressions to infer a key or statement behavior.
+
+## Dependency and MSRV policy
+
+The registry `sqlparser` 0.62.0 source omits recursion accounting in
+`parse_interval`: that path can recurse without consuming the configured
+recursion budget. `Cargo.toml` therefore declares the exact upstream Git source
+and revision containing the correction. The registry tag by itself is not the
+selected or reviewed source. The direct source pin can be replaced only when
+BriskDB deliberately upgrades to a release containing the correction and its
+regression suite passes unchanged.
+
+Git and path consumers inherit that direct source revision. Cargo normalizes a
+Git dependency to its registry version when packaging a crate for crates.io, so
+BriskDB sets `publish = false` while this temporary source pin is required. Do
+not enable crates.io publishing until a registry release containing the
+correction is selected, or an equivalently reviewed published dependency is
+available.
+
+BriskDB enables `sqlparser`'s recursive-protection support in addition to
+setting the explicit depth limit. In the dependency graph selected by the
+spike, the newest `psm` release admitted by `stacker` pulls in build
+dependencies that require Rust 1.88. BriskDB supports Rust 1.85, so both
+`Cargo.toml` and `Cargo.lock` constrain `psm` to `0.1.28`, whose dependency
+graph builds on the declared MSRV. The direct constraint makes this behavior
+carry into Git and path consumers instead of depending only on BriskDB's root
+lockfile.
+
+This compatibility constraint is intentional, not cleanup noise. Parser or
+lockfile updates must run the complete locked test and documentation suite on
+Rust 1.85 as well as stable, and must not raise the MSRV accidentally. Removing
+recursive protection requires a separate parser-design review with deep-nesting
+regression tests; merely retaining a numeric depth option is not sufficient
+justification.
+
+## Verification obligations
+
+The parser boundary is covered independently of execution. Its unit tests must
+include representative SQLite, PostgreSQL, and MySQL constructs; dialect-only
+quoting and placeholders; strings and comments containing keywords or
+semicolons; ordered multi-statement input; malformed and incomplete syntax;
+and every exact resource boundary. Deeply nested and arbitrary valid UTF-8
+input must return a classified result without panic, abort, or stack overflow.
+The nested-`INTERVAL` regression that exercises the upstream 0.62.0 hole runs
+in a subprocess so a future stack overflow or abort is observed as a failed
+test instead of terminating the test harness. The child must exit normally
+with the configured recursion-limit error.
+
+Structural tests must assert AST meaning for tricky statements rather than
+matching SQL substrings. Source review and dependency review must also confirm
+that BriskDB has no regular-expression parser or routing helper. A transitive
+regular-expression crate elsewhere in `Cargo.lock` is not evidence of SQL
+routing; the architectural proof is that this layer returns structured syntax
+and makes no routing decision.
+
+This decision changes no HTTP request or response shape, routing result,
+configuration, manifest schema, shard file, or stored data.

--- a/src/protocol/http.rs
+++ b/src/protocol/http.rs
@@ -266,7 +266,10 @@ mod tests {
     use tower::ServiceExt;
 
     use super::*;
-    use crate::core::{Column, DataType, EngineErrorKind, EngineOptions, ResultLimits, Row};
+    use crate::{
+        core::{Column, DataType, EngineErrorKind, EngineOptions, ResultLimits, Row},
+        sql::MAX_PARSED_SQL_BYTES,
+    };
 
     fn engine_router(database: Arc<Database>) -> Router {
         router_with_engine(Engine::from_database(database))
@@ -462,6 +465,38 @@ mod tests {
             json!([{"name": "answer", "data_type": "unknown"}])
         );
         assert_eq!(body["rows"], json!([[42]]));
+    }
+
+    #[tokio::test]
+    async fn current_http_sql_remains_raw_sqlite_pass_through_until_planner_integration() {
+        let temp = tempfile::tempdir().unwrap();
+        let database = Arc::new(Database::open(temp.path(), 2).unwrap());
+        let expected_shard = database.shard_for_key(b"raw-http-parser-boundary");
+        let application = engine_router(database);
+        let mut raw_sql = "SELECT 7 AS value".to_owned();
+        raw_sql.push_str(&" ".repeat(MAX_PARSED_SQL_BYTES));
+        assert!(raw_sql.len() > MAX_PARSED_SQL_BYTES);
+
+        assert_eq!(
+            request_json(
+                &application,
+                Method::POST,
+                "/v1/query",
+                Some(json!({
+                    "shard_key": "raw-http-parser-boundary",
+                    "sql": raw_sql
+                })),
+            )
+            .await,
+            (
+                StatusCode::OK,
+                json!({
+                    "shard": expected_shard,
+                    "columns": [{"name": "value", "data_type": "unknown"}],
+                    "rows": [[7]]
+                })
+            )
+        );
     }
 
     #[tokio::test]

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -1,7 +1,15 @@
-//! SQLite SQL execution and value conversion.
+//! Protocol-neutral SQL parsing, SQLite execution, and value conversion.
 //!
-//! SQL remains deliberate SQLite pass-through during this phase. Parsing and
-//! dialect normalization are later roadmap work.
+//! The parser facade produces a bounded, dialect-explicit opaque AST for later
+//! planning work. Current execution remains deliberate SQLite pass-through;
+//! parsing does not yet gate, rewrite, classify, route, or execute statements.
+
+mod parser;
+
+pub use parser::{
+    MAX_PARSED_SQL_BYTES, MAX_PARSED_SQL_STATEMENTS, ParsedSql, SQL_PARSE_RECURSION_LIMIT,
+    SqlDialect, parse,
+};
 
 use rusqlite::{
     Connection, params_from_iter,

--- a/src/sql/parser.rs
+++ b/src/sql/parser.rs
@@ -1,0 +1,526 @@
+use std::{borrow::Cow, fmt};
+
+use sqlparser::{
+    ast::Statement as AstStatement,
+    dialect::{Dialect, MySqlDialect, PostgreSqlDialect, SQLiteDialect},
+    parser::{Parser, ParserError},
+};
+
+use crate::core::{EngineError, EngineErrorKind, EngineResult};
+
+/// Maximum byte length accepted by the protocol-neutral parser facade.
+pub const MAX_PARSED_SQL_BYTES: usize = 65_536;
+
+/// Maximum number of AST statements returned from one parser invocation.
+pub const MAX_PARSED_SQL_STATEMENTS: usize = 256;
+
+/// Maximum recursive parser depth for one SQL input.
+pub const SQL_PARSE_RECURSION_LIMIT: usize = 32;
+
+/// The syntax dialect of SQL before any later compatibility normalization.
+///
+/// Callers must select the dialect from trusted connection or API context.
+/// BriskDB never guesses a dialect and never falls back to a permissive union.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SqlDialect {
+    Sqlite,
+    PostgreSql,
+    MySql,
+}
+
+impl SqlDialect {
+    /// Every source dialect currently understood by the parser facade.
+    pub const ALL: &'static [Self] = &[Self::Sqlite, Self::PostgreSql, Self::MySql];
+
+    /// Return the stable display name used in trusted diagnostics.
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Sqlite => "SQLite",
+            Self::PostgreSql => "PostgreSQL",
+            Self::MySql => "MySQL",
+        }
+    }
+}
+
+impl fmt::Display for SqlDialect {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.name())
+    }
+}
+
+/// Byte-exact SQL source together with its ordered, opaque parsed AST.
+///
+/// The AST deliberately remains an implementation detail until the common SQL
+/// subset and planner consume it. Rendering an AST can remove comments and
+/// normalize spelling or whitespace, so [`ParsedSql::source`] is the only SQL
+/// text that later execution may treat as the caller's original input.
+#[derive(Clone, PartialEq, Eq)]
+pub struct ParsedSql {
+    dialect: SqlDialect,
+    source: String,
+    statements: Vec<AstStatement>,
+}
+
+impl ParsedSql {
+    /// Return the explicitly selected source dialect.
+    pub const fn dialect(&self) -> SqlDialect {
+        self.dialect
+    }
+
+    /// Return the caller's byte-exact SQL source.
+    pub fn source(&self) -> &str {
+        &self.source
+    }
+
+    /// Return the number of ordered top-level statements in the opaque AST.
+    pub fn statement_count(&self) -> usize {
+        self.statements.len()
+    }
+
+    /// Return whether the input contained no statements, such as whitespace or
+    /// comments only.
+    pub fn is_empty(&self) -> bool {
+        self.statements.is_empty()
+    }
+}
+
+impl fmt::Debug for ParsedSql {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ParsedSql")
+            .field("dialect", &self.dialect)
+            .field("source_bytes", &self.source.len())
+            .field("statement_count", &self.statements.len())
+            .finish()
+    }
+}
+
+/// Parse SQL with an explicit source dialect into an ordered, opaque AST.
+///
+/// This is a syntax operation only. A successful parse does not mean that the
+/// statement belongs to BriskDB's supported subset, is semantically valid, is
+/// authorized, has a routing plan, or can execute on SQLite.
+pub fn parse<'a>(dialect: SqlDialect, source: impl Into<Cow<'a, str>>) -> EngineResult<ParsedSql> {
+    let source = source.into();
+    if source.len() > MAX_PARSED_SQL_BYTES {
+        return Err(EngineError::new(
+            EngineErrorKind::LimitExceeded,
+            format!("SQL text exceeds the {MAX_PARSED_SQL_BYTES}-byte parser limit"),
+        ));
+    }
+    if source.as_bytes().contains(&0) {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidQuery,
+            "SQL text contains a NUL byte",
+        ));
+    }
+
+    let statements = match dialect {
+        SqlDialect::Sqlite => parse_with(&SQLiteDialect {}, &source),
+        SqlDialect::PostgreSql => parse_with(&PostgreSqlDialect {}, &source),
+        SqlDialect::MySql => parse_with(&MySqlDialect {}, &source),
+    }
+    .map_err(|error| classify_parser_error(dialect, error))?;
+
+    if statements.len() > MAX_PARSED_SQL_STATEMENTS {
+        return Err(EngineError::new(
+            EngineErrorKind::LimitExceeded,
+            format!("SQL text exceeds the {MAX_PARSED_SQL_STATEMENTS}-statement parser limit"),
+        ));
+    }
+
+    Ok(ParsedSql {
+        dialect,
+        source: source.into_owned(),
+        statements,
+    })
+}
+
+fn parse_with(dialect: &dyn Dialect, source: &str) -> Result<Vec<AstStatement>, ParserError> {
+    let mut parser = Parser::new(dialect)
+        .with_recursion_limit(SQL_PARSE_RECURSION_LIMIT)
+        .try_with_sql(source)?;
+    parser.parse_statements()
+}
+
+fn classify_parser_error(dialect: SqlDialect, error: ParserError) -> EngineError {
+    match error {
+        ParserError::RecursionLimitExceeded => EngineError::from_source(
+            EngineErrorKind::LimitExceeded,
+            format!(
+                "{dialect} SQL exceeds the parser recursion limit of {SQL_PARSE_RECURSION_LIMIT}"
+            ),
+            error,
+        ),
+        ParserError::TokenizerError(_) | ParserError::ParserError(_) => EngineError::from_source(
+            EngineErrorKind::InvalidQuery,
+            format!("SQL is not valid {dialect} syntax"),
+            error,
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        error::Error,
+        process::{Command, Stdio},
+        thread,
+        time::{Duration, Instant},
+    };
+
+    use sqlparser::ast::{Expr, SelectItem, SetExpr, Statement, Value};
+
+    use super::*;
+
+    const INTERVAL_RECURSION_CHILD: &str = "BRISKDB_INTERVAL_RECURSION_CHILD";
+
+    fn first_projection_expression(parsed: &ParsedSql) -> &Expr {
+        let Statement::Query(query) = &parsed.statements[0] else {
+            panic!("expected a query AST")
+        };
+        let SetExpr::Select(select) = query.body.as_ref() else {
+            panic!("expected a SELECT AST")
+        };
+        let SelectItem::UnnamedExpr(expression) = &select.projection[0] else {
+            panic!("expected an unnamed projection expression")
+        };
+        expression
+    }
+
+    fn assert_placeholder(parsed: &ParsedSql, expected: &str) {
+        let Expr::Value(value) = first_projection_expression(parsed) else {
+            panic!("expected a placeholder value")
+        };
+        assert_eq!(value.value, Value::Placeholder(expected.to_owned()));
+    }
+
+    #[test]
+    fn dialect_names_and_iteration_are_stable() {
+        assert_eq!(
+            SqlDialect::ALL,
+            &[
+                SqlDialect::Sqlite,
+                SqlDialect::PostgreSql,
+                SqlDialect::MySql
+            ]
+        );
+        assert_eq!(SqlDialect::Sqlite.name(), "SQLite");
+        assert_eq!(SqlDialect::PostgreSql.name(), "PostgreSQL");
+        assert_eq!(SqlDialect::MySql.name(), "MySQL");
+        assert_eq!(SqlDialect::MySql.to_string(), "MySQL");
+    }
+
+    #[test]
+    fn common_sql_has_the_same_ast_in_every_source_dialect() {
+        let source = "SELECT tenant_id FROM widgets WHERE tenant_id = 7";
+        let parsed = SqlDialect::ALL
+            .iter()
+            .copied()
+            .map(|dialect| parse(dialect, source).unwrap())
+            .collect::<Vec<_>>();
+
+        assert_eq!(parsed[0].statements, parsed[1].statements);
+        assert_eq!(parsed[1].statements, parsed[2].statements);
+        assert!(parsed.iter().all(|batch| batch.source() == source));
+    }
+
+    #[test]
+    fn explicit_dialects_preserve_placeholder_and_quote_semantics_without_fallback() {
+        let sqlite = parse(SqlDialect::Sqlite, "SELECT ?1").unwrap();
+        assert_placeholder(&sqlite, "?1");
+        let postgres = parse(SqlDialect::PostgreSql, "SELECT $1").unwrap();
+        assert_placeholder(&postgres, "$1");
+        let mysql = parse(SqlDialect::MySql, "SELECT ?").unwrap();
+        assert_placeholder(&mysql, "?");
+
+        assert_eq!(
+            parse(SqlDialect::PostgreSql, "SELECT ?")
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::InvalidQuery
+        );
+        assert!(matches!(
+            first_projection_expression(&parse(SqlDialect::MySql, "SELECT $1").unwrap()),
+            Expr::Identifier(identifier) if identifier.value == "$1"
+        ));
+        assert!(matches!(
+            first_projection_expression(
+                &parse(SqlDialect::PostgreSql, "SELECT \"mixedCase\"").unwrap()
+            ),
+            Expr::Identifier(identifier) if identifier.value == "mixedCase"
+        ));
+        assert!(matches!(
+            first_projection_expression(
+                &parse(SqlDialect::MySql, "SELECT \"mixedCase\"").unwrap()
+            ),
+            Expr::Value(value) if value.value == Value::DoubleQuotedString("mixedCase".to_owned())
+        ));
+        assert!(matches!(
+            first_projection_expression(
+                &parse(SqlDialect::MySql, "SELECT `backtick_name`").unwrap()
+            ),
+            Expr::Identifier(identifier) if identifier.value == "backtick_name"
+        ));
+        assert!(matches!(
+            first_projection_expression(
+                &parse(SqlDialect::Sqlite, "SELECT [bracket_name]").unwrap()
+            ),
+            Expr::Identifier(identifier) if identifier.value == "bracket_name"
+        ));
+        assert_eq!(
+            parse(SqlDialect::PostgreSql, "SELECT `backtick_name`")
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::InvalidQuery
+        );
+
+        assert!(parse(SqlDialect::Sqlite, "CREATE TABLE untyped(value)").is_ok());
+        assert_eq!(
+            parse(SqlDialect::PostgreSql, "CREATE TABLE untyped(value)")
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::InvalidQuery
+        );
+    }
+
+    #[test]
+    fn representative_phase_three_shapes_parse_without_defining_support() {
+        let cases = [
+            "CREATE TABLE widgets(id INTEGER PRIMARY KEY, tenant_id INTEGER)",
+            "CREATE INDEX widgets_tenant ON widgets(tenant_id)",
+            "SELECT id FROM widgets WHERE tenant_id = 1",
+            "INSERT INTO widgets(id, tenant_id) VALUES (1, 1)",
+            "UPDATE widgets SET tenant_id = 2 WHERE id = 1",
+            "DELETE FROM widgets WHERE id = 1",
+            "BEGIN",
+            "COMMIT",
+            "ROLLBACK",
+        ];
+
+        for dialect in SqlDialect::ALL.iter().copied() {
+            for source in cases {
+                let parsed = parse(dialect, source)
+                    .unwrap_or_else(|error| panic!("{dialect} rejected {source}: {error}"));
+                assert_eq!(parsed.statement_count(), 1, "{dialect}: {source}");
+            }
+        }
+    }
+
+    #[test]
+    fn ordered_batches_do_not_split_semicolons_inside_literals_or_comments() {
+        let source = "/* lead ; */ SELECT ';' AS marker; -- middle ;\nSELECT 2";
+        let parsed = parse(SqlDialect::PostgreSql, source).unwrap();
+
+        assert_eq!(parsed.source(), source);
+        assert_eq!(parsed.dialect(), SqlDialect::PostgreSql);
+        assert_eq!(parsed.statement_count(), 2);
+        assert!(!parsed.is_empty());
+        assert!(
+            parsed
+                .statements
+                .iter()
+                .all(|statement| matches!(statement, Statement::Query(_)))
+        );
+    }
+
+    #[test]
+    fn whitespace_and_comments_produce_an_empty_ast_without_policy_classification() {
+        for source in ["", "   \n\t", "  -- no statement ;\n /* still none */ "] {
+            let parsed = parse(SqlDialect::Sqlite, source).unwrap();
+
+            assert!(parsed.is_empty());
+            assert_eq!(parsed.statement_count(), 0);
+            assert_eq!(parsed.source(), source);
+        }
+    }
+
+    #[test]
+    fn parser_is_syntax_only_and_does_not_define_semantic_support() {
+        let parsed = parse(
+            SqlDialect::PostgreSql,
+            "CREATE TABLE duplicated(id INTEGER, id INTEGER)",
+        )
+        .unwrap();
+        assert_eq!(parsed.statement_count(), 1);
+    }
+
+    #[test]
+    fn source_is_byte_exact_while_debug_output_is_bounded_and_redacted() {
+        let source = "select /* private comment */ 'sensitive literal'";
+        let parsed = parse(SqlDialect::Sqlite, source).unwrap();
+        let debug = format!("{parsed:?}");
+
+        assert_eq!(parsed.source(), source);
+        assert!(debug.contains("source_bytes"));
+        assert!(debug.contains("statement_count"));
+        assert!(!debug.contains("private comment"));
+        assert!(!debug.contains("sensitive literal"));
+        assert_eq!(parsed.clone(), parsed);
+    }
+
+    #[test]
+    fn valid_unicode_corpus_is_owned_and_parsed_without_panicking() {
+        let sources = [
+            "SELECT '雪だるま ☃'",
+            "SELECT 'مرحبا بالعالم'",
+            "SELECT '👩‍💻; not a separator'",
+            "-- Ελληνικό σχόλιο ;\nSELECT 'naïve café'",
+        ];
+
+        for dialect in SqlDialect::ALL.iter().copied() {
+            for source in sources {
+                let outcome = std::panic::catch_unwind(|| parse(dialect, source));
+                let parsed = outcome
+                    .unwrap_or_else(|_| panic!("{dialect} panicked for valid UTF-8 input"))
+                    .unwrap_or_else(|error| panic!("{dialect} rejected the UTF-8 corpus: {error}"));
+                assert_eq!(parsed.source().as_bytes(), source.as_bytes());
+                assert_eq!(parsed.statement_count(), 1);
+            }
+        }
+    }
+
+    #[test]
+    fn byte_and_statement_limits_are_exact() {
+        let mut exact = "SELECT 1".to_owned();
+        exact.push_str(&" ".repeat(MAX_PARSED_SQL_BYTES - exact.len()));
+        let parsed = parse(SqlDialect::Sqlite, exact.clone()).unwrap();
+        assert_eq!(parsed.source().len(), MAX_PARSED_SQL_BYTES);
+
+        exact.push(' ');
+        let too_long = parse(SqlDialect::Sqlite, exact).unwrap_err();
+        assert_eq!(too_long.kind(), EngineErrorKind::LimitExceeded);
+
+        let exact_batch = (0..MAX_PARSED_SQL_STATEMENTS)
+            .map(|_| "SELECT 1")
+            .collect::<Vec<_>>()
+            .join(";");
+        assert_eq!(
+            parse(SqlDialect::Sqlite, exact_batch)
+                .unwrap()
+                .statement_count(),
+            MAX_PARSED_SQL_STATEMENTS
+        );
+
+        let too_many = (0..=MAX_PARSED_SQL_STATEMENTS)
+            .map(|_| "SELECT 1")
+            .collect::<Vec<_>>()
+            .join(";");
+        let error = parse(SqlDialect::Sqlite, too_many).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+    }
+
+    #[test]
+    fn nul_and_malformed_sql_are_invalid_queries_with_fixed_diagnostics() {
+        let nul = parse(SqlDialect::Sqlite, "SELECT\0private").unwrap_err();
+        assert_eq!(nul.kind(), EngineErrorKind::InvalidQuery);
+        assert_eq!(nul.diagnostic(), "SQL text contains a NUL byte");
+
+        let malformed_source = "SELECT 'sensitive literal' +";
+        let malformed = parse(SqlDialect::PostgreSql, malformed_source).unwrap_err();
+        assert_eq!(malformed.kind(), EngineErrorKind::InvalidQuery);
+        assert_eq!(malformed.diagnostic(), "SQL is not valid PostgreSQL syntax");
+        assert!(!malformed.diagnostic().contains(malformed_source));
+        assert!(malformed.source().is_some());
+    }
+
+    #[test]
+    fn configured_expression_recursion_is_a_limit_error() {
+        let expression = (0..SQL_PARSE_RECURSION_LIMIT + 8)
+            .fold("terminal_value".to_owned(), |nested, index| {
+                format!("value_{index} OR ({nested})")
+            });
+        let source = format!("SELECT * FROM widgets WHERE {expression}");
+        let error = parse(SqlDialect::PostgreSql, source).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+        assert!(
+            error
+                .source()
+                .is_some_and(|source| source.downcast_ref::<ParserError>()
+                    == Some(&ParserError::RecursionLimitExceeded))
+        );
+    }
+
+    #[test]
+    fn deep_interval_recursion_is_rejected_without_aborting_the_process() {
+        if std::env::var_os(INTERVAL_RECURSION_CHILD).is_some() {
+            let source = format!("SELECT {}1", "INTERVAL ".repeat(1_000));
+            let error = parse(SqlDialect::PostgreSql, source).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+            assert!(error.source().is_some_and(|source| {
+                source.downcast_ref::<ParserError>() == Some(&ParserError::RecursionLimitExceeded)
+            }));
+            return;
+        }
+
+        let qualified_name = std::any::type_name_of_val(
+            &deep_interval_recursion_is_rejected_without_aborting_the_process,
+        );
+        let crate_prefix = concat!(env!("CARGO_CRATE_NAME"), "::");
+        let test_name = qualified_name
+            .strip_prefix(crate_prefix)
+            .unwrap_or(qualified_name);
+        let mut child = Command::new(std::env::current_exe().unwrap())
+            .arg("--exact")
+            .arg(test_name)
+            .arg("--nocapture")
+            .env(INTERVAL_RECURSION_CHILD, "1")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            if child.try_wait().unwrap().is_some() {
+                break;
+            }
+            if Instant::now() >= deadline {
+                child.kill().unwrap();
+                let output = child.wait_with_output().unwrap();
+                panic!(
+                    "parser regression child timed out: stdout={} stderr={}",
+                    String::from_utf8_lossy(&output.stdout),
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        let output = child.wait_with_output().unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            output.status.success(),
+            "nested parser child failed: status={} stdout={} stderr={}",
+            output.status,
+            stdout,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            stdout.contains("running 1 test") && stdout.contains(test_name),
+            "parser regression child did not run the exact test: {stdout}"
+        );
+    }
+
+    #[test]
+    fn parsed_sql_is_owned_send_sync_and_parser_state_is_not_shared() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<ParsedSql>();
+
+        let threads = (0..24)
+            .map(|index| {
+                thread::spawn(move || {
+                    let dialect = SqlDialect::ALL[index % SqlDialect::ALL.len()];
+                    let source = format!("SELECT {index}");
+                    parse(dialect, source)
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for (index, handle) in threads.into_iter().enumerate() {
+            let parsed = handle.join().unwrap().unwrap();
+            assert_eq!(parsed.source(), format!("SELECT {index}"));
+            assert_eq!(parsed.statement_count(), 1);
+        }
+    }
+}

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -9,7 +9,7 @@ use axum::Router;
 use briskdb::{
     api, core,
     protocol::{error, http},
-    server, storage,
+    server, sql, storage,
 };
 
 fn insert_catalog_fixture(root: &Path) {
@@ -147,6 +147,48 @@ fn legacy_and_explicit_module_paths_are_both_available() {
         error::mysql_error(core::EngineErrorKind::UniqueViolation).error_number,
         1062
     );
+}
+
+#[test]
+fn protocol_neutral_sql_parser_facade_is_public_bounded_and_opt_in() {
+    fn assert_owned_public<T: Clone + Send + Sync + 'static>() {}
+    assert_owned_public::<sql::ParsedSql>();
+    assert_owned_public::<sql::SqlDialect>();
+
+    let cases = [
+        (sql::SqlDialect::Sqlite, "SELECT ?1"),
+        (sql::SqlDialect::PostgreSql, "SELECT $1"),
+        (sql::SqlDialect::MySql, "SELECT ?"),
+    ];
+    for (dialect, source) in cases {
+        let parsed = sql::parse(dialect, source.to_owned()).unwrap();
+        assert_eq!(parsed.dialect(), dialect);
+        assert_eq!(parsed.source(), source);
+        assert_eq!(parsed.statement_count(), 1);
+        assert!(!parsed.is_empty());
+    }
+
+    let empty = sql::parse(sql::SqlDialect::Sqlite, "-- comment only").unwrap();
+    assert!(empty.is_empty());
+    assert_eq!(empty.statement_count(), 0);
+
+    let invalid = sql::parse(sql::SqlDialect::PostgreSql, "SELECT ?").unwrap_err();
+    assert_eq!(invalid.kind(), core::EngineErrorKind::InvalidQuery);
+
+    let too_long = " ".repeat(sql::MAX_PARSED_SQL_BYTES + 1);
+    let limited = sql::parse(sql::SqlDialect::Sqlite, too_long).unwrap_err();
+    assert_eq!(limited.kind(), core::EngineErrorKind::LimitExceeded);
+    assert_eq!(sql::MAX_PARSED_SQL_STATEMENTS, 256);
+    assert_eq!(sql::SQL_PARSE_RECURSION_LIMIT, 32);
+
+    // The facade is infrastructure for the later common-subset planner. The
+    // existing raw SQLite path deliberately does not invoke it yet.
+    let temp = tempfile::tempdir().unwrap();
+    let database = core::Database::open(temp.path(), 2).unwrap();
+    let mut raw_sql = "SELECT 1".to_owned();
+    raw_sql.push_str(&" ".repeat(sql::MAX_PARSED_SQL_BYTES));
+    let result = database.query("parser-opt-in", &raw_sql, &[]).unwrap();
+    assert_eq!(result.rows()[0].get(0), Some(&core::Value::Int64(1)));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add a protocol-neutral, dialect-explicit SQL parser facade for SQLite, PostgreSQL, and MySQL
- retain byte-exact source SQL while keeping the dependency AST opaque outside the SQL module
- classify syntax and parser-limit failures through existing engine error kinds
- bound parser input bytes, statement count, and recursion depth, with focused unit and subprocess regression coverage
- keep the current HTTP and synchronous SQLite execution paths unchanged until the later subset and planner issues
- document parser selection, dependency/MSRV constraints, compatibility behavior, and later-roadmap boundaries

The parser uses an exact reviewed upstream `sqlparser` snapshot with recursive protection. BriskDB remains non-publishable while that direct source pin is required, and a fresh Rust 1.85 path consumer was verified to inherit the exact parser revision and `psm` compatibility constraint.

## Tests

- [x] Unit tests cover all three dialects, quoting and placeholder differences, common AST structure, batches, malformed input, exact limits, Unicode, ownership, and concurrent parsing.
- [x] HTTP and public-API regression tests prove the parser is public and bounded without changing current raw SQLite execution.
- [x] The deep nested-interval regression runs in an exact child test with a timeout.
- [x] `cargo fmt --all --check`
- [x] `git diff --check`
- [x] `cargo clippy --locked --all-targets --all-features -- -D warnings`
- [x] `cargo test --locked --all-targets --all-features`
- [x] `cargo test --locked --doc --all-features`
- [x] `cargo +1.85.0 test --locked --all-targets --all-features`
- [x] `cargo +1.85.0 test --locked --doc --all-features`
- [x] fresh downstream path-consumer `cargo +1.85.0 check`

## Compatibility and operations

- No HTTP request/response, routing, configuration, manifest, shard-file, or stored-data format changes.
- No regex-based SQL classification or routing was introduced.
- Public compatibility and parser decision documentation are updated.

Closes #19
