### PR TITLE
Translate compatible SQL to SQLite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1062,6 +1062,17 @@ source = "git+https://github.com/apache/datafusion-sqlparser-rs?rev=33521a534eae
 dependencies = [
  "log",
  "recursive",
+ "sqlparser_derive",
+]
+
+[[package]]
+name = "sqlparser_derive"
+version = "0.5.0"
+source = "git+https://github.com/apache/datafusion-sqlparser-rs?rev=33521a534eae72188e06ce0ce4836d19c7f3458a#33521a534eae72188e06ce0ce4836d19c7f3458a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serde_json = "1.0"
 # The exact upstream revision contains the post-0.62.0 `parse_interval`
 # recursion fix. This must remain a direct source pin so downstream BriskDB
 # consumers inherit it; a root-only `[patch]` would not propagate.
-sqlparser = { version = "=0.62.0", git = "https://github.com/apache/datafusion-sqlparser-rs", rev = "33521a534eae72188e06ce0ce4836d19c7f3458a", default-features = false, features = ["std", "recursive-protection"] }
+sqlparser = { version = "=0.62.0", git = "https://github.com/apache/datafusion-sqlparser-rs", rev = "33521a534eae72188e06ce0ce4836d19c7f3458a", default-features = false, features = ["std", "recursive-protection", "visitor"] }
 # `recursive` admits newer `psm` releases whose build dependencies require
 # Rust 1.88. The direct exact constraint preserves BriskDB's Rust 1.85 MSRV for
 # both this repository and downstream consumers until that graph is corrected.

--- a/README.md
+++ b/README.md
@@ -182,8 +182,13 @@ Rust callers may explicitly parse SQL and consume the result with
 `validate_common_subset(ParsedSql)`, receiving an owned opaque `CommonSql` on
 success. They may then opt into `normalize_placeholders(CommonSql)`, receiving
 canonical SQLite `?N` text and per-statement occurrence-to-index metadata
-without supplying parameter values. Given a complete bound-value slice and a
-logical catalog database, callers may then invoke
+without supplying parameter values. Callers can consume that result with
+`translate_sql(NormalizedSql, SqlTranslationMode)`: explicit compatibility mode
+maps the documented finite type and syntax set to separate canonical SQLite
+SQL, while strict mode requires SQLite input and preserves the
+placeholder-normalized SQLite text exactly. The translated result retains its
+`NormalizedSql` for routing analysis. Given a complete bound-value slice and a
+logical catalog database, callers may invoke
 `infer_shard_keys(&Catalog, LogicalDatabaseId, &NormalizedSql, statement_index,
 parameters)` to classify the statement as not applicable, not sharded,
 unconstrained, contradictory, exact, or multiple and inspect any typed inferred
@@ -196,9 +201,11 @@ That call compares finite inferred and explicit routes by physical shard,
 rejects cross-shard or otherwise unroutable cataloged sharded DML, prevents
 shard-key updates, and exposes the accepted `assigned_shard()`. The plan
 records schema and routing provenance but does not classify complete request
-behavior, translate SQL, or execute anything. The HTTP execute, query, and
+behavior or execute anything. Translation and planning remain independent
+opt-in branches over the same normalized request. The HTTP execute, query, and
 migration endpoints invoke none of these opt-in layers and retain their
-existing raw SQLite behavior.
+existing raw SQLite behavior. The exact translation matrix and strict-mode
+boundary are in [`docs/SQL_TRANSLATION.md`](docs/SQL_TRANSLATION.md).
 
 `EngineOptions` permits 1–16 active connections and 1–1,024 queued operations
 per shard, with at most 512 active connections across all shards.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -211,7 +211,7 @@ interrupted schema migration can be diagnosed and resumed.
 - [x] Plan prepared statements at bind/execute time, not parse time, because a
   routing key may be supplied as a bound parameter.
 - [x] Reject conflicting keys and unroutable writes before execution.
-- [ ] Translate a deliberately small set of type names and syntax differences;
+- [x] Translate a deliberately small set of type names and syntax differences;
   preserve a strict mode that exposes SQLite SQL directly.
 - [ ] Implement protocol-neutral prepare/bind/describe/execute lifecycle and a
   bounded per-session prepared-statement cache.
@@ -271,8 +271,9 @@ inside a single-shard transaction, handle errors, and reconnect cleanly.
   `COM_STMT_EXECUTE`, reset, and close.
 - [ ] Map BriskDB types, nulls, status flags, affected rows, generated-key
   behavior, warnings, MySQL error numbers, and SQLSTATE values.
-- [ ] Add selected MySQL syntax normalization: backtick identifiers, boolean
-  conventions, `LIMIT offset,count`, and documented type aliases.
+- [ ] Apply the implemented selected MySQL normalization for backtick
+  identifiers, Boolean conventions, `LIMIT offset,count`, and documented type
+  aliases to the MySQL wire request lifecycle.
 - [ ] Emulate the small session surface that real drivers issue automatically,
   including `SET NAMES`, selected `SHOW VARIABLES`, and selected `SELECT @@...`
   probes; test each shim rather than inventing a broad fake catalog.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,7 +23,7 @@ server ---------> protocol::http
 | --- | --- | --- |
 | `core` | Protocol-neutral `Engine`, `Session`, statements, values, results, errors, read-only logical catalog, synchronous bound-value-aware plans, and single-shard routing policy; stable key routing; bounded per-shard admission and connection pools; routed execute/query and journaled schema migration | JSON/HTTP types, listeners, or Axum handlers |
 | `storage` | Versioned routing/logical manifest, shard layout, migration journal and recovery, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
-| `sql` | Dialect-explicit SQL syntax parsing, recursive common-subset validation, source-preserving placeholder normalization, catalog-aware typed shard-key inference, and narrow crate-private DML-shape inspection behind BriskDB-owned boundaries; exact source retention; SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, key hashing or shard selection, session/write policy, filesystem layout, protocol responses, protocol-buffer ownership, or protocol-specific support policy |
+| `sql` | Dialect-explicit SQL syntax parsing, recursive common-subset validation, source-preserving placeholder normalization, explicit strict/compatibility translation, catalog-aware typed shard-key inference, and narrow crate-private DML-shape inspection behind BriskDB-owned boundaries; exact source retention; SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, key hashing or shard selection, session/write policy, filesystem layout, protocol responses, protocol-buffer ownership, or protocol-specific support policy |
 | `protocol::http` | HTTP request extraction plus JSON/BriskDB value and RFC 9457 problem-detail encoding | BLAKE3 routing, shard files, or rusqlite calls |
 | `protocol::error` | Exhaustive HTTP, PostgreSQL, and MySQL mappings from stable engine error kinds | SQLite errors, routing decisions, or wire-protocol session state |
 | `server` | Process configuration, database assembly, listener binding, and tracked Axum HTTP/1 connection lifecycle | SQL parsing or storage implementation details |
@@ -124,9 +124,9 @@ contract](SQL_SUBSET.md).
 
 The current HTTP execute/query and migration paths deliberately remain raw
 SQLite pass-through and call none of the parser, subset validator, placeholder
-normalizer, shard-key inference, or bound statement-planning layers. Issues
-#19 through #24 therefore change no HTTP shape, SQL acceptance, execution
-routing, or storage behavior.
+normalizer, translator, shard-key inference, or bound statement-planning
+layers. Issues #19 through #25 therefore change no HTTP shape, SQL acceptance,
+execution routing, or storage behavior.
 
 ### Placeholder-normalization boundary
 
@@ -152,6 +152,29 @@ filesystem, or execution access and does not decide whether a statement batch
 may execute; issue #27 owns that policy. The normative API, dialect rules,
 limits, errors, and tests are in the [SQL parameter-normalization
 contract](SQL_PARAMETERS.md).
+
+### SQL-translation boundary
+
+`translate_sql(NormalizedSql, SqlTranslationMode)` consumes an owned normalized
+request and returns an owned `TranslatedSql`. Strict mode accepts only SQLite
+source and preserves `sqlite_parameter_sql()` byte-for-byte. Compatibility mode
+clones the validated opaque AST, applies the finite dialect-specific type and
+syntax matrix, resolves every retained placeholder to its existing `?N`
+identity, and renders separate canonical SQLite SQL. Exact original source and
+the complete normalized representation remain retained.
+
+Compatibility integers canonicalize to `BIGINT` rather than exact SQLite
+`INTEGER`, avoiding accidental `INTEGER PRIMARY KEY` rowid-alias behavior.
+Boolean declarations/literals, variable text and binary declarations,
+64-bit-real aliases, backtick identifiers, transaction aliases, and comma-form
+limits have the only documented mappings. Other types and syntax remain
+unsupported. Canonical compatibility rendering may normalize formatting and
+comments; strict mode does not render the AST.
+
+Translation is stateless and protocol-neutral. It accepts no catalog, values,
+session, storage, or routing state and does not prepare or execute SQL. There is
+no configured default mode yet. The full matrix, result, errors, non-goals, and
+tests are normative in the [SQL translation contract](SQL_TRANSLATION.md).
 
 ### Shard-key inference boundary
 
@@ -213,13 +236,13 @@ must establish that the physical schema and routing snapshot remain
 authoritative before using a plan.
 
 The planner is stateless and its assignment is still non-executable. It does
-not translate SQL, mutate a session, cache a prepared statement, apply batch
-policy, open a shard connection, scatter reads, or execute anything. The
+not invoke translation, mutate a session, cache a prepared statement, apply
+batch policy, open a shard connection, scatter reads, or execute anything. The
 normative API, assignment matrix, encoding, provenance, error, boundary, and
 testing rules are in the [bound statement-planning and routing-policy
-contract](SQL_PLANNING.md). Issues #25 through #27 own translation,
-prepared-statement/session lifecycle, and authoritative statement/batch policy
-respectively.
+contract](SQL_PLANNING.md). Translation is the separate implemented issue #25
+branch over the same `NormalizedSql`; issues #26 and #27 own
+prepared-statement/session lifecycle and authoritative statement/batch policy.
 
 ## Manifest storage boundary
 

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -157,6 +157,16 @@ fixed categories and positions and never contain SQL, literal or marker text,
 bound values, formatted AST output, or source locations. See the [SQL
 parameter-normalization contract](SQL_PARAMETERS.md).
 
+The opt-in SQL translator reports `InvalidArgument` when strict SQLite mode is
+requested for PostgreSQL or MySQL input. Compatibility mode reports
+`Unsupported` for a parsed type outside its finite mapping and `InvalidQuery`
+when canonical rendering would contain a NUL byte. A mismatch between retained
+statement, column, or placeholder metadata is `Internal`. Translation
+diagnostics identify only the trusted dialect and one-based statement or
+column position where useful; they never contain SQL, identifier or type
+spelling, literal text, parameters, or formatted AST output. See the [SQL
+translation contract](SQL_TRANSLATION.md).
+
 The opt-in shard-key inference layer reports an out-of-range statement index,
 wrong bound-value count, or missing logical database as `InvalidArgument`; an
 unknown table in the selected database as `InvalidQuery`; an incompatible key

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -17,14 +17,14 @@ document defines the SQL and behavioral contract separately from connectivity.
   promise for it.
 
 The syntax parser, recursive common-subset validator, placeholder normalizer,
-catalog-aware shard-key inference API, and synchronous engine bound-statement
-planner are now available behind BriskDB-owned types. Validation is explicit
-and returns `Unsupported` for a parsed form outside the subset; parser
-acceptance alone is not product support. Normalization, inference, bound
-planning, and routing policy are also explicit. The current experimental HTTP
-interface is still a raw SQLite pass-through and can execute uncontracted
-SQLite syntax because it calls none of these layers. That behavior is not a
-compatibility promise.
+finite SQL translator, catalog-aware shard-key inference API, and synchronous
+engine bound-statement planner are now available behind BriskDB-owned types.
+Validation is explicit and returns `Unsupported` for a parsed form outside the
+subset; parser acceptance alone is not product support. Translation,
+normalization, inference, bound planning, and routing policy are also explicit.
+The current experimental HTTP interface is still a raw SQLite pass-through and
+can execute uncontracted SQLite syntax because it calls none of these layers.
+That behavior is not a compatibility promise.
 
 ## Compatibility layers
 
@@ -33,7 +33,7 @@ BriskDB tracks three independent compatibility layers:
 1. **Wire compatibility** lets an existing driver connect, authenticate,
    prepare and bind statements, receive typed rows, and manage session state.
 2. **SQL compatibility** parses a documented common subset and translates
-   selected PostgreSQL or MySQL syntax into SQLite operations.
+   selected PostgreSQL or MySQL syntax into SQLite SQL.
 3. **Behavioral compatibility** emulates the metadata, type, error, transaction,
    and session behavior needed by specifically tested clients and tools.
 
@@ -44,33 +44,38 @@ than claiming to be a drop-in PostgreSQL or MySQL replacement.
 ## Current implementation
 
 Only the experimental HTTP network interface is implemented today. There is no
-PostgreSQL or MySQL listener or general dialect translation layer yet. The
-public Rust SQL facade can parse an explicitly selected SQLite, PostgreSQL, or
-MySQL dialect, consume that result with
+PostgreSQL or MySQL listener. The public Rust SQL facade can parse an explicitly
+selected SQLite, PostgreSQL, or MySQL dialect, consume that result with
 `validate_common_subset(ParsedSql)`, and then opt into
-`normalize_placeholders(CommonSql)`. That step yields canonical SQLite `?N`
-text and per-statement parameter metadata. Callers may then pass one
-statement's exact bound-value slice and selected logical database to
-`infer_shard_keys`, which returns a typed key classification. Synchronous
+`normalize_placeholders(CommonSql)`. That step yields source-preserving SQLite
+`?N` text and per-statement parameter metadata. A caller can consume the owned
+normalized result with `translate_sql`, explicitly selecting either finite
+compatibility translation or strict SQLite preservation; there is no default
+mode. Translation returns separate SQLite SQL while retaining the exact source
+and normalized bind metadata.
+
+Callers may pass one statement's exact bound-value slice and selected logical
+database from the retained normalized result to `infer_shard_keys`, which
+returns a typed key classification. Synchronous
 `Engine::plan_bound_statement` accepts the same concrete bind plus an optional
 explicit routing byte sequence, retains the inference, and produces owned
 physical routes with schema and routing provenance. It compares finite inferred
 and explicit routes by physical shard, rejects unroutable cataloged sharded
-DML, and records a valid single-shard assignment. It does not generally
-translate, authorize, enforce batch policy, or execute a statement. HTTP
-requests still send SQLite SQL directly to `rusqlite`; they do not pass through
-these opt-in SQL layers.
+DML, and records a valid single-shard assignment. The planner does not invoke
+translation, authorize, enforce batch policy, or execute a statement. HTTP
+requests still send caller-provided SQLite SQL directly to `rusqlite`; they do
+not pass through these opt-in SQL layers.
 
 | Interface | Status | SQL accepted | Routing |
 | --- | --- | --- | --- |
 | HTTP `/v1/execute` | Experimental | One SQLite statement with positional parameters | Required caller-provided `shard_key` |
 | HTTP `/v1/query` | Experimental | One prepared SQLite statement executed through the row-returning path | Required caller-provided `shard_key` |
 | HTTP `/v1/admin/broadcast` | Experimental | A journaled parameterless SQLite schema batch | Preflight on every shard, then ascending resumable apply |
-| PostgreSQL wire protocol | Planned | Common subset plus documented PostgreSQL normalization | Rust inference and bind-time single-shard routing policy implemented; wire lifecycle and session integration planned |
-| MySQL wire protocol | Planned | Common subset plus documented MySQL normalization | Rust inference and bind-time single-shard routing policy implemented; wire lifecycle and session integration planned |
+| PostgreSQL wire protocol | Planned | Rust parsing, validation, placeholder normalization, and finite compatibility translation implemented; listener adoption planned | Rust inference and bind-time single-shard routing policy implemented; wire lifecycle and session integration planned |
+| MySQL wire protocol | Planned | Rust parsing, validation, placeholder normalization, and finite compatibility translation implemented; listener adoption planned | Rust inference and bind-time single-shard routing policy implemented; wire lifecycle and session integration planned |
 
-The parser, subset validator, placeholder normalizer, shard-key inference
-function, and engine planner are implemented Rust APIs, not network
+The parser, subset validator, placeholder normalizer, SQL translator, shard-key
+inference function, and engine planner are implemented Rust APIs, not network
 interfaces. Each step is opt-in and does not change any current network row in
 this table.
 
@@ -273,8 +278,9 @@ dialect and parsed-batch types. The pinned snapshot contains corrected
 `parse_interval` recursion accounting plus other reviewed upstream changes
 after the `v0.62.0` tag. Callers select SQLite, PostgreSQL, or MySQL explicitly;
 generic parsing, dialect autodetection, and fallback parsing are not available.
-Exact SQL is retained because formatting an AST is not source preserving and
-formatted AST text is never sent to SQLite.
+Exact SQL is retained because formatting an AST is not source preserving.
+Compatibility translation renders a separate canonical SQLite representation;
+the current network paths do not consume that representation.
 
 Parsing establishes only that one dialect recognizes the syntax. It does not
 make a statement part of BriskDB's supported common subset or establish that
@@ -290,26 +296,29 @@ when every top-level statement and nested form is in the first subset. Empty
 and mixed batches may validate because request-level batch policy remains issue
 #27. `normalize_placeholders(CommonSql)` then returns an owned `NormalizedSql`
 with canonical SQLite parameter text and one parameter record per statement.
-`infer_shard_keys` can consume that result with catalog context and a complete
-bound-value slice for one statement. `Engine::plan_bound_statement` consumes
-that same concrete bind when a caller needs physical routes and a validated
-single-shard assignment. The SQL wrapper types retain exact source, dialect,
-and statement count without exposing the upstream AST or rendering SQL in
-`Debug` output.
+`translate_sql` can consume it and return an owned `TranslatedSql` containing a
+separate SQLite representation while retaining the complete normalized result.
+`infer_shard_keys` can use that retained result with catalog context and a
+complete bound-value slice for one statement. `Engine::plan_bound_statement`
+consumes that same concrete bind when a caller needs physical routes and a
+validated single-shard assignment. The SQL wrapper types retain exact source,
+dialect, and statement count without exposing the upstream AST or rendering
+SQL in `Debug` output.
 
-The parser, validator, and normalizer have no routing or storage access. The
-implemented inference layer borrows only the read-only logical catalog and
-protocol-neutral bound values; it consumes structural syntax, never
-regular-expression matches over raw or formatted SQL. See the [SQL parser
-decision record](SQL_PARSER.md) for the dependency and resource contract, the
-[common SQL subset contract](SQL_SUBSET.md) for the normative recursive
-whitelist, and the [SQL parameter-normalization
-contract](SQL_PARAMETERS.md) for numbering and source-preservation rules. The
-[shard-key inference contract](SQL_SHARD_KEYS.md) defines the supported proof
-grammar and typed result. The [bound statement-planning and routing-policy
-contract](SQL_PLANNING.md) defines canonical route bytes, occurrence ordering,
-physical-target comparison, write rejection, provenance, and the
-non-executable planning boundary.
+The parser, validator, normalizer, and translator have no routing or storage
+access. The implemented inference layer borrows only the read-only logical
+catalog and protocol-neutral bound values; it consumes structural syntax,
+never regular-expression matches over raw or formatted SQL. See the [SQL
+parser decision record](SQL_PARSER.md) for the dependency and resource
+contract, the [common SQL subset contract](SQL_SUBSET.md) for the normative
+recursive whitelist, the [SQL parameter-normalization
+contract](SQL_PARAMETERS.md) for numbering and source-preservation rules, and
+the [SQL translation contract](SQL_TRANSLATION.md) for modes and the finite
+type and syntax matrix. The [shard-key inference contract](SQL_SHARD_KEYS.md)
+defines the supported proof grammar and typed result. The [bound
+statement-planning and routing-policy contract](SQL_PLANNING.md) defines
+canonical route bytes, occurrence ordering, physical-target comparison, write
+rejection, provenance, and the non-executable planning boundary.
 
 ### Implemented pass-through surface
 
@@ -351,7 +360,7 @@ The opt-in validator recursively admits these statement families:
 | --- | --- |
 | `CREATE TABLE` | One unqualified persistent table, optional `IF NOT EXISTS`, one or more columns with any explicit parsed type, and the supported literal defaults plus primary-key, unique, and check constraints |
 | `CREATE INDEX` | A named optional-unique index on plain columns of one unqualified table; `IF NOT EXISTS` and `ASC`/`DESC` are accepted |
-| `SELECT` | A nonempty projection with zero or one plain table; optional simple alias, `ALL`/`DISTINCT`, scalar filtering/grouping, `HAVING`, expression ordering, and standard numeric-or-placeholder limit/offset; PostgreSQL `LIMIT ALL` is parser-equivalent to no limit |
+| `SELECT` | A nonempty projection with zero or one plain table; optional simple alias, `ALL`/`DISTINCT`, scalar filtering/grouping, `HAVING`, expression ordering, and standard or MySQL/SQLite comma-form numeric-or-placeholder limit/offset; PostgreSQL `LIMIT ALL` is parser-equivalent to no limit |
 | `INSERT` | One named table, an explicit column list unique under conservative ASCII case folding, and one or more equal-width `VALUES` rows |
 | `UPDATE` | One plain table, single-column assignments whose targets are unique under conservative ASCII case folding, and an optional predicate |
 | `DELETE` | One plain `FROM` table and an optional predicate |
@@ -370,15 +379,18 @@ name, and diagnostic rules are normative in
 [the common SQL subset contract](SQL_SUBSET.md).
 
 This implemented status means structural validation exists and is tested. It
-does not mean the subset is connected to execution. Column type names are only
-required to be explicit; type compatibility and translation remain issue #25.
-Insert/update duplicate checks fold ASCII letter case regardless of quoting but
-do not define general identifier normalization, which also remains issue #25.
+does not mean the subset is connected to execution. Column type names need only
+be explicit at validation; the separate compatibility translator applies its
+finite dialect-specific declaration whitelist. Insert/update duplicate checks
+fold ASCII letter case regardless of quoting. Compatibility translation
+canonicalizes accepted backtick-quoted identifiers, but does not define general
+case folding, Unicode normalization, collation, or catalog equivalence.
 Placeholder normalization is the separate implemented issue #21 layer described
-below, and catalog-aware typed key extraction is the implemented issue #22
-layer. Synchronous bind-time route construction is the implemented issue #23
-layer, and issue #24 adds physical-target comparison, assigned shards, and
-rejection of conflicting or unroutable cataloged sharded writes.
+below, the translator is the implemented issue #25 layer, and catalog-aware
+typed key extraction is the implemented issue #22 layer. Synchronous bind-time
+route construction is the implemented issue #23 layer, and issue #24 adds
+physical-target comparison, assigned shards, and rejection of conflicting or
+unroutable cataloged sharded writes.
 Prepare/bind/describe/execute state remains issue #26, and empty or
 multi-statement execution policy remains issue #27.
 
@@ -413,8 +425,34 @@ error contract are in [SQL parameter normalization](SQL_PARAMETERS.md).
 
 This implemented normalization does not bind or count supplied values, infer a
 shard, translate other dialect syntax, create a prepared statement, classify
-statement behavior, authorize a request, or execute SQL. The HTTP and engine
-paths continue to bind their existing caller-supplied SQLite SQL directly.
+statement behavior, authorize a request, or execute SQL. Translation is the
+separate opt-in layer described next. The HTTP and engine paths continue to
+bind their existing caller-supplied SQLite SQL directly.
+
+### Implemented SQL translation
+
+The public Rust function `translate_sql(NormalizedSql, SqlTranslationMode)` is
+an opt-in, protocol-neutral step. There is deliberately no default mode.
+`StrictSqlite` accepts only SQLite source and returns
+`NormalizedSql::sqlite_parameter_sql()` byte for byte. `Compatibility` clones
+the validated AST, applies the documented finite mappings, and renders a
+separate canonical SQLite string. Both results retain the exact original source
+and complete normalized placeholder metadata.
+
+The compatibility type whitelist is keyed by source dialect. It maps selected
+signed integer declarations to `BIGINT`, Boolean declarations to `BOOLEAN`,
+selected 64-bit floating-point declarations to `REAL`, variable text to `TEXT`,
+and variable binary to `BLOB`. It rejects declarations outside that matrix
+instead of choosing an uncontracted representation. Strict SQLite translation
+continues to preserve arbitrary validated SQLite declared type names.
+
+The syntax mappings cover accepted backtick-quoted identifiers, Boolean
+literals, transaction aliases, and MySQL/SQLite comma-form limits. Placeholder
+indices retain their statement-local source identities even when comma-limit
+operands are reordered. This layer does not implement server-specific value or
+result metadata adapters, identifier case folding, collations, function shims,
+upserts, wire session behavior, preparation, routing, or execution. The exact
+matrix and error contract are in [SQL translation](SQL_TRANSLATION.md).
 
 ### Implemented shard-key inference
 
@@ -481,16 +519,16 @@ not implemented unless listed as implemented in this document.
 | Area | PostgreSQL | BriskDB contract |
 | --- | --- | --- |
 | Parameters | `$1`, `$2`, ... | Implemented opt-in Rust normalization, typed inference, and single-shard routing policy from a supplied bound slice; wire bind lifecycle remains planned |
-| Identifier quoting | Double quotes | Passed through where SQLite semantics agree |
-| Type system | Static types identified by OIDs | Planned loss-aware mapping to BriskDB types and SQLite storage classes |
-| Boolean | Dedicated `boolean` type | Stored as SQLite integer `0` or `1`; protocol adapter returns a Boolean value |
+| Identifier quoting | Double quotes | Retained by opt-in compatibility translation; PostgreSQL case folding and catalog equivalence are not claimed |
+| Type system | Static types identified by OIDs | Opt-in Rust translation maps a finite declaration set to `BIGINT`, `BOOLEAN`, `REAL`, `TEXT`, or `BLOB`; OID and value/result adaptation remain planned |
+| Boolean | Dedicated `boolean` type | Opt-in translation maps the declaration to `BOOLEAN` and literals to `1`/`0`; Boolean wire/result metadata remains planned |
 | `serial`, identity, sequences | Sequence-backed generation | Unsupported until explicit sequence/identity semantics are designed |
-| `bytea` | Binary value | Planned mapping to SQLite `BLOB` |
+| `bytea` | Binary value | Opt-in declaration translation maps it to SQLite `BLOB`; binary value and wire adaptation remain planned |
 | `json` / `jsonb` | Distinct PostgreSQL types | Planned JSON validation; no promise of PostgreSQL `jsonb` storage or operators |
 | Arrays, ranges, enums, domains | Native PostgreSQL types | Unsupported initially |
 | Schemas and `search_path` | Multiple schemas per database | Unsupported initially; compatibility shims may expose one logical schema |
 | `RETURNING` | Common DML feature | Not in the initial common subset |
-| `ON CONFLICT` | PostgreSQL upsert syntax | Supported only after a tested translation contract is defined |
+| `ON CONFLICT` | PostgreSQL upsert syntax | Outside the initial common subset and unsupported |
 | Functions/operators | PostgreSQL catalog | SQLite functions/operators unless an explicit shim is documented |
 | System catalogs | `pg_catalog`, `information_schema` | Only queries required by named, tested clients will be emulated |
 | Error behavior | SQLSTATE and failed transaction state | Stable error-kind-to-SQLSTATE mapping defined; wire encoding and `I`/`T`/`E` transaction states planned |
@@ -509,15 +547,15 @@ engine used by PostgreSQL and HTTP.
 | Area | MySQL | BriskDB contract |
 | --- | --- | --- |
 | Parameters | `?` in prepared statements | Implemented opt-in Rust normalization, typed inference, and single-shard routing policy from a supplied bound slice; wire bind lifecycle remains planned |
-| Identifier quoting | Backticks by default | Planned normalization; double-quoted strict SQL remains available |
-| Type system | Static signed/unsigned column types | BriskDB retains `UInt64` without narrowing; current SQLite binding rejects values above `i64::MAX` until an explicit storage mapping exists |
-| Boolean | Commonly `TINYINT(1)` | Stored as SQLite integer `0` or `1`; protocol adapter returns documented metadata |
+| Identifier quoting | Backticks by default | Opt-in compatibility translation emits safely escaped double-quoted SQLite identifiers; case and collation equivalence are not claimed |
+| Type system | Static signed/unsigned column types | Opt-in Rust translation maps a finite signed integer, Boolean, 64-bit float, text, and binary declaration set; unsigned declarations are rejected, and translation performs no value or result adaptation. Independently, BriskDB retains `UInt64` values without narrowing, while current SQLite binding rejects values above `i64::MAX` until a storage mapping exists |
+| Boolean | Commonly `TINYINT(1)` | Opt-in translation maps exactly `TINYINT(1)` to `BOOLEAN` and Boolean literals to `1`/`0`; wire/result metadata remains planned |
 | `AUTO_INCREMENT` | Table column attribute | Unsupported until generated-key semantics are designed |
-| `UNSIGNED`, display widths | MySQL column attributes | No current SQLite equivalent; unsupported initially |
+| `UNSIGNED`, display widths | MySQL column attributes | Rejected by compatibility translation, except that exactly `TINYINT(1)` is the documented Boolean declaration |
 | `DATETIME`, `TIMESTAMP` | Distinct MySQL temporal behavior | No implicit compatibility; canonical timestamp encoding must be defined first |
 | `JSON` | Native MySQL JSON type | Planned JSON validation stored using the canonical BriskDB representation |
-| `LIMIT offset,count` | MySQL syntax | Planned normalization to canonical limit/offset form |
-| `ON DUPLICATE KEY UPDATE` | MySQL upsert syntax | Unsupported until a tested translation contract is defined |
+| `LIMIT offset,count` | MySQL syntax | Opt-in compatibility translation emits `LIMIT count OFFSET offset` while retaining placeholder identities |
+| `ON DUPLICATE KEY UPDATE` | MySQL upsert syntax | Outside the initial common subset and unsupported |
 | Engines, character sets, collations | Per-table/column options | Engine clauses unsupported; charset/collation behavior must be explicitly mapped |
 | Session probes | `SET NAMES`, `SHOW VARIABLES`, `SELECT @@...` | Only the subset required by named, tested clients will be emulated |
 | Metadata | `information_schema` and MySQL metadata commands | Minimal tested compatibility only |
@@ -528,6 +566,8 @@ engine used by PostgreSQL and HTTP.
 
 SQLite is the execution authority. Unless BriskDB documents a compatibility
 translation, its behavior follows SQLite rather than PostgreSQL or MySQL.
+Compatibility translation is a finite mapping, not a claim of full server
+semantics. `StrictSqlite` preserves normalized SQLite source instead.
 
 - SQLite values use the `NULL`, `INTEGER`, `REAL`, `TEXT`, and `BLOB` storage
   classes. Ordinary tables use type affinity rather than rigid column typing.
@@ -541,8 +581,9 @@ translation, its behavior follows SQLite rather than PostgreSQL or MySQL.
 - Numeric conversion, collation, null ordering, division, and comparison rules
   can differ from both server databases. Distributed merge operations must
   reproduce the chosen SQLite semantics explicitly.
-- `STRICT` tables can provide stronger enforcement, but BriskDB does not enable
-  strict mode implicitly.
+- SQLite `STRICT` tables can provide stronger enforcement, but BriskDB does not
+  enable them implicitly. That table option is unrelated to
+  `SqlTranslationMode::StrictSqlite`.
 
 See SQLite's official [SQL language reference](https://www.sqlite.org/lang.html)
 and [datatype documentation](https://www.sqlite.org/datatype3.html) for the
@@ -641,7 +682,8 @@ and failure tests that establish such a guarantee.
 A syntax or behavior moves from planned to implemented only with tests at the
 right boundary:
 
-- unit tests for parsing, normalization, routing, type conversion, and errors;
+- unit tests for parsing, normalization, translation, routing, type conversion,
+  and errors;
 - golden tests for wire messages, placeholders, type metadata, and error codes;
 - differential tests against a single SQLite reference database for supported
   SQL and scatter/gather behavior;

--- a/docs/SQL_PARAMETERS.md
+++ b/docs/SQL_PARAMETERS.md
@@ -23,6 +23,11 @@ engine do not invoke this opt-in layer; they retain their existing raw SQLite
 behavior. Issue #27 owns whether an empty batch, one statement, or a particular
 multi-statement combination may execute.
 
+The separate [SQL translation layer](SQL_TRANSLATION.md) can consume the
+result and either expose the normalized SQLite text exactly in strict mode or
+render the documented finite compatibility subset as canonical SQLite SQL.
+Translation remains an explicit additional call.
+
 ## Public result
 
 `NormalizedSql` retains both representations:
@@ -148,11 +153,12 @@ A successful `NormalizedSql` does not establish that:
 
 - the caller supplied exactly `parameter_count()` values until the separate
   shard-key inference call validates that count;
-- non-shard-key parameters have types compatible with later translation and
+- non-shard-key parameters have types compatible with translation and
   execution;
 - an inferred value has been encoded, hashed, or routed to one shard;
 - catalog names and types exist or are compatible;
-- non-placeholder PostgreSQL or MySQL syntax has been translated to SQLite;
+- non-placeholder PostgreSQL or MySQL syntax has been translated to SQLite
+  until the separate `translate_sql` call succeeds;
 - a statement or batch is permitted by an endpoint or session;
 - a prepared statement has been described, cached, bound, or executed; or
 - execution would preserve all source-dialect semantics.
@@ -162,9 +168,9 @@ metadata plus a catalog database and exact bound-value slice. The implemented
 [bound statement planner and routing policy](SQL_PLANNING.md) uses that result
 only after values are bound, compares finite physical targets, rejects
 unroutable cataloged sharded writes, and records a valid single-shard
-assignment. Issues #25 through #27 own syntax/type translation,
-prepared-statement state, and request-level statement classification
-respectively.
+assignment. The implemented issue #25 translation layer is separate from this
+normalizer. Issues #26 and #27 own prepared-statement state and request-level
+statement classification respectively.
 
 ## Verification obligations
 

--- a/docs/SQL_PARSER.md
+++ b/docs/SQL_PARSER.md
@@ -8,7 +8,9 @@ invent its own routing rules. This record selects the parser dependency and
 defines that boundary. The separate [common SQL subset contract](SQL_SUBSET.md)
 defines the opt-in structural validator, and the [SQL parameter-normalization
 contract](SQL_PARAMETERS.md) defines the opt-in dialect-specific placeholder
-rewrite. None of these layers is in the current HTTP execution path.
+rewrite. The [SQL translation contract](SQL_TRANSLATION.md) defines the
+implemented opt-in strict and finite compatibility modes. None of these layers
+is in the current HTTP execution path.
 
 ## Decision
 
@@ -45,9 +47,11 @@ it through BriskDB-owned interfaces, but protocol adapters must not depend on
 
 `sqlparser`'s formatter is not a source-preserving serializer: it can normalize
 comments, whitespace, quoting, and keyword presentation. BriskDB therefore
-never executes an AST's `Display` output and does not use that output as a
-migration identity. Execution and byte-identity operations retain their exact
-original SQL unless a later, documented translation produces separate SQL.
+never treats an AST's `Display` output as original source or migration identity.
+Strict SQLite translation and byte-identity operations retain exact normalized
+source. The implemented compatibility translator is the one documented layer
+that deliberately renders a cloned validated AST into a separate
+`TranslatedSql::sqlite_sql()` representation.
 
 ## Syntax-only contract
 
@@ -67,7 +71,8 @@ In particular, this layer does not:
 - itself plan bound statements; issue #23 implements that as the separate
   synchronous `Engine::plan_bound_statement` layer, and issue #24 extends that
   call with physical-target comparison and sharded-write policy;
-- translate types or syntax, or choose strict SQLite mode (issue #25);
+- itself translate types or syntax; issue #25 implements that as the separate
+  `translate_sql(NormalizedSql, SqlTranslationMode)` layer;
 - implement prepare/bind/describe/execute state or caches (issue #26); or
 - classify statement behavior or reject unsafe multi-statement combinations
   (issue #27).
@@ -81,11 +86,11 @@ that still does not grant permission to execute an empty or mixed batch.
 
 The existing HTTP execute, query, and migration paths remain raw SQLite
 pass-through surfaces with their existing authorizer and endpoint-specific
-rules. They call neither this parser, the opt-in common-subset validator, nor
-the opt-in placeholder normalizer, shard-key inference, or bound statement
-planner. Connecting those layers before translation, the prepared execution
-lifecycle, and request-level statement policy are implemented would change the
-experimental HTTP SQL surface.
+rules. They call neither this parser, the opt-in common-subset validator,
+placeholder normalizer, translator, shard-key inference, nor bound statement
+planner. Connecting those layers before the prepared execution lifecycle and
+request-level statement policy are implemented would change the experimental
+HTTP SQL surface.
 
 ## Resource and error boundaries
 
@@ -130,7 +135,11 @@ correction is selected, or an equivalently reviewed published dependency is
 available.
 
 BriskDB enables `sqlparser`'s recursive-protection support in addition to
-setting the explicit depth limit. In the dependency graph selected by the
+setting the explicit depth limit. It also enables the dependency's visitor
+derives so the compatibility translator can mutate every identifier and value
+in the already bounded, validated AST without maintaining a second recursive
+expression walker. Upstream visitor types remain private to the SQL module.
+In the dependency graph selected by the
 spike, the newest `psm` release admitted by `stacker` pulls in build
 dependencies that require Rust 1.88. BriskDB supports Rust 1.85, so both
 `Cargo.toml` and `Cargo.lock` constrain `psm` to `0.1.28`, whose dependency

--- a/docs/SQL_PLANNING.md
+++ b/docs/SQL_PLANNING.md
@@ -230,16 +230,19 @@ execution path. In particular:
 - no read scatter, merge, contradiction short circuit, or write executes here;
 - no transaction pinning or cross-call routing context is applied;
 - no per-session or global prepared-statement cache is created;
-- no PostgreSQL or MySQL syntax or type is translated;
+- planning does not invoke the separate PostgreSQL/MySQL-to-SQLite translation
+  layer;
 - no complete read/write/schema/session or batch classifier is published; and
 - the current HTTP execute, query, and migration paths do not invoke parsing,
   validation, normalization, inference, or planning.
 
-Issue #25 owns selected syntax and type translation. Issue #26 owns the
-protocol-neutral prepare/bind/describe/execute lifecycle, session integration,
-provenance revalidation, and bounded per-session cache. Issue #27 owns the
-authoritative statement-behavior and empty, single-, and multi-statement
-request policy. Later query-planner work owns scatter/gather execution.
+The implemented issue #25 translation API can independently consume the same
+normalized statement, but it neither changes nor executes a bound plan. Issue
+#26 owns the protocol-neutral prepare/bind/describe/execute lifecycle, session
+integration, provenance revalidation, and bounded per-session cache. Issue #27
+owns the authoritative statement-behavior and empty, single-, and
+multi-statement request policy. Later query-planner work owns scatter/gather
+execution.
 
 ## Verification obligations
 

--- a/docs/SQL_SHARD_KEYS.md
+++ b/docs/SQL_SHARD_KEYS.md
@@ -166,9 +166,10 @@ The implemented synchronous
 bind/execute time and turns every inferred value into an owned route. It
 retains optional explicit routing separately, compares finite physical targets,
 rejects unroutable sharded DML, and records a valid single-shard assignment.
-The result is still not executable. Later work owns syntax translation,
-prepared-statement lifecycle, authoritative statement classification, and
-wire-protocol integration.
+The result is still not executable. The implemented issue #25 translator is a
+separate opt-in operation over the same normalized SQL; it does not change an
+inference result. Later work owns prepared-statement lifecycle, authoritative
+statement classification, and wire-protocol integration.
 
 ## Verification obligations
 

--- a/docs/SQL_SUBSET.md
+++ b/docs/SQL_SUBSET.md
@@ -45,11 +45,11 @@ A successful `CommonSql` does not mean that the SQL:
 - has been executed.
 
 Those responsibilities remain with the implemented issue #21 normalization,
-issue #22 inference, and issues #23/#24 bound planning and routing-policy
-layers, issues #25 through #27, and the later wire frontends. Validation never
-consults parameters, a session, the logical catalog, storage, routing state,
-the filesystem, or SQLite. It never formats or searches SQL text to make a
-structural decision.
+issue #22 inference, issues #23/#24 bound planning and routing-policy layers,
+the separate issue #25 translation layer, issues #26/#27, and the later wire
+frontends. Validation never consults parameters, a session, the logical
+catalog, storage, routing state, the filesystem, or SQLite. It never formats or
+searches SQL text to make a structural decision.
 
 Empty and comment-only parsed batches validate successfully. Every statement in
 a mixed batch is checked independently and source order is retained, but that
@@ -62,7 +62,7 @@ statement behavior classification, and safe statement combinations.
 | --- | --- | --- |
 | `CREATE TABLE` | One unqualified, persistent table; optional `IF NOT EXISTS`; one or more columns, each with an explicit parsed type; the column and table constraints described below | Qualified names, temporary or other table modifiers, table-as-query, `LIKE`/clone, storage/lifecycle/vendor options, partitioning/inheritance, SQLite `STRICT` or `WITHOUT ROWID` |
 | `CREATE INDEX` | A named, unqualified index on one unqualified table; optional `UNIQUE` and `IF NOT EXISTS`; one or more plain columns with optional `ASC` or `DESC` | Unnamed, qualified, expression, or partial indexes; `USING`, operator classes, `INCLUDE`, null-order, concurrent/async, storage, or vendor options |
-| `SELECT` | A nonempty projection with no `FROM` or one unqualified base table; optional simple table alias, `ALL`/`DISTINCT`, `WHERE`, `GROUP BY`, `HAVING`, expression `ORDER BY`, and standard `LIMIT`/`OFFSET` | CTEs, set operations, nested queries, multiple tables, joins, derived/table functions, `DISTINCT ON`, `SELECT INTO`, windows, locks, `FETCH`, `TOP`, query hints/settings/formats, MySQL comma-form limit |
+| `SELECT` | A nonempty projection with no `FROM` or one unqualified base table; optional simple table alias, `ALL`/`DISTINCT`, `WHERE`, `GROUP BY`, `HAVING`, expression `ORDER BY`, and either standard `LIMIT`/`OFFSET` or the MySQL/SQLite comma-form limit | CTEs, set operations, nested queries, multiple tables, joins, derived/table functions, `DISTINCT ON`, `SELECT INTO`, windows, locks, `FETCH`, `TOP`, query hints/settings/formats |
 | `INSERT` | `INSERT INTO` one unqualified named table with a nonempty explicit column list whose names are unique under ASCII case folding, plus one or more equal-width `VALUES` rows | Omitted, exact-duplicate, or ASCII-case-only duplicate columns; row-width mismatch; `DEFAULT VALUES`; `INSERT ... SELECT`; aliases; conflict/upsert/ignore/replace forms; partitioning; `RETURNING`; output; multi-table, format, or settings clauses |
 | `UPDATE` | One unqualified base table with an optional simple alias, one or more single-column assignments whose targets are unique under ASCII case folding, and an optional `WHERE` | Joins, qualified or tuple assignment targets, exact-duplicate or ASCII-case-only duplicate targets, `FROM`, conflict modes, `RETURNING`, output, `ORDER BY`, or `LIMIT` |
 | `DELETE` | `DELETE FROM` exactly one unqualified base table with an optional simple alias and optional `WHERE` | Missing `FROM`, multiple tables, joins, `USING`, `RETURNING`, output, `ORDER BY`, or `LIMIT` |
@@ -76,9 +76,10 @@ an explicit `AND NO CHAIN`, to the same semantic AST forms. The validator
 deliberately accepts that AST family and does not search retained source text to
 distinguish equivalent spellings; the explicit source dialect must still parse
 a spelling first. `BEGIN`, `COMMIT`, and `ROLLBACK` remain syntax families only
-at this boundary. Canonical syntax translation remains issue #25. Real
-multi-call transaction state, failed-transaction behavior, connection and shard
-pinning, and protocol status reporting remain issues #34 and #47.
+at this boundary. The separate issue #25 compatibility translator canonicalizes
+the accepted aliases to SQLite SQL. Real multi-call transaction state,
+failed-transaction behavior, connection and shard pinning, and protocol status
+reporting remain issues #34 and #47.
 
 An absent `WHERE` on `UPDATE` or `DELETE` is structurally valid. Likewise,
 validation does not inspect whether an assignment changes a shard-key column.
@@ -100,14 +101,17 @@ wildcard modifiers.
 Insert column lists and update assignment targets reject exact duplicates and
 names that differ only by ASCII letter case, regardless of quoting. This is a
 conservative common key for duplicate detection, not full PostgreSQL, MySQL,
-SQLite, Unicode, quoted-identifier, or catalog normalization. General
-identifier normalization and translation remain issue #25.
+SQLite, Unicode, quoted-identifier, or catalog normalization. The separate
+compatibility translator converts accepted MySQL backtick quoting to SQLite
+double quoting; it does not add general case, Unicode, or catalog-name
+normalization.
 
 The validator requires every `CREATE TABLE` column to have an explicit parsed
 type, but it deliberately does not restrict the type name. Acceptance therefore
 does not promise a cross-protocol representation or SQLite translation for that
-type. Canonical type aliases, dialect differences, and strict SQLite mode remain
-issue #25.
+type. The separate [SQL translation contract](SQL_TRANSLATION.md) defines the
+finite type whitelist used by compatibility mode and the exact preservation
+provided by strict SQLite mode.
 
 ### Table constraints and defaults
 
@@ -162,12 +166,15 @@ unknown function are rejected.
 
 `WHERE`, assignment, and `GROUP BY` expressions cannot contain aggregates.
 Insert row expressions use the same scalar grammar but cannot reference a
-column. A retained `LIMIT` or `OFFSET` value accepts only an unsigned digit-only
-numeric literal or a placeholder. The pinned parser represents PostgreSQL
-`LIMIT ALL` as the same absent-limit AST as omitting the clause, so structural
-validation accepts that AST-equivalent spelling and does not inspect source text
-to distinguish it. Placeholder spelling, numbering, count, and binding are not
-validated or changed here. The separate [SQL parameter-normalization
+column. A retained standard `LIMIT`/`OFFSET` operand or comma-form offset/count
+operand accepts only an unsigned digit-only numeric literal or a placeholder.
+The validator retains operand identity; compatibility translation later
+rewrites comma form to `LIMIT count OFFSET offset`. The pinned parser represents
+PostgreSQL `LIMIT ALL` as the same absent-limit AST as omitting the clause, so
+structural validation accepts that AST-equivalent spelling and does not inspect
+source text to distinguish it. Placeholder spelling, numbering, count, and
+binding are not validated or changed here. The separate [SQL
+parameter-normalization
 contract](SQL_PARAMETERS.md) defines the implemented opt-in numbering step,
 which consumes `CommonSql` without accepting bound values.
 The [shard-key inference contract](SQL_SHARD_KEYS.md) then defines the exact

--- a/docs/SQL_TRANSLATION.md
+++ b/docs/SQL_TRANSLATION.md
@@ -1,0 +1,199 @@
+# SQL translation
+
+Status: implemented for roadmap issue #25
+
+BriskDB exposes an opt-in, protocol-neutral translation step after common SQL
+validation and placeholder normalization:
+
+```rust
+translate_sql(
+    normalized: NormalizedSql,
+    mode: SqlTranslationMode,
+) -> EngineResult<TranslatedSql>
+```
+
+The call consumes the owned `NormalizedSql` and returns an owned
+`TranslatedSql`. The result retains the exact original source, source dialect,
+statement parameter layouts, and complete normalized representation. It also
+contains a separate `sqlite_sql()` string for a later SQLite prepare step.
+
+Translation is pure SQL analysis. It accepts no catalog, session, routing key,
+bound values, storage handle, or protocol object. It does not prepare,
+authorize, classify a request batch, route, or execute a statement.
+
+## Explicit modes
+
+BriskDB deliberately has no default translation mode. The roadmap leaves the
+eventual server default undecided, so callers select a mode explicitly from
+trusted connection or API context.
+
+### `StrictSqlite`
+
+Strict mode requires input parsed as `SqlDialect::Sqlite`. Input parsed as
+PostgreSQL or MySQL returns `InvalidArgument` rather than silently changing its
+dialect.
+
+The output is byte-for-byte equal to
+`NormalizedSql::sqlite_parameter_sql()`. Comments, whitespace, CRLF, keyword
+case, quoted identifiers, literals, UTF-8, separators, and arbitrary explicit
+SQLite declared type names remain unchanged. Only the earlier positional
+placeholder normalization may differ from `source()`.
+
+Strict translation does not bypass parsing, common-subset validation, or
+placeholder normalization. It is also unrelated to SQLite's
+`CREATE TABLE ... STRICT` option, which remains outside the structural common
+subset. Existing raw HTTP SQLite pass-through remains a separate interface and
+is not routed through this API.
+
+### `Compatibility`
+
+Compatibility mode clones the already validated opaque AST, applies only the
+finite mappings below, replaces placeholders with their existing SQLite `?N`
+identities, and renders canonical SQLite SQL. `source()` remains the exact
+caller input and is authoritative for source identity.
+
+Canonical rendering may change comments, whitespace, keyword case, redundant
+parentheses, identifier presentation, and statement separators. Ordered
+statements are joined with `; `; an empty or comment-only input produces empty
+SQLite SQL. Rendered compatibility SQL must never be used as application-schema
+migration identity.
+
+## Type mapping
+
+Compatibility translation admits only the mappings in this section. The
+whitelist is keyed by both source dialect and parsed type because the parser can
+recognize spellings that the named server dialect does not promise.
+
+| Logical family | SQLite source spellings | PostgreSQL source spellings | MySQL source spellings | Canonical declaration |
+| --- | --- | --- | --- | --- |
+| Signed integer | Bare `TINYINT`, `SMALLINT`, `MEDIUMINT`, `INT`, `INTEGER`, `BIGINT` | Bare `INT2`, `SMALLINT`, `INT`, `INTEGER`, `INT4`, `BIGINT`, `INT8` | Bare `TINYINT`, `SMALLINT`, `MEDIUMINT`, `INT`, `INTEGER`, `BIGINT` | `BIGINT` |
+| Boolean | `BOOL`, `BOOLEAN` | `BOOL`, `BOOLEAN` | `BOOL`, `BOOLEAN`, exactly `TINYINT(1)` | `BOOLEAN` |
+| 64-bit floating point | `REAL` | `FLOAT8`, `DOUBLE PRECISION` | Bare `DOUBLE`, `DOUBLE PRECISION` | `REAL` |
+| Variable text | `TEXT`, `VARCHAR[(n)]`, `CHAR[ACTER] VARYING[(n)]` | Same variable-text family | Same variable-text family | `TEXT` |
+| Variable binary | `BLOB` | `BYTEA` | `BLOB`, `VARBINARY[(n)]` | `BLOB` |
+
+`n` is an unsigned integer with no length unit. Accepted varying text and
+binary lengths are declaration metadata only: BriskDB removes them and SQLite
+does not enforce those source-server length limits.
+
+Signed integers canonicalize to `BIGINT`, not exact SQLite `INTEGER`. SQLite
+gives `INTEGER PRIMARY KEY` special rowid-alias and generated-rowid behavior.
+Compatibility mode does not invent that behavior for PostgreSQL or MySQL
+integer aliases. Strict SQLite mode retains an explicitly requested
+`INTEGER PRIMARY KEY` declaration exactly.
+
+`TINYINT(1)` is accepted only as the documented MySQL Boolean convention. The
+canonical `BOOLEAN` declaration and translated `0`/`1` literals do not add a
+Boolean check constraint; ordinary SQLite affinity rules remain authoritative.
+
+The initial compatibility set rejects, among other forms:
+
+- signed integer display widths other than MySQL `TINYINT(1)` and every
+  unsigned or zero-fill integer;
+- `DECIMAL`, `NUMERIC`, PostgreSQL `REAL`/`FLOAT4`, MySQL `FLOAT`/`REAL`, and
+  parameterized floating-point types;
+- fixed `CHAR` and `BINARY`, whose padding semantics are not reproduced;
+- temporal, interval, JSON/JSONB, UUID, bit-string, array, range, enum, domain,
+  serial, identity, and custom types; and
+- `VARCHAR(MAX)`, `VARBINARY(MAX)`, and explicit character-length units.
+
+Those exclusions avoid choosing representations whose cross-protocol value or
+comparison behavior has not been specified. Strict SQLite mode continues to
+pass arbitrary validated SQLite declared type names through unchanged.
+
+## Syntax mapping
+
+Compatibility mode implements only these syntax differences:
+
+| Accepted source form | Canonical SQLite form |
+| --- | --- |
+| MySQL or SQLite backtick-quoted identifier | Double-quoted SQLite identifier, with decoded embedded characters re-escaped |
+| Boolean literal `TRUE` / `FALSE` | Integer literal `1` / `0` |
+| `BEGIN`, `BEGIN TRANSACTION`, or `BEGIN WORK` | `BEGIN` |
+| Accepted plain `COMMIT` aliases, including `WORK`, `TRAN`, and `AND NO CHAIN` | `COMMIT` |
+| Accepted full rollback/`ABORT` aliases, including `AND NO CHAIN` | `ROLLBACK` |
+| MySQL or SQLite `LIMIT offset, count` | `LIMIT count OFFSET offset` |
+| `OFFSET n ROW` / `OFFSET n ROWS` when represented by the accepted AST | `OFFSET n` |
+
+PostgreSQL `LIMIT ALL` is represented by the pinned parser as the same absent
+limit as an omitted clause and therefore renders with no limit. Standard
+`LIMIT count OFFSET offset` remains canonical.
+
+MySQL comma-limit operands are reordered structurally, but placeholder identity
+is not. For example:
+
+```text
+source:  SELECT `id` FROM `items` WHERE `tenant_id` = ? LIMIT ?, ?
+indices:                                               1       2  3
+SQLite:  SELECT "id" FROM "items" WHERE "tenant_id" = ?1 LIMIT ?3 OFFSET ?2
+```
+
+The translator looks up each placeholder by its retained statement-local source
+span, so PostgreSQL repeats/gaps and reordered MySQL operands keep their
+original bound-value identity. Numbering still restarts for each statement.
+
+Unquoted identifier spelling is retained by the canonical AST. This layer does
+not claim PostgreSQL/MySQL case folding, Unicode normalization, collation, or
+catalog equivalence. It adds no casts, scalar-function shims, upsert,
+`RETURNING`, generated columns, joins, engine clauses, character sets, or
+session statements.
+
+## Result contract
+
+`TranslatedSql` exposes:
+
+- `dialect()` and `mode()`;
+- exact original `source()`;
+- separate `sqlite_sql()`;
+- `normalized_sql()` for the normalized AST and bind metadata still consumed
+  by shard inference and `Engine::plan_bound_statement`;
+- `statement_parameters()` in original source occurrence order; and
+- `statement_count()` and `is_empty()`.
+
+The type is owned, cloneable, `Send`, and `Sync`. Its `Debug` output contains
+only dialect, mode, byte counts, and statement count. It never renders source,
+translated SQL, identifiers, literals, or placeholder spelling.
+
+## Errors and precedence
+
+| Condition | `EngineErrorKind` |
+| --- | --- |
+| `StrictSqlite` with PostgreSQL or MySQL source | `InvalidArgument` |
+| A `CREATE TABLE` column uses a type outside the dialect-specific compatibility whitelist | `Unsupported` |
+| Canonical rendering contains a NUL decoded from source-dialect literal syntax | `InvalidQuery` |
+| Retained AST, statement, parameter, or placeholder-span metadata is inconsistent | `Internal` |
+
+Parsing, subset, and placeholder-normalization errors occur before this API and
+retain their existing kinds. Translation checks the mode first, then statements
+and `CREATE TABLE` columns in source order. The first unsupported type wins.
+
+Diagnostics use fixed categories plus one-based statement and column ordinals
+where useful. They contain no SQL, identifier or type spelling, comment,
+literal, marker, parameter value, formatted AST, or source location. A failure
+retains no caller buffer and changes no shared state; a later independent call
+can succeed.
+
+## Deliberate boundaries
+
+Issue #25 adds no CLI flag, environment variable, listener default, HTTP field,
+wire message, catalog rule, session state, prepared-statement cache, routing
+decision, SQLite execution call, manifest migration, shard-file change, or
+storage-format version. The current HTTP execute/query/migration paths continue
+to send caller-provided SQLite SQL directly to their existing engine paths.
+
+Issue #26 owns protocol-neutral prepare/bind/describe/execute state and adoption
+of `sqlite_sql()`. Issue #27 owns authoritative statement behavior and empty,
+single-, or multi-statement request policy. Schema execution must still use the
+journaled migration path, and later execution must revalidate planning
+provenance before consuming an assigned shard.
+
+## Verification obligations
+
+Tests cover every accepted type alias and excluded family; dialect-specific
+whitelisting; exact strict-mode preservation; canonical identifier, Boolean,
+transaction, and limit syntax; repeated, gapped, reordered, and per-statement
+placeholder identities; empty and 256-statement batches; NUL and synthetic
+metadata failures; diagnostic and `Debug` redaction; deterministic concurrent
+translation; recovery after independent errors; equivalent SQLite,
+PostgreSQL, and MySQL declarations, plans, and executed SQLite results; and the
+absence of changes to raw SQLite execution.

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -872,6 +872,12 @@ later storage-hardening certification.
 - SQLite lock contention remains retryable `Busy`; permission, read-only, full,
   and I/O failures retain the storage error taxonomy.
 
+Issue #25's SQL translation API is an in-memory, opt-in SQL-layer operation. It
+does not change the manifest version, shard files, stored schema text, migration
+digest, or migration identity. Schema migration continues to retain and compare
+the caller's exact submitted SQL; canonical compatibility output is never used
+as storage identity.
+
 The checksums are corruption detectors, not authentication. Both use unkeyed
 BLAKE3 and are writable by anyone who can modify the data directory. The
 manifest root covers canonical control-plane values, not raw SQLite pages. The

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -12,6 +12,7 @@ mod inference;
 mod normalizer;
 mod parser;
 mod subset;
+mod translator;
 
 pub(crate) use dml::{RoutedDml, routed_dml_shape};
 
@@ -24,6 +25,7 @@ pub use parser::{
     SqlDialect, parse,
 };
 pub use subset::{CommonSql, MAX_COMMON_SQL_EXPRESSION_DEPTH, validate_common_subset};
+pub use translator::{SqlTranslationMode, TranslatedSql, translate_sql};
 
 use rusqlite::{
     Connection, params_from_iter,

--- a/src/sql/normalizer.rs
+++ b/src/sql/normalizer.rs
@@ -75,6 +75,17 @@ impl NormalizedSql {
             .ok()
             .map(|index| placeholders[index].index)
     }
+
+    #[cfg(test)]
+    pub(super) fn corrupt_first_placeholder_for_test(&mut self) {
+        if let Some(placeholders) = self
+            .statement_placeholders
+            .iter_mut()
+            .find(|placeholders| !placeholders.is_empty())
+        {
+            placeholders.remove(0);
+        }
+    }
 }
 
 impl fmt::Debug for NormalizedSql {

--- a/src/sql/subset.rs
+++ b/src/sql/subset.rs
@@ -653,23 +653,27 @@ fn validate_limit_clause(
     limit_clause: &LimitClause,
     validation: &mut ValidationState,
 ) -> SubsetResult {
-    let LimitClause::LimitOffset {
-        limit,
-        offset,
-        limit_by,
-    } = limit_clause
-    else {
-        return unsupported("comma-form LIMIT");
-    };
-    let Some(limit) = limit else {
-        return unsupported("LIMIT ALL");
-    };
-    if !limit_by.is_empty() {
-        return unsupported("LIMIT BY");
-    }
-    validate_limit_value(limit, validation)?;
-    if let Some(offset) = offset {
-        validate_limit_value(&offset.value, validation)?;
+    match limit_clause {
+        LimitClause::LimitOffset {
+            limit,
+            offset,
+            limit_by,
+        } => {
+            let Some(limit) = limit else {
+                return unsupported("LIMIT ALL");
+            };
+            if !limit_by.is_empty() {
+                return unsupported("LIMIT BY");
+            }
+            validate_limit_value(limit, validation)?;
+            if let Some(offset) = offset {
+                validate_limit_value(&offset.value, validation)?;
+            }
+        }
+        LimitClause::OffsetCommaLimit { offset, limit } => {
+            validate_limit_value(offset, validation)?;
+            validate_limit_value(limit, validation)?;
+        }
     }
     Ok(())
 }
@@ -1352,7 +1356,13 @@ mod tests {
             SqlDialect::PostgreSql,
             "SELECT COUNT(id, tenant_id) FROM widgets",
         );
-        assert_unsupported(SqlDialect::MySql, "SELECT * FROM widgets LIMIT 10, 20");
+    }
+
+    #[test]
+    fn comma_limit_is_structurally_admitted_for_later_translation() {
+        assert_supported(SqlDialect::MySql, "SELECT * FROM widgets LIMIT 10, 20");
+        assert_supported(SqlDialect::Sqlite, "SELECT * FROM widgets LIMIT 10, 20");
+        assert_supported(SqlDialect::MySql, "SELECT * FROM widgets LIMIT ?, ?");
     }
 
     #[test]

--- a/src/sql/translator.rs
+++ b/src/sql/translator.rs
@@ -1,0 +1,941 @@
+use std::{fmt, ops::ControlFlow};
+
+use sqlparser::ast::{
+    BinaryLength, CharacterLength, DataType as AstDataType, ExactNumberInfo, Ident, LimitClause,
+    Offset, OffsetRows, Query as AstQuery, Statement as AstStatement, Value as AstValue,
+    ValueWithSpan, VisitMut, VisitorMut,
+};
+
+use super::{NormalizedSql, SqlDialect, StatementParameters};
+use crate::core::{EngineError, EngineErrorKind, EngineResult};
+
+/// The SQL compatibility policy applied after structural validation and
+/// placeholder normalization.
+///
+/// BriskDB deliberately has no default translation mode. A caller selects one
+/// from trusted connection or API context for every request.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SqlTranslationMode {
+    /// Translate the documented common compatibility surface to canonical
+    /// SQLite SQL.
+    Compatibility,
+    /// Preserve validated SQLite SQL directly, apart from the placeholder
+    /// normalization that already produced [`NormalizedSql`].
+    StrictSqlite,
+}
+
+impl SqlTranslationMode {
+    /// Every currently implemented translation mode.
+    pub const ALL: &'static [Self] = &[Self::Compatibility, Self::StrictSqlite];
+
+    /// Return the stable display name used in trusted diagnostics.
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Compatibility => "compatibility",
+            Self::StrictSqlite => "strict SQLite",
+        }
+    }
+}
+
+impl fmt::Display for SqlTranslationMode {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.name())
+    }
+}
+
+/// Owned SQL ready for a later SQLite prepare step.
+///
+/// The original validated and normalized request remains available through
+/// [`Self::normalized_sql`]. Compatibility output is a separate canonical
+/// representation; it is never authoritative for migration identity or source
+/// diagnostics.
+#[derive(Clone, PartialEq, Eq)]
+pub struct TranslatedSql {
+    normalized: NormalizedSql,
+    mode: SqlTranslationMode,
+    sqlite_sql: String,
+}
+
+impl TranslatedSql {
+    /// Return the explicitly selected source dialect.
+    pub const fn dialect(&self) -> SqlDialect {
+        self.normalized.dialect()
+    }
+
+    /// Return the translation policy used to produce the SQLite SQL.
+    pub const fn mode(&self) -> SqlTranslationMode {
+        self.mode
+    }
+
+    /// Return the caller's byte-exact original SQL source.
+    pub fn source(&self) -> &str {
+        self.normalized.source()
+    }
+
+    /// Return the separate SQL text for a later SQLite prepare step.
+    pub fn sqlite_sql(&self) -> &str {
+        &self.sqlite_sql
+    }
+
+    /// Borrow the validated placeholder-normalized request retained for
+    /// routing inference and bound-statement planning.
+    pub const fn normalized_sql(&self) -> &NormalizedSql {
+        &self.normalized
+    }
+
+    /// Return one parameter layout for each top-level statement.
+    pub fn statement_parameters(&self) -> &[StatementParameters] {
+        self.normalized.statement_parameters()
+    }
+
+    /// Return the number of independently translated top-level statements.
+    pub fn statement_count(&self) -> usize {
+        self.normalized.statement_count()
+    }
+
+    /// Return whether the parsed input contained no statements.
+    pub fn is_empty(&self) -> bool {
+        self.normalized.is_empty()
+    }
+}
+
+impl fmt::Debug for TranslatedSql {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("TranslatedSql")
+            .field("dialect", &self.dialect())
+            .field("mode", &self.mode)
+            .field("source_bytes", &self.source().len())
+            .field("sqlite_sql_bytes", &self.sqlite_sql.len())
+            .field("statement_count", &self.statement_count())
+            .finish()
+    }
+}
+
+/// Translate normalized common SQL into a separate SQLite representation.
+///
+/// Strict mode accepts only input parsed with [`SqlDialect::Sqlite`] and
+/// returns its source-preserving placeholder-normalized SQL unchanged.
+/// Compatibility mode canonicalizes the documented finite type and syntax
+/// matrix. This function is stateless and does not inspect a catalog, route,
+/// prepare, authorize, or execute any statement.
+pub fn translate_sql(
+    normalized: NormalizedSql,
+    mode: SqlTranslationMode,
+) -> EngineResult<TranslatedSql> {
+    match mode {
+        SqlTranslationMode::StrictSqlite => {
+            if normalized.dialect() != SqlDialect::Sqlite {
+                return Err(EngineError::new(
+                    EngineErrorKind::InvalidArgument,
+                    "strict SQLite translation requires SQLite source SQL",
+                ));
+            }
+            let sqlite_sql = normalized.sqlite_parameter_sql().to_owned();
+            Ok(TranslatedSql {
+                normalized,
+                mode,
+                sqlite_sql,
+            })
+        }
+        SqlTranslationMode::Compatibility => {
+            let sqlite_sql = translate_compatibility(&normalized)?;
+            Ok(TranslatedSql {
+                normalized,
+                mode,
+                sqlite_sql,
+            })
+        }
+    }
+}
+
+fn translate_compatibility(normalized: &NormalizedSql) -> EngineResult<String> {
+    let mut statements = normalized.common().statements().to_vec();
+    if statements.len() != normalized.statement_count()
+        || normalized.statement_parameters().len() != normalized.statement_count()
+    {
+        return Err(translation_invariant());
+    }
+
+    for (statement_index, statement) in statements.iter_mut().enumerate() {
+        translate_column_types(normalized.dialect(), statement_index, statement)?;
+
+        let expected_placeholders =
+            normalized.statement_parameters()[statement_index].occurrence_count();
+        let mut visitor = CompatibilityVisitor {
+            normalized,
+            statement_index,
+            placeholder_count: 0,
+        };
+        if statement.visit(&mut visitor).is_break()
+            || visitor.placeholder_count != expected_placeholders
+        {
+            return Err(translation_invariant());
+        }
+    }
+
+    let sqlite_sql = statements
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join("; ");
+    if sqlite_sql.as_bytes().contains(&0) {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidQuery,
+            "translated SQL contains a NUL byte",
+        ));
+    }
+    Ok(sqlite_sql)
+}
+
+fn translate_column_types(
+    dialect: SqlDialect,
+    statement_index: usize,
+    statement: &mut AstStatement,
+) -> EngineResult<()> {
+    let AstStatement::CreateTable(table) = statement else {
+        return Ok(());
+    };
+
+    for (column_index, column) in table.columns.iter_mut().enumerate() {
+        let Some(translated) = translated_data_type(dialect, &column.data_type) else {
+            return Err(EngineError::new(
+                EngineErrorKind::Unsupported,
+                format!(
+                    "statement {} column {} uses a type outside the translated SQL compatibility set",
+                    statement_index + 1,
+                    column_index + 1
+                ),
+            ));
+        };
+        column.data_type = translated;
+    }
+    Ok(())
+}
+
+fn translated_data_type(dialect: SqlDialect, data_type: &AstDataType) -> Option<AstDataType> {
+    let translated = match dialect {
+        SqlDialect::Sqlite => sqlite_compatibility_type(data_type),
+        SqlDialect::PostgreSql => postgres_compatibility_type(data_type),
+        SqlDialect::MySql => mysql_compatibility_type(data_type),
+    }?;
+    Some(translated.into_ast())
+}
+
+#[derive(Clone, Copy)]
+enum CompatibilityType {
+    Integer,
+    Boolean,
+    Real,
+    Text,
+    Blob,
+}
+
+impl CompatibilityType {
+    const fn into_ast(self) -> AstDataType {
+        match self {
+            Self::Integer => AstDataType::BigInt(None),
+            Self::Boolean => AstDataType::Boolean,
+            Self::Real => AstDataType::Real,
+            Self::Text => AstDataType::Text,
+            Self::Blob => AstDataType::Blob(None),
+        }
+    }
+}
+
+fn sqlite_compatibility_type(data_type: &AstDataType) -> Option<CompatibilityType> {
+    match data_type {
+        AstDataType::TinyInt(None)
+        | AstDataType::SmallInt(None)
+        | AstDataType::MediumInt(None)
+        | AstDataType::Int(None)
+        | AstDataType::Integer(None)
+        | AstDataType::BigInt(None) => Some(CompatibilityType::Integer),
+        AstDataType::Bool | AstDataType::Boolean => Some(CompatibilityType::Boolean),
+        AstDataType::Real => Some(CompatibilityType::Real),
+        AstDataType::Text => Some(CompatibilityType::Text),
+        AstDataType::Varchar(length)
+        | AstDataType::CharacterVarying(length)
+        | AstDataType::CharVarying(length)
+            if varying_character_length_is_supported(length) =>
+        {
+            Some(CompatibilityType::Text)
+        }
+        AstDataType::Blob(None) => Some(CompatibilityType::Blob),
+        _ => None,
+    }
+}
+
+fn postgres_compatibility_type(data_type: &AstDataType) -> Option<CompatibilityType> {
+    match data_type {
+        AstDataType::Int2(None)
+        | AstDataType::SmallInt(None)
+        | AstDataType::Int(None)
+        | AstDataType::Integer(None)
+        | AstDataType::Int4(None)
+        | AstDataType::BigInt(None)
+        | AstDataType::Int8(None) => Some(CompatibilityType::Integer),
+        AstDataType::Bool | AstDataType::Boolean => Some(CompatibilityType::Boolean),
+        AstDataType::Float8 | AstDataType::DoublePrecision => Some(CompatibilityType::Real),
+        AstDataType::Text => Some(CompatibilityType::Text),
+        AstDataType::Varchar(length)
+        | AstDataType::CharacterVarying(length)
+        | AstDataType::CharVarying(length)
+            if varying_character_length_is_supported(length) =>
+        {
+            Some(CompatibilityType::Text)
+        }
+        AstDataType::Bytea => Some(CompatibilityType::Blob),
+        _ => None,
+    }
+}
+
+fn mysql_compatibility_type(data_type: &AstDataType) -> Option<CompatibilityType> {
+    match data_type {
+        AstDataType::TinyInt(Some(1)) | AstDataType::Bool | AstDataType::Boolean => {
+            Some(CompatibilityType::Boolean)
+        }
+        AstDataType::TinyInt(None)
+        | AstDataType::SmallInt(None)
+        | AstDataType::MediumInt(None)
+        | AstDataType::Int(None)
+        | AstDataType::Integer(None)
+        | AstDataType::BigInt(None) => Some(CompatibilityType::Integer),
+        AstDataType::Double(ExactNumberInfo::None) | AstDataType::DoublePrecision => {
+            Some(CompatibilityType::Real)
+        }
+        AstDataType::Text => Some(CompatibilityType::Text),
+        AstDataType::Varchar(length)
+        | AstDataType::CharacterVarying(length)
+        | AstDataType::CharVarying(length)
+            if varying_character_length_is_supported(length) =>
+        {
+            Some(CompatibilityType::Text)
+        }
+        AstDataType::Blob(None) => Some(CompatibilityType::Blob),
+        AstDataType::Varbinary(length) if varying_binary_length_is_supported(length) => {
+            Some(CompatibilityType::Blob)
+        }
+        _ => None,
+    }
+}
+
+fn varying_character_length_is_supported(length: &Option<CharacterLength>) -> bool {
+    matches!(
+        length,
+        None | Some(CharacterLength::IntegerLength { unit: None, .. })
+    )
+}
+
+fn varying_binary_length_is_supported(length: &Option<BinaryLength>) -> bool {
+    matches!(length, None | Some(BinaryLength::IntegerLength { .. }))
+}
+
+#[derive(Clone, Copy)]
+struct TranslationInvariant;
+
+struct CompatibilityVisitor<'a> {
+    normalized: &'a NormalizedSql,
+    statement_index: usize,
+    placeholder_count: usize,
+}
+
+impl VisitorMut for CompatibilityVisitor<'_> {
+    type Break = TranslationInvariant;
+
+    fn pre_visit_statement(&mut self, statement: &mut AstStatement) -> ControlFlow<Self::Break> {
+        if let AstStatement::StartTransaction { transaction, .. } = statement {
+            *transaction = None;
+        }
+        ControlFlow::Continue(())
+    }
+
+    fn pre_visit_query(&mut self, query: &mut AstQuery) -> ControlFlow<Self::Break> {
+        query.limit_clause = query
+            .limit_clause
+            .take()
+            .map(|limit_clause| match limit_clause {
+                LimitClause::LimitOffset {
+                    limit,
+                    mut offset,
+                    limit_by,
+                } => {
+                    if let Some(offset) = &mut offset {
+                        offset.rows = OffsetRows::None;
+                    }
+                    LimitClause::LimitOffset {
+                        limit,
+                        offset,
+                        limit_by,
+                    }
+                }
+                LimitClause::OffsetCommaLimit { offset, limit } => LimitClause::LimitOffset {
+                    limit: Some(limit),
+                    offset: Some(Offset {
+                        value: offset,
+                        rows: OffsetRows::None,
+                    }),
+                    limit_by: Vec::new(),
+                },
+            });
+        ControlFlow::Continue(())
+    }
+
+    fn pre_visit_value(&mut self, value: &mut ValueWithSpan) -> ControlFlow<Self::Break> {
+        match &value.value {
+            AstValue::Placeholder(_) => {
+                let Some(index) = self
+                    .normalized
+                    .parameter_index(self.statement_index, value.span)
+                else {
+                    return ControlFlow::Break(TranslationInvariant);
+                };
+                value.value = AstValue::Placeholder(format!("?{index}"));
+                self.placeholder_count += 1;
+            }
+            AstValue::Boolean(boolean) => {
+                value.value = AstValue::Number(if *boolean { "1" } else { "0" }.to_owned(), false);
+            }
+            _ => {}
+        }
+        ControlFlow::Continue(())
+    }
+
+    fn pre_visit_ident(&mut self, identifier: &mut Ident) -> ControlFlow<Self::Break> {
+        if identifier.quote_style == Some('`') {
+            identifier.quote_style = Some('"');
+        }
+        ControlFlow::Continue(())
+    }
+}
+
+fn translation_invariant() -> EngineError {
+    EngineError::new(
+        EngineErrorKind::Internal,
+        "translation metadata does not match the retained normalized SQL",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::thread;
+
+    use rusqlite::Connection;
+
+    use super::*;
+    use crate::{
+        core::Value,
+        sql::{execute_batch, normalize_placeholders, parse, query, validate_common_subset},
+    };
+
+    fn normalize(dialect: SqlDialect, source: &str) -> EngineResult<NormalizedSql> {
+        normalize_placeholders(validate_common_subset(parse(dialect, source)?)?)
+    }
+
+    fn translate(
+        dialect: SqlDialect,
+        source: &str,
+        mode: SqlTranslationMode,
+    ) -> EngineResult<TranslatedSql> {
+        translate_sql(normalize(dialect, source)?, mode)
+    }
+
+    fn compatibility(dialect: SqlDialect, source: &str) -> EngineResult<TranslatedSql> {
+        translate(dialect, source, SqlTranslationMode::Compatibility)
+    }
+
+    #[test]
+    fn modes_and_owned_result_are_public_exact_and_redacted() {
+        fn assert_owned<T: Clone + Send + Sync + 'static>() {}
+        assert_owned::<SqlTranslationMode>();
+        assert_owned::<TranslatedSql>();
+
+        assert_eq!(
+            SqlTranslationMode::ALL,
+            &[
+                SqlTranslationMode::Compatibility,
+                SqlTranslationMode::StrictSqlite
+            ]
+        );
+        assert_eq!(SqlTranslationMode::Compatibility.name(), "compatibility");
+        assert_eq!(
+            SqlTranslationMode::StrictSqlite.to_string(),
+            "strict SQLite"
+        );
+
+        let source = "-- private π\r\nCREATE TABLE `private_table` (`id` PRIVATE_TYPE DEFAULT TRUE);\r\nSELECT ?2, ?, 'private ?'; -- tail\r\n";
+        let translated =
+            translate(SqlDialect::Sqlite, source, SqlTranslationMode::StrictSqlite).unwrap();
+
+        assert_eq!(translated.dialect(), SqlDialect::Sqlite);
+        assert_eq!(translated.mode(), SqlTranslationMode::StrictSqlite);
+        assert_eq!(translated.source(), source);
+        assert_eq!(
+            translated.sqlite_sql(),
+            "-- private π\r\nCREATE TABLE `private_table` (`id` PRIVATE_TYPE DEFAULT TRUE);\r\nSELECT ?2, ?3, 'private ?'; -- tail\r\n"
+        );
+        assert_eq!(translated.statement_count(), 2);
+        assert!(!translated.is_empty());
+        assert_eq!(translated.statement_parameters().len(), 2);
+        assert_eq!(
+            translated.normalized_sql().sqlite_parameter_sql(),
+            translated.sqlite_sql()
+        );
+        assert_eq!(translated.clone(), translated);
+
+        let debug = format!("{translated:?}");
+        assert!(debug.contains("StrictSqlite"));
+        assert!(debug.contains("source_bytes"));
+        assert!(!debug.contains("private"));
+        assert!(!debug.contains('π'));
+
+        for dialect in [SqlDialect::PostgreSql, SqlDialect::MySql] {
+            let marker = if dialect == SqlDialect::PostgreSql {
+                "$1"
+            } else {
+                "?"
+            };
+            let error = translate(
+                dialect,
+                &format!("SELECT {marker}"),
+                SqlTranslationMode::StrictSqlite,
+            )
+            .unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::InvalidArgument);
+            assert!(!error.diagnostic().contains(marker));
+        }
+    }
+
+    #[test]
+    fn equivalent_dialect_types_have_one_canonical_sqlite_declaration() {
+        let sources = [
+            (
+                SqlDialect::Sqlite,
+                "CREATE TABLE \"t\" (\"i\" INTEGER PRIMARY KEY, \"b\" BOOLEAN, \"r\" REAL, \"s\" VARCHAR(12), \"x\" BLOB)",
+            ),
+            (
+                SqlDialect::PostgreSql,
+                "CREATE TABLE \"t\" (\"i\" INT8 PRIMARY KEY, \"b\" BOOL, \"r\" FLOAT8, \"s\" CHARACTER VARYING(12), \"x\" BYTEA)",
+            ),
+            (
+                SqlDialect::MySql,
+                "CREATE TABLE `t` (`i` BIGINT PRIMARY KEY, `b` TINYINT(1), `r` DOUBLE, `s` VARCHAR(12), `x` VARBINARY(12))",
+            ),
+        ];
+        let expected = "CREATE TABLE \"t\" (\"i\" BIGINT PRIMARY KEY, \"b\" BOOLEAN, \"r\" REAL, \"s\" TEXT, \"x\" BLOB)";
+
+        for (dialect, source) in sources {
+            let translated = compatibility(dialect, source).unwrap();
+            assert_eq!(translated.sqlite_sql(), expected, "{dialect}");
+            assert_eq!(translated.source(), source);
+        }
+
+        let strict = translate(
+            SqlDialect::Sqlite,
+            sources[0].1,
+            SqlTranslationMode::StrictSqlite,
+        )
+        .unwrap();
+        assert_eq!(strict.sqlite_sql(), sources[0].1);
+        assert!(strict.sqlite_sql().contains("INTEGER PRIMARY KEY"));
+    }
+
+    #[test]
+    fn finite_type_alias_matrix_is_dialect_specific() {
+        let cases: &[(SqlDialect, &[(&str, &str)])] = &[
+            (
+                SqlDialect::Sqlite,
+                &[
+                    ("TINYINT", "BIGINT"),
+                    ("SMALLINT", "BIGINT"),
+                    ("MEDIUMINT", "BIGINT"),
+                    ("INT", "BIGINT"),
+                    ("INTEGER", "BIGINT"),
+                    ("BIGINT", "BIGINT"),
+                    ("BOOL", "BOOLEAN"),
+                    ("BOOLEAN", "BOOLEAN"),
+                    ("REAL", "REAL"),
+                    ("TEXT", "TEXT"),
+                    ("VARCHAR(20)", "TEXT"),
+                    ("CHARACTER VARYING(20)", "TEXT"),
+                    ("CHAR VARYING", "TEXT"),
+                    ("BLOB", "BLOB"),
+                ],
+            ),
+            (
+                SqlDialect::PostgreSql,
+                &[
+                    ("INT2", "BIGINT"),
+                    ("SMALLINT", "BIGINT"),
+                    ("INT", "BIGINT"),
+                    ("INTEGER", "BIGINT"),
+                    ("INT4", "BIGINT"),
+                    ("BIGINT", "BIGINT"),
+                    ("INT8", "BIGINT"),
+                    ("BOOL", "BOOLEAN"),
+                    ("BOOLEAN", "BOOLEAN"),
+                    ("FLOAT8", "REAL"),
+                    ("DOUBLE PRECISION", "REAL"),
+                    ("TEXT", "TEXT"),
+                    ("VARCHAR", "TEXT"),
+                    ("VARCHAR(20)", "TEXT"),
+                    ("CHARACTER VARYING(20)", "TEXT"),
+                    ("CHAR VARYING", "TEXT"),
+                    ("BYTEA", "BLOB"),
+                ],
+            ),
+            (
+                SqlDialect::MySql,
+                &[
+                    ("TINYINT", "BIGINT"),
+                    ("TINYINT(1)", "BOOLEAN"),
+                    ("SMALLINT", "BIGINT"),
+                    ("MEDIUMINT", "BIGINT"),
+                    ("INT", "BIGINT"),
+                    ("INTEGER", "BIGINT"),
+                    ("BIGINT", "BIGINT"),
+                    ("BOOL", "BOOLEAN"),
+                    ("BOOLEAN", "BOOLEAN"),
+                    ("DOUBLE", "REAL"),
+                    ("DOUBLE PRECISION", "REAL"),
+                    ("TEXT", "TEXT"),
+                    ("VARCHAR(20)", "TEXT"),
+                    ("CHARACTER VARYING(20)", "TEXT"),
+                    ("CHAR VARYING", "TEXT"),
+                    ("BLOB", "BLOB"),
+                    ("VARBINARY", "BLOB"),
+                    ("VARBINARY(20)", "BLOB"),
+                ],
+            ),
+        ];
+
+        for (dialect, aliases) in cases {
+            for (source_type, expected_type) in *aliases {
+                let source = format!("CREATE TABLE types (value {source_type})");
+                let translated = compatibility(*dialect, &source)
+                    .unwrap_or_else(|error| panic!("{dialect} rejected {source_type}: {error}"));
+                assert_eq!(
+                    translated.sqlite_sql(),
+                    format!("CREATE TABLE types (value {expected_type})"),
+                    "{dialect} {source_type}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn unsupported_types_are_redacted_ordered_and_recoverable() {
+        let unsupported = [
+            (SqlDialect::Sqlite, "PRIVATE_TYPE"),
+            (SqlDialect::Sqlite, "NUMERIC"),
+            (SqlDialect::PostgreSql, "REAL"),
+            (SqlDialect::PostgreSql, "FLOAT4"),
+            (SqlDialect::PostgreSql, "NUMERIC(12, 2)"),
+            (SqlDialect::PostgreSql, "UUID"),
+            (SqlDialect::PostgreSql, "JSONB"),
+            (SqlDialect::PostgreSql, "TIMESTAMP"),
+            (SqlDialect::PostgreSql, "INTERVAL"),
+            (SqlDialect::PostgreSql, "BIT(8)"),
+            (SqlDialect::PostgreSql, "INTEGER[]"),
+            (SqlDialect::PostgreSql, "VARCHAR(MAX)"),
+            (SqlDialect::PostgreSql, "VARCHAR(20 CHARACTERS)"),
+            (SqlDialect::PostgreSql, "CHARACTER VARYING(20 OCTETS)"),
+            (SqlDialect::PostgreSql, "SERIAL"),
+            (SqlDialect::PostgreSql, "CHAR(8)"),
+            (SqlDialect::MySql, "INT(11)"),
+            (SqlDialect::MySql, "TINYINT(2)"),
+            (SqlDialect::MySql, "BIGINT UNSIGNED"),
+            (SqlDialect::MySql, "FLOAT"),
+            (SqlDialect::MySql, "REAL"),
+            (SqlDialect::MySql, "DECIMAL(12, 2)"),
+            (SqlDialect::MySql, "DATETIME"),
+            (SqlDialect::MySql, "JSON"),
+            (SqlDialect::MySql, "ENUM('a', 'b')"),
+            (SqlDialect::MySql, "BIT(8)"),
+            (SqlDialect::MySql, "VARBINARY(MAX)"),
+            (SqlDialect::MySql, "CHAR(8)"),
+            (SqlDialect::MySql, "BINARY(8)"),
+        ];
+
+        for (dialect, source_type) in unsupported {
+            let source = format!("CREATE TABLE private_name (private_column {source_type})");
+            let error = compatibility(dialect, &source).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::Unsupported, "{source}");
+            assert!(error.diagnostic().contains("statement 1 column 1"));
+            assert!(!error.diagnostic().contains("private"));
+            assert!(!error.diagnostic().contains(source_type));
+        }
+
+        let batch = "CREATE TABLE first (ok BIGINT); CREATE TABLE second (ok TEXT, private_column PRIVATE_TYPE); CREATE TABLE third (later PRIVATE_TYPE)";
+        let error = compatibility(SqlDialect::Sqlite, batch).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Unsupported);
+        assert!(error.diagnostic().contains("statement 2 column 2"));
+        assert!(!error.diagnostic().contains("private"));
+
+        let recovered =
+            compatibility(SqlDialect::Sqlite, "CREATE TABLE recovered (value BIGINT)").unwrap();
+        assert_eq!(
+            recovered.sqlite_sql(),
+            "CREATE TABLE recovered (value BIGINT)"
+        );
+    }
+
+    #[test]
+    fn syntax_translation_is_canonical_and_identifier_safe() {
+        let source = "CREATE TABLE `odd``table` (`a\"b` BOOLEAN DEFAULT TRUE, `select` BIGINT, CHECK (`a\"b` = FALSE)); SELECT `w`.`a\"b` AS `from` FROM `odd``table` AS `w` WHERE `w`.`a\"b` = TRUE ORDER BY `from`";
+        let translated = compatibility(SqlDialect::MySql, source).unwrap();
+        assert_eq!(
+            translated.sqlite_sql(),
+            "CREATE TABLE \"odd`table\" (\"a\"\"b\" BOOLEAN DEFAULT 1, \"select\" BIGINT, CHECK (\"a\"\"b\" = 0)); SELECT \"w\".\"a\"\"b\" AS \"from\" FROM \"odd`table\" AS \"w\" WHERE \"w\".\"a\"\"b\" = 1 ORDER BY \"from\""
+        );
+
+        let transactions = compatibility(
+            SqlDialect::PostgreSql,
+            "BEGIN WORK; COMMIT TRANSACTION; ABORT AND NO CHAIN",
+        )
+        .unwrap();
+        assert_eq!(transactions.sqlite_sql(), "BEGIN; COMMIT; ROLLBACK");
+
+        let type_like_text = compatibility(
+            SqlDialect::MySql,
+            "SELECT 'BIGINT `private` TRUE' AS `VARCHAR`",
+        )
+        .unwrap();
+        assert_eq!(
+            type_like_text.sqlite_sql(),
+            "SELECT 'BIGINT `private` TRUE' AS \"VARCHAR\""
+        );
+    }
+
+    #[test]
+    fn every_common_statement_family_uses_the_same_canonical_rewrite() {
+        let source = "CREATE TABLE `items` (`id` BIGINT PRIMARY KEY, `enabled` BOOLEAN); CREATE INDEX `items_enabled` ON `items` (`enabled`); INSERT INTO `items` (`id`, `enabled`) VALUES (?, TRUE), (?, FALSE); UPDATE `items` SET `enabled` = ? WHERE `id` = ?; SELECT `id` AS `value` FROM `items` WHERE `enabled` = ? ORDER BY `id`; DELETE FROM `items` WHERE `id` = ?";
+        let translated = compatibility(SqlDialect::MySql, source).unwrap();
+
+        assert_eq!(
+            translated.sqlite_sql(),
+            "CREATE TABLE \"items\" (\"id\" BIGINT PRIMARY KEY, \"enabled\" BOOLEAN); CREATE INDEX \"items_enabled\" ON \"items\"(\"enabled\"); INSERT INTO \"items\" (\"id\", \"enabled\") VALUES (?1, 1), (?2, 0); UPDATE \"items\" SET \"enabled\" = ?1 WHERE \"id\" = ?2; SELECT \"id\" AS \"value\" FROM \"items\" WHERE \"enabled\" = ?1 ORDER BY \"id\"; DELETE FROM \"items\" WHERE \"id\" = ?1"
+        );
+        assert_eq!(translated.statement_count(), 6);
+        assert_eq!(
+            translated
+                .statement_parameters()
+                .iter()
+                .map(StatementParameters::parameter_indices)
+                .collect::<Vec<_>>(),
+            vec![
+                &[][..],
+                &[][..],
+                &[1, 2][..],
+                &[1, 2][..],
+                &[1][..],
+                &[1][..]
+            ]
+        );
+
+        let sqlite_round_trip = normalize(SqlDialect::Sqlite, translated.sqlite_sql()).unwrap();
+        assert_eq!(
+            sqlite_round_trip.sqlite_parameter_sql(),
+            translated.sqlite_sql()
+        );
+    }
+
+    #[test]
+    fn comma_limit_reorders_syntax_without_reordering_bind_identity() {
+        let source = "SELECT `tenant_id` FROM `widgets` WHERE `tenant_id` = ? ORDER BY `tenant_id` LIMIT ?, ?";
+        let translated = compatibility(SqlDialect::MySql, source).unwrap();
+        assert_eq!(
+            translated.sqlite_sql(),
+            "SELECT \"tenant_id\" FROM \"widgets\" WHERE \"tenant_id\" = ?1 ORDER BY \"tenant_id\" LIMIT ?3 OFFSET ?2"
+        );
+        assert_eq!(translated.statement_parameters().len(), 1);
+        assert_eq!(
+            translated.statement_parameters()[0].parameter_indices(),
+            &[1, 2, 3]
+        );
+        assert_eq!(
+            translated.normalized_sql().sqlite_parameter_sql(),
+            "SELECT `tenant_id` FROM `widgets` WHERE `tenant_id` = ?1 ORDER BY `tenant_id` LIMIT ?2, ?3"
+        );
+
+        let batch = compatibility(SqlDialect::MySql, "SELECT ?; SELECT ? LIMIT ?, ?").unwrap();
+        assert_eq!(
+            batch.sqlite_sql(),
+            "SELECT ?1; SELECT ?1 LIMIT ?3 OFFSET ?2"
+        );
+        assert_eq!(batch.statement_parameters()[0].parameter_indices(), &[1]);
+        assert_eq!(
+            batch.statement_parameters()[1].parameter_indices(),
+            &[1, 2, 3]
+        );
+
+        let postgres = compatibility(
+            SqlDialect::PostgreSql,
+            "SELECT $2, $1, $2 LIMIT $3 OFFSET $1",
+        )
+        .unwrap();
+        assert_eq!(
+            postgres.sqlite_sql(),
+            "SELECT ?2, ?1, ?2 LIMIT ?3 OFFSET ?1"
+        );
+        assert_eq!(
+            postgres.statement_parameters()[0].parameter_indices(),
+            &[2, 1, 2, 3, 1]
+        );
+
+        for source in [
+            "SELECT $1 LIMIT $2 OFFSET $3 ROW",
+            "SELECT $1 LIMIT $2 OFFSET $3 ROWS",
+        ] {
+            assert_eq!(
+                compatibility(SqlDialect::PostgreSql, source)
+                    .unwrap()
+                    .sqlite_sql(),
+                "SELECT ?1 LIMIT ?2 OFFSET ?3"
+            );
+        }
+    }
+
+    #[test]
+    fn translated_dialects_execute_with_equal_sqlite_results() {
+        let cases = [
+            (
+                SqlDialect::Sqlite,
+                "SELECT \"value\" FROM \"items\" WHERE \"value\" >= ?1 ORDER BY \"value\" LIMIT ?2 OFFSET ?3",
+                vec![Value::Int64(2), Value::Int64(2), Value::Int64(1)],
+            ),
+            (
+                SqlDialect::PostgreSql,
+                "SELECT \"value\" FROM \"items\" WHERE \"value\" >= $1 ORDER BY \"value\" LIMIT $2 OFFSET $3",
+                vec![Value::Int64(2), Value::Int64(2), Value::Int64(1)],
+            ),
+            (
+                SqlDialect::MySql,
+                "SELECT `value` FROM `items` WHERE `value` >= ? ORDER BY `value` LIMIT ?, ?",
+                vec![Value::Int64(2), Value::Int64(1), Value::Int64(2)],
+            ),
+        ];
+
+        let mut results = Vec::new();
+        for (dialect, source, parameters) in cases {
+            let connection = Connection::open_in_memory().unwrap();
+            let ddl = compatibility(
+                dialect,
+                match dialect {
+                    SqlDialect::Sqlite => {
+                        "CREATE TABLE \"items\" (\"value\" INTEGER, \"enabled\" BOOLEAN)"
+                    }
+                    SqlDialect::PostgreSql => {
+                        "CREATE TABLE \"items\" (\"value\" INT8, \"enabled\" BOOL)"
+                    }
+                    SqlDialect::MySql => {
+                        "CREATE TABLE `items` (`value` BIGINT, `enabled` TINYINT(1))"
+                    }
+                },
+            )
+            .unwrap();
+            execute_batch(&connection, ddl.sqlite_sql()).unwrap();
+            execute_batch(
+                &connection,
+                "INSERT INTO items(value, enabled) VALUES (1, 1), (2, 0), (3, 1), (4, 1), (5, 0)",
+            )
+            .unwrap();
+
+            let translated = compatibility(dialect, source).unwrap();
+            results.push(query(&connection, translated.sqlite_sql(), &parameters).unwrap());
+        }
+
+        assert_eq!(results[0], results[1]);
+        assert_eq!(results[1], results[2]);
+        assert_eq!(
+            results[0]
+                .rows()
+                .iter()
+                .map(|row| row.get(0).cloned().unwrap())
+                .collect::<Vec<_>>(),
+            vec![Value::Int64(3), Value::Int64(4)]
+        );
+    }
+
+    #[test]
+    fn empty_batches_limits_concurrency_and_recovery_are_stateless() {
+        let empty_source = "-- private empty\n";
+        let compatible = compatibility(SqlDialect::Sqlite, empty_source).unwrap();
+        assert!(compatible.is_empty());
+        assert_eq!(compatible.sqlite_sql(), "");
+        assert_eq!(compatible.source(), empty_source);
+        let strict = translate(
+            SqlDialect::Sqlite,
+            empty_source,
+            SqlTranslationMode::StrictSqlite,
+        )
+        .unwrap();
+        assert_eq!(strict.sqlite_sql(), empty_source);
+
+        let maximum_batch = "SELECT 1;".repeat(256);
+        let translated = compatibility(SqlDialect::Sqlite, &maximum_batch).unwrap();
+        assert_eq!(translated.statement_count(), 256);
+        assert_eq!(translated.sqlite_sql().matches("SELECT 1").count(), 256);
+
+        let normalized = normalize(
+            SqlDialect::MySql,
+            "SELECT `value` FROM `items` WHERE `value` = ? LIMIT ?, ?",
+        )
+        .unwrap();
+        let expected = compatibility(SqlDialect::MySql, normalized.source())
+            .unwrap()
+            .sqlite_sql()
+            .to_owned();
+        let threads = (0..24)
+            .map(|_| {
+                let normalized = normalized.clone();
+                thread::spawn(move || {
+                    translate_sql(normalized, SqlTranslationMode::Compatibility)
+                        .unwrap()
+                        .sqlite_sql()
+                        .to_owned()
+                })
+            })
+            .collect::<Vec<_>>();
+        for thread in threads {
+            assert_eq!(thread.join().unwrap(), expected);
+        }
+
+        let mismatch = translate(
+            SqlDialect::PostgreSql,
+            "SELECT $1",
+            SqlTranslationMode::StrictSqlite,
+        )
+        .unwrap_err();
+        assert_eq!(mismatch.kind(), EngineErrorKind::InvalidArgument);
+        assert_eq!(
+            compatibility(SqlDialect::PostgreSql, "SELECT $1")
+                .unwrap()
+                .sqlite_sql(),
+            "SELECT ?1"
+        );
+    }
+
+    #[test]
+    fn nul_and_inconsistent_metadata_fail_with_stable_redacted_errors() {
+        let source = r"SELECT 'private\0literal'";
+        let error = compatibility(SqlDialect::MySql, source).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::InvalidQuery);
+        assert!(!error.diagnostic().contains("private"));
+        assert!(!error.diagnostic().contains("literal"));
+
+        let mut normalized = normalize(SqlDialect::PostgreSql, "SELECT $1").unwrap();
+        normalized.corrupt_first_placeholder_for_test();
+        let error = translate_sql(normalized, SqlTranslationMode::Compatibility).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Internal);
+        assert!(!error.diagnostic().contains("$1"));
+
+        assert_eq!(
+            compatibility(SqlDialect::PostgreSql, "SELECT $1")
+                .unwrap()
+                .sqlite_sql(),
+            "SELECT ?1"
+        );
+    }
+}

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -292,6 +292,119 @@ fn placeholder_normalization_is_public_owned_bounded_and_opt_in() {
 }
 
 #[test]
+fn sql_translation_is_public_owned_dialect_equivalent_and_opt_in() {
+    fn assert_owned_public<T: Clone + Send + Sync + 'static>() {}
+    assert_owned_public::<sql::SqlTranslationMode>();
+    assert_owned_public::<sql::TranslatedSql>();
+
+    let ddl = [
+        (
+            sql::SqlDialect::Sqlite,
+            "CREATE TABLE \"typed\" (\"id\" INTEGER PRIMARY KEY, \"enabled\" BOOLEAN, \"payload\" BLOB)",
+        ),
+        (
+            sql::SqlDialect::PostgreSql,
+            "CREATE TABLE \"typed\" (\"id\" INT8 PRIMARY KEY, \"enabled\" BOOL, \"payload\" BYTEA)",
+        ),
+        (
+            sql::SqlDialect::MySql,
+            "CREATE TABLE `typed` (`id` BIGINT PRIMARY KEY, `enabled` TINYINT(1), `payload` VARBINARY(64))",
+        ),
+    ];
+    for (dialect, source) in ddl {
+        let normalized = sql::normalize_placeholders(
+            sql::validate_common_subset(sql::parse(dialect, source).unwrap()).unwrap(),
+        )
+        .unwrap();
+        let translated =
+            sql::translate_sql(normalized, sql::SqlTranslationMode::Compatibility).unwrap();
+        assert_eq!(translated.dialect(), dialect);
+        assert_eq!(translated.mode(), sql::SqlTranslationMode::Compatibility);
+        assert_eq!(translated.source(), source);
+        assert_eq!(
+            translated.sqlite_sql(),
+            "CREATE TABLE \"typed\" (\"id\" BIGINT PRIMARY KEY, \"enabled\" BOOLEAN, \"payload\" BLOB)"
+        );
+    }
+
+    let strict_source = "-- exact SQLite\r\nSELECT ?2, ?, 'private ?';\r\n";
+    let strict = sql::translate_sql(
+        sql::normalize_placeholders(
+            sql::validate_common_subset(
+                sql::parse(sql::SqlDialect::Sqlite, strict_source).unwrap(),
+            )
+            .unwrap(),
+        )
+        .unwrap(),
+        sql::SqlTranslationMode::StrictSqlite,
+    )
+    .unwrap();
+    assert_eq!(
+        strict.sqlite_sql(),
+        "-- exact SQLite\r\nSELECT ?2, ?3, 'private ?';\r\n"
+    );
+    assert!(!format!("{strict:?}").contains("private"));
+
+    let temp = tempfile::tempdir().unwrap();
+    drop(core::Database::open(temp.path(), 4).unwrap());
+    insert_catalog_fixture(temp.path());
+    let database = Arc::new(core::Database::open(temp.path(), 4).unwrap());
+    let engine = core::Engine::from_database(Arc::clone(&database));
+    let tenant = database.catalog().database("tenant").unwrap().unwrap();
+    let parameter = [core::Value::Text("tenant-public-translation".to_owned())];
+    let requests = [
+        (
+            sql::SqlDialect::Sqlite,
+            "SELECT tenant_id FROM accounts WHERE tenant_id = ?1",
+        ),
+        (
+            sql::SqlDialect::PostgreSql,
+            "SELECT tenant_id FROM accounts WHERE tenant_id = $1",
+        ),
+        (
+            sql::SqlDialect::MySql,
+            "SELECT tenant_id FROM accounts WHERE tenant_id = ?",
+        ),
+    ];
+    let plans = requests.map(|(dialect, source)| {
+        let translated = sql::translate_sql(
+            sql::normalize_placeholders(
+                sql::validate_common_subset(sql::parse(dialect, source).unwrap()).unwrap(),
+            )
+            .unwrap(),
+            sql::SqlTranslationMode::Compatibility,
+        )
+        .unwrap();
+        assert_eq!(
+            translated.sqlite_sql(),
+            "SELECT tenant_id FROM accounts WHERE tenant_id = ?1"
+        );
+        engine
+            .plan_bound_statement(
+                tenant.id(),
+                translated.normalized_sql(),
+                0,
+                &parameter,
+                None,
+            )
+            .unwrap()
+    });
+    assert_eq!(plans[0], plans[1]);
+    assert_eq!(plans[1], plans[2]);
+
+    // Translation remains opt-in. Existing raw SQLite execution continues to
+    // accept its current named-parameter behavior directly.
+    let raw = database
+        .query(
+            "translation-opt-in",
+            "SELECT :value",
+            &[core::Value::Int64(29)],
+        )
+        .unwrap();
+    assert_eq!(raw.rows()[0].get(0), Some(&core::Value::Int64(29)));
+}
+
+#[test]
 fn shard_key_inference_is_public_typed_and_opt_in() {
     fn assert_owned_public<T: Clone + Send + Sync + 'static>() {}
     assert_owned_public::<sql::ShardKeyInference>();


### PR DESCRIPTION
Closes #25.

## What changed

- add public, owned `SqlTranslationMode`, `TranslatedSql`, and `translate_sql`
- implement an explicit SQLite-only strict mode that preserves normalized SQL exactly
- implement a finite compatibility mode for documented SQLite, PostgreSQL, and MySQL type aliases and syntax differences
- retain statement-local placeholder identity through canonical rendering and MySQL/SQLite comma-limit reordering
- admit comma-form limits at the common-subset boundary for later translation
- enable the pinned parser's visitor feature without changing its exact revision or the Rust 1.85 dependency pins
- document the complete translation matrix, errors, boundaries, and unchanged raw HTTP/storage behavior

## Why

Phase 3 needs one protocol-neutral SQLite representation for the deliberately small shared SQL surface while still allowing callers to request exact normalized SQLite SQL. This keeps translation explicit and separate from routing, preparation, execution, sessions, listeners, and migration identity.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --locked --all-targets --all-features`
- `cargo test --locked --doc --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo +1.85.0 test --locked --all-targets --all-features`
- `cargo +1.85.0 test --locked --doc --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --no-deps --all-features`
- independent production-code, acceptance/test/docs, and dependency/MSRV reviews: no blockers

Final local counts: 458 library tests, 7 binary tests, 6 workload tests, 14 public API tests, and storage benchmark smoke all pass on stable and Rust 1.85.
