### PR TITLE
Normalize SQL placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ The [SQL parser decision record](docs/SQL_PARSER.md) defines the shared,
 dialect-explicit syntax boundary and its resource and dependency limits.
 The [common SQL subset contract](docs/SQL_SUBSET.md) defines the opt-in,
 protocol-neutral structural validator and its exact accepted statement forms.
+The [SQL parameter-normalization contract](docs/SQL_PARAMETERS.md) defines the
+opt-in dialect-specific rewrite to canonical SQLite positional parameters and
+its per-statement binding metadata.
 The [error contract](docs/ERRORS.md) defines stable engine error kinds, safe
 HTTP problem details, and the mappings reserved for future PostgreSQL and MySQL
 adapters.
@@ -45,8 +48,9 @@ minimum supported Rust version (MSRV) and the latest stable toolchain.
 - Explicit graceful drain, forced cancellation, and blocking handle cleanup
 - Protocol-neutral typed values, ordered columns, positional rows, and results
 - A bounded SQL AST parser plus recursive common-subset validator for explicit
-  SQLite, PostgreSQL, and MySQL dialects, isolated from the current raw SQLite
-  HTTP execution path
+  SQLite, PostgreSQL, and MySQL dialects, followed by opt-in source-preserving
+  placeholder normalization and per-statement binding metadata, all isolated
+  from the current raw SQLite HTTP execution path
 - A transactionally versioned `manifest.sqlite` with durable 4,096-bucket
   routing plus logical-database and table metadata
 - Identity-bound, WAL-enabled SQLite shard files that are never silently
@@ -167,9 +171,11 @@ connections rather than reserving every shard pool.
 
 Rust callers may explicitly parse SQL and consume the result with
 `validate_common_subset(ParsedSql)`, receiving an owned opaque `CommonSql` on
-success. This validation step does not normalize, route, plan, authorize, or
-execute SQL. The HTTP execute, query, and migration endpoints do not invoke it
-and retain their existing raw SQLite behavior.
+success. They may then opt into `normalize_placeholders(CommonSql)`, receiving
+canonical SQLite `?N` text and per-statement occurrence-to-index metadata
+without supplying parameter values. These steps do not route, plan, authorize,
+or execute SQL. The HTTP execute, query, and migration endpoints invoke neither
+layer and retain their existing raw SQLite behavior.
 
 `EngineOptions` permits 1–16 active connections and 1–1,024 queued operations
 per shard, with at most 512 active connections across all shards.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -204,7 +204,7 @@ interrupted schema migration can be diagnosed and resumed.
   spike; do not route by regular expression.
 - [x] Define the first common SQL subset: `CREATE TABLE`, indexes, `SELECT`,
   `INSERT`, `UPDATE`, `DELETE`, `BEGIN`, `COMMIT`, and `ROLLBACK`.
-- [ ] Normalize placeholders (`$1`, PostgreSQL/MySQL `?`) to SQLite parameters
+- [x] Normalize placeholders (`$1`, PostgreSQL/MySQL `?`) to SQLite parameters
   without interpolating values into SQL text.
 - [ ] Infer shard keys from predicates and inserted values, including bound
   parameters and multi-row inserts.
@@ -370,8 +370,8 @@ The first buildable slices should be small and merge independently:
 4. Define manifest schema v2 and golden routing vectors.
 5. Add the virtual-bucket map while test data can still be discarded.
 6. Add `Session`, transaction state, and one-shard pinning.
-7. Add SQL parsing and structural common-subset validation without syntax
-   translation.
+7. Add SQL parsing, structural common-subset validation, and source-preserving
+   placeholder normalization without general syntax translation.
 8. Infer routing for one-table equality CRUD and reject unroutable writes.
 9. Spike PostgreSQL simple-query connectivity end to end.
 10. Add PostgreSQL extended query flow, then reuse the same conformance suite

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,7 +23,7 @@ server ---------> protocol::http
 | --- | --- | --- |
 | `core` | Protocol-neutral `Engine`, `Session`, statements, values, results, errors, and read-only logical catalog; stable key routing; bounded per-shard admission and connection pools; routed execute/query and journaled schema migration | JSON/HTTP types, listeners, or Axum handlers |
 | `storage` | Versioned routing/logical manifest, shard layout, migration journal and recovery, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
-| `sql` | Dialect-explicit SQL syntax parsing and recursive common-subset validation behind BriskDB-owned opaque types; exact source retention; SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, routing, catalog lookup, filesystem layout, protocol responses, or protocol-specific support policy |
+| `sql` | Dialect-explicit SQL syntax parsing, recursive common-subset validation, and source-preserving placeholder normalization behind BriskDB-owned types; exact source retention; SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, routing, catalog lookup, filesystem layout, protocol responses, bound-value ownership, or protocol-specific support policy |
 | `protocol::http` | HTTP request extraction plus JSON/BriskDB value and RFC 9457 problem-detail encoding | BLAKE3 routing, shard files, or rusqlite calls |
 | `protocol::error` | Exhaustive HTTP, PostgreSQL, and MySQL mappings from stable engine error kinds | SQLite errors, routing decisions, or wire-protocol session state |
 | `server` | Process configuration, database assembly, listener binding, and tracked Axum HTTP/1 connection lifecycle | SQL parsing or storage implementation details |
@@ -92,10 +92,10 @@ deterministic and keeps the dependency replaceable.
 
 Parsing is syntax recognition, not support validation or planning. The parser
 has no session, parameter, catalog, storage, or routing access. The separate
-common-subset validator and later normalization and planner layers consume
-structural syntax through BriskDB-owned interfaces; shard-key inference must not
-inspect raw or formatted SQL with regular expressions. Exact input remains
-authoritative because AST formatting is lossy and is never executed.
+common-subset validator, placeholder normalizer, and later planner layers
+consume structural syntax through BriskDB-owned interfaces; shard-key inference
+must not inspect raw or formatted SQL with regular expressions. Exact input
+remains authoritative because AST formatting is lossy and is never executed.
 
 Inputs are bounded to 65,536 UTF-8 bytes, 256 statements, and recursion depth
 32. The dependency's recursive-protection feature remains enabled. Parse and
@@ -122,9 +122,34 @@ The normative accepted forms and exclusions are in the [common SQL subset
 contract](SQL_SUBSET.md).
 
 The current HTTP execute/query and migration paths deliberately remain raw
-SQLite pass-through and call neither the parser nor the subset validator.
-Issues #19 and #20 therefore change no HTTP shape, SQL acceptance, routing, or
-storage behavior.
+SQLite pass-through and call neither the parser, subset validator, nor
+placeholder normalizer. Issues #19 through #21 therefore change no HTTP shape,
+SQL acceptance, routing, or storage behavior.
+
+### Placeholder-normalization boundary
+
+`normalize_placeholders(CommonSql)` consumes the owned subset marker and
+returns an owned `NormalizedSql`. It retains the exact source and produces a
+separate `sqlite_parameter_sql()` representation in which only accepted
+placeholder spans become canonical SQLite `?N` markers. PostgreSQL `$N`
+retains `N`; MySQL `?` is numbered consecutively; SQLite `?` and `?NNN` use
+SQLite's max-so-far rule. Numbering restarts per top-level statement and is
+bounded by `MAX_SQL_PARAMETERS` (32,766).
+
+Each statement, including one without placeholders, has an ordered
+`StatementParameters` record with its largest assigned index, occurrence
+count, and occurrence-to-index sequence. This metadata lets later bind-time
+planning distinguish repeated parameters and gaps without owning protocol
+buffers. It does not inspect the bound values themselves.
+
+Normalization uses retained AST placeholder spans rather than regular
+expressions or AST formatting. Every non-marker byte remains exact, including
+comments, literals, whitespace, and UTF-8 text. SQLite named parameters are
+deliberately unsupported. The layer has no session, catalog, storage, routing,
+filesystem, or execution access and does not decide whether a statement batch
+may execute; issue #27 owns that policy. The normative API, dialect rules,
+limits, errors, and tests are in the [SQL parameter-normalization
+contract](SQL_PARAMETERS.md).
 
 ## Manifest storage boundary
 

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -146,6 +146,17 @@ exceeding that limit is `LimitExceeded`. Empty and mixed batches can pass
 structural validation; later request-level classification decides whether they
 may execute. See the [common SQL subset contract](SQL_SUBSET.md).
 
+The opt-in placeholder normalizer classifies a zero positional index or marker
+spelling incompatible with the selected PostgreSQL or MySQL dialect as
+`InvalidQuery`. A named SQLite parameter is deliberately `Unsupported`.
+Assigning an index greater than `MAX_SQL_PARAMETERS` (32,766) within one
+statement is `LimitExceeded`; numbering restarts at each statement. A mismatch
+between a retained placeholder span and the retained exact source violates an
+internal SQL-layer invariant and is `Internal`. Normalization diagnostics use
+fixed categories and positions and never contain SQL, literal or marker text,
+bound values, formatted AST output, or source locations. See the [SQL
+parameter-normalization contract](SQL_PARAMETERS.md).
+
 The core contains no HTTP, PostgreSQL, or MySQL response types. Conversely,
 protocol adapters do not inspect SQLite errors. This lets every frontend share
 one error identity while retaining its own response encoding.

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -16,12 +16,14 @@ document defines the SQL and behavioral contract separately from connectivity.
 - **Unsupported** means BriskDB rejects the behavior or makes no compatibility
   promise for it.
 
-The syntax parser and recursive common-subset validator are now available behind
-BriskDB-owned opaque types. Validation is explicit and returns `Unsupported`
-for a parsed form outside the subset; parser acceptance alone is not product
-support. The current experimental HTTP interface is still a raw SQLite
-pass-through and can execute uncontracted SQLite syntax because it calls neither
-layer. That behavior is not a compatibility promise.
+The syntax parser, recursive common-subset validator, and placeholder
+normalizer are now available behind BriskDB-owned types. Validation is explicit
+and returns `Unsupported` for a parsed form outside the subset; parser
+acceptance alone is not product support. Normalization is also explicit and
+rewrites only validated placeholder spans. The current experimental HTTP
+interface is still a raw SQLite pass-through and can execute uncontracted
+SQLite syntax because it calls none of these layers. That behavior is not a
+compatibility promise.
 
 ## Compatibility layers
 
@@ -41,13 +43,15 @@ than claiming to be a drop-in PostgreSQL or MySQL replacement.
 ## Current implementation
 
 Only the experimental HTTP network interface is implemented today. There is no
-PostgreSQL or MySQL listener or dialect translation layer yet. The public Rust
-SQL facade can parse an explicitly selected SQLite, PostgreSQL, or MySQL dialect
-and can consume that result with `validate_common_subset(ParsedSql)`, yielding
-an opaque `CommonSql` after recursive structural validation. Neither operation
-plans, routes, translates, authorizes, or executes a statement. HTTP requests
-still send SQLite SQL directly to `rusqlite`; they do not pass through the
-parser or subset validator.
+PostgreSQL or MySQL listener or general dialect translation layer yet. The
+public Rust SQL facade can parse an explicitly selected SQLite, PostgreSQL, or
+MySQL dialect, consume that result with
+`validate_common_subset(ParsedSql)`, and then opt into
+`normalize_placeholders(CommonSql)`. The final step yields canonical SQLite
+`?N` text and per-statement parameter metadata without accepting values. None
+of these operations plans, routes, generally translates, authorizes, or
+executes a statement. HTTP requests still send SQLite SQL directly to
+`rusqlite`; they do not pass through these opt-in SQL layers.
 
 | Interface | Status | SQL accepted | Routing |
 | --- | --- | --- | --- |
@@ -57,9 +61,9 @@ parser or subset validator.
 | PostgreSQL wire protocol | Planned | Common subset plus documented PostgreSQL normalization | SQL/bound-parameter inference with explicit session fallback |
 | MySQL wire protocol | Planned | Common subset plus documented MySQL normalization | SQL/bound-parameter inference with explicit session fallback |
 
-The parser and subset validator are implemented Rust APIs, not network
-interfaces. Structural validation is opt-in and does not change any row in this
-table.
+The parser, subset validator, and placeholder normalizer are implemented Rust
+APIs, not network interfaces. Each step is opt-in and does not change any row
+in this table.
 
 Every HTTP operation now calls the same protocol-neutral async engine intended
 for future PostgreSQL and MySQL adapters. Execute and query requests create a
@@ -167,11 +171,14 @@ no schema change. Cancellation during one shard transaction rolls that
 transaction back, although a commit that wins a close race remains durable and
 is reconciled from the retained journal prefix.
 
-### Current parameter and result conversion
+### Current HTTP parameter and result conversion
 
 Use SQLite positional placeholders such as `?1` and `?2`. Values are never
 interpolated into SQL text. The HTTP adapter converts JSON parameters into
 protocol-neutral BriskDB values; the SQL layer binds only those typed values.
+This existing execution-time binding is separate from the opt-in
+`normalize_placeholders(CommonSql)` Rust API: the HTTP adapter neither invokes
+that function nor changes the caller's SQL marker text.
 
 | JSON input | SQLite binding |
 | --- | --- |
@@ -272,15 +279,18 @@ multi-statement combinations are safe.
 consumes the opaque parsed result and returns an owned opaque `CommonSql` only
 when every top-level statement and nested form is in the first subset. Empty
 and mixed batches may validate because request-level batch policy remains issue
-#27. Both marker types retain exact source, dialect, and statement count without
+#27. `normalize_placeholders(CommonSql)` then returns an owned `NormalizedSql`
+with canonical SQLite parameter text and one parameter record per statement.
+All three types retain exact source, dialect, and statement count without
 exposing the upstream AST or rendering SQL in `Debug` output.
 
-The parser and validator have no routing or storage access. Future shard
-inference and statement classification consume structural syntax, never
+The parser, validator, and normalizer have no routing or storage access. Future
+shard inference and statement classification consume structural syntax, never
 regular-expression matches over raw or formatted SQL. See the [SQL parser
-decision record](SQL_PARSER.md) for the dependency and resource contract and
-the [common SQL subset contract](SQL_SUBSET.md) for the normative recursive
-whitelist.
+decision record](SQL_PARSER.md) for the dependency and resource contract, the
+[common SQL subset contract](SQL_SUBSET.md) for the normative recursive
+whitelist, and the [SQL parameter-normalization
+contract](SQL_PARAMETERS.md) for numbering and source-preservation rules.
 
 ### Implemented pass-through surface
 
@@ -345,11 +355,11 @@ does not mean the subset is connected to execution. Column type names are only
 required to be explicit; type compatibility and translation remain issue #25.
 Insert/update duplicate checks fold ASCII letter case regardless of quoting but
 do not define general identifier normalization, which also remains issue #25.
-Placeholders remain unchanged for issue #21. Catalog-aware key extraction,
-single-shard proof, bind-time planning, and rejection of conflicting or
-unroutable writes remain issues #22 through #24. Prepare/bind/describe/execute
-state remains issue #26, and empty or multi-statement execution policy remains
-issue #27.
+Placeholder normalization is the separate implemented issue #21 layer described
+below. Catalog-aware key extraction, single-shard proof, bind-time planning,
+and rejection of conflicting or unroutable writes remain issues #22 through
+#24. Prepare/bind/describe/execute state remains issue #26, and empty or
+multi-statement execution policy remains issue #27.
 
 The validator independently caps recursive expression AST depth at 128. This
 also bounds flat operator chains that parse iteratively; exceeding the limit is
@@ -362,6 +372,28 @@ transactions through protocol-neutral session state. Writes with no provable
 shard, conflicting shard keys, unsafe statement combinations, and cross-shard
 transactions will be rejected before changing data.
 
+### Implemented placeholder normalization
+
+The public Rust function `normalize_placeholders(CommonSql)` is opt-in and
+accepts no bound values. Its `NormalizedSql::sqlite_parameter_sql()` output
+retains every non-marker byte while representing each accepted marker as a
+canonical SQLite `?N`. `statement_parameters()` reports each statement's
+largest parameter index, occurrence count, and occurrence-to-index sequence.
+Numbering restarts per statement; those records do not grant permission to
+execute a batch.
+
+PostgreSQL `$N` retains index `N`, including repeats, gaps, and out-of-order
+occurrences. MySQL bare `?` markers receive consecutive indices from one.
+SQLite positional `?` and `?NNN` follow SQLite's native max-so-far rule, while
+SQLite named markers are deliberately unsupported. No assigned index may
+exceed `MAX_SQL_PARAMETERS` (32,766). The complete API, examples, limits, and
+error contract are in [SQL parameter normalization](SQL_PARAMETERS.md).
+
+This implemented normalization does not bind or count supplied values, infer a
+shard, translate other dialect syntax, create a prepared statement, classify
+statement behavior, authorize a request, or execute SQL. The HTTP and engine
+paths continue to bind their existing caller-supplied SQLite SQL directly.
+
 ## PostgreSQL differences
 
 The PostgreSQL listener will target the frontend/backend wire protocol and a
@@ -370,7 +402,7 @@ not implemented unless listed as implemented in this document.
 
 | Area | PostgreSQL | BriskDB contract |
 | --- | --- | --- |
-| Parameters | `$1`, `$2`, ... | Planned normalization to bound SQLite parameters; routing occurs at bind/execute time |
+| Parameters | `$1`, `$2`, ... | Implemented opt-in Rust normalization to SQLite `?N`; value binding, wire support, and bind-time routing remain planned |
 | Identifier quoting | Double quotes | Passed through where SQLite semantics agree |
 | Type system | Static types identified by OIDs | Planned loss-aware mapping to BriskDB types and SQLite storage classes |
 | Boolean | Dedicated `boolean` type | Stored as SQLite integer `0` or `1`; protocol adapter returns a Boolean value |
@@ -398,7 +430,7 @@ engine used by PostgreSQL and HTTP.
 
 | Area | MySQL | BriskDB contract |
 | --- | --- | --- |
-| Parameters | `?` in prepared statements | Planned normalization to bound SQLite parameters; no string interpolation |
+| Parameters | `?` in prepared statements | Implemented opt-in Rust normalization to consecutive SQLite `?N`; value binding and wire support remain planned |
 | Identifier quoting | Backticks by default | Planned normalization; double-quoted strict SQL remains available |
 | Type system | Static signed/unsigned column types | BriskDB retains `UInt64` without narrowing; current SQLite binding rejects values above `i64::MAX` until an explicit storage mapping exists |
 | Boolean | Commonly `TINYINT(1)` | Stored as SQLite integer `0` or `1`; protocol adapter returns documented metadata |

--- a/docs/SQL_PARAMETERS.md
+++ b/docs/SQL_PARAMETERS.md
@@ -1,0 +1,171 @@
+# SQL parameter normalization
+
+Status: implemented for roadmap issue #21
+
+BriskDB exposes an opt-in, protocol-neutral placeholder normalizer for SQL that
+has already passed the common-subset validator:
+
+```rust
+normalize_placeholders(common: CommonSql) -> EngineResult<NormalizedSql>
+```
+
+The normalizer consumes the owned [`CommonSql`](SQL_SUBSET.md) marker and
+returns an owned `NormalizedSql`. Callers can inspect its source dialect,
+byte-exact original source, rewritten SQLite parameter SQL, statement count,
+empty-batch state, and one `StatementParameters` record per statement. The
+public SQLite parameter-index ceiling is `MAX_SQL_PARAMETERS`, currently
+32,766.
+
+This layer changes placeholder tokens only. No parameter values enter the
+normalizer, and values are never rendered or interpolated into SQL text. The
+current HTTP execute, query, and migration endpoints and the asynchronous
+engine do not invoke this opt-in layer; they retain their existing raw SQLite
+behavior. Issue #27 owns whether an empty batch, one statement, or a particular
+multi-statement combination may execute.
+
+## Public result
+
+`NormalizedSql` retains both representations:
+
+- `source()` returns the caller's exact original SQL;
+- `sqlite_parameter_sql()` returns the same text with accepted placeholder
+  tokens replaced by canonical SQLite `?N` tokens;
+- `dialect()`, `statement_count()`, and `is_empty()` retain the validated input
+  metadata; and
+- `statement_parameters()` returns `&[StatementParameters]` in statement order.
+
+Each `StatementParameters` reports:
+
+- `parameter_count()`: the largest parameter index assigned in that statement,
+  or zero when the statement has no placeholders;
+- `occurrence_count()`: the number of placeholder occurrences in that
+  statement; and
+- `parameter_indices()`: the assigned one-based index for each occurrence in
+  source order.
+
+`parameter_count()` is intentionally not always the same as
+`occurrence_count()`. Repeated PostgreSQL parameters share one index, and an
+explicit PostgreSQL or SQLite index can leave a gap. Numbering restarts for
+each top-level statement. The per-statement records describe binding; they do
+not authorize batch execution.
+
+For example, PostgreSQL `SELECT $2, $1, $2` becomes
+`SELECT ?2, ?1, ?2`. Its parameter count is 2, its occurrence count is 3, and
+its parameter indices are `[2, 1, 2]`.
+
+## Dialect rules
+
+The source dialect selected during parsing determines the accepted marker
+grammar. BriskDB does not autodetect or retry another dialect.
+
+### PostgreSQL
+
+PostgreSQL `$N` markers retain their positive numeric identity and become
+SQLite `?N`. Repeated markers continue to refer to the same bound value;
+out-of-order markers and gaps are retained. Decimal spelling is canonicalized,
+so leading zeroes do not survive in the SQLite parameter SQL.
+
+```text
+source:  SELECT $02, $1, $02
+SQLite:  SELECT ?2, ?1, ?2
+indices: [2, 1, 2]
+```
+
+Index zero is invalid. An index above `MAX_SQL_PARAMETERS` exceeds the
+normalizer limit.
+
+### MySQL
+
+Each MySQL prepared-statement `?` marker receives the next index from left to
+right, starting at one for each statement.
+
+```text
+source:  INSERT INTO widgets (tenant_id, name) VALUES (?, ?)
+SQLite:  INSERT INTO widgets (tenant_id, name) VALUES (?1, ?2)
+indices: [1, 2]
+```
+
+MySQL source SQL does not acquire PostgreSQL-style numbered parameters at this
+layer. The selected parser and subset boundary determine whether another token
+is a placeholder, an identifier, or invalid syntax before normalization.
+
+### SQLite
+
+SQLite positional `?` and `?NNN` markers follow SQLite's native left-to-right
+numbering. An explicit `?NNN` uses `NNN`. A bare `?` uses one more than the
+largest index assigned earlier in the same statement. A later explicit index
+may reuse or fall below that maximum; it does not renumber earlier occurrences.
+
+```text
+source:  SELECT ?2, ?, ?1, ?
+SQLite:  SELECT ?2, ?3, ?1, ?4
+indices: [2, 3, 1, 4]
+```
+
+SQLite named parameters such as `:name`, `@name`, and `$name` are deliberately
+outside this contract. They are rejected as `Unsupported` rather than assigned
+an order whose aliasing behavior could differ across frontends. Positional
+index zero is invalid, and an assigned index above `MAX_SQL_PARAMETERS`
+exceeds the normalizer limit.
+
+## Source preservation
+
+The normalizer uses placeholder nodes and source spans retained from the parsed
+and validated AST. It does not find markers with regular expressions, render
+the AST, or rewrite arbitrary token-shaped text. Every byte outside an accepted
+placeholder span remains identical, including whitespace, comments, quoted
+identifiers, string literals, semicolons, and UTF-8 text. Marker-like text in a
+comment or literal is therefore unchanged.
+
+The rewritten string is a separate representation. `source()` remains the
+original input, so normalization cannot change migration identity or make a
+lossy AST formatter authoritative.
+
+## Limits and errors
+
+Limits apply independently to each statement:
+
+| Condition | `EngineErrorKind` |
+| --- | --- |
+| Positional marker index zero | `InvalidQuery` |
+| Marker spelling incompatible with the selected PostgreSQL or MySQL dialect | `InvalidQuery` |
+| Assigned index greater than `MAX_SQL_PARAMETERS` (32,766) | `LimitExceeded` |
+| Named SQLite marker | `Unsupported` |
+| Retained placeholder span does not match the retained source | `Internal` |
+
+Diagnostics identify a fixed normalization category and statement or
+occurrence position where useful. They do not contain submitted SQL, literals,
+marker spelling, parameter values, formatted AST output, or source locations.
+Protocol adapters must serialize the fixed public mapping for the error kind,
+not the internal diagnostic.
+
+Parser input, statement-count, and recursion limits still apply before this
+layer, as does the common-subset validator's expression-depth limit.
+
+## Boundaries after normalization
+
+A successful `NormalizedSql` does not establish that:
+
+- the caller supplied exactly `parameter_count()` values with compatible
+  types;
+- a bound value identifies one shard;
+- catalog names and types exist or are compatible;
+- non-placeholder PostgreSQL or MySQL syntax has been translated to SQLite;
+- a statement or batch is permitted by an endpoint or session;
+- a prepared statement has been described, cached, bound, or executed; or
+- execution would preserve all source-dialect semantics.
+
+Issues #22 through #27 own shard-key inference, bind-time planning, conflicting
+or unroutable key rejection, syntax/type translation, prepared-statement state,
+and request-level statement classification respectively.
+
+## Verification obligations
+
+Tests cover each dialect's numbering rules, repeats, gaps, mixed explicit and
+anonymous SQLite markers, per-statement reset, empty and marker-free input,
+exact preservation of comments/literals/whitespace/UTF-8, zero,
+exact-maximum, and over-maximum index cases, named SQLite rejection, diagnostic
+and `Debug` redaction, cloning, concurrent normalization, and recovery after an
+independent error. A raw HTTP regression must continue to bind SQLite named
+parameters without calling this layer, proving that issue #21 did not change
+current execution behavior.

--- a/docs/SQL_PARSER.md
+++ b/docs/SQL_PARSER.md
@@ -6,8 +6,9 @@ BriskDB needs one syntax boundary that PostgreSQL, MySQL, HTTP, and future
 frontends can share without making a protocol adapter understand SQLite or
 invent its own routing rules. This record selects the parser dependency and
 defines that boundary. The separate [common SQL subset contract](SQL_SUBSET.md)
-defines the opt-in structural validator; neither layer is in the current HTTP
-execution path.
+defines the opt-in structural validator, and the [SQL parameter-normalization
+contract](SQL_PARAMETERS.md) defines the opt-in dialect-specific placeholder
+rewrite. None of these layers is in the current HTTP execution path.
 
 ## Decision
 
@@ -38,9 +39,9 @@ SQLite.
 
 The SQL module retains the exact input text alongside an ordered parsed batch.
 The upstream AST stays opaque outside BriskDB's SQL boundary. The implemented
-common-subset validator and later normalizers and planners inspect it through
-BriskDB-owned interfaces, but protocol adapters must not depend on `sqlparser`
-AST types.
+common-subset validator and placeholder normalizer, and later planners, inspect
+it through BriskDB-owned interfaces, but protocol adapters must not depend on
+`sqlparser` AST types.
 
 `sqlparser`'s formatter is not a source-preserving serializer: it can normalize
 comments, whitespace, quoting, and keyword presentation. BriskDB therefore
@@ -59,7 +60,8 @@ In particular, this layer does not:
 
 - itself define or enforce the common SQL subset; issue #20 implements that as
   the separate `validate_common_subset(ParsedSql)` layer;
-- normalize placeholders (issue #21);
+- normalize placeholders; issue #21 implements that as the separate
+  `normalize_placeholders(CommonSql)` layer;
 - infer shard keys or inspect bound values (issue #22);
 - plan prepared statements at bind time (issue #23);
 - reject conflicting keys or unroutable writes (issue #24);
@@ -77,10 +79,10 @@ that still does not grant permission to execute an empty or mixed batch.
 
 The existing HTTP execute, query, and migration paths remain raw SQLite
 pass-through surfaces with their existing authorizer and endpoint-specific
-rules. They call neither this parser nor the opt-in common-subset validator.
-Connecting those layers before normalization, planning, translation, and
-request-level statement policy are implemented would change the experimental
-HTTP SQL surface.
+rules. They call neither this parser, the opt-in common-subset validator, nor
+the opt-in placeholder normalizer. Connecting those layers before planning,
+translation, and request-level statement policy are implemented would change
+the experimental HTTP SQL surface.
 
 ## Resource and error boundaries
 

--- a/docs/SQL_SUBSET.md
+++ b/docs/SQL_SUBSET.md
@@ -33,7 +33,8 @@ The complete batch succeeds as one validation operation or returns
 A successful `CommonSql` does not mean that the SQL:
 
 - names existing databases, tables, columns, constraints, or types;
-- has normalized or correctly numbered placeholders;
+- has normalized or correctly numbered placeholders until the separate
+  [`normalize_placeholders`](SQL_PARAMETERS.md) step succeeds;
 - can be routed to one shard or has a bound routing value;
 - is safe to execute as an empty, single-, or multi-statement request;
 - has a prepared-statement plan or protocol result description;
@@ -41,10 +42,11 @@ A successful `CommonSql` does not mean that the SQL:
 - is authorized for a particular endpoint or session; or
 - has been executed.
 
-Those responsibilities remain with issues #21 through #27 and the later wire
-frontends. Validation never consults parameters, a session, the logical
-catalog, storage, routing state, the filesystem, or SQLite. It never formats or
-searches SQL text to make a structural decision.
+Those responsibilities remain with the implemented issue #21 normalization
+layer, issues #22 through #27, and the later wire frontends. Validation never
+consults parameters, a session, the logical catalog, storage, routing state,
+the filesystem, or SQLite. It never formats or searches SQL text to make a
+structural decision.
 
 Empty and comment-only parsed batches validate successfully. Every statement in
 a mixed batch is checked independently and source order is retained, but that
@@ -159,8 +161,9 @@ numeric literal or a placeholder. The pinned parser represents PostgreSQL
 `LIMIT ALL` as the same absent-limit AST as omitting the clause, so structural
 validation accepts that AST-equivalent spelling and does not inspect source text
 to distinguish it. Placeholder spelling, numbering, count, and binding are not
-validated or changed here; issue #21 owns normalization without value
-interpolation.
+validated or changed here. The separate [SQL parameter-normalization
+contract](SQL_PARAMETERS.md) defines the implemented opt-in numbering step,
+which consumes `CommonSql` without accepting bound values.
 
 Common-subset expression validation has its own maximum recursive AST depth of
 128. This catches long flat operator chains, which the parser can build

--- a/src/protocol/http.rs
+++ b/src/protocol/http.rs
@@ -268,7 +268,9 @@ mod tests {
     use super::*;
     use crate::{
         core::{Column, DataType, EngineErrorKind, EngineOptions, ResultLimits, Row},
-        sql::{MAX_PARSED_SQL_BYTES, SqlDialect, parse, validate_common_subset},
+        sql::{
+            MAX_PARSED_SQL_BYTES, SqlDialect, normalize_placeholders, parse, validate_common_subset,
+        },
     };
 
     fn engine_router(database: Arc<Database>) -> Router {
@@ -519,6 +521,41 @@ mod tests {
                 Some(json!({
                     "shard_key": "subset-http-boundary",
                     "sql": source
+                })),
+            )
+            .await,
+            (
+                StatusCode::OK,
+                json!({
+                    "shard": expected_shard,
+                    "columns": [{"name": "value", "data_type": "unknown"}],
+                    "rows": [[9]]
+                })
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn placeholder_normalization_does_not_change_the_current_http_parameter_path() {
+        let source = "SELECT :value AS value";
+        let common = validate_common_subset(parse(SqlDialect::Sqlite, source).unwrap()).unwrap();
+        let normalization_error = normalize_placeholders(common).unwrap_err();
+        assert_eq!(normalization_error.kind(), EngineErrorKind::Unsupported);
+
+        let temp = tempfile::tempdir().unwrap();
+        let database = Arc::new(Database::open(temp.path(), 2).unwrap());
+        let expected_shard = database.shard_for_key(b"normalizer-http-boundary");
+        let application = engine_router(database);
+
+        assert_eq!(
+            request_json(
+                &application,
+                Method::POST,
+                "/v1/query",
+                Some(json!({
+                    "shard_key": "normalizer-http-boundary",
+                    "sql": source,
+                    "params": [9]
                 })),
             )
             .await,

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -1,13 +1,19 @@
 //! Protocol-neutral SQL parsing, SQLite execution, and value conversion.
 //!
 //! The parser facade produces a bounded, dialect-explicit opaque AST. The
-//! common-subset validator recursively admits only protocol-neutral SQL shapes
-//! for later planning work. Current execution remains deliberate SQLite
-//! pass-through; neither layer gates, rewrites, routes, or executes statements.
+//! common-subset validator recursively admits only protocol-neutral SQL shapes,
+//! and the placeholder normalizer produces a separate source-preserving SQLite
+//! parameter representation for later planning work. Current execution remains
+//! deliberate SQLite pass-through; these opt-in layers do not gate, route, or
+//! execute statements.
 
+mod normalizer;
 mod parser;
 mod subset;
 
+pub use normalizer::{
+    MAX_SQL_PARAMETERS, NormalizedSql, StatementParameters, normalize_placeholders,
+};
 pub use parser::{
     MAX_PARSED_SQL_BYTES, MAX_PARSED_SQL_STATEMENTS, ParsedSql, SQL_PARSE_RECURSION_LIMIT,
     SqlDialect, parse,

--- a/src/sql/normalizer.rs
+++ b/src/sql/normalizer.rs
@@ -1,0 +1,701 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt,
+};
+
+use sqlparser::tokenizer::{Location, Span};
+
+use super::{CommonSql, SqlDialect};
+use crate::core::{EngineError, EngineErrorKind, EngineResult};
+
+/// BriskDB's largest parameter index for placeholder normalization.
+///
+/// This matches the default maximum variable number in BriskDB's bundled
+/// SQLite configuration. Parameter indexes and counts are local to one
+/// top-level statement.
+pub const MAX_SQL_PARAMETERS: usize = 32_766;
+
+/// Common SQL with source-dialect placeholders rewritten to numbered SQLite
+/// parameter markers.
+///
+/// The original SQL remains available through [`Self::source`]. Only accepted
+/// placeholder spans differ in [`Self::sqlite_parameter_sql`]; this layer does
+/// not render the AST, translate other dialect syntax, bind values, or execute
+/// a statement.
+#[derive(Clone, PartialEq, Eq)]
+pub struct NormalizedSql {
+    common: CommonSql,
+    sqlite_parameter_sql: String,
+    statement_parameters: Vec<StatementParameters>,
+}
+
+impl NormalizedSql {
+    /// Return the explicitly selected source dialect.
+    pub const fn dialect(&self) -> SqlDialect {
+        self.common.dialect()
+    }
+
+    /// Return the caller's byte-exact SQL source before marker normalization.
+    pub fn source(&self) -> &str {
+        self.common.source()
+    }
+
+    /// Return SQL with only placeholder markers converted to SQLite `?N` form.
+    ///
+    /// This is not necessarily executable SQLite SQL because later work owns
+    /// translation of other source-dialect syntax.
+    pub fn sqlite_parameter_sql(&self) -> &str {
+        &self.sqlite_parameter_sql
+    }
+
+    /// Return the number of independently normalized top-level statements.
+    pub fn statement_count(&self) -> usize {
+        self.common.statement_count()
+    }
+
+    /// Return whether the parsed input contained no statements.
+    pub fn is_empty(&self) -> bool {
+        self.common.is_empty()
+    }
+
+    /// Return one parameter layout for each top-level statement, in order.
+    pub fn statement_parameters(&self) -> &[StatementParameters] {
+        &self.statement_parameters
+    }
+}
+
+impl fmt::Debug for NormalizedSql {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("NormalizedSql")
+            .field("dialect", &self.dialect())
+            .field("source_bytes", &self.source().len())
+            .field(
+                "sqlite_parameter_sql_bytes",
+                &self.sqlite_parameter_sql.len(),
+            )
+            .field("statement_count", &self.statement_count())
+            .finish()
+    }
+}
+
+/// Parameter numbering for one normalized top-level statement.
+///
+/// Indexes are one-based SQLite binding indexes in lexical occurrence order.
+/// `parameter_count` is the greatest referenced index, so it includes gaps in
+/// PostgreSQL `$N` and SQLite `?N` numbering.
+#[derive(Clone, PartialEq, Eq)]
+pub struct StatementParameters {
+    parameter_count: usize,
+    parameter_indices: Vec<usize>,
+}
+
+impl StatementParameters {
+    /// Return the greatest parameter index used by this statement.
+    pub const fn parameter_count(&self) -> usize {
+        self.parameter_count
+    }
+
+    /// Return the number of placeholder occurrences in this statement.
+    pub fn occurrence_count(&self) -> usize {
+        self.parameter_indices.len()
+    }
+
+    /// Return each one-based parameter index in lexical occurrence order.
+    pub fn parameter_indices(&self) -> &[usize] {
+        &self.parameter_indices
+    }
+}
+
+impl fmt::Debug for StatementParameters {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StatementParameters")
+            .field("parameter_count", &self.parameter_count)
+            .field("occurrence_count", &self.parameter_indices.len())
+            .finish()
+    }
+}
+
+/// Normalize placeholders after common-subset validation.
+///
+/// PostgreSQL `$N` indexes are preserved, MySQL bare `?` markers are numbered
+/// by occurrence, and SQLite positional `?`/`?N` markers retain SQLite's native
+/// numbering. Numbering restarts for every top-level statement. No parameter
+/// values enter this operation.
+pub fn normalize_placeholders(common: CommonSql) -> EngineResult<NormalizedSql> {
+    if common.statement_placeholders().len() != common.statement_count() {
+        return Err(normalization_invariant());
+    }
+
+    let mut planned = Vec::new();
+    let mut statement_parameters = Vec::with_capacity(common.statement_count());
+
+    for (statement_index, placeholders) in common.statement_placeholders().iter().enumerate() {
+        let mut placeholders = placeholders.iter().collect::<Vec<_>>();
+        placeholders.sort_unstable_by_key(|placeholder| placeholder.span);
+
+        let mut parameter_indices = Vec::with_capacity(placeholders.len());
+        let mut greatest_index = 0;
+
+        for (occurrence_index, placeholder) in placeholders.into_iter().enumerate() {
+            let index = parameter_index(
+                common.dialect(),
+                &placeholder.marker,
+                greatest_index,
+                statement_index,
+                occurrence_index,
+            )?;
+            greatest_index = greatest_index.max(index);
+            parameter_indices.push(index);
+            planned.push(PlannedPlaceholder {
+                marker: placeholder.marker.clone(),
+                span: placeholder.span,
+                index,
+            });
+        }
+
+        statement_parameters.push(StatementParameters {
+            parameter_count: greatest_index,
+            parameter_indices,
+        });
+    }
+
+    let sqlite_parameter_sql = rewrite_placeholders(common.source(), &planned)?;
+    Ok(NormalizedSql {
+        common,
+        sqlite_parameter_sql,
+        statement_parameters,
+    })
+}
+
+fn parameter_index(
+    dialect: SqlDialect,
+    marker: &str,
+    greatest_index: usize,
+    statement_index: usize,
+    occurrence_index: usize,
+) -> EngineResult<usize> {
+    match dialect {
+        SqlDialect::PostgreSql => parse_numbered_marker(marker, '$')
+            .map_err(|failure| marker_failure(failure, dialect, statement_index, occurrence_index)),
+        SqlDialect::MySql if marker == "?" => {
+            next_parameter_index(greatest_index, statement_index, occurrence_index)
+        }
+        SqlDialect::MySql => Err(invalid_marker(dialect, statement_index, occurrence_index)),
+        SqlDialect::Sqlite if marker == "?" => {
+            next_parameter_index(greatest_index, statement_index, occurrence_index)
+        }
+        SqlDialect::Sqlite if marker.starts_with('?') => parse_numbered_marker(marker, '?')
+            .map_err(|failure| marker_failure(failure, dialect, statement_index, occurrence_index)),
+        SqlDialect::Sqlite
+            if marker.starts_with(':') || marker.starts_with('@') || marker.starts_with('$') =>
+        {
+            Err(EngineError::new(
+                EngineErrorKind::Unsupported,
+                format!(
+                    "statement {} placeholder {} uses a named SQLite parameter; only positional parameters are supported",
+                    statement_index + 1,
+                    occurrence_index + 1
+                ),
+            ))
+        }
+        SqlDialect::Sqlite => Err(invalid_marker(dialect, statement_index, occurrence_index)),
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MarkerFailure {
+    Invalid,
+    LimitExceeded,
+}
+
+fn parse_numbered_marker(marker: &str, prefix: char) -> Result<usize, MarkerFailure> {
+    let Some(digits) = marker.strip_prefix(prefix) else {
+        return Err(MarkerFailure::Invalid);
+    };
+    if digits.is_empty() || !digits.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(MarkerFailure::Invalid);
+    }
+
+    let mut index = 0_usize;
+    for byte in digits.bytes() {
+        let digit = usize::from(byte - b'0');
+        index = index
+            .checked_mul(10)
+            .and_then(|value| value.checked_add(digit))
+            .ok_or(MarkerFailure::LimitExceeded)?;
+        if index > MAX_SQL_PARAMETERS {
+            return Err(MarkerFailure::LimitExceeded);
+        }
+    }
+
+    if index == 0 {
+        Err(MarkerFailure::Invalid)
+    } else {
+        Ok(index)
+    }
+}
+
+fn next_parameter_index(
+    greatest_index: usize,
+    statement_index: usize,
+    occurrence_index: usize,
+) -> EngineResult<usize> {
+    let index = greatest_index
+        .checked_add(1)
+        .ok_or_else(|| parameter_limit(statement_index, occurrence_index))?;
+    if index > MAX_SQL_PARAMETERS {
+        return Err(parameter_limit(statement_index, occurrence_index));
+    }
+    Ok(index)
+}
+
+fn marker_failure(
+    failure: MarkerFailure,
+    dialect: SqlDialect,
+    statement_index: usize,
+    occurrence_index: usize,
+) -> EngineError {
+    match failure {
+        MarkerFailure::Invalid => invalid_marker(dialect, statement_index, occurrence_index),
+        MarkerFailure::LimitExceeded => parameter_limit(statement_index, occurrence_index),
+    }
+}
+
+fn invalid_marker(
+    dialect: SqlDialect,
+    statement_index: usize,
+    occurrence_index: usize,
+) -> EngineError {
+    EngineError::new(
+        EngineErrorKind::InvalidQuery,
+        format!(
+            "statement {} placeholder {} is not valid {} positional parameter syntax",
+            statement_index + 1,
+            occurrence_index + 1,
+            dialect.name()
+        ),
+    )
+}
+
+fn parameter_limit(statement_index: usize, occurrence_index: usize) -> EngineError {
+    EngineError::new(
+        EngineErrorKind::LimitExceeded,
+        format!(
+            "statement {} placeholder {} exceeds the normalized SQL parameter limit of {MAX_SQL_PARAMETERS}",
+            statement_index + 1,
+            occurrence_index + 1
+        ),
+    )
+}
+
+struct PlannedPlaceholder {
+    marker: String,
+    span: Span,
+    index: usize,
+}
+
+fn rewrite_placeholders(source: &str, planned: &[PlannedPlaceholder]) -> EngineResult<String> {
+    if planned.is_empty() {
+        return Ok(source.to_owned());
+    }
+
+    let mut planned = planned.iter().collect::<Vec<_>>();
+    planned.sort_unstable_by_key(|placeholder| placeholder.span);
+
+    let mut locations = BTreeSet::new();
+    for placeholder in &planned {
+        if placeholder.span.start >= placeholder.span.end
+            || placeholder.span.start == Location::empty()
+            || placeholder.span.end == Location::empty()
+        {
+            return Err(normalization_invariant());
+        }
+        locations.insert(placeholder.span.start);
+        locations.insert(placeholder.span.end);
+    }
+    let offsets = source_offsets(source, &locations)?;
+
+    let mut normalized = String::with_capacity(source.len());
+    let mut cursor = 0;
+    for placeholder in planned {
+        let Some(&start) = offsets.get(&placeholder.span.start) else {
+            return Err(normalization_invariant());
+        };
+        let Some(&end) = offsets.get(&placeholder.span.end) else {
+            return Err(normalization_invariant());
+        };
+        if start < cursor || start >= end || end > source.len() {
+            return Err(normalization_invariant());
+        }
+        if source.get(start..end) != Some(placeholder.marker.as_str()) {
+            return Err(normalization_invariant());
+        }
+
+        normalized.push_str(&source[cursor..start]);
+        normalized.push('?');
+        normalized.push_str(&placeholder.index.to_string());
+        cursor = end;
+    }
+    normalized.push_str(&source[cursor..]);
+    Ok(normalized)
+}
+
+fn source_offsets(
+    source: &str,
+    locations: &BTreeSet<Location>,
+) -> EngineResult<BTreeMap<Location, usize>> {
+    let mut offsets = BTreeMap::new();
+    let mut location = Location::new(1, 1);
+    if locations.contains(&location) {
+        offsets.insert(location, 0);
+    }
+
+    for (byte_offset, character) in source.char_indices() {
+        location = if character == '\n' {
+            Location::new(
+                location
+                    .line
+                    .checked_add(1)
+                    .ok_or_else(normalization_invariant)?,
+                1,
+            )
+        } else {
+            Location::new(
+                location.line,
+                location
+                    .column
+                    .checked_add(1)
+                    .ok_or_else(normalization_invariant)?,
+            )
+        };
+        if locations.contains(&location) {
+            offsets.insert(location, byte_offset + character.len_utf8());
+        }
+    }
+
+    if offsets.len() != locations.len() {
+        return Err(normalization_invariant());
+    }
+    Ok(offsets)
+}
+
+fn normalization_invariant() -> EngineError {
+    EngineError::new(
+        EngineErrorKind::Internal,
+        "placeholder metadata does not match the retained SQL text",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::thread;
+
+    use super::*;
+    use crate::{
+        core::Value,
+        sql::{parse, query, validate_common_subset},
+    };
+
+    fn normalize(dialect: SqlDialect, source: &str) -> EngineResult<NormalizedSql> {
+        normalize_placeholders(validate_common_subset(parse(dialect, source)?)?)
+    }
+
+    fn assert_layout(
+        normalized: &NormalizedSql,
+        statement: usize,
+        count: usize,
+        indices: &[usize],
+    ) {
+        let layout = &normalized.statement_parameters()[statement];
+        assert_eq!(layout.parameter_count(), count);
+        assert_eq!(layout.occurrence_count(), indices.len());
+        assert_eq!(layout.parameter_indices(), indices);
+    }
+
+    #[test]
+    fn dialect_markers_normalize_to_numbered_sqlite_parameters() {
+        let postgres = normalize(SqlDialect::PostgreSql, "SELECT $2, $1, $2, $05").unwrap();
+        assert_eq!(postgres.sqlite_parameter_sql(), "SELECT ?2, ?1, ?2, ?5");
+        assert_layout(&postgres, 0, 5, &[2, 1, 2, 5]);
+
+        let mysql = normalize(SqlDialect::MySql, "SELECT ?, ?, ?").unwrap();
+        assert_eq!(mysql.sqlite_parameter_sql(), "SELECT ?1, ?2, ?3");
+        assert_layout(&mysql, 0, 3, &[1, 2, 3]);
+
+        let sqlite = normalize(SqlDialect::Sqlite, "SELECT ?2, ?, ?1, ?").unwrap();
+        assert_eq!(sqlite.sqlite_parameter_sql(), "SELECT ?2, ?3, ?1, ?4");
+        assert_layout(&sqlite, 0, 4, &[2, 3, 1, 4]);
+    }
+
+    #[test]
+    fn exact_source_is_retained_and_only_ast_placeholder_spans_change() {
+        let source = "-- $8 and ? stay comments\r\nSELECT 'é🙂 $9 ?' AS note,\r\n       $02 AS value -- $7 ?\r\n";
+        let normalized = normalize(SqlDialect::PostgreSql, source).unwrap();
+        assert_eq!(normalized.source(), source);
+        assert_eq!(
+            normalized.sqlite_parameter_sql(),
+            "-- $8 and ? stay comments\r\nSELECT 'é🙂 $9 ?' AS note,\r\n       ?2 AS value -- $7 ?\r\n"
+        );
+        assert_layout(&normalized, 0, 2, &[2]);
+    }
+
+    #[test]
+    fn quoted_identifiers_and_other_dialect_text_are_not_rewritten() {
+        let postgres = normalize(
+            SqlDialect::PostgreSql,
+            "SELECT \"$1\" FROM widgets WHERE tenant_id = $1",
+        )
+        .unwrap();
+        assert_eq!(
+            postgres.sqlite_parameter_sql(),
+            "SELECT \"$1\" FROM widgets WHERE tenant_id = ?1"
+        );
+
+        let mysql = normalize(SqlDialect::MySql, "SELECT $1").unwrap();
+        assert_eq!(mysql.sqlite_parameter_sql(), "SELECT $1");
+        assert_layout(&mysql, 0, 0, &[]);
+    }
+
+    #[test]
+    fn numbering_and_layouts_are_statement_local() {
+        let normalized = normalize(SqlDialect::MySql, "SELECT ?; SELECT 1; SELECT ?, ?").unwrap();
+        assert_eq!(
+            normalized.sqlite_parameter_sql(),
+            "SELECT ?1; SELECT 1; SELECT ?1, ?2"
+        );
+        assert_eq!(normalized.statement_count(), 3);
+        assert_eq!(normalized.statement_parameters().len(), 3);
+        assert_layout(&normalized, 0, 1, &[1]);
+        assert_layout(&normalized, 1, 0, &[]);
+        assert_layout(&normalized, 2, 2, &[1, 2]);
+    }
+
+    #[test]
+    fn empty_and_parameterless_inputs_have_complete_empty_layouts() {
+        let empty = normalize(SqlDialect::Sqlite, " -- comment only\n").unwrap();
+        assert!(empty.is_empty());
+        assert_eq!(empty.statement_count(), 0);
+        assert!(empty.statement_parameters().is_empty());
+        assert_eq!(empty.sqlite_parameter_sql(), empty.source());
+
+        let batch = normalize(SqlDialect::Sqlite, "BEGIN; SELECT 1; COMMIT").unwrap();
+        assert_eq!(batch.statement_parameters().len(), 3);
+        assert!(
+            batch.statement_parameters().iter().all(
+                |layout| layout.parameter_count() == 0 && layout.parameter_indices().is_empty()
+            )
+        );
+        assert_eq!(batch.sqlite_parameter_sql(), batch.source());
+    }
+
+    #[test]
+    fn every_parameter_bearing_statement_family_records_occurrences() {
+        let cases = [
+            (
+                "SELECT $1, COUNT($2) FROM widgets WHERE tenant_id = $3 GROUP BY $4 HAVING COUNT($5) > $6 ORDER BY $7 LIMIT $8 OFFSET $9",
+                (9, vec![1, 2, 3, 4, 5, 6, 7, 8, 9]),
+            ),
+            (
+                "INSERT INTO widgets(id, tenant_id) VALUES ($2, $1), ($2, $1)",
+                (2, vec![2, 1, 2, 1]),
+            ),
+            (
+                "UPDATE widgets SET tenant_id = $2, id = $1 WHERE tenant_id = $2",
+                (2, vec![2, 1, 2]),
+            ),
+            ("DELETE FROM widgets WHERE tenant_id = $1", (1, vec![1])),
+        ];
+
+        for (source, (count, indices)) in cases {
+            let normalized = normalize(SqlDialect::PostgreSql, source).unwrap();
+            assert_layout(&normalized, 0, count, &indices);
+        }
+    }
+
+    #[test]
+    fn recursive_expression_sites_retain_lexical_parameter_order() {
+        let source = "SELECT CASE WHEN NOT ($1 BETWEEN $2 AND $3) THEN -$4 ELSE $5 END FROM widgets WHERE tenant_id IN ($6, $7) AND id LIKE $8";
+        let normalized = normalize(SqlDialect::PostgreSql, source).unwrap();
+        assert_layout(&normalized, 0, 8, &[1, 2, 3, 4, 5, 6, 7, 8]);
+    }
+
+    #[test]
+    fn incompatible_zero_named_and_parser_broad_markers_are_classified() {
+        for (dialect, source) in [
+            (SqlDialect::PostgreSql, "SELECT $0"),
+            (SqlDialect::PostgreSql, "SELECT $name"),
+            (SqlDialect::PostgreSql, "SELECT $1abc"),
+            (SqlDialect::PostgreSql, "SELECT :name"),
+            (SqlDialect::MySql, "SELECT ?0"),
+            (SqlDialect::MySql, "SELECT ?1"),
+            (SqlDialect::MySql, "SELECT :name"),
+            (SqlDialect::Sqlite, "SELECT ?0"),
+        ] {
+            let error = normalize(dialect, source).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::InvalidQuery, "{source}");
+            assert!(!error.diagnostic().contains(source));
+        }
+
+        for source in ["SELECT :name", "SELECT @name", "SELECT $name"] {
+            let error = normalize(SqlDialect::Sqlite, source).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::Unsupported, "{source}");
+            assert!(!error.diagnostic().contains(source));
+        }
+    }
+
+    #[test]
+    fn exact_parameter_limit_is_accepted_and_larger_indexes_are_rejected() {
+        for (dialect, marker) in [
+            (SqlDialect::PostgreSql, "$32766"),
+            (SqlDialect::Sqlite, "?32766"),
+        ] {
+            let normalized = normalize(dialect, &format!("SELECT {marker}")).unwrap();
+            assert_layout(&normalized, 0, MAX_SQL_PARAMETERS, &[MAX_SQL_PARAMETERS]);
+        }
+
+        for (dialect, marker) in [
+            (SqlDialect::PostgreSql, "$32767"),
+            (SqlDialect::PostgreSql, "$999999999999999999999999999999999"),
+            (SqlDialect::Sqlite, "?32767"),
+        ] {
+            let source = format!("SELECT {marker}");
+            let error = normalize(dialect, &source).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+            assert!(error.diagnostic().contains(&MAX_SQL_PARAMETERS.to_string()));
+            assert!(!error.diagnostic().contains(marker));
+        }
+
+        let assigned_overflow = normalize(SqlDialect::Sqlite, "SELECT ?32766, ?").unwrap_err();
+        assert_eq!(assigned_overflow.kind(), EngineErrorKind::LimitExceeded);
+        assert!(
+            assigned_overflow
+                .diagnostic()
+                .contains(&MAX_SQL_PARAMETERS.to_string())
+        );
+    }
+
+    #[test]
+    fn normalized_sql_executes_with_out_of_band_values() {
+        let normalized = normalize(
+            SqlDialect::PostgreSql,
+            "SELECT $2 AS second, $1 AS first, $2 = $2 AS repeated",
+        )
+        .unwrap();
+        let first = "O'Reilly; SELECT 99".to_owned();
+        let second = "quoted ' value; -- unchanged".to_owned();
+        let connection = rusqlite::Connection::open_in_memory().unwrap();
+        let result = query(
+            &connection,
+            normalized.sqlite_parameter_sql(),
+            &[Value::Text(first.clone()), Value::Text(second.clone())],
+        )
+        .unwrap();
+
+        assert_eq!(result.rows()[0].get(0), Some(&Value::Text(second)));
+        assert_eq!(result.rows()[0].get(1), Some(&Value::Text(first)));
+        assert_eq!(result.rows()[0].get(2), Some(&Value::Int64(1)));
+        assert_eq!(
+            normalized.sqlite_parameter_sql(),
+            "SELECT ?2 AS second, ?1 AS first, ?2 = ?2 AS repeated"
+        );
+    }
+
+    #[test]
+    fn normalized_types_are_owned_cloneable_and_redacted() {
+        fn assert_owned<T: Clone + Send + Sync + 'static>() {}
+        assert_owned::<NormalizedSql>();
+        assert_owned::<StatementParameters>();
+
+        let source = "SELECT $1, 'private literal'";
+        let normalized = normalize(SqlDialect::PostgreSql, source).unwrap();
+        let debug = format!("{normalized:?}");
+        let layout_debug = format!("{:?}", normalized.statement_parameters()[0]);
+
+        assert_eq!(normalized.clone(), normalized);
+        assert!(debug.contains("source_bytes"));
+        assert!(debug.contains("sqlite_parameter_sql_bytes"));
+        assert!(!debug.contains("private literal"));
+        assert!(layout_debug.contains("occurrence_count"));
+        assert!(!layout_debug.contains("private literal"));
+    }
+
+    #[test]
+    fn concurrent_normalization_is_deterministic() {
+        let common = validate_common_subset(
+            parse(
+                SqlDialect::PostgreSql,
+                "SELECT $2, $1, $2 FROM widgets WHERE tenant_id = $1",
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        let threads = (0..24)
+            .map(|_| {
+                let common = common.clone();
+                thread::spawn(move || normalize_placeholders(common))
+            })
+            .collect::<Vec<_>>();
+
+        for thread in threads {
+            let normalized = thread.join().unwrap().unwrap();
+            assert_eq!(
+                normalized.sqlite_parameter_sql(),
+                "SELECT ?2, ?1, ?2 FROM widgets WHERE tenant_id = ?1"
+            );
+            assert_layout(&normalized, 0, 2, &[2, 1, 2, 1]);
+        }
+    }
+
+    #[test]
+    fn one_normalization_error_does_not_affect_later_calls() {
+        let invalid = normalize(SqlDialect::PostgreSql, "SELECT $0").unwrap_err();
+        assert_eq!(invalid.kind(), EngineErrorKind::InvalidQuery);
+
+        let normalized = normalize(SqlDialect::PostgreSql, "SELECT $1").unwrap();
+        assert_eq!(normalized.sqlite_parameter_sql(), "SELECT ?1");
+        assert_layout(&normalized, 0, 1, &[1]);
+    }
+
+    #[test]
+    fn source_span_invariant_failures_are_internal_and_redacted() {
+        let cases = [
+            vec![PlannedPlaceholder {
+                marker: "$2".to_owned(),
+                span: Span::new(Location::new(1, 8), Location::new(1, 10)),
+                index: 2,
+            }],
+            vec![PlannedPlaceholder {
+                marker: "$1".to_owned(),
+                span: Span::new(Location::new(2, 1), Location::new(2, 3)),
+                index: 1,
+            }],
+            vec![PlannedPlaceholder {
+                marker: "$1".to_owned(),
+                span: Span::new(Location::new(1, 8), Location::new(1, 8)),
+                index: 1,
+            }],
+            vec![
+                PlannedPlaceholder {
+                    marker: "$1".to_owned(),
+                    span: Span::new(Location::new(1, 8), Location::new(1, 10)),
+                    index: 1,
+                },
+                PlannedPlaceholder {
+                    marker: "$1".to_owned(),
+                    span: Span::new(Location::new(1, 8), Location::new(1, 10)),
+                    index: 1,
+                },
+            ],
+        ];
+
+        for planned in cases {
+            let error = rewrite_placeholders("SELECT $1", &planned).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::Internal);
+            assert!(!error.diagnostic().contains("SELECT"));
+            assert!(!error.diagnostic().contains("$1"));
+            assert!(!error.diagnostic().contains("$2"));
+        }
+    }
+}

--- a/src/sql/subset.rs
+++ b/src/sql/subset.rs
@@ -10,6 +10,7 @@ use sqlparser::ast::{
     TableConstraint, TableFactor, TableObject, TableWithJoins, UnaryOperator, UniqueConstraint,
     Update, Value, WildcardAdditionalOptions,
 };
+use sqlparser::tokenizer::Span;
 
 use super::{ParsedSql, SqlDialect};
 use crate::core::{EngineError, EngineErrorKind, EngineResult};
@@ -28,6 +29,7 @@ pub const MAX_COMMON_SQL_EXPRESSION_DEPTH: usize = 128;
 #[derive(Clone, PartialEq, Eq)]
 pub struct CommonSql {
     parsed: ParsedSql,
+    statement_placeholders: Vec<Vec<CommonPlaceholder>>,
 }
 
 impl CommonSql {
@@ -50,6 +52,16 @@ impl CommonSql {
     pub fn is_empty(&self) -> bool {
         self.parsed.is_empty()
     }
+
+    pub(super) fn statement_placeholders(&self) -> &[Vec<CommonPlaceholder>] {
+        &self.statement_placeholders
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub(super) struct CommonPlaceholder {
+    pub(super) marker: String,
+    pub(super) span: Span,
 }
 
 impl fmt::Debug for CommonSql {
@@ -69,8 +81,10 @@ impl fmt::Debug for CommonSql {
 /// Empty batches and otherwise-valid statement combinations are accepted here;
 /// a later classification layer owns request-level batch policy.
 pub fn validate_common_subset(parsed: ParsedSql) -> EngineResult<CommonSql> {
+    let mut statement_placeholders = Vec::with_capacity(parsed.statement_count());
     for (index, statement) in parsed.statements().iter().enumerate() {
-        validate_statement(statement).map_err(|violation| {
+        let mut validation = ValidationState::default();
+        validate_statement(statement, &mut validation).map_err(|violation| {
             let diagnostic = if violation.kind == EngineErrorKind::LimitExceeded {
                 format!(
                     "statement {} exceeds the common SQL expression depth limit of {}",
@@ -86,9 +100,27 @@ pub fn validate_common_subset(parsed: ParsedSql) -> EngineResult<CommonSql> {
             };
             EngineError::new(violation.kind, diagnostic)
         })?;
+        statement_placeholders.push(validation.placeholders);
     }
 
-    Ok(CommonSql { parsed })
+    Ok(CommonSql {
+        parsed,
+        statement_placeholders,
+    })
+}
+
+#[derive(Default)]
+struct ValidationState {
+    placeholders: Vec<CommonPlaceholder>,
+}
+
+impl ValidationState {
+    fn record_placeholder(&mut self, marker: &str, span: Span) {
+        self.placeholders.push(CommonPlaceholder {
+            marker: marker.to_owned(),
+            span,
+        });
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -113,14 +145,14 @@ const fn expression_depth_exceeded<T>() -> SubsetResult<T> {
     })
 }
 
-fn validate_statement(statement: &AstStatement) -> SubsetResult {
+fn validate_statement(statement: &AstStatement, validation: &mut ValidationState) -> SubsetResult {
     match statement {
         AstStatement::CreateTable(table) => validate_create_table(table),
         AstStatement::CreateIndex(index) => validate_create_index(index),
-        AstStatement::Query(query) => validate_query(query),
-        AstStatement::Insert(insert) => validate_insert(insert),
-        AstStatement::Update(update) => validate_update(update),
-        AstStatement::Delete(delete) => validate_delete(delete),
+        AstStatement::Query(query) => validate_query(query, validation),
+        AstStatement::Insert(insert) => validate_insert(insert, validation),
+        AstStatement::Update(update) => validate_update(update, validation),
+        AstStatement::Delete(delete) => validate_delete(delete, validation),
         AstStatement::StartTransaction {
             modes,
             begin,
@@ -387,7 +419,11 @@ fn validate_check(constraint: &CheckConstraint) -> SubsetResult {
     if constraint.enforced.is_some() {
         return unsupported("CHECK enforcement modifiers");
     }
-    validate_expression(constraint.expr.as_ref(), ExprContext::CHECK)
+    validate_expression(
+        constraint.expr.as_ref(),
+        ExprContext::CHECK,
+        &mut ValidationState::default(),
+    )
 }
 
 fn validate_create_index(index: &CreateIndex) -> SubsetResult {
@@ -431,7 +467,7 @@ fn validate_index_column(column: &IndexColumn) -> SubsetResult {
     Ok(())
 }
 
-fn validate_query(query: &Query) -> SubsetResult {
+fn validate_query(query: &Query, validation: &mut ValidationState) -> SubsetResult {
     let Query {
         with,
         body,
@@ -461,17 +497,17 @@ fn validate_query(query: &Query) -> SubsetResult {
     let SetExpr::Select(select) = body.as_ref() else {
         return unsupported("set operations, VALUES, or nested queries");
     };
-    validate_select(select)?;
+    validate_select(select, validation)?;
     if let Some(order_by) = order_by {
-        validate_order_by(order_by)?;
+        validate_order_by(order_by, validation)?;
     }
     if let Some(limit_clause) = limit_clause {
-        validate_limit_clause(limit_clause)?;
+        validate_limit_clause(limit_clause, validation)?;
     }
     Ok(())
 }
 
-fn validate_select(select: &Select) -> SubsetResult {
+fn validate_select(select: &Select, validation: &mut ValidationState) -> SubsetResult {
     let Select {
         select_token: _,
         optimizer_hints,
@@ -532,15 +568,15 @@ fn validate_select(select: &Select) -> SubsetResult {
         validate_simple_table(table, true)?;
     }
     for item in projection {
-        validate_select_item(item)?;
+        validate_select_item(item, validation)?;
     }
     if let Some(selection) = selection {
-        validate_expression(selection, ExprContext::SCALAR)?;
+        validate_expression(selection, ExprContext::SCALAR, validation)?;
     }
     match group_by {
         GroupByExpr::Expressions(expressions, modifiers) if modifiers.is_empty() => {
             for expression in expressions {
-                validate_expression(expression, ExprContext::SCALAR)?;
+                validate_expression(expression, ExprContext::SCALAR, validation)?;
             }
         }
         GroupByExpr::Expressions(_, _) | GroupByExpr::All(_) => {
@@ -548,16 +584,18 @@ fn validate_select(select: &Select) -> SubsetResult {
         }
     }
     if let Some(having) = having {
-        validate_expression(having, ExprContext::SELECT)?;
+        validate_expression(having, ExprContext::SELECT, validation)?;
     }
     Ok(())
 }
 
-fn validate_select_item(item: &SelectItem) -> SubsetResult {
+fn validate_select_item(item: &SelectItem, validation: &mut ValidationState) -> SubsetResult {
     match item {
-        SelectItem::UnnamedExpr(expression) => validate_expression(expression, ExprContext::SELECT),
+        SelectItem::UnnamedExpr(expression) => {
+            validate_expression(expression, ExprContext::SELECT, validation)
+        }
         SelectItem::ExprWithAlias { expr, alias: _ } => {
-            validate_expression(expr, ExprContext::SELECT)
+            validate_expression(expr, ExprContext::SELECT, validation)
         }
         SelectItem::Wildcard(options) if wildcard_options_are_empty(options) => Ok(()),
         SelectItem::QualifiedWildcard(
@@ -581,7 +619,7 @@ fn wildcard_options_are_empty(options: &WildcardAdditionalOptions) -> bool {
         && options.opt_alias.is_none()
 }
 
-fn validate_order_by(order_by: &OrderBy) -> SubsetResult {
+fn validate_order_by(order_by: &OrderBy, validation: &mut ValidationState) -> SubsetResult {
     if order_by.interpolate.is_some() {
         return unsupported("ORDER BY interpolation");
     }
@@ -589,22 +627,28 @@ fn validate_order_by(order_by: &OrderBy) -> SubsetResult {
         return unsupported("ORDER BY ALL");
     };
     for expression in expressions {
-        validate_order_by_expression(expression)?;
+        validate_order_by_expression(expression, validation)?;
     }
     Ok(())
 }
 
-fn validate_order_by_expression(order_by: &OrderByExpr) -> SubsetResult {
+fn validate_order_by_expression(
+    order_by: &OrderByExpr,
+    validation: &mut ValidationState,
+) -> SubsetResult {
     if order_by.with_fill.is_some()
         || order_by.options.nulls_first.is_some()
         || matches!(order_by.options.sort, Some(OrderBySort::Using(_)))
     {
         return unsupported("ORDER BY options");
     }
-    validate_expression(&order_by.expr, ExprContext::SELECT)
+    validate_expression(&order_by.expr, ExprContext::SELECT, validation)
 }
 
-fn validate_limit_clause(limit_clause: &LimitClause) -> SubsetResult {
+fn validate_limit_clause(
+    limit_clause: &LimitClause,
+    validation: &mut ValidationState,
+) -> SubsetResult {
     let LimitClause::LimitOffset {
         limit,
         offset,
@@ -619,14 +663,14 @@ fn validate_limit_clause(limit_clause: &LimitClause) -> SubsetResult {
     if !limit_by.is_empty() {
         return unsupported("LIMIT BY");
     }
-    validate_limit_value(limit)?;
+    validate_limit_value(limit, validation)?;
     if let Some(offset) = offset {
-        validate_limit_value(&offset.value)?;
+        validate_limit_value(&offset.value, validation)?;
     }
     Ok(())
 }
 
-fn validate_insert(insert: &Insert) -> SubsetResult {
+fn validate_insert(insert: &Insert, validation: &mut ValidationState) -> SubsetResult {
     let Insert {
         insert_token: _,
         optimizer_hints,
@@ -698,10 +742,14 @@ fn validate_insert(insert: &Insert) -> SubsetResult {
     let Some(source) = source else {
         return unsupported("INSERT without VALUES");
     };
-    validate_insert_values(source, columns.len())
+    validate_insert_values(source, columns.len(), validation)
 }
 
-fn validate_insert_values(query: &Query, column_count: usize) -> SubsetResult {
+fn validate_insert_values(
+    query: &Query,
+    column_count: usize,
+    validation: &mut ValidationState,
+) -> SubsetResult {
     if query.with.is_some()
         || query.order_by.is_some()
         || query.limit_clause.is_some()
@@ -725,13 +773,13 @@ fn validate_insert_values(query: &Query, column_count: usize) -> SubsetResult {
             return unsupported("INSERT row width mismatch");
         }
         for expression in row.iter() {
-            validate_expression(expression, ExprContext::INSERT_VALUE)?;
+            validate_expression(expression, ExprContext::INSERT_VALUE, validation)?;
         }
     }
     Ok(())
 }
 
-fn validate_update(update: &Update) -> SubsetResult {
+fn validate_update(update: &Update, validation: &mut ValidationState) -> SubsetResult {
     if !update.optimizer_hints.is_empty()
         || update.from.is_some()
         || update.returning.is_some()
@@ -755,15 +803,15 @@ fn validate_update(update: &Update) -> SubsetResult {
         if !seen.insert(key) {
             return unsupported("duplicate UPDATE assignment targets");
         }
-        validate_expression(&assignment.value, ExprContext::SCALAR)?;
+        validate_expression(&assignment.value, ExprContext::SCALAR, validation)?;
     }
     if let Some(selection) = &update.selection {
-        validate_expression(selection, ExprContext::SCALAR)?;
+        validate_expression(selection, ExprContext::SCALAR, validation)?;
     }
     Ok(())
 }
 
-fn validate_delete(delete: &Delete) -> SubsetResult {
+fn validate_delete(delete: &Delete, validation: &mut ValidationState) -> SubsetResult {
     if !delete.optimizer_hints.is_empty()
         || !delete.tables.is_empty()
         || delete.using.is_some()
@@ -782,7 +830,7 @@ fn validate_delete(delete: &Delete) -> SubsetResult {
     };
     validate_simple_table(table, true)?;
     if let Some(selection) = &delete.selection {
-        validate_expression(selection, ExprContext::SCALAR)?;
+        validate_expression(selection, ExprContext::SCALAR, validation)?;
     }
     Ok(())
 }
@@ -860,14 +908,19 @@ impl ExprContext {
     }
 }
 
-fn validate_expression(expression: &Expr, context: ExprContext) -> SubsetResult {
-    validate_expression_at_depth(expression, context, 1)
+fn validate_expression(
+    expression: &Expr,
+    context: ExprContext,
+    validation: &mut ValidationState,
+) -> SubsetResult {
+    validate_expression_at_depth(expression, context, 1, validation)
 }
 
 fn validate_expression_at_depth(
     expression: &Expr,
     context: ExprContext,
     depth: usize,
+    validation: &mut ValidationState,
 ) -> SubsetResult {
     if depth > MAX_COMMON_SQL_EXPRESSION_DEPTH {
         return expression_depth_exceeded();
@@ -877,7 +930,13 @@ fn validate_expression_at_depth(
     match expression {
         Expr::Identifier(_) if context.identifiers => Ok(()),
         Expr::CompoundIdentifier(parts) if context.identifiers && parts.len() == 2 => Ok(()),
-        Expr::Value(value) => validate_value(&value.value, context.placeholders),
+        Expr::Value(value) => {
+            validate_value(&value.value, context.placeholders)?;
+            if let Value::Placeholder(marker) = &value.value {
+                validation.record_placeholder(marker, value.span);
+            }
+            Ok(())
+        }
         Expr::Nested(expression)
         | Expr::IsNull(expression)
         | Expr::IsNotNull(expression)
@@ -885,15 +944,15 @@ fn validate_expression_at_depth(
         | Expr::IsNotTrue(expression)
         | Expr::IsFalse(expression)
         | Expr::IsNotFalse(expression) => {
-            validate_expression_at_depth(expression, context, child_depth)
+            validate_expression_at_depth(expression, context, child_depth, validation)
         }
         Expr::UnaryOp {
             op: UnaryOperator::Plus | UnaryOperator::Minus | UnaryOperator::Not,
             expr,
-        } => validate_expression_at_depth(expr, context, child_depth),
+        } => validate_expression_at_depth(expr, context, child_depth, validation),
         Expr::BinaryOp { left, op, right } if binary_operator_is_common(op) => {
-            validate_expression_at_depth(left, context, child_depth)?;
-            validate_expression_at_depth(right, context, child_depth)
+            validate_expression_at_depth(left, context, child_depth, validation)?;
+            validate_expression_at_depth(right, context, child_depth, validation)
         }
         Expr::Between {
             expr,
@@ -901,18 +960,18 @@ fn validate_expression_at_depth(
             low,
             high,
         } => {
-            validate_expression_at_depth(expr, context, child_depth)?;
-            validate_expression_at_depth(low, context, child_depth)?;
-            validate_expression_at_depth(high, context, child_depth)
+            validate_expression_at_depth(expr, context, child_depth, validation)?;
+            validate_expression_at_depth(low, context, child_depth, validation)?;
+            validate_expression_at_depth(high, context, child_depth, validation)
         }
         Expr::InList {
             expr,
             list,
             negated: _,
         } if !list.is_empty() => {
-            validate_expression_at_depth(expr, context, child_depth)?;
+            validate_expression_at_depth(expr, context, child_depth, validation)?;
             for item in list {
-                validate_expression_at_depth(item, context, child_depth)?;
+                validate_expression_at_depth(item, context, child_depth, validation)?;
             }
             Ok(())
         }
@@ -923,8 +982,8 @@ fn validate_expression_at_depth(
             escape_char,
             negated: _,
         } if !any && escape_char.is_none() => {
-            validate_expression_at_depth(expr, context, child_depth)?;
-            validate_expression_at_depth(pattern, context, child_depth)
+            validate_expression_at_depth(expr, context, child_depth, validation)?;
+            validate_expression_at_depth(pattern, context, child_depth, validation)
         }
         Expr::Case {
             case_token: _,
@@ -934,20 +993,23 @@ fn validate_expression_at_depth(
             else_result,
         } => {
             if let Some(operand) = operand {
-                validate_expression_at_depth(operand, context, child_depth)?;
+                validate_expression_at_depth(operand, context, child_depth, validation)?;
             }
             for branch in conditions {
-                validate_expression_at_depth(&branch.condition, context, child_depth)?;
-                validate_expression_at_depth(&branch.result, context, child_depth)?;
+                validate_expression_at_depth(&branch.condition, context, child_depth, validation)?;
+                validate_expression_at_depth(&branch.result, context, child_depth, validation)?;
             }
             if let Some(else_result) = else_result {
-                validate_expression_at_depth(else_result, context, child_depth)?;
+                validate_expression_at_depth(else_result, context, child_depth, validation)?;
             }
             Ok(())
         }
-        Expr::Function(function) if context.aggregates => {
-            validate_aggregate(function, context.without_aggregates(), child_depth)
-        }
+        Expr::Function(function) if context.aggregates => validate_aggregate(
+            function,
+            context.without_aggregates(),
+            child_depth,
+            validation,
+        ),
         _ => unsupported("expression form"),
     }
 }
@@ -987,6 +1049,7 @@ fn validate_aggregate(
     function: &Function,
     argument_context: ExprContext,
     argument_depth: usize,
+    validation: &mut ValidationState,
 ) -> SubsetResult {
     let [ObjectNamePart::Identifier(name)] = function.name.0.as_slice() else {
         return unsupported("qualified aggregate functions");
@@ -1017,7 +1080,7 @@ fn validate_aggregate(
     };
     match argument {
         FunctionArgExpr::Expr(expression) => {
-            validate_expression_at_depth(expression, argument_context, argument_depth)
+            validate_expression_at_depth(expression, argument_context, argument_depth, validation)
         }
         FunctionArgExpr::Wildcard
             if aggregate == "COUNT" && arguments.duplicate_treatment.is_none() =>
@@ -1056,13 +1119,16 @@ fn is_numeric_literal(expression: &Expr) -> bool {
     }
 }
 
-fn validate_limit_value(expression: &Expr) -> SubsetResult {
+fn validate_limit_value(expression: &Expr, validation: &mut ValidationState) -> SubsetResult {
     match expression {
         Expr::Value(value) => match &value.value {
             Value::Number(number, false) if number.bytes().all(|byte| byte.is_ascii_digit()) => {
                 Ok(())
             }
-            Value::Placeholder(_) => Ok(()),
+            Value::Placeholder(marker) => {
+                validation.record_placeholder(marker, value.span);
+                Ok(())
+            }
             _ => unsupported("LIMIT or OFFSET value"),
         },
         _ => unsupported("LIMIT or OFFSET value"),

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -227,6 +227,71 @@ fn common_sql_subset_validation_is_public_owned_and_opt_in() {
 }
 
 #[test]
+fn placeholder_normalization_is_public_owned_bounded_and_opt_in() {
+    fn assert_owned_public<T: Clone + Send + Sync + 'static>() {}
+    assert_owned_public::<sql::NormalizedSql>();
+    assert_owned_public::<sql::StatementParameters>();
+    assert_eq!(sql::MAX_SQL_PARAMETERS, 32_766);
+
+    for (dialect, source, expected, count, indices) in [
+        (
+            sql::SqlDialect::Sqlite,
+            "SELECT ?2, ?, ?1",
+            "SELECT ?2, ?3, ?1",
+            3,
+            vec![2, 3, 1],
+        ),
+        (
+            sql::SqlDialect::PostgreSql,
+            "SELECT $2, $1, $2",
+            "SELECT ?2, ?1, ?2",
+            2,
+            vec![2, 1, 2],
+        ),
+        (
+            sql::SqlDialect::MySql,
+            "SELECT ?, ?",
+            "SELECT ?1, ?2",
+            2,
+            vec![1, 2],
+        ),
+    ] {
+        let common = sql::validate_common_subset(sql::parse(dialect, source).unwrap()).unwrap();
+        let normalized = sql::normalize_placeholders(common).unwrap();
+        let parameters = &normalized.statement_parameters()[0];
+
+        assert_eq!(normalized.dialect(), dialect);
+        assert_eq!(normalized.source(), source);
+        assert_eq!(normalized.sqlite_parameter_sql(), expected);
+        assert_eq!(normalized.statement_count(), 1);
+        assert!(!normalized.is_empty());
+        assert_eq!(parameters.parameter_count(), count);
+        assert_eq!(parameters.occurrence_count(), indices.len());
+        assert_eq!(parameters.parameter_indices(), indices);
+    }
+
+    let named =
+        sql::validate_common_subset(sql::parse(sql::SqlDialect::Sqlite, "SELECT :value").unwrap())
+            .unwrap();
+    let unsupported = sql::normalize_placeholders(named).unwrap_err();
+    assert_eq!(unsupported.kind(), core::EngineErrorKind::Unsupported);
+
+    // Normalization is opt-in infrastructure. Existing raw SQLite callers keep
+    // their current marker behavior until the planned prepare/bind path adopts
+    // the normalized representation.
+    let temp = tempfile::tempdir().unwrap();
+    let database = core::Database::open(temp.path(), 2).unwrap();
+    let result = database
+        .query(
+            "normalizer-opt-in",
+            "SELECT :value",
+            &[core::Value::Int64(9)],
+        )
+        .unwrap();
+    assert_eq!(result.rows()[0].get(0), Some(&core::Value::Int64(9)));
+}
+
+#[test]
 fn logical_catalog_types_and_access_are_public_and_protocol_neutral() {
     fn assert_public_metadata<T: Clone + Send + Sync + 'static>() {}
 


### PR DESCRIPTION
## Summary

- add an opt-in `normalize_placeholders(CommonSql)` API with owned, redacted results
- normalize PostgreSQL `$N`, MySQL `?`, and SQLite positional markers to canonical SQLite `?N` text without accepting values
- retain exact source text and expose per-statement counts plus occurrence-to-index metadata
- cover numbering, gaps, repeats, Unicode spans, limits, errors, concurrency, recovery, SQLite execution, public API, and the unchanged HTTP path
- document the complete parameter-normalization contract and mark roadmap issue #21 complete

## Validation

- `cargo +stable fmt --all --check`
- `cargo +stable clippy --locked --all-targets --all-features -- -D warnings`
- `cargo +stable test --locked --all-targets --all-features`
- `cargo +stable test --locked --doc --all-features`
- `cargo +1.85.0 test --locked --all-targets --all-features`
- `cargo +1.85.0 test --locked --doc --all-features`
- independent code and contract review with no remaining findings

Closes #21
