### PR TITLE
Infer shard keys from predicates and inserted values

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ protocol-neutral structural validator and its exact accepted statement forms.
 The [SQL parameter-normalization contract](docs/SQL_PARAMETERS.md) defines the
 opt-in dialect-specific rewrite to canonical SQLite positional parameters and
 its per-statement binding metadata.
+The [shard-key inference contract](docs/SQL_SHARD_KEYS.md) defines the opt-in,
+catalog-aware extraction of typed keys from predicates, bound parameters, and
+multi-row inserts without routing or execution.
 The [error contract](docs/ERRORS.md) defines stable engine error kinds, safe
 HTTP problem details, and the mappings reserved for future PostgreSQL and MySQL
 adapters.
@@ -49,8 +52,9 @@ minimum supported Rust version (MSRV) and the latest stable toolchain.
 - Protocol-neutral typed values, ordered columns, positional rows, and results
 - A bounded SQL AST parser plus recursive common-subset validator for explicit
   SQLite, PostgreSQL, and MySQL dialects, followed by opt-in source-preserving
-  placeholder normalization and per-statement binding metadata, all isolated
-  from the current raw SQLite HTTP execution path
+  placeholder normalization, per-statement binding metadata, and catalog-aware
+  typed shard-key inference, all isolated from the current raw SQLite HTTP
+  execution path
 - A transactionally versioned `manifest.sqlite` with durable 4,096-bucket
   routing plus logical-database and table metadata
 - Identity-bound, WAL-enabled SQLite shard files that are never silently
@@ -173,9 +177,15 @@ Rust callers may explicitly parse SQL and consume the result with
 `validate_common_subset(ParsedSql)`, receiving an owned opaque `CommonSql` on
 success. They may then opt into `normalize_placeholders(CommonSql)`, receiving
 canonical SQLite `?N` text and per-statement occurrence-to-index metadata
-without supplying parameter values. These steps do not route, plan, authorize,
-or execute SQL. The HTTP execute, query, and migration endpoints invoke neither
-layer and retain their existing raw SQLite behavior.
+without supplying parameter values. Given a complete bound-value slice and a
+logical catalog database, callers may then invoke
+`infer_shard_keys(&Catalog, LogicalDatabaseId, &NormalizedSql, statement_index,
+parameters)` to classify the statement as not applicable, not sharded,
+unconstrained, contradictory, exact, or multiple and inspect any typed inferred
+values. These steps do not hash a key, select a shard, plan, authorize, enforce
+write policy, or execute SQL. The HTTP execute, query, and migration endpoints
+invoke none of these opt-in layers and retain their existing raw SQLite
+behavior.
 
 `EngineOptions` permits 1–16 active connections and 1–1,024 queued operations
 per shard, with at most 512 active connections across all shards.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -206,7 +206,7 @@ interrupted schema migration can be diagnosed and resumed.
   `INSERT`, `UPDATE`, `DELETE`, `BEGIN`, `COMMIT`, and `ROLLBACK`.
 - [x] Normalize placeholders (`$1`, PostgreSQL/MySQL `?`) to SQLite parameters
   without interpolating values into SQL text.
-- [ ] Infer shard keys from predicates and inserted values, including bound
+- [x] Infer shard keys from predicates and inserted values, including bound
   parameters and multi-row inserts.
 - [ ] Plan prepared statements at bind/execute time, not parse time, because a
   routing key may be supplied as a bound parameter.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,7 +23,7 @@ server ---------> protocol::http
 | --- | --- | --- |
 | `core` | Protocol-neutral `Engine`, `Session`, statements, values, results, errors, and read-only logical catalog; stable key routing; bounded per-shard admission and connection pools; routed execute/query and journaled schema migration | JSON/HTTP types, listeners, or Axum handlers |
 | `storage` | Versioned routing/logical manifest, shard layout, migration journal and recovery, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
-| `sql` | Dialect-explicit SQL syntax parsing, recursive common-subset validation, and source-preserving placeholder normalization behind BriskDB-owned types; exact source retention; SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, routing, catalog lookup, filesystem layout, protocol responses, bound-value ownership, or protocol-specific support policy |
+| `sql` | Dialect-explicit SQL syntax parsing, recursive common-subset validation, source-preserving placeholder normalization, and catalog-aware typed shard-key inference behind BriskDB-owned types; exact source retention; SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, key hashing or shard selection, session/write policy, filesystem layout, protocol responses, protocol-buffer ownership, or protocol-specific support policy |
 | `protocol::http` | HTTP request extraction plus JSON/BriskDB value and RFC 9457 problem-detail encoding | BLAKE3 routing, shard files, or rusqlite calls |
 | `protocol::error` | Exhaustive HTTP, PostgreSQL, and MySQL mappings from stable engine error kinds | SQLite errors, routing decisions, or wire-protocol session state |
 | `server` | Process configuration, database assembly, listener binding, and tracked Axum HTTP/1 connection lifecycle | SQL parsing or storage implementation details |
@@ -92,10 +92,11 @@ deterministic and keeps the dependency replaceable.
 
 Parsing is syntax recognition, not support validation or planning. The parser
 has no session, parameter, catalog, storage, or routing access. The separate
-common-subset validator, placeholder normalizer, and later planner layers
-consume structural syntax through BriskDB-owned interfaces; shard-key inference
-must not inspect raw or formatted SQL with regular expressions. Exact input
-remains authoritative because AST formatting is lossy and is never executed.
+common-subset validator, placeholder normalizer, shard-key inference layer, and
+later planner layers consume structural syntax through BriskDB-owned
+interfaces; shard-key inference does not inspect raw or formatted SQL with
+regular expressions. Exact input remains authoritative because AST formatting
+is lossy and is never executed.
 
 Inputs are bounded to 65,536 UTF-8 bytes, 256 statements, and recursion depth
 32. The dependency's recursive-protection feature remains enabled. Parse and
@@ -122,9 +123,9 @@ The normative accepted forms and exclusions are in the [common SQL subset
 contract](SQL_SUBSET.md).
 
 The current HTTP execute/query and migration paths deliberately remain raw
-SQLite pass-through and call neither the parser, subset validator, nor
-placeholder normalizer. Issues #19 through #21 therefore change no HTTP shape,
-SQL acceptance, routing, or storage behavior.
+SQLite pass-through and call none of the parser, subset validator, placeholder
+normalizer, or shard-key inference layers. Issues #19 through #22 therefore
+change no HTTP shape, SQL acceptance, routing, or storage behavior.
 
 ### Placeholder-normalization boundary
 
@@ -150,6 +151,31 @@ filesystem, or execution access and does not decide whether a statement batch
 may execute; issue #27 owns that policy. The normative API, dialect rules,
 limits, errors, and tests are in the [SQL parameter-normalization
 contract](SQL_PARAMETERS.md).
+
+### Shard-key inference boundary
+
+`infer_shard_keys(&Catalog, LogicalDatabaseId, &NormalizedSql,
+statement_index, parameters)` borrows an immutable catalog snapshot, one
+normalized batch, and the selected statement's complete protocol-neutral
+`Value` slice. It resolves the accepted base table and cataloged shard-key type,
+then produces an owned `ShardKeyInference` classification and typed values.
+
+For `SELECT`, `UPDATE`, and `DELETE`, the layer proves finite key sets only from
+direct `Int64` or `Binary` shard-column equality and combines those sets through
+Boolean `AND` and `OR`. Non-null `Text` equality remains unconstrained until the
+catalog declares and physical schemas enforce comparison collation. For
+`INSERT`, inference examines the explicit shard-key column in every `VALUES`
+row and retains one value per row, including text values. The result
+distinguishes statements that are not applicable, known non-sharded tables,
+unconstrained predicates, contradictions, one exact key, and multiple keys.
+
+This layer is catalog-aware and accepts bound values, but remains read-only and
+statement-local. It does not own the catalog or caller values, encode or hash a
+key, read the bucket map, choose a shard, construct an execution plan, apply
+write policy, mutate session state, or execute SQL. Issue #23 owns bind/execute
+planning and routing; issue #24 owns rejection of conflicting or unroutable
+writes. The normative proof, type, result, error, and testing rules are in the
+[shard-key inference contract](SQL_SHARD_KEYS.md).
 
 ## Manifest storage boundary
 

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -157,6 +157,16 @@ fixed categories and positions and never contain SQL, literal or marker text,
 bound values, formatted AST output, or source locations. See the [SQL
 parameter-normalization contract](SQL_PARAMETERS.md).
 
+The opt-in shard-key inference layer reports an out-of-range statement index,
+wrong bound-value count, or missing logical database as `InvalidArgument`; an
+unknown table in the selected database as `InvalidQuery`; an incompatible key
+value as `TypeMismatch`; a signed-integer overflow as `NumericOutOfRange`; an
+invalid UTF-8 text key as `InvalidTextEncoding`; and a null inserted shard key
+as `NotNullViolation`. Inference diagnostics may identify the one-based
+statement position and a fixed category, but never contain SQL, identifier
+spelling, literal or bound values, key contents, formatted AST output, or source
+locations. See the [shard-key inference contract](SQL_SHARD_KEYS.md).
+
 The core contains no HTTP, PostgreSQL, or MySQL response types. Conversely,
 protocol adapters do not inspect SQLite errors. This lets every frontend share
 one error identity while retaining its own response encoding.

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -16,11 +16,11 @@ document defines the SQL and behavioral contract separately from connectivity.
 - **Unsupported** means BriskDB rejects the behavior or makes no compatibility
   promise for it.
 
-The syntax parser, recursive common-subset validator, and placeholder
-normalizer are now available behind BriskDB-owned types. Validation is explicit
-and returns `Unsupported` for a parsed form outside the subset; parser
-acceptance alone is not product support. Normalization is also explicit and
-rewrites only validated placeholder spans. The current experimental HTTP
+The syntax parser, recursive common-subset validator, placeholder normalizer,
+and catalog-aware shard-key inference API are now available behind BriskDB-owned
+types. Validation is explicit and returns `Unsupported` for a parsed form
+outside the subset; parser acceptance alone is not product support.
+Normalization and inference are also explicit. The current experimental HTTP
 interface is still a raw SQLite pass-through and can execute uncontracted
 SQLite syntax because it calls none of these layers. That behavior is not a
 compatibility promise.
@@ -47,23 +47,26 @@ PostgreSQL or MySQL listener or general dialect translation layer yet. The
 public Rust SQL facade can parse an explicitly selected SQLite, PostgreSQL, or
 MySQL dialect, consume that result with
 `validate_common_subset(ParsedSql)`, and then opt into
-`normalize_placeholders(CommonSql)`. The final step yields canonical SQLite
-`?N` text and per-statement parameter metadata without accepting values. None
-of these operations plans, routes, generally translates, authorizes, or
-executes a statement. HTTP requests still send SQLite SQL directly to
-`rusqlite`; they do not pass through these opt-in SQL layers.
+`normalize_placeholders(CommonSql)`. That step yields canonical SQLite `?N`
+text and per-statement parameter metadata. Callers may then pass one
+statement's exact bound-value slice and selected logical database to
+`infer_shard_keys`, which returns a typed key classification. None of these
+operations hashes a key, selects a shard, plans, generally translates,
+authorizes, enforces write policy, or executes a statement. HTTP requests still
+send SQLite SQL directly to `rusqlite`; they do not pass through these opt-in
+SQL layers.
 
 | Interface | Status | SQL accepted | Routing |
 | --- | --- | --- | --- |
 | HTTP `/v1/execute` | Experimental | One SQLite statement with positional parameters | Required caller-provided `shard_key` |
 | HTTP `/v1/query` | Experimental | One prepared SQLite statement executed through the row-returning path | Required caller-provided `shard_key` |
 | HTTP `/v1/admin/broadcast` | Experimental | A journaled parameterless SQLite schema batch | Preflight on every shard, then ascending resumable apply |
-| PostgreSQL wire protocol | Planned | Common subset plus documented PostgreSQL normalization | SQL/bound-parameter inference with explicit session fallback |
-| MySQL wire protocol | Planned | Common subset plus documented MySQL normalization | SQL/bound-parameter inference with explicit session fallback |
+| PostgreSQL wire protocol | Planned | Common subset plus documented PostgreSQL normalization | Rust inference implemented; wire bind-time planning and session fallback planned |
+| MySQL wire protocol | Planned | Common subset plus documented MySQL normalization | Rust inference implemented; wire bind-time planning and session fallback planned |
 
-The parser, subset validator, and placeholder normalizer are implemented Rust
-APIs, not network interfaces. Each step is opt-in and does not change any row
-in this table.
+The parser, subset validator, placeholder normalizer, and shard-key inference
+function are implemented Rust APIs, not network interfaces. Each step is
+opt-in and does not change any current network row in this table.
 
 Every HTTP operation now calls the same protocol-neutral async engine intended
 for future PostgreSQL and MySQL adapters. Execute and query requests create a
@@ -281,16 +284,21 @@ when every top-level statement and nested form is in the first subset. Empty
 and mixed batches may validate because request-level batch policy remains issue
 #27. `normalize_placeholders(CommonSql)` then returns an owned `NormalizedSql`
 with canonical SQLite parameter text and one parameter record per statement.
-All three types retain exact source, dialect, and statement count without
-exposing the upstream AST or rendering SQL in `Debug` output.
+`infer_shard_keys` can consume that result with catalog context and a complete
+bound-value slice for one statement. The SQL wrapper types retain exact source,
+dialect, and statement count without exposing the upstream AST or rendering
+SQL in `Debug` output.
 
-The parser, validator, and normalizer have no routing or storage access. Future
-shard inference and statement classification consume structural syntax, never
+The parser, validator, and normalizer have no routing or storage access. The
+implemented inference layer borrows only the read-only logical catalog and
+protocol-neutral bound values; it consumes structural syntax, never
 regular-expression matches over raw or formatted SQL. See the [SQL parser
 decision record](SQL_PARSER.md) for the dependency and resource contract, the
 [common SQL subset contract](SQL_SUBSET.md) for the normative recursive
 whitelist, and the [SQL parameter-normalization
-contract](SQL_PARAMETERS.md) for numbering and source-preservation rules.
+contract](SQL_PARAMETERS.md) for numbering and source-preservation rules. The
+[shard-key inference contract](SQL_SHARD_KEYS.md) defines the supported proof
+grammar and typed result.
 
 ### Implemented pass-through surface
 
@@ -356,10 +364,11 @@ required to be explicit; type compatibility and translation remain issue #25.
 Insert/update duplicate checks fold ASCII letter case regardless of quoting but
 do not define general identifier normalization, which also remains issue #25.
 Placeholder normalization is the separate implemented issue #21 layer described
-below. Catalog-aware key extraction, single-shard proof, bind-time planning,
-and rejection of conflicting or unroutable writes remain issues #22 through
-#24. Prepare/bind/describe/execute state remains issue #26, and empty or
-multi-statement execution policy remains issue #27.
+below, and catalog-aware typed key extraction is the implemented issue #22
+layer. Bind-time planning and routing remain issue #23; rejection of conflicting
+or unroutable writes remains issue #24. Prepare/bind/describe/execute state
+remains issue #26, and empty or multi-statement execution policy remains issue
+#27.
 
 The validator independently caps recursive expression AST depth at 128. This
 also bounds flat operator chains that parse iteratively; exceeding the limit is
@@ -394,6 +403,31 @@ shard, translate other dialect syntax, create a prepared statement, classify
 statement behavior, authorize a request, or execute SQL. The HTTP and engine
 paths continue to bind their existing caller-supplied SQLite SQL directly.
 
+### Implemented shard-key inference
+
+The public Rust function `infer_shard_keys` is an opt-in statement-local call
+over a `Catalog`, selected `LogicalDatabaseId`, `NormalizedSql`, zero-based
+statement index, and exact bound `Value` slice. It resolves known table
+placement and a sharded table's key column/type. Its owned result distinguishes
+not-applicable, non-sharded, unconstrained, contradictory, exact, and multiple
+key outcomes and exposes typed integer, text, or binary values.
+
+For `SELECT`, `UPDATE`, and `DELETE`, direct equality against an `Int64` or
+`Binary` shard-key column produces a finite key set; Boolean `AND` intersects
+and `OR` unions those proofs. Non-null `Text` equality remains unconstrained
+because the current catalog does not declare or enforce comparison collation.
+Other predicates do not establish a key. For `INSERT`, every `VALUES` row's
+explicit shard-key cell must be a compatible direct literal or placeholder to
+produce a complete result, and one value per row is retained, including text
+values. The exact identifier, value, result, and error rules are in [shard-key
+inference](SQL_SHARD_KEYS.md).
+
+Inference does not encode, hash, route, plan, authorize, enforce, or execute.
+Issue #23 will use the result at bind/execute time to construct a plan and
+routing decision. Issue #24 will decide which conflicting, multiple, or
+unconstrained write outcomes must be rejected before execution. The raw HTTP
+and engine paths do not invoke inference.
+
 ## PostgreSQL differences
 
 The PostgreSQL listener will target the frontend/backend wire protocol and a
@@ -402,7 +436,7 @@ not implemented unless listed as implemented in this document.
 
 | Area | PostgreSQL | BriskDB contract |
 | --- | --- | --- |
-| Parameters | `$1`, `$2`, ... | Implemented opt-in Rust normalization to SQLite `?N`; value binding, wire support, and bind-time routing remain planned |
+| Parameters | `$1`, `$2`, ... | Implemented opt-in Rust normalization to SQLite `?N` and typed inference from a supplied bound slice; wire binding and bind-time routing remain planned |
 | Identifier quoting | Double quotes | Passed through where SQLite semantics agree |
 | Type system | Static types identified by OIDs | Planned loss-aware mapping to BriskDB types and SQLite storage classes |
 | Boolean | Dedicated `boolean` type | Stored as SQLite integer `0` or `1`; protocol adapter returns a Boolean value |
@@ -430,7 +464,7 @@ engine used by PostgreSQL and HTTP.
 
 | Area | MySQL | BriskDB contract |
 | --- | --- | --- |
-| Parameters | `?` in prepared statements | Implemented opt-in Rust normalization to consecutive SQLite `?N`; value binding and wire support remain planned |
+| Parameters | `?` in prepared statements | Implemented opt-in Rust normalization to consecutive SQLite `?N` and typed inference from a supplied bound slice; wire binding and routing remain planned |
 | Identifier quoting | Backticks by default | Planned normalization; double-quoted strict SQL remains available |
 | Type system | Static signed/unsigned column types | BriskDB retains `UInt64` without narrowing; current SQLite binding rejects values above `i64::MAX` until an explicit storage mapping exists |
 | Boolean | Commonly `TINYINT(1)` | Stored as SQLite integer `0` or `1`; protocol adapter returns documented metadata |
@@ -494,7 +528,11 @@ underlying execution semantics.
 - Logical metadata is currently read-only and advisory. Fresh manifests and
   upgrades originating before v4 contain no table rows; v4-to-v5 retains every
   validated v4 logical-catalog row. Existing physical tables are not inferred
-  or adopted, and catalog contents do not alter SQL planning or execution.
+  or adopted. The opt-in Rust inference API can consult catalog contents, but
+  they do not alter current SQL planning, routing, or execution.
+- Opt-in inference can extract typed cataloged keys from supported equality
+  predicates and every row of a supported `INSERT`; it does not select a shard
+  or change current HTTP behavior.
 - Point queries and writes visit only that shard.
 - No scatter/gather query path exists.
 - Unique constraints and transactions are local to one SQLite shard.
@@ -509,8 +547,9 @@ underlying execution semantics.
 - Every sharded table declares one non-null shard-key column in the catalog.
 - Canonical key encoding, hash version, virtual bucket count, and bucket map are
   persisted in the manifest.
-- The planner extracts equality keys from SQL and bound parameters. An explicit
-  session routing key remains a controlled fallback.
+- At bind/execute time, the planner consumes typed equality keys inferred from
+  SQL and bound parameters. An explicit session routing key remains a
+  controlled fallback.
 - A transaction is pinned to its first shard. Targeting another shard returns a
   stable cross-shard-transaction error.
 - Read-only plans may scatter with bounded concurrency and deterministic merge.

--- a/docs/SQL_PARAMETERS.md
+++ b/docs/SQL_PARAMETERS.md
@@ -146,18 +146,22 @@ layer, as does the common-subset validator's expression-depth limit.
 
 A successful `NormalizedSql` does not establish that:
 
-- the caller supplied exactly `parameter_count()` values with compatible
-  types;
-- a bound value identifies one shard;
+- the caller supplied exactly `parameter_count()` values until the separate
+  shard-key inference call validates that count;
+- non-shard-key parameters have types compatible with later translation and
+  execution;
+- an inferred value has been encoded, hashed, or routed to one shard;
 - catalog names and types exist or are compatible;
 - non-placeholder PostgreSQL or MySQL syntax has been translated to SQLite;
 - a statement or batch is permitted by an endpoint or session;
 - a prepared statement has been described, cached, bound, or executed; or
 - execution would preserve all source-dialect semantics.
 
-Issues #22 through #27 own shard-key inference, bind-time planning, conflicting
-or unroutable key rejection, syntax/type translation, prepared-statement state,
-and request-level statement classification respectively.
+The implemented [shard-key inference contract](SQL_SHARD_KEYS.md) consumes this
+metadata plus a catalog database and exact bound-value slice. Issues #23
+through #27 own bind-time planning and routing, conflicting or unroutable write
+rejection, syntax/type translation, prepared-statement state, and request-level
+statement classification respectively.
 
 ## Verification obligations
 

--- a/docs/SQL_PARSER.md
+++ b/docs/SQL_PARSER.md
@@ -62,7 +62,8 @@ In particular, this layer does not:
   the separate `validate_common_subset(ParsedSql)` layer;
 - normalize placeholders; issue #21 implements that as the separate
   `normalize_placeholders(CommonSql)` layer;
-- infer shard keys or inspect bound values (issue #22);
+- infer shard keys or inspect bound values; issue #22 implements that as the
+  separate `infer_shard_keys` layer;
 - plan prepared statements at bind time (issue #23);
 - reject conflicting keys or unroutable writes (issue #24);
 - translate types or syntax, or choose strict SQLite mode (issue #25);
@@ -80,9 +81,9 @@ that still does not grant permission to execute an empty or mixed batch.
 The existing HTTP execute, query, and migration paths remain raw SQLite
 pass-through surfaces with their existing authorizer and endpoint-specific
 rules. They call neither this parser, the opt-in common-subset validator, nor
-the opt-in placeholder normalizer. Connecting those layers before planning,
-translation, and request-level statement policy are implemented would change
-the experimental HTTP SQL surface.
+the opt-in placeholder normalizer or shard-key inference layer. Connecting
+those layers before planning, translation, and request-level statement policy
+are implemented would change the experimental HTTP SQL surface.
 
 ## Resource and error boundaries
 

--- a/docs/SQL_SHARD_KEYS.md
+++ b/docs/SQL_SHARD_KEYS.md
@@ -1,0 +1,180 @@
+# Shard-key inference
+
+Status: implemented for roadmap issue #22
+
+BriskDB exposes opt-in, protocol-neutral shard-key inference for one statement
+that has passed the common-subset validator and placeholder normalizer:
+
+```rust
+infer_shard_keys(
+    catalog: &Catalog,
+    database: LogicalDatabaseId,
+    normalized: &NormalizedSql,
+    statement_index: usize,
+    parameters: &[Value],
+) -> EngineResult<ShardKeyInference>
+```
+
+`statement_index` is zero-based. `parameters` must be the complete bound-value
+slice for that statement and have exactly its normalized `parameter_count()`.
+Numbered PostgreSQL and SQLite markers can leave unused positions, but those
+positions still count toward the required slice length. Inference resolves
+placeholder occurrences through the retained source spans and normalized
+indices; values are never interpolated into SQL text.
+
+This API performs catalog-aware analysis only. It does not encode or hash a
+key, select a virtual bucket or physical shard, build an execution plan,
+authorize a statement, enforce write policy, or execute SQL.
+
+## Result contract
+
+`ShardKeyInference` owns its result and reports `table_id()`, `key_type()`,
+`kind()`, and `values()`. Its category has these meanings:
+
+| Kind | Meaning |
+| --- | --- |
+| `NotApplicable` | The statement has no catalog table that needs key inference, such as DDL, transaction control, or `SELECT` without `FROM` |
+| `NotSharded` | The selected catalog table has `Global` or `Catalog` placement |
+| `Unconstrained` | The table is sharded, but the supported analysis cannot prove a finite key set |
+| `Contradiction` | A predicate proves that no non-null shard key can match |
+| `Exact` | The supported proof grammar establishes one distinct key under the declared key-type semantics |
+| `Multiple` | Two or more distinct inferred keys are present |
+
+`ShardKeyValue` is one of `Int64(i64)`, `Text(String)`, or `Binary(Vec<u8>)`
+and exposes matching typed accessors. Predicate results retain unique values in
+deterministic expression order. A complete multi-row `INSERT` retains one
+value per row in row order, including duplicates; its `Exact` or `Multiple`
+category still depends on the number of distinct values.
+
+The `Debug` representations report metadata and counts without rendering key
+contents. They do not render submitted SQL or the dependency-owned AST.
+
+## Catalog and identifier resolution
+
+Inference uses the requested `LogicalDatabaseId` and resolves one accepted base
+table within that database. A missing logical database is `InvalidArgument`; a
+table absent from the selected database is `InvalidQuery`.
+
+Catalog identifiers use the manifest's canonical lowercase ASCII contract.
+Unquoted SQL identifiers are ASCII-folded before catalog comparison; quoted
+identifiers compare exactly. A qualified shard-key reference must use the
+table alias when an alias is present, or the table name when there is no alias.
+An unrelated qualifier does not constrain the shard key.
+
+Known `Global` and `Catalog` tables return `NotSharded` with their table ID and
+no key type or values. Statements that do not reference a table return
+`NotApplicable` with no table ID, key type, or values.
+
+## Predicate inference
+
+For `SELECT`, `UPDATE`, and `DELETE`, inference examines only the `WHERE`
+predicate. Projection, grouping, `HAVING`, ordering, limits, and `UPDATE`
+assignments do not establish a routing key at this layer.
+
+The finite proof grammar is deliberately small:
+
+- direct equality between an `Int64` or `Binary` shard-key column and a
+  compatible literal or placeholder, in either operand order, produces one
+  value;
+- transparent parentheses do not change that result;
+- `AND` intersects the key sets proven by its operands;
+- `OR` unions finite key sets, but any unconstrained branch makes the complete
+  `OR` unconstrained; and
+- all other accepted expressions contribute no finite proof.
+
+Consequently, `tenant_id = 1 AND tenant_id = 2` is `Contradiction`, while
+`tenant_id = 1 OR tenant_id = 2` is `Multiple`. A comparison to `NULL` also
+produces `Contradiction`, because cataloged shard keys are non-null. Operators
+such as inequalities, `IN`, `BETWEEN`, `LIKE`, `NOT`, arithmetic, and `CASE`
+remain `Unconstrained` unless another `AND` branch independently proves a
+finite set.
+
+The current catalog declares UTF-8 `Text` key values but does not declare or
+enforce their comparison collation. A non-null `Text` equality predicate is
+therefore `Unconstrained`, even when its literal or bound value has the correct
+type: case- or accent-folding equality could match a different key identity.
+`Text = NULL` remains `Contradiction` because shard-key non-nullness is part of
+the declaration. Text extraction from `INSERT` is unaffected because it
+reports the value being supplied rather than proving comparison semantics.
+
+## INSERT inference
+
+An accepted `INSERT` has an explicit column list and one or more equal-width
+`VALUES` rows. Inference finds the cataloged shard-key column and evaluates its
+cell in every row.
+
+- A compatible direct literal or placeholder contributes one row value.
+- Repeated placeholders and repeated values retain one result entry per row.
+- Omitting the shard-key column or using a non-atomic cell expression returns
+  `Unconstrained` with no values.
+- A literal or bound `NULL` returns `NotNullViolation`.
+- A complete row set with one distinct value is `Exact`; two or more distinct
+  values are `Multiple`.
+
+This classification does not decide whether a multi-key insert may run. Issue
+#24 owns rejection of conflicting or unroutable writes.
+
+## Value compatibility
+
+Inference uses the shard-key type declared by the catalog:
+
+| Catalog key type | Accepted SQL literal | Accepted bound `Value` |
+| --- | --- | --- |
+| `Int64` | An integral decimal magnitude with nested unary `+`/`-`, within the signed 64-bit range | `Int64`, or `UInt64` when it converts losslessly to `i64` |
+| `Text` | A single-quoted string for `INSERT` extraction; predicate equality remains unconstrained without collation metadata | Valid UTF-8 `Text`, with the same predicate limitation |
+| `Binary` | None in the first common literal subset | `Binary` |
+
+Compatible literal and bound values become the same `ShardKeyValue` form.
+Text is not Unicode-normalized. An incompatible type is `TypeMismatch`, a
+signed-integer overflow is `NumericOutOfRange`, and an `InvalidText` value for
+a text key is `InvalidTextEncoding`.
+
+## Errors and diagnostics
+
+| Condition | `EngineErrorKind` |
+| --- | --- |
+| Statement index outside the normalized batch | `InvalidArgument` |
+| Bound-value count differs from the selected statement's normalized parameter count | `InvalidArgument` |
+| Selected logical database does not exist | `InvalidArgument` |
+| Selected table is absent from that logical database | `InvalidQuery` |
+| Value is incompatible with the cataloged shard-key type | `TypeMismatch` |
+| Integer is outside the signed 64-bit range | `NumericOutOfRange` |
+| Bound text is not valid UTF-8 | `InvalidTextEncoding` |
+| An `INSERT` supplies `NULL` for the non-null shard key | `NotNullViolation` |
+| Retained validated/normalized metadata is internally inconsistent | `Internal` |
+
+Diagnostics use fixed statement and inference categories where useful. They do
+not contain submitted SQL, table or column spelling, literal or bound values,
+formatted AST output, source locations, or catalog key contents. Protocol
+adapters must serialize the fixed public mapping for the error kind rather than
+the internal diagnostic.
+
+## Execution and storage boundaries
+
+Shard-key inference is a read-only call over immutable SQL metadata, a catalog
+snapshot, and a borrowed parameter slice. It does not mutate the catalog,
+manifest, shard files, configuration, session, or caller values. It introduces
+no storage-format or network-contract change.
+
+The current HTTP execute, query, and migration paths do not invoke parsing,
+common-subset validation, normalization, or inference. They retain their
+existing raw SQLite SQL and caller-provided `shard_key` behavior.
+
+Issue #23 will invoke inference at bind/execute time and turn its result into a
+protocol-neutral plan and routing decision. Issue #24 will enforce the write
+rules for conflicting, multiple, or unconstrained keys. Later work owns syntax
+translation, prepared-statement lifecycle, statement classification, and wire
+protocol integration.
+
+## Verification obligations
+
+Tests cover all result categories; literal and bound keys in SQLite,
+PostgreSQL, and MySQL syntax; numbered gaps and repeated parameters; identifier
+quoting, aliases, and qualifiers; Boolean intersection, union, and
+contradiction; `SELECT`, `UPDATE`, and `DELETE`; multi-row inserts and retained
+duplicates; all three catalog key types and the conservative text-collation
+boundary; range, type, text, null, database,
+table, statement-index, and arity errors; empty and multi-statement batches;
+redacted diagnostics and `Debug`; concurrent deterministic inference; and
+successful inference after an independent error. Raw HTTP regressions continue
+to prove that this opt-in API does not change current execution behavior.

--- a/docs/SQL_SUBSET.md
+++ b/docs/SQL_SUBSET.md
@@ -35,18 +35,20 @@ A successful `CommonSql` does not mean that the SQL:
 - names existing databases, tables, columns, constraints, or types;
 - has normalized or correctly numbered placeholders until the separate
   [`normalize_placeholders`](SQL_PARAMETERS.md) step succeeds;
-- can be routed to one shard or has a bound routing value;
+- has an inferred key until the separate catalog-aware
+  [`infer_shard_keys`](SQL_SHARD_KEYS.md) step succeeds;
+- can be routed to one shard even after inference reports values;
 - is safe to execute as an empty, single-, or multi-statement request;
 - has a prepared-statement plan or protocol result description;
 - has been translated to SQLite or preserves source-dialect semantics;
 - is authorized for a particular endpoint or session; or
 - has been executed.
 
-Those responsibilities remain with the implemented issue #21 normalization
-layer, issues #22 through #27, and the later wire frontends. Validation never
-consults parameters, a session, the logical catalog, storage, routing state,
-the filesystem, or SQLite. It never formats or searches SQL text to make a
-structural decision.
+Those responsibilities remain with the implemented issue #21 normalization and
+issue #22 inference layers, issues #23 through #27, and the later wire
+frontends. Validation never consults parameters, a session, the logical
+catalog, storage, routing state, the filesystem, or SQLite. It never formats or
+searches SQL text to make a structural decision.
 
 Empty and comment-only parsed batches validate successfully. Every statement in
 a mixed batch is checked independently and source order is retained, but that
@@ -79,8 +81,8 @@ pinning, and protocol status reporting remain issues #34 and #47.
 
 An absent `WHERE` on `UPDATE` or `DELETE` is structurally valid. Likewise,
 validation does not inspect whether an assignment changes a shard-key column.
-Catalog-aware key extraction and rejection of conflicting or unroutable writes
-remain issues #22 and #24.
+The separate inference layer classifies the supported predicate proof; issue
+#24 owns rejection of conflicting or unroutable writes and assignment policy.
 
 ### Names, aliases, and types
 
@@ -164,6 +166,10 @@ to distinguish it. Placeholder spelling, numbering, count, and binding are not
 validated or changed here. The separate [SQL parameter-normalization
 contract](SQL_PARAMETERS.md) defines the implemented opt-in numbering step,
 which consumes `CommonSql` without accepting bound values.
+The [shard-key inference contract](SQL_SHARD_KEYS.md) then defines the exact
+catalog-aware predicate and `INSERT` value forms that produce typed key values;
+general expression support here is intentionally broader than that finite
+proof grammar.
 
 Common-subset expression validation has its own maximum recursive AST depth of
 128. This catches long flat operator chains, which the parser can build

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -245,7 +245,7 @@ Table placement and shard-key type use stable numeric codes:
 | `placement` | `2` | `Global` | Shard-key column and type must both be null |
 | `placement` | `3` | `Catalog` | Shard-key column and type must both be null |
 | `shard_key_type` | `1` | `Int64` | Signed 64-bit integer |
-| `shard_key_type` | `2` | `Text` | UTF-8 text without Unicode normalization |
+| `shard_key_type` | `2` | `Text` | UTF-8 text without Unicode normalization; no comparison collation is declared |
 | `shard_key_type` | `3` | `Binary` | Arbitrary bytes |
 
 `Sharded` means the same logical schema is expected on every shard and rows
@@ -253,17 +253,20 @@ are key-routed. `Global` describes small replicated lookup data. `Catalog`
 describes manifest-owned metadata rather than a user shard table.
 
 The loaded `Catalog` is read-only to callers and remains advisory in version 7:
-there is no table-catalog mutation API, planner integration, or enforcement
-against physical shard schemas. The engine publishes a newly committed schema
-generation into its shared catalog snapshot only after every shard has reached
-that generation. Fresh initialization and every v1/v2/v3 upgrade leave
-`briskdb_tables` empty; a v4-to-v5 upgrade retains every validated v4 catalog
-row. Schema migration does not inspect, infer, or mutate `briskdb_tables` from
-the journaled SQL; the physical-schema fingerprint independently establishes
-exact consensus across shards. Tables that are absent from the advisory catalog
-remain usable through the existing explicit-key execute/query API. Version-5
-adoption preserves existing tables and rows while adding only BriskDB-owned
-shard identity metadata.
+the opt-in SQL inference API may consult its database, table placement, and key
+metadata, but there is no table-catalog mutation API, execution-plan
+integration, routing enforcement, or enforcement against physical shard
+schemas. The engine publishes a newly committed schema generation into its
+shared catalog snapshot only after every shard has reached that generation.
+Fresh initialization and every v1/v2/v3 upgrade leave `briskdb_tables` empty;
+a v4-to-v5 upgrade retains every validated v4 catalog row. Schema migration
+does not inspect, infer, or mutate `briskdb_tables` from the journaled SQL; the
+physical-schema fingerprint independently establishes exact consensus across
+shards. Tables that are absent from the advisory catalog remain usable through
+the existing explicit-key execute/query API. Version-5 adoption preserves
+existing tables and rows while adding only BriskDB-owned shard identity
+metadata. Shard-key inference changes no manifest table, encoding, version, or
+upgrade rule.
 
 ### Application-schema migration journal
 

--- a/src/core/catalog.rs
+++ b/src/core/catalog.rs
@@ -118,7 +118,7 @@ impl LogicalDatabaseMetadata {
 pub enum ShardKeyType {
     /// Signed 64-bit integer.
     Int64,
-    /// UTF-8 text, declared without Unicode normalization.
+    /// UTF-8 text, declared without Unicode normalization or collation.
     Text,
     /// Arbitrary bytes.
     Binary,
@@ -150,8 +150,9 @@ impl ShardKeyMetadata {
 
 /// Declared physical placement of a logical table.
 ///
-/// These declarations are advisory in manifest v4. Schema-journal work will
-/// make them authoritative for physical DDL and query planning.
+/// These declarations remain advisory in the current manifest. Future
+/// catalog-driven DDL and physical-schema validation must make them
+/// authoritative before execution planning relies on them.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum TablePlacement {

--- a/src/sql/inference.rs
+++ b/src/sql/inference.rs
@@ -1,0 +1,1859 @@
+use std::{collections::HashSet, fmt};
+
+use sqlparser::ast::{
+    BinaryOperator, Expr, FromTable, Ident, ObjectName, ObjectNamePart, SetExpr,
+    Statement as AstStatement, TableFactor, TableObject, TableWithJoins, UnaryOperator,
+    Value as AstValue,
+};
+use sqlparser::tokenizer::Span;
+
+use super::NormalizedSql;
+use crate::core::{
+    Catalog, EngineError, EngineErrorKind, EngineResult, LogicalDatabaseId, ShardKeyType, TableId,
+    TableMetadata, TablePlacement, Value,
+};
+
+/// Result category for one statement's shard-key inference.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ShardKeyInferenceKind {
+    /// The statement does not reference a catalog table that needs routing.
+    NotApplicable,
+    /// The statement references a known global or catalog-placed table.
+    NotSharded,
+    /// The statement targets a sharded table but does not prove a finite key set.
+    Unconstrained,
+    /// The predicate proves that no non-null shard key can match.
+    Contradiction,
+    /// The supported analysis proves exactly one distinct shard-key value.
+    Exact,
+    /// The statement contains two or more distinct inferred shard-key values.
+    Multiple,
+}
+
+/// One typed shard-key value inferred from SQL or a bound parameter.
+#[non_exhaustive]
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub enum ShardKeyValue {
+    /// A signed 64-bit integer key.
+    Int64(i64),
+    /// A UTF-8 text key, without Unicode normalization.
+    Text(String),
+    /// An arbitrary binary key.
+    Binary(Vec<u8>),
+}
+
+impl ShardKeyValue {
+    /// Return this value's declared shard-key type.
+    pub const fn key_type(&self) -> ShardKeyType {
+        match self {
+            Self::Int64(_) => ShardKeyType::Int64,
+            Self::Text(_) => ShardKeyType::Text,
+            Self::Binary(_) => ShardKeyType::Binary,
+        }
+    }
+
+    /// Return the signed integer value when this is an `Int64` key.
+    pub const fn as_i64(&self) -> Option<i64> {
+        match self {
+            Self::Int64(value) => Some(*value),
+            Self::Text(_) | Self::Binary(_) => None,
+        }
+    }
+
+    /// Return the text value when this is a text key.
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            Self::Text(value) => Some(value),
+            Self::Int64(_) | Self::Binary(_) => None,
+        }
+    }
+
+    /// Return the bytes when this is a binary key.
+    pub fn as_bytes(&self) -> Option<&[u8]> {
+        match self {
+            Self::Binary(value) => Some(value),
+            Self::Int64(_) | Self::Text(_) => None,
+        }
+    }
+}
+
+impl fmt::Debug for ShardKeyValue {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Int64(_) => formatter.write_str("Int64(<redacted>)"),
+            Self::Text(value) => formatter
+                .debug_struct("Text")
+                .field("bytes", &value.len())
+                .finish(),
+            Self::Binary(value) => formatter
+                .debug_struct("Binary")
+                .field("bytes", &value.len())
+                .finish(),
+        }
+    }
+}
+
+/// Owned shard-key inference for one normalized top-level statement.
+///
+/// This result describes values only. It does not encode or hash a key, choose
+/// a physical shard, authorize a statement, or decide whether multiple or
+/// unconstrained keys may execute.
+#[derive(Clone, PartialEq, Eq)]
+pub struct ShardKeyInference {
+    table_id: Option<TableId>,
+    key_type: Option<ShardKeyType>,
+    kind: ShardKeyInferenceKind,
+    values: Vec<ShardKeyValue>,
+}
+
+impl ShardKeyInference {
+    /// Return the resolved catalog table, if this statement references one.
+    pub const fn table_id(&self) -> Option<TableId> {
+        self.table_id
+    }
+
+    /// Return the declared key type when the resolved table is sharded.
+    pub const fn key_type(&self) -> Option<ShardKeyType> {
+        self.key_type
+    }
+
+    /// Return the inference category.
+    pub const fn kind(&self) -> ShardKeyInferenceKind {
+        self.kind
+    }
+
+    /// Return inferred values in deterministic expression or INSERT-row order.
+    ///
+    /// Predicate results contain unique values. Complete INSERT results retain
+    /// one value per row, including duplicates.
+    pub fn values(&self) -> &[ShardKeyValue] {
+        &self.values
+    }
+}
+
+impl fmt::Debug for ShardKeyInference {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ShardKeyInference")
+            .field("table_id", &self.table_id)
+            .field("key_type", &self.key_type)
+            .field("kind", &self.kind)
+            .field("value_count", &self.values.len())
+            .finish()
+    }
+}
+
+/// Infer shard-key constraints and supplied values for one normalized statement.
+///
+/// `statement_index` is zero-based. `parameters` is the complete bound-value
+/// slice for that statement and must match its normalized parameter count,
+/// including unused gaps in numbered PostgreSQL or SQLite markers. Inference
+/// is read-only and statement-local; later planning and policy layers decide
+/// whether and where the statement can execute.
+pub fn infer_shard_keys(
+    catalog: &Catalog,
+    database: LogicalDatabaseId,
+    normalized: &NormalizedSql,
+    statement_index: usize,
+    parameters: &[Value],
+) -> EngineResult<ShardKeyInference> {
+    let Some(statement) = normalized.common().statements().get(statement_index) else {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            "SQL statement index is outside the normalized batch",
+        ));
+    };
+    let Some(layout) = normalized.statement_parameters().get(statement_index) else {
+        return Err(inference_invariant());
+    };
+    if parameters.len() != layout.parameter_count() {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            format!(
+                "statement {} requires exactly {} bound parameters for shard-key inference",
+                statement_index + 1,
+                layout.parameter_count()
+            ),
+        ));
+    }
+    let Some(database) = catalog.database_by_id(database) else {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            "selected logical database does not exist",
+        ));
+    };
+
+    let context = InferenceContext {
+        catalog,
+        database_name: database.name(),
+        normalized,
+        statement_index,
+        parameters,
+    };
+    infer_statement(statement, &context)
+}
+
+struct InferenceContext<'a> {
+    catalog: &'a Catalog,
+    database_name: &'a str,
+    normalized: &'a NormalizedSql,
+    statement_index: usize,
+    parameters: &'a [Value],
+}
+
+fn infer_statement(
+    statement: &AstStatement,
+    context: &InferenceContext<'_>,
+) -> EngineResult<ShardKeyInference> {
+    match statement {
+        AstStatement::Query(query) => {
+            let SetExpr::Select(select) = query.body.as_ref() else {
+                return Err(inference_invariant());
+            };
+            let Some(table) = select.from.first() else {
+                return Ok(not_applicable());
+            };
+            if select.from.len() != 1 {
+                return Err(inference_invariant());
+            }
+            infer_predicate_statement(table, select.selection.as_ref(), context)
+        }
+        AstStatement::Update(update) => {
+            infer_predicate_statement(&update.table, update.selection.as_ref(), context)
+        }
+        AstStatement::Delete(delete) => {
+            let FromTable::WithFromKeyword(tables) = &delete.from else {
+                return Err(inference_invariant());
+            };
+            let [table] = tables.as_slice() else {
+                return Err(inference_invariant());
+            };
+            infer_predicate_statement(table, delete.selection.as_ref(), context)
+        }
+        AstStatement::Insert(insert) => infer_insert(insert, context),
+        AstStatement::CreateTable(_)
+        | AstStatement::CreateIndex(_)
+        | AstStatement::StartTransaction { .. }
+        | AstStatement::Commit { .. }
+        | AstStatement::Rollback { .. } => Ok(not_applicable()),
+        _ => Err(inference_invariant()),
+    }
+}
+
+fn infer_predicate_statement(
+    table: &TableWithJoins,
+    predicate: Option<&Expr>,
+    context: &InferenceContext<'_>,
+) -> EngineResult<ShardKeyInference> {
+    let binding = table_binding(table)?;
+    let table = resolve_table(&binding, context)?;
+    let shard_key = match table.placement() {
+        TablePlacement::Sharded(shard_key) => shard_key,
+        TablePlacement::Global | TablePlacement::Catalog => {
+            return Ok(not_sharded(table.id()));
+        }
+    };
+
+    let Some(predicate) = predicate else {
+        return Ok(unconstrained(table.id(), shard_key.key_type()));
+    };
+    let target = PredicateTarget {
+        qualifier: binding.qualifier,
+        column: shard_key.column(),
+        key_type: shard_key.key_type(),
+    };
+    let domain = infer_predicate(predicate, &target, context)?;
+    Ok(finish_predicate(table.id(), shard_key.key_type(), domain))
+}
+
+fn infer_insert(
+    insert: &sqlparser::ast::Insert,
+    context: &InferenceContext<'_>,
+) -> EngineResult<ShardKeyInference> {
+    let TableObject::TableName(table_name) = &insert.table else {
+        return Err(inference_invariant());
+    };
+    let binding = insert_binding(table_name)?;
+    let table = resolve_table(&binding, context)?;
+    let shard_key = match table.placement() {
+        TablePlacement::Sharded(shard_key) => shard_key,
+        TablePlacement::Global | TablePlacement::Catalog => {
+            return Ok(not_sharded(table.id()));
+        }
+    };
+
+    let mut column_index = None;
+    for (index, column) in insert.columns.iter().enumerate() {
+        if identifier_matches_catalog(column_ident(column)?, shard_key.column()) {
+            column_index = Some(index);
+            break;
+        }
+    }
+    let Some(column_index) = column_index else {
+        return Ok(unconstrained(table.id(), shard_key.key_type()));
+    };
+    let Some(source) = &insert.source else {
+        return Err(inference_invariant());
+    };
+    let SetExpr::Values(values) = source.body.as_ref() else {
+        return Err(inference_invariant());
+    };
+
+    let mut inferred = Vec::with_capacity(values.rows.len());
+    let mut complete = true;
+    for row in &values.rows {
+        let Some(expression) = row.get(column_index) else {
+            return Err(inference_invariant());
+        };
+        match infer_atom(expression, shard_key.key_type(), context)? {
+            InferredAtom::Value(value) => inferred.push(value),
+            InferredAtom::Null => {
+                return Err(EngineError::new(
+                    EngineErrorKind::NotNullViolation,
+                    format!(
+                        "statement {} supplies NULL for its non-null shard key",
+                        context.statement_index + 1
+                    ),
+                ));
+            }
+            InferredAtom::Unresolved => {
+                complete = false;
+            }
+        }
+    }
+
+    if !complete {
+        return Ok(unconstrained(table.id(), shard_key.key_type()));
+    }
+    if inferred.is_empty() {
+        return Err(inference_invariant());
+    }
+    let kind = if distinct_value_count(&inferred) == 1 {
+        ShardKeyInferenceKind::Exact
+    } else {
+        ShardKeyInferenceKind::Multiple
+    };
+    Ok(ShardKeyInference {
+        table_id: Some(table.id()),
+        key_type: Some(shard_key.key_type()),
+        kind,
+        values: inferred,
+    })
+}
+
+struct TableBinding {
+    catalog_name: String,
+    qualifier: String,
+}
+
+fn table_binding(table: &TableWithJoins) -> EngineResult<TableBinding> {
+    if !table.joins.is_empty() {
+        return Err(inference_invariant());
+    }
+    let TableFactor::Table { name, alias, .. } = &table.relation else {
+        return Err(inference_invariant());
+    };
+    let source_name = object_identifier(name)?;
+    let Some(catalog_name) = catalog_identifier(source_name) else {
+        return Err(unknown_table());
+    };
+    let qualifier = alias.as_ref().map_or_else(
+        || reference_identifier(source_name),
+        |alias| reference_identifier(&alias.name),
+    );
+    Ok(TableBinding {
+        catalog_name,
+        qualifier,
+    })
+}
+
+fn insert_binding(name: &ObjectName) -> EngineResult<TableBinding> {
+    let source_name = object_identifier(name)?;
+    let Some(catalog_name) = catalog_identifier(source_name) else {
+        return Err(unknown_table());
+    };
+    Ok(TableBinding {
+        qualifier: reference_identifier(source_name),
+        catalog_name,
+    })
+}
+
+fn object_identifier(name: &ObjectName) -> EngineResult<&Ident> {
+    let [ObjectNamePart::Identifier(identifier)] = name.0.as_slice() else {
+        return Err(inference_invariant());
+    };
+    Ok(identifier)
+}
+
+fn column_ident(name: &ObjectName) -> EngineResult<&Ident> {
+    let [ObjectNamePart::Identifier(identifier)] = name.0.as_slice() else {
+        return Err(inference_invariant());
+    };
+    Ok(identifier)
+}
+
+fn catalog_identifier(identifier: &Ident) -> Option<String> {
+    let value = if identifier.quote_style.is_none() {
+        identifier.value.to_ascii_lowercase()
+    } else {
+        identifier.value.clone()
+    };
+    crate::core::validate_catalog_identifier(&value).then_some(value)
+}
+
+fn reference_identifier(identifier: &Ident) -> String {
+    if identifier.quote_style.is_none() {
+        identifier.value.to_ascii_lowercase()
+    } else {
+        identifier.value.clone()
+    }
+}
+
+fn identifier_matches_catalog(identifier: &Ident, canonical: &str) -> bool {
+    if identifier.quote_style.is_none() {
+        identifier.value.eq_ignore_ascii_case(canonical)
+    } else {
+        identifier.value == canonical
+    }
+}
+
+fn resolve_table<'a>(
+    binding: &TableBinding,
+    context: &'a InferenceContext<'_>,
+) -> EngineResult<&'a TableMetadata> {
+    context
+        .catalog
+        .table(context.database_name, &binding.catalog_name)?
+        .ok_or_else(unknown_table)
+}
+
+fn unknown_table() -> EngineError {
+    EngineError::new(
+        EngineErrorKind::InvalidQuery,
+        "SQL statement references a table absent from the selected logical database",
+    )
+}
+
+struct PredicateTarget<'a> {
+    qualifier: String,
+    column: &'a str,
+    key_type: ShardKeyType,
+}
+
+enum KeyDomain {
+    Any,
+    Finite(Vec<ShardKeyValue>),
+}
+
+fn infer_predicate(
+    expression: &Expr,
+    target: &PredicateTarget<'_>,
+    context: &InferenceContext<'_>,
+) -> EngineResult<KeyDomain> {
+    let expression = peel_nested(expression);
+    match expression {
+        Expr::BinaryOp {
+            left,
+            op: BinaryOperator::Eq,
+            right,
+        } => {
+            if is_shard_column(left, target) {
+                return atom_domain(right, target.key_type, context);
+            }
+            if is_shard_column(right, target) {
+                return atom_domain(left, target.key_type, context);
+            }
+            Ok(KeyDomain::Any)
+        }
+        Expr::BinaryOp {
+            left,
+            op: BinaryOperator::And,
+            right,
+        } => Ok(intersect_domains(
+            infer_predicate(left, target, context)?,
+            infer_predicate(right, target, context)?,
+        )),
+        Expr::BinaryOp {
+            left,
+            op: BinaryOperator::Or,
+            right,
+        } => Ok(union_domains(
+            infer_predicate(left, target, context)?,
+            infer_predicate(right, target, context)?,
+        )),
+        _ => Ok(KeyDomain::Any),
+    }
+}
+
+fn atom_domain(
+    expression: &Expr,
+    key_type: ShardKeyType,
+    context: &InferenceContext<'_>,
+) -> EngineResult<KeyDomain> {
+    if matches!(key_type, ShardKeyType::Text) {
+        return text_atom_domain(expression, context);
+    }
+    Ok(match infer_atom(expression, key_type, context)? {
+        InferredAtom::Value(value) => KeyDomain::Finite(vec![value]),
+        InferredAtom::Null => KeyDomain::Finite(Vec::new()),
+        InferredAtom::Unresolved => KeyDomain::Any,
+    })
+}
+
+fn text_atom_domain(expression: &Expr, context: &InferenceContext<'_>) -> EngineResult<KeyDomain> {
+    let Expr::Value(value) = peel_nested(expression) else {
+        return Ok(KeyDomain::Any);
+    };
+    match &value.value {
+        AstValue::Placeholder(_) => match bound_parameter(value.span, context)? {
+            Value::Null => Ok(KeyDomain::Finite(Vec::new())),
+            Value::Text(_) => Ok(KeyDomain::Any),
+            Value::InvalidText(_) => Err(EngineError::new(
+                EngineErrorKind::InvalidTextEncoding,
+                format!(
+                    "statement {} binds non-UTF-8 text to its shard key",
+                    context.statement_index + 1
+                ),
+            )),
+            _ => Err(type_mismatch(context)),
+        },
+        AstValue::Null => Ok(KeyDomain::Finite(Vec::new())),
+        AstValue::SingleQuotedString(_) => Ok(KeyDomain::Any),
+        AstValue::Number(_, false) | AstValue::Boolean(_) => Err(type_mismatch(context)),
+        _ => Err(inference_invariant()),
+    }
+}
+
+fn is_shard_column(expression: &Expr, target: &PredicateTarget<'_>) -> bool {
+    match peel_nested(expression) {
+        Expr::Identifier(column) => identifier_matches_catalog(column, target.column),
+        Expr::CompoundIdentifier(parts) => {
+            let [qualifier, column] = parts.as_slice() else {
+                return false;
+            };
+            reference_identifier(qualifier) == target.qualifier
+                && identifier_matches_catalog(column, target.column)
+        }
+        _ => false,
+    }
+}
+
+fn intersect_domains(left: KeyDomain, right: KeyDomain) -> KeyDomain {
+    match (left, right) {
+        (KeyDomain::Any, domain) | (domain, KeyDomain::Any) => domain,
+        (KeyDomain::Finite(left), KeyDomain::Finite(right)) => KeyDomain::Finite(
+            left.into_iter()
+                .filter(|value| right.contains(value))
+                .collect(),
+        ),
+    }
+}
+
+fn union_domains(left: KeyDomain, right: KeyDomain) -> KeyDomain {
+    match (left, right) {
+        (KeyDomain::Any, _) | (_, KeyDomain::Any) => KeyDomain::Any,
+        (KeyDomain::Finite(mut left), KeyDomain::Finite(right)) => {
+            for value in right {
+                if !left.contains(&value) {
+                    left.push(value);
+                }
+            }
+            KeyDomain::Finite(left)
+        }
+    }
+}
+
+enum InferredAtom {
+    Unresolved,
+    Null,
+    Value(ShardKeyValue),
+}
+
+fn infer_atom(
+    expression: &Expr,
+    key_type: ShardKeyType,
+    context: &InferenceContext<'_>,
+) -> EngineResult<InferredAtom> {
+    let expression = peel_nested(expression);
+    if matches!(key_type, ShardKeyType::Int64)
+        && matches!(expression, Expr::UnaryOp { .. } | Expr::Value(_))
+    {
+        match signed_integer_literal(expression) {
+            IntegerLiteral::Value(value) => {
+                return Ok(InferredAtom::Value(ShardKeyValue::Int64(value)));
+            }
+            IntegerLiteral::OutOfRange => return Err(numeric_out_of_range(context)),
+            IntegerLiteral::NonIntegral => return Err(type_mismatch(context)),
+            IntegerLiteral::NotNumeric => {}
+        }
+    }
+
+    let Expr::Value(value) = expression else {
+        return Ok(InferredAtom::Unresolved);
+    };
+    match &value.value {
+        AstValue::Placeholder(_) => {
+            bound_atom(bound_parameter(value.span, context)?, key_type, context)
+        }
+        AstValue::Null => Ok(InferredAtom::Null),
+        AstValue::SingleQuotedString(value) if matches!(key_type, ShardKeyType::Text) => {
+            Ok(InferredAtom::Value(ShardKeyValue::Text(value.clone())))
+        }
+        AstValue::Number(_, false) | AstValue::SingleQuotedString(_) | AstValue::Boolean(_) => {
+            Err(type_mismatch(context))
+        }
+        _ => Err(inference_invariant()),
+    }
+}
+
+fn bound_parameter<'a>(span: Span, context: &'a InferenceContext<'_>) -> EngineResult<&'a Value> {
+    let Some(index) = context
+        .normalized
+        .parameter_index(context.statement_index, span)
+    else {
+        return Err(inference_invariant());
+    };
+    index
+        .checked_sub(1)
+        .and_then(|index| context.parameters.get(index))
+        .ok_or_else(inference_invariant)
+}
+
+fn bound_atom(
+    value: &Value,
+    key_type: ShardKeyType,
+    context: &InferenceContext<'_>,
+) -> EngineResult<InferredAtom> {
+    if matches!(value, Value::Null) {
+        return Ok(InferredAtom::Null);
+    }
+    let inferred = match (key_type, value) {
+        (ShardKeyType::Int64, Value::Int64(value)) => ShardKeyValue::Int64(*value),
+        (ShardKeyType::Int64, Value::UInt64(value)) => {
+            let value = i64::try_from(*value).map_err(|_| numeric_out_of_range(context))?;
+            ShardKeyValue::Int64(value)
+        }
+        (ShardKeyType::Text, Value::Text(value)) => ShardKeyValue::Text(value.clone()),
+        (ShardKeyType::Text, Value::InvalidText(_)) => {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidTextEncoding,
+                format!(
+                    "statement {} binds non-UTF-8 text to its shard key",
+                    context.statement_index + 1
+                ),
+            ));
+        }
+        (ShardKeyType::Binary, Value::Binary(value)) => ShardKeyValue::Binary(value.clone()),
+        _ => return Err(type_mismatch(context)),
+    };
+    Ok(InferredAtom::Value(inferred))
+}
+
+enum IntegerLiteral {
+    NotNumeric,
+    NonIntegral,
+    OutOfRange,
+    Value(i64),
+}
+
+fn signed_integer_literal(expression: &Expr) -> IntegerLiteral {
+    let mut expression = expression;
+    let mut negative = false;
+    loop {
+        match peel_nested(expression) {
+            Expr::UnaryOp {
+                op: UnaryOperator::Plus,
+                expr,
+            } => expression = expr,
+            Expr::UnaryOp {
+                op: UnaryOperator::Minus,
+                expr,
+            } => {
+                negative = !negative;
+                expression = expr;
+            }
+            Expr::Value(value) => {
+                let AstValue::Number(number, false) = &value.value else {
+                    return IntegerLiteral::NotNumeric;
+                };
+                if number.is_empty() || !number.bytes().all(|byte| byte.is_ascii_digit()) {
+                    return IntegerLiteral::NonIntegral;
+                }
+                let limit = if negative {
+                    i64::MAX as u64 + 1
+                } else {
+                    i64::MAX as u64
+                };
+                let mut magnitude = 0_u64;
+                for byte in number.bytes() {
+                    magnitude = match magnitude
+                        .checked_mul(10)
+                        .and_then(|value| value.checked_add(u64::from(byte - b'0')))
+                    {
+                        Some(value) if value <= limit => value,
+                        Some(_) | None => return IntegerLiteral::OutOfRange,
+                    };
+                }
+                if negative && magnitude == i64::MAX as u64 + 1 {
+                    return IntegerLiteral::Value(i64::MIN);
+                }
+                let value = magnitude as i64;
+                return IntegerLiteral::Value(if negative { -value } else { value });
+            }
+            _ => return IntegerLiteral::NotNumeric,
+        }
+    }
+}
+
+fn peel_nested(mut expression: &Expr) -> &Expr {
+    while let Expr::Nested(inner) = expression {
+        expression = inner;
+    }
+    expression
+}
+
+fn finish_predicate(
+    table_id: TableId,
+    key_type: ShardKeyType,
+    domain: KeyDomain,
+) -> ShardKeyInference {
+    match domain {
+        KeyDomain::Any => unconstrained(table_id, key_type),
+        KeyDomain::Finite(values) if values.is_empty() => ShardKeyInference {
+            table_id: Some(table_id),
+            key_type: Some(key_type),
+            kind: ShardKeyInferenceKind::Contradiction,
+            values,
+        },
+        KeyDomain::Finite(values) if values.len() == 1 => ShardKeyInference {
+            table_id: Some(table_id),
+            key_type: Some(key_type),
+            kind: ShardKeyInferenceKind::Exact,
+            values,
+        },
+        KeyDomain::Finite(values) => ShardKeyInference {
+            table_id: Some(table_id),
+            key_type: Some(key_type),
+            kind: ShardKeyInferenceKind::Multiple,
+            values,
+        },
+    }
+}
+
+fn not_applicable() -> ShardKeyInference {
+    ShardKeyInference {
+        table_id: None,
+        key_type: None,
+        kind: ShardKeyInferenceKind::NotApplicable,
+        values: Vec::new(),
+    }
+}
+
+fn not_sharded(table_id: TableId) -> ShardKeyInference {
+    ShardKeyInference {
+        table_id: Some(table_id),
+        key_type: None,
+        kind: ShardKeyInferenceKind::NotSharded,
+        values: Vec::new(),
+    }
+}
+
+fn unconstrained(table_id: TableId, key_type: ShardKeyType) -> ShardKeyInference {
+    ShardKeyInference {
+        table_id: Some(table_id),
+        key_type: Some(key_type),
+        kind: ShardKeyInferenceKind::Unconstrained,
+        values: Vec::new(),
+    }
+}
+
+fn distinct_value_count(values: &[ShardKeyValue]) -> usize {
+    values.iter().collect::<HashSet<_>>().len()
+}
+
+fn type_mismatch(context: &InferenceContext<'_>) -> EngineError {
+    EngineError::new(
+        EngineErrorKind::TypeMismatch,
+        format!(
+            "statement {} has a shard-key value incompatible with its catalog type",
+            context.statement_index + 1
+        ),
+    )
+}
+
+fn numeric_out_of_range(context: &InferenceContext<'_>) -> EngineError {
+    EngineError::new(
+        EngineErrorKind::NumericOutOfRange,
+        format!(
+            "statement {} has a shard-key integer outside the signed 64-bit range",
+            context.statement_index + 1
+        ),
+    )
+}
+
+fn inference_invariant() -> EngineError {
+    EngineError::new(
+        EngineErrorKind::Internal,
+        "normalized SQL metadata is inconsistent during shard-key inference",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{Arc, Barrier},
+        thread,
+    };
+
+    use super::*;
+    use crate::{
+        core::{LogicalDatabaseMetadata, ShardKeyMetadata},
+        sql::{SqlDialect, normalize_placeholders, parse, validate_common_subset},
+    };
+
+    const DEFAULT_DATABASE: u64 = 1;
+    const TENANT_DATABASE: u64 = 9;
+    const BLOBS_TABLE: u64 = 2;
+    const COUNTRIES_TABLE: u64 = 3;
+    const EVENTS_TABLE: u64 = 4;
+    const INTERNAL_CATALOG_TABLE: u64 = 5;
+    const ACCOUNTS_TABLE: u64 = 30;
+
+    fn sample_catalog() -> Catalog {
+        Catalog::from_validated_parts(
+            1,
+            7,
+            DEFAULT_DATABASE,
+            vec![
+                LogicalDatabaseMetadata::from_validated(DEFAULT_DATABASE, "default".to_owned()),
+                LogicalDatabaseMetadata::from_validated(TENANT_DATABASE, "tenant".to_owned()),
+            ]
+            .into_boxed_slice(),
+            vec![
+                TableMetadata::from_validated(
+                    BLOBS_TABLE,
+                    DEFAULT_DATABASE,
+                    "blobs".to_owned(),
+                    TablePlacement::Sharded(ShardKeyMetadata::from_validated(
+                        "tenant_id".to_owned(),
+                        ShardKeyType::Binary,
+                    )),
+                ),
+                TableMetadata::from_validated(
+                    COUNTRIES_TABLE,
+                    DEFAULT_DATABASE,
+                    "countries".to_owned(),
+                    TablePlacement::Global,
+                ),
+                TableMetadata::from_validated(
+                    EVENTS_TABLE,
+                    DEFAULT_DATABASE,
+                    "events".to_owned(),
+                    TablePlacement::Sharded(ShardKeyMetadata::from_validated(
+                        "tenant_id".to_owned(),
+                        ShardKeyType::Int64,
+                    )),
+                ),
+                TableMetadata::from_validated(
+                    INTERNAL_CATALOG_TABLE,
+                    DEFAULT_DATABASE,
+                    "internal_catalog".to_owned(),
+                    TablePlacement::Catalog,
+                ),
+                TableMetadata::from_validated(
+                    ACCOUNTS_TABLE,
+                    TENANT_DATABASE,
+                    "accounts".to_owned(),
+                    TablePlacement::Sharded(ShardKeyMetadata::from_validated(
+                        "tenant_id".to_owned(),
+                        ShardKeyType::Text,
+                    )),
+                ),
+            ]
+            .into_boxed_slice(),
+        )
+    }
+
+    fn normalize(dialect: SqlDialect, source: &str) -> NormalizedSql {
+        let parsed = parse(dialect, source.to_owned()).unwrap();
+        let common = validate_common_subset(parsed).unwrap();
+        normalize_placeholders(common).unwrap()
+    }
+
+    fn infer(
+        catalog: &Catalog,
+        database: u64,
+        dialect: SqlDialect,
+        source: &str,
+        parameters: &[Value],
+    ) -> EngineResult<ShardKeyInference> {
+        let normalized = normalize(dialect, source);
+        infer_shard_keys(
+            catalog,
+            LogicalDatabaseId::new(database).unwrap(),
+            &normalized,
+            0,
+            parameters,
+        )
+    }
+
+    fn assert_result(
+        inference: &ShardKeyInference,
+        table_id: Option<u64>,
+        key_type: Option<ShardKeyType>,
+        kind: ShardKeyInferenceKind,
+        values: &[ShardKeyValue],
+    ) {
+        assert_eq!(inference.table_id().map(TableId::get), table_id);
+        assert_eq!(inference.key_type(), key_type);
+        assert_eq!(inference.kind(), kind);
+        assert_eq!(inference.values(), values);
+    }
+
+    fn assert_kind(error: EngineError, expected: EngineErrorKind) {
+        assert_eq!(error.kind(), expected, "{error:?}");
+    }
+
+    #[test]
+    fn public_values_and_results_are_owned_cloneable_and_redacted() {
+        fn assert_public_shape<T: Clone + Send + Sync + 'static>() {}
+        assert_public_shape::<ShardKeyInference>();
+        assert_public_shape::<ShardKeyInferenceKind>();
+        assert_public_shape::<ShardKeyValue>();
+
+        let integer = ShardKeyValue::Int64(42);
+        let text = ShardKeyValue::Text("private-tenant".to_owned());
+        let binary = ShardKeyValue::Binary(vec![0xde, 0xad, 0xbe, 0xef]);
+        assert_eq!(integer.key_type(), ShardKeyType::Int64);
+        assert_eq!(integer.as_i64(), Some(42));
+        assert_eq!(integer.as_str(), None);
+        assert_eq!(integer.as_bytes(), None);
+        assert_eq!(text.key_type(), ShardKeyType::Text);
+        assert_eq!(text.as_str(), Some("private-tenant"));
+        assert_eq!(binary.key_type(), ShardKeyType::Binary);
+        assert_eq!(binary.as_bytes(), Some(&[0xde, 0xad, 0xbe, 0xef][..]));
+
+        let debug = format!("{integer:?} {text:?} {binary:?}");
+        assert!(!debug.contains("42"));
+        assert!(!debug.contains("private-tenant"));
+        assert!(!debug.contains("deadbeef"));
+
+        let catalog = sample_catalog();
+        let result = infer(
+            &catalog,
+            TENANT_DATABASE,
+            SqlDialect::PostgreSql,
+            "INSERT INTO accounts (tenant_id) VALUES ('private-tenant')",
+            &[],
+        )
+        .unwrap();
+        let cloned = result.clone();
+        assert_eq!(cloned, result);
+        let debug = format!("{result:?}");
+        assert!(!debug.contains("private-tenant"));
+        assert!(debug.contains("value_count: 1"));
+    }
+
+    #[test]
+    fn marker_spans_select_the_correct_statement_local_bound_value() {
+        let catalog = sample_catalog();
+        let postgres = infer(
+            &catalog,
+            DEFAULT_DATABASE,
+            SqlDialect::PostgreSql,
+            "SELECT $1 FROM events WHERE tenant_id = $2",
+            &[Value::Text("projection".to_owned()), Value::Int64(72)],
+        )
+        .unwrap();
+        assert_result(
+            &postgres,
+            Some(EVENTS_TABLE),
+            Some(ShardKeyType::Int64),
+            ShardKeyInferenceKind::Exact,
+            &[ShardKeyValue::Int64(72)],
+        );
+
+        let mysql = infer(
+            &catalog,
+            DEFAULT_DATABASE,
+            SqlDialect::MySql,
+            "UPDATE events SET payload = ? WHERE tenant_id = ?",
+            &[Value::Text("assignment".to_owned()), Value::Int64(81)],
+        )
+        .unwrap();
+        assert_eq!(mysql.values(), &[ShardKeyValue::Int64(81)]);
+
+        let sqlite = infer(
+            &catalog,
+            DEFAULT_DATABASE,
+            SqlDialect::Sqlite,
+            "SELECT ?2 FROM events WHERE tenant_id = ?1",
+            &[Value::Int64(93), Value::Text("projection".to_owned())],
+        )
+        .unwrap();
+        assert_eq!(sqlite.values(), &[ShardKeyValue::Int64(93)]);
+    }
+
+    #[test]
+    fn predicate_domain_algebra_is_conservative_and_deterministic() {
+        let catalog = sample_catalog();
+        let cases = [
+            (
+                "tenant_id = 1 AND payload = 9",
+                ShardKeyInferenceKind::Exact,
+                vec![ShardKeyValue::Int64(1)],
+            ),
+            (
+                "tenant_id = 1 OR payload = 9",
+                ShardKeyInferenceKind::Unconstrained,
+                vec![],
+            ),
+            (
+                "tenant_id = 1 OR tenant_id = 2",
+                ShardKeyInferenceKind::Multiple,
+                vec![ShardKeyValue::Int64(1), ShardKeyValue::Int64(2)],
+            ),
+            (
+                "tenant_id = 1 AND tenant_id = 2",
+                ShardKeyInferenceKind::Contradiction,
+                vec![],
+            ),
+            (
+                "tenant_id = 1 OR tenant_id = 1",
+                ShardKeyInferenceKind::Exact,
+                vec![ShardKeyValue::Int64(1)],
+            ),
+            (
+                "(1 = (tenant_id)) AND (tenant_id = 1 OR tenant_id = 3)",
+                ShardKeyInferenceKind::Exact,
+                vec![ShardKeyValue::Int64(1)],
+            ),
+            (
+                "tenant_id = NULL OR tenant_id = 7",
+                ShardKeyInferenceKind::Exact,
+                vec![ShardKeyValue::Int64(7)],
+            ),
+            (
+                "tenant_id = NULL AND payload = 9",
+                ShardKeyInferenceKind::Contradiction,
+                vec![],
+            ),
+        ];
+
+        for (predicate, kind, values) in cases {
+            let source = format!("SELECT * FROM events WHERE {predicate}");
+            let result =
+                infer(&catalog, DEFAULT_DATABASE, SqlDialect::Sqlite, &source, &[]).unwrap();
+            assert_result(
+                &result,
+                Some(EVENTS_TABLE),
+                Some(ShardKeyType::Int64),
+                kind,
+                &values,
+            );
+        }
+    }
+
+    #[test]
+    fn bound_predicate_values_are_compared_after_binding() {
+        let catalog = sample_catalog();
+        for (operator, right, kind, values) in [
+            (
+                "AND",
+                7,
+                ShardKeyInferenceKind::Exact,
+                vec![ShardKeyValue::Int64(7)],
+            ),
+            ("AND", 8, ShardKeyInferenceKind::Contradiction, vec![]),
+            (
+                "OR",
+                7,
+                ShardKeyInferenceKind::Exact,
+                vec![ShardKeyValue::Int64(7)],
+            ),
+            (
+                "OR",
+                8,
+                ShardKeyInferenceKind::Multiple,
+                vec![ShardKeyValue::Int64(7), ShardKeyValue::Int64(8)],
+            ),
+        ] {
+            let source =
+                format!("SELECT * FROM events WHERE tenant_id = $1 {operator} tenant_id = $2");
+            let result = infer(
+                &catalog,
+                DEFAULT_DATABASE,
+                SqlDialect::PostgreSql,
+                &source,
+                &[Value::Int64(7), Value::Int64(right)],
+            )
+            .unwrap();
+            assert_eq!(result.kind(), kind);
+            assert_eq!(result.values(), values);
+        }
+    }
+
+    #[test]
+    fn direct_key_atom_errors_are_independent_of_logical_branch_order() {
+        let catalog = sample_catalog();
+        for predicate in [
+            "payload = 1 OR tenant_id = 9223372036854775808",
+            "tenant_id = 9223372036854775808 OR payload = 1",
+            "payload = 1 AND tenant_id = 9223372036854775808",
+            "tenant_id = 9223372036854775808 AND payload = 1",
+        ] {
+            let source = format!("SELECT * FROM events WHERE {predicate}");
+            let error =
+                infer(&catalog, DEFAULT_DATABASE, SqlDialect::Sqlite, &source, &[]).unwrap_err();
+            assert_kind(error, EngineErrorKind::NumericOutOfRange);
+        }
+    }
+
+    #[test]
+    fn unsupported_predicate_shapes_do_not_claim_a_finite_key_set() {
+        let catalog = sample_catalog();
+        for predicate in [
+            "tenant_id > 1",
+            "tenant_id IN (1, 2)",
+            "tenant_id BETWEEN 1 AND 2",
+            "NOT tenant_id = 1",
+            "tenant_id + 1 = 2",
+            "CASE WHEN tenant_id = 1 THEN 1 ELSE 0 END = 1",
+            "tenant_id IS NULL",
+        ] {
+            let source = format!("SELECT * FROM events WHERE {predicate}");
+            let result =
+                infer(&catalog, DEFAULT_DATABASE, SqlDialect::Sqlite, &source, &[]).unwrap();
+            assert_eq!(result.kind(), ShardKeyInferenceKind::Unconstrained);
+            assert!(result.values().is_empty());
+        }
+    }
+
+    #[test]
+    fn aliases_qualifiers_and_identifier_quoting_follow_sql_reference_rules() {
+        let catalog = sample_catalog();
+        for (source, kind) in [
+            (
+                "SELECT * FROM events e WHERE e.tenant_id = 4",
+                ShardKeyInferenceKind::Exact,
+            ),
+            (
+                "SELECT * FROM events e WHERE events.tenant_id = 4",
+                ShardKeyInferenceKind::Unconstrained,
+            ),
+            (
+                "SELECT * FROM events WHERE events.tenant_id = 4",
+                ShardKeyInferenceKind::Exact,
+            ),
+            (
+                "SELECT * FROM events e WHERE other.tenant_id = 4",
+                ShardKeyInferenceKind::Unconstrained,
+            ),
+            (
+                "SELECT * FROM EVENTS WHERE TENANT_ID = 4",
+                ShardKeyInferenceKind::Exact,
+            ),
+            (
+                "SELECT * FROM \"events\" WHERE \"tenant_id\" = 4",
+                ShardKeyInferenceKind::Exact,
+            ),
+            (
+                "SELECT * FROM events \"E\" WHERE \"E\".tenant_id = 4",
+                ShardKeyInferenceKind::Exact,
+            ),
+            (
+                "SELECT * FROM events \"E\" WHERE e.tenant_id = 4",
+                ShardKeyInferenceKind::Unconstrained,
+            ),
+            (
+                "SELECT * FROM events WHERE \"TENANT_ID\" = 4",
+                ShardKeyInferenceKind::Unconstrained,
+            ),
+        ] {
+            let result = infer(
+                &catalog,
+                DEFAULT_DATABASE,
+                SqlDialect::PostgreSql,
+                source,
+                &[],
+            )
+            .unwrap();
+            assert_eq!(result.kind(), kind, "{source}");
+        }
+
+        let error = infer(
+            &catalog,
+            DEFAULT_DATABASE,
+            SqlDialect::PostgreSql,
+            "SELECT * FROM \"EVENTS\" WHERE tenant_id = 4",
+            &[],
+        )
+        .unwrap_err();
+        assert_kind(error, EngineErrorKind::InvalidQuery);
+    }
+
+    #[test]
+    fn select_update_and_delete_only_consider_their_where_predicate() {
+        let catalog = sample_catalog();
+        for source in [
+            "SELECT tenant_id FROM events WHERE 8 = tenant_id ORDER BY tenant_id LIMIT 1",
+            "UPDATE events SET tenant_id = 99, payload = 8 WHERE tenant_id = 8",
+            "DELETE FROM events WHERE (tenant_id) = (8)",
+        ] {
+            let result =
+                infer(&catalog, DEFAULT_DATABASE, SqlDialect::Sqlite, source, &[]).unwrap();
+            assert_eq!(result.kind(), ShardKeyInferenceKind::Exact, "{source}");
+            assert_eq!(result.values(), &[ShardKeyValue::Int64(8)]);
+        }
+
+        for source in [
+            "SELECT tenant_id = 8 FROM events",
+            "SELECT payload FROM events GROUP BY payload HAVING tenant_id = 8",
+            "SELECT payload FROM events ORDER BY tenant_id = 8 LIMIT 1",
+            "UPDATE events SET tenant_id = 8 WHERE payload = 1",
+        ] {
+            let result =
+                infer(&catalog, DEFAULT_DATABASE, SqlDialect::Sqlite, source, &[]).unwrap();
+            assert_eq!(
+                result.kind(),
+                ShardKeyInferenceKind::Unconstrained,
+                "{source}"
+            );
+        }
+    }
+
+    #[test]
+    fn multi_row_insert_preserves_row_order_and_duplicate_keys() {
+        let catalog = sample_catalog();
+        let result = infer(
+            &catalog,
+            TENANT_DATABASE,
+            SqlDialect::PostgreSql,
+            "INSERT INTO accounts (payload, tenant_id) VALUES ($1, 'alpha'), ($2, $3), ($4, 'alpha')",
+            &[
+                Value::Int64(1),
+                Value::Int64(2),
+                Value::Text("beta".to_owned()),
+                Value::Int64(3),
+            ],
+        )
+        .unwrap();
+        assert_result(
+            &result,
+            Some(ACCOUNTS_TABLE),
+            Some(ShardKeyType::Text),
+            ShardKeyInferenceKind::Multiple,
+            &[
+                ShardKeyValue::Text("alpha".to_owned()),
+                ShardKeyValue::Text("beta".to_owned()),
+                ShardKeyValue::Text("alpha".to_owned()),
+            ],
+        );
+
+        let same = infer(
+            &catalog,
+            TENANT_DATABASE,
+            SqlDialect::MySql,
+            "INSERT INTO accounts (tenant_id, payload) VALUES (?, 1), (?, 2), (?, 3)",
+            &[
+                Value::Text("same".to_owned()),
+                Value::Text("same".to_owned()),
+                Value::Text("same".to_owned()),
+            ],
+        )
+        .unwrap();
+        assert_eq!(same.kind(), ShardKeyInferenceKind::Exact);
+        assert_eq!(same.values().len(), 3);
+        assert!(
+            same.values()
+                .iter()
+                .all(|value| value.as_str() == Some("same"))
+        );
+
+        let middle = infer(
+            &catalog,
+            DEFAULT_DATABASE,
+            SqlDialect::Sqlite,
+            "INSERT INTO events (left_value, tenant_id, right_value) VALUES (?2, ?1, ?3)",
+            &[
+                Value::Int64(17),
+                Value::Text("left".to_owned()),
+                Value::Boolean(true),
+            ],
+        )
+        .unwrap();
+        assert_eq!(middle.kind(), ShardKeyInferenceKind::Exact);
+        assert_eq!(middle.values(), &[ShardKeyValue::Int64(17)]);
+    }
+
+    #[test]
+    fn inserts_without_a_direct_value_for_every_shard_key_are_unconstrained() {
+        let catalog = sample_catalog();
+        for source in [
+            "INSERT INTO events (payload) VALUES (1), (2)",
+            "INSERT INTO events (tenant_id, payload) VALUES (1 + 1, 2)",
+            "INSERT INTO events (payload, tenant_id) VALUES (1, 7), (2, 8 + 1)",
+        ] {
+            let result =
+                infer(&catalog, DEFAULT_DATABASE, SqlDialect::Sqlite, source, &[]).unwrap();
+            assert_eq!(
+                result.kind(),
+                ShardKeyInferenceKind::Unconstrained,
+                "{source}"
+            );
+            assert!(result.values().is_empty());
+        }
+    }
+
+    #[test]
+    fn null_insert_keys_are_rejected_for_literals_and_bound_values() {
+        let catalog = sample_catalog();
+        for (source, parameters) in [
+            (
+                "INSERT INTO events (tenant_id, payload) VALUES (NULL, 1)",
+                vec![],
+            ),
+            (
+                "INSERT INTO events (tenant_id, payload) VALUES (?1, 1)",
+                vec![Value::Null],
+            ),
+            (
+                "INSERT INTO events (tenant_id) VALUES (1 + 1), (NULL)",
+                vec![],
+            ),
+            (
+                "INSERT INTO events (tenant_id) VALUES (NULL), (1 + 1)",
+                vec![],
+            ),
+        ] {
+            let error = infer(
+                &catalog,
+                DEFAULT_DATABASE,
+                SqlDialect::Sqlite,
+                source,
+                &parameters,
+            )
+            .unwrap_err();
+            assert_kind(error, EngineErrorKind::NotNullViolation);
+        }
+
+        for source in [
+            "INSERT INTO events (tenant_id) VALUES (1 + 1), ('wrong')",
+            "INSERT INTO events (tenant_id) VALUES ('wrong'), (1 + 1)",
+        ] {
+            let error =
+                infer(&catalog, DEFAULT_DATABASE, SqlDialect::Sqlite, source, &[]).unwrap_err();
+            assert_kind(error, EngineErrorKind::TypeMismatch);
+        }
+
+        for source in [
+            "INSERT INTO events (tenant_id) VALUES (1 + 1), (9223372036854775808)",
+            "INSERT INTO events (tenant_id) VALUES (9223372036854775808), (1 + 1)",
+        ] {
+            let error =
+                infer(&catalog, DEFAULT_DATABASE, SqlDialect::Sqlite, source, &[]).unwrap_err();
+            assert_kind(error, EngineErrorKind::NumericOutOfRange);
+        }
+    }
+
+    #[test]
+    fn integer_keys_accept_full_signed_range_and_lossless_unsigned_values() {
+        let catalog = sample_catalog();
+        for (literal, expected) in [
+            ("0", 0),
+            ("+42", 42),
+            ("-(-7)", 7),
+            ("9223372036854775807", i64::MAX),
+            ("-9223372036854775808", i64::MIN),
+        ] {
+            let source = format!("SELECT * FROM events WHERE tenant_id = {literal}");
+            let result =
+                infer(&catalog, DEFAULT_DATABASE, SqlDialect::Sqlite, &source, &[]).unwrap();
+            assert_eq!(result.values(), &[ShardKeyValue::Int64(expected)]);
+        }
+
+        for (value, expected) in [
+            (Value::Int64(i64::MIN), i64::MIN),
+            (Value::UInt64(i64::MAX as u64), i64::MAX),
+        ] {
+            let result = infer(
+                &catalog,
+                DEFAULT_DATABASE,
+                SqlDialect::Sqlite,
+                "SELECT * FROM events WHERE tenant_id = ?1",
+                &[value],
+            )
+            .unwrap();
+            assert_eq!(result.values()[0].as_i64(), Some(expected));
+        }
+    }
+
+    #[test]
+    fn integer_overflow_and_incompatible_key_types_have_stable_error_kinds() {
+        let catalog = sample_catalog();
+        for literal in ["9223372036854775808", "-9223372036854775809"] {
+            let source = format!("SELECT * FROM events WHERE tenant_id = {literal}");
+            let error =
+                infer(&catalog, DEFAULT_DATABASE, SqlDialect::Sqlite, &source, &[]).unwrap_err();
+            assert_kind(error, EngineErrorKind::NumericOutOfRange);
+        }
+        let error = infer(
+            &catalog,
+            DEFAULT_DATABASE,
+            SqlDialect::Sqlite,
+            "SELECT * FROM events WHERE tenant_id = ?1",
+            &[Value::UInt64(i64::MAX as u64 + 1)],
+        )
+        .unwrap_err();
+        assert_kind(error, EngineErrorKind::NumericOutOfRange);
+
+        let incompatible = [
+            Value::Boolean(true),
+            Value::Float64(1.0),
+            Value::decimal("1.0").unwrap(),
+            Value::Text("1".to_owned()),
+            Value::InvalidText(vec![b'1']),
+            Value::Binary(vec![1]),
+        ];
+        for value in incompatible {
+            let error = infer(
+                &catalog,
+                DEFAULT_DATABASE,
+                SqlDialect::Sqlite,
+                "SELECT * FROM events WHERE tenant_id = ?1",
+                &[value],
+            )
+            .unwrap_err();
+            assert_kind(error, EngineErrorKind::TypeMismatch);
+        }
+        for literal in ["1.5", "'1'", "TRUE"] {
+            let source = format!("SELECT * FROM events WHERE tenant_id = {literal}");
+            let error =
+                infer(&catalog, DEFAULT_DATABASE, SqlDialect::Sqlite, &source, &[]).unwrap_err();
+            assert_kind(error, EngineErrorKind::TypeMismatch);
+        }
+    }
+
+    #[test]
+    fn text_predicates_need_collation_metadata_and_binary_keys_are_exact() {
+        let catalog = sample_catalog();
+        let text = infer(
+            &catalog,
+            TENANT_DATABASE,
+            SqlDialect::PostgreSql,
+            "SELECT * FROM accounts WHERE tenant_id = $1",
+            &[Value::Text("snowman-☃".to_owned())],
+        )
+        .unwrap();
+        assert_eq!(text.kind(), ShardKeyInferenceKind::Unconstrained);
+        assert!(text.values().is_empty());
+
+        let text_literal = infer(
+            &catalog,
+            TENANT_DATABASE,
+            SqlDialect::PostgreSql,
+            "SELECT * FROM accounts WHERE tenant_id = 'snowman-☃'",
+            &[],
+        )
+        .unwrap();
+        assert_eq!(text_literal.kind(), ShardKeyInferenceKind::Unconstrained);
+        assert!(text_literal.values().is_empty());
+
+        let folded_candidates = infer(
+            &catalog,
+            TENANT_DATABASE,
+            SqlDialect::MySql,
+            "SELECT * FROM accounts WHERE tenant_id = 'A' OR tenant_id = 'a'",
+            &[],
+        )
+        .unwrap();
+        assert_eq!(
+            folded_candidates.kind(),
+            ShardKeyInferenceKind::Unconstrained
+        );
+        assert!(folded_candidates.values().is_empty());
+
+        let bound_null = infer(
+            &catalog,
+            TENANT_DATABASE,
+            SqlDialect::PostgreSql,
+            "SELECT * FROM accounts WHERE tenant_id = $1",
+            &[Value::Null],
+        )
+        .unwrap();
+        assert_eq!(bound_null.kind(), ShardKeyInferenceKind::Contradiction);
+        assert!(bound_null.values().is_empty());
+
+        let invalid = infer(
+            &catalog,
+            TENANT_DATABASE,
+            SqlDialect::PostgreSql,
+            "SELECT * FROM accounts WHERE tenant_id = $1",
+            &[Value::InvalidText(vec![0xff, 0xfe])],
+        )
+        .unwrap_err();
+        assert_kind(invalid, EngineErrorKind::InvalidTextEncoding);
+
+        let binary = infer(
+            &catalog,
+            DEFAULT_DATABASE,
+            SqlDialect::MySql,
+            "SELECT * FROM blobs WHERE tenant_id = ?",
+            &[Value::Binary(vec![0, 1, 2, 255])],
+        )
+        .unwrap();
+        assert_eq!(binary.values()[0].as_bytes(), Some(&[0, 1, 2, 255][..]));
+
+        for (database, source, value) in [
+            (
+                TENANT_DATABASE,
+                "SELECT * FROM accounts WHERE tenant_id = $1",
+                Value::Binary(vec![1]),
+            ),
+            (
+                DEFAULT_DATABASE,
+                "SELECT * FROM blobs WHERE tenant_id = $1",
+                Value::Text("bytes".to_owned()),
+            ),
+        ] {
+            let error =
+                infer(&catalog, database, SqlDialect::PostgreSql, source, &[value]).unwrap_err();
+            assert_kind(error, EngineErrorKind::TypeMismatch);
+        }
+        let literal_binary = infer(
+            &catalog,
+            DEFAULT_DATABASE,
+            SqlDialect::PostgreSql,
+            "SELECT * FROM blobs WHERE tenant_id = 'bytes'",
+            &[],
+        )
+        .unwrap_err();
+        assert_kind(literal_binary, EngineErrorKind::TypeMismatch);
+
+        for value in [
+            Value::Boolean(true),
+            Value::Int64(1),
+            Value::UInt64(1),
+            Value::Float64(1.0),
+            Value::decimal("1.0").unwrap(),
+            Value::Binary(vec![1]),
+        ] {
+            let error = infer(
+                &catalog,
+                TENANT_DATABASE,
+                SqlDialect::PostgreSql,
+                "SELECT * FROM accounts WHERE tenant_id = $1",
+                &[value],
+            )
+            .unwrap_err();
+            assert_kind(error, EngineErrorKind::TypeMismatch);
+        }
+
+        for value in [
+            Value::Boolean(true),
+            Value::Int64(1),
+            Value::UInt64(1),
+            Value::Float64(1.0),
+            Value::decimal("1.0").unwrap(),
+            Value::Text("one".to_owned()),
+            Value::InvalidText(vec![0xff]),
+        ] {
+            let error = infer(
+                &catalog,
+                DEFAULT_DATABASE,
+                SqlDialect::PostgreSql,
+                "SELECT * FROM blobs WHERE tenant_id = $1",
+                &[value],
+            )
+            .unwrap_err();
+            assert_kind(error, EngineErrorKind::TypeMismatch);
+        }
+
+        for (database, source) in [
+            (
+                TENANT_DATABASE,
+                "SELECT * FROM accounts WHERE tenant_id = NULL",
+            ),
+            (
+                DEFAULT_DATABASE,
+                "SELECT * FROM blobs WHERE tenant_id = NULL",
+            ),
+        ] {
+            let result = infer(&catalog, database, SqlDialect::PostgreSql, source, &[]).unwrap();
+            assert_eq!(result.kind(), ShardKeyInferenceKind::Contradiction);
+            assert!(result.values().is_empty());
+        }
+    }
+
+    #[test]
+    fn nonsharded_and_non_table_statements_have_distinct_results() {
+        let catalog = sample_catalog();
+        for (source, table_id) in [
+            ("SELECT * FROM countries", COUNTRIES_TABLE),
+            (
+                "DELETE FROM internal_catalog WHERE id = 1",
+                INTERNAL_CATALOG_TABLE,
+            ),
+        ] {
+            let result =
+                infer(&catalog, DEFAULT_DATABASE, SqlDialect::Sqlite, source, &[]).unwrap();
+            assert_result(
+                &result,
+                Some(table_id),
+                None,
+                ShardKeyInferenceKind::NotSharded,
+                &[],
+            );
+        }
+
+        for source in [
+            "SELECT 1",
+            "CREATE TABLE local_table (id INTEGER)",
+            "CREATE INDEX local_index ON local_table (id)",
+            "BEGIN",
+            "COMMIT",
+            "ROLLBACK",
+        ] {
+            let result =
+                infer(&catalog, DEFAULT_DATABASE, SqlDialect::Sqlite, source, &[]).unwrap();
+            assert_result(
+                &result,
+                None,
+                None,
+                ShardKeyInferenceKind::NotApplicable,
+                &[],
+            );
+        }
+    }
+
+    #[test]
+    fn database_and_table_resolution_are_explicit_and_database_scoped() {
+        let catalog = sample_catalog();
+        let accounts = infer(
+            &catalog,
+            TENANT_DATABASE,
+            SqlDialect::PostgreSql,
+            "SELECT * FROM accounts WHERE tenant_id = 'tenant-a'",
+            &[],
+        )
+        .unwrap();
+        assert_eq!(
+            accounts.table_id(),
+            Some(TableId::new(ACCOUNTS_TABLE).unwrap())
+        );
+
+        let missing_in_default = infer(
+            &catalog,
+            DEFAULT_DATABASE,
+            SqlDialect::PostgreSql,
+            "SELECT * FROM accounts WHERE tenant_id = 'tenant-a'",
+            &[],
+        )
+        .unwrap_err();
+        assert_kind(missing_in_default, EngineErrorKind::InvalidQuery);
+
+        let missing_table = infer(
+            &catalog,
+            DEFAULT_DATABASE,
+            SqlDialect::Sqlite,
+            "SELECT * FROM missing WHERE tenant_id = 1",
+            &[],
+        )
+        .unwrap_err();
+        assert_kind(missing_table, EngineErrorKind::InvalidQuery);
+
+        let normalized = normalize(SqlDialect::Sqlite, "SELECT 1");
+        let missing_database = infer_shard_keys(
+            &catalog,
+            LogicalDatabaseId::new(99).unwrap(),
+            &normalized,
+            0,
+            &[],
+        )
+        .unwrap_err();
+        assert_kind(missing_database, EngineErrorKind::InvalidArgument);
+    }
+
+    #[test]
+    fn exact_parameter_arity_and_statement_index_are_validated_first() {
+        let catalog = sample_catalog();
+        let normalized = normalize(
+            SqlDialect::PostgreSql,
+            "SELECT * FROM events WHERE tenant_id = $2",
+        );
+        for parameters in [vec![], vec![Value::Null], vec![Value::Null; 3]] {
+            let error = infer_shard_keys(
+                &catalog,
+                LogicalDatabaseId::new(DEFAULT_DATABASE).unwrap(),
+                &normalized,
+                0,
+                &parameters,
+            )
+            .unwrap_err();
+            assert_kind(error, EngineErrorKind::InvalidArgument);
+        }
+        let exact = infer_shard_keys(
+            &catalog,
+            LogicalDatabaseId::new(DEFAULT_DATABASE).unwrap(),
+            &normalized,
+            0,
+            &[Value::Text("gap".to_owned()), Value::Int64(6)],
+        )
+        .unwrap();
+        assert_eq!(exact.values(), &[ShardKeyValue::Int64(6)]);
+
+        let bad_index = infer_shard_keys(
+            &catalog,
+            LogicalDatabaseId::new(DEFAULT_DATABASE).unwrap(),
+            &normalized,
+            1,
+            &[],
+        )
+        .unwrap_err();
+        assert_kind(bad_index, EngineErrorKind::InvalidArgument);
+
+        let empty = normalize(SqlDialect::Sqlite, "-- no statements");
+        let empty_index = infer_shard_keys(
+            &catalog,
+            LogicalDatabaseId::new(DEFAULT_DATABASE).unwrap(),
+            &empty,
+            0,
+            &[],
+        )
+        .unwrap_err();
+        assert_kind(empty_index, EngineErrorKind::InvalidArgument);
+
+        let unknown_table = normalize(SqlDialect::MySql, "SELECT ? FROM missing");
+        let arity = infer_shard_keys(
+            &catalog,
+            LogicalDatabaseId::new(DEFAULT_DATABASE).unwrap(),
+            &unknown_table,
+            0,
+            &[],
+        )
+        .unwrap_err();
+        assert_kind(arity, EngineErrorKind::InvalidArgument);
+    }
+
+    #[test]
+    fn batches_reset_parameter_numbering_and_select_statements_by_index() {
+        let catalog = sample_catalog();
+        let normalized = normalize(
+            SqlDialect::MySql,
+            "SELECT ? FROM events WHERE tenant_id = ?; SELECT ? FROM events WHERE tenant_id = ?",
+        );
+        assert_eq!(normalized.statement_count(), 2);
+        for (statement_index, key) in [(0, 11), (1, 22)] {
+            let result = infer_shard_keys(
+                &catalog,
+                LogicalDatabaseId::new(DEFAULT_DATABASE).unwrap(),
+                &normalized,
+                statement_index,
+                &[Value::Text("projection".to_owned()), Value::Int64(key)],
+            )
+            .unwrap();
+            assert_eq!(result.values(), &[ShardKeyValue::Int64(key)]);
+        }
+
+        let repeated = infer(
+            &catalog,
+            DEFAULT_DATABASE,
+            SqlDialect::PostgreSql,
+            "SELECT * FROM events WHERE tenant_id = $1 OR tenant_id = $1",
+            &[Value::Int64(33)],
+        )
+        .unwrap();
+        assert_eq!(repeated.kind(), ShardKeyInferenceKind::Exact);
+        assert_eq!(repeated.values(), &[ShardKeyValue::Int64(33)]);
+    }
+
+    #[test]
+    fn diagnostics_do_not_include_sql_or_bound_key_contents() {
+        let catalog = sample_catalog();
+        let sql_secret = "SQL_SECRET_7A9C";
+        let value_secret = "VALUE_SECRET_4B2D";
+        let source = format!("SELECT * FROM missing_{sql_secret} WHERE tenant_id = $1");
+        let error = infer(
+            &catalog,
+            DEFAULT_DATABASE,
+            SqlDialect::PostgreSql,
+            &source,
+            &[Value::Text(value_secret.to_owned())],
+        )
+        .unwrap_err();
+        let debug = format!("{error:?}");
+        assert!(!error.diagnostic().contains(sql_secret));
+        assert!(!error.diagnostic().contains(value_secret));
+        assert!(!debug.contains(sql_secret));
+        assert!(!debug.contains(value_secret));
+
+        let type_error = infer(
+            &catalog,
+            DEFAULT_DATABASE,
+            SqlDialect::PostgreSql,
+            "SELECT * FROM events WHERE tenant_id = $1",
+            &[Value::Text(value_secret.to_owned())],
+        )
+        .unwrap_err();
+        assert!(!type_error.diagnostic().contains(value_secret));
+        assert!(!format!("{type_error:?}").contains(value_secret));
+    }
+
+    #[test]
+    fn inference_is_deterministic_under_concurrency_and_recovers_after_errors() {
+        const WORKERS: usize = 12;
+        let catalog = Arc::new(sample_catalog());
+        let normalized = Arc::new(normalize(
+            SqlDialect::PostgreSql,
+            "SELECT * FROM events WHERE tenant_id = $1 OR tenant_id = $2",
+        ));
+        let barrier = Arc::new(Barrier::new(WORKERS));
+        let mut workers = Vec::new();
+        for _ in 0..WORKERS {
+            let catalog = Arc::clone(&catalog);
+            let normalized = Arc::clone(&normalized);
+            let barrier = Arc::clone(&barrier);
+            workers.push(thread::spawn(move || {
+                barrier.wait();
+                for _ in 0..100 {
+                    let result = infer_shard_keys(
+                        &catalog,
+                        LogicalDatabaseId::new(DEFAULT_DATABASE).unwrap(),
+                        &normalized,
+                        0,
+                        &[Value::Int64(7), Value::Int64(9)],
+                    )
+                    .unwrap();
+                    assert_eq!(result.kind(), ShardKeyInferenceKind::Multiple);
+                    assert_eq!(
+                        result.values(),
+                        &[ShardKeyValue::Int64(7), ShardKeyValue::Int64(9)]
+                    );
+                }
+            }));
+        }
+        for worker in workers {
+            worker.join().unwrap();
+        }
+
+        let failed = infer_shard_keys(
+            &catalog,
+            LogicalDatabaseId::new(DEFAULT_DATABASE).unwrap(),
+            &normalized,
+            0,
+            &[Value::Int64(7)],
+        )
+        .unwrap_err();
+        assert_kind(failed, EngineErrorKind::InvalidArgument);
+        let recovered = infer_shard_keys(
+            &catalog,
+            LogicalDatabaseId::new(DEFAULT_DATABASE).unwrap(),
+            &normalized,
+            0,
+            &[Value::Int64(7), Value::Int64(9)],
+        )
+        .unwrap();
+        assert_eq!(recovered.kind(), ShardKeyInferenceKind::Multiple);
+    }
+}

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -7,10 +7,12 @@
 //! deliberate SQLite pass-through; these opt-in layers do not gate, route, or
 //! execute statements.
 
+mod inference;
 mod normalizer;
 mod parser;
 mod subset;
 
+pub use inference::{ShardKeyInference, ShardKeyInferenceKind, ShardKeyValue, infer_shard_keys};
 pub use normalizer::{
     MAX_SQL_PARAMETERS, NormalizedSql, StatementParameters, normalize_placeholders,
 };

--- a/src/sql/normalizer.rs
+++ b/src/sql/normalizer.rs
@@ -27,6 +27,7 @@ pub struct NormalizedSql {
     common: CommonSql,
     sqlite_parameter_sql: String,
     statement_parameters: Vec<StatementParameters>,
+    statement_placeholders: Vec<Vec<NormalizedPlaceholder>>,
 }
 
 impl NormalizedSql {
@@ -61,6 +62,18 @@ impl NormalizedSql {
     /// Return one parameter layout for each top-level statement, in order.
     pub fn statement_parameters(&self) -> &[StatementParameters] {
         &self.statement_parameters
+    }
+
+    pub(super) fn common(&self) -> &CommonSql {
+        &self.common
+    }
+
+    pub(super) fn parameter_index(&self, statement_index: usize, span: Span) -> Option<usize> {
+        let placeholders = self.statement_placeholders.get(statement_index)?;
+        placeholders
+            .binary_search_by_key(&span, |placeholder| placeholder.span)
+            .ok()
+            .map(|index| placeholders[index].index)
     }
 }
 
@@ -130,12 +143,14 @@ pub fn normalize_placeholders(common: CommonSql) -> EngineResult<NormalizedSql> 
 
     let mut planned = Vec::new();
     let mut statement_parameters = Vec::with_capacity(common.statement_count());
+    let mut statement_placeholders = Vec::with_capacity(common.statement_count());
 
     for (statement_index, placeholders) in common.statement_placeholders().iter().enumerate() {
         let mut placeholders = placeholders.iter().collect::<Vec<_>>();
         placeholders.sort_unstable_by_key(|placeholder| placeholder.span);
 
         let mut parameter_indices = Vec::with_capacity(placeholders.len());
+        let mut normalized_placeholders = Vec::with_capacity(placeholders.len());
         let mut greatest_index = 0;
 
         for (occurrence_index, placeholder) in placeholders.into_iter().enumerate() {
@@ -148,6 +163,10 @@ pub fn normalize_placeholders(common: CommonSql) -> EngineResult<NormalizedSql> 
             )?;
             greatest_index = greatest_index.max(index);
             parameter_indices.push(index);
+            normalized_placeholders.push(NormalizedPlaceholder {
+                span: placeholder.span,
+                index,
+            });
             planned.push(PlannedPlaceholder {
                 marker: placeholder.marker.clone(),
                 span: placeholder.span,
@@ -159,6 +178,7 @@ pub fn normalize_placeholders(common: CommonSql) -> EngineResult<NormalizedSql> 
             parameter_count: greatest_index,
             parameter_indices,
         });
+        statement_placeholders.push(normalized_placeholders);
     }
 
     let sqlite_parameter_sql = rewrite_placeholders(common.source(), &planned)?;
@@ -166,7 +186,14 @@ pub fn normalize_placeholders(common: CommonSql) -> EngineResult<NormalizedSql> 
         common,
         sqlite_parameter_sql,
         statement_parameters,
+        statement_placeholders,
     })
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct NormalizedPlaceholder {
+    span: Span,
+    index: usize,
 }
 
 fn parameter_index(

--- a/src/sql/subset.rs
+++ b/src/sql/subset.rs
@@ -56,6 +56,10 @@ impl CommonSql {
     pub(super) fn statement_placeholders(&self) -> &[Vec<CommonPlaceholder>] {
         &self.statement_placeholders
     }
+
+    pub(super) fn statements(&self) -> &[AstStatement] {
+        self.parsed.statements()
+    }
 }
 
 #[derive(Clone, PartialEq, Eq)]

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -292,6 +292,58 @@ fn placeholder_normalization_is_public_owned_bounded_and_opt_in() {
 }
 
 #[test]
+fn shard_key_inference_is_public_typed_and_opt_in() {
+    fn assert_owned_public<T: Clone + Send + Sync + 'static>() {}
+    assert_owned_public::<sql::ShardKeyInference>();
+    assert_owned_public::<sql::ShardKeyInferenceKind>();
+    assert_owned_public::<sql::ShardKeyValue>();
+
+    let temp = tempfile::tempdir().unwrap();
+    drop(core::Database::open(temp.path(), 4).unwrap());
+    insert_catalog_fixture(temp.path());
+    let database = core::Database::open(temp.path(), 4).unwrap();
+    let tenant = database.catalog().database("tenant").unwrap().unwrap();
+
+    let source = "INSERT INTO accounts (payload, tenant_id) VALUES ($1, $2), ($3, 'tenant-b')";
+    let parsed = sql::parse(sql::SqlDialect::PostgreSql, source).unwrap();
+    let common = sql::validate_common_subset(parsed).unwrap();
+    let normalized = sql::normalize_placeholders(common).unwrap();
+    let inference = sql::infer_shard_keys(
+        database.catalog(),
+        tenant.id(),
+        &normalized,
+        0,
+        &[
+            core::Value::Text("payload-a".to_owned()),
+            core::Value::Text("tenant-a".to_owned()),
+            core::Value::Text("payload-b".to_owned()),
+        ],
+    )
+    .unwrap();
+
+    assert_eq!(inference.table_id().unwrap().get(), 30);
+    assert_eq!(inference.key_type(), Some(core::ShardKeyType::Text));
+    assert_eq!(inference.kind(), sql::ShardKeyInferenceKind::Multiple);
+    assert_eq!(inference.values().len(), 2);
+    assert_eq!(inference.values()[0].key_type(), core::ShardKeyType::Text);
+    assert_eq!(inference.values()[0].as_str(), Some("tenant-a"));
+    assert_eq!(inference.values()[0].as_i64(), None);
+    assert_eq!(inference.values()[0].as_bytes(), None);
+    assert_eq!(inference.values()[1].as_str(), Some("tenant-b"));
+
+    let debug = format!("{inference:?}");
+    assert!(!debug.contains("tenant-a"));
+    assert!(!debug.contains("tenant-b"));
+
+    // Inference is read-only, protocol-neutral analysis. The existing raw
+    // database interface still executes caller-provided SQLite directly.
+    let raw = database
+        .query("inference-opt-in", "SELECT 23", &[])
+        .unwrap();
+    assert_eq!(raw.rows()[0].get(0), Some(&core::Value::Int64(23)));
+}
+
+#[test]
 fn logical_catalog_types_and_access_are_public_and_protocol_neutral() {
     fn assert_public_metadata<T: Clone + Send + Sync + 'static>() {}
 


### PR DESCRIPTION
## Summary

- add a public, protocol-neutral `infer_shard_keys` API with typed inference results
- infer integer and binary predicate keys with deterministic AND/OR domain algebra
- infer all typed multi-row INSERT keys while retaining row order and duplicates
- resolve bound parameters through exact statement-local AST spans across SQLite, PostgreSQL, and MySQL syntax
- preserve conservative text predicate behavior until catalog collation semantics are available
- document the API, boundaries, errors, compatibility, and unchanged raw HTTP behavior

## Why

Issue #22 needs catalog-aware shard-key extraction before bind-time planning can be implemented. This keeps parsing, inference, routing, policy, and execution as separate protocol-neutral layers.

## Validation

- `cargo fmt --all --check`
- `cargo test --locked --all-targets --all-features`
- `cargo test --locked --doc --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- Rust 1.85: full all-target/all-feature and doc test suites
- independent implementation review with no remaining blockers

Closes #22