### PR TITLE
Plan statements from bound values

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ its per-statement binding metadata.
 The [shard-key inference contract](docs/SQL_SHARD_KEYS.md) defines the opt-in,
 catalog-aware extraction of typed keys from predicates, bound parameters, and
 multi-row inserts without routing or execution.
+The [bound statement-planning contract](docs/SQL_PLANNING.md) defines the
+synchronous engine API that turns one statement's actual bound values into
+owned advisory routes while retaining routing provenance and an independent
+explicit fallback.
 The [error contract](docs/ERRORS.md) defines stable engine error kinds, safe
 HTTP problem details, and the mappings reserved for future PostgreSQL and MySQL
 adapters.
@@ -53,8 +57,8 @@ minimum supported Rust version (MSRV) and the latest stable toolchain.
 - A bounded SQL AST parser plus recursive common-subset validator for explicit
   SQLite, PostgreSQL, and MySQL dialects, followed by opt-in source-preserving
   placeholder normalization, per-statement binding metadata, and catalog-aware
-  typed shard-key inference, all isolated from the current raw SQLite HTTP
-  execution path
+  typed shard-key inference plus synchronous bound-value-aware advisory
+  routing plans, all isolated from the current raw SQLite HTTP execution path
 - A transactionally versioned `manifest.sqlite` with durable 4,096-bucket
   routing plus logical-database and table metadata
 - Identity-bound, WAL-enabled SQLite shard files that are never silently
@@ -182,10 +186,15 @@ logical catalog database, callers may then invoke
 `infer_shard_keys(&Catalog, LogicalDatabaseId, &NormalizedSql, statement_index,
 parameters)` to classify the statement as not applicable, not sharded,
 unconstrained, contradictory, exact, or multiple and inspect any typed inferred
-values. These steps do not hash a key, select a shard, plan, authorize, enforce
-write policy, or execute SQL. The HTTP execute, query, and migration endpoints
-invoke none of these opt-in layers and retain their existing raw SQLite
-behavior.
+values. Given the same normalized statement and actual bound values, callers
+may instead use synchronous
+`Engine::plan_bound_statement(database, normalized, statement_index,
+parameters, explicit_routing_key)` to retain the inference and produce one
+owned canonical route per inferred value plus an independent explicit route.
+The plan records schema and routing provenance but does not choose between
+inferred and explicit routes, enforce write or batch policy, translate SQL, or
+execute anything. The HTTP execute, query, and migration endpoints invoke none
+of these opt-in layers and retain their existing raw SQLite behavior.
 
 `EngineOptions` permits 1–16 active connections and 1–1,024 queued operations
 per shard, with at most 512 active connections across all shards.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -208,7 +208,7 @@ interrupted schema migration can be diagnosed and resumed.
   without interpolating values into SQL text.
 - [x] Infer shard keys from predicates and inserted values, including bound
   parameters and multi-row inserts.
-- [ ] Plan prepared statements at bind/execute time, not parse time, because a
+- [x] Plan prepared statements at bind/execute time, not parse time, because a
   routing key may be supplied as a bound parameter.
 - [ ] Reject conflicting keys and unroutable writes before execution.
 - [ ] Translate a deliberately small set of type names and syntax differences;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,7 +21,7 @@ server ---------> protocol::http
 
 | Module | Responsibility | Must not own |
 | --- | --- | --- |
-| `core` | Protocol-neutral `Engine`, `Session`, statements, values, results, errors, and read-only logical catalog; stable key routing; bounded per-shard admission and connection pools; routed execute/query and journaled schema migration | JSON/HTTP types, listeners, or Axum handlers |
+| `core` | Protocol-neutral `Engine`, `Session`, statements, values, results, errors, read-only logical catalog, and synchronous bound-value-aware advisory plans; stable key routing; bounded per-shard admission and connection pools; routed execute/query and journaled schema migration | JSON/HTTP types, listeners, or Axum handlers |
 | `storage` | Versioned routing/logical manifest, shard layout, migration journal and recovery, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
 | `sql` | Dialect-explicit SQL syntax parsing, recursive common-subset validation, source-preserving placeholder normalization, and catalog-aware typed shard-key inference behind BriskDB-owned types; exact source retention; SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, key hashing or shard selection, session/write policy, filesystem layout, protocol responses, protocol-buffer ownership, or protocol-specific support policy |
 | `protocol::http` | HTTP request extraction plus JSON/BriskDB value and RFC 9457 problem-detail encoding | BLAKE3 routing, shard files, or rusqlite calls |
@@ -124,8 +124,9 @@ contract](SQL_SUBSET.md).
 
 The current HTTP execute/query and migration paths deliberately remain raw
 SQLite pass-through and call none of the parser, subset validator, placeholder
-normalizer, or shard-key inference layers. Issues #19 through #22 therefore
-change no HTTP shape, SQL acceptance, routing, or storage behavior.
+normalizer, shard-key inference, or bound statement-planning layers. Issues
+#19 through #23 therefore change no HTTP shape, SQL acceptance, execution
+routing, or storage behavior.
 
 ### Placeholder-normalization boundary
 
@@ -172,10 +173,43 @@ unconstrained predicates, contradictions, one exact key, and multiple keys.
 This layer is catalog-aware and accepts bound values, but remains read-only and
 statement-local. It does not own the catalog or caller values, encode or hash a
 key, read the bucket map, choose a shard, construct an execution plan, apply
-write policy, mutate session state, or execute SQL. Issue #23 owns bind/execute
-planning and routing; issue #24 owns rejection of conflicting or unroutable
-writes. The normative proof, type, result, error, and testing rules are in the
-[shard-key inference contract](SQL_SHARD_KEYS.md).
+write policy, mutate session state, or execute SQL. The separate core planner
+owns bind-time canonical encoding and routing; issue #24 owns rejection of
+conflicting or unroutable writes. The normative proof, type, result, error, and
+testing rules are in the [shard-key inference contract](SQL_SHARD_KEYS.md).
+
+### Bound statement-planning boundary
+
+Synchronous `Engine::plan_bound_statement` accepts one `NormalizedSql`
+statement, its complete bound `Value` slice, the selected logical database, and
+an optional explicit routing byte sequence. It invokes inference only after
+the bound values exist, encodes every inferred value, and looks each occurrence
+up through the validated routing catalog. The returned `BoundStatementPlan`
+owns the inference and one `PlannedRoute` per inferred value in matching order,
+including duplicate multi-row values and distinct keys that happen to select
+the same physical shard.
+
+Canonical version-1 inferred bytes are the shortest signed decimal ASCII form
+for `Int64`, exact UTF-8 for `Text`, and exact bytes for `Binary`. Explicit
+routing bytes are retained exactly. Inferred routes and the optional explicit
+route remain separate: this layer does not select a winner, compare them for
+write eligibility, reject any inference category, or decide whether scatter is
+allowed.
+
+Planning holds the existing schema-operation guard while it reads logical and
+routing state. The owned result records schema generation, map generation, and
+the hash, key-encoding, and bucket-algorithm versions used for the lookup. That
+provenance does not reserve future state; an eventual execution integration
+must establish that the physical schema and routing snapshot remain
+authoritative before using a plan.
+
+The planner is advisory and stateless. It does not translate SQL, mutate a
+session, cache a prepared statement, apply write or batch policy, open a shard
+connection, or execute anything. The normative API, encoding, provenance,
+error, boundary, and testing rules are in the [bound statement-planning
+contract](SQL_PLANNING.md). Issues #24 through #27 own write policy,
+translation, prepared-statement/session lifecycle, and statement/batch policy
+respectively.
 
 ## Manifest storage boundary
 

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -167,6 +167,15 @@ statement position and a fixed category, but never contain SQL, identifier
 spelling, literal or bound values, key contents, formatted AST output, or source
 locations. See the [shard-key inference contract](SQL_SHARD_KEYS.md).
 
+The synchronous bound statement planner preserves those inference error kinds
+and diagnostics. Before inference it also acquires ordinary schema-operation
+admission, so a migrating gate returns `Busy`, a pending migration returns
+`FailedPrecondition`, and a degraded gate returns `DataCorruption`. A shape
+inconsistency between a successful inference and its route entries is
+`Internal`. Planning adds no new error kind, retains no failed parameters, and
+does not change protocol mappings. See the [bound statement-planning
+contract](SQL_PLANNING.md).
+
 The core contains no HTTP, PostgreSQL, or MySQL response types. Conversely,
 protocol adapters do not inspect SQLite errors. This lets every frontend share
 one error identity while retaining its own response encoding.

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -17,13 +17,13 @@ document defines the SQL and behavioral contract separately from connectivity.
   promise for it.
 
 The syntax parser, recursive common-subset validator, placeholder normalizer,
-and catalog-aware shard-key inference API are now available behind BriskDB-owned
-types. Validation is explicit and returns `Unsupported` for a parsed form
-outside the subset; parser acceptance alone is not product support.
-Normalization and inference are also explicit. The current experimental HTTP
-interface is still a raw SQLite pass-through and can execute uncontracted
-SQLite syntax because it calls none of these layers. That behavior is not a
-compatibility promise.
+catalog-aware shard-key inference API, and synchronous engine bound-statement
+planner are now available behind BriskDB-owned types. Validation is explicit
+and returns `Unsupported` for a parsed form outside the subset; parser
+acceptance alone is not product support. Normalization, inference, and advisory
+planning are also explicit. The current experimental HTTP interface is still a
+raw SQLite pass-through and can execute uncontracted SQLite syntax because it
+calls none of these layers. That behavior is not a compatibility promise.
 
 ## Compatibility layers
 
@@ -50,23 +50,26 @@ MySQL dialect, consume that result with
 `normalize_placeholders(CommonSql)`. That step yields canonical SQLite `?N`
 text and per-statement parameter metadata. Callers may then pass one
 statement's exact bound-value slice and selected logical database to
-`infer_shard_keys`, which returns a typed key classification. None of these
-operations hashes a key, selects a shard, plans, generally translates,
-authorizes, enforces write policy, or executes a statement. HTTP requests still
-send SQLite SQL directly to `rusqlite`; they do not pass through these opt-in
-SQL layers.
+`infer_shard_keys`, which returns a typed key classification. Synchronous
+`Engine::plan_bound_statement` accepts the same concrete bind plus an optional
+explicit routing byte sequence, retains the inference, and produces owned
+advisory physical routes with schema and routing provenance. It does not choose
+between inferred and explicit routes, generally translate, authorize, enforce
+write or batch policy, or execute a statement. HTTP requests still send SQLite
+SQL directly to `rusqlite`; they do not pass through these opt-in SQL layers.
 
 | Interface | Status | SQL accepted | Routing |
 | --- | --- | --- | --- |
 | HTTP `/v1/execute` | Experimental | One SQLite statement with positional parameters | Required caller-provided `shard_key` |
 | HTTP `/v1/query` | Experimental | One prepared SQLite statement executed through the row-returning path | Required caller-provided `shard_key` |
 | HTTP `/v1/admin/broadcast` | Experimental | A journaled parameterless SQLite schema batch | Preflight on every shard, then ascending resumable apply |
-| PostgreSQL wire protocol | Planned | Common subset plus documented PostgreSQL normalization | Rust inference implemented; wire bind-time planning and session fallback planned |
-| MySQL wire protocol | Planned | Common subset plus documented MySQL normalization | Rust inference implemented; wire bind-time planning and session fallback planned |
+| PostgreSQL wire protocol | Planned | Common subset plus documented PostgreSQL normalization | Rust inference and advisory bind-time planning implemented; wire lifecycle, routing policy, and session fallback planned |
+| MySQL wire protocol | Planned | Common subset plus documented MySQL normalization | Rust inference and advisory bind-time planning implemented; wire lifecycle, routing policy, and session fallback planned |
 
-The parser, subset validator, placeholder normalizer, and shard-key inference
-function are implemented Rust APIs, not network interfaces. Each step is
-opt-in and does not change any current network row in this table.
+The parser, subset validator, placeholder normalizer, shard-key inference
+function, and engine planner are implemented Rust APIs, not network
+interfaces. Each step is opt-in and does not change any current network row in
+this table.
 
 Every HTTP operation now calls the same protocol-neutral async engine intended
 for future PostgreSQL and MySQL adapters. Execute and query requests create a
@@ -285,9 +288,10 @@ and mixed batches may validate because request-level batch policy remains issue
 #27. `normalize_placeholders(CommonSql)` then returns an owned `NormalizedSql`
 with canonical SQLite parameter text and one parameter record per statement.
 `infer_shard_keys` can consume that result with catalog context and a complete
-bound-value slice for one statement. The SQL wrapper types retain exact source,
-dialect, and statement count without exposing the upstream AST or rendering
-SQL in `Debug` output.
+bound-value slice for one statement. `Engine::plan_bound_statement` consumes
+that same concrete bind when a caller needs advisory routes. The SQL wrapper
+types retain exact source, dialect, and statement count without exposing the
+upstream AST or rendering SQL in `Debug` output.
 
 The parser, validator, and normalizer have no routing or storage access. The
 implemented inference layer borrows only the read-only logical catalog and
@@ -298,7 +302,9 @@ decision record](SQL_PARSER.md) for the dependency and resource contract, the
 whitelist, and the [SQL parameter-normalization
 contract](SQL_PARAMETERS.md) for numbering and source-preservation rules. The
 [shard-key inference contract](SQL_SHARD_KEYS.md) defines the supported proof
-grammar and typed result.
+grammar and typed result. The [bound statement-planning
+contract](SQL_PLANNING.md) defines canonical route bytes, occurrence ordering,
+routing provenance, and the advisory execution boundary.
 
 ### Implemented pass-through surface
 
@@ -365,10 +371,10 @@ Insert/update duplicate checks fold ASCII letter case regardless of quoting but
 do not define general identifier normalization, which also remains issue #25.
 Placeholder normalization is the separate implemented issue #21 layer described
 below, and catalog-aware typed key extraction is the implemented issue #22
-layer. Bind-time planning and routing remain issue #23; rejection of conflicting
-or unroutable writes remains issue #24. Prepare/bind/describe/execute state
-remains issue #26, and empty or multi-statement execution policy remains issue
-#27.
+layer. Synchronous advisory bind-time planning and routing are the implemented
+issue #23 layer; rejection of conflicting or unroutable writes remains issue
+#24. Prepare/bind/describe/execute state remains issue #26, and empty or
+multi-statement execution policy remains issue #27.
 
 The validator independently caps recursive expression AST depth at 128. This
 also bounds flat operator chains that parse iteratively; exceeding the limit is
@@ -423,10 +429,33 @@ values. The exact identifier, value, result, and error rules are in [shard-key
 inference](SQL_SHARD_KEYS.md).
 
 Inference does not encode, hash, route, plan, authorize, enforce, or execute.
-Issue #23 will use the result at bind/execute time to construct a plan and
-routing decision. Issue #24 will decide which conflicting, multiple, or
-unconstrained write outcomes must be rejected before execution. The raw HTTP
-and engine paths do not invoke inference.
+The implemented planner described below uses the result at bind/execute time to
+construct advisory routes. Issue #24 will decide which conflicting, multiple,
+or unconstrained write outcomes must be rejected before execution. The raw
+HTTP execution paths do not invoke inference.
+
+### Implemented bound statement planning
+
+The synchronous public Rust method `Engine::plan_bound_statement` accepts a
+logical database, `NormalizedSql`, zero-based statement index, exact bound
+`Value` slice, and optional explicit routing bytes. It runs inference only
+after those concrete values exist and returns an owned `BoundStatementPlan`.
+
+Each inferred `Int64` becomes shortest signed decimal ASCII, `Text` becomes
+exact UTF-8, and `Binary` remains exact bytes. Explicit routing bytes also
+remain exact. The plan retains one route per inferred occurrence in matching
+order, including duplicate multi-row values and distinct keys that choose the
+same shard. Its explicit route remains separate even when it agrees with an
+inferred key or shard.
+
+Planning holds the schema-operation guard while consulting the catalog. The
+result records schema generation, routing-map generation, and hash,
+key-encoding, and bucket-algorithm versions. Those fields describe the snapshot
+used to build the plan; they do not reserve that snapshot for future execution.
+The method does not choose routing precedence, reject a classification,
+translate SQL, mutate a session, cache a prepared statement, apply write or
+batch policy, or execute SQLite. The exact contract is in [bound statement
+planning](SQL_PLANNING.md).
 
 ## PostgreSQL differences
 
@@ -436,7 +465,7 @@ not implemented unless listed as implemented in this document.
 
 | Area | PostgreSQL | BriskDB contract |
 | --- | --- | --- |
-| Parameters | `$1`, `$2`, ... | Implemented opt-in Rust normalization to SQLite `?N` and typed inference from a supplied bound slice; wire binding and bind-time routing remain planned |
+| Parameters | `$1`, `$2`, ... | Implemented opt-in Rust normalization, typed inference, and advisory routing from a supplied bound slice; wire bind lifecycle and routing policy remain planned |
 | Identifier quoting | Double quotes | Passed through where SQLite semantics agree |
 | Type system | Static types identified by OIDs | Planned loss-aware mapping to BriskDB types and SQLite storage classes |
 | Boolean | Dedicated `boolean` type | Stored as SQLite integer `0` or `1`; protocol adapter returns a Boolean value |
@@ -464,7 +493,7 @@ engine used by PostgreSQL and HTTP.
 
 | Area | MySQL | BriskDB contract |
 | --- | --- | --- |
-| Parameters | `?` in prepared statements | Implemented opt-in Rust normalization to consecutive SQLite `?N` and typed inference from a supplied bound slice; wire binding and routing remain planned |
+| Parameters | `?` in prepared statements | Implemented opt-in Rust normalization, typed inference, and advisory routing from a supplied bound slice; wire bind lifecycle and routing policy remain planned |
 | Identifier quoting | Backticks by default | Planned normalization; double-quoted strict SQL remains available |
 | Type system | Static signed/unsigned column types | BriskDB retains `UInt64` without narrowing; current SQLite binding rejects values above `i64::MAX` until an explicit storage mapping exists |
 | Boolean | Commonly `TINYINT(1)` | Stored as SQLite integer `0` or `1`; protocol adapter returns documented metadata |
@@ -528,11 +557,14 @@ underlying execution semantics.
 - Logical metadata is currently read-only and advisory. Fresh manifests and
   upgrades originating before v4 contain no table rows; v4-to-v5 retains every
   validated v4 logical-catalog row. Existing physical tables are not inferred
-  or adopted. The opt-in Rust inference API can consult catalog contents, but
-  they do not alter current SQL planning, routing, or execution.
+  or adopted. The opt-in Rust inference and advisory planning APIs can consult
+  catalog contents, but they do not alter current HTTP routing or execution.
 - Opt-in inference can extract typed cataloged keys from supported equality
-  predicates and every row of a supported `INSERT`; it does not select a shard
-  or change current HTTP behavior.
+  predicates and every row of a supported `INSERT`.
+- Opt-in bound planning converts every inferred occurrence to an owned route,
+  retains an independent explicit route, and records catalog/routing
+  provenance; it does not make a plan executable or change current HTTP
+  behavior.
 - Point queries and writes visit only that shard.
 - No scatter/gather query path exists.
 - Unique constraints and transactions are local to one SQLite shard.
@@ -547,9 +579,9 @@ underlying execution semantics.
 - Every sharded table declares one non-null shard-key column in the catalog.
 - Canonical key encoding, hash version, virtual bucket count, and bucket map are
   persisted in the manifest.
-- At bind/execute time, the planner consumes typed equality keys inferred from
-  SQL and bound parameters. An explicit session routing key remains a
-  controlled fallback.
+- Execution validates bound-plan provenance, applies write/read assignment
+  policy, and uses an explicit session routing key only as a controlled
+  fallback.
 - A transaction is pinned to its first shard. Targeting another shard returns a
   stable cross-shard-transaction error.
 - Read-only plans may scatter with bounded concurrency and deterministic merge.

--- a/docs/SQL_PARAMETERS.md
+++ b/docs/SQL_PARAMETERS.md
@@ -158,10 +158,11 @@ A successful `NormalizedSql` does not establish that:
 - execution would preserve all source-dialect semantics.
 
 The implemented [shard-key inference contract](SQL_SHARD_KEYS.md) consumes this
-metadata plus a catalog database and exact bound-value slice. Issues #23
-through #27 own bind-time planning and routing, conflicting or unroutable write
-rejection, syntax/type translation, prepared-statement state, and request-level
-statement classification respectively.
+metadata plus a catalog database and exact bound-value slice. The implemented
+[bound statement planner](SQL_PLANNING.md) uses that result to produce advisory
+routes only after values are bound. Issues #24 through #27 own conflicting or
+unroutable write rejection, syntax/type translation, prepared-statement state,
+and request-level statement classification respectively.
 
 ## Verification obligations
 

--- a/docs/SQL_PARSER.md
+++ b/docs/SQL_PARSER.md
@@ -64,7 +64,8 @@ In particular, this layer does not:
   `normalize_placeholders(CommonSql)` layer;
 - infer shard keys or inspect bound values; issue #22 implements that as the
   separate `infer_shard_keys` layer;
-- plan prepared statements at bind time (issue #23);
+- itself plan bound statements; issue #23 implements that as the separate
+  synchronous `Engine::plan_bound_statement` layer;
 - reject conflicting keys or unroutable writes (issue #24);
 - translate types or syntax, or choose strict SQLite mode (issue #25);
 - implement prepare/bind/describe/execute state or caches (issue #26); or
@@ -81,9 +82,10 @@ that still does not grant permission to execute an empty or mixed batch.
 The existing HTTP execute, query, and migration paths remain raw SQLite
 pass-through surfaces with their existing authorizer and endpoint-specific
 rules. They call neither this parser, the opt-in common-subset validator, nor
-the opt-in placeholder normalizer or shard-key inference layer. Connecting
-those layers before planning, translation, and request-level statement policy
-are implemented would change the experimental HTTP SQL surface.
+the opt-in placeholder normalizer, shard-key inference, or bound statement
+planner. Connecting those layers before translation, write policy, and
+request-level statement policy are implemented would change the experimental
+HTTP SQL surface.
 
 ## Resource and error boundaries
 

--- a/docs/SQL_PLANNING.md
+++ b/docs/SQL_PLANNING.md
@@ -1,0 +1,176 @@
+# Bound statement planning
+
+Status: implemented for roadmap issue #23
+
+BriskDB exposes a synchronous, protocol-neutral engine call that plans one
+normalized statement from the values actually bound for that execution:
+
+```rust
+Engine::plan_bound_statement(
+    &self,
+    database: LogicalDatabaseId,
+    normalized: &NormalizedSql,
+    statement_index: usize,
+    parameters: &[Value],
+    explicit_routing_key: Option<&[u8]>,
+) -> EngineResult<BoundStatementPlan>
+```
+
+`statement_index` is zero-based. `parameters` must be the complete bound-value
+slice for that statement, exactly as required by
+[`infer_shard_keys`](SQL_SHARD_KEYS.md). Requiring that slice is the important
+timing boundary: a statement whose shard key is a placeholder cannot be routed
+when SQL is parsed or prepared, because its value does not exist yet. A
+frontend calls this API for a concrete bind/execute operation.
+
+This is an advisory planning API. It infers typed shard-key values, converts
+them to canonical routing bytes, and looks up their current physical shards.
+It does not execute SQL or make a statement executable.
+
+## Result contract
+
+`BoundStatementPlan` owns all of its results and reports:
+
+- `database()`: the logical database used for catalog resolution;
+- `statement_index()`: the selected statement in the normalized batch;
+- `inference()`: the complete owned `ShardKeyInference` result;
+- `inferred_routes()`: one `PlannedRoute` for every entry returned by
+  `inference().values()`, in the same order;
+- `explicit_route()`: the independently planned caller-supplied routing key,
+  when one was supplied; and
+- `schema_generation()`, `map_generation()`, `hash_version()`,
+  `key_encoding_version()`, and `bucket_algorithm_version()`: the catalog and
+  routing provenance observed while the plan was produced.
+
+Each `PlannedRoute` owns its canonical `key_bytes()` and reports the selected
+physical `shard()`. Owning the bytes keeps the plan independent of frontend
+parameter buffers after the call returns.
+
+The plan retains the inference classification even when there is no inferred
+route. `NotApplicable`, `NotSharded`, `Unconstrained`, and `Contradiction`
+therefore remain successful advisory results with an empty
+`inferred_routes()` slice. An explicit route can still be present in any of
+those cases.
+
+`Debug` output reports identifiers, versions, shard IDs, and counts where
+useful. It does not render SQL, AST contents, inferred key values, explicit key
+bytes, or parameter values.
+
+## Canonical routing-key bytes
+
+Planner key encoding version 1 converts typed inferred values as follows:
+
+| Inferred type | Canonical routing bytes |
+| --- | --- |
+| `Int64` | Shortest signed base-10 ASCII form, with `0` for zero, `-` only for negative values, and no leading zeroes |
+| `Text` | Exact UTF-8 bytes, with no Unicode normalization or case conversion |
+| `Binary` | Exact bytes, including empty values and embedded zero bytes |
+
+An `Int64` value of `-42`, for example, becomes the three ASCII bytes
+`b"-42"`; `i64::MIN` and `i64::MAX` are supported without narrowing. The
+encoding adds no type, database, table, or column prefix.
+
+`explicit_routing_key` is already an untyped routing byte sequence. Its bytes
+are retained exactly, including an empty sequence; they are not parsed,
+normalized, or converted through the typed encoding table.
+
+Both inferred and explicit bytes enter the same persisted, versioned routing
+catalog: BLAKE3 hash version 1, bucket algorithm version 1, and the catalog's
+current virtual-bucket map select the physical shard. The recorded versions
+and map generation identify the routing rules used by this plan.
+
+## Occurrence and ordering rules
+
+`inferred_routes()` is aligned one-for-one with
+`inference().values()`. Planning does not collapse entries merely because:
+
+- two `INSERT` rows supply the same logical key;
+- two distinct keys currently map to the same physical shard; or
+- an inferred key and the explicit routing key select the same shard.
+
+This preserves multi-row `INSERT` row order and every inferred occurrence for
+the later policy layer. An implementation may share immutable owned storage
+for duplicate canonical bytes, but the public route entry for each occurrence
+remains present.
+
+## Inferred and explicit routes remain separate
+
+The explicit route is a candidate fallback, not an override selected by this
+API. Planning deliberately does not:
+
+- choose inferred routing over explicit routing or the reverse;
+- declare matching key bytes or matching physical shards sufficient;
+- reject different inferred and explicit keys;
+- reject `Multiple`, `Unconstrained`, or `Contradiction` inference;
+- decide whether a read may scatter; or
+- decide whether a write may execute.
+
+Roadmap issue #24 owns those assignment and write-policy decisions. Keeping
+both inputs in the plan lets that layer compare logical keys and plan shape
+without losing information during routing.
+
+## Catalog coordination and provenance
+
+The engine acquires the existing schema-operation guard before reading the
+logical catalog and routing snapshot. A schema migration cannot begin while
+the plan is being assembled. If the gate is already migrating or degraded,
+planning returns the same protocol-neutral gate error as other ordinary engine
+operations. The guard is released when the synchronous call returns.
+
+The successful plan records the application-schema generation, routing-map
+generation, hash version, key-encoding version, and bucket-algorithm version
+used by the call. These fields are provenance, not a lease on future state.
+This issue does not connect a plan to execution, so no SQLite statement runs
+under that provenance yet. A future execution path must establish that the
+physical schema and routing snapshot are still authoritative and reject or
+replan stale provenance before using the planned shards.
+
+The logical table catalog remains read-only and advisory. Planning does not
+assert that its table metadata describes an existing physical SQLite table or
+column. Physical catalog authority and execution validation remain future
+integration work.
+
+## Errors and recovery
+
+Planning returns shard-key inference errors unchanged, including invalid
+database, table, statement index, parameter arity, key type, integer range,
+text encoding, and non-null cases. It can additionally return the existing
+schema-gate errors while a migration or degraded state excludes ordinary work.
+An internally inconsistent inference/result shape is `Internal`.
+
+An error does not retain caller parameters, mutate the normalized SQL, poison
+the engine, or populate session state. A later independent call may succeed.
+
+## Deliberate boundaries
+
+Issue #23 introduces no configuration, CLI option, network message, HTTP shape,
+manifest migration, shard-file change, or new SQLite execution path. In
+particular:
+
+- `Engine::plan_bound_statement` is synchronous and stateless; it neither
+  accepts nor mutates a `Session`;
+- no per-session or global prepared-statement cache is created;
+- no PostgreSQL or MySQL syntax or type is translated;
+- no write, scatter, transaction, authorization, or batch policy is applied;
+- no statement is prepared, described, executed, or returned to a client; and
+- the current HTTP execute, query, and migration paths do not invoke parsing,
+  common-subset validation, normalization, inference, or this planner.
+
+Issue #24 owns conflicting and unroutable write policy. Issue #25 owns selected
+syntax and type translation. Issue #26 owns the protocol-neutral
+prepare/bind/describe/execute lifecycle, session integration, and bounded
+per-session cache. Issue #27 owns statement behavior and empty, single-, and
+multi-statement request policy.
+
+## Verification obligations
+
+Tests cover canonical bytes for signed integer boundaries, UTF-8 text, and
+arbitrary binary values; explicit keys including empty and binary sequences;
+all inference classifications; route ordering and retained duplicate
+multi-row values; distinct logical keys that choose the same physical shard;
+independent inferred and explicit routes; schema and routing provenance;
+schema-gate exclusion and recovery; every supported source dialect; numbered
+parameter gaps and rebinding the same normalized statement; propagated
+inference errors and recovery; deterministic concurrent calls; owned results;
+and redacted diagnostics and `Debug` output. Raw HTTP regressions continue to
+prove that advisory planning does not change existing execution behavior.

--- a/docs/SQL_SHARD_KEYS.md
+++ b/docs/SQL_SHARD_KEYS.md
@@ -160,11 +160,13 @@ The current HTTP execute, query, and migration paths do not invoke parsing,
 common-subset validation, normalization, or inference. They retain their
 existing raw SQLite SQL and caller-provided `shard_key` behavior.
 
-Issue #23 will invoke inference at bind/execute time and turn its result into a
-protocol-neutral plan and routing decision. Issue #24 will enforce the write
-rules for conflicting, multiple, or unconstrained keys. Later work owns syntax
-translation, prepared-statement lifecycle, statement classification, and wire
-protocol integration.
+The implemented synchronous
+[`Engine::plan_bound_statement`](SQL_PLANNING.md) API invokes inference at
+bind/execute time and turns every inferred value into an owned advisory route.
+It retains an optional explicit route separately and does not make the result
+executable. Issue #24 will enforce the write rules for conflicting, multiple,
+or unconstrained keys. Later work owns syntax translation, prepared-statement
+lifecycle, statement classification, and wire-protocol integration.
 
 ## Verification obligations
 

--- a/docs/SQL_SUBSET.md
+++ b/docs/SQL_SUBSET.md
@@ -44,11 +44,11 @@ A successful `CommonSql` does not mean that the SQL:
 - is authorized for a particular endpoint or session; or
 - has been executed.
 
-Those responsibilities remain with the implemented issue #21 normalization and
-issue #22 inference layers, issues #23 through #27, and the later wire
-frontends. Validation never consults parameters, a session, the logical
-catalog, storage, routing state, the filesystem, or SQLite. It never formats or
-searches SQL text to make a structural decision.
+Those responsibilities remain with the implemented issue #21 normalization,
+issue #22 inference, and issue #23 advisory planning layers, issues #24 through
+#27, and the later wire frontends. Validation never consults parameters, a
+session, the logical catalog, storage, routing state, the filesystem, or
+SQLite. It never formats or searches SQL text to make a structural decision.
 
 Empty and comment-only parsed batches validate successfully. Every statement in
 a mixed batch is checked independently and source order is retained, but that

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -494,7 +494,7 @@ The routing singleton contains exactly these generation-1 values:
 | Field | Value | Contract |
 | --- | --- | --- |
 | `hash_version` | `1` | BLAKE3 of the canonical key bytes, using digest bytes `0..8` as an unsigned little-endian `u64` |
-| `key_encoding_version` | `1` | Exact caller-supplied bytes; string shard keys contribute their UTF-8 bytes, with no Unicode normalization |
+| `key_encoding_version` | `1` | Canonical bytes defined below for raw, explicit, and typed inferred routing keys |
 | `bucket_algorithm_version` | `1` | Compatibility-preserving range algorithm below |
 | `virtual_bucket_count` | `4096` | Fixed virtual bucket space `0..4095` |
 | `map_generation` | `1` | Initial committed bucket map and the only generation version 7 can interpret |
@@ -505,6 +505,16 @@ the 4,096 bucket IDs into contiguous ranges whose sizes differ by at most one.
 For initial shard count `N`, shard `s` owns the range beginning at
 `s * base + min(s, extra)`, where `base = 4096 / N` and
 `extra = 4096 % N`.
+
+Key encoding version 1 preserves every raw `Database`/`Engine` routing key and
+every explicit bound-plan routing key exactly as supplied. The bound statement
+planner converts inferred `Int64` keys to their shortest signed base-10 ASCII
+form, inferred `Text` keys to exact UTF-8 without Unicode normalization or case
+conversion, and inferred `Binary` keys to exact bytes. The encoding adds no
+type, logical-database, table, or column prefix. These typed rules define input
+to the already persisted version-1 hash; issue #23 adds no manifest or shard
+format change. The complete advisory planning contract is in
+[bound statement planning](SQL_PLANNING.md).
 
 Bucket algorithm version 1 deliberately preserves legacy placement even when
 `N` does not divide 4,096. Given the version-1 64-bit hash `H`:

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -12,10 +12,10 @@ use std::{
 use tokio::{sync::OwnedMutexGuard, task::JoinHandle};
 
 use super::{
-    BlockingPool, CancelOnDrop, CancellationReason, CancellationToken, Database, EngineError,
-    EngineErrorKind, EngineOptions, EngineResult, EngineState, Lifecycle, OperationControl,
-    OperationLease, RequestContext, ResultLimits, ResultSet, Routed, Session, SessionInner,
-    ShutdownReport, Value, wait_for_cancellation, wait_pending,
+    BlockingPool, BoundStatementPlan, CancelOnDrop, CancellationReason, CancellationToken,
+    Database, EngineError, EngineErrorKind, EngineOptions, EngineResult, EngineState, Lifecycle,
+    LogicalDatabaseId, OperationControl, OperationLease, RequestContext, ResultLimits, ResultSet,
+    Routed, Session, SessionInner, ShutdownReport, Value, wait_for_cancellation, wait_pending,
 };
 use crate::{
     sql,
@@ -287,6 +287,41 @@ impl Engine {
     /// Return the immutable logical database and table catalog.
     pub fn catalog(&self) -> &super::Catalog {
         self.inner.database.catalog()
+    }
+
+    /// Plan one normalized statement from its actual bound parameter values.
+    ///
+    /// `statement_index` is zero-based. `explicit_routing_key` is retained as
+    /// an independent fallback route; later policy decides whether inferred
+    /// and explicit routes are compatible and executable.
+    pub fn plan_bound_statement(
+        &self,
+        database: LogicalDatabaseId,
+        normalized: &sql::NormalizedSql,
+        statement_index: usize,
+        parameters: &[Value],
+        explicit_routing_key: Option<&[u8]>,
+    ) -> EngineResult<BoundStatementPlan> {
+        let _schema_operation = self.inner.database.storage.enter_schema_operation()?;
+        let (hash_version, key_encoding_version, bucket_algorithm_version, map_generation) =
+            self.inner.database.routing_provenance();
+        super::planner::plan_bound_statement(
+            super::planner::BoundStatementPlanInput::new(
+                self.catalog(),
+                database,
+                normalized,
+                statement_index,
+                parameters,
+                explicit_routing_key,
+            ),
+            super::planner::RoutingProvenance::new(
+                hash_version,
+                key_encoding_version,
+                bucket_algorithm_version,
+                map_generation,
+            ),
+            |key| self.inner.database.shard_for_key(key),
+        )
     }
 
     /// Return the engine's immutable pool and admission options.

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -9,6 +9,7 @@ mod engine;
 mod error;
 mod lifecycle;
 mod options;
+mod planner;
 mod routing;
 mod session;
 mod types;
@@ -36,6 +37,7 @@ pub use options::{
     EngineOptions, MAX_CONNECTIONS_PER_SHARD, MAX_QUEUE_CAPACITY_PER_SHARD, MAX_REQUEST_TIMEOUT_MS,
     MAX_RESULT_BYTES, MAX_RESULT_ROWS, MAX_SHUTDOWN_GRACE_MS, ResultLimits,
 };
+pub use planner::{BoundStatementPlan, PlannedRoute};
 pub(crate) use routing::{
     BUCKET_ALGORITHM_VERSION, HASH_VERSION, INITIAL_MAP_GENERATION, KEY_ENCODING_VERSION,
     RoutingCatalog, VIRTUAL_BUCKET_COUNT, initial_physical_shard,
@@ -81,6 +83,10 @@ impl Database {
 
     pub fn shard_for_key(&self, key: &[u8]) -> u16 {
         self.storage.shard_for_key(key)
+    }
+
+    pub(crate) fn routing_provenance(&self) -> (u32, u32, u32, u64) {
+        self.storage.routing_provenance()
     }
 
     pub fn execute_routed(

--- a/src/core/planner.rs
+++ b/src/core/planner.rs
@@ -1,0 +1,1019 @@
+//! Bound-value-aware, protocol-neutral statement routing plans.
+
+use std::{collections::HashMap, fmt, sync::Arc};
+
+use crate::sql::{
+    NormalizedSql, ShardKeyInference, ShardKeyInferenceKind, ShardKeyValue, infer_shard_keys,
+};
+
+use super::{Catalog, EngineError, EngineErrorKind, EngineResult, LogicalDatabaseId, Value};
+
+/// One owned canonical routing key and its selected physical shard.
+#[derive(Clone, PartialEq, Eq)]
+pub struct PlannedRoute {
+    key_bytes: Arc<[u8]>,
+    shard: u16,
+}
+
+impl PlannedRoute {
+    /// Return the canonical version-1 routing-key bytes.
+    pub fn key_bytes(&self) -> &[u8] {
+        &self.key_bytes
+    }
+
+    /// Return the physical shard selected by the current bucket map.
+    pub const fn shard(&self) -> u16 {
+        self.shard
+    }
+}
+
+impl fmt::Debug for PlannedRoute {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PlannedRoute")
+            .field("key_bytes", &"<redacted>")
+            .field("shard", &self.shard)
+            .finish()
+    }
+}
+
+/// Owned routing metadata produced from one statement's actual bound values.
+///
+/// Inferred routes remain aligned one-for-one with
+/// [`ShardKeyInference::values`], including duplicate `INSERT` row values. An
+/// explicit route is retained independently so the later write-policy layer
+/// can compare it with inferred routes. This plan does not choose between
+/// those sources, reject a plan, translate SQL, or execute anything.
+#[derive(Clone, PartialEq, Eq)]
+pub struct BoundStatementPlan {
+    database: LogicalDatabaseId,
+    schema_generation: u64,
+    hash_version: u32,
+    key_encoding_version: u32,
+    bucket_algorithm_version: u32,
+    map_generation: u64,
+    statement_index: usize,
+    inference: ShardKeyInference,
+    inferred_routes: Vec<PlannedRoute>,
+    explicit_route: Option<PlannedRoute>,
+}
+
+impl BoundStatementPlan {
+    /// Return the logical database used for catalog resolution.
+    pub const fn database(&self) -> LogicalDatabaseId {
+        self.database
+    }
+
+    /// Return the application-schema generation observed while planning.
+    pub const fn schema_generation(&self) -> u64 {
+        self.schema_generation
+    }
+
+    /// Return the routing hash version used to select physical shards.
+    pub const fn hash_version(&self) -> u32 {
+        self.hash_version
+    }
+
+    /// Return the canonical routing-key encoding version used by this plan.
+    pub const fn key_encoding_version(&self) -> u32 {
+        self.key_encoding_version
+    }
+
+    /// Return the virtual-bucket selection algorithm version.
+    pub const fn bucket_algorithm_version(&self) -> u32 {
+        self.bucket_algorithm_version
+    }
+
+    /// Return the immutable routing-map generation used by this plan.
+    pub const fn map_generation(&self) -> u64 {
+        self.map_generation
+    }
+
+    /// Return the zero-based top-level statement index.
+    pub const fn statement_index(&self) -> usize {
+        self.statement_index
+    }
+
+    /// Return the typed shard-key inference retained by this plan.
+    pub const fn inference(&self) -> &ShardKeyInference {
+        &self.inference
+    }
+
+    /// Return one inferred route per inferred value, in matching order.
+    pub fn inferred_routes(&self) -> &[PlannedRoute] {
+        &self.inferred_routes
+    }
+
+    /// Return the independently planned explicit routing fallback, if supplied.
+    pub const fn explicit_route(&self) -> Option<&PlannedRoute> {
+        self.explicit_route.as_ref()
+    }
+}
+
+impl fmt::Debug for BoundStatementPlan {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BoundStatementPlan")
+            .field("database", &self.database)
+            .field("schema_generation", &self.schema_generation)
+            .field("hash_version", &self.hash_version)
+            .field("key_encoding_version", &self.key_encoding_version)
+            .field("bucket_algorithm_version", &self.bucket_algorithm_version)
+            .field("map_generation", &self.map_generation)
+            .field("statement_index", &self.statement_index)
+            .field("inference", &self.inference)
+            .field("inferred_route_count", &self.inferred_routes.len())
+            .field("has_explicit_route", &self.explicit_route.is_some())
+            .finish()
+    }
+}
+
+pub(super) struct BoundStatementPlanInput<'a> {
+    catalog: &'a Catalog,
+    database: LogicalDatabaseId,
+    normalized: &'a NormalizedSql,
+    statement_index: usize,
+    parameters: &'a [Value],
+    explicit_routing_key: Option<&'a [u8]>,
+}
+
+impl<'a> BoundStatementPlanInput<'a> {
+    pub(super) const fn new(
+        catalog: &'a Catalog,
+        database: LogicalDatabaseId,
+        normalized: &'a NormalizedSql,
+        statement_index: usize,
+        parameters: &'a [Value],
+        explicit_routing_key: Option<&'a [u8]>,
+    ) -> Self {
+        Self {
+            catalog,
+            database,
+            normalized,
+            statement_index,
+            parameters,
+            explicit_routing_key,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct RoutingProvenance {
+    hash_version: u32,
+    key_encoding_version: u32,
+    bucket_algorithm_version: u32,
+    map_generation: u64,
+}
+
+impl RoutingProvenance {
+    pub(super) const fn new(
+        hash_version: u32,
+        key_encoding_version: u32,
+        bucket_algorithm_version: u32,
+        map_generation: u64,
+    ) -> Self {
+        Self {
+            hash_version,
+            key_encoding_version,
+            bucket_algorithm_version,
+            map_generation,
+        }
+    }
+}
+
+pub(super) fn plan_bound_statement<F>(
+    input: BoundStatementPlanInput<'_>,
+    provenance: RoutingProvenance,
+    mut shard_for_key: F,
+) -> EngineResult<BoundStatementPlan>
+where
+    F: FnMut(&[u8]) -> u16,
+{
+    let BoundStatementPlanInput {
+        catalog,
+        database,
+        normalized,
+        statement_index,
+        parameters,
+        explicit_routing_key,
+    } = input;
+    let schema_generation = catalog.schema_generation();
+    let inference = infer_shard_keys(catalog, database, normalized, statement_index, parameters)?;
+    validate_inference_shape(&inference)?;
+
+    let mut unique_routes = HashMap::<&ShardKeyValue, PlannedRoute>::new();
+    let mut inferred_routes = Vec::with_capacity(inference.values().len());
+    for value in inference.values() {
+        if let Some(route) = unique_routes.get(value) {
+            inferred_routes.push(route.clone());
+            continue;
+        }
+        let key_bytes = canonical_key_bytes(value);
+        let route = PlannedRoute {
+            shard: shard_for_key(&key_bytes),
+            key_bytes,
+        };
+        unique_routes.insert(value, route.clone());
+        inferred_routes.push(route);
+    }
+    drop(unique_routes);
+
+    let explicit_route = explicit_routing_key.map(|key| PlannedRoute {
+        shard: shard_for_key(key),
+        key_bytes: Arc::from(key),
+    });
+
+    Ok(BoundStatementPlan {
+        database,
+        schema_generation,
+        hash_version: provenance.hash_version,
+        key_encoding_version: provenance.key_encoding_version,
+        bucket_algorithm_version: provenance.bucket_algorithm_version,
+        map_generation: provenance.map_generation,
+        statement_index,
+        inference,
+        inferred_routes,
+        explicit_route,
+    })
+}
+
+fn validate_inference_shape(inference: &ShardKeyInference) -> EngineResult<()> {
+    let valid = match inference.kind() {
+        ShardKeyInferenceKind::Exact | ShardKeyInferenceKind::Multiple => {
+            !inference.values().is_empty()
+        }
+        ShardKeyInferenceKind::NotApplicable
+        | ShardKeyInferenceKind::NotSharded
+        | ShardKeyInferenceKind::Unconstrained
+        | ShardKeyInferenceKind::Contradiction => inference.values().is_empty(),
+    };
+    if valid {
+        Ok(())
+    } else {
+        Err(EngineError::new(
+            EngineErrorKind::Internal,
+            "shard-key inference is inconsistent during bound statement planning",
+        ))
+    }
+}
+
+fn canonical_key_bytes(value: &ShardKeyValue) -> Arc<[u8]> {
+    match value {
+        ShardKeyValue::Int64(value) => Arc::from(value.to_string().into_bytes()),
+        ShardKeyValue::Text(value) => Arc::from(value.as_bytes()),
+        ShardKeyValue::Binary(value) => Arc::from(value.as_slice()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{Arc, Barrier},
+        thread,
+    };
+
+    use super::*;
+    use crate::{
+        core::{
+            BUCKET_ALGORITHM_VERSION, Database, Engine, HASH_VERSION, INITIAL_MAP_GENERATION,
+            KEY_ENCODING_VERSION, LogicalDatabaseMetadata, RoutingCatalog, ShardKeyMetadata,
+            ShardKeyType, TableMetadata, TablePlacement, VIRTUAL_BUCKET_COUNT,
+            initial_physical_shard,
+        },
+        sql::{SqlDialect, normalize_placeholders, parse, validate_common_subset},
+    };
+
+    const DEFAULT_DATABASE: u64 = 1;
+    const TENANT_DATABASE: u64 = 9;
+    const BLOBS_TABLE: u64 = 2;
+    const COUNTRIES_TABLE: u64 = 3;
+    const EVENTS_TABLE: u64 = 4;
+    const INTERNAL_CATALOG_TABLE: u64 = 5;
+    const ACCOUNTS_TABLE: u64 = 30;
+
+    fn sample_catalog() -> Catalog {
+        Catalog::from_validated_parts(
+            1,
+            7,
+            DEFAULT_DATABASE,
+            vec![
+                LogicalDatabaseMetadata::from_validated(DEFAULT_DATABASE, "default".to_owned()),
+                LogicalDatabaseMetadata::from_validated(TENANT_DATABASE, "tenant".to_owned()),
+            ]
+            .into_boxed_slice(),
+            vec![
+                TableMetadata::from_validated(
+                    BLOBS_TABLE,
+                    DEFAULT_DATABASE,
+                    "blobs".to_owned(),
+                    TablePlacement::Sharded(ShardKeyMetadata::from_validated(
+                        "tenant_id".to_owned(),
+                        ShardKeyType::Binary,
+                    )),
+                ),
+                TableMetadata::from_validated(
+                    COUNTRIES_TABLE,
+                    DEFAULT_DATABASE,
+                    "countries".to_owned(),
+                    TablePlacement::Global,
+                ),
+                TableMetadata::from_validated(
+                    EVENTS_TABLE,
+                    DEFAULT_DATABASE,
+                    "events".to_owned(),
+                    TablePlacement::Sharded(ShardKeyMetadata::from_validated(
+                        "tenant_id".to_owned(),
+                        ShardKeyType::Int64,
+                    )),
+                ),
+                TableMetadata::from_validated(
+                    INTERNAL_CATALOG_TABLE,
+                    DEFAULT_DATABASE,
+                    "internal_catalog".to_owned(),
+                    TablePlacement::Catalog,
+                ),
+                TableMetadata::from_validated(
+                    ACCOUNTS_TABLE,
+                    TENANT_DATABASE,
+                    "accounts".to_owned(),
+                    TablePlacement::Sharded(ShardKeyMetadata::from_validated(
+                        "tenant_id".to_owned(),
+                        ShardKeyType::Text,
+                    )),
+                ),
+            ]
+            .into_boxed_slice(),
+        )
+    }
+
+    fn normalize(dialect: SqlDialect, source: &str) -> NormalizedSql {
+        normalize_placeholders(validate_common_subset(parse(dialect, source).unwrap()).unwrap())
+            .unwrap()
+    }
+
+    fn database_id(value: u64) -> LogicalDatabaseId {
+        LogicalDatabaseId::new(value).unwrap()
+    }
+
+    fn routing_catalog(shard_count: u16) -> RoutingCatalog {
+        RoutingCatalog::from_validated_parts(
+            shard_count,
+            HASH_VERSION,
+            KEY_ENCODING_VERSION,
+            BUCKET_ALGORITHM_VERSION,
+            INITIAL_MAP_GENERATION,
+            (0..VIRTUAL_BUCKET_COUNT)
+                .map(|bucket| initial_physical_shard(bucket, shard_count))
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        )
+    }
+
+    fn plan(
+        catalog: &Catalog,
+        database: u64,
+        normalized: &NormalizedSql,
+        statement_index: usize,
+        parameters: &[Value],
+        explicit_routing_key: Option<&[u8]>,
+    ) -> EngineResult<BoundStatementPlan> {
+        let routing = routing_catalog(4);
+        plan_bound_statement(
+            BoundStatementPlanInput::new(
+                catalog,
+                database_id(database),
+                normalized,
+                statement_index,
+                parameters,
+                explicit_routing_key,
+            ),
+            RoutingProvenance::new(
+                routing.hash_version(),
+                routing.key_encoding_version(),
+                routing.bucket_algorithm_version(),
+                routing.map_generation(),
+            ),
+            |key| routing.shard_for_key(key),
+        )
+    }
+
+    #[test]
+    fn public_plan_types_are_owned_cloneable_thread_safe_and_redacted() {
+        fn assert_owned<T: Clone + Send + Sync + 'static>() {}
+        assert_owned::<BoundStatementPlan>();
+        assert_owned::<PlannedRoute>();
+
+        let catalog = sample_catalog();
+        let normalized = normalize(
+            SqlDialect::PostgreSql,
+            "INSERT INTO accounts (tenant_id) VALUES ('private-tenant')",
+        );
+        let plan = plan(
+            &catalog,
+            TENANT_DATABASE,
+            &normalized,
+            0,
+            &[],
+            Some(b"private-explicit-key"),
+        )
+        .unwrap();
+        assert_eq!(plan.clone(), plan);
+        assert_eq!(plan.inferred_routes()[0].key_bytes(), b"private-tenant");
+        assert_eq!(
+            plan.explicit_route().unwrap().key_bytes(),
+            b"private-explicit-key"
+        );
+
+        let debug = format!("{plan:?} {:?}", plan.explicit_route().unwrap());
+        assert!(!debug.contains("private-tenant"));
+        assert!(!debug.contains("private-explicit-key"));
+        assert!(debug.contains("<redacted>"));
+    }
+
+    #[test]
+    fn canonical_key_encoding_v1_has_frozen_typed_bytes() {
+        for (value, expected) in [
+            (ShardKeyValue::Int64(i64::MIN), i64::MIN.to_string()),
+            (ShardKeyValue::Int64(-1), "-1".to_owned()),
+            (ShardKeyValue::Int64(0), "0".to_owned()),
+            (ShardKeyValue::Int64(1), "1".to_owned()),
+            (ShardKeyValue::Int64(i64::MAX), i64::MAX.to_string()),
+        ] {
+            assert_eq!(canonical_key_bytes(&value).as_ref(), expected.as_bytes());
+        }
+
+        for text in ["", "a\0b", "snowman-☃", "é", "e\u{301}"] {
+            assert_eq!(
+                canonical_key_bytes(&ShardKeyValue::Text(text.to_owned())).as_ref(),
+                text.as_bytes()
+            );
+        }
+        assert_ne!("é".as_bytes(), "e\u{301}".as_bytes());
+
+        for bytes in [
+            Vec::new(),
+            vec![0],
+            vec![0, 1, 2, 0xff],
+            vec![0xff, 0, 0x80],
+        ] {
+            assert_eq!(
+                canonical_key_bytes(&ShardKeyValue::Binary(bytes.clone())).as_ref(),
+                bytes
+            );
+        }
+    }
+
+    #[test]
+    fn equivalent_integer_forms_converge_on_one_canonical_route() {
+        let catalog = sample_catalog();
+        let literal = plan(
+            &catalog,
+            DEFAULT_DATABASE,
+            &normalize(
+                SqlDialect::Sqlite,
+                "SELECT * FROM events WHERE tenant_id = 1",
+            ),
+            0,
+            &[],
+            None,
+        )
+        .unwrap();
+        let signed = plan(
+            &catalog,
+            DEFAULT_DATABASE,
+            &normalize(
+                SqlDialect::Sqlite,
+                "SELECT * FROM events WHERE tenant_id = +001",
+            ),
+            0,
+            &[],
+            None,
+        )
+        .unwrap();
+        let bound = plan(
+            &catalog,
+            DEFAULT_DATABASE,
+            &normalize(
+                SqlDialect::PostgreSql,
+                "SELECT * FROM events WHERE tenant_id = $1",
+            ),
+            0,
+            &[Value::Int64(1)],
+            None,
+        )
+        .unwrap();
+
+        for candidate in [&literal, &signed, &bound] {
+            assert_eq!(candidate.inferred_routes()[0].key_bytes(), b"1");
+            assert_eq!(candidate.inferred_routes()[0], literal.inferred_routes()[0]);
+        }
+    }
+
+    #[test]
+    fn actual_bound_values_drive_replanning_for_every_marker_dialect() {
+        let catalog = sample_catalog();
+        let cases = [
+            (
+                SqlDialect::PostgreSql,
+                "SELECT $1 FROM events WHERE tenant_id = $2",
+                vec![Value::Text("projection".to_owned()), Value::Int64(12)],
+                vec![Value::Text("projection".to_owned()), Value::Int64(34)],
+                b"12".as_slice(),
+                b"34".as_slice(),
+            ),
+            (
+                SqlDialect::MySql,
+                "UPDATE events SET payload = ? WHERE tenant_id = ?",
+                vec![Value::Text("first".to_owned()), Value::Int64(56)],
+                vec![Value::Text("second".to_owned()), Value::Int64(78)],
+                b"56".as_slice(),
+                b"78".as_slice(),
+            ),
+            (
+                SqlDialect::Sqlite,
+                "SELECT ?2 FROM events WHERE tenant_id = ?1",
+                vec![Value::Int64(90), Value::Text("first".to_owned())],
+                vec![Value::Int64(91), Value::Text("second".to_owned())],
+                b"90".as_slice(),
+                b"91".as_slice(),
+            ),
+        ];
+
+        for (dialect, source, first_values, second_values, first_key, second_key) in cases {
+            let normalized = normalize(dialect, source);
+            let first = plan(
+                &catalog,
+                DEFAULT_DATABASE,
+                &normalized,
+                0,
+                &first_values,
+                None,
+            )
+            .unwrap();
+            let second = plan(
+                &catalog,
+                DEFAULT_DATABASE,
+                &normalized,
+                0,
+                &second_values,
+                None,
+            )
+            .unwrap();
+            assert_eq!(first.inferred_routes()[0].key_bytes(), first_key);
+            assert_eq!(second.inferred_routes()[0].key_bytes(), second_key);
+            assert_ne!(first.inferred_routes()[0], second.inferred_routes()[0]);
+        }
+    }
+
+    #[test]
+    fn equivalent_typed_requests_produce_equal_plans_across_dialects() {
+        let catalog = sample_catalog();
+        let plans = [
+            (
+                SqlDialect::Sqlite,
+                "SELECT * FROM events WHERE tenant_id = ?1",
+            ),
+            (
+                SqlDialect::PostgreSql,
+                "SELECT * FROM events WHERE tenant_id = $1",
+            ),
+            (
+                SqlDialect::MySql,
+                "SELECT * FROM events WHERE tenant_id = ?",
+            ),
+        ]
+        .map(|(dialect, source)| {
+            plan(
+                &catalog,
+                DEFAULT_DATABASE,
+                &normalize(dialect, source),
+                0,
+                &[Value::Int64(42)],
+                Some(b"frontend-independent-route"),
+            )
+            .unwrap()
+        });
+
+        assert_eq!(plans[0], plans[1]);
+        assert_eq!(plans[1], plans[2]);
+        assert_eq!(plans[0].inferred_routes()[0].key_bytes(), b"42");
+    }
+
+    #[test]
+    fn every_inference_kind_keeps_explicit_routing_independent() {
+        let catalog = sample_catalog();
+        let cases = [
+            ("SELECT 1", ShardKeyInferenceKind::NotApplicable, 0_usize),
+            (
+                "SELECT * FROM countries",
+                ShardKeyInferenceKind::NotSharded,
+                0,
+            ),
+            (
+                "SELECT * FROM events",
+                ShardKeyInferenceKind::Unconstrained,
+                0,
+            ),
+            (
+                "SELECT * FROM events WHERE tenant_id = NULL",
+                ShardKeyInferenceKind::Contradiction,
+                0,
+            ),
+            (
+                "SELECT * FROM events WHERE tenant_id = 7",
+                ShardKeyInferenceKind::Exact,
+                1,
+            ),
+            (
+                "SELECT * FROM events WHERE tenant_id = 7 OR tenant_id = 8",
+                ShardKeyInferenceKind::Multiple,
+                2,
+            ),
+        ];
+
+        for (source, kind, route_count) in cases {
+            let normalized = normalize(SqlDialect::Sqlite, source);
+            for explicit in [None, Some(b"".as_slice()), Some(b"fallback".as_slice())] {
+                let plan = plan(&catalog, DEFAULT_DATABASE, &normalized, 0, &[], explicit).unwrap();
+                assert_eq!(plan.inference().kind(), kind, "{source}");
+                assert_eq!(plan.inferred_routes().len(), route_count, "{source}");
+                assert_eq!(
+                    plan.explicit_route().is_some(),
+                    explicit.is_some(),
+                    "{source}"
+                );
+                if let Some(explicit) = explicit {
+                    assert_eq!(plan.explicit_route().unwrap().key_bytes(), explicit);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn multirow_insert_routes_preserve_order_duplicates_and_shared_storage() {
+        let catalog = sample_catalog();
+        let normalized = normalize(
+            SqlDialect::MySql,
+            "INSERT INTO events (tenant_id) VALUES (?), (?), (?)",
+        );
+        let plan = plan(
+            &catalog,
+            DEFAULT_DATABASE,
+            &normalized,
+            0,
+            &[Value::Int64(11), Value::Int64(22), Value::Int64(11)],
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(plan.inference().kind(), ShardKeyInferenceKind::Multiple);
+        assert_eq!(
+            plan.inferred_routes()
+                .iter()
+                .map(PlannedRoute::key_bytes)
+                .collect::<Vec<_>>(),
+            [b"11".as_slice(), b"22".as_slice(), b"11".as_slice()]
+        );
+        assert!(Arc::ptr_eq(
+            &plan.inferred_routes[0].key_bytes,
+            &plan.inferred_routes[2].key_bytes
+        ));
+        assert_eq!(plan.inferred_routes[0], plan.inferred_routes[2]);
+    }
+
+    #[test]
+    fn distinct_logical_keys_are_never_collapsed_by_physical_shard() {
+        let catalog = sample_catalog();
+        let normalized = normalize(
+            SqlDialect::Sqlite,
+            "SELECT * FROM events WHERE tenant_id = 1 OR tenant_id = 2",
+        );
+        let plan = plan_bound_statement(
+            BoundStatementPlanInput::new(
+                &catalog,
+                database_id(DEFAULT_DATABASE),
+                &normalized,
+                0,
+                &[],
+                Some(b"explicit"),
+            ),
+            RoutingProvenance::new(1, 1, 1, 1),
+            |_| 3,
+        )
+        .unwrap();
+
+        assert_eq!(plan.inference().kind(), ShardKeyInferenceKind::Multiple);
+        assert_eq!(plan.inferred_routes().len(), 2);
+        assert_eq!(plan.inferred_routes()[0].key_bytes(), b"1");
+        assert_eq!(plan.inferred_routes()[1].key_bytes(), b"2");
+        assert!(
+            plan.inferred_routes()
+                .iter()
+                .all(|route| route.shard() == 3)
+        );
+        assert_eq!(plan.explicit_route().unwrap().shard(), 3);
+    }
+
+    #[test]
+    fn text_predicates_remain_conservative_while_text_inserts_are_routed() {
+        let catalog = sample_catalog();
+        let predicate = plan(
+            &catalog,
+            TENANT_DATABASE,
+            &normalize(
+                SqlDialect::PostgreSql,
+                "SELECT * FROM accounts WHERE tenant_id = $1",
+            ),
+            0,
+            &[Value::Text("tenant-a".to_owned())],
+            Some(b"caller-route"),
+        )
+        .unwrap();
+        assert_eq!(
+            predicate.inference().kind(),
+            ShardKeyInferenceKind::Unconstrained
+        );
+        assert!(predicate.inferred_routes().is_empty());
+        assert_eq!(
+            predicate.explicit_route().unwrap().key_bytes(),
+            b"caller-route"
+        );
+
+        let insert = plan(
+            &catalog,
+            TENANT_DATABASE,
+            &normalize(
+                SqlDialect::PostgreSql,
+                "INSERT INTO accounts (tenant_id) VALUES ($1)",
+            ),
+            0,
+            &[Value::Text("tenant-a".to_owned())],
+            None,
+        )
+        .unwrap();
+        assert_eq!(insert.inference().kind(), ShardKeyInferenceKind::Exact);
+        assert_eq!(insert.inferred_routes()[0].key_bytes(), b"tenant-a");
+    }
+
+    #[test]
+    fn inference_errors_propagate_and_do_not_poison_later_plans() {
+        let catalog = sample_catalog();
+        let int_bound = normalize(
+            SqlDialect::PostgreSql,
+            "SELECT * FROM events WHERE tenant_id = $1",
+        );
+        for (parameters, kind) in [
+            (Vec::new(), EngineErrorKind::InvalidArgument),
+            (
+                vec![Value::Text("wrong-type".to_owned())],
+                EngineErrorKind::TypeMismatch,
+            ),
+            (
+                vec![Value::UInt64(u64::MAX)],
+                EngineErrorKind::NumericOutOfRange,
+            ),
+        ] {
+            assert_eq!(
+                plan(&catalog, DEFAULT_DATABASE, &int_bound, 0, &parameters, None,)
+                    .unwrap_err()
+                    .kind(),
+                kind
+            );
+        }
+
+        let invalid_text = plan(
+            &catalog,
+            TENANT_DATABASE,
+            &normalize(
+                SqlDialect::PostgreSql,
+                "INSERT INTO accounts (tenant_id) VALUES ($1)",
+            ),
+            0,
+            &[Value::InvalidText(vec![0xff])],
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(invalid_text.kind(), EngineErrorKind::InvalidTextEncoding);
+
+        let null_insert = plan(
+            &catalog,
+            DEFAULT_DATABASE,
+            &normalize(
+                SqlDialect::PostgreSql,
+                "INSERT INTO events (tenant_id) VALUES ($1)",
+            ),
+            0,
+            &[Value::Null],
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(null_insert.kind(), EngineErrorKind::NotNullViolation);
+
+        let missing_table = plan(
+            &catalog,
+            DEFAULT_DATABASE,
+            &normalize(SqlDialect::Sqlite, "SELECT * FROM missing"),
+            0,
+            &[],
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(missing_table.kind(), EngineErrorKind::InvalidQuery);
+
+        let missing_database = plan(
+            &catalog,
+            99,
+            &normalize(SqlDialect::Sqlite, "SELECT 1"),
+            0,
+            &[],
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(missing_database.kind(), EngineErrorKind::InvalidArgument);
+
+        let bad_statement_index =
+            plan(&catalog, DEFAULT_DATABASE, &int_bound, 1, &[], None).unwrap_err();
+        assert_eq!(bad_statement_index.kind(), EngineErrorKind::InvalidArgument);
+
+        let recovered = plan(
+            &catalog,
+            DEFAULT_DATABASE,
+            &int_bound,
+            0,
+            &[Value::Int64(42)],
+            None,
+        )
+        .unwrap();
+        assert_eq!(recovered.inferred_routes()[0].key_bytes(), b"42");
+    }
+
+    #[test]
+    fn statement_local_batch_indexes_use_statement_local_parameters() {
+        let catalog = sample_catalog();
+        let normalized = normalize(
+            SqlDialect::MySql,
+            "SELECT ? FROM events WHERE tenant_id = ?; \
+             SELECT ? FROM events WHERE tenant_id = ?",
+        );
+        let first = plan(
+            &catalog,
+            DEFAULT_DATABASE,
+            &normalized,
+            0,
+            &[Value::Text("first".to_owned()), Value::Int64(12)],
+            None,
+        )
+        .unwrap();
+        let second = plan(
+            &catalog,
+            DEFAULT_DATABASE,
+            &normalized,
+            1,
+            &[Value::Text("second".to_owned()), Value::Int64(34)],
+            None,
+        )
+        .unwrap();
+        assert_eq!(first.statement_index(), 0);
+        assert_eq!(second.statement_index(), 1);
+        assert_eq!(first.inferred_routes()[0].key_bytes(), b"12");
+        assert_eq!(second.inferred_routes()[0].key_bytes(), b"34");
+
+        let numbered_gap = normalize(
+            SqlDialect::PostgreSql,
+            "SELECT * FROM events WHERE tenant_id = $2",
+        );
+        let gap_plan = plan(
+            &catalog,
+            DEFAULT_DATABASE,
+            &numbered_gap,
+            0,
+            &[Value::Text("unused-gap".to_owned()), Value::Int64(56)],
+            None,
+        )
+        .unwrap();
+        assert_eq!(gap_plan.inferred_routes()[0].key_bytes(), b"56");
+    }
+
+    #[test]
+    fn concurrent_planning_is_deterministic_and_read_only() {
+        let catalog = Arc::new(sample_catalog());
+        let normalized = Arc::new(normalize(
+            SqlDialect::PostgreSql,
+            "INSERT INTO events (tenant_id) VALUES ($1), ($2), ($1)",
+        ));
+        let barrier = Arc::new(Barrier::new(9));
+        let mut threads = Vec::new();
+        for _ in 0..8 {
+            let catalog = Arc::clone(&catalog);
+            let normalized = Arc::clone(&normalized);
+            let barrier = Arc::clone(&barrier);
+            threads.push(thread::spawn(move || {
+                barrier.wait();
+                plan(
+                    &catalog,
+                    DEFAULT_DATABASE,
+                    &normalized,
+                    0,
+                    &[Value::Int64(7), Value::Int64(8)],
+                    Some(b"parallel-explicit"),
+                )
+                .unwrap()
+            }));
+        }
+        barrier.wait();
+        let plans = threads
+            .into_iter()
+            .map(|thread| thread.join().unwrap())
+            .collect::<Vec<_>>();
+        assert!(plans.windows(2).all(|pair| pair[0] == pair[1]));
+    }
+
+    #[test]
+    fn engine_planning_records_provenance_and_does_not_enter_execution_lifecycle() {
+        let temp = tempfile::tempdir().unwrap();
+        let database = Arc::new(Database::open(temp.path(), 4).unwrap());
+        let engine = Engine::from_database(Arc::clone(&database));
+        let normalized = normalize(SqlDialect::Sqlite, "SELECT 1");
+        let logical_database = engine.catalog().default_database().id();
+
+        assert_eq!(engine.active_operations_for_test(), 0);
+        let before = engine
+            .plan_bound_statement(logical_database, &normalized, 0, &[], Some(b"raw\0route"))
+            .unwrap();
+        assert_eq!(engine.active_operations_for_test(), 0);
+        assert_eq!(before.database(), logical_database);
+        assert_eq!(before.schema_generation(), 0);
+        assert_eq!(before.hash_version(), HASH_VERSION);
+        assert_eq!(before.key_encoding_version(), KEY_ENCODING_VERSION);
+        assert_eq!(before.bucket_algorithm_version(), BUCKET_ALGORITHM_VERSION);
+        assert_eq!(before.map_generation(), INITIAL_MAP_GENERATION);
+        assert_eq!(before.statement_index(), 0);
+        assert_eq!(before.explicit_route().unwrap().key_bytes(), b"raw\0route");
+        assert_eq!(
+            before.explicit_route().unwrap().shard(),
+            database.shard_for_key(b"raw\0route")
+        );
+
+        database
+            .broadcast("CREATE TABLE planning_generation (id INTEGER PRIMARY KEY)")
+            .unwrap();
+        let after = engine
+            .plan_bound_statement(logical_database, &normalized, 0, &[], None)
+            .unwrap();
+        assert_eq!(after.schema_generation(), 1);
+        assert_eq!(after.map_generation(), before.map_generation());
+    }
+
+    #[test]
+    fn engine_planning_honors_schema_gate_states_and_recovers_after_migration() {
+        let temp = tempfile::tempdir().unwrap();
+        let database = Arc::new(Database::open(temp.path(), 2).unwrap());
+        let engine = Engine::from_database(Arc::clone(&database));
+        let normalized = normalize(SqlDialect::Sqlite, "SELECT 1");
+        let logical_database = engine.catalog().default_database().id();
+
+        let migration = database.storage.begin_schema_migration().unwrap();
+        migration.wait_for_quiescence_blocking();
+        assert_eq!(
+            engine
+                .plan_bound_statement(logical_database, &normalized, 0, &[], None)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::Busy
+        );
+        drop(migration);
+        assert!(
+            engine
+                .plan_bound_statement(logical_database, &normalized, 0, &[], None)
+                .is_ok()
+        );
+
+        let pending_root = tempfile::tempdir().unwrap();
+        let pending_database = Arc::new(Database::open(pending_root.path(), 2).unwrap());
+        let pending_engine = Engine::from_database(Arc::clone(&pending_database));
+        let pending = pending_database.storage.begin_schema_migration().unwrap();
+        pending.wait_for_quiescence_blocking();
+        pending.publish_pending().unwrap();
+        let pending_database_id = pending_engine.catalog().default_database().id();
+        assert_eq!(
+            pending_engine
+                .plan_bound_statement(pending_database_id, &normalized, 0, &[], None)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+
+        let degraded_root = tempfile::tempdir().unwrap();
+        let degraded_database = Arc::new(Database::open(degraded_root.path(), 2).unwrap());
+        let degraded_engine = Engine::from_database(Arc::clone(&degraded_database));
+        degraded_database.storage.mark_schema_degraded();
+        let degraded_database_id = degraded_engine.catalog().default_database().id();
+        assert_eq!(
+            degraded_engine
+                .plan_bound_statement(degraded_database_id, &normalized, 0, &[], None)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::DataCorruption
+        );
+    }
+}

--- a/src/core/routing.rs
+++ b/src/core/routing.rs
@@ -48,6 +48,22 @@ impl RoutingCatalog {
         self.initial_shard_count
     }
 
+    pub(crate) const fn hash_version(&self) -> u32 {
+        self.hash_version
+    }
+
+    pub(crate) const fn key_encoding_version(&self) -> u32 {
+        self.key_encoding_version
+    }
+
+    pub(crate) const fn bucket_algorithm_version(&self) -> u32 {
+        self.bucket_algorithm_version
+    }
+
+    pub(crate) const fn map_generation(&self) -> u64 {
+        self.map_generation
+    }
+
     pub(crate) fn shard_for_key(&self, key: &[u8]) -> u16 {
         let bucket = usize::from(self.bucket_for_key(key));
         self.buckets[bucket]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -515,6 +515,16 @@ impl Storage {
         self.catalog.routing().shard_for_key(key)
     }
 
+    pub(crate) fn routing_provenance(&self) -> (u32, u32, u32, u64) {
+        let routing = self.catalog.routing();
+        (
+            routing.hash_version(),
+            routing.key_encoding_version(),
+            routing.bucket_algorithm_version(),
+            routing.map_generation(),
+        )
+    }
+
     pub(crate) fn logical_catalog(&self) -> &Catalog {
         self.catalog.logical()
     }

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -343,6 +343,146 @@ fn shard_key_inference_is_public_typed_and_opt_in() {
     assert_eq!(raw.rows()[0].get(0), Some(&core::Value::Int64(23)));
 }
 
+#[tokio::test]
+async fn bound_statement_planning_is_public_owned_value_aware_and_opt_in() {
+    fn assert_owned_public<T: Clone + Send + Sync + 'static>() {}
+    assert_owned_public::<core::BoundStatementPlan>();
+    assert_owned_public::<core::PlannedRoute>();
+
+    let temp = tempfile::tempdir().unwrap();
+    drop(core::Database::open(temp.path(), 8).unwrap());
+    insert_catalog_fixture(temp.path());
+    let database = Arc::new(core::Database::open(temp.path(), 8).unwrap());
+    let engine = core::Engine::from_database(Arc::clone(&database));
+    let tenant = database.catalog().database("tenant").unwrap().unwrap();
+
+    let source = "INSERT INTO accounts (tenant_id) VALUES ($1), ($2), ($3)";
+    let parsed = sql::parse(sql::SqlDialect::PostgreSql, source).unwrap();
+    let common = sql::validate_common_subset(parsed).unwrap();
+    let normalized = sql::normalize_placeholders(common).unwrap();
+    let first_keys = [
+        "tenant-alpha-sensitive",
+        "tenant-snowman-☃",
+        "tenant-alpha-sensitive",
+    ];
+    let first_parameters = first_keys
+        .iter()
+        .map(|key| core::Value::Text((*key).to_owned()))
+        .collect::<Vec<_>>();
+    let explicit_key = b"\0explicit-route-sensitive-\xff";
+
+    let plan = engine
+        .plan_bound_statement(
+            tenant.id(),
+            &normalized,
+            0,
+            &first_parameters,
+            Some(explicit_key),
+        )
+        .unwrap();
+
+    assert_eq!(plan.database(), tenant.id());
+    assert_eq!(
+        plan.schema_generation(),
+        database.catalog().schema_generation()
+    );
+    assert_eq!(plan.hash_version(), 1);
+    assert_eq!(plan.key_encoding_version(), 1);
+    assert_eq!(plan.bucket_algorithm_version(), 1);
+    assert_eq!(plan.map_generation(), 1);
+    assert_eq!(plan.statement_index(), 0);
+    assert_eq!(
+        plan.inference().kind(),
+        sql::ShardKeyInferenceKind::Multiple
+    );
+    assert_eq!(plan.inference().values().len(), first_keys.len());
+    assert_eq!(plan.inferred_routes().len(), first_keys.len());
+
+    for ((value, route), expected_key) in plan
+        .inference()
+        .values()
+        .iter()
+        .zip(plan.inferred_routes())
+        .zip(first_keys)
+    {
+        assert_eq!(value.as_str(), Some(expected_key));
+        assert_eq!(route.key_bytes(), expected_key.as_bytes());
+        assert_eq!(
+            route.shard(),
+            database.shard_for_key(expected_key.as_bytes())
+        );
+    }
+    assert_eq!(plan.inferred_routes()[0], plan.inferred_routes()[2]);
+
+    let explicit_route = plan.explicit_route().unwrap();
+    assert_eq!(explicit_route.key_bytes(), explicit_key);
+    assert_eq!(explicit_route.shard(), database.shard_for_key(explicit_key));
+    assert!(
+        plan.inferred_routes()
+            .iter()
+            .all(|route| route.key_bytes() != explicit_route.key_bytes())
+    );
+
+    let plan_debug = format!("{plan:?}");
+    let route_debug = format!("{explicit_route:?}");
+    for sensitive in [
+        "tenant-alpha-sensitive",
+        "tenant-snowman-☃",
+        "explicit-route-sensitive",
+    ] {
+        assert!(!plan_debug.contains(sensitive));
+        assert!(!route_debug.contains(sensitive));
+    }
+
+    let cloned = plan.clone();
+    assert_eq!(cloned, plan);
+    assert_eq!(thread::spawn(move || cloned).join().unwrap(), plan);
+
+    let second_keys = ["tenant-bravo", "tenant-charlie", "tenant-bravo"];
+    let second_parameters = second_keys
+        .iter()
+        .map(|key| core::Value::Text((*key).to_owned()))
+        .collect::<Vec<_>>();
+    let replanned = engine
+        .plan_bound_statement(tenant.id(), &normalized, 0, &second_parameters, None)
+        .unwrap();
+    assert_eq!(replanned.inferred_routes().len(), second_keys.len());
+    assert!(replanned.explicit_route().is_none());
+    for (route, expected_key) in replanned.inferred_routes().iter().zip(second_keys) {
+        assert_eq!(route.key_bytes(), expected_key.as_bytes());
+        assert_eq!(
+            route.shard(),
+            database.shard_for_key(expected_key.as_bytes())
+        );
+    }
+    assert_ne!(replanned.inferred_routes()[0], plan.inferred_routes()[0]);
+
+    // Planning remains opt-in analysis: existing raw Database and Engine
+    // execution paths continue to execute caller-provided SQLite directly.
+    let raw = database
+        .query(
+            "planner-database-regression",
+            "SELECT ?1",
+            &[core::Value::Int64(37)],
+        )
+        .unwrap();
+    assert_eq!(raw.rows()[0].get(0), Some(&core::Value::Int64(37)));
+
+    let session = engine.session();
+    session
+        .set_routing_key("planner-engine-regression")
+        .await
+        .unwrap();
+    let routed = engine
+        .query(
+            &session,
+            core::Statement::new("SELECT ?1", vec![core::Value::Int64(41)]),
+        )
+        .await
+        .unwrap();
+    assert_eq!(routed.value.rows()[0].get(0), Some(&core::Value::Int64(41)));
+}
+
 #[test]
 fn logical_catalog_types_and_access_are_public_and_protocol_neutral() {
     fn assert_public_metadata<T: Clone + Send + Sync + 'static>() {}


### PR DESCRIPTION
Closes #23

## Summary

- add synchronous protocol-neutral bound statement planning at the Engine boundary
- preserve typed inference, ordered inferred routes, independent explicit routing, and schema/routing provenance
- define canonical Int64, Text, and Binary key bytes without integrating execution or later routing policy
- document the planning contract and storage/error implications
- add comprehensive unit and public API coverage, including equal plans across SQLite, PostgreSQL, and MySQL inputs

## Verification

- cargo fmt --all -- --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-targets --all-features
- cargo test --locked --doc --all-features
- cargo +1.85.0 test --locked --all-targets --all-features
- cargo +1.85.0 test --locked --doc --all-features
- RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps --all-features
- git diff --check

Two independent reviews found no blockers.