### PR TITLE
Define the first common SQL subset

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The [SQL compatibility contract](docs/SQL_COMPATIBILITY.md) distinguishes the
 current SQLite pass-through API from planned PostgreSQL and MySQL compatibility.
 The [SQL parser decision record](docs/SQL_PARSER.md) defines the shared,
 dialect-explicit syntax boundary and its resource and dependency limits.
+The [common SQL subset contract](docs/SQL_SUBSET.md) defines the opt-in,
+protocol-neutral structural validator and its exact accepted statement forms.
 The [error contract](docs/ERRORS.md) defines stable engine error kinds, safe
 HTTP problem details, and the mappings reserved for future PostgreSQL and MySQL
 adapters.
@@ -42,8 +44,9 @@ minimum supported Rust version (MSRV) and the latest stable toolchain.
 - Finite per-query row/logical-byte budgets with no partial results
 - Explicit graceful drain, forced cancellation, and blocking handle cleanup
 - Protocol-neutral typed values, ordered columns, positional rows, and results
-- A bounded SQL AST parser for explicit SQLite, PostgreSQL, and MySQL dialects,
-  isolated from the current raw SQLite HTTP execution path
+- A bounded SQL AST parser plus recursive common-subset validator for explicit
+  SQLite, PostgreSQL, and MySQL dialects, isolated from the current raw SQLite
+  HTTP execution path
 - A transactionally versioned `manifest.sqlite` with durable 4,096-bucket
   routing plus logical-database and table metadata
 - Identity-bound, WAL-enabled SQLite shard files that are never silently
@@ -161,6 +164,12 @@ growing work without bound. Connections are opened lazily and reused. Broadcast
 is now a journaled schema migration: it excludes new ordinary work, waits for
 previously admitted operations to drain, and uses dedicated migration
 connections rather than reserving every shard pool.
+
+Rust callers may explicitly parse SQL and consume the result with
+`validate_common_subset(ParsedSql)`, receiving an owned opaque `CommonSql` on
+success. This validation step does not normalize, route, plan, authorize, or
+execute SQL. The HTTP execute, query, and migration endpoints do not invoke it
+and retain their existing raw SQLite behavior.
 
 `EngineOptions` permits 1–16 active connections and 1–1,024 queued operations
 per shard, with at most 512 active connections across all shards.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -202,7 +202,7 @@ interrupted schema migration can be diagnosed and resumed.
 
 - [x] Parse SQL into an AST using a maintained parser after a focused parser
   spike; do not route by regular expression.
-- [ ] Define the first common SQL subset: `CREATE TABLE`, indexes, `SELECT`,
+- [x] Define the first common SQL subset: `CREATE TABLE`, indexes, `SELECT`,
   `INSERT`, `UPDATE`, `DELETE`, `BEGIN`, `COMMIT`, and `ROLLBACK`.
 - [ ] Normalize placeholders (`$1`, PostgreSQL/MySQL `?`) to SQLite parameters
   without interpolating values into SQL text.
@@ -370,7 +370,8 @@ The first buildable slices should be small and merge independently:
 4. Define manifest schema v2 and golden routing vectors.
 5. Add the virtual-bucket map while test data can still be discarded.
 6. Add `Session`, transaction state, and one-shard pinning.
-7. Add SQL parsing and plan classification without syntax translation.
+7. Add SQL parsing and structural common-subset validation without syntax
+   translation.
 8. Infer routing for one-table equality CRUD and reject unroutable writes.
 9. Spike PostgreSQL simple-query connectivity end to end.
 10. Add PostgreSQL extended query flow, then reuse the same conformance suite

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,7 +23,7 @@ server ---------> protocol::http
 | --- | --- | --- |
 | `core` | Protocol-neutral `Engine`, `Session`, statements, values, results, errors, and read-only logical catalog; stable key routing; bounded per-shard admission and connection pools; routed execute/query and journaled schema migration | JSON/HTTP types, listeners, or Axum handlers |
 | `storage` | Versioned routing/logical manifest, shard layout, migration journal and recovery, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
-| `sql` | Dialect-explicit SQL syntax parsing behind BriskDB-owned opaque types; exact source retention; SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, routing, filesystem layout, protocol responses, or independent support policy |
+| `sql` | Dialect-explicit SQL syntax parsing and recursive common-subset validation behind BriskDB-owned opaque types; exact source retention; SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, routing, catalog lookup, filesystem layout, protocol responses, or protocol-specific support policy |
 | `protocol::http` | HTTP request extraction plus JSON/BriskDB value and RFC 9457 problem-detail encoding | BLAKE3 routing, shard files, or rusqlite calls |
 | `protocol::error` | Exhaustive HTTP, PostgreSQL, and MySQL mappings from stable engine error kinds | SQLite errors, routing decisions, or wire-protocol session state |
 | `server` | Process configuration, database assembly, listener binding, and tracked Axum HTTP/1 connection lifecycle | SQL parsing or storage implementation details |
@@ -91,11 +91,11 @@ autodetection, or fallback parse. This makes a frontend's dialect choice
 deterministic and keeps the dependency replaceable.
 
 Parsing is syntax recognition, not support validation or planning. The parser
-has no session, parameter, catalog, storage, or routing access. The later common
-subset, normalization, and planner layers will consume structural syntax
-through BriskDB-owned interfaces; shard-key inference must not inspect raw or
-formatted SQL with regular expressions. Exact input remains authoritative
-because AST formatting is lossy and is never executed.
+has no session, parameter, catalog, storage, or routing access. The separate
+common-subset validator and later normalization and planner layers consume
+structural syntax through BriskDB-owned interfaces; shard-key inference must not
+inspect raw or formatted SQL with regular expressions. Exact input remains
+authoritative because AST formatting is lossy and is never executed.
 
 Inputs are bounded to 65,536 UTF-8 bytes, 256 statements, and recursion depth
 32. The dependency's recursive-protection feature remains enabled. Parse and
@@ -103,10 +103,28 @@ limit failures use protocol-neutral engine error kinds, whose diagnostics stay
 internal. The full dependency, error, testing, and non-goal contract is in the
 [SQL parser decision record](SQL_PARSER.md).
 
+### Common-subset boundary
+
+`validate_common_subset(ParsedSql)` consumes an opaque parsed batch and returns
+an owned opaque `CommonSql` only when every statement recursively uses the
+documented first subset. The marker retains the exact source, dialect, and
+statement count without exposing the upstream AST. Parsed but unsupported
+statement or expression forms return `Unsupported`; parse and parser-limit
+failures retain their existing kinds.
+
+Validation is structural and stateless. It does not normalize placeholders,
+translate type names or syntax, inspect parameters or the catalog, infer a
+shard, build a plan, classify statement behavior, authorize an endpoint, or
+execute SQL. Empty and mixed batches can validate because issue #27 owns
+request-level batch policy. Recursive expression validation has an independent
+depth limit of 128 so iteratively parsed flat operator chains remain bounded.
+The normative accepted forms and exclusions are in the [common SQL subset
+contract](SQL_SUBSET.md).
+
 The current HTTP execute/query and migration paths deliberately remain raw
-SQLite pass-through. Connecting this parser to execution would define
-common-subset and strict-mode behavior owned by later roadmap issues, so issue
-#19 changes no HTTP shape, SQL acceptance, routing, or storage behavior.
+SQLite pass-through and call neither the parser nor the subset validator.
+Issues #19 and #20 therefore change no HTTP shape, SQL acceptance, routing, or
+storage behavior.
 
 ## Manifest storage boundary
 

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -137,6 +137,15 @@ location, and submitted SQL remain trusted diagnostics only. Protocol adapters
 serialize the fixed mapping for the BriskDB error kind and never expose those
 diagnostics to a client.
 
+The opt-in common-subset validator classifies a parsed top-level statement or
+nested form outside its documented structural contract as `Unsupported`. Its
+internal diagnostic contains the one-based statement position and a fixed
+feature category, never the submitted SQL, a literal, formatted AST output, or
+a parser diagnostic. Its independent recursive expression-depth limit is 128;
+exceeding that limit is `LimitExceeded`. Empty and mixed batches can pass
+structural validation; later request-level classification decides whether they
+may execute. See the [common SQL subset contract](SQL_SUBSET.md).
+
 The core contains no HTTP, PostgreSQL, or MySQL response types. Conversely,
 protocol adapters do not inspect SQLite errors. This lets every frontend share
 one error identity while retaining its own response encoding.

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -16,12 +16,12 @@ document defines the SQL and behavioral contract separately from connectivity.
 - **Unsupported** means BriskDB rejects the behavior or makes no compatibility
   promise for it.
 
-The syntax parser is now available behind a BriskDB-owned boundary. Later
-subset validation and protocol adapters will fail explicitly for unsupported
-syntax and must not silently reinterpret a statement with materially different
-semantics. The current experimental HTTP interface is still a raw SQLite
-pass-through and can execute uncontracted SQLite syntax; that behavior is not a
-compatibility promise.
+The syntax parser and recursive common-subset validator are now available behind
+BriskDB-owned opaque types. Validation is explicit and returns `Unsupported`
+for a parsed form outside the subset; parser acceptance alone is not product
+support. The current experimental HTTP interface is still a raw SQLite
+pass-through and can execute uncontracted SQLite syntax because it calls neither
+layer. That behavior is not a compatibility promise.
 
 ## Compatibility layers
 
@@ -40,12 +40,14 @@ than claiming to be a drop-in PostgreSQL or MySQL replacement.
 
 ## Current implementation
 
-Only the experimental HTTP interface is implemented today. There is no
-PostgreSQL or MySQL listener or dialect translation layer yet. A bounded syntax
-parser can produce an opaque AST for an explicitly selected SQLite,
-PostgreSQL, or MySQL dialect, but it does not validate the supported subset,
-plan, route, or execute a statement. HTTP requests still send SQLite SQL
-directly to `rusqlite`; they do not pass through the parser.
+Only the experimental HTTP network interface is implemented today. There is no
+PostgreSQL or MySQL listener or dialect translation layer yet. The public Rust
+SQL facade can parse an explicitly selected SQLite, PostgreSQL, or MySQL dialect
+and can consume that result with `validate_common_subset(ParsedSql)`, yielding
+an opaque `CommonSql` after recursive structural validation. Neither operation
+plans, routes, translates, authorizes, or executes a statement. HTTP requests
+still send SQLite SQL directly to `rusqlite`; they do not pass through the
+parser or subset validator.
 
 | Interface | Status | SQL accepted | Routing |
 | --- | --- | --- | --- |
@@ -54,6 +56,10 @@ directly to `rusqlite`; they do not pass through the parser.
 | HTTP `/v1/admin/broadcast` | Experimental | A journaled parameterless SQLite schema batch | Preflight on every shard, then ascending resumable apply |
 | PostgreSQL wire protocol | Planned | Common subset plus documented PostgreSQL normalization | SQL/bound-parameter inference with explicit session fallback |
 | MySQL wire protocol | Planned | Common subset plus documented MySQL normalization | SQL/bound-parameter inference with explicit session fallback |
+
+The parser and subset validator are implemented Rust APIs, not network
+interfaces. Structural validation is opt-in and does not change any row in this
+table.
 
 Every HTTP operation now calls the same protocol-neutral async engine intended
 for future PostgreSQL and MySQL adapters. Execute and query requests create a
@@ -262,10 +268,19 @@ but the current execution surfaces retain their existing endpoint-specific
 single-statement and migration rules; later classification will decide which
 multi-statement combinations are safe.
 
-The parser has no routing or storage access. Future shard inference and
-statement classification consume structural syntax, never regular-expression
-matches over raw or formatted SQL. See the [SQL parser decision
-record](SQL_PARSER.md) for the dependency, error, MSRV, and non-goal contract.
+`validate_common_subset(ParsedSql)` is the separate support-validation step. It
+consumes the opaque parsed result and returns an owned opaque `CommonSql` only
+when every top-level statement and nested form is in the first subset. Empty
+and mixed batches may validate because request-level batch policy remains issue
+#27. Both marker types retain exact source, dialect, and statement count without
+exposing the upstream AST or rendering SQL in `Debug` output.
+
+The parser and validator have no routing or storage access. Future shard
+inference and statement classification consume structural syntax, never
+regular-expression matches over raw or formatted SQL. See the [SQL parser
+decision record](SQL_PARSER.md) for the dependency and resource contract and
+the [common SQL subset contract](SQL_SUBSET.md) for the normative recursive
+whitelist.
 
 ### Implemented pass-through surface
 
@@ -299,21 +314,53 @@ The synchronous public Rust `Database` methods remain available for source
 compatibility. Network frontends use `Engine`; retaining `Database` does not
 authorize an adapter to bypass the shared asynchronous boundary.
 
-### Planned common subset
+### Implemented structural common subset
 
-The first driver-capable SQL subset will include:
+The opt-in validator recursively admits these statement families:
 
-- `CREATE TABLE` and `CREATE INDEX` through journaled schema migrations;
-- `SELECT`, including documented filters, ordering, limits, and aggregates;
-- `INSERT`, `UPDATE`, and `DELETE` when a single shard can be proven;
-- `BEGIN`, `COMMIT`, and `ROLLBACK` for transactions pinned to one shard; and
-- protocol-neutral prepare, bind, describe, execute, and close operations.
+| Family | Structural contract |
+| --- | --- |
+| `CREATE TABLE` | One unqualified persistent table, optional `IF NOT EXISTS`, one or more columns with any explicit parsed type, and the supported literal defaults plus primary-key, unique, and check constraints |
+| `CREATE INDEX` | A named optional-unique index on plain columns of one unqualified table; `IF NOT EXISTS` and `ASC`/`DESC` are accepted |
+| `SELECT` | A nonempty projection with zero or one plain table; optional simple alias, `ALL`/`DISTINCT`, scalar filtering/grouping, `HAVING`, expression ordering, and standard numeric-or-placeholder limit/offset; PostgreSQL `LIMIT ALL` is parser-equivalent to no limit |
+| `INSERT` | One named table, an explicit column list unique under conservative ASCII case folding, and one or more equal-width `VALUES` rows |
+| `UPDATE` | One plain table, single-column assignments whose targets are unique under conservative ASCII case folding, and an optional predicate |
+| `DELETE` | One plain `FROM` table and an optional predicate |
+| Transactions | Plain `BEGIN`/`BEGIN TRANSACTION`/`BEGIN WORK`; the semantic commit AST including parser-accepted `TRANSACTION`/`WORK`/`TRAN` suffix aliases and explicit `AND NO CHAIN`; and the equivalent full-rollback AST including those forms and `ABORT`; no modes, `AND CHAIN`, blocks, or savepoints |
 
-The implemented parser supplies structured syntax without deciding support or
-routing. Later subset validation and planning will classify statements before
-execution. Writes with no provable shard, writes with conflicting shard keys,
-unsafe multi-statement requests, and cross-shard transactions will be rejected
-before changing data.
+Scalar expressions include the documented literals and placeholders,
+one-/two-part column references, arithmetic/comparison/Boolean operators,
+null/Boolean predicates, nonempty `IN`, `BETWEEN`, `LIKE` without `ESCAPE`, and
+`CASE`. Projection, `HAVING`, and ordering also admit unqualified, unquoted
+`COUNT`, `SUM`, `AVG`, `MIN`, and `MAX` with one expression argument, including
+duplicate treatment; `COUNT(*)` is supported. Scalar functions, casts,
+subqueries, joins, CTEs, set operations, windows, DML `RETURNING`, upserts,
+foreign keys, generated columns, expression/partial indexes, and all other
+forms are outside this first subset. The exact clause, expression, constraint,
+name, and diagnostic rules are normative in
+[the common SQL subset contract](SQL_SUBSET.md).
+
+This implemented status means structural validation exists and is tested. It
+does not mean the subset is connected to execution. Column type names are only
+required to be explicit; type compatibility and translation remain issue #25.
+Insert/update duplicate checks fold ASCII letter case regardless of quoting but
+do not define general identifier normalization, which also remains issue #25.
+Placeholders remain unchanged for issue #21. Catalog-aware key extraction,
+single-shard proof, bind-time planning, and rejection of conflicting or
+unroutable writes remain issues #22 through #24. Prepare/bind/describe/execute
+state remains issue #26, and empty or multi-statement execution policy remains
+issue #27.
+
+The validator independently caps recursive expression AST depth at 128. This
+also bounds flat operator chains that parse iteratively; exceeding the limit is
+reported as `LimitExceeded`.
+
+The future driver-capable execution path will send `CREATE TABLE` and
+`CREATE INDEX` through journaled schema migrations, route accepted CRUD only after its
+single-shard or supported read plan is established, and implement real
+transactions through protocol-neutral session state. Writes with no provable
+shard, conflicting shard keys, unsafe statement combinations, and cross-shard
+transactions will be rejected before changing data.
 
 ## PostgreSQL differences
 

--- a/docs/SQL_PARSER.md
+++ b/docs/SQL_PARSER.md
@@ -5,8 +5,9 @@ Status: accepted for roadmap issue #19
 BriskDB needs one syntax boundary that PostgreSQL, MySQL, HTTP, and future
 frontends can share without making a protocol adapter understand SQLite or
 invent its own routing rules. This record selects the parser dependency and
-defines that boundary. It does not define the supported BriskDB SQL subset or
-put the parser in the current HTTP execution path.
+defines that boundary. The separate [common SQL subset contract](SQL_SUBSET.md)
+defines the opt-in structural validator; neither layer is in the current HTTP
+execution path.
 
 ## Decision
 
@@ -36,9 +37,10 @@ MySQL adapter will select MySQL, and a strict SQLite surface will select
 SQLite.
 
 The SQL module retains the exact input text alongside an ordered parsed batch.
-The upstream AST stays opaque outside BriskDB's SQL boundary. Later validators,
-normalizers, and planners can inspect it through BriskDB-owned interfaces, but
-protocol adapters must not depend on `sqlparser` AST types.
+The upstream AST stays opaque outside BriskDB's SQL boundary. The implemented
+common-subset validator and later normalizers and planners inspect it through
+BriskDB-owned interfaces, but protocol adapters must not depend on `sqlparser`
+AST types.
 
 `sqlparser`'s formatter is not a source-preserving serializer: it can normalize
 comments, whitespace, quoting, and keyword presentation. BriskDB therefore
@@ -55,7 +57,8 @@ executing it on SQLite would preserve the source dialect's semantics.
 
 In particular, this layer does not:
 
-- define or enforce the common SQL subset (issue #20);
+- itself define or enforce the common SQL subset; issue #20 implements that as
+  the separate `validate_common_subset(ParsedSql)` layer;
 - normalize placeholders (issue #21);
 - infer shard keys or inspect bound values (issue #22);
 - plan prepared statements at bind time (issue #23);
@@ -68,14 +71,16 @@ In particular, this layer does not:
 The parser may return several statements in source order. The 256-statement
 limit below is a resource bound, not permission to execute a batch. Whether a
 particular surface accepts one statement or a safe combination remains issue
-#27. Likewise, later subset validation must return an explicit unsupported
-error instead of treating parser acceptance as product support.
+#27. The implemented subset validator checks each ordered statement
+independently and returns `Unsupported` for a parsed form outside its contract;
+that still does not grant permission to execute an empty or mixed batch.
 
 The existing HTTP execute, query, and migration paths remain raw SQLite
 pass-through surfaces with their existing authorizer and endpoint-specific
-rules. They do not call this parser yet. Gating them now would silently replace
-SQLite's accepted syntax with `sqlparser`'s coverage before strict-mode and
-common-subset policy is defined.
+rules. They call neither this parser nor the opt-in common-subset validator.
+Connecting those layers before normalization, planning, translation, and
+request-level statement policy are implemented would change the experimental
+HTTP SQL surface.
 
 ## Resource and error boundaries
 
@@ -92,10 +97,10 @@ Empty, whitespace-only, and comment-only input successfully produces an empty
 AST; whether a later request surface permits that is classification policy for
 issue #27. NUL input, malformed tokens, incomplete syntax, and other parse
 failures are `InvalidQuery`. A syntactically valid statement that is outside
-BriskDB's eventual common subset is not a parse failure; subset validation will
-classify it later. Public protocol errors continue to use the fixed safe text
-for the error kind and must not serialize SQL text, parser diagnostics, source
-locations, or internal error chains.
+BriskDB's common subset is not a parse failure; `validate_common_subset`
+classifies it as `Unsupported`. Public protocol errors continue to use the fixed
+safe text for the error kind and must not serialize SQL text, parser diagnostics,
+source locations, or internal error chains.
 
 The parser is stateless and has no catalog, storage, session, parameters,
 filesystem, or routing access. Routing will consume structural AST information
@@ -155,5 +160,6 @@ regular-expression crate elsewhere in `Cargo.lock` is not evidence of SQL
 routing; the architectural proof is that this layer returns structured syntax
 and makes no routing decision.
 
-This decision changes no HTTP request or response shape, routing result,
-configuration, manifest schema, shard file, or stored data.
+This decision and the later opt-in subset validator change no HTTP request or
+response shape, routing result, configuration, manifest schema, shard file, or
+stored data.

--- a/docs/SQL_SUBSET.md
+++ b/docs/SQL_SUBSET.md
@@ -1,0 +1,200 @@
+# Common SQL subset
+
+Status: implemented for roadmap issue #20
+
+BriskDB exposes a protocol-neutral structural validator for the first SQL
+subset shared by SQLite, PostgreSQL, MySQL, and future frontends. Callers first
+parse with an explicit [`SqlDialect`](../src/sql/parser.rs), then consume the
+result with:
+
+```rust
+validate_common_subset(parsed: ParsedSql) -> EngineResult<CommonSql>
+```
+
+`CommonSql` is an owned, opaque marker that retains the selected dialect, the
+byte-exact source, and the ordered statement count. It does not expose the
+dependency-owned AST. Its `Debug` representation reports only the dialect,
+source byte count, and statement count; it does not render SQL or AST contents.
+
+Validation is deliberately opt-in. The current HTTP execute, query, and schema
+migration paths remain raw SQLite pass-through surfaces and do not call either
+the parser or this validator. Issue #20 therefore changes no HTTP request or
+response shape, SQL accepted by HTTP, routing result, transaction behavior,
+configuration, manifest, shard file, or stored data.
+
+## Boundary
+
+The validator answers one question: does every parsed statement use only the
+structural forms in this document? It recursively checks nested clauses and
+expressions rather than accepting a statement from its top-level keyword alone.
+The complete batch succeeds as one validation operation or returns
+`Unsupported` for the first rejected statement.
+
+A successful `CommonSql` does not mean that the SQL:
+
+- names existing databases, tables, columns, constraints, or types;
+- has normalized or correctly numbered placeholders;
+- can be routed to one shard or has a bound routing value;
+- is safe to execute as an empty, single-, or multi-statement request;
+- has a prepared-statement plan or protocol result description;
+- has been translated to SQLite or preserves source-dialect semantics;
+- is authorized for a particular endpoint or session; or
+- has been executed.
+
+Those responsibilities remain with issues #21 through #27 and the later wire
+frontends. Validation never consults parameters, a session, the logical
+catalog, storage, routing state, the filesystem, or SQLite. It never formats or
+searches SQL text to make a structural decision.
+
+Empty and comment-only parsed batches validate successfully. Every statement in
+a mixed batch is checked independently and source order is retained, but that
+is not permission to execute the batch. Issue #27 owns empty-request policy,
+statement behavior classification, and safe statement combinations.
+
+## Statement forms
+
+| Family | Accepted structural form | Rejected forms include |
+| --- | --- | --- |
+| `CREATE TABLE` | One unqualified, persistent table; optional `IF NOT EXISTS`; one or more columns, each with an explicit parsed type; the column and table constraints described below | Qualified names, temporary or other table modifiers, table-as-query, `LIKE`/clone, storage/lifecycle/vendor options, partitioning/inheritance, SQLite `STRICT` or `WITHOUT ROWID` |
+| `CREATE INDEX` | A named, unqualified index on one unqualified table; optional `UNIQUE` and `IF NOT EXISTS`; one or more plain columns with optional `ASC` or `DESC` | Unnamed, qualified, expression, or partial indexes; `USING`, operator classes, `INCLUDE`, null-order, concurrent/async, storage, or vendor options |
+| `SELECT` | A nonempty projection with no `FROM` or one unqualified base table; optional simple table alias, `ALL`/`DISTINCT`, `WHERE`, `GROUP BY`, `HAVING`, expression `ORDER BY`, and standard `LIMIT`/`OFFSET` | CTEs, set operations, nested queries, multiple tables, joins, derived/table functions, `DISTINCT ON`, `SELECT INTO`, windows, locks, `FETCH`, `TOP`, query hints/settings/formats, MySQL comma-form limit |
+| `INSERT` | `INSERT INTO` one unqualified named table with a nonempty explicit column list whose names are unique under ASCII case folding, plus one or more equal-width `VALUES` rows | Omitted, exact-duplicate, or ASCII-case-only duplicate columns; row-width mismatch; `DEFAULT VALUES`; `INSERT ... SELECT`; aliases; conflict/upsert/ignore/replace forms; partitioning; `RETURNING`; output; multi-table, format, or settings clauses |
+| `UPDATE` | One unqualified base table with an optional simple alias, one or more single-column assignments whose targets are unique under ASCII case folding, and an optional `WHERE` | Joins, qualified or tuple assignment targets, exact-duplicate or ASCII-case-only duplicate targets, `FROM`, conflict modes, `RETURNING`, output, `ORDER BY`, or `LIMIT` |
+| `DELETE` | `DELETE FROM` exactly one unqualified base table with an optional simple alias and optional `WHERE` | Missing `FROM`, multiple tables, joins, `USING`, `RETURNING`, output, `ORDER BY`, or `LIMIT` |
+| `BEGIN` | `BEGIN`, `BEGIN TRANSACTION`, or `BEGIN WORK` | `START TRANSACTION`, `BEGIN TRAN`, transaction modes, SQLite deferred/immediate/exclusive modifiers, or procedural blocks |
+| `COMMIT` | The plain commit AST produced from `COMMIT`, its parser-accepted `TRANSACTION`, `WORK`, or `TRAN` suffix aliases, and explicit `AND NO CHAIN` | `AND CHAIN`, procedural `END`, or other modifiers |
+| `ROLLBACK` | The plain full-rollback AST produced from `ROLLBACK`, its parser-accepted `TRANSACTION`, `WORK`, or `TRAN` suffix aliases, `ABORT`, and explicit `AND NO CHAIN` | Rollback to a savepoint or `AND CHAIN` |
+| Other statements | None | `ALTER`, `DROP`, views, savepoints, session statements, administrative statements, and every other top-level statement family |
+
+The pinned parser collapses the listed plain commit and rollback aliases, plus
+an explicit `AND NO CHAIN`, to the same semantic AST forms. The validator
+deliberately accepts that AST family and does not search retained source text to
+distinguish equivalent spellings; the explicit source dialect must still parse
+a spelling first. `BEGIN`, `COMMIT`, and `ROLLBACK` remain syntax families only
+at this boundary. Canonical syntax translation remains issue #25. Real
+multi-call transaction state, failed-transaction behavior, connection and shard
+pinning, and protocol status reporting remain issues #34 and #47.
+
+An absent `WHERE` on `UPDATE` or `DELETE` is structurally valid. Likewise,
+validation does not inspect whether an assignment changes a shard-key column.
+Catalog-aware key extraction and rejection of conflicting or unroutable writes
+remain issues #22 and #24.
+
+### Names, aliases, and types
+
+Table, index, insert-column, and update-target object names must contain exactly
+one parsed name part. A scalar column reference may contain one part or exactly
+two parts such as `alias.column`. A table alias is accepted when it has no
+column-alias list or vendor-specific `AT` clause. A projection may use one
+expression alias, `*`, or a one-part qualified wildcard such as `w.*`, without
+wildcard modifiers.
+
+Insert column lists and update assignment targets reject exact duplicates and
+names that differ only by ASCII letter case, regardless of quoting. This is a
+conservative common key for duplicate detection, not full PostgreSQL, MySQL,
+SQLite, Unicode, quoted-identifier, or catalog normalization. General
+identifier normalization and translation remain issue #25.
+
+The validator requires every `CREATE TABLE` column to have an explicit parsed
+type, but it deliberately does not restrict the type name. Acceptance therefore
+does not promise a cross-protocol representation or SQLite translation for that
+type. Canonical type aliases, dialect differences, and strict SQLite mode remain
+issue #25.
+
+### Table constraints and defaults
+
+The following column options are accepted:
+
+- unnamed `NULL` and `NOT NULL`;
+- an unnamed literal `DEFAULT`;
+- optionally named `PRIMARY KEY`, `UNIQUE`, and `CHECK` constraints.
+
+Table-level `PRIMARY KEY`, `UNIQUE`, and `CHECK` constraints are accepted.
+Primary-key and unique column lists must use plain columns with optional `ASC`
+or `DESC`; index types, include columns, operator classes, null-distinctness,
+constraint characteristics, and other options are rejected. Foreign keys,
+generated or identity columns, collations, character sets, comments,
+autoincrement forms, conflict clauses, and other column/table constraints are
+outside the subset.
+
+A default may be `NULL`, a Boolean, a numeric literal without an `L` suffix, a
+single-quoted string, a parenthesized accepted literal, or unary `+`/`-` applied to a numeric
+literal. Functions, identifiers, placeholders, and other default expressions
+are rejected. A `CHECK` uses the scalar expression subset below but cannot use
+placeholders or aggregate functions.
+
+## Expression forms
+
+The validator accepts these recursively composed expression forms where the
+owning statement context permits them:
+
+- one-part identifiers and two-part column references;
+- `NULL`, Boolean, numeric literals without an `L` suffix, and single-quoted
+  string literals;
+- source-dialect placeholder nodes outside schema expressions;
+- parentheses;
+- unary `+`, `-`, and `NOT`;
+- arithmetic `+`, `-`, `*`, `/`, and `%`;
+- comparisons `=`, `<>`/`!=`, `<`, `<=`, `>`, and `>=`;
+- Boolean `AND` and `OR`;
+- `IS NULL`, `IS NOT NULL`, `IS TRUE`, `IS NOT TRUE`, `IS FALSE`, and
+  `IS NOT FALSE`;
+- `BETWEEN`/`NOT BETWEEN`;
+- `IN`/`NOT IN` with a nonempty expression list;
+- `LIKE`/`NOT LIKE` without `ANY` or an `ESCAPE` clause; and
+- simple or searched `CASE` expressions.
+
+The only accepted functions are the unqualified, unquoted aggregate names
+`COUNT`, `SUM`, `AVG`, `MIN`, and `MAX` in projection, `HAVING`, and `ORDER BY`
+contexts. They take exactly one unnamed expression argument; duplicate treatment
+such as `DISTINCT` is accepted. `COUNT(*)` is also accepted without duplicate
+treatment. Aggregate filters, windows, null treatment, within-group clauses,
+nested aggregates, qualified wildcards, named arguments, and every scalar or
+unknown function are rejected.
+
+`WHERE`, assignment, and `GROUP BY` expressions cannot contain aggregates.
+Insert row expressions use the same scalar grammar but cannot reference a
+column. A retained `LIMIT` or `OFFSET` value accepts only an unsigned digit-only
+numeric literal or a placeholder. The pinned parser represents PostgreSQL
+`LIMIT ALL` as the same absent-limit AST as omitting the clause, so structural
+validation accepts that AST-equivalent spelling and does not inspect source text
+to distinguish it. Placeholder spelling, numbering, count, and binding are not
+validated or changed here; issue #21 owns normalization without value
+interpolation.
+
+Common-subset expression validation has its own maximum recursive AST depth of
+128. This catches long flat operator chains, which the parser can build
+iteratively as deeply nested AST nodes without reaching its parser recursion
+limit. Exceeding this validator limit returns `LimitExceeded` before deeper
+validation; it is not classified as unsupported syntax.
+
+Subqueries, casts, collations, empty `IN` lists, dialect-specific literal forms
+and operators, JSON/array/row expressions, scalar functions, and all other AST
+expression forms are outside the subset.
+
+## Errors and diagnostics
+
+Parsing happens before subset validation:
+
+| Condition | `EngineErrorKind` |
+| --- | --- |
+| Tokenization or syntax failure | `InvalidQuery` |
+| Parser byte, statement-count, or recursion limit, or common-subset expression depth limit | `LimitExceeded` |
+| Parsed statement or nested form outside this contract | `Unsupported` |
+
+An unsupported diagnostic identifies the one-based statement position and a
+fixed feature category. It does not contain submitted SQL, literals, formatted
+AST output, parser diagnostics, or source locations. Protocol adapters must use
+the fixed public mapping for `Unsupported` rather than serializing the internal
+diagnostic.
+
+## Verification obligations
+
+Tests cover a common form of every statement family in all three source
+dialects, every recursive clause boundary, exact source ownership, redacted
+debug and unsupported diagnostics, empty and mixed batches, dialect-native
+placeholders, multi-row insert width, duplicate insert/update targets,
+concurrent validation, ordinary nested expressions, and the exact independent
+validator-depth boundary for flat operator chains. A raw HTTP regression must
+also continue to execute SQLite syntax outside this subset, proving that this
+opt-in marker has not become an implicit HTTP execution gate.

--- a/src/protocol/http.rs
+++ b/src/protocol/http.rs
@@ -268,7 +268,7 @@ mod tests {
     use super::*;
     use crate::{
         core::{Column, DataType, EngineErrorKind, EngineOptions, ResultLimits, Row},
-        sql::MAX_PARSED_SQL_BYTES,
+        sql::{MAX_PARSED_SQL_BYTES, SqlDialect, parse, validate_common_subset},
     };
 
     fn engine_router(database: Arc<Database>) -> Router {
@@ -494,6 +494,40 @@ mod tests {
                     "shard": expected_shard,
                     "columns": [{"name": "value", "data_type": "unknown"}],
                     "rows": [[7]]
+                })
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn common_subset_validation_does_not_change_the_current_http_query_path() {
+        let source = "WITH answer(value) AS (VALUES (9)) SELECT value FROM answer";
+        let validation_error =
+            validate_common_subset(parse(SqlDialect::Sqlite, source).unwrap()).unwrap_err();
+        assert_eq!(validation_error.kind(), EngineErrorKind::Unsupported);
+
+        let temp = tempfile::tempdir().unwrap();
+        let database = Arc::new(Database::open(temp.path(), 2).unwrap());
+        let expected_shard = database.shard_for_key(b"subset-http-boundary");
+        let application = engine_router(database);
+
+        assert_eq!(
+            request_json(
+                &application,
+                Method::POST,
+                "/v1/query",
+                Some(json!({
+                    "shard_key": "subset-http-boundary",
+                    "sql": source
+                })),
+            )
+            .await,
+            (
+                StatusCode::OK,
+                json!({
+                    "shard": expected_shard,
+                    "columns": [{"name": "value", "data_type": "unknown"}],
+                    "rows": [[9]]
                 })
             )
         );

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -1,15 +1,18 @@
 //! Protocol-neutral SQL parsing, SQLite execution, and value conversion.
 //!
-//! The parser facade produces a bounded, dialect-explicit opaque AST for later
-//! planning work. Current execution remains deliberate SQLite pass-through;
-//! parsing does not yet gate, rewrite, classify, route, or execute statements.
+//! The parser facade produces a bounded, dialect-explicit opaque AST. The
+//! common-subset validator recursively admits only protocol-neutral SQL shapes
+//! for later planning work. Current execution remains deliberate SQLite
+//! pass-through; neither layer gates, rewrites, routes, or executes statements.
 
 mod parser;
+mod subset;
 
 pub use parser::{
     MAX_PARSED_SQL_BYTES, MAX_PARSED_SQL_STATEMENTS, ParsedSql, SQL_PARSE_RECURSION_LIMIT,
     SqlDialect, parse,
 };
+pub use subset::{CommonSql, MAX_COMMON_SQL_EXPRESSION_DEPTH, validate_common_subset};
 
 use rusqlite::{
     Connection, params_from_iter,

--- a/src/sql/parser.rs
+++ b/src/sql/parser.rs
@@ -83,6 +83,10 @@ impl ParsedSql {
     pub fn is_empty(&self) -> bool {
         self.statements.is_empty()
     }
+
+    pub(super) fn statements(&self) -> &[AstStatement] {
+        &self.statements
+    }
 }
 
 impl fmt::Debug for ParsedSql {

--- a/src/sql/subset.rs
+++ b/src/sql/subset.rs
@@ -1,0 +1,1455 @@
+use std::{collections::HashSet, fmt};
+
+use sqlparser::ast::{
+    AssignmentTarget, BeginTransactionKind, BinaryOperator, CheckConstraint, ColumnOption,
+    CreateIndex, CreateTable, CreateTableOptions, DataType, Delete, Distinct, Expr, FromTable,
+    Function, FunctionArg, FunctionArgExpr, FunctionArguments, GroupByExpr, HiveDistributionStyle,
+    IndexColumn, Insert, LimitClause, NullsDistinctOption, ObjectName, ObjectNamePart, OrderBy,
+    OrderByExpr, OrderByKind, OrderBySort, PrimaryKeyConstraint, Query, Select, SelectFlavor,
+    SelectItem, SelectItemQualifiedWildcardKind, SetExpr, Statement as AstStatement,
+    TableConstraint, TableFactor, TableObject, TableWithJoins, UnaryOperator, UniqueConstraint,
+    Update, Value, WildcardAdditionalOptions,
+};
+
+use super::{ParsedSql, SqlDialect};
+use crate::core::{EngineError, EngineErrorKind, EngineResult};
+
+/// Maximum recursive expression depth accepted by common-subset validation.
+///
+/// This is independent of parser recursion: a long, flat operator chain can
+/// parse iteratively but still produce a deeply nested AST.
+pub const MAX_COMMON_SQL_EXPRESSION_DEPTH: usize = 128;
+
+/// SQL that has passed BriskDB's protocol-neutral structural subset validator.
+///
+/// Validation does not normalize placeholders, translate types, infer a shard,
+/// plan execution, or decide whether an empty or multi-statement request may
+/// execute. Those remain separate layers over this opaque marker type.
+#[derive(Clone, PartialEq, Eq)]
+pub struct CommonSql {
+    parsed: ParsedSql,
+}
+
+impl CommonSql {
+    /// Return the explicitly selected source dialect.
+    pub const fn dialect(&self) -> SqlDialect {
+        self.parsed.dialect()
+    }
+
+    /// Return the caller's byte-exact SQL source.
+    pub fn source(&self) -> &str {
+        self.parsed.source()
+    }
+
+    /// Return the number of independently validated statements.
+    pub fn statement_count(&self) -> usize {
+        self.parsed.statement_count()
+    }
+
+    /// Return whether the parsed input contained no statements.
+    pub fn is_empty(&self) -> bool {
+        self.parsed.is_empty()
+    }
+}
+
+impl fmt::Debug for CommonSql {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CommonSql")
+            .field("dialect", &self.dialect())
+            .field("source_bytes", &self.source().len())
+            .field("statement_count", &self.statement_count())
+            .finish()
+    }
+}
+
+/// Validate every parsed statement against BriskDB's first common SQL subset.
+///
+/// The batch is validated atomically and retains its exact source and order.
+/// Empty batches and otherwise-valid statement combinations are accepted here;
+/// a later classification layer owns request-level batch policy.
+pub fn validate_common_subset(parsed: ParsedSql) -> EngineResult<CommonSql> {
+    for (index, statement) in parsed.statements().iter().enumerate() {
+        validate_statement(statement).map_err(|violation| {
+            let diagnostic = if violation.kind == EngineErrorKind::LimitExceeded {
+                format!(
+                    "statement {} exceeds the common SQL expression depth limit of {}",
+                    index + 1,
+                    MAX_COMMON_SQL_EXPRESSION_DEPTH
+                )
+            } else {
+                format!(
+                    "statement {} is outside the common SQL subset: {}",
+                    index + 1,
+                    violation.feature
+                )
+            };
+            EngineError::new(violation.kind, diagnostic)
+        })?;
+    }
+
+    Ok(CommonSql { parsed })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SubsetViolation {
+    kind: EngineErrorKind,
+    feature: &'static str,
+}
+
+type SubsetResult<T = ()> = Result<T, SubsetViolation>;
+
+const fn unsupported<T>(feature: &'static str) -> SubsetResult<T> {
+    Err(SubsetViolation {
+        kind: EngineErrorKind::Unsupported,
+        feature,
+    })
+}
+
+const fn expression_depth_exceeded<T>() -> SubsetResult<T> {
+    Err(SubsetViolation {
+        kind: EngineErrorKind::LimitExceeded,
+        feature: "expression depth",
+    })
+}
+
+fn validate_statement(statement: &AstStatement) -> SubsetResult {
+    match statement {
+        AstStatement::CreateTable(table) => validate_create_table(table),
+        AstStatement::CreateIndex(index) => validate_create_index(index),
+        AstStatement::Query(query) => validate_query(query),
+        AstStatement::Insert(insert) => validate_insert(insert),
+        AstStatement::Update(update) => validate_update(update),
+        AstStatement::Delete(delete) => validate_delete(delete),
+        AstStatement::StartTransaction {
+            modes,
+            begin,
+            transaction,
+            modifier,
+            statements,
+            exception,
+            has_end_keyword,
+        } => {
+            if !begin {
+                return unsupported("START TRANSACTION");
+            }
+            if !modes.is_empty()
+                || modifier.is_some()
+                || !statements.is_empty()
+                || exception.is_some()
+                || *has_end_keyword
+            {
+                return unsupported("transaction modes or procedural blocks");
+            }
+            if matches!(transaction, Some(BeginTransactionKind::Tran)) {
+                return unsupported("BEGIN TRAN");
+            }
+            Ok(())
+        }
+        AstStatement::Commit {
+            chain,
+            end,
+            modifier,
+        } if !chain && !end && modifier.is_none() => Ok(()),
+        AstStatement::Commit { .. } => unsupported("COMMIT modifiers"),
+        AstStatement::Rollback { chain, savepoint } if !chain && savepoint.is_none() => Ok(()),
+        AstStatement::Rollback { .. } => unsupported("ROLLBACK modifiers or savepoints"),
+        _ => unsupported("statement type"),
+    }
+}
+
+fn validate_create_table(table: &CreateTable) -> SubsetResult {
+    let CreateTable {
+        or_replace,
+        temporary,
+        unlogged,
+        external,
+        dynamic,
+        global,
+        if_not_exists: _,
+        transient,
+        volatile,
+        iceberg,
+        snapshot,
+        name,
+        columns,
+        constraints,
+        hive_distribution,
+        hive_formats,
+        table_options,
+        file_format,
+        location,
+        query,
+        without_rowid,
+        like,
+        clone,
+        version,
+        comment,
+        on_commit,
+        on_cluster,
+        primary_key,
+        order_by,
+        partition_by,
+        cluster_by,
+        clustered_by,
+        inherits,
+        partition_of,
+        for_values,
+        strict,
+        copy_grants,
+        enable_schema_evolution,
+        change_tracking,
+        data_retention_time_in_days,
+        max_data_extension_time_in_days,
+        default_ddl_collation,
+        with_aggregation_policy,
+        with_row_access_policy,
+        with_storage_lifecycle_policy,
+        with_tags,
+        external_volume,
+        with_connection,
+        base_location,
+        catalog,
+        catalog_sync,
+        storage_serialization_policy,
+        target_lag,
+        warehouse,
+        refresh_mode,
+        initialize,
+        require_user,
+        diststyle,
+        distkey,
+        sortkey,
+        backup,
+        multiset,
+        fallback,
+        with_data,
+    } = table;
+
+    if *or_replace
+        || *temporary
+        || *unlogged
+        || *external
+        || *dynamic
+        || global.is_some()
+        || *transient
+        || *volatile
+        || *iceberg
+        || *snapshot
+    {
+        return unsupported("CREATE TABLE modifiers");
+    }
+    if !matches!(hive_distribution, HiveDistributionStyle::NONE)
+        || hive_formats.is_some()
+        || !matches!(table_options, CreateTableOptions::None)
+        || file_format.is_some()
+        || location.is_some()
+    {
+        return unsupported("CREATE TABLE storage options");
+    }
+    if query.is_some()
+        || like.is_some()
+        || clone.is_some()
+        || version.is_some()
+        || comment.is_some()
+        || on_commit.is_some()
+        || on_cluster.is_some()
+    {
+        return unsupported("CREATE TABLE source or lifecycle clauses");
+    }
+    if *without_rowid || *strict {
+        return unsupported("SQLite-specific CREATE TABLE options");
+    }
+    if primary_key.is_some()
+        || order_by.is_some()
+        || partition_by.is_some()
+        || cluster_by.is_some()
+        || clustered_by.is_some()
+        || inherits.is_some()
+        || partition_of.is_some()
+        || for_values.is_some()
+    {
+        return unsupported("CREATE TABLE partitioning or inheritance");
+    }
+    if *copy_grants
+        || enable_schema_evolution.is_some()
+        || change_tracking.is_some()
+        || data_retention_time_in_days.is_some()
+        || max_data_extension_time_in_days.is_some()
+        || default_ddl_collation.is_some()
+        || with_aggregation_policy.is_some()
+        || with_row_access_policy.is_some()
+        || with_storage_lifecycle_policy.is_some()
+        || with_tags.is_some()
+        || external_volume.is_some()
+        || with_connection.is_some()
+        || base_location.is_some()
+        || catalog.is_some()
+        || catalog_sync.is_some()
+        || storage_serialization_policy.is_some()
+        || target_lag.is_some()
+        || warehouse.is_some()
+        || refresh_mode.is_some()
+        || initialize.is_some()
+        || *require_user
+        || diststyle.is_some()
+        || distkey.is_some()
+        || sortkey.is_some()
+        || backup.is_some()
+        || multiset.is_some()
+        || fallback.is_some()
+        || with_data.is_some()
+    {
+        return unsupported("vendor-specific CREATE TABLE options");
+    }
+
+    validate_one_part_name(name, "qualified table names")?;
+    if columns.is_empty() {
+        return unsupported("CREATE TABLE without columns");
+    }
+    for column in columns {
+        if column.data_type == DataType::Unspecified {
+            return unsupported("columns without an explicit type");
+        }
+        for option in &column.options {
+            validate_column_option(option.name.is_some(), &option.option)?;
+        }
+    }
+    for constraint in constraints {
+        validate_table_constraint(constraint)?;
+    }
+    Ok(())
+}
+
+fn validate_column_option(named: bool, option: &ColumnOption) -> SubsetResult {
+    match option {
+        ColumnOption::Null | ColumnOption::NotNull if !named => Ok(()),
+        ColumnOption::Default(expression) if !named => validate_default_expression(expression),
+        ColumnOption::PrimaryKey(constraint) => validate_primary_key(constraint, true),
+        ColumnOption::Unique(constraint) => validate_unique(constraint, true),
+        ColumnOption::Check(constraint) => validate_check(constraint),
+        ColumnOption::Null | ColumnOption::NotNull | ColumnOption::Default(_) => {
+            unsupported("named NULL or DEFAULT column options")
+        }
+        _ => unsupported("column option"),
+    }
+}
+
+fn validate_table_constraint(constraint: &TableConstraint) -> SubsetResult {
+    match constraint {
+        TableConstraint::PrimaryKey(constraint) => validate_primary_key(constraint, false),
+        TableConstraint::Unique(constraint) => validate_unique(constraint, false),
+        TableConstraint::Check(constraint) => validate_check(constraint),
+        TableConstraint::ForeignKey(_) => unsupported("foreign keys"),
+        _ => unsupported("table constraint"),
+    }
+}
+
+fn validate_primary_key(constraint: &PrimaryKeyConstraint, allow_empty: bool) -> SubsetResult {
+    if constraint.index_name.is_some()
+        || constraint.index_type.is_some()
+        || !constraint.include.is_empty()
+        || !constraint.index_options.is_empty()
+        || constraint.characteristics.is_some()
+    {
+        return unsupported("PRIMARY KEY options");
+    }
+    if constraint.columns.is_empty() && !allow_empty {
+        return unsupported("PRIMARY KEY without columns");
+    }
+    for column in &constraint.columns {
+        validate_index_column(column)?;
+    }
+    Ok(())
+}
+
+fn validate_unique(constraint: &UniqueConstraint, allow_empty: bool) -> SubsetResult {
+    if constraint.index_name.is_some()
+        || !constraint.index_type_display.is_none()
+        || constraint.index_type.is_some()
+        || !constraint.include.is_empty()
+        || !constraint.index_options.is_empty()
+        || constraint.characteristics.is_some()
+        || !matches!(constraint.nulls_distinct, NullsDistinctOption::None)
+    {
+        return unsupported("UNIQUE constraint options");
+    }
+    if constraint.columns.is_empty() && !allow_empty {
+        return unsupported("UNIQUE constraint without columns");
+    }
+    for column in &constraint.columns {
+        validate_index_column(column)?;
+    }
+    Ok(())
+}
+
+fn validate_check(constraint: &CheckConstraint) -> SubsetResult {
+    if constraint.enforced.is_some() {
+        return unsupported("CHECK enforcement modifiers");
+    }
+    validate_expression(constraint.expr.as_ref(), ExprContext::CHECK)
+}
+
+fn validate_create_index(index: &CreateIndex) -> SubsetResult {
+    let Some(name) = &index.name else {
+        return unsupported("unnamed indexes");
+    };
+    validate_one_part_name(name, "qualified index names")?;
+    validate_one_part_name(&index.table_name, "qualified table names")?;
+    if index.columns.is_empty() {
+        return unsupported("indexes without columns");
+    }
+    if index.using.is_some()
+        || index.concurrently
+        || index.r#async
+        || !index.include.is_empty()
+        || index.nulls_distinct.is_some()
+        || !index.with.is_empty()
+        || index.predicate.is_some()
+        || !index.index_options.is_empty()
+        || !index.alter_options.is_empty()
+    {
+        return unsupported("CREATE INDEX options");
+    }
+    for column in &index.columns {
+        validate_index_column(column)?;
+    }
+    Ok(())
+}
+
+fn validate_index_column(column: &IndexColumn) -> SubsetResult {
+    if column.operator_class.is_some()
+        || column.column.with_fill.is_some()
+        || column.column.options.nulls_first.is_some()
+        || matches!(column.column.options.sort, Some(OrderBySort::Using(_)))
+    {
+        return unsupported("index column options");
+    }
+    if !matches!(column.column.expr, Expr::Identifier(_)) {
+        return unsupported("expression indexes");
+    }
+    Ok(())
+}
+
+fn validate_query(query: &Query) -> SubsetResult {
+    let Query {
+        with,
+        body,
+        order_by,
+        limit_clause,
+        fetch,
+        locks,
+        for_clause,
+        settings,
+        format_clause,
+        pipe_operators,
+    } = query;
+
+    if with.is_some() {
+        return unsupported("common table expressions");
+    }
+    if fetch.is_some()
+        || !locks.is_empty()
+        || for_clause.is_some()
+        || settings.is_some()
+        || format_clause.is_some()
+        || !pipe_operators.is_empty()
+    {
+        return unsupported("query suffix clauses");
+    }
+
+    let SetExpr::Select(select) = body.as_ref() else {
+        return unsupported("set operations, VALUES, or nested queries");
+    };
+    validate_select(select)?;
+    if let Some(order_by) = order_by {
+        validate_order_by(order_by)?;
+    }
+    if let Some(limit_clause) = limit_clause {
+        validate_limit_clause(limit_clause)?;
+    }
+    Ok(())
+}
+
+fn validate_select(select: &Select) -> SubsetResult {
+    let Select {
+        select_token: _,
+        optimizer_hints,
+        distinct,
+        select_modifiers,
+        top,
+        top_before_distinct,
+        projection,
+        exclude,
+        into,
+        from,
+        lateral_views,
+        prewhere,
+        selection,
+        connect_by,
+        group_by,
+        cluster_by,
+        distribute_by,
+        sort_by,
+        having,
+        named_window,
+        qualify,
+        window_before_qualify,
+        value_table_mode,
+        flavor,
+    } = select;
+
+    if !optimizer_hints.is_empty()
+        || select_modifiers.is_some()
+        || top.is_some()
+        || *top_before_distinct
+        || exclude.is_some()
+        || into.is_some()
+        || !lateral_views.is_empty()
+        || prewhere.is_some()
+        || !connect_by.is_empty()
+        || !cluster_by.is_empty()
+        || !distribute_by.is_empty()
+        || !sort_by.is_empty()
+        || !named_window.is_empty()
+        || qualify.is_some()
+        || *window_before_qualify
+        || value_table_mode.is_some()
+        || !matches!(flavor, SelectFlavor::Standard)
+    {
+        return unsupported("SELECT modifiers");
+    }
+    if matches!(distinct, Some(Distinct::On(_))) {
+        return unsupported("DISTINCT ON");
+    }
+    if projection.is_empty() {
+        return unsupported("SELECT without a projection");
+    }
+    if from.len() > 1 {
+        return unsupported("multiple FROM tables");
+    }
+    if let Some(table) = from.first() {
+        validate_simple_table(table, true)?;
+    }
+    for item in projection {
+        validate_select_item(item)?;
+    }
+    if let Some(selection) = selection {
+        validate_expression(selection, ExprContext::SCALAR)?;
+    }
+    match group_by {
+        GroupByExpr::Expressions(expressions, modifiers) if modifiers.is_empty() => {
+            for expression in expressions {
+                validate_expression(expression, ExprContext::SCALAR)?;
+            }
+        }
+        GroupByExpr::Expressions(_, _) | GroupByExpr::All(_) => {
+            return unsupported("GROUP BY modifiers");
+        }
+    }
+    if let Some(having) = having {
+        validate_expression(having, ExprContext::SELECT)?;
+    }
+    Ok(())
+}
+
+fn validate_select_item(item: &SelectItem) -> SubsetResult {
+    match item {
+        SelectItem::UnnamedExpr(expression) => validate_expression(expression, ExprContext::SELECT),
+        SelectItem::ExprWithAlias { expr, alias: _ } => {
+            validate_expression(expr, ExprContext::SELECT)
+        }
+        SelectItem::Wildcard(options) if wildcard_options_are_empty(options) => Ok(()),
+        SelectItem::QualifiedWildcard(
+            SelectItemQualifiedWildcardKind::ObjectName(name),
+            options,
+        ) if wildcard_options_are_empty(options) => {
+            validate_one_part_name(name, "qualified wildcard prefixes")
+        }
+        SelectItem::ExprWithAliases { .. }
+        | SelectItem::QualifiedWildcard(_, _)
+        | SelectItem::Wildcard(_) => unsupported("projection aliases or wildcard modifiers"),
+    }
+}
+
+fn wildcard_options_are_empty(options: &WildcardAdditionalOptions) -> bool {
+    options.opt_ilike.is_none()
+        && options.opt_exclude.is_none()
+        && options.opt_except.is_none()
+        && options.opt_replace.is_none()
+        && options.opt_rename.is_none()
+        && options.opt_alias.is_none()
+}
+
+fn validate_order_by(order_by: &OrderBy) -> SubsetResult {
+    if order_by.interpolate.is_some() {
+        return unsupported("ORDER BY interpolation");
+    }
+    let OrderByKind::Expressions(expressions) = &order_by.kind else {
+        return unsupported("ORDER BY ALL");
+    };
+    for expression in expressions {
+        validate_order_by_expression(expression)?;
+    }
+    Ok(())
+}
+
+fn validate_order_by_expression(order_by: &OrderByExpr) -> SubsetResult {
+    if order_by.with_fill.is_some()
+        || order_by.options.nulls_first.is_some()
+        || matches!(order_by.options.sort, Some(OrderBySort::Using(_)))
+    {
+        return unsupported("ORDER BY options");
+    }
+    validate_expression(&order_by.expr, ExprContext::SELECT)
+}
+
+fn validate_limit_clause(limit_clause: &LimitClause) -> SubsetResult {
+    let LimitClause::LimitOffset {
+        limit,
+        offset,
+        limit_by,
+    } = limit_clause
+    else {
+        return unsupported("comma-form LIMIT");
+    };
+    let Some(limit) = limit else {
+        return unsupported("LIMIT ALL");
+    };
+    if !limit_by.is_empty() {
+        return unsupported("LIMIT BY");
+    }
+    validate_limit_value(limit)?;
+    if let Some(offset) = offset {
+        validate_limit_value(&offset.value)?;
+    }
+    Ok(())
+}
+
+fn validate_insert(insert: &Insert) -> SubsetResult {
+    let Insert {
+        insert_token: _,
+        optimizer_hints,
+        or,
+        ignore,
+        into,
+        table,
+        table_alias,
+        columns,
+        overwrite,
+        source,
+        assignments,
+        partitioned,
+        after_columns,
+        has_table_keyword,
+        on,
+        returning,
+        output,
+        replace_into,
+        priority,
+        insert_alias,
+        settings,
+        format_clause,
+        multi_table_insert_type,
+        multi_table_into_clauses,
+        multi_table_when_clauses,
+        multi_table_else_clause,
+    } = insert;
+
+    if !optimizer_hints.is_empty()
+        || or.is_some()
+        || *ignore
+        || !into
+        || table_alias.is_some()
+        || *overwrite
+        || !assignments.is_empty()
+        || partitioned.is_some()
+        || !after_columns.is_empty()
+        || *has_table_keyword
+        || on.is_some()
+        || returning.is_some()
+        || output.is_some()
+        || *replace_into
+        || priority.is_some()
+        || insert_alias.is_some()
+        || settings.is_some()
+        || format_clause.is_some()
+        || multi_table_insert_type.is_some()
+        || !multi_table_into_clauses.is_empty()
+        || !multi_table_when_clauses.is_empty()
+        || multi_table_else_clause.is_some()
+    {
+        return unsupported("INSERT modifiers");
+    }
+    let TableObject::TableName(table_name) = table else {
+        return unsupported("INSERT targets other than a named table");
+    };
+    validate_one_part_name(table_name, "qualified table names")?;
+    if columns.is_empty() {
+        return unsupported("INSERT without an explicit column list");
+    }
+    let mut seen = HashSet::new();
+    for column in columns {
+        let key = common_identifier_key(column, "qualified INSERT columns")?;
+        if !seen.insert(key) {
+            return unsupported("duplicate INSERT columns");
+        }
+    }
+    let Some(source) = source else {
+        return unsupported("INSERT without VALUES");
+    };
+    validate_insert_values(source, columns.len())
+}
+
+fn validate_insert_values(query: &Query, column_count: usize) -> SubsetResult {
+    if query.with.is_some()
+        || query.order_by.is_some()
+        || query.limit_clause.is_some()
+        || query.fetch.is_some()
+        || !query.locks.is_empty()
+        || query.for_clause.is_some()
+        || query.settings.is_some()
+        || query.format_clause.is_some()
+        || !query.pipe_operators.is_empty()
+    {
+        return unsupported("INSERT source query clauses");
+    }
+    let SetExpr::Values(values) = query.body.as_ref() else {
+        return unsupported("INSERT sources other than VALUES");
+    };
+    if values.explicit_row || values.value_keyword || values.rows.is_empty() {
+        return unsupported("VALUES modifiers or empty VALUES");
+    }
+    for row in &values.rows {
+        if row.len() != column_count {
+            return unsupported("INSERT row width mismatch");
+        }
+        for expression in row.iter() {
+            validate_expression(expression, ExprContext::INSERT_VALUE)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_update(update: &Update) -> SubsetResult {
+    if !update.optimizer_hints.is_empty()
+        || update.from.is_some()
+        || update.returning.is_some()
+        || update.output.is_some()
+        || update.or.is_some()
+        || !update.order_by.is_empty()
+        || update.limit.is_some()
+    {
+        return unsupported("UPDATE modifiers");
+    }
+    validate_simple_table(&update.table, true)?;
+    if update.assignments.is_empty() {
+        return unsupported("UPDATE without assignments");
+    }
+    let mut seen = HashSet::new();
+    for assignment in &update.assignments {
+        let AssignmentTarget::ColumnName(column) = &assignment.target else {
+            return unsupported("tuple UPDATE assignments");
+        };
+        let key = common_identifier_key(column, "qualified UPDATE assignment targets")?;
+        if !seen.insert(key) {
+            return unsupported("duplicate UPDATE assignment targets");
+        }
+        validate_expression(&assignment.value, ExprContext::SCALAR)?;
+    }
+    if let Some(selection) = &update.selection {
+        validate_expression(selection, ExprContext::SCALAR)?;
+    }
+    Ok(())
+}
+
+fn validate_delete(delete: &Delete) -> SubsetResult {
+    if !delete.optimizer_hints.is_empty()
+        || !delete.tables.is_empty()
+        || delete.using.is_some()
+        || delete.returning.is_some()
+        || delete.output.is_some()
+        || !delete.order_by.is_empty()
+        || delete.limit.is_some()
+    {
+        return unsupported("DELETE modifiers");
+    }
+    let FromTable::WithFromKeyword(tables) = &delete.from else {
+        return unsupported("DELETE without FROM");
+    };
+    let [table] = tables.as_slice() else {
+        return unsupported("DELETE with multiple tables");
+    };
+    validate_simple_table(table, true)?;
+    if let Some(selection) = &delete.selection {
+        validate_expression(selection, ExprContext::SCALAR)?;
+    }
+    Ok(())
+}
+
+fn validate_simple_table(table: &TableWithJoins, allow_alias: bool) -> SubsetResult {
+    if !table.joins.is_empty() {
+        return unsupported("joins");
+    }
+    let TableFactor::Table {
+        name,
+        alias,
+        args,
+        with_hints,
+        version,
+        with_ordinality,
+        partitions,
+        json_path,
+        sample,
+        index_hints,
+    } = &table.relation
+    else {
+        return unsupported("derived tables or table functions");
+    };
+    validate_one_part_name(name, "qualified table names")?;
+    if args.is_some()
+        || !with_hints.is_empty()
+        || version.is_some()
+        || *with_ordinality
+        || !partitions.is_empty()
+        || json_path.is_some()
+        || sample.is_some()
+        || !index_hints.is_empty()
+    {
+        return unsupported("table reference options");
+    }
+    if let Some(alias) = alias {
+        if !allow_alias || !alias.columns.is_empty() || alias.at.is_some() {
+            return unsupported("table alias options");
+        }
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+struct ExprContext {
+    identifiers: bool,
+    placeholders: bool,
+    aggregates: bool,
+}
+
+impl ExprContext {
+    const SCALAR: Self = Self {
+        identifiers: true,
+        placeholders: true,
+        aggregates: false,
+    };
+    const SELECT: Self = Self {
+        aggregates: true,
+        ..Self::SCALAR
+    };
+    const INSERT_VALUE: Self = Self {
+        identifiers: false,
+        ..Self::SCALAR
+    };
+    const CHECK: Self = Self {
+        placeholders: false,
+        ..Self::SCALAR
+    };
+
+    const fn without_aggregates(self) -> Self {
+        Self {
+            aggregates: false,
+            ..self
+        }
+    }
+}
+
+fn validate_expression(expression: &Expr, context: ExprContext) -> SubsetResult {
+    validate_expression_at_depth(expression, context, 1)
+}
+
+fn validate_expression_at_depth(
+    expression: &Expr,
+    context: ExprContext,
+    depth: usize,
+) -> SubsetResult {
+    if depth > MAX_COMMON_SQL_EXPRESSION_DEPTH {
+        return expression_depth_exceeded();
+    }
+    let child_depth = depth + 1;
+
+    match expression {
+        Expr::Identifier(_) if context.identifiers => Ok(()),
+        Expr::CompoundIdentifier(parts) if context.identifiers && parts.len() == 2 => Ok(()),
+        Expr::Value(value) => validate_value(&value.value, context.placeholders),
+        Expr::Nested(expression)
+        | Expr::IsNull(expression)
+        | Expr::IsNotNull(expression)
+        | Expr::IsTrue(expression)
+        | Expr::IsNotTrue(expression)
+        | Expr::IsFalse(expression)
+        | Expr::IsNotFalse(expression) => {
+            validate_expression_at_depth(expression, context, child_depth)
+        }
+        Expr::UnaryOp {
+            op: UnaryOperator::Plus | UnaryOperator::Minus | UnaryOperator::Not,
+            expr,
+        } => validate_expression_at_depth(expr, context, child_depth),
+        Expr::BinaryOp { left, op, right } if binary_operator_is_common(op) => {
+            validate_expression_at_depth(left, context, child_depth)?;
+            validate_expression_at_depth(right, context, child_depth)
+        }
+        Expr::Between {
+            expr,
+            negated: _,
+            low,
+            high,
+        } => {
+            validate_expression_at_depth(expr, context, child_depth)?;
+            validate_expression_at_depth(low, context, child_depth)?;
+            validate_expression_at_depth(high, context, child_depth)
+        }
+        Expr::InList {
+            expr,
+            list,
+            negated: _,
+        } if !list.is_empty() => {
+            validate_expression_at_depth(expr, context, child_depth)?;
+            for item in list {
+                validate_expression_at_depth(item, context, child_depth)?;
+            }
+            Ok(())
+        }
+        Expr::Like {
+            any,
+            expr,
+            pattern,
+            escape_char,
+            negated: _,
+        } if !any && escape_char.is_none() => {
+            validate_expression_at_depth(expr, context, child_depth)?;
+            validate_expression_at_depth(pattern, context, child_depth)
+        }
+        Expr::Case {
+            case_token: _,
+            end_token: _,
+            operand,
+            conditions,
+            else_result,
+        } => {
+            if let Some(operand) = operand {
+                validate_expression_at_depth(operand, context, child_depth)?;
+            }
+            for branch in conditions {
+                validate_expression_at_depth(&branch.condition, context, child_depth)?;
+                validate_expression_at_depth(&branch.result, context, child_depth)?;
+            }
+            if let Some(else_result) = else_result {
+                validate_expression_at_depth(else_result, context, child_depth)?;
+            }
+            Ok(())
+        }
+        Expr::Function(function) if context.aggregates => {
+            validate_aggregate(function, context.without_aggregates(), child_depth)
+        }
+        _ => unsupported("expression form"),
+    }
+}
+
+fn validate_value(value: &Value, allow_placeholder: bool) -> SubsetResult {
+    match value {
+        Value::Number(_, false)
+        | Value::SingleQuotedString(_)
+        | Value::Boolean(_)
+        | Value::Null => Ok(()),
+        Value::Placeholder(_) if allow_placeholder => Ok(()),
+        Value::Placeholder(_) => unsupported("placeholders in schema expressions"),
+        _ => unsupported("literal form"),
+    }
+}
+
+fn binary_operator_is_common(operator: &BinaryOperator) -> bool {
+    matches!(
+        operator,
+        BinaryOperator::Plus
+            | BinaryOperator::Minus
+            | BinaryOperator::Multiply
+            | BinaryOperator::Divide
+            | BinaryOperator::Modulo
+            | BinaryOperator::Gt
+            | BinaryOperator::Lt
+            | BinaryOperator::GtEq
+            | BinaryOperator::LtEq
+            | BinaryOperator::Eq
+            | BinaryOperator::NotEq
+            | BinaryOperator::And
+            | BinaryOperator::Or
+    )
+}
+
+fn validate_aggregate(
+    function: &Function,
+    argument_context: ExprContext,
+    argument_depth: usize,
+) -> SubsetResult {
+    let [ObjectNamePart::Identifier(name)] = function.name.0.as_slice() else {
+        return unsupported("qualified aggregate functions");
+    };
+    if name.quote_style.is_some() || function.uses_odbc_syntax {
+        return unsupported("quoted or ODBC aggregate functions");
+    }
+    let aggregate = name.value.to_ascii_uppercase();
+    if !matches!(aggregate.as_str(), "COUNT" | "SUM" | "AVG" | "MIN" | "MAX") {
+        return unsupported("scalar or unknown functions");
+    }
+    if !matches!(function.parameters, FunctionArguments::None)
+        || function.filter.is_some()
+        || function.null_treatment.is_some()
+        || function.over.is_some()
+        || !function.within_group.is_empty()
+    {
+        return unsupported("aggregate function modifiers");
+    }
+    let FunctionArguments::List(arguments) = &function.args else {
+        return unsupported("aggregate function arguments");
+    };
+    if !arguments.clauses.is_empty() || arguments.args.len() != 1 {
+        return unsupported("aggregate function arguments");
+    }
+    let FunctionArg::Unnamed(argument) = &arguments.args[0] else {
+        return unsupported("named aggregate arguments");
+    };
+    match argument {
+        FunctionArgExpr::Expr(expression) => {
+            validate_expression_at_depth(expression, argument_context, argument_depth)
+        }
+        FunctionArgExpr::Wildcard
+            if aggregate == "COUNT" && arguments.duplicate_treatment.is_none() =>
+        {
+            Ok(())
+        }
+        FunctionArgExpr::QualifiedWildcard(_)
+        | FunctionArgExpr::Wildcard
+        | FunctionArgExpr::WildcardWithOptions(_) => unsupported("aggregate wildcard arguments"),
+    }
+}
+
+fn validate_default_expression(expression: &Expr) -> SubsetResult {
+    let mut expression = expression;
+    loop {
+        match expression {
+            Expr::Nested(inner) => expression = inner,
+            Expr::Value(value) => return validate_value(&value.value, false),
+            Expr::UnaryOp {
+                op: UnaryOperator::Plus | UnaryOperator::Minus,
+                expr,
+            } if is_numeric_literal(expr) => return Ok(()),
+            _ => return unsupported("DEFAULT expressions other than literals"),
+        }
+    }
+}
+
+fn is_numeric_literal(expression: &Expr) -> bool {
+    let mut expression = expression;
+    loop {
+        match expression {
+            Expr::Nested(inner) => expression = inner,
+            Expr::Value(value) => return matches!(value.value, Value::Number(_, false)),
+            _ => return false,
+        }
+    }
+}
+
+fn validate_limit_value(expression: &Expr) -> SubsetResult {
+    match expression {
+        Expr::Value(value) => match &value.value {
+            Value::Number(number, false) if number.bytes().all(|byte| byte.is_ascii_digit()) => {
+                Ok(())
+            }
+            Value::Placeholder(_) => Ok(()),
+            _ => unsupported("LIMIT or OFFSET value"),
+        },
+        _ => unsupported("LIMIT or OFFSET value"),
+    }
+}
+
+fn validate_one_part_name(name: &ObjectName, feature: &'static str) -> SubsetResult {
+    if matches!(name.0.as_slice(), [ObjectNamePart::Identifier(_)]) {
+        Ok(())
+    } else {
+        unsupported(feature)
+    }
+}
+
+fn common_identifier_key(name: &ObjectName, feature: &'static str) -> SubsetResult<String> {
+    let [ObjectNamePart::Identifier(identifier)] = name.0.as_slice() else {
+        return unsupported(feature);
+    };
+    Ok(identifier.value.to_ascii_lowercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::thread;
+
+    use super::*;
+    use crate::sql::{MAX_PARSED_SQL_BYTES, parse};
+
+    fn validate(dialect: SqlDialect, source: &str) -> EngineResult<CommonSql> {
+        validate_common_subset(parse(dialect, source)?)
+    }
+
+    fn assert_supported(dialect: SqlDialect, source: &str) {
+        validate(dialect, source)
+            .unwrap_or_else(|error| panic!("{dialect} rejected {source}: {error}"));
+    }
+
+    fn assert_unsupported(dialect: SqlDialect, source: &str) {
+        let error = match validate(dialect, source) {
+            Ok(_) => panic!("{dialect} unexpectedly accepted {source}"),
+            Err(error) => error,
+        };
+        assert_eq!(error.kind(), EngineErrorKind::Unsupported, "{source}");
+    }
+
+    #[test]
+    fn every_statement_family_has_a_common_form_in_all_source_dialects() {
+        let common = [
+            "CREATE TABLE IF NOT EXISTS widgets(id INTEGER PRIMARY KEY, tenant_id INTEGER NOT NULL, score INTEGER DEFAULT 0, UNIQUE (tenant_id), CHECK (score >= 0))",
+            "CREATE UNIQUE INDEX widgets_tenant ON widgets(tenant_id, score DESC)",
+            "SELECT tenant_id, COUNT(*) AS total FROM widgets WHERE score BETWEEN 1 AND 9 AND tenant_id IS NOT NULL GROUP BY tenant_id HAVING COUNT(*) > 0 ORDER BY total DESC LIMIT 10 OFFSET 2",
+            "SELECT ALL tenant_id FROM widgets",
+            "SELECT DISTINCT tenant_id FROM widgets",
+            "UPDATE widgets SET score = score + 1 WHERE tenant_id = 7",
+            "DELETE FROM widgets WHERE tenant_id = 7",
+            "BEGIN",
+            "BEGIN TRANSACTION",
+            "BEGIN WORK",
+            "COMMIT",
+            "ROLLBACK",
+        ];
+
+        for dialect in SqlDialect::ALL.iter().copied() {
+            for source in common {
+                assert_supported(dialect, source);
+            }
+        }
+
+        for (dialect, placeholder) in [
+            (SqlDialect::Sqlite, "?1"),
+            (SqlDialect::PostgreSql, "$1"),
+            (SqlDialect::MySql, "?"),
+        ] {
+            assert_supported(
+                dialect,
+                &format!(
+                    "INSERT INTO widgets(id, tenant_id, score) VALUES ({placeholder}, 1, 2), (3, 1, 4)"
+                ),
+            );
+        }
+    }
+
+    #[test]
+    fn common_sql_is_owned_exact_and_redacted() {
+        fn assert_owned<T: Clone + Send + Sync + 'static>() {}
+        assert_owned::<CommonSql>();
+
+        let source = "SELECT 'private value' AS label";
+        let common = validate(SqlDialect::Sqlite, source).unwrap();
+        let debug = format!("{common:?}");
+
+        assert_eq!(common.dialect(), SqlDialect::Sqlite);
+        assert_eq!(common.source(), source);
+        assert_eq!(common.statement_count(), 1);
+        assert!(!common.is_empty());
+        assert_eq!(common.clone(), common);
+        assert!(debug.contains("source_bytes"));
+        assert!(debug.contains("statement_count"));
+        assert!(!debug.contains("private value"));
+    }
+
+    #[test]
+    fn empty_and_mixed_batches_are_validated_without_execution_policy() {
+        let empty = validate(SqlDialect::Sqlite, " -- no statement\n").unwrap();
+        assert!(empty.is_empty());
+
+        let source = "CREATE TABLE widgets(id INTEGER PRIMARY KEY); INSERT INTO widgets(id) VALUES (1); SELECT id FROM widgets; BEGIN; COMMIT";
+        let common = validate(SqlDialect::Sqlite, source).unwrap();
+        assert_eq!(common.source(), source);
+        assert_eq!(common.statement_count(), 5);
+
+        for (source, ordinal) in [
+            ("CREATE VIEW deferred AS SELECT 1; SELECT 2; SELECT 3", 1),
+            ("SELECT 1; CREATE VIEW deferred AS SELECT 2; SELECT 3", 2),
+            ("SELECT 1; SELECT 2; CREATE VIEW deferred AS SELECT 3", 3),
+        ] {
+            let error = validate(SqlDialect::Sqlite, source).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::Unsupported);
+            assert!(error.diagnostic().contains(&format!("statement {ordinal}")));
+            assert!(!error.diagnostic().contains(source));
+        }
+    }
+
+    #[test]
+    fn unsupported_top_level_statements_are_not_confused_with_parse_errors() {
+        for source in [
+            "DROP TABLE widgets",
+            "ALTER TABLE widgets ADD COLUMN label TEXT",
+            "CREATE VIEW widget_ids AS SELECT id FROM widgets",
+            "SAVEPOINT nested",
+            "RELEASE SAVEPOINT nested",
+        ] {
+            assert_unsupported(SqlDialect::Sqlite, source);
+        }
+
+        let malformed = validate(SqlDialect::Sqlite, "SELECT +").unwrap_err();
+        assert_eq!(malformed.kind(), EngineErrorKind::InvalidQuery);
+    }
+
+    #[test]
+    fn create_table_recursively_rejects_non_common_options() {
+        let cases = [
+            "CREATE TEMP TABLE widgets(id INTEGER)",
+            "CREATE TABLE widgets AS SELECT 1 AS id",
+            "CREATE TABLE widgets(id INTEGER) WITHOUT ROWID",
+            "CREATE TABLE widgets(id INTEGER) STRICT",
+            "CREATE TABLE child(id INTEGER REFERENCES parent(id))",
+            "CREATE TABLE child(id INTEGER, FOREIGN KEY(id) REFERENCES parent(id))",
+            "CREATE TABLE widgets(id INTEGER GENERATED ALWAYS AS (1) STORED)",
+            "CREATE TABLE widgets(id INTEGER DEFAULT (abs(1)))",
+            "CREATE TABLE widgets(id INTEGER CHECK (id > ?1))",
+            "CREATE TABLE qualified.widgets(id INTEGER)",
+            "CREATE TABLE widgets(id)",
+        ];
+        for source in cases {
+            assert_unsupported(SqlDialect::Sqlite, source);
+        }
+
+        assert_supported(
+            SqlDialect::Sqlite,
+            "CREATE TABLE widgets(id CUSTOM_TYPE DEFAULT -1, label TEXT NULL, CONSTRAINT widgets_id UNIQUE(id), CHECK(id >= 0))",
+        );
+    }
+
+    #[test]
+    fn create_index_accepts_only_named_plain_columns() {
+        assert_supported(
+            SqlDialect::Sqlite,
+            "CREATE INDEX IF NOT EXISTS widgets_idx ON widgets(id ASC, tenant_id DESC)",
+        );
+        for source in [
+            "CREATE INDEX widgets_idx ON widgets((id + 1))",
+            "CREATE INDEX widgets_idx ON widgets(id) WHERE id > 0",
+        ] {
+            assert_unsupported(SqlDialect::Sqlite, source);
+        }
+        for source in [
+            "CREATE INDEX widgets_idx ON widgets USING btree (id)",
+            "CREATE INDEX widgets_idx ON widgets(id) INCLUDE (tenant_id)",
+        ] {
+            assert_unsupported(SqlDialect::PostgreSql, source);
+        }
+    }
+
+    #[test]
+    fn common_expressions_and_aggregates_are_recursive() {
+        let source = "SELECT CASE WHEN score IS NULL THEN 0 ELSE score + 1 END AS adjusted, COUNT(DISTINCT tenant_id), MIN(score), MAX(score), SUM(score), AVG(score) FROM widgets WHERE tenant_id IN (1, ?1) AND score NOT BETWEEN 2 AND 3 AND label LIKE 'a%' GROUP BY score HAVING SUM(score) > 0 ORDER BY COUNT(*) DESC LIMIT ?2 OFFSET 1";
+        assert_supported(SqlDialect::Sqlite, source);
+    }
+
+    #[test]
+    fn select_rejects_every_deferred_query_shape() {
+        for source in [
+            "WITH selected AS (SELECT 1) SELECT * FROM selected",
+            "SELECT 1 UNION SELECT 2",
+            "SELECT * FROM widgets JOIN tenants ON widgets.tenant_id = tenants.id",
+            "SELECT * FROM widgets, tenants",
+            "SELECT (SELECT 1)",
+            "SELECT upper(label) FROM widgets",
+            "SELECT CAST(score AS TEXT) FROM widgets",
+            "SELECT id FROM widgets WHERE id IN (SELECT id FROM archived_widgets)",
+            "SELECT id FROM widgets WHERE label LIKE 'a%' ESCAPE '!'",
+            "SELECT * FROM widgets ORDER BY score NULLS FIRST",
+            "SELECT schema.widgets.* FROM widgets",
+        ] {
+            assert_unsupported(SqlDialect::Sqlite, source);
+        }
+        assert_unsupported(
+            SqlDialect::PostgreSql,
+            "SELECT DISTINCT ON (tenant_id) tenant_id FROM widgets",
+        );
+        assert_unsupported(
+            SqlDialect::PostgreSql,
+            "SELECT COUNT(*) OVER () FROM widgets",
+        );
+        assert_unsupported(
+            SqlDialect::PostgreSql,
+            "SELECT COUNT(id, tenant_id) FROM widgets",
+        );
+        assert_unsupported(SqlDialect::MySql, "SELECT * FROM widgets LIMIT 10, 20");
+    }
+
+    #[test]
+    fn insert_requires_explicit_equal_width_values_without_modifiers() {
+        assert_supported(
+            SqlDialect::PostgreSql,
+            "INSERT INTO widgets(id, tenant_id) VALUES ($1, 1), (2, $2)",
+        );
+        for source in [
+            "INSERT INTO widgets VALUES (1)",
+            "INSERT INTO widgets(id, tenant_id) VALUES (1)",
+            "INSERT INTO widgets(id, id) VALUES (1, 2)",
+            "INSERT INTO widgets(id, ID) VALUES (1, 2)",
+            "INSERT INTO widgets(id) SELECT id FROM old_widgets",
+            "INSERT INTO widgets(id) VALUES (1) RETURNING id",
+        ] {
+            assert_unsupported(SqlDialect::PostgreSql, source);
+        }
+        assert_unsupported(
+            SqlDialect::Sqlite,
+            "INSERT INTO widgets(id) VALUES (1) ON CONFLICT(id) DO NOTHING",
+        );
+        assert_unsupported(
+            SqlDialect::MySql,
+            "INSERT IGNORE INTO widgets(id) VALUES (1)",
+        );
+    }
+
+    #[test]
+    fn update_validates_shape_but_leaves_routing_for_later() {
+        assert_supported(SqlDialect::Sqlite, "UPDATE widgets SET score = score + 1");
+        assert_supported(
+            SqlDialect::PostgreSql,
+            "UPDATE widgets AS w SET score = $1 WHERE w.tenant_id = $2",
+        );
+        for source in [
+            "UPDATE widgets SET score = 1, score = 2",
+            "UPDATE widgets SET score = 1, SCORE = 2",
+            "UPDATE widgets SET (score, tenant_id) = (1, 2)",
+            "UPDATE widgets SET score = other.score FROM other WHERE widgets.id = other.id",
+            "UPDATE widgets SET score = 1 RETURNING score",
+        ] {
+            assert_unsupported(SqlDialect::PostgreSql, source);
+        }
+        assert_unsupported(
+            SqlDialect::MySql,
+            "UPDATE widgets SET score = 1 ORDER BY id LIMIT 1",
+        );
+        assert_unsupported(
+            SqlDialect::Sqlite,
+            "UPDATE OR REPLACE widgets SET score = 1",
+        );
+    }
+
+    #[test]
+    fn delete_validates_shape_but_leaves_routing_for_later() {
+        assert_supported(SqlDialect::Sqlite, "DELETE FROM widgets");
+        assert_supported(
+            SqlDialect::PostgreSql,
+            "DELETE FROM widgets AS w WHERE w.tenant_id = $1",
+        );
+        assert_unsupported(
+            SqlDialect::PostgreSql,
+            "DELETE FROM widgets USING tenants WHERE widgets.tenant_id = tenants.id",
+        );
+        assert_unsupported(SqlDialect::PostgreSql, "DELETE FROM widgets RETURNING id");
+        assert_unsupported(SqlDialect::MySql, "DELETE FROM widgets ORDER BY id LIMIT 1");
+    }
+
+    #[test]
+    fn transaction_variants_are_narrow_and_state_free() {
+        for source in [
+            "ABORT",
+            "COMMIT TRANSACTION",
+            "COMMIT WORK",
+            "COMMIT TRAN",
+            "COMMIT AND NO CHAIN",
+            "ROLLBACK TRANSACTION",
+            "ROLLBACK WORK",
+            "ROLLBACK TRAN",
+            "ROLLBACK AND NO CHAIN",
+            "ABORT AND NO CHAIN",
+        ] {
+            assert_supported(SqlDialect::PostgreSql, source);
+        }
+
+        for source in [
+            "START TRANSACTION",
+            "BEGIN IMMEDIATE",
+            "ROLLBACK TO SAVEPOINT nested",
+        ] {
+            let dialect = if source == "BEGIN IMMEDIATE" {
+                SqlDialect::Sqlite
+            } else {
+                SqlDialect::PostgreSql
+            };
+            assert_unsupported(dialect, source);
+        }
+        assert_unsupported(SqlDialect::PostgreSql, "COMMIT AND CHAIN");
+    }
+
+    #[test]
+    fn unsupported_diagnostics_never_contain_source_sql() {
+        let source = "SELECT upper('private literal')";
+        let error = validate(SqlDialect::Sqlite, source).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Unsupported);
+        assert!(!error.diagnostic().contains(source));
+        assert!(!error.diagnostic().contains("private literal"));
+        assert!(error.diagnostic().contains("statement 1"));
+    }
+
+    #[test]
+    fn concurrent_validation_owns_no_shared_mutable_parser_state() {
+        let parsed = parse(
+            SqlDialect::PostgreSql,
+            "SELECT tenant_id FROM widgets WHERE tenant_id = $1",
+        )
+        .unwrap();
+        let threads = (0..24)
+            .map(|_| {
+                let parsed = parsed.clone();
+                thread::spawn(move || validate_common_subset(parsed))
+            })
+            .collect::<Vec<_>>();
+
+        for handle in threads {
+            let common = handle.join().unwrap().unwrap();
+            assert_eq!(common.statement_count(), 1);
+        }
+    }
+
+    #[test]
+    fn ordinary_parenthesized_expression_depth_remains_supported() {
+        let expression = (0..16).fold("tenant_id = 1".to_owned(), |inner, _| {
+            format!("({inner} AND tenant_id = 1)")
+        });
+        assert_supported(
+            SqlDialect::PostgreSql,
+            &format!("SELECT tenant_id FROM widgets WHERE {expression}"),
+        );
+    }
+
+    #[test]
+    fn flat_operator_chains_have_an_exact_independent_validation_depth_limit() {
+        fn source_with_terms(terms: usize) -> String {
+            let expression = std::iter::repeat_n("1", terms)
+                .collect::<Vec<_>>()
+                .join(" + ");
+            format!("SELECT {expression}")
+        }
+
+        let source = source_with_terms(MAX_COMMON_SQL_EXPRESSION_DEPTH);
+        assert_supported(SqlDialect::PostgreSql, &source);
+
+        let source = source_with_terms(MAX_COMMON_SQL_EXPRESSION_DEPTH + 1);
+        let error = validate(SqlDialect::PostgreSql, &source).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+        assert!(
+            error
+                .diagnostic()
+                .contains(&MAX_COMMON_SQL_EXPRESSION_DEPTH.to_string())
+        );
+        assert!(!error.diagnostic().contains(&source));
+
+        let source = source_with_terms(12_000);
+        assert!(source.len() < MAX_PARSED_SQL_BYTES);
+        let error = validate(SqlDialect::PostgreSql, &source).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+    }
+}

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -181,14 +181,49 @@ fn protocol_neutral_sql_parser_facade_is_public_bounded_and_opt_in() {
     assert_eq!(sql::MAX_PARSED_SQL_STATEMENTS, 256);
     assert_eq!(sql::SQL_PARSE_RECURSION_LIMIT, 32);
 
-    // The facade is infrastructure for the later common-subset planner. The
-    // existing raw SQLite path deliberately does not invoke it yet.
+    // Parsing and subset validation are opt-in infrastructure. The existing
+    // raw SQLite path deliberately does not invoke either layer yet.
     let temp = tempfile::tempdir().unwrap();
     let database = core::Database::open(temp.path(), 2).unwrap();
     let mut raw_sql = "SELECT 1".to_owned();
     raw_sql.push_str(&" ".repeat(sql::MAX_PARSED_SQL_BYTES));
     let result = database.query("parser-opt-in", &raw_sql, &[]).unwrap();
     assert_eq!(result.rows()[0].get(0), Some(&core::Value::Int64(1)));
+}
+
+#[test]
+fn common_sql_subset_validation_is_public_owned_and_opt_in() {
+    fn assert_owned_public<T: Clone + Send + Sync + 'static>() {}
+    assert_owned_public::<sql::CommonSql>();
+    assert_eq!(sql::MAX_COMMON_SQL_EXPRESSION_DEPTH, 128);
+
+    for (dialect, source) in [
+        (sql::SqlDialect::Sqlite, "SELECT ?1 AS value"),
+        (sql::SqlDialect::PostgreSql, "SELECT $1 AS value"),
+        (sql::SqlDialect::MySql, "SELECT ? AS value"),
+    ] {
+        let common = sql::validate_common_subset(sql::parse(dialect, source).unwrap()).unwrap();
+        assert_eq!(common.dialect(), dialect);
+        assert_eq!(common.source(), source);
+        assert_eq!(common.statement_count(), 1);
+        assert!(!common.is_empty());
+    }
+
+    let cte = "WITH answer(value) AS (VALUES (9)) SELECT value FROM answer";
+    let unsupported =
+        sql::validate_common_subset(sql::parse(sql::SqlDialect::Sqlite, cte.to_owned()).unwrap())
+            .unwrap_err();
+    assert_eq!(unsupported.kind(), core::EngineErrorKind::Unsupported);
+    assert!(!unsupported.diagnostic().contains(cte));
+
+    let malformed = sql::parse(sql::SqlDialect::Sqlite, "SELECT +").unwrap_err();
+    assert_eq!(malformed.kind(), core::EngineErrorKind::InvalidQuery);
+
+    // The structural validator does not alter the current execution path.
+    let temp = tempfile::tempdir().unwrap();
+    let database = core::Database::open(temp.path(), 2).unwrap();
+    let result = database.query("subset-opt-in", cte, &[]).unwrap();
+    assert_eq!(result.rows()[0].get(0), Some(&core::Value::Int64(9)));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add the public `validate_common_subset(ParsedSql) -> EngineResult<CommonSql>` API
- recursively validate the first shared DDL, query, DML, and transaction forms across SQLite, PostgreSQL, and MySQL source dialects
- preserve exact source and dialect metadata while returning `Unsupported` for parsed forms outside the subset
- bound recursive expression validation independently at 128 AST levels
- document the normative statement, expression, error, and downstream-planning boundaries

## Behavior

This is an opt-in structural validation layer. It does not normalize placeholders, translate types, infer shards, plan, authorize, or execute SQL. Existing raw SQLite HTTP behavior remains unchanged and has a direct regression test.

The validator covers `CREATE TABLE`, `CREATE INDEX`, `SELECT`, `INSERT`, `UPDATE`, `DELETE`, `BEGIN`, `COMMIT`, and `ROLLBACK`, including nested expression and clause checks. Empty and mixed batches remain structural inputs for the later request-policy issue.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features`
- `cargo test --locked --doc --all-features`
- `cargo +1.85.0 test --locked --all-targets --all-features`
- `cargo +1.85.0 test --locked --doc --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --no-deps --all-features`
- independent read-only implementation and contract review

Closes #20
