### PR TITLE
Reject conflicting and unroutable writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ catalog-aware extraction of typed keys from predicates, bound parameters, and
 multi-row inserts without routing or execution.
 The [bound statement-planning contract](docs/SQL_PLANNING.md) defines the
 synchronous engine API that turns one statement's actual bound values into
-owned advisory routes while retaining routing provenance and an independent
-explicit fallback.
+owned routes, validates inferred and explicit physical targets, rejects
+unroutable sharded writes, and records a single-shard assignment where valid.
 The [error contract](docs/ERRORS.md) defines stable engine error kinds, safe
 HTTP problem details, and the mappings reserved for future PostgreSQL and MySQL
 adapters.
@@ -57,8 +57,9 @@ minimum supported Rust version (MSRV) and the latest stable toolchain.
 - A bounded SQL AST parser plus recursive common-subset validator for explicit
   SQLite, PostgreSQL, and MySQL dialects, followed by opt-in source-preserving
   placeholder normalization, per-statement binding metadata, and catalog-aware
-  typed shard-key inference plus synchronous bound-value-aware advisory
-  routing plans, all isolated from the current raw SQLite HTTP execution path
+  typed shard-key inference plus synchronous bound-value-aware routing plans
+  with single-shard write policy, all isolated from the current raw SQLite HTTP
+  execution path
 - A transactionally versioned `manifest.sqlite` with durable 4,096-bucket
   routing plus logical-database and table metadata
 - Identity-bound, WAL-enabled SQLite shard files that are never silently
@@ -191,10 +192,13 @@ may instead use synchronous
 `Engine::plan_bound_statement(database, normalized, statement_index,
 parameters, explicit_routing_key)` to retain the inference and produce one
 owned canonical route per inferred value plus an independent explicit route.
-The plan records schema and routing provenance but does not choose between
-inferred and explicit routes, enforce write or batch policy, translate SQL, or
-execute anything. The HTTP execute, query, and migration endpoints invoke none
-of these opt-in layers and retain their existing raw SQLite behavior.
+That call compares finite inferred and explicit routes by physical shard,
+rejects cross-shard or otherwise unroutable cataloged sharded DML, prevents
+shard-key updates, and exposes the accepted `assigned_shard()`. The plan
+records schema and routing provenance but does not classify complete request
+behavior, translate SQL, or execute anything. The HTTP execute, query, and
+migration endpoints invoke none of these opt-in layers and retain their
+existing raw SQLite behavior.
 
 `EngineOptions` permits 1–16 active connections and 1–1,024 queued operations
 per shard, with at most 512 active connections across all shards.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -210,7 +210,7 @@ interrupted schema migration can be diagnosed and resumed.
   parameters and multi-row inserts.
 - [x] Plan prepared statements at bind/execute time, not parse time, because a
   routing key may be supplied as a bound parameter.
-- [ ] Reject conflicting keys and unroutable writes before execution.
+- [x] Reject conflicting keys and unroutable writes before execution.
 - [ ] Translate a deliberately small set of type names and syntax differences;
   preserve a strict mode that exposes SQLite SQL directly.
 - [ ] Implement protocol-neutral prepare/bind/describe/execute lifecycle and a

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,9 +21,9 @@ server ---------> protocol::http
 
 | Module | Responsibility | Must not own |
 | --- | --- | --- |
-| `core` | Protocol-neutral `Engine`, `Session`, statements, values, results, errors, read-only logical catalog, and synchronous bound-value-aware advisory plans; stable key routing; bounded per-shard admission and connection pools; routed execute/query and journaled schema migration | JSON/HTTP types, listeners, or Axum handlers |
+| `core` | Protocol-neutral `Engine`, `Session`, statements, values, results, errors, read-only logical catalog, synchronous bound-value-aware plans, and single-shard routing policy; stable key routing; bounded per-shard admission and connection pools; routed execute/query and journaled schema migration | JSON/HTTP types, listeners, or Axum handlers |
 | `storage` | Versioned routing/logical manifest, shard layout, migration journal and recovery, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
-| `sql` | Dialect-explicit SQL syntax parsing, recursive common-subset validation, source-preserving placeholder normalization, and catalog-aware typed shard-key inference behind BriskDB-owned types; exact source retention; SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, key hashing or shard selection, session/write policy, filesystem layout, protocol responses, protocol-buffer ownership, or protocol-specific support policy |
+| `sql` | Dialect-explicit SQL syntax parsing, recursive common-subset validation, source-preserving placeholder normalization, catalog-aware typed shard-key inference, and narrow crate-private DML-shape inspection behind BriskDB-owned boundaries; exact source retention; SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, key hashing or shard selection, session/write policy, filesystem layout, protocol responses, protocol-buffer ownership, or protocol-specific support policy |
 | `protocol::http` | HTTP request extraction plus JSON/BriskDB value and RFC 9457 problem-detail encoding | BLAKE3 routing, shard files, or rusqlite calls |
 | `protocol::error` | Exhaustive HTTP, PostgreSQL, and MySQL mappings from stable engine error kinds | SQLite errors, routing decisions, or wire-protocol session state |
 | `server` | Process configuration, database assembly, listener binding, and tracked Axum HTTP/1 connection lifecycle | SQL parsing or storage implementation details |
@@ -125,7 +125,7 @@ contract](SQL_SUBSET.md).
 The current HTTP execute/query and migration paths deliberately remain raw
 SQLite pass-through and call none of the parser, subset validator, placeholder
 normalizer, shard-key inference, or bound statement-planning layers. Issues
-#19 through #23 therefore change no HTTP shape, SQL acceptance, execution
+#19 through #24 therefore change no HTTP shape, SQL acceptance, execution
 routing, or storage behavior.
 
 ### Placeholder-normalization boundary
@@ -174,9 +174,10 @@ This layer is catalog-aware and accepts bound values, but remains read-only and
 statement-local. It does not own the catalog or caller values, encode or hash a
 key, read the bucket map, choose a shard, construct an execution plan, apply
 write policy, mutate session state, or execute SQL. The separate core planner
-owns bind-time canonical encoding and routing; issue #24 owns rejection of
-conflicting or unroutable writes. The normative proof, type, result, error, and
-testing rules are in the [shard-key inference contract](SQL_SHARD_KEYS.md).
+owns bind-time canonical encoding, physical routing, and rejection of
+conflicting or unroutable sharded DML. The normative proof, type, result,
+error, and testing rules are in the [shard-key inference
+contract](SQL_SHARD_KEYS.md).
 
 ### Bound statement-planning boundary
 
@@ -192,9 +193,17 @@ the same physical shard.
 Canonical version-1 inferred bytes are the shortest signed decimal ASCII form
 for `Int64`, exact UTF-8 for `Text`, and exact bytes for `Binary`. Explicit
 routing bytes are retained exactly. Inferred routes and the optional explicit
-route remain separate: this layer does not select a winner, compare them for
-write eligibility, reject any inference category, or decide whether scatter is
-allowed.
+route remain separate in the result. Policy compares them by physical shard,
+never by opaque bytes, and records `assigned_shard()` when one valid target
+exists. Distinct logical keys co-located on one shard remain separate route
+occurrences but form one physical assignment.
+
+The SQL layer exposes only a crate-private inspection of whether the selected
+AST is `INSERT`, `UPDATE`, or `DELETE` and whether an `UPDATE` targets the
+cataloged shard-key column. Core uses that shape to reject unproven inserts,
+multi-shard writes, broad updates/deletes without explicit fallback, and every
+shard-key assignment. Full read/write/schema/session behavior and batch
+classification remain issue #27.
 
 Planning holds the existing schema-operation guard while it reads logical and
 routing state. The owned result records schema generation, map generation, and
@@ -203,12 +212,13 @@ provenance does not reserve future state; an eventual execution integration
 must establish that the physical schema and routing snapshot remain
 authoritative before using a plan.
 
-The planner is advisory and stateless. It does not translate SQL, mutate a
-session, cache a prepared statement, apply write or batch policy, open a shard
-connection, or execute anything. The normative API, encoding, provenance,
-error, boundary, and testing rules are in the [bound statement-planning
-contract](SQL_PLANNING.md). Issues #24 through #27 own write policy,
-translation, prepared-statement/session lifecycle, and statement/batch policy
+The planner is stateless and its assignment is still non-executable. It does
+not translate SQL, mutate a session, cache a prepared statement, apply batch
+policy, open a shard connection, scatter reads, or execute anything. The
+normative API, assignment matrix, encoding, provenance, error, boundary, and
+testing rules are in the [bound statement-planning and routing-policy
+contract](SQL_PLANNING.md). Issues #25 through #27 own translation,
+prepared-statement/session lifecycle, and authoritative statement/batch policy
 respectively.
 
 ## Manifest storage boundary

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -170,10 +170,15 @@ locations. See the [shard-key inference contract](SQL_SHARD_KEYS.md).
 The synchronous bound statement planner preserves those inference error kinds
 and diagnostics. Before inference it also acquires ordinary schema-operation
 admission, so a migrating gate returns `Busy`, a pending migration returns
-`FailedPrecondition`, and a degraded gate returns `DataCorruption`. A shape
-inconsistency between a successful inference and its route entries is
-`Internal`. Planning adds no new error kind, retains no failed parameters, and
-does not change protocol mappings. See the [bound statement-planning
+`FailedPrecondition`, and a degraded gate returns `DataCorruption`. Routing
+policy reports an explicit physical-shard conflict, or a sharded
+`UPDATE`/`DELETE` missing both finite inference and explicit fallback, as
+`InvalidArgument`. A shard-key `UPDATE`, an `INSERT` without a proven key for
+every row, or a finite write spanning physical shards is `InvalidQuery`.
+Retained metadata inconsistency is `Internal`. Policy diagnostics contain no
+SQL, identifier spelling, parameter value, or routing-key bytes. Planning adds
+no new error kind, retains no failed parameters, and does not change protocol
+mappings. See the [bound statement-planning and routing-policy
 contract](SQL_PLANNING.md).
 
 The core contains no HTTP, PostgreSQL, or MySQL response types. Conversely,

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -20,10 +20,11 @@ The syntax parser, recursive common-subset validator, placeholder normalizer,
 catalog-aware shard-key inference API, and synchronous engine bound-statement
 planner are now available behind BriskDB-owned types. Validation is explicit
 and returns `Unsupported` for a parsed form outside the subset; parser
-acceptance alone is not product support. Normalization, inference, and advisory
-planning are also explicit. The current experimental HTTP interface is still a
-raw SQLite pass-through and can execute uncontracted SQLite syntax because it
-calls none of these layers. That behavior is not a compatibility promise.
+acceptance alone is not product support. Normalization, inference, bound
+planning, and routing policy are also explicit. The current experimental HTTP
+interface is still a raw SQLite pass-through and can execute uncontracted
+SQLite syntax because it calls none of these layers. That behavior is not a
+compatibility promise.
 
 ## Compatibility layers
 
@@ -53,18 +54,20 @@ statement's exact bound-value slice and selected logical database to
 `infer_shard_keys`, which returns a typed key classification. Synchronous
 `Engine::plan_bound_statement` accepts the same concrete bind plus an optional
 explicit routing byte sequence, retains the inference, and produces owned
-advisory physical routes with schema and routing provenance. It does not choose
-between inferred and explicit routes, generally translate, authorize, enforce
-write or batch policy, or execute a statement. HTTP requests still send SQLite
-SQL directly to `rusqlite`; they do not pass through these opt-in SQL layers.
+physical routes with schema and routing provenance. It compares finite inferred
+and explicit routes by physical shard, rejects unroutable cataloged sharded
+DML, and records a valid single-shard assignment. It does not generally
+translate, authorize, enforce batch policy, or execute a statement. HTTP
+requests still send SQLite SQL directly to `rusqlite`; they do not pass through
+these opt-in SQL layers.
 
 | Interface | Status | SQL accepted | Routing |
 | --- | --- | --- | --- |
 | HTTP `/v1/execute` | Experimental | One SQLite statement with positional parameters | Required caller-provided `shard_key` |
 | HTTP `/v1/query` | Experimental | One prepared SQLite statement executed through the row-returning path | Required caller-provided `shard_key` |
 | HTTP `/v1/admin/broadcast` | Experimental | A journaled parameterless SQLite schema batch | Preflight on every shard, then ascending resumable apply |
-| PostgreSQL wire protocol | Planned | Common subset plus documented PostgreSQL normalization | Rust inference and advisory bind-time planning implemented; wire lifecycle, routing policy, and session fallback planned |
-| MySQL wire protocol | Planned | Common subset plus documented MySQL normalization | Rust inference and advisory bind-time planning implemented; wire lifecycle, routing policy, and session fallback planned |
+| PostgreSQL wire protocol | Planned | Common subset plus documented PostgreSQL normalization | Rust inference and bind-time single-shard routing policy implemented; wire lifecycle and session integration planned |
+| MySQL wire protocol | Planned | Common subset plus documented MySQL normalization | Rust inference and bind-time single-shard routing policy implemented; wire lifecycle and session integration planned |
 
 The parser, subset validator, placeholder normalizer, shard-key inference
 function, and engine planner are implemented Rust APIs, not network
@@ -289,9 +292,10 @@ and mixed batches may validate because request-level batch policy remains issue
 with canonical SQLite parameter text and one parameter record per statement.
 `infer_shard_keys` can consume that result with catalog context and a complete
 bound-value slice for one statement. `Engine::plan_bound_statement` consumes
-that same concrete bind when a caller needs advisory routes. The SQL wrapper
-types retain exact source, dialect, and statement count without exposing the
-upstream AST or rendering SQL in `Debug` output.
+that same concrete bind when a caller needs physical routes and a validated
+single-shard assignment. The SQL wrapper types retain exact source, dialect,
+and statement count without exposing the upstream AST or rendering SQL in
+`Debug` output.
 
 The parser, validator, and normalizer have no routing or storage access. The
 implemented inference layer borrows only the read-only logical catalog and
@@ -302,9 +306,10 @@ decision record](SQL_PARSER.md) for the dependency and resource contract, the
 whitelist, and the [SQL parameter-normalization
 contract](SQL_PARAMETERS.md) for numbering and source-preservation rules. The
 [shard-key inference contract](SQL_SHARD_KEYS.md) defines the supported proof
-grammar and typed result. The [bound statement-planning
+grammar and typed result. The [bound statement-planning and routing-policy
 contract](SQL_PLANNING.md) defines canonical route bytes, occurrence ordering,
-routing provenance, and the advisory execution boundary.
+physical-target comparison, write rejection, provenance, and the
+non-executable planning boundary.
 
 ### Implemented pass-through surface
 
@@ -371,9 +376,10 @@ Insert/update duplicate checks fold ASCII letter case regardless of quoting but
 do not define general identifier normalization, which also remains issue #25.
 Placeholder normalization is the separate implemented issue #21 layer described
 below, and catalog-aware typed key extraction is the implemented issue #22
-layer. Synchronous advisory bind-time planning and routing are the implemented
-issue #23 layer; rejection of conflicting or unroutable writes remains issue
-#24. Prepare/bind/describe/execute state remains issue #26, and empty or
+layer. Synchronous bind-time route construction is the implemented issue #23
+layer, and issue #24 adds physical-target comparison, assigned shards, and
+rejection of conflicting or unroutable cataloged sharded writes.
+Prepare/bind/describe/execute state remains issue #26, and empty or
 multi-statement execution policy remains issue #27.
 
 The validator independently caps recursive expression AST depth at 128. This
@@ -381,11 +387,12 @@ also bounds flat operator chains that parse iteratively; exceeding the limit is
 reported as `LimitExceeded`.
 
 The future driver-capable execution path will send `CREATE TABLE` and
-`CREATE INDEX` through journaled schema migrations, route accepted CRUD only after its
-single-shard or supported read plan is established, and implement real
-transactions through protocol-neutral session state. Writes with no provable
-shard, conflicting shard keys, unsafe statement combinations, and cross-shard
-transactions will be rejected before changing data.
+`CREATE INDEX` through journaled schema migrations, consume only an accepted
+single-shard write or supported read plan, revalidate its provenance, and
+implement real transactions through protocol-neutral session state. The
+implemented planning API already rejects unroutable or conflicting cataloged
+writes; unsafe statement combinations and cross-shard transactions remain
+later request/session policy.
 
 ### Implemented placeholder normalization
 
@@ -430,9 +437,9 @@ inference](SQL_SHARD_KEYS.md).
 
 Inference does not encode, hash, route, plan, authorize, enforce, or execute.
 The implemented planner described below uses the result at bind/execute time to
-construct advisory routes. Issue #24 will decide which conflicting, multiple,
-or unconstrained write outcomes must be rejected before execution. The raw
-HTTP execution paths do not invoke inference.
+construct routes, validate physical-target compatibility, and reject
+unroutable sharded DML. The raw HTTP execution paths do not invoke inference or
+that policy.
 
 ### Implemented bound statement planning
 
@@ -448,14 +455,22 @@ order, including duplicate multi-row values and distinct keys that choose the
 same shard. Its explicit route remains separate even when it agrees with an
 inferred key or shard.
 
+Finite inferred routes take precedence. Optional explicit context must select
+the same physical shard as every inferred occurrence; matching raw bytes are
+not required. Multiple logical keys are accepted for a write only when they
+co-locate on one physical shard. `INSERT` must prove every row's key;
+unconstrained or contradictory `UPDATE`/`DELETE` requires explicit fallback;
+and every assignment to a cataloged shard-key column is rejected. A successful
+single-shard plan exposes `assigned_shard()`.
+
 Planning holds the schema-operation guard while consulting the catalog. The
 result records schema generation, routing-map generation, and hash,
 key-encoding, and bucket-algorithm versions. Those fields describe the snapshot
 used to build the plan; they do not reserve that snapshot for future execution.
-The method does not choose routing precedence, reject a classification,
-translate SQL, mutate a session, cache a prepared statement, apply write or
-batch policy, or execute SQLite. The exact contract is in [bound statement
-planning](SQL_PLANNING.md).
+The method does not translate SQL, mutate a session, cache a prepared
+statement, apply complete statement/batch policy, scatter reads, or execute
+SQLite. The exact matrix and error precedence are in [bound statement planning
+and routing policy](SQL_PLANNING.md).
 
 ## PostgreSQL differences
 
@@ -465,7 +480,7 @@ not implemented unless listed as implemented in this document.
 
 | Area | PostgreSQL | BriskDB contract |
 | --- | --- | --- |
-| Parameters | `$1`, `$2`, ... | Implemented opt-in Rust normalization, typed inference, and advisory routing from a supplied bound slice; wire bind lifecycle and routing policy remain planned |
+| Parameters | `$1`, `$2`, ... | Implemented opt-in Rust normalization, typed inference, and single-shard routing policy from a supplied bound slice; wire bind lifecycle remains planned |
 | Identifier quoting | Double quotes | Passed through where SQLite semantics agree |
 | Type system | Static types identified by OIDs | Planned loss-aware mapping to BriskDB types and SQLite storage classes |
 | Boolean | Dedicated `boolean` type | Stored as SQLite integer `0` or `1`; protocol adapter returns a Boolean value |
@@ -493,7 +508,7 @@ engine used by PostgreSQL and HTTP.
 
 | Area | MySQL | BriskDB contract |
 | --- | --- | --- |
-| Parameters | `?` in prepared statements | Implemented opt-in Rust normalization, typed inference, and advisory routing from a supplied bound slice; wire bind lifecycle and routing policy remain planned |
+| Parameters | `?` in prepared statements | Implemented opt-in Rust normalization, typed inference, and single-shard routing policy from a supplied bound slice; wire bind lifecycle remains planned |
 | Identifier quoting | Backticks by default | Planned normalization; double-quoted strict SQL remains available |
 | Type system | Static signed/unsigned column types | BriskDB retains `UInt64` without narrowing; current SQLite binding rejects values above `i64::MAX` until an explicit storage mapping exists |
 | Boolean | Commonly `TINYINT(1)` | Stored as SQLite integer `0` or `1`; protocol adapter returns documented metadata |
@@ -557,14 +572,15 @@ underlying execution semantics.
 - Logical metadata is currently read-only and advisory. Fresh manifests and
   upgrades originating before v4 contain no table rows; v4-to-v5 retains every
   validated v4 logical-catalog row. Existing physical tables are not inferred
-  or adopted. The opt-in Rust inference and advisory planning APIs can consult
+  or adopted. The opt-in Rust inference and planning/policy APIs can consult
   catalog contents, but they do not alter current HTTP routing or execution.
 - Opt-in inference can extract typed cataloged keys from supported equality
   predicates and every row of a supported `INSERT`.
 - Opt-in bound planning converts every inferred occurrence to an owned route,
   retains an independent explicit route, and records catalog/routing
-  provenance; it does not make a plan executable or change current HTTP
-  behavior.
+  provenance. It compares finite routes by physical shard, rejects unroutable
+  cataloged sharded writes, and records an accepted single-shard assignment;
+  it does not make a plan executable or change current HTTP behavior.
 - Point queries and writes visit only that shard.
 - No scatter/gather query path exists.
 - Unique constraints and transactions are local to one SQLite shard.
@@ -579,9 +595,9 @@ underlying execution semantics.
 - Every sharded table declares one non-null shard-key column in the catalog.
 - Canonical key encoding, hash version, virtual bucket count, and bucket map are
   persisted in the manifest.
-- Execution validates bound-plan provenance, applies write/read assignment
-  policy, and uses an explicit session routing key only as a controlled
-  fallback.
+- Execution validates bound-plan provenance, consumes the implemented
+  single-shard write/read assignment, and uses session routing state only
+  through the prepared execution lifecycle.
 - A transaction is pinned to its first shard. Targeting another shard returns a
   stable cross-shard-transaction error.
 - Read-only plans may scatter with bounded concurrency and deterministic merge.

--- a/docs/SQL_PARAMETERS.md
+++ b/docs/SQL_PARAMETERS.md
@@ -159,10 +159,12 @@ A successful `NormalizedSql` does not establish that:
 
 The implemented [shard-key inference contract](SQL_SHARD_KEYS.md) consumes this
 metadata plus a catalog database and exact bound-value slice. The implemented
-[bound statement planner](SQL_PLANNING.md) uses that result to produce advisory
-routes only after values are bound. Issues #24 through #27 own conflicting or
-unroutable write rejection, syntax/type translation, prepared-statement state,
-and request-level statement classification respectively.
+[bound statement planner and routing policy](SQL_PLANNING.md) uses that result
+only after values are bound, compares finite physical targets, rejects
+unroutable cataloged sharded writes, and records a valid single-shard
+assignment. Issues #25 through #27 own syntax/type translation,
+prepared-statement state, and request-level statement classification
+respectively.
 
 ## Verification obligations
 

--- a/docs/SQL_PARSER.md
+++ b/docs/SQL_PARSER.md
@@ -65,8 +65,8 @@ In particular, this layer does not:
 - infer shard keys or inspect bound values; issue #22 implements that as the
   separate `infer_shard_keys` layer;
 - itself plan bound statements; issue #23 implements that as the separate
-  synchronous `Engine::plan_bound_statement` layer;
-- reject conflicting keys or unroutable writes (issue #24);
+  synchronous `Engine::plan_bound_statement` layer, and issue #24 extends that
+  call with physical-target comparison and sharded-write policy;
 - translate types or syntax, or choose strict SQLite mode (issue #25);
 - implement prepare/bind/describe/execute state or caches (issue #26); or
 - classify statement behavior or reject unsafe multi-statement combinations
@@ -83,9 +83,9 @@ The existing HTTP execute, query, and migration paths remain raw SQLite
 pass-through surfaces with their existing authorizer and endpoint-specific
 rules. They call neither this parser, the opt-in common-subset validator, nor
 the opt-in placeholder normalizer, shard-key inference, or bound statement
-planner. Connecting those layers before translation, write policy, and
-request-level statement policy are implemented would change the experimental
-HTTP SQL surface.
+planner. Connecting those layers before translation, the prepared execution
+lifecycle, and request-level statement policy are implemented would change the
+experimental HTTP SQL surface.
 
 ## Resource and error boundaries
 

--- a/docs/SQL_PLANNING.md
+++ b/docs/SQL_PLANNING.md
@@ -1,8 +1,8 @@
-# Bound statement planning
+# Bound statement planning and routing policy
 
-Status: implemented for roadmap issue #23
+Status: implemented for roadmap issues #23 and #24
 
-BriskDB exposes a synchronous, protocol-neutral engine call that plans one
+BriskDB exposes one synchronous, protocol-neutral engine call that plans a
 normalized statement from the values actually bound for that execution:
 
 ```rust
@@ -18,14 +18,16 @@ Engine::plan_bound_statement(
 
 `statement_index` is zero-based. `parameters` must be the complete bound-value
 slice for that statement, exactly as required by
-[`infer_shard_keys`](SQL_SHARD_KEYS.md). Requiring that slice is the important
-timing boundary: a statement whose shard key is a placeholder cannot be routed
-when SQL is parsed or prepared, because its value does not exist yet. A
-frontend calls this API for a concrete bind/execute operation.
+[`infer_shard_keys`](SQL_SHARD_KEYS.md). A statement whose shard key is a
+placeholder cannot be routed when SQL is parsed or prepared because its value
+does not exist yet. A frontend calls this API for a concrete bind/execute
+operation.
 
-This is an advisory planning API. It infers typed shard-key values, converts
-them to canonical routing bytes, and looks up their current physical shards.
-It does not execute SQL or make a statement executable.
+The call performs protocol-neutral analysis only. It infers typed shard-key
+values, converts them to canonical routing bytes, looks up physical shards,
+compares optional explicit routing context, applies the first single-shard DML
+rules, and records an assigned shard when one is valid. It does not prepare,
+translate, authorize, or execute SQL.
 
 ## Result contract
 
@@ -36,25 +38,93 @@ It does not execute SQL or make a statement executable.
 - `inference()`: the complete owned `ShardKeyInference` result;
 - `inferred_routes()`: one `PlannedRoute` for every entry returned by
   `inference().values()`, in the same order;
-- `explicit_route()`: the independently planned caller-supplied routing key,
-  when one was supplied; and
+- `explicit_route()`: the independently retained caller-supplied routing key,
+  when one was supplied;
+- `assigned_shard()`: the physical shard selected by routing policy, or `None`
+  when no single-shard assignment exists; and
 - `schema_generation()`, `map_generation()`, `hash_version()`,
   `key_encoding_version()`, and `bucket_algorithm_version()`: the catalog and
   routing provenance observed while the plan was produced.
 
-Each `PlannedRoute` owns its canonical `key_bytes()` and reports the selected
+Each `PlannedRoute` owns its canonical `key_bytes()` and reports its current
 physical `shard()`. Owning the bytes keeps the plan independent of frontend
 parameter buffers after the call returns.
 
-The plan retains the inference classification even when there is no inferred
-route. `NotApplicable`, `NotSharded`, `Unconstrained`, and `Contradiction`
-therefore remain successful advisory results with an empty
-`inferred_routes()` slice. An explicit route can still be present in any of
-those cases.
+`assigned_shard()` is an assignment, not permission to execute. `None` is a
+normal successful result for a statement that is not sharded and for a read
+that still needs later scatter or empty-result planning. Every accepted write
+to a cataloged sharded table has `Some(shard)`.
 
 `Debug` output reports identifiers, versions, shard IDs, and counts where
 useful. It does not render SQL, AST contents, inferred key values, explicit key
 bytes, or parameter values.
+
+## Routing precedence
+
+For a cataloged sharded table, planning applies this order:
+
+1. Use finite routes inferred from the normalized AST and actual bound values.
+2. If inference produced no route, use explicit routing context where the DML
+   rules below permit a fallback.
+3. Leave a read without one physical target unassigned for later scatter or
+   empty-result planning.
+4. Reject a write that cannot be assigned to exactly one physical shard.
+
+An explicit route never narrows or overrides finite inference. When inferred
+routes exist, an explicit route is compatible only if it selects the same
+physical shard as every inferred occurrence. Compatibility compares physical
+shards, not key bytes: distinct opaque keys that currently map to the same
+shard are compatible. A mismatch is `InvalidArgument`.
+
+The plan continues to retain both route sources after a successful comparison.
+This preserves their provenance for later session and execution work.
+
+## Read assignment
+
+This issue deliberately does not publish a full statement-behavior classifier;
+issue #27 owns that API. At this boundary, the retained normalized AST is
+inspected only far enough to identify `INSERT`, `UPDATE`, and `DELETE`. Other
+sharded statements follow the read/deferred-assignment rules:
+
+| Inference result | No explicit route | Compatible explicit route |
+| --- | --- | --- |
+| `Exact`, or `Multiple` whose occurrences all select one shard | Assign that inferred shard | Assign that inferred shard |
+| `Multiple` spanning physical shards | Leave unassigned for later scatter | Reject because one explicit route cannot agree with every inferred route |
+| `Unconstrained` | Leave unassigned for later scatter | Assign the explicit shard |
+| `Contradiction` | Leave unassigned for later empty-result/validation policy | Assign the explicit shard |
+| `NotApplicable` or `NotSharded` | Leave unassigned | Leave unassigned; retain explicit context only as advisory metadata |
+
+No scatter execution or no-row short circuit is implemented here. In
+particular, a contradictory predicate is still allowed to reach later SQLite
+prepare and validation work rather than having this advisory layer invent a
+result.
+
+## Sharded write policy
+
+The first sharded DML contract is intentionally single-shard:
+
+| DML shape | Accepted assignment |
+| --- | --- |
+| `INSERT` with a proven key for every row | Every inferred occurrence must select one physical shard; an explicit route, if present, must select that shard |
+| `INSERT` with an omitted or non-atomic shard-key value | Rejected even when explicit context exists, because the row's actual placement was not proven |
+| `UPDATE` or `DELETE` with finite inference | Every inferred route must select one physical shard; a compatible explicit route may also be retained |
+| `UPDATE` or `DELETE` with `Unconstrained` or `Contradiction` inference | Requires an explicit fallback and assigns its physical shard |
+| Any finite write spanning physical shards | Rejected before execution; explicit context cannot repair or narrow it |
+
+Duplicate `INSERT` keys and distinct logical keys that collide on one physical
+shard are valid single-shard writes. Their individual route occurrences remain
+visible in the plan.
+
+A cataloged shard-key column is immutable in this first contract. Every
+sharded `UPDATE` assignment targeting it is rejected, including self-assignment,
+assigning the same literal, assigning a placeholder, and a statement whose
+predicate is contradictory. Unquoted identifiers use the inference layer's
+ASCII case-folded catalog comparison; quoted identifiers compare exactly.
+Row movement between shards is not implemented.
+
+`NotApplicable` and `NotSharded` statements do not become successful sharded
+writes. Global, catalog, and schema placement have separate future execution
+paths and retain `assigned_shard() == None` here.
 
 ## Canonical routing-key bytes
 
@@ -66,9 +136,9 @@ Planner key encoding version 1 converts typed inferred values as follows:
 | `Text` | Exact UTF-8 bytes, with no Unicode normalization or case conversion |
 | `Binary` | Exact bytes, including empty values and embedded zero bytes |
 
-An `Int64` value of `-42`, for example, becomes the three ASCII bytes
-`b"-42"`; `i64::MIN` and `i64::MAX` are supported without narrowing. The
-encoding adds no type, database, table, or column prefix.
+An `Int64` value of `-42`, for example, becomes `b"-42"`; `i64::MIN` and
+`i64::MAX` are supported without narrowing. The encoding adds no type,
+database, table, or column prefix.
 
 `explicit_routing_key` is already an untyped routing byte sequence. Its bytes
 are retained exactly, including an empty sequence; they are not parsed,
@@ -77,7 +147,7 @@ normalized, or converted through the typed encoding table.
 Both inferred and explicit bytes enter the same persisted, versioned routing
 catalog: BLAKE3 hash version 1, bucket algorithm version 1, and the catalog's
 current virtual-bucket map select the physical shard. The recorded versions
-and map generation identify the routing rules used by this plan.
+and map generation identify the routing rules used by the plan.
 
 ## Occurrence and ordering rules
 
@@ -88,42 +158,28 @@ and map generation identify the routing rules used by this plan.
 - two distinct keys currently map to the same physical shard; or
 - an inferred key and the explicit routing key select the same shard.
 
-This preserves multi-row `INSERT` row order and every inferred occurrence for
-the later policy layer. An implementation may share immutable owned storage
-for duplicate canonical bytes, but the public route entry for each occurrence
-remains present.
-
-## Inferred and explicit routes remain separate
-
-The explicit route is a candidate fallback, not an override selected by this
-API. Planning deliberately does not:
-
-- choose inferred routing over explicit routing or the reverse;
-- declare matching key bytes or matching physical shards sufficient;
-- reject different inferred and explicit keys;
-- reject `Multiple`, `Unconstrained`, or `Contradiction` inference;
-- decide whether a read may scatter; or
-- decide whether a write may execute.
-
-Roadmap issue #24 owns those assignment and write-policy decisions. Keeping
-both inputs in the plan lets that layer compare logical keys and plan shape
-without losing information during routing.
+This preserves multi-row order and every inferred occurrence. The
+implementation shares immutable owned byte storage for duplicate typed values,
+but still exposes one `PlannedRoute` per occurrence. Physical shard
+deduplication is used only to decide whether the statement has one
+single-shard assignable target.
 
 ## Catalog coordination and provenance
 
 The engine acquires the existing schema-operation guard before reading the
-logical catalog and routing snapshot. A schema migration cannot begin while
-the plan is being assembled. If the gate is already migrating or degraded,
-planning returns the same protocol-neutral gate error as other ordinary engine
-operations. The guard is released when the synchronous call returns.
+logical catalog and keeps it across inference, route construction, narrow DML
+inspection, and policy validation. A schema migration cannot begin during the
+call. If the gate is already migrating or degraded, planning returns the same
+protocol-neutral gate error as other ordinary engine operations before
+statement policy is evaluated. The guard is released when the synchronous
+call returns.
 
-The successful plan records the application-schema generation, routing-map
-generation, hash version, key-encoding version, and bucket-algorithm version
-used by the call. These fields are provenance, not a lease on future state.
-This issue does not connect a plan to execution, so no SQLite statement runs
-under that provenance yet. A future execution path must establish that the
+The successful plan records the application-schema generation,
+routing-map generation, hash version, key-encoding version, and
+bucket-algorithm version used by the call. These fields are provenance, not a
+lease on future state. A future execution path must establish that the
 physical schema and routing snapshot are still authoritative and reject or
-replan stale provenance before using the planned shards.
+replan stale provenance before using `assigned_shard()`.
 
 The logical table catalog remains read-only and advisory. Planning does not
 assert that its table metadata describes an existing physical SQLite table or
@@ -132,45 +188,69 @@ integration work.
 
 ## Errors and recovery
 
-Planning returns shard-key inference errors unchanged, including invalid
-database, table, statement index, parameter arity, key type, integer range,
-text encoding, and non-null cases. It can additionally return the existing
-schema-gate errors while a migration or degraded state excludes ordinary work.
-An internally inconsistent inference/result shape is `Internal`.
+The caller reaches this API only after parsing, subset validation, and
+normalization succeed. Planning preserves shard-key inference errors and can
+also return:
 
-An error does not retain caller parameters, mutate the normalized SQL, poison
-the engine, or populate session state. A later independent call may succeed.
+| Condition | `EngineErrorKind` |
+| --- | --- |
+| Explicit physical shard conflicts with any finite inferred route | `InvalidArgument` |
+| `UPDATE` or `DELETE` has no finite route and no explicit fallback | `InvalidArgument` |
+| A sharded `UPDATE` assigns the cataloged shard-key column | `InvalidQuery` |
+| A sharded `INSERT` does not prove every row's key | `InvalidQuery` |
+| A finite sharded write spans physical shards | `InvalidQuery` |
+| Retained inference, catalog, AST, or route metadata is inconsistent | `Internal` |
+
+Schema-gate errors retain their existing `Busy`, `FailedPrecondition`, and
+`DataCorruption` classifications. No new error kind or protocol mapping is
+introduced.
+
+Error precedence is deterministic: schema admission and inference happen
+first; an attempted shard-key update is rejected next; finite explicit-route
+conflicts are checked next; remaining write routability is checked last. Thus
+a shard-key update wins over a conflicting explicit key, while a multi-target
+write with an explicit route that disagrees with part of its finite inference
+is `InvalidArgument`.
+
+Policy diagnostics use fixed categories. They contain no submitted SQL,
+identifier spelling, literal, parameter value, routing-key bytes, or formatted
+AST. An error retains no caller buffer, changes no normalized SQL or session,
+and poisons no engine state; a later independent call can succeed.
 
 ## Deliberate boundaries
 
-Issue #23 introduces no configuration, CLI option, network message, HTTP shape,
-manifest migration, shard-file change, or new SQLite execution path. In
-particular:
+Issues #23 and #24 add no configuration, CLI option, environment variable,
+network message, HTTP shape, manifest migration, shard-file change, or SQLite
+execution path. In particular:
 
 - `Engine::plan_bound_statement` is synchronous and stateless; it neither
   accepts nor mutates a `Session`;
+- `assigned_shard()` is not consumed by the current raw HTTP or engine execute
+  and query paths;
+- no read scatter, merge, contradiction short circuit, or write executes here;
+- no transaction pinning or cross-call routing context is applied;
 - no per-session or global prepared-statement cache is created;
 - no PostgreSQL or MySQL syntax or type is translated;
-- no write, scatter, transaction, authorization, or batch policy is applied;
-- no statement is prepared, described, executed, or returned to a client; and
+- no complete read/write/schema/session or batch classifier is published; and
 - the current HTTP execute, query, and migration paths do not invoke parsing,
-  common-subset validation, normalization, inference, or this planner.
+  validation, normalization, inference, or planning.
 
-Issue #24 owns conflicting and unroutable write policy. Issue #25 owns selected
-syntax and type translation. Issue #26 owns the protocol-neutral
-prepare/bind/describe/execute lifecycle, session integration, and bounded
-per-session cache. Issue #27 owns statement behavior and empty, single-, and
-multi-statement request policy.
+Issue #25 owns selected syntax and type translation. Issue #26 owns the
+protocol-neutral prepare/bind/describe/execute lifecycle, session integration,
+provenance revalidation, and bounded per-session cache. Issue #27 owns the
+authoritative statement-behavior and empty, single-, and multi-statement
+request policy. Later query-planner work owns scatter/gather execution.
 
 ## Verification obligations
 
-Tests cover canonical bytes for signed integer boundaries, UTF-8 text, and
-arbitrary binary values; explicit keys including empty and binary sequences;
-all inference classifications; route ordering and retained duplicate
-multi-row values; distinct logical keys that choose the same physical shard;
-independent inferred and explicit routes; schema and routing provenance;
-schema-gate exclusion and recovery; every supported source dialect; numbered
-parameter gaps and rebinding the same normalized statement; propagated
-inference errors and recovery; deterministic concurrent calls; owned results;
-and redacted diagnostics and `Debug` output. Raw HTTP regressions continue to
-prove that advisory planning does not change existing execution behavior.
+Tests cover canonical bytes; every inference classification; inferred route
+ordering and duplicate storage sharing; physical same-shard key collisions;
+same-shard and conflicting explicit context including empty/binary bytes;
+single- and multi-row `INSERT`; exact, multiple, unconstrained, and
+contradictory `UPDATE`/`DELETE`; immutable shard-key assignments under all
+source dialects and statement indexes; read deferral; error precedence and
+redaction; policy-error retries; deterministic valid and rejected concurrent
+calls; schema-gate precedence and recovery; owned
+public results; provenance; and equivalent SQLite, PostgreSQL, and MySQL typed
+requests. Raw HTTP regressions prove that opt-in planning still does not change
+existing execution behavior.

--- a/docs/SQL_SHARD_KEYS.md
+++ b/docs/SQL_SHARD_KEYS.md
@@ -111,8 +111,9 @@ cell in every row.
 - A complete row set with one distinct value is `Exact`; two or more distinct
   values are `Multiple`.
 
-This classification does not decide whether a multi-key insert may run. Issue
-#24 owns rejection of conflicting or unroutable writes.
+This inference classification alone does not decide whether a multi-key insert
+may run. The implemented [bound planning and routing policy](SQL_PLANNING.md)
+accepts it only when every occurrence selects one physical shard.
 
 ## Value compatibility
 
@@ -162,11 +163,12 @@ existing raw SQLite SQL and caller-provided `shard_key` behavior.
 
 The implemented synchronous
 [`Engine::plan_bound_statement`](SQL_PLANNING.md) API invokes inference at
-bind/execute time and turns every inferred value into an owned advisory route.
-It retains an optional explicit route separately and does not make the result
-executable. Issue #24 will enforce the write rules for conflicting, multiple,
-or unconstrained keys. Later work owns syntax translation, prepared-statement
-lifecycle, statement classification, and wire-protocol integration.
+bind/execute time and turns every inferred value into an owned route. It
+retains optional explicit routing separately, compares finite physical targets,
+rejects unroutable sharded DML, and records a valid single-shard assignment.
+The result is still not executable. Later work owns syntax translation,
+prepared-statement lifecycle, authoritative statement classification, and
+wire-protocol integration.
 
 ## Verification obligations
 

--- a/docs/SQL_SUBSET.md
+++ b/docs/SQL_SUBSET.md
@@ -45,10 +45,11 @@ A successful `CommonSql` does not mean that the SQL:
 - has been executed.
 
 Those responsibilities remain with the implemented issue #21 normalization,
-issue #22 inference, and issue #23 advisory planning layers, issues #24 through
-#27, and the later wire frontends. Validation never consults parameters, a
-session, the logical catalog, storage, routing state, the filesystem, or
-SQLite. It never formats or searches SQL text to make a structural decision.
+issue #22 inference, and issues #23/#24 bound planning and routing-policy
+layers, issues #25 through #27, and the later wire frontends. Validation never
+consults parameters, a session, the logical catalog, storage, routing state,
+the filesystem, or SQLite. It never formats or searches SQL text to make a
+structural decision.
 
 Empty and comment-only parsed batches validate successfully. Every statement in
 a mixed batch is checked independently and source order is retained, but that
@@ -81,8 +82,11 @@ pinning, and protocol status reporting remain issues #34 and #47.
 
 An absent `WHERE` on `UPDATE` or `DELETE` is structurally valid. Likewise,
 validation does not inspect whether an assignment changes a shard-key column.
-The separate inference layer classifies the supported predicate proof; issue
-#24 owns rejection of conflicting or unroutable writes and assignment policy.
+The separate inference layer classifies the supported predicate proof. The
+implemented [bound planning and routing-policy layer](SQL_PLANNING.md) performs
+the narrow catalog-aware `UPDATE` target check and rejects conflicting or
+unroutable sharded DML. That does not broaden structural validation or replace
+the complete statement classifier owned by issue #27.
 
 ### Names, aliases, and types
 

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -512,9 +512,12 @@ planner converts inferred `Int64` keys to their shortest signed base-10 ASCII
 form, inferred `Text` keys to exact UTF-8 without Unicode normalization or case
 conversion, and inferred `Binary` keys to exact bytes. The encoding adds no
 type, logical-database, table, or column prefix. These typed rules define input
-to the already persisted version-1 hash; issue #23 adds no manifest or shard
-format change. The complete advisory planning contract is in
-[bound statement planning](SQL_PLANNING.md).
+to the already persisted version-1 hash. Routing policy compares and
+deduplicates only the physical shard IDs produced by that persisted catalog;
+it does not rewrite or persist key bytes. Issues #23 and #24 add no manifest
+version, encoding, bucket-map, shard-file, or migration change. The complete
+planning and policy contract is in [bound statement
+planning](SQL_PLANNING.md).
 
 Bucket algorithm version 1 deliberately preserves legacy placement even when
 `N` does not divide 4,096. Given the version-1 64-bit hash `H`:

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -291,9 +291,11 @@ impl Engine {
 
     /// Plan one normalized statement from its actual bound parameter values.
     ///
-    /// `statement_index` is zero-based. `explicit_routing_key` is retained as
-    /// an independent fallback route; later policy decides whether inferred
-    /// and explicit routes are compatible and executable.
+    /// `statement_index` is zero-based. Planning infers routes, retains an
+    /// optional explicit fallback, applies single-shard write policy, and
+    /// returns the assigned physical shard when one is valid. Finite inferred
+    /// routes and an explicit route must select the same physical shard.
+    /// Planning remains synchronous and does not prepare or execute SQL.
     pub fn plan_bound_statement(
         &self,
         database: LogicalDatabaseId,

--- a/src/core/planner.rs
+++ b/src/core/planner.rs
@@ -3,10 +3,13 @@
 use std::{collections::HashMap, fmt, sync::Arc};
 
 use crate::sql::{
-    NormalizedSql, ShardKeyInference, ShardKeyInferenceKind, ShardKeyValue, infer_shard_keys,
+    NormalizedSql, RoutedDml, ShardKeyInference, ShardKeyInferenceKind, ShardKeyValue,
+    infer_shard_keys, routed_dml_shape,
 };
 
-use super::{Catalog, EngineError, EngineErrorKind, EngineResult, LogicalDatabaseId, Value};
+use super::{
+    Catalog, EngineError, EngineErrorKind, EngineResult, LogicalDatabaseId, TablePlacement, Value,
+};
 
 /// One owned canonical routing key and its selected physical shard.
 #[derive(Clone, PartialEq, Eq)]
@@ -41,9 +44,10 @@ impl fmt::Debug for PlannedRoute {
 ///
 /// Inferred routes remain aligned one-for-one with
 /// [`ShardKeyInference::values`], including duplicate `INSERT` row values. An
-/// explicit route is retained independently so the later write-policy layer
-/// can compare it with inferred routes. This plan does not choose between
-/// those sources, reject a plan, translate SQL, or execute anything.
+/// explicit route is retained independently even after routing policy compares
+/// it with inferred routes. A successful plan records the one assigned shard
+/// when the statement has a valid single-shard route. It does not translate SQL
+/// or execute anything.
 #[derive(Clone, PartialEq, Eq)]
 pub struct BoundStatementPlan {
     database: LogicalDatabaseId,
@@ -56,6 +60,7 @@ pub struct BoundStatementPlan {
     inference: ShardKeyInference,
     inferred_routes: Vec<PlannedRoute>,
     explicit_route: Option<PlannedRoute>,
+    assigned_shard: Option<u16>,
 }
 
 impl BoundStatementPlan {
@@ -108,6 +113,15 @@ impl BoundStatementPlan {
     pub const fn explicit_route(&self) -> Option<&PlannedRoute> {
         self.explicit_route.as_ref()
     }
+
+    /// Return the physical shard assigned by routing policy, if any.
+    ///
+    /// `None` is retained for non-sharded statements and reads that still need
+    /// later scatter or empty-result planning. Every accepted sharded write has
+    /// an assigned shard.
+    pub const fn assigned_shard(&self) -> Option<u16> {
+        self.assigned_shard
+    }
 }
 
 impl fmt::Debug for BoundStatementPlan {
@@ -124,6 +138,7 @@ impl fmt::Debug for BoundStatementPlan {
             .field("inference", &self.inference)
             .field("inferred_route_count", &self.inferred_routes.len())
             .field("has_explicit_route", &self.explicit_route.is_some())
+            .field("assigned_shard", &self.assigned_shard)
             .finish()
     }
 }
@@ -223,6 +238,37 @@ where
         key_bytes: Arc::from(key),
     });
 
+    let shard_key_column = sharded_key_column(catalog, database, &inference)?;
+    let dml = shard_key_column
+        .map(|column| routed_dml_shape(normalized, statement_index, column))
+        .transpose()?
+        .flatten();
+    let inferred_shards = inferred_shards(&inferred_routes);
+
+    if matches!(
+        dml,
+        Some(RoutedDml::Update {
+            assigns_shard_key: true
+        })
+    ) {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidQuery,
+            "sharded UPDATE cannot assign the shard-key column",
+        ));
+    }
+    validate_explicit_route(&inferred_routes, explicit_route.as_ref())?;
+    validate_sharded_write(dml, inferred_shards, explicit_route.as_ref())?;
+
+    let assigned_shard = if shard_key_column.is_some() {
+        match inferred_shards {
+            InferredShards::None => explicit_route.as_ref().map(PlannedRoute::shard),
+            InferredShards::One(shard) => Some(shard),
+            InferredShards::Multiple => None,
+        }
+    } else {
+        None
+    };
+
     Ok(BoundStatementPlan {
         database,
         schema_generation,
@@ -234,7 +280,113 @@ where
         inference,
         inferred_routes,
         explicit_route,
+        assigned_shard,
     })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InferredShards {
+    None,
+    One(u16),
+    Multiple,
+}
+
+fn inferred_shards(routes: &[PlannedRoute]) -> InferredShards {
+    let Some(first) = routes.first() else {
+        return InferredShards::None;
+    };
+    if routes.iter().all(|route| route.shard == first.shard) {
+        InferredShards::One(first.shard)
+    } else {
+        InferredShards::Multiple
+    }
+}
+
+fn validate_explicit_route(
+    inferred_routes: &[PlannedRoute],
+    explicit_route: Option<&PlannedRoute>,
+) -> EngineResult<()> {
+    let Some(explicit_route) = explicit_route else {
+        return Ok(());
+    };
+    if inferred_routes
+        .iter()
+        .all(|inferred| inferred.shard == explicit_route.shard)
+    {
+        Ok(())
+    } else {
+        Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            "explicit routing key conflicts with inferred statement routing",
+        ))
+    }
+}
+
+fn validate_sharded_write(
+    dml: Option<RoutedDml>,
+    inferred_shards: InferredShards,
+    explicit_route: Option<&PlannedRoute>,
+) -> EngineResult<()> {
+    match dml {
+        Some(RoutedDml::Insert) => match inferred_shards {
+            InferredShards::One(_) => Ok(()),
+            InferredShards::None | InferredShards::Multiple => Err(EngineError::new(
+                EngineErrorKind::InvalidQuery,
+                "sharded INSERT requires a proven routing key for every row",
+            )),
+        },
+        Some(RoutedDml::Update {
+            assigns_shard_key: false,
+        })
+        | Some(RoutedDml::Delete) => match inferred_shards {
+            InferredShards::One(_) => Ok(()),
+            InferredShards::None if explicit_route.is_some() => Ok(()),
+            InferredShards::None => Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "sharded write requires an inferred or explicit routing key",
+            )),
+            InferredShards::Multiple => Err(EngineError::new(
+                EngineErrorKind::InvalidQuery,
+                "sharded write targets more than one physical shard",
+            )),
+        },
+        Some(RoutedDml::Update {
+            assigns_shard_key: true,
+        }) => Err(EngineError::new(
+            EngineErrorKind::Internal,
+            "routing policy accepted an invalid shard-key update",
+        )),
+        None => Ok(()),
+    }
+}
+
+fn sharded_key_column<'a>(
+    catalog: &'a Catalog,
+    database: LogicalDatabaseId,
+    inference: &ShardKeyInference,
+) -> EngineResult<Option<&'a str>> {
+    let sharded = matches!(
+        inference.kind(),
+        ShardKeyInferenceKind::Unconstrained
+            | ShardKeyInferenceKind::Contradiction
+            | ShardKeyInferenceKind::Exact
+            | ShardKeyInferenceKind::Multiple
+    );
+    if !sharded {
+        return Ok(None);
+    }
+    let table = inference
+        .table_id()
+        .and_then(|id| catalog.table_by_id(id))
+        .filter(|table| table.database_id() == database)
+        .ok_or_else(planning_invariant)?;
+    let TablePlacement::Sharded(shard_key) = table.placement() else {
+        return Err(planning_invariant());
+    };
+    if inference.key_type() != Some(shard_key.key_type()) {
+        return Err(planning_invariant());
+    }
+    Ok(Some(shard_key.column()))
 }
 
 fn validate_inference_shape(inference: &ShardKeyInference) -> EngineResult<()> {
@@ -250,11 +402,15 @@ fn validate_inference_shape(inference: &ShardKeyInference) -> EngineResult<()> {
     if valid {
         Ok(())
     } else {
-        Err(EngineError::new(
-            EngineErrorKind::Internal,
-            "shard-key inference is inconsistent during bound statement planning",
-        ))
+        Err(planning_invariant())
     }
+}
+
+fn planning_invariant() -> EngineError {
+    EngineError::new(
+        EngineErrorKind::Internal,
+        "shard-key inference is inconsistent during bound statement planning",
+    )
 }
 
 fn canonical_key_bytes(value: &ShardKeyValue) -> Arc<[u8]> {
@@ -268,6 +424,7 @@ fn canonical_key_bytes(value: &ShardKeyValue) -> Arc<[u8]> {
 #[cfg(test)]
 mod tests {
     use std::{
+        path::Path,
         sync::{Arc, Barrier},
         thread,
     };
@@ -346,6 +503,33 @@ mod tests {
         )
     }
 
+    fn insert_engine_catalog_fixture(root: &Path) {
+        let manifest = rusqlite::Connection::open(root.join("manifest.sqlite")).unwrap();
+        manifest
+            .execute_batch(
+                "PRAGMA foreign_keys = ON;
+                 BEGIN IMMEDIATE;
+                 DROP TABLE briskdb_integrity;
+                 DROP TABLE briskdb_metadata;
+                 CREATE TABLE briskdb_metadata (
+                     requires_manifest_version INTEGER NOT NULL
+                         CHECK (requires_manifest_version >= 6)
+                 ) STRICT;
+                 INSERT INTO briskdb_metadata VALUES (6);
+                 INSERT INTO briskdb_tables (
+                    table_id,
+                    database_id,
+                    table_name,
+                    placement,
+                    shard_key_column,
+                    shard_key_type
+                 ) VALUES (4, 1, 'events', 1, 'tenant_id', 1);
+                 PRAGMA user_version = 6;
+                 COMMIT;",
+            )
+            .unwrap();
+    }
+
     fn normalize(dialect: SqlDialect, source: &str) -> NormalizedSql {
         normalize_placeholders(validate_common_subset(parse(dialect, source).unwrap()).unwrap())
             .unwrap()
@@ -369,6 +553,33 @@ mod tests {
         )
     }
 
+    fn distinct_key_with_same_shard(routing: &RoutingCatalog, reference: &[u8]) -> Vec<u8> {
+        let shard = routing.shard_for_key(reference);
+        (0_u64..)
+            .map(|candidate| format!("same-shard-{candidate}").into_bytes())
+            .find(|candidate| {
+                candidate.as_slice() != reference && routing.shard_for_key(candidate) == shard
+            })
+            .unwrap()
+    }
+
+    fn same_shard_int_pair(routing: &RoutingCatalog) -> (i64, i64) {
+        let first = 0_i64;
+        let shard = routing.shard_for_key(first.to_string().as_bytes());
+        let second = (1_i64..)
+            .find(|candidate| routing.shard_for_key(candidate.to_string().as_bytes()) == shard)
+            .unwrap();
+        (first, second)
+    }
+
+    fn split_test_router(key: &[u8]) -> u16 {
+        match key {
+            b"7" | b"same-shard-context" => 1,
+            b"8" => 2,
+            _ => 3,
+        }
+    }
+
     fn plan(
         catalog: &Catalog,
         database: u64,
@@ -378,6 +589,29 @@ mod tests {
         explicit_routing_key: Option<&[u8]>,
     ) -> EngineResult<BoundStatementPlan> {
         let routing = routing_catalog(4);
+        plan_with_router(
+            catalog,
+            database,
+            normalized,
+            statement_index,
+            parameters,
+            explicit_routing_key,
+            |key| routing.shard_for_key(key),
+        )
+    }
+
+    fn plan_with_router<F>(
+        catalog: &Catalog,
+        database: u64,
+        normalized: &NormalizedSql,
+        statement_index: usize,
+        parameters: &[Value],
+        explicit_routing_key: Option<&[u8]>,
+        shard_for_key: F,
+    ) -> EngineResult<BoundStatementPlan>
+    where
+        F: FnMut(&[u8]) -> u16,
+    {
         plan_bound_statement(
             BoundStatementPlanInput::new(
                 catalog,
@@ -388,12 +622,12 @@ mod tests {
                 explicit_routing_key,
             ),
             RoutingProvenance::new(
-                routing.hash_version(),
-                routing.key_encoding_version(),
-                routing.bucket_algorithm_version(),
-                routing.map_generation(),
+                HASH_VERSION,
+                KEY_ENCODING_VERSION,
+                BUCKET_ALGORITHM_VERSION,
+                INITIAL_MAP_GENERATION,
             ),
-            |key| routing.shard_for_key(key),
+            shard_for_key,
         )
     }
 
@@ -408,26 +642,32 @@ mod tests {
             SqlDialect::PostgreSql,
             "INSERT INTO accounts (tenant_id) VALUES ('private-tenant')",
         );
+        let routing = routing_catalog(4);
+        let explicit_routing_key = distinct_key_with_same_shard(&routing, b"private-tenant");
         let plan = plan(
             &catalog,
             TENANT_DATABASE,
             &normalized,
             0,
             &[],
-            Some(b"private-explicit-key"),
+            Some(&explicit_routing_key),
         )
         .unwrap();
         assert_eq!(plan.clone(), plan);
         assert_eq!(plan.inferred_routes()[0].key_bytes(), b"private-tenant");
         assert_eq!(
             plan.explicit_route().unwrap().key_bytes(),
-            b"private-explicit-key"
+            explicit_routing_key
         );
 
         let debug = format!("{plan:?} {:?}", plan.explicit_route().unwrap());
         assert!(!debug.contains("private-tenant"));
-        assert!(!debug.contains("private-explicit-key"));
+        assert!(!debug.contains(std::str::from_utf8(&explicit_routing_key).unwrap()));
         assert!(debug.contains("<redacted>"));
+        assert_eq!(
+            plan.assigned_shard(),
+            Some(plan.inferred_routes()[0].shard())
+        );
     }
 
     #[test]
@@ -589,7 +829,7 @@ mod tests {
                 &normalize(dialect, source),
                 0,
                 &[Value::Int64(42)],
-                Some(b"frontend-independent-route"),
+                Some(b"42"),
             )
             .unwrap()
         });
@@ -600,7 +840,44 @@ mod tests {
     }
 
     #[test]
-    fn every_inference_kind_keeps_explicit_routing_independent() {
+    fn equivalent_typed_writes_produce_equal_assignments_across_dialects() {
+        let catalog = sample_catalog();
+        let plans = [
+            (
+                SqlDialect::Sqlite,
+                "UPDATE events SET payload = ?1 WHERE tenant_id = ?2",
+            ),
+            (
+                SqlDialect::PostgreSql,
+                "UPDATE events SET payload = $1 WHERE tenant_id = $2",
+            ),
+            (
+                SqlDialect::MySql,
+                "UPDATE events SET payload = ? WHERE tenant_id = ?",
+            ),
+        ]
+        .map(|(dialect, source)| {
+            plan(
+                &catalog,
+                DEFAULT_DATABASE,
+                &normalize(dialect, source),
+                0,
+                &[Value::Text("same-write".to_owned()), Value::Int64(42)],
+                Some(b"42"),
+            )
+            .unwrap()
+        });
+
+        assert_eq!(plans[0], plans[1]);
+        assert_eq!(plans[1], plans[2]);
+        assert_eq!(
+            plans[0].assigned_shard(),
+            Some(plans[0].inferred_routes()[0].shard())
+        );
+    }
+
+    #[test]
+    fn every_inference_kind_has_a_stable_read_assignment() {
         let catalog = sample_catalog();
         let cases = [
             ("SELECT 1", ShardKeyInferenceKind::NotApplicable, 0_usize),
@@ -633,18 +910,39 @@ mod tests {
 
         for (source, kind, route_count) in cases {
             let normalized = normalize(SqlDialect::Sqlite, source);
-            for explicit in [None, Some(b"".as_slice()), Some(b"fallback".as_slice())] {
-                let plan = plan(&catalog, DEFAULT_DATABASE, &normalized, 0, &[], explicit).unwrap();
-                assert_eq!(plan.inference().kind(), kind, "{source}");
-                assert_eq!(plan.inferred_routes().len(), route_count, "{source}");
-                assert_eq!(
-                    plan.explicit_route().is_some(),
-                    explicit.is_some(),
-                    "{source}"
-                );
-                if let Some(explicit) = explicit {
-                    assert_eq!(plan.explicit_route().unwrap().key_bytes(), explicit);
-                }
+            let without_explicit =
+                plan(&catalog, DEFAULT_DATABASE, &normalized, 0, &[], None).unwrap();
+            assert_eq!(without_explicit.inference().kind(), kind, "{source}");
+            assert_eq!(
+                without_explicit.inferred_routes().len(),
+                route_count,
+                "{source}"
+            );
+            let inferred_shards = inferred_shards(without_explicit.inferred_routes());
+            let expected = match inferred_shards {
+                InferredShards::One(shard) => Some(shard),
+                InferredShards::None | InferredShards::Multiple => None,
+            };
+            assert_eq!(without_explicit.assigned_shard(), expected, "{source}");
+
+            if route_count == 0 {
+                let explicit = b"fallback";
+                let plan = plan(
+                    &catalog,
+                    DEFAULT_DATABASE,
+                    &normalized,
+                    0,
+                    &[],
+                    Some(explicit),
+                )
+                .unwrap();
+                assert_eq!(plan.explicit_route().unwrap().key_bytes(), explicit);
+                let expected = matches!(
+                    kind,
+                    ShardKeyInferenceKind::Unconstrained | ShardKeyInferenceKind::Contradiction
+                )
+                .then_some(plan.explicit_route().unwrap().shard());
+                assert_eq!(plan.assigned_shard(), expected, "{source}");
             }
         }
     }
@@ -656,12 +954,18 @@ mod tests {
             SqlDialect::MySql,
             "INSERT INTO events (tenant_id) VALUES (?), (?), (?)",
         );
+        let routing = routing_catalog(4);
+        let (first, second) = same_shard_int_pair(&routing);
         let plan = plan(
             &catalog,
             DEFAULT_DATABASE,
             &normalized,
             0,
-            &[Value::Int64(11), Value::Int64(22), Value::Int64(11)],
+            &[
+                Value::Int64(first),
+                Value::Int64(second),
+                Value::Int64(first),
+            ],
             None,
         )
         .unwrap();
@@ -672,13 +976,21 @@ mod tests {
                 .iter()
                 .map(PlannedRoute::key_bytes)
                 .collect::<Vec<_>>(),
-            [b"11".as_slice(), b"22".as_slice(), b"11".as_slice()]
+            [
+                first.to_string().as_bytes(),
+                second.to_string().as_bytes(),
+                first.to_string().as_bytes()
+            ]
         );
         assert!(Arc::ptr_eq(
             &plan.inferred_routes[0].key_bytes,
             &plan.inferred_routes[2].key_bytes
         ));
         assert_eq!(plan.inferred_routes[0], plan.inferred_routes[2]);
+        assert_eq!(
+            plan.assigned_shard(),
+            Some(plan.inferred_routes()[0].shard())
+        );
     }
 
     #[test]
@@ -712,6 +1024,452 @@ mod tests {
                 .all(|route| route.shard() == 3)
         );
         assert_eq!(plan.explicit_route().unwrap().shard(), 3);
+        assert_eq!(plan.assigned_shard(), Some(3));
+    }
+
+    #[test]
+    fn explicit_routes_compare_physical_shards_and_never_key_bytes() {
+        let catalog = sample_catalog();
+        let normalized = normalize(
+            SqlDialect::PostgreSql,
+            "UPDATE events SET payload = 1 WHERE tenant_id = 7",
+        );
+
+        for explicit in [b"7".as_slice(), b"same-shard-context".as_slice()] {
+            let plan = plan_with_router(
+                &catalog,
+                DEFAULT_DATABASE,
+                &normalized,
+                0,
+                &[],
+                Some(explicit),
+                split_test_router,
+            )
+            .unwrap();
+            assert_eq!(plan.inferred_routes()[0].shard(), 1);
+            assert_eq!(plan.explicit_route().unwrap().key_bytes(), explicit);
+            assert_eq!(plan.explicit_route().unwrap().shard(), 1);
+            assert_eq!(plan.assigned_shard(), Some(1));
+        }
+
+        for explicit in [
+            b"different-shard-context".as_slice(),
+            b"".as_slice(),
+            b"private\0\xffcontext".as_slice(),
+        ] {
+            let error = plan_with_router(
+                &catalog,
+                DEFAULT_DATABASE,
+                &normalized,
+                0,
+                &[],
+                Some(explicit),
+                split_test_router,
+            )
+            .unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::InvalidArgument);
+            let diagnostic = error.to_string();
+            assert!(!diagnostic.contains("different-shard-context"));
+            assert!(!diagnostic.contains("private"));
+        }
+    }
+
+    #[test]
+    fn multi_key_writes_require_one_physical_shard_while_reads_defer_scatter() {
+        let catalog = sample_catalog();
+        let writes = [
+            "INSERT INTO events (tenant_id) VALUES (7), (8)",
+            "UPDATE events SET payload = 1 WHERE tenant_id = 7 OR tenant_id = 8",
+            "DELETE FROM events WHERE tenant_id = 7 OR tenant_id = 8",
+        ];
+
+        for dialect in SqlDialect::ALL.iter().copied() {
+            for source in writes {
+                let normalized = normalize(dialect, source);
+                let error = plan_with_router(
+                    &catalog,
+                    DEFAULT_DATABASE,
+                    &normalized,
+                    0,
+                    &[],
+                    None,
+                    split_test_router,
+                )
+                .unwrap_err();
+                assert_eq!(
+                    error.kind(),
+                    EngineErrorKind::InvalidQuery,
+                    "{dialect}: {source}"
+                );
+
+                let conflict = plan_with_router(
+                    &catalog,
+                    DEFAULT_DATABASE,
+                    &normalized,
+                    0,
+                    &[],
+                    Some(b"7"),
+                    split_test_router,
+                )
+                .unwrap_err();
+                assert_eq!(
+                    conflict.kind(),
+                    EngineErrorKind::InvalidArgument,
+                    "{dialect}: {source}"
+                );
+
+                let co_located = plan_with_router(
+                    &catalog,
+                    DEFAULT_DATABASE,
+                    &normalized,
+                    0,
+                    &[],
+                    Some(b"different-logical-key"),
+                    |_| 2,
+                )
+                .unwrap();
+                assert_eq!(co_located.inferred_routes().len(), 2);
+                assert!(
+                    co_located
+                        .inferred_routes()
+                        .iter()
+                        .all(|route| route.shard() == 2)
+                );
+                assert_eq!(co_located.assigned_shard(), Some(2));
+            }
+        }
+
+        let read = normalize(
+            SqlDialect::Sqlite,
+            "SELECT * FROM events WHERE tenant_id = 7 OR tenant_id = 8",
+        );
+        let deferred = plan_with_router(
+            &catalog,
+            DEFAULT_DATABASE,
+            &read,
+            0,
+            &[],
+            None,
+            split_test_router,
+        )
+        .unwrap();
+        assert_eq!(deferred.inference().kind(), ShardKeyInferenceKind::Multiple);
+        assert_eq!(deferred.assigned_shard(), None);
+        assert_eq!(
+            deferred
+                .inferred_routes()
+                .iter()
+                .map(PlannedRoute::shard)
+                .collect::<Vec<_>>(),
+            [1, 2]
+        );
+        assert_eq!(
+            plan_with_router(
+                &catalog,
+                DEFAULT_DATABASE,
+                &read,
+                0,
+                &[],
+                Some(b"7"),
+                split_test_router,
+            )
+            .unwrap_err()
+            .kind(),
+            EngineErrorKind::InvalidArgument
+        );
+    }
+
+    #[test]
+    fn predicate_writes_need_explicit_fallback_when_inference_has_no_route() {
+        let catalog = sample_catalog();
+        let statements = [
+            (
+                "UPDATE events SET payload = 1",
+                ShardKeyInferenceKind::Unconstrained,
+            ),
+            (
+                "UPDATE events SET payload = 1 WHERE tenant_id = NULL",
+                ShardKeyInferenceKind::Contradiction,
+            ),
+            ("DELETE FROM events", ShardKeyInferenceKind::Unconstrained),
+            (
+                "DELETE FROM events WHERE tenant_id = NULL",
+                ShardKeyInferenceKind::Contradiction,
+            ),
+        ];
+
+        for dialect in SqlDialect::ALL.iter().copied() {
+            for (source, kind) in statements {
+                let normalized = normalize(dialect, source);
+                let error = plan_with_router(
+                    &catalog,
+                    DEFAULT_DATABASE,
+                    &normalized,
+                    0,
+                    &[],
+                    None,
+                    split_test_router,
+                )
+                .unwrap_err();
+                assert_eq!(
+                    error.kind(),
+                    EngineErrorKind::InvalidArgument,
+                    "{dialect}: {source}"
+                );
+
+                for explicit in [b"".as_slice(), b"fallback\0\xff".as_slice()] {
+                    let plan = plan_with_router(
+                        &catalog,
+                        DEFAULT_DATABASE,
+                        &normalized,
+                        0,
+                        &[],
+                        Some(explicit),
+                        split_test_router,
+                    )
+                    .unwrap();
+                    assert_eq!(plan.inference().kind(), kind);
+                    assert!(plan.inferred_routes().is_empty());
+                    assert_eq!(
+                        plan.assigned_shard(),
+                        Some(plan.explicit_route().unwrap().shard())
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn inserts_without_a_proven_row_key_reject_even_with_explicit_context() {
+        let catalog = sample_catalog();
+        let sources = [
+            "INSERT INTO events (payload) VALUES (1)",
+            "INSERT INTO events (tenant_id) VALUES (1 + 0)",
+        ];
+
+        for dialect in SqlDialect::ALL.iter().copied() {
+            for source in sources {
+                let normalized = normalize(dialect, source);
+                for explicit in [None, Some(b"fallback".as_slice())] {
+                    let error = plan_with_router(
+                        &catalog,
+                        DEFAULT_DATABASE,
+                        &normalized,
+                        0,
+                        &[],
+                        explicit,
+                        split_test_router,
+                    )
+                    .unwrap_err();
+                    assert_eq!(
+                        error.kind(),
+                        EngineErrorKind::InvalidQuery,
+                        "{dialect}: {source}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn shard_key_updates_are_rejected_before_other_routing_errors() {
+        let catalog = sample_catalog();
+        let sources = [
+            "UPDATE events SET tenant_id = tenant_id WHERE tenant_id = 7",
+            "UPDATE events SET TENANT_ID = 7 WHERE tenant_id = 7",
+            "UPDATE events SET payload = 1, tenant_id = 8 WHERE tenant_id = NULL",
+        ];
+
+        for dialect in SqlDialect::ALL.iter().copied() {
+            for source in sources {
+                let error = plan_with_router(
+                    &catalog,
+                    DEFAULT_DATABASE,
+                    &normalize(dialect, source),
+                    0,
+                    &[],
+                    Some(b"different-shard-context"),
+                    split_test_router,
+                )
+                .unwrap_err();
+                assert_eq!(
+                    error.kind(),
+                    EngineErrorKind::InvalidQuery,
+                    "{dialect}: {source}"
+                );
+                assert!(!error.to_string().contains("tenant_id"));
+            }
+        }
+
+        for (dialect, source) in [
+            (
+                SqlDialect::Sqlite,
+                "UPDATE events SET tenant_id = ?1 WHERE tenant_id = ?2",
+            ),
+            (
+                SqlDialect::PostgreSql,
+                "UPDATE events SET tenant_id = $1 WHERE tenant_id = $2",
+            ),
+            (
+                SqlDialect::MySql,
+                "UPDATE events SET tenant_id = ? WHERE tenant_id = ?",
+            ),
+        ] {
+            let error = plan_with_router(
+                &catalog,
+                DEFAULT_DATABASE,
+                &normalize(dialect, source),
+                0,
+                &[Value::Int64(7), Value::Int64(7)],
+                None,
+                split_test_router,
+            )
+            .unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::InvalidQuery, "{dialect}");
+        }
+
+        let inference_first = plan_with_router(
+            &catalog,
+            DEFAULT_DATABASE,
+            &normalize(
+                SqlDialect::PostgreSql,
+                "UPDATE events SET tenant_id = $1 WHERE tenant_id = $2",
+            ),
+            0,
+            &[Value::Int64(7)],
+            None,
+            split_test_router,
+        )
+        .unwrap_err();
+        assert_eq!(inference_first.kind(), EngineErrorKind::InvalidArgument);
+
+        let batch = normalize(
+            SqlDialect::Sqlite,
+            "UPDATE events SET payload = 1 WHERE tenant_id = 7; \
+             UPDATE events SET tenant_id = 8 WHERE tenant_id = 7",
+        );
+        let first = plan_with_router(
+            &catalog,
+            DEFAULT_DATABASE,
+            &batch,
+            0,
+            &[],
+            None,
+            split_test_router,
+        )
+        .unwrap();
+        assert_eq!(first.assigned_shard(), Some(1));
+        assert_eq!(
+            plan_with_router(
+                &catalog,
+                DEFAULT_DATABASE,
+                &batch,
+                1,
+                &[],
+                None,
+                split_test_router,
+            )
+            .unwrap_err()
+            .kind(),
+            EngineErrorKind::InvalidQuery
+        );
+
+        let global = plan_with_router(
+            &catalog,
+            DEFAULT_DATABASE,
+            &normalize(SqlDialect::Sqlite, "UPDATE countries SET tenant_id = 1"),
+            0,
+            &[],
+            None,
+            split_test_router,
+        )
+        .unwrap();
+        assert_eq!(global.inference().kind(), ShardKeyInferenceKind::NotSharded);
+        assert_eq!(global.assigned_shard(), None);
+    }
+
+    #[test]
+    fn routing_policy_errors_are_stateless_and_concurrent() {
+        let catalog = Arc::new(sample_catalog());
+        let normalized = Arc::new(normalize(
+            SqlDialect::PostgreSql,
+            "INSERT INTO events (tenant_id) VALUES (7), (8)",
+        ));
+        let barrier = Arc::new(Barrier::new(9));
+        let mut threads = Vec::new();
+        for _ in 0..8 {
+            let catalog = Arc::clone(&catalog);
+            let normalized = Arc::clone(&normalized);
+            let barrier = Arc::clone(&barrier);
+            threads.push(thread::spawn(move || {
+                barrier.wait();
+                plan_with_router(
+                    &catalog,
+                    DEFAULT_DATABASE,
+                    &normalized,
+                    0,
+                    &[],
+                    None,
+                    split_test_router,
+                )
+                .unwrap_err()
+            }));
+        }
+        barrier.wait();
+        let errors = threads
+            .into_iter()
+            .map(|thread| thread.join().unwrap())
+            .collect::<Vec<_>>();
+        assert!(
+            errors
+                .iter()
+                .all(|error| error.kind() == EngineErrorKind::InvalidQuery)
+        );
+        assert!(
+            errors
+                .windows(2)
+                .all(|pair| pair[0].to_string() == pair[1].to_string())
+        );
+
+        let recovered = plan_with_router(
+            &catalog,
+            DEFAULT_DATABASE,
+            &normalized,
+            0,
+            &[],
+            Some(b"same-shard-context"),
+            |_| 1,
+        )
+        .unwrap();
+        assert_eq!(recovered.assigned_shard(), Some(1));
+
+        let broad = normalize(SqlDialect::PostgreSql, "DELETE FROM events");
+        assert_eq!(
+            plan_with_router(
+                &catalog,
+                DEFAULT_DATABASE,
+                &broad,
+                0,
+                &[],
+                None,
+                split_test_router,
+            )
+            .unwrap_err()
+            .kind(),
+            EngineErrorKind::InvalidArgument
+        );
+        assert!(
+            plan_with_router(
+                &catalog,
+                DEFAULT_DATABASE,
+                &broad,
+                0,
+                &[],
+                Some(b"fallback"),
+                split_test_router,
+            )
+            .is_ok()
+        );
     }
 
     #[test]
@@ -897,6 +1655,8 @@ mod tests {
     #[test]
     fn concurrent_planning_is_deterministic_and_read_only() {
         let catalog = Arc::new(sample_catalog());
+        let routing = routing_catalog(4);
+        let (first, second) = same_shard_int_pair(&routing);
         let normalized = Arc::new(normalize(
             SqlDialect::PostgreSql,
             "INSERT INTO events (tenant_id) VALUES ($1), ($2), ($1)",
@@ -914,8 +1674,8 @@ mod tests {
                     DEFAULT_DATABASE,
                     &normalized,
                     0,
-                    &[Value::Int64(7), Value::Int64(8)],
-                    Some(b"parallel-explicit"),
+                    &[Value::Int64(first), Value::Int64(second)],
+                    None,
                 )
                 .unwrap()
             }));
@@ -1014,6 +1774,67 @@ mod tests {
                 .unwrap_err()
                 .kind(),
             EngineErrorKind::DataCorruption
+        );
+    }
+
+    #[test]
+    fn schema_gate_precedes_write_policy_and_a_later_valid_plan_recovers() {
+        let temp = tempfile::tempdir().unwrap();
+        drop(Database::open(temp.path(), 2).unwrap());
+        insert_engine_catalog_fixture(temp.path());
+        let database = Arc::new(Database::open(temp.path(), 2).unwrap());
+        let engine = Engine::from_database(Arc::clone(&database));
+        let logical_database = engine.catalog().default_database().id();
+        let broad_write = normalize(SqlDialect::Sqlite, "DELETE FROM events");
+        let invalid_bind = normalize(
+            SqlDialect::Sqlite,
+            "UPDATE events SET payload = ?1 WHERE tenant_id = ?2",
+        );
+
+        let migration = database.storage.begin_schema_migration().unwrap();
+        migration.wait_for_quiescence_blocking();
+        assert_eq!(
+            engine
+                .plan_bound_statement(logical_database, &broad_write, 0, &[], None)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::Busy
+        );
+        assert_eq!(
+            engine
+                .plan_bound_statement(logical_database, &invalid_bind, 0, &[Value::Int64(1)], None,)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::Busy
+        );
+        drop(migration);
+
+        assert_eq!(
+            engine
+                .plan_bound_statement(logical_database, &invalid_bind, 0, &[Value::Int64(1)], None,)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::InvalidArgument
+        );
+        assert_eq!(
+            engine
+                .plan_bound_statement(logical_database, &broad_write, 0, &[], None)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::InvalidArgument
+        );
+        let recovered = engine
+            .plan_bound_statement(
+                logical_database,
+                &normalize(SqlDialect::Sqlite, "DELETE FROM events WHERE tenant_id = 7"),
+                0,
+                &[],
+                None,
+            )
+            .unwrap();
+        assert_eq!(
+            recovered.assigned_shard(),
+            Some(database.shard_for_key(b"7"))
         );
     }
 }

--- a/src/sql/dml.rs
+++ b/src/sql/dml.rs
@@ -1,0 +1,161 @@
+//! Narrow routed-DML inspection used by bound statement policy.
+
+use sqlparser::ast::{AssignmentTarget, Statement as AstStatement};
+
+use super::{NormalizedSql, inference::identifier_matches_catalog};
+use crate::core::{EngineError, EngineErrorKind, EngineResult};
+
+/// The statement shapes whose physical placement can change shard data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RoutedDml {
+    Insert,
+    Update { assigns_shard_key: bool },
+    Delete,
+}
+
+/// Inspect only the DML details needed by single-shard routing policy.
+///
+/// Full statement behavior and batch classification remain a separate layer.
+pub(crate) fn routed_dml_shape(
+    normalized: &NormalizedSql,
+    statement_index: usize,
+    shard_key_column: &str,
+) -> EngineResult<Option<RoutedDml>> {
+    let Some(statement) = normalized.common().statements().get(statement_index) else {
+        return Err(routing_policy_invariant());
+    };
+    let shape = match statement {
+        AstStatement::Insert(_) => Some(RoutedDml::Insert),
+        AstStatement::Update(update) => {
+            let mut assigns_shard_key = false;
+            for assignment in &update.assignments {
+                let AssignmentTarget::ColumnName(column) = &assignment.target else {
+                    return Err(routing_policy_invariant());
+                };
+                let identifier = super::inference::column_ident(column)?;
+                assigns_shard_key |= identifier_matches_catalog(identifier, shard_key_column);
+            }
+            Some(RoutedDml::Update { assigns_shard_key })
+        }
+        AstStatement::Delete(_) => Some(RoutedDml::Delete),
+        _ => None,
+    };
+    Ok(shape)
+}
+
+fn routing_policy_invariant() -> EngineError {
+    EngineError::new(
+        EngineErrorKind::Internal,
+        "normalized SQL metadata is inconsistent during routing policy inspection",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sql::{SqlDialect, normalize_placeholders, parse, validate_common_subset};
+
+    fn inspect(dialect: SqlDialect, source: &str) -> Option<RoutedDml> {
+        let normalized = normalize_placeholders(
+            validate_common_subset(parse(dialect, source).unwrap()).unwrap(),
+        )
+        .unwrap();
+        routed_dml_shape(&normalized, 0, "tenant_id").unwrap()
+    }
+
+    #[test]
+    fn routed_dml_shapes_are_dialect_independent() {
+        for dialect in SqlDialect::ALL.iter().copied() {
+            assert_eq!(
+                inspect(dialect, "INSERT INTO events (tenant_id) VALUES (1)"),
+                Some(RoutedDml::Insert)
+            );
+            assert_eq!(
+                inspect(dialect, "UPDATE events SET payload = 1 WHERE tenant_id = 1"),
+                Some(RoutedDml::Update {
+                    assigns_shard_key: false
+                })
+            );
+            assert_eq!(
+                inspect(dialect, "DELETE FROM events WHERE tenant_id = 1"),
+                Some(RoutedDml::Delete)
+            );
+            assert_eq!(
+                inspect(dialect, "SELECT * FROM events WHERE tenant_id = 1"),
+                None
+            );
+            assert_eq!(inspect(dialect, "BEGIN"), None);
+        }
+    }
+
+    #[test]
+    fn shard_key_update_matching_obeys_catalog_identifier_rules() {
+        for dialect in SqlDialect::ALL.iter().copied() {
+            for source in [
+                "UPDATE events SET tenant_id = 1",
+                "UPDATE events SET TENANT_ID = TENANT_ID",
+                "UPDATE events SET payload = 1, tenant_id = 2",
+            ] {
+                assert_eq!(
+                    inspect(dialect, source),
+                    Some(RoutedDml::Update {
+                        assigns_shard_key: true
+                    }),
+                    "{dialect}: {source}"
+                );
+            }
+            assert_eq!(
+                inspect(dialect, "UPDATE events SET payload = tenant_id"),
+                Some(RoutedDml::Update {
+                    assigns_shard_key: false
+                })
+            );
+        }
+
+        assert_eq!(
+            inspect(
+                SqlDialect::PostgreSql,
+                "UPDATE events SET \"tenant_id\" = 1"
+            ),
+            Some(RoutedDml::Update {
+                assigns_shard_key: true
+            })
+        );
+        assert_eq!(
+            inspect(
+                SqlDialect::PostgreSql,
+                "UPDATE events SET \"TENANT_ID\" = 1"
+            ),
+            Some(RoutedDml::Update {
+                assigns_shard_key: false
+            })
+        );
+        assert_eq!(
+            inspect(SqlDialect::MySql, "UPDATE events SET `tenant_id` = 1"),
+            Some(RoutedDml::Update {
+                assigns_shard_key: true
+            })
+        );
+        assert_eq!(
+            inspect(SqlDialect::MySql, "UPDATE events SET `TENANT_ID` = 1"),
+            Some(RoutedDml::Update {
+                assigns_shard_key: false
+            })
+        );
+    }
+
+    #[test]
+    fn inconsistent_statement_index_is_an_internal_redacted_error() {
+        let normalized = normalize_placeholders(
+            validate_common_subset(
+                parse(SqlDialect::Sqlite, "UPDATE events SET tenant_id = 1").unwrap(),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        let error = routed_dml_shape(&normalized, 1, "tenant_id").unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Internal);
+        assert!(!error.to_string().contains("events"));
+        assert!(!error.to_string().contains("tenant_id"));
+    }
+}

--- a/src/sql/inference.rs
+++ b/src/sql/inference.rs
@@ -386,7 +386,7 @@ fn object_identifier(name: &ObjectName) -> EngineResult<&Ident> {
     Ok(identifier)
 }
 
-fn column_ident(name: &ObjectName) -> EngineResult<&Ident> {
+pub(super) fn column_ident(name: &ObjectName) -> EngineResult<&Ident> {
     let [ObjectNamePart::Identifier(identifier)] = name.0.as_slice() else {
         return Err(inference_invariant());
     };
@@ -410,7 +410,7 @@ fn reference_identifier(identifier: &Ident) -> String {
     }
 }
 
-fn identifier_matches_catalog(identifier: &Ident, canonical: &str) -> bool {
+pub(super) fn identifier_matches_catalog(identifier: &Ident, canonical: &str) -> bool {
     if identifier.quote_style.is_none() {
         identifier.value.eq_ignore_ascii_case(canonical)
     } else {

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -7,10 +7,13 @@
 //! deliberate SQLite pass-through; these opt-in layers do not gate, route, or
 //! execute statements.
 
+mod dml;
 mod inference;
 mod normalizer;
 mod parser;
 mod subset;
+
+pub(crate) use dml::{RoutedDml, routed_dml_shape};
 
 pub use inference::{ShardKeyInference, ShardKeyInferenceKind, ShardKeyValue, infer_shard_keys};
 pub use normalizer::{

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -346,6 +346,36 @@ fn shard_key_inference_is_public_typed_and_opt_in() {
 #[tokio::test]
 async fn bound_statement_planning_is_public_owned_value_aware_and_opt_in() {
     fn assert_owned_public<T: Clone + Send + Sync + 'static>() {}
+    fn same_shard_text_pair(database: &core::Database, prefix: &str) -> ([String; 2], u16) {
+        let first = format!("{prefix}-0");
+        let shard = database.shard_for_key(first.as_bytes());
+        let second = (1_u64..)
+            .map(|candidate| format!("{prefix}-{candidate}"))
+            .find(|candidate| database.shard_for_key(candidate.as_bytes()) == shard)
+            .unwrap();
+        ([first, second], shard)
+    }
+    fn binary_key_for_shard(database: &core::Database, shard: u16, prefix: &str) -> Vec<u8> {
+        (0_u64..)
+            .map(|candidate| {
+                let mut key = format!("\0{prefix}-{candidate}").into_bytes();
+                key.push(0xff);
+                key
+            })
+            .find(|candidate| database.shard_for_key(candidate) == shard)
+            .unwrap()
+    }
+    fn binary_key_for_other_shard(database: &core::Database, shard: u16, prefix: &str) -> Vec<u8> {
+        (0_u64..)
+            .map(|candidate| {
+                let mut key = format!("\0{prefix}-{candidate}").into_bytes();
+                key.push(0xff);
+                key
+            })
+            .find(|candidate| database.shard_for_key(candidate) != shard)
+            .unwrap()
+    }
+
     assert_owned_public::<core::BoundStatementPlan>();
     assert_owned_public::<core::PlannedRoute>();
 
@@ -360,16 +390,18 @@ async fn bound_statement_planning_is_public_owned_value_aware_and_opt_in() {
     let parsed = sql::parse(sql::SqlDialect::PostgreSql, source).unwrap();
     let common = sql::validate_common_subset(parsed).unwrap();
     let normalized = sql::normalize_placeholders(common).unwrap();
+    let (first_distinct_keys, first_shard) =
+        same_shard_text_pair(&database, "tenant-alpha-sensitive");
     let first_keys = [
-        "tenant-alpha-sensitive",
-        "tenant-snowman-☃",
-        "tenant-alpha-sensitive",
+        first_distinct_keys[0].as_str(),
+        first_distinct_keys[1].as_str(),
+        first_distinct_keys[0].as_str(),
     ];
     let first_parameters = first_keys
         .iter()
         .map(|key| core::Value::Text((*key).to_owned()))
         .collect::<Vec<_>>();
-    let explicit_key = b"\0explicit-route-sensitive-\xff";
+    let explicit_key = binary_key_for_shard(&database, first_shard, "explicit-route-sensitive");
 
     let plan = engine
         .plan_bound_statement(
@@ -377,7 +409,7 @@ async fn bound_statement_planning_is_public_owned_value_aware_and_opt_in() {
             &normalized,
             0,
             &first_parameters,
-            Some(explicit_key),
+            Some(explicit_key.as_slice()),
         )
         .unwrap();
 
@@ -397,6 +429,7 @@ async fn bound_statement_planning_is_public_owned_value_aware_and_opt_in() {
     );
     assert_eq!(plan.inference().values().len(), first_keys.len());
     assert_eq!(plan.inferred_routes().len(), first_keys.len());
+    assert_eq!(plan.assigned_shard(), Some(first_shard));
 
     for ((value, route), expected_key) in plan
         .inference()
@@ -411,12 +444,13 @@ async fn bound_statement_planning_is_public_owned_value_aware_and_opt_in() {
             route.shard(),
             database.shard_for_key(expected_key.as_bytes())
         );
+        assert_eq!(route.shard(), first_shard);
     }
     assert_eq!(plan.inferred_routes()[0], plan.inferred_routes()[2]);
 
     let explicit_route = plan.explicit_route().unwrap();
     assert_eq!(explicit_route.key_bytes(), explicit_key);
-    assert_eq!(explicit_route.shard(), database.shard_for_key(explicit_key));
+    assert_eq!(explicit_route.shard(), first_shard);
     assert!(
         plan.inferred_routes()
             .iter()
@@ -425,11 +459,7 @@ async fn bound_statement_planning_is_public_owned_value_aware_and_opt_in() {
 
     let plan_debug = format!("{plan:?}");
     let route_debug = format!("{explicit_route:?}");
-    for sensitive in [
-        "tenant-alpha-sensitive",
-        "tenant-snowman-☃",
-        "explicit-route-sensitive",
-    ] {
+    for sensitive in ["tenant-alpha-sensitive", "explicit-route-sensitive"] {
         assert!(!plan_debug.contains(sensitive));
         assert!(!route_debug.contains(sensitive));
     }
@@ -438,7 +468,48 @@ async fn bound_statement_planning_is_public_owned_value_aware_and_opt_in() {
     assert_eq!(cloned, plan);
     assert_eq!(thread::spawn(move || cloned).join().unwrap(), plan);
 
-    let second_keys = ["tenant-bravo", "tenant-charlie", "tenant-bravo"];
+    let conflicting_key =
+        binary_key_for_other_shard(&database, first_shard, "conflicting-explicit-sensitive");
+    assert_ne!(database.shard_for_key(&conflicting_key), first_shard);
+    let conflict = engine
+        .plan_bound_statement(
+            tenant.id(),
+            &normalized,
+            0,
+            &first_parameters,
+            Some(conflicting_key.as_slice()),
+        )
+        .unwrap_err();
+    assert_eq!(conflict.kind(), core::EngineErrorKind::InvalidArgument);
+    assert_eq!(conflict.code(), "invalid_argument");
+    let conflict_debug = format!("{conflict:?}");
+    for sensitive in [
+        first_distinct_keys[0].as_str(),
+        first_distinct_keys[1].as_str(),
+        "conflicting-explicit-sensitive",
+    ] {
+        assert!(!conflict.diagnostic().contains(sensitive));
+        assert!(!conflict_debug.contains(sensitive));
+    }
+
+    let recovered = engine
+        .plan_bound_statement(
+            tenant.id(),
+            &normalized,
+            0,
+            &first_parameters,
+            Some(explicit_key.as_slice()),
+        )
+        .unwrap();
+    assert_eq!(recovered, plan);
+
+    let (second_distinct_keys, second_shard) =
+        same_shard_text_pair(&database, "tenant-bravo-sensitive");
+    let second_keys = [
+        second_distinct_keys[0].as_str(),
+        second_distinct_keys[1].as_str(),
+        second_distinct_keys[0].as_str(),
+    ];
     let second_parameters = second_keys
         .iter()
         .map(|key| core::Value::Text((*key).to_owned()))
@@ -448,12 +519,14 @@ async fn bound_statement_planning_is_public_owned_value_aware_and_opt_in() {
         .unwrap();
     assert_eq!(replanned.inferred_routes().len(), second_keys.len());
     assert!(replanned.explicit_route().is_none());
+    assert_eq!(replanned.assigned_shard(), Some(second_shard));
     for (route, expected_key) in replanned.inferred_routes().iter().zip(second_keys) {
         assert_eq!(route.key_bytes(), expected_key.as_bytes());
         assert_eq!(
             route.shard(),
             database.shard_for_key(expected_key.as_bytes())
         );
+        assert_eq!(route.shard(), second_shard);
     }
     assert_ne!(replanned.inferred_routes()[0], plan.inferred_routes()[0]);
 


### PR DESCRIPTION
Closes #24

## Summary

- assign bound statements to physical shards when routing proves a single target
- reject explicit-route conflicts, cross-shard or unproven writes, and shard-key updates before execution
- keep read scatter deferred and global/catalog statements protocol-neutral
- document routing behavior and compatibility boundaries
- add exhaustive dialect, precedence, concurrency, recovery, redaction, and public API tests

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features`
- `cargo test --locked --doc --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --no-deps --all-features`
- `cargo +1.85.0 test --locked --all-targets --all-features`
- `cargo +1.85.0 test --locked --doc --all-features`

Two independent reviews found no blockers.
