### PR TITLE
Implement prepared statement lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ The [bound statement-planning contract](docs/SQL_PLANNING.md) defines the
 synchronous engine API that turns one statement's actual bound values into
 owned routes, validates inferred and explicit physical targets, rejects
 unroutable sharded writes, and records a single-shard assignment where valid.
+The [prepared-statement contract](docs/SQL_PREPARED_STATEMENTS.md) defines the
+protocol-neutral prepare/bind/describe/execute lifecycle, session-scoped
+statement and portal caches, exact resource limits, metadata refresh, and
+supported physical-target execution boundary shared by future adapters.
 The [error contract](docs/ERRORS.md) defines stable engine error kinds, safe
 HTTP problem details, and the mappings reserved for future PostgreSQL and MySQL
 adapters.
@@ -54,6 +58,9 @@ minimum supported Rust version (MSRV) and the latest stable toolchain.
 - Finite per-query row/logical-byte budgets with no partial results
 - Explicit graceful drain, forced cancellation, and blocking handle cleanup
 - Protocol-neutral typed values, ordered columns, positional rows, and results
+- A bounded per-session prepared-statement and immutable bound-portal lifecycle
+  with transient shard-0 metadata compilation, bind-time routing snapshots,
+  fresh execute-time planning, and supported physical-target execution
 - A bounded SQL AST parser plus recursive common-subset validator for explicit
   SQLite, PostgreSQL, and MySQL dialects, followed by opt-in source-preserving
   placeholder normalization, per-statement binding metadata, and catalog-aware
@@ -110,6 +117,21 @@ SIGTERM stop new admissions, drain or cancel admitted SQLite work, close idle
 handles, and then stop the process. Accepted HTTP connections are tracked;
 connections that outlive the grace window are force-closed and joined before
 the server returns.
+
+Each session defaults to at most 128 prepared statements, 128 bound portals,
+and a 16 MiB ceiling for retained bound values/captured routing bytes and one
+bind's conservative planning expansion. Configure
+these with `--max-prepared-statements-per-session` /
+`BRISKDB_MAX_PREPARED_STATEMENTS_PER_SESSION`,
+`--max-portals-per-session` / `BRISKDB_MAX_PORTALS_PER_SESSION`, and
+`--max-retained-bound-value-bytes` /
+`BRISKDB_MAX_RETAINED_BOUND_VALUE_BYTES`. The hard caps are 1,024 statements,
+1,024 portals, and 1 GiB. Full caches reject new entries without evicting open
+handles. Before planner allocation, the captured route is charged once and
+every normalized marker occurrence charges twice its logical accounted value
+bytes against the same byte ceiling; repeated markers are charged per
+occurrence even though the portal retains one bound value. This is an
+accounting model, not a retained wire encoding.
 
 Create a table on every shard:
 
@@ -199,13 +221,35 @@ parameters, explicit_routing_key)` to retain the inference and produce one
 owned canonical route per inferred value plus an independent explicit route.
 That call compares finite inferred and explicit routes by physical shard,
 rejects cross-shard or otherwise unroutable cataloged sharded DML, prevents
-shard-key updates, and exposes the accepted `assigned_shard()`. The plan
-records schema and routing provenance but does not classify complete request
-behavior or execute anything. Translation and planning remain independent
-opt-in branches over the same normalized request. The HTTP execute, query, and
-migration endpoints invoke none of these opt-in layers and retain their
-existing raw SQLite behavior. The exact translation matrix and strict-mode
-boundary are in [`docs/SQL_TRANSLATION.md`](docs/SQL_TRANSLATION.md).
+shard-key updates, and exposes the accepted `assigned_shard()`. The synchronous
+plan API records schema and routing provenance but does not classify complete
+request behavior or execute anything.
+
+Rust callers can instead create a `PrepareRequest` with an explicit logical
+database, dialect, translation mode, and SQL string. `Engine::prepare_statement`
+runs the complete frontend pipeline, requires exactly one top-level statement,
+transiently compiles metadata on shard 0, and caches only BriskDB-owned SQL and
+metadata in the session. `bind_statement` snapshots typed values and the
+session's current route into an immutable portal after transiently validating a
+plan from those concrete values. `describe_prepared` returns owned `Unknown`
+parameter/result types and refreshes column metadata after a schema-generation
+change.
+`execute_portal` always plans again from the retained values and route snapshot
+under the current schema guard. It runs accepted sharded work on its assigned
+shard and safe column-producing `NotApplicable`/`Global` reads on deterministic
+shard 0, returning routed rows or an affected-row count. There is no implicit
+cache eviction, no retained plan, `rusqlite` statement, or connection, and
+closing a statement closes all of its portals. Complete statement behavior and
+batch classification remain issue #27; sharded reads requiring scatter do not
+execute through this lifecycle.
+
+Translation and planning remain independently callable branches over the same
+normalized request. The HTTP execute, query, and migration endpoints invoke
+none of these opt-in/prepared layers and retain their existing raw SQLite
+behavior. The exact translation matrix and strict-mode boundary are in
+[`docs/SQL_TRANSLATION.md`](docs/SQL_TRANSLATION.md), and the complete lifecycle
+is in
+[`docs/SQL_PREPARED_STATEMENTS.md`](docs/SQL_PREPARED_STATEMENTS.md).
 
 `EngineOptions` permits 1–16 active connections and 1–1,024 queued operations
 per shard, with at most 512 active connections across all shards.
@@ -309,9 +353,9 @@ Independent `Database` and `Engine` handles in one process that resolve to the
 same canonical data directory share schema coordination. Separate BriskDB
 server processes must not use the same data directory.
 
-Near-term work includes authentication, richer migration administration and
-status APIs in issue #53, scatter/gather reads, observability, and backup
-tooling.
+Near-term work includes authoritative statement and batch classification,
+authentication, richer migration administration and status APIs in issue #53,
+scatter/gather reads, observability, and backup tooling.
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -213,7 +213,7 @@ interrupted schema migration can be diagnosed and resumed.
 - [x] Reject conflicting keys and unroutable writes before execution.
 - [x] Translate a deliberately small set of type names and syntax differences;
   preserve a strict mode that exposes SQLite SQL directly.
-- [ ] Implement protocol-neutral prepare/bind/describe/execute lifecycle and a
+- [x] Implement protocol-neutral prepare/bind/describe/execute lifecycle and a
   bounded per-session prepared-statement cache.
 - [ ] Classify statements by read/write/schema/session behavior and block unsafe
   multi-statement combinations.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,7 +21,7 @@ server ---------> protocol::http
 
 | Module | Responsibility | Must not own |
 | --- | --- | --- |
-| `core` | Protocol-neutral `Engine`, `Session`, statements, values, results, errors, read-only logical catalog, synchronous bound-value-aware plans, and single-shard routing policy; stable key routing; bounded per-shard admission and connection pools; routed execute/query and journaled schema migration | JSON/HTTP types, listeners, or Axum handlers |
+| `core` | Protocol-neutral `Engine`, `Session`, statements, immutable bound portals, values, results, errors, read-only logical catalog, synchronous bound-value-aware plans, prepared lifecycle, and sharded routing policy; stable key routing; bounded per-session and per-shard admission; routed execution and journaled schema migration | JSON/HTTP types, listeners, or Axum handlers |
 | `storage` | Versioned routing/logical manifest, shard layout, migration journal and recovery, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
 | `sql` | Dialect-explicit SQL syntax parsing, recursive common-subset validation, source-preserving placeholder normalization, explicit strict/compatibility translation, catalog-aware typed shard-key inference, and narrow crate-private DML-shape inspection behind BriskDB-owned boundaries; exact source retention; SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, key hashing or shard selection, session/write policy, filesystem layout, protocol responses, protocol-buffer ownership, or protocol-specific support policy |
 | `protocol::http` | HTTP request extraction plus JSON/BriskDB value and RFC 9457 problem-detail encoding | BLAKE3 routing, shard files, or rusqlite calls |
@@ -75,11 +75,11 @@ durably published generation in place; consequently, its public
 That is an intentional pre-1.0 source-level change.
 
 The module names are stable boundaries, not a claim that later roadmap work is
-already complete. The async engine, session lifecycle, bounded per-shard pools,
-request controls, and explicit shutdown lifecycle are now in place. The
-synchronous `Database` API remains available as a Rust compatibility surface;
-existing engine and server entry points retain their signatures and delegate to
-the controlled defaults.
+already complete. The async engine, session and prepared-object lifecycle,
+bounded per-session caches, bounded per-shard pools, request controls, and
+explicit shutdown lifecycle are now in place. The synchronous `Database` API
+remains available as a Rust compatibility surface; existing engine and server
+entry points retain their signatures and delegate to the controlled defaults.
 
 ## SQL parser boundary
 
@@ -124,9 +124,10 @@ contract](SQL_SUBSET.md).
 
 The current HTTP execute/query and migration paths deliberately remain raw
 SQLite pass-through and call none of the parser, subset validator, placeholder
-normalizer, translator, shard-key inference, or bound statement-planning
-layers. Issues #19 through #25 therefore change no HTTP shape, SQL acceptance,
-execution routing, or storage behavior.
+normalizer, translator, shard-key inference, bound statement-planning, or
+prepared-lifecycle layers. Issues #19 through #26 therefore change no HTTP
+shape, SQL acceptance, execution routing, or storage behavior. Rust callers can
+now invoke those layers together through the separate prepared API.
 
 ### Placeholder-normalization boundary
 
@@ -142,7 +143,9 @@ Each statement, including one without placeholders, has an ordered
 `StatementParameters` record with its largest assigned index, occurrence
 count, and occurrence-to-index sequence. This metadata lets later bind-time
 planning distinguish repeated parameters and gaps without owning protocol
-buffers. It does not inspect the bound values themselves.
+buffers. Prepared bind uses that occurrence sequence for its conservative
+planning-expansion preflight; normalization itself does not inspect the bound
+values.
 
 Normalization uses retained AST placeholder spans rather than regular
 expressions or AST formatting. Every non-marker byte remains exact, including
@@ -231,18 +234,61 @@ classification remain issue #27.
 Planning holds the existing schema-operation guard while it reads logical and
 routing state. The owned result records schema generation, map generation, and
 the hash, key-encoding, and bucket-algorithm versions used for the lookup. That
-provenance does not reserve future state; an eventual execution integration
-must establish that the physical schema and routing snapshot remain
-authoritative before using a plan.
+provenance does not reserve future state. Prepared bind uses a transient plan
+for validation; portal execution always creates a new plan from the portal's
+owned bind snapshot under its current schema-operation guard.
 
-The planner is stateless and its assignment is still non-executable. It does
-not invoke translation, mutate a session, cache a prepared statement, apply
-batch policy, open a shard connection, scatter reads, or execute anything. The
-normative API, assignment matrix, encoding, provenance, error, boundary, and
-testing rules are in the [bound statement-planning and routing-policy
+The public planner remains stateless and its assignment alone is not execution
+permission. It does not invoke translation, mutate a session, cache a prepared
+statement, apply batch policy, open a shard connection, scatter reads, or
+execute anything. The normative API, assignment matrix, encoding, provenance,
+error, boundary, and testing rules are in the
+[bound statement-planning and routing-policy
 contract](SQL_PLANNING.md). Translation is the separate implemented issue #25
-branch over the same `NormalizedSql`; issues #26 and #27 own
-prepared-statement/session lifecycle and authoritative statement/batch policy.
+branch over the same `NormalizedSql`; issue #26's prepared lifecycle consumes
+both layers, while issue #27 still owns authoritative statement/batch policy.
+
+### Prepared-statement and portal boundary
+
+`Engine::prepare_statement` accepts an owned `PrepareRequest` with one logical
+database, source dialect, explicit translation mode, and SQL string. It runs
+parse, exact-one top-level validation, subset validation, placeholder
+normalization, and translation, then transiently compiles metadata on shard 0.
+The session cache retains only BriskDB-owned `TranslatedSql` plus owned
+parameter/column metadata. No `rusqlite::Statement`, rows iterator, SQLite
+connection, pool handle, or protocol buffer crosses the operation boundary.
+
+Prepared-statement and portal IDs are opaque, monotonic, never reused, and
+bound to their process-unique owning session. Binding validates concrete typed
+values with a transient plan, snapshots the session routing bytes, and stores
+only that snapshot and the values in an immutable logical portal. Later
+session-route changes do not affect it. Describing after a schema-generation
+change recompiles owned metadata on shard 0. Every execution plans again from
+the portal snapshot under the current schema/routing guard before choosing the
+supported physical target. Safe
+column-producing `NotApplicable` and `Global` reads may use deterministic shard
+0; a sharded read that still needs scatter remains unsupported. Catalog
+placement is never exposed as an application read target.
+
+Per-session limits independently bound statement count, portal count, and the
+logical accounted value bytes plus routing bytes retained by all portals. Full
+caches return `LimitExceeded`; there is no implicit eviction. Closing a
+statement cascades to its portals, closing a portal releases its bytes, and
+closing the session clears all prepared state. Same-session operations are
+serialized by the existing session mutex, including SQLite metadata and
+execution work.
+
+The retained-value ceiling also preflights one bind's transient planning
+expansion by charging its captured route once and each normalized marker
+occurrence twice; repeated markers cannot cause unbounded inference/route
+allocation before the check.
+
+The prepared lifecycle integrates the previously independent SQL and planning
+layers but deliberately does not publish the complete statement classifier,
+execute a multi-statement batch, scatter reads, or implement transactions.
+Those remain issue #27 and the later planner/transaction milestones. The
+complete API, accounting, execution, error, adapter, and persistence contract
+is in [prepared statements and bound portals](SQL_PREPARED_STATEMENTS.md).
 
 ## Manifest storage boundary
 
@@ -414,8 +460,11 @@ The current routing context is an optional caller-supplied shard key. Routed
 execute and query operations require that context, and the engine alone hashes
 it and reports the selected shard in `Routed<T>`. `Statement` owns its SQL text
 and typed parameters so an adapter can hand work across the asynchronous
-boundary without borrowing protocol buffers. `EngineStatus` exposes the shard
-count needed by health reporting without exposing the storage implementation.
+boundary without borrowing protocol buffers. Prepared statements and portals
+are session-scoped logical objects; binding captures the routing context so a
+later session change cannot retarget an existing portal. `EngineStatus` exposes
+the shard count and prepared-state limits needed by health/configuration
+reporting without exposing the storage implementation.
 
 HTTP is stateless at this stage: each execute or query request creates a fresh
 session and initializes its routing context from the request's `shard_key`.
@@ -439,10 +488,15 @@ constructors and server assembly use the defaults, so their APIs and behavior
 remain compatible. Server configuration exposes
 `--connections-per-shard` / `BRISKDB_CONNECTIONS_PER_SHARD` and
 `--queue-capacity-per-shard` / `BRISKDB_QUEUE_CAPACITY_PER_SHARD`.
-The same options boundary carries finite result rows/bytes, the optional
-engine-wide request timeout, and the shutdown grace period. The binary exposes
-them as `--max-result-rows`, `--max-result-bytes`,
-`--request-timeout-ms`, and `--shutdown-grace-ms` with corresponding
+The same options boundary carries finite result rows/bytes, per-session
+prepared-statement count, portal count and a retained-value/per-bind-planning
+byte ceiling, the optional engine-wide request timeout, and the shutdown grace
+period. Prepared defaults are 128 statements, 128 portals, and 16 MiB;
+configurable hard caps are 1,024, 1,024, and 1 GiB. The binary exposes these as
+`--max-result-rows`,
+`--max-result-bytes`, `--max-prepared-statements-per-session`,
+`--max-portals-per-session`, `--max-retained-bound-value-bytes`,
+`--request-timeout-ms`, and `--shutdown-grace-ms`, with corresponding
 `BRISKDB_*` environment variables.
 
 When a shard has no active slot and its admission queue is full, a new operation
@@ -523,11 +577,13 @@ retired, preventing a late signal from affecting the next request.
 `RequestContext` supplies a sticky cancellation token, an optional absolute
 deadline, and optional narrower result limits. The engine default deadline and
 result budget are owned by `EngineOptions`, so protocol adapters contain no
-SQLite control policy. Queries account a stable logical result representation
-while stepping SQLite and before cloning payloads. A row or byte overflow
-returns no partial `ResultSet`; query statements must be read-only so early
-termination cannot hide DML `RETURNING` effects. The exact accounting contract
-is documented in [request controls](REQUEST_CONTROLS.md).
+SQLite control policy. Prepare, bind, describe, and portal execution expose the
+same `*_with_context` boundary as raw operations. Queries and prepared row
+results account a stable logical representation while stepping SQLite and
+before cloning payloads. A row or byte overflow returns no partial
+`ResultSet`; row-producing writes are rejected so early termination cannot hide
+DML effects. The exact accounting contract is documented in
+[request controls](REQUEST_CONTROLS.md).
 
 All engine clones share one mutex-protected lifecycle. The mutex makes the
 `Running` admission check and active-operation increment atomic with
@@ -536,7 +592,9 @@ All engine clones share one mutex-protected lifecycle. The mutex makes the
 the admitted set and still waits for blocking cleanup before closing idle
 SQLite handles on a worker and marking `Stopped`. A timed-out cleanup remains
 `Draining` and can be resumed. Ordinary clone destruction does not initiate
-this explicit asynchronous path.
+this explicit asynchronous path. Prepared statement/portal close and terminal
+session close remain available as in-memory cleanup while draining; no
+prepared state is persisted for restart recovery.
 
 The server owns accepted HTTP/1 connections in a tracked task set. It stops
 engine admission before dropping the listener, starts HTTP and core draining
@@ -551,10 +609,12 @@ single-shard pinning remain deferred to the PostgreSQL and MySQL transaction
 work in issues #34 and #47. `Ready` and `Closed` therefore describe session
 lifecycle, not SQL transaction state.
 
-The pool/request-control boundary changed Rust orchestration and added opt-in
-`EngineOptions` plus pool-sizing CLI/environment configuration. That earlier
-change did not alter option defaults, HTTP routes or JSON shapes, shard routing,
-storage formats, WAL or synchronous settings, or stored data.
+The pool/request-control and prepared-cache boundaries changed Rust
+orchestration and added opt-in `EngineOptions` plus CLI/environment
+configuration. They did not alter HTTP routes or JSON shapes, shard routing,
+storage formats, WAL or synchronous settings, or stored schema. Prepared
+execution can have the ordinary application-row effects of its one selected
+SQLite statement.
 
 ## Error boundary
 

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -191,6 +191,38 @@ no new error kind, retains no failed parameters, and does not change protocol
 mappings. See the [bound statement-planning and routing-policy
 contract](SQL_PLANNING.md).
 
+The prepared lifecycle preserves each earlier frontend/planner kind. Prepare
+adds `InvalidArgument` for an unknown logical database and for anything other
+than exactly one top-level statement, `LimitExceeded` for a full session
+statement cache, and `InvalidQuery` when SQLite cannot transiently compile the
+translated SQL on shard 0. Bind preserves parameter-count, value-conversion,
+inference, and planning errors, and adds `LimitExceeded` for a full portal cache
+or retained-value byte budget, or when the captured route and repeated
+normalized occurrences exceed the conservative per-bind planning ceiling
+before allocation. Describe preserves transient SQLite compilation errors. A
+normalized-versus-SQLite parameter-count disagreement or retained accounting
+inconsistency is `Internal`.
+
+Prepared-statement and portal handles are session-scoped. A handle from another
+session/engine, a closed session, or an absent statement/portal is
+`FailedPrecondition`; closing an already absent same-session handle instead
+returns `false`. Portal execution reports `PermissionDenied` for catalog
+placement and `Unsupported` for a sharded read that still needs scatter or
+another unimplemented target. Safe column-producing `NotApplicable` and
+`Global` reads use deterministic shard 0; accepted sharded work uses its
+current assigned shard. Cancellation, deadlines, pool admission, schema-gate
+state, SQLite execution, constraints, and result limits retain their existing
+kinds.
+
+A failed prepare or bind publishes no handle, full caches evict nothing, and an
+execution failure retains its portal. Protocol adapters still serialize only
+the fixed public mapping for the error kind. Redacted `Debug` applies to the
+prepare request, cached state, portal, plan, and description; trusted internal
+value-conversion diagnostics may contain the rejected value, and
+`PreparedExecution` `Debug` intentionally contains user-visible results. See
+the complete [prepared statements and bound portals
+contract](SQL_PREPARED_STATEMENTS.md).
+
 The core contains no HTTP, PostgreSQL, or MySQL response types. Conversely,
 protocol adapters do not inspect SQLite errors. This lets every frontend share
 one error identity while retaining its own response encoding.

--- a/docs/REQUEST_CONTROLS.md
+++ b/docs/REQUEST_CONTROLS.md
@@ -6,8 +6,9 @@ therefore share the same resource and cleanup semantics.
 
 ## Per-request context
 
-The existing `Engine::execute`, `query`, `broadcast`, and `status` methods keep
-their signatures and use a default `RequestContext`. `broadcast` now means a
+The existing `Engine::execute`, `query`, `broadcast`, and `status` methods, plus
+`prepare_statement`, `bind_statement`, `describe_prepared`, and
+`execute_portal`, use a default `RequestContext`. `broadcast` now means a
 journaled application-schema migration. Frontends that have their own
 cancellation or deadline source can call the corresponding `*_with_context`
 method:
@@ -45,6 +46,14 @@ therefore end SQLite lock waits or expensive preparation before the main SQL
 call starts. Opening the database file itself is an operating-system call and
 cannot be synchronously interrupted, but controls are checked before any
 SQLite configuration or statement work proceeds.
+
+Prepared operations use the same boundary. Prepare and a schema-refreshing
+describe can wait for shard 0 and transient SQLite metadata compilation. Bind
+can wait for the serialized session before it validates and snapshots values.
+Portal execution can wait for its selected shard and runs with the same
+exact-handle interruption and cleanup as raw execution. Cancellation before a
+prepared object is published leaves the session cache unchanged; a cancelled
+or failed execution retains the existing portal.
 
 Completion wins a very close race with cancellation. A statement that is known
 to have completed successfully returns success rather than a misleading
@@ -84,12 +93,38 @@ and SQLite can still allocate its current row internally. The logical limit is
 not an HTTP encoded-body limit; for example, the current JSON representation of
 a blob expands bytes into JSON integers.
 
-The query path accepts only SQLite statements reported as read-only. This
-prevents an early result-budget failure from accompanying a partially consumed
-DML `RETURNING` statement. Execute and schema migration do not materialize a
-`ResultSet` and are unaffected by query result budgets. A future scatter/gather
-implementation must apply one budget to the combined result, not a fresh budget
-for every shard.
+The raw query path accepts only SQLite statements reported as read-only. The
+prepared executor likewise rejects row-producing writes. These rules prevent
+an early result-budget failure from accompanying a partially consumed DML
+`RETURNING` statement. Raw execute, prepared affected-row results, and schema
+migration do not materialize a `ResultSet` and are unaffected by query result
+budgets. A future scatter/gather implementation must apply one budget to the
+combined result, not a fresh budget for every shard.
+
+## Prepared-session limits
+
+Prepared caches have a separate finite per-session budget: 128 statements, 128
+portals, and a 16 MiB retained-value/per-bind-planning ceiling by default, with
+hard caps of 1,024, 1,024, and 1 GiB. Full caches return `LimitExceeded` without
+evicting open handles. `EngineOptions`, server CLI flags, and `BRISKDB_*`
+environment variables can configure each value.
+
+This retained-value budget is independent of materialized-result bytes. Its
+logical accounting charges one type-tag byte and an eight-byte length for each
+parameter, the documented value payload, and exactly the captured route's byte
+length. It does not serialize or retain a wire encoding. Explicit close or
+terminal session close releases the charge. The exact model and configuration
+names are in
+[prepared statements and bound portals](SQL_PREPARED_STATEMENTS.md).
+
+Before planner allocation, one bind also compares a conservative transient sum
+to the same byte ceiling. The sum starts with one exact copy of the captured
+routing-key bytes. Each normalized marker occurrence then charges twice its
+referenced logical accounted value bytes (one type-tag byte, an eight-byte
+length, and its payload), once for a possible typed-inference copy and once for
+a possible canonical-route copy. Repeated markers are charged again. The
+transient sum is not retained or added to existing portal bytes. A failure
+returns `LimitExceeded` before planning and publishes no portal.
 
 ## Schema-migration controls
 
@@ -143,6 +178,12 @@ If forced cleanup also exceeds its grace period, shutdown returns
 shutdown is idempotent, and dropping one shutdown waiter does not strand the
 shared lifecycle. Dropping an ordinary `Engine` clone does not initiate
 shutdown; embedders should call the explicit asynchronous hook.
+
+Prepared statement/portal close and `Session::close` are in-memory cleanup and
+remain available while the engine is draining. Terminal session close waits
+for an admitted same-session operation, then clears every statement, portal,
+captured route/value, and routing context. Nothing in the prepared cache is
+persisted or recovered after process shutdown.
 
 The server constructs its SIGINT/SIGTERM receivers before logging readiness on
 supported Unix hosts. It transitions the engine to `Draining` before dropping

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -62,22 +62,26 @@ explicit routing byte sequence, retains the inference, and produces owned
 physical routes with schema and routing provenance. It compares finite inferred
 and explicit routes by physical shard, rejects unroutable cataloged sharded
 DML, and records a valid single-shard assignment. The planner does not invoke
-translation, authorize, enforce batch policy, or execute a statement. HTTP
-requests still send caller-provided SQLite SQL directly to `rusqlite`; they do
-not pass through these opt-in SQL layers.
+translation, authorize, enforce batch policy, or execute a statement. The
+protocol-neutral prepared lifecycle composes these SQL stages for exactly one
+statement, binds typed values into a session-scoped portal, refreshes stale
+description metadata, plans freshly at every execution, and executes supported
+physical targets. HTTP requests still send caller-provided SQLite SQL directly
+to the raw engine path; they do not
+pass through these opt-in SQL layers.
 
 | Interface | Status | SQL accepted | Routing |
 | --- | --- | --- | --- |
 | HTTP `/v1/execute` | Experimental | One SQLite statement with positional parameters | Required caller-provided `shard_key` |
-| HTTP `/v1/query` | Experimental | One prepared SQLite statement executed through the row-returning path | Required caller-provided `shard_key` |
+| HTTP `/v1/query` | Experimental | One raw SQLite statement prepared transiently by the row-returning path; no session cache | Required caller-provided `shard_key` |
 | HTTP `/v1/admin/broadcast` | Experimental | A journaled parameterless SQLite schema batch | Preflight on every shard, then ascending resumable apply |
-| PostgreSQL wire protocol | Planned | Rust parsing, validation, placeholder normalization, and finite compatibility translation implemented; listener adoption planned | Rust inference and bind-time single-shard routing policy implemented; wire lifecycle and session integration planned |
-| MySQL wire protocol | Planned | Rust parsing, validation, placeholder normalization, and finite compatibility translation implemented; listener adoption planned | Rust inference and bind-time single-shard routing policy implemented; wire lifecycle and session integration planned |
+| PostgreSQL wire protocol | Planned | Rust parsing, validation, placeholder normalization, finite compatibility translation, and prepared lifecycle implemented; listener adoption planned | Core bind validation, routing snapshots, current execute-time planning, and supported target execution implemented; wire mapping planned |
+| MySQL wire protocol | Planned | Rust parsing, validation, placeholder normalization, finite compatibility translation, and prepared lifecycle implemented; listener adoption planned | Core bind validation, routing snapshots, current execute-time planning, and supported target execution implemented; wire mapping planned |
 
 The parser, subset validator, placeholder normalizer, SQL translator, shard-key
-inference function, and engine planner are implemented Rust APIs, not network
-interfaces. Each step is opt-in and does not change any current network row in
-this table.
+inference function, engine planner, and prepared lifecycle are implemented Rust
+APIs, not PostgreSQL or MySQL network interfaces. They do not change any
+current HTTP row in this table.
 
 Every HTTP operation now calls the same protocol-neutral async engine intended
 for future PostgreSQL and MySQL adapters. Execute and query requests create a
@@ -319,6 +323,10 @@ defines the supported proof grammar and typed result. The [bound
 statement-planning and routing-policy contract](SQL_PLANNING.md) defines
 canonical route bytes, occurrence ordering, physical-target comparison, write
 rejection, provenance, and the non-executable planning boundary.
+The [prepared statements and bound portals
+contract](SQL_PREPARED_STATEMENTS.md) defines the composed exact-one-statement
+lifecycle, session limits, metadata, routing snapshots, current execution
+planning, and supported physical targets.
 
 ### Implemented pass-through surface
 
@@ -391,20 +399,20 @@ typed key extraction is the implemented issue #22 layer. Synchronous bind-time
 route construction is the implemented issue #23 layer, and issue #24 adds
 physical-target comparison, assigned shards, and rejection of conflicting or
 unroutable cataloged sharded writes.
-Prepare/bind/describe/execute state remains issue #26, and empty or
-multi-statement execution policy remains issue #27.
+Issue #26 adds the prepared/bind/describe/execute state described below. Empty
+or multi-statement request policy remains issue #27; a prepared handle requires
+exactly one statement as its own cardinality rule.
 
 The validator independently caps recursive expression AST depth at 128. This
 also bounds flat operator chains that parse iteratively; exceeding the limit is
 reported as `LimitExceeded`.
 
-The future driver-capable execution path will send `CREATE TABLE` and
-`CREATE INDEX` through journaled schema migrations, consume only an accepted
-single-shard write or supported read plan, revalidate its provenance, and
-implement real transactions through protocol-neutral session state. The
-implemented planning API already rejects unroutable or conflicting cataloged
-writes; unsafe statement combinations and cross-shard transactions remain
-later request/session policy.
+The driver-capable Rust execution path now consumes accepted sharded writes and
+supported read targets and creates a fresh plan under every execution's current
+schema guard. Persistent `CREATE TABLE` and `CREATE INDEX` must still use
+journaled schema migrations, and real transactions still require
+protocol-neutral transaction state. Unsafe statement combinations and
+cross-shard transactions remain later request/session policy.
 
 ### Implemented placeholder normalization
 
@@ -425,9 +433,10 @@ error contract are in [SQL parameter normalization](SQL_PARAMETERS.md).
 
 This implemented normalization does not bind or count supplied values, infer a
 shard, translate other dialect syntax, create a prepared statement, classify
-statement behavior, authorize a request, or execute SQL. Translation is the
-separate opt-in layer described next. The HTTP and engine paths continue to
-bind their existing caller-supplied SQLite SQL directly.
+statement behavior, authorize a request, or execute SQL by itself. Translation
+is the separate opt-in layer described next. The prepared lifecycle composes
+both layers, while the raw HTTP paths continue to bind caller-supplied SQLite
+SQL directly.
 
 ### Implemented SQL translation
 
@@ -510,6 +519,35 @@ statement, apply complete statement/batch policy, scatter reads, or execute
 SQLite. The exact matrix and error precedence are in [bound statement planning
 and routing policy](SQL_PLANNING.md).
 
+### Implemented prepared-statement lifecycle
+
+The public async Rust engine accepts a `PrepareRequest` with one logical
+database, explicit source dialect, explicit translation mode, and SQL string.
+Prepare runs parsing through translation, requires exactly one top-level
+statement, and transiently compiles parameter/column metadata on shard 0. A
+session retains only BriskDB-owned translated SQL and owned metadata; no SQLite
+statement or connection is cached.
+
+Binding validates a complete typed `Value` slice with a transient plan,
+snapshots the session's current routing key, and returns an opaque
+session-scoped `PortalId`. The portal retains the values and routing snapshot,
+not a plan. Describe returns ordered columns and one `Unknown` type per
+parameter/result column and refreshes metadata after schema migration. Every
+execution creates a fresh plan under its current schema guard. It runs accepted
+sharded work on its assigned shard and safe
+column-producing `NotApplicable`/`Global` reads on deterministic shard 0;
+catalog reads and sharded reads requiring scatter remain unsupported. Results
+are the same protocol-neutral routed rowset or affected-row count for SQLite,
+PostgreSQL, and MySQL source.
+
+Per-session statement, portal, retained-bound-value, and per-bind planning
+limits are finite and have no implicit eviction. Planning preflight charges the
+captured route once and each marker occurrence twice. Explicit close releases
+entries; closing a statement also invalidates all dependent portals. The API,
+defaults, logical byte accounting, request controls, errors, and storage
+boundary are normative in
+[prepared statements and bound portals](SQL_PREPARED_STATEMENTS.md).
+
 ## PostgreSQL differences
 
 The PostgreSQL listener will target the frontend/backend wire protocol and a
@@ -518,7 +556,7 @@ not implemented unless listed as implemented in this document.
 
 | Area | PostgreSQL | BriskDB contract |
 | --- | --- | --- |
-| Parameters | `$1`, `$2`, ... | Implemented opt-in Rust normalization, typed inference, and single-shard routing policy from a supplied bound slice; wire bind lifecycle remains planned |
+| Parameters | `$1`, `$2`, ... | Rust normalization and session-scoped prepare/bind/describe/execute are implemented; PostgreSQL message/name/type mapping remains planned |
 | Identifier quoting | Double quotes | Retained by opt-in compatibility translation; PostgreSQL case folding and catalog equivalence are not claimed |
 | Type system | Static types identified by OIDs | Opt-in Rust translation maps a finite declaration set to `BIGINT`, `BOOLEAN`, `REAL`, `TEXT`, or `BLOB`; OID and value/result adaptation remain planned |
 | Boolean | Dedicated `boolean` type | Opt-in translation maps the declaration to `BOOLEAN` and literals to `1`/`0`; Boolean wire/result metadata remains planned |
@@ -546,7 +584,7 @@ engine used by PostgreSQL and HTTP.
 
 | Area | MySQL | BriskDB contract |
 | --- | --- | --- |
-| Parameters | `?` in prepared statements | Implemented opt-in Rust normalization, typed inference, and single-shard routing policy from a supplied bound slice; wire bind lifecycle remains planned |
+| Parameters | `?` in prepared statements | Rust normalization and session-scoped prepare/bind/describe/execute are implemented; MySQL command/type mapping remains planned |
 | Identifier quoting | Backticks by default | Opt-in compatibility translation emits safely escaped double-quoted SQLite identifiers; case and collation equivalence are not claimed |
 | Type system | Static signed/unsigned column types | Opt-in Rust translation maps a finite signed integer, Boolean, 64-bit float, text, and binary declaration set; unsigned declarations are rejected, and translation performs no value or result adaptation. Independently, BriskDB retains `UInt64` values without narrowing, while current SQLite binding rejects values above `i64::MAX` until a storage mapping exists |
 | Boolean | Commonly `TINYINT(1)` | Opt-in translation maps exactly `TINYINT(1)` to `BOOLEAN` and Boolean literals to `1`/`0`; wire/result metadata remains planned |
@@ -620,8 +658,12 @@ underlying execution semantics.
 - Opt-in bound planning converts every inferred occurrence to an owned route,
   retains an independent explicit route, and records catalog/routing
   provenance. It compares finite routes by physical shard, rejects unroutable
-  cataloged sharded writes, and records an accepted single-shard assignment;
-  it does not make a plan executable or change current HTTP behavior.
+  cataloged sharded writes, and records an accepted single-shard assignment.
+- The Rust prepared lifecycle snapshots bound values and session routing in an
+  immutable portal, transiently validates at bind, plans on every execution,
+  executes accepted sharded targets, and uses shard 0 for supported
+  replicated-schema reads. It does not change current HTTP behavior or
+  implement scatter reads.
 - Point queries and writes visit only that shard.
 - No scatter/gather query path exists.
 - Unique constraints and transactions are local to one SQLite shard.
@@ -636,9 +678,6 @@ underlying execution semantics.
 - Every sharded table declares one non-null shard-key column in the catalog.
 - Canonical key encoding, hash version, virtual bucket count, and bucket map are
   persisted in the manifest.
-- Execution validates bound-plan provenance, consumes the implemented
-  single-shard write/read assignment, and uses session routing state only
-  through the prepared execution lifecycle.
 - A transaction is pinned to its first shard. Targeting another shard returns a
   stable cross-shard-transaction error.
 - Read-only plans may scatter with bounded concurrency and deterministic merge.

--- a/docs/SQL_PARAMETERS.md
+++ b/docs/SQL_PARAMETERS.md
@@ -18,10 +18,11 @@ public SQLite parameter-index ceiling is `MAX_SQL_PARAMETERS`, currently
 
 This layer changes placeholder tokens only. No parameter values enter the
 normalizer, and values are never rendered or interpolated into SQL text. The
-current HTTP execute, query, and migration endpoints and the asynchronous
-engine do not invoke this opt-in layer; they retain their existing raw SQLite
-behavior. Issue #27 owns whether an empty batch, one statement, or a particular
-multi-statement combination may execute.
+current HTTP execute, query, and migration endpoints do not invoke this opt-in
+layer; they retain their existing raw SQLite behavior. The asynchronous
+prepared lifecycle does invoke it and requires exactly one statement before it
+creates a prepared handle. Issue #27 still owns general empty-batch and
+multi-statement request policy.
 
 The separate [SQL translation layer](SQL_TRANSLATION.md) can consume the
 result and either expose the normalized SQLite text exactly in strict mode or
@@ -53,6 +54,12 @@ Each `StatementParameters` reports:
 explicit PostgreSQL or SQLite index can leave a gap. Numbering restarts for
 each top-level statement. The per-statement records describe binding; they do
 not authorize batch execution.
+
+The prepared bind path also walks `parameter_indices()` in this exact
+occurrence order before planner allocation. It charges every occurrence,
+including repeated references to one parameter, against the conservative
+per-bind planning-expansion limit. This use does not change normalization or
+retain a bound value in `NormalizedSql`.
 
 For example, PostgreSQL `SELECT $2, $1, $2` becomes
 `SELECT ?2, ?1, ?2`. Its parameter count is 2, its occurrence count is 3, and
@@ -169,8 +176,10 @@ metadata plus a catalog database and exact bound-value slice. The implemented
 only after values are bound, compares finite physical targets, rejects
 unroutable cataloged sharded writes, and records a valid single-shard
 assignment. The implemented issue #25 translation layer is separate from this
-normalizer. Issues #26 and #27 own prepared-statement state and request-level
-statement classification respectively.
+normalizer. The implemented
+[prepared-statement lifecycle](SQL_PREPARED_STATEMENTS.md) runs normalization
+during prepare, retains its metadata, and uses it again at bind. Issue #27 owns
+request-level statement classification.
 
 ## Verification obligations
 

--- a/docs/SQL_PARSER.md
+++ b/docs/SQL_PARSER.md
@@ -73,7 +73,8 @@ In particular, this layer does not:
   call with physical-target comparison and sharded-write policy;
 - itself translate types or syntax; issue #25 implements that as the separate
   `translate_sql(NormalizedSql, SqlTranslationMode)` layer;
-- implement prepare/bind/describe/execute state or caches (issue #26); or
+- implement prepare/bind/describe/execute state or caches (issue #26 provides
+  those as a separate core layer); or
 - classify statement behavior or reject unsafe multi-statement combinations
   (issue #27).
 
@@ -88,9 +89,10 @@ The existing HTTP execute, query, and migration paths remain raw SQLite
 pass-through surfaces with their existing authorizer and endpoint-specific
 rules. They call neither this parser, the opt-in common-subset validator,
 placeholder normalizer, translator, shard-key inference, nor bound statement
-planner. Connecting those layers before the prepared execution lifecycle and
-request-level statement policy are implemented would change the experimental
-HTTP SQL surface.
+planner. The separate Rust
+[prepared lifecycle](SQL_PREPARED_STATEMENTS.md) now connects those layers for
+an exact-one-statement handle without changing the experimental HTTP SQL
+surface. Request-level statement and batch policy remains issue #27.
 
 ## Resource and error boundaries
 

--- a/docs/SQL_PLANNING.md
+++ b/docs/SQL_PLANNING.md
@@ -20,8 +20,9 @@ Engine::plan_bound_statement(
 slice for that statement, exactly as required by
 [`infer_shard_keys`](SQL_SHARD_KEYS.md). A statement whose shard key is a
 placeholder cannot be routed when SQL is parsed or prepared because its value
-does not exist yet. A frontend calls this API for a concrete bind/execute
-operation.
+does not exist yet. A frontend may call this API directly for a concrete bind,
+while the prepared lifecycle invokes the same admitted planner when validating
+a new portal and again for every execution.
 
 The call performs protocol-neutral analysis only. It infers typed shard-key
 values, converts them to canonical routing bytes, looks up physical shards,
@@ -54,6 +55,14 @@ parameter buffers after the call returns.
 normal successful result for a statement that is not sharded and for a read
 that still needs later scatter or empty-result planning. Every accepted write
 to a cataloged sharded table has `Some(shard)`.
+
+The [prepared execution lifecycle](SQL_PREPARED_STATEMENTS.md) consumes this
+result only after values are bound. Bind validates then discards one plan;
+execution creates another under its current schema guard. Execution uses an
+assigned shard for cataloged sharded work and may select deterministic shard 0
+for a safe column-producing `NotApplicable` or `Global` read. It still rejects
+catalog placement and sharded reads that need scatter. That target-selection
+integration does not change this planner's meaning of `assigned_shard()`.
 
 `Debug` output reports identifiers, versions, shard IDs, and counts where
 useful. It does not render SQL, AST contents, inferred key values, explicit key
@@ -123,8 +132,10 @@ ASCII case-folded catalog comparison; quoted identifiers compare exactly.
 Row movement between shards is not implemented.
 
 `NotApplicable` and `NotSharded` statements do not become successful sharded
-writes. Global, catalog, and schema placement have separate future execution
-paths and retain `assigned_shard() == None` here.
+writes. Global and Catalog placement, plus schema/session statements, retain
+`assigned_shard() == None` at this planning layer. Downstream execution policy
+decides whether a specific unassigned statement can run; the prepared lifecycle
+currently reads Global data on shard 0 and rejects Catalog placement.
 
 ## Canonical routing-key bytes
 
@@ -177,14 +188,16 @@ call returns.
 The successful plan records the application-schema generation,
 routing-map generation, hash version, key-encoding version, and
 bucket-algorithm version used by the call. These fields are provenance, not a
-lease on future state. A future execution path must establish that the
-physical schema and routing snapshot are still authoritative and reject or
-replan stale provenance before using `assigned_shard()`.
+lease on future state. Portal execution establishes that the physical schema
+and routing snapshot remain authoritative by producing a new plan from the
+portal's owned values and route snapshot under every execution's fresh
+schema-operation guard. Bind uses its plan only for transient validation.
 
 The logical table catalog remains read-only and advisory. Planning does not
 assert that its table metadata describes an existing physical SQLite table or
-column. Physical catalog authority and execution validation remain future
-integration work.
+column. Prepared setup transiently compiles translated SQL against shard 0, but
+it does not reconcile advisory table rows with the physical schema or mutate
+the catalog.
 
 ## Errors and recovery
 
@@ -219,17 +232,22 @@ and poisons no engine state; a later independent call can succeed.
 
 ## Deliberate boundaries
 
-Issues #23 and #24 add no configuration, CLI option, environment variable,
-network message, HTTP shape, manifest migration, shard-file change, or SQLite
-execution path. In particular:
+The direct issues #23 and #24 planner API itself adds no configuration, network
+message, HTTP shape, manifest migration, shard-file change, or SQLite execution
+path. In particular:
 
 - `Engine::plan_bound_statement` is synchronous and stateless; it neither
   accepts nor mutates a `Session`;
-- `assigned_shard()` is not consumed by the current raw HTTP or engine execute
-  and query paths;
+- `assigned_shard()` is not consumed by the current raw HTTP execute/query
+  paths, but it is consumed by issue #26 portal execution;
 - no read scatter, merge, contradiction short circuit, or write executes here;
 - no transaction pinning or cross-call routing context is applied;
-- no per-session or global prepared-statement cache is created;
+- this synchronous method creates no per-session or global cache; issue #26
+  retains only typed values and a routing snapshot in each portal, not this
+  plan;
+- the prepared bind path applies its occurrence-based planning-expansion byte
+  ceiling before calling this method; a direct stateless planner call has no
+  session cache or `PreparedStatementLimits` to consult;
 - planning does not invoke the separate PostgreSQL/MySQL-to-SQLite translation
   layer;
 - no complete read/write/schema/session or batch classifier is published; and
@@ -237,9 +255,10 @@ execution path. In particular:
   validation, normalization, inference, or planning.
 
 The implemented issue #25 translation API can independently consume the same
-normalized statement, but it neither changes nor executes a bound plan. Issue
-#26 owns the protocol-neutral prepare/bind/describe/execute lifecycle, session
-integration, provenance revalidation, and bounded per-session cache. Issue #27
+normalized statement, but it neither changes nor executes a bound plan. The
+implemented issue #26 protocol-neutral prepare/bind/describe/execute lifecycle
+integrates translation and planning, validates transiently at bind, and plans
+again from the bounded session portal's snapshot at every execution. Issue #27
 owns the authoritative statement-behavior and empty, single-, and
 multi-statement request policy. Later query-planner work owns scatter/gather
 execution.

--- a/docs/SQL_PREPARED_STATEMENTS.md
+++ b/docs/SQL_PREPARED_STATEMENTS.md
@@ -1,0 +1,429 @@
+# Prepared statements and bound portals
+
+Status: implemented for roadmap issue #26
+
+BriskDB exposes one protocol-neutral lifecycle for SQL submitted by SQLite,
+PostgreSQL, MySQL, and future adapters. A frontend owns a `Session`, explicitly
+selects the logical database, source dialect, and translation mode, and maps its
+wire concepts onto BriskDB's opaque prepared-statement and portal handles.
+
+```rust
+use briskdb::{
+    core::{
+        DescribeTarget, Engine, EngineResult, LogicalDatabaseId, PrepareRequest,
+        PreparedExecution, Session, Value,
+    },
+    sql::{SqlDialect, SqlTranslationMode},
+};
+
+async fn example(
+    engine: &Engine,
+    session: &Session,
+    database: LogicalDatabaseId,
+) -> EngineResult<()> {
+    let statement = engine
+        .prepare_statement(
+            session,
+            PrepareRequest::new(
+                database,
+                SqlDialect::PostgreSql,
+                SqlTranslationMode::Compatibility,
+                "SELECT payload FROM events WHERE tenant_id = $1",
+            ),
+        )
+        .await?;
+
+    let _description = engine
+        .describe_prepared(session, DescribeTarget::Statement(statement))
+        .await?;
+    let portal = engine
+        .bind_statement(session, statement, vec![Value::from(7_i64)])
+        .await?;
+    let routed = engine.execute_portal(session, portal).await?;
+
+    match routed.value {
+        PreparedExecution::Rows(rows) => {
+            // Encode `rows` for the calling protocol.
+            let _ = rows;
+        }
+        PreparedExecution::AffectedRows(rows) => {
+            // Encode the command count for the calling protocol.
+            let _ = rows;
+        }
+        _ => {}
+    }
+    Ok(())
+}
+```
+
+## Public lifecycle
+
+The public engine methods are:
+
+```text
+prepare_statement(&Session, PrepareRequest)
+    -> EngineResult<PreparedStatementId>
+bind_statement(&Session, PreparedStatementId, Vec<Value>)
+    -> EngineResult<PortalId>
+describe_prepared(&Session, DescribeTarget)
+    -> EngineResult<PreparedStatementDescription>
+execute_portal(&Session, PortalId)
+    -> EngineResult<Routed<PreparedExecution>>
+close_prepared_statement(&Session, PreparedStatementId)
+    -> EngineResult<bool>
+close_portal(&Session, PortalId)
+    -> EngineResult<bool>
+```
+
+Prepare, bind, describe, and execute also have `*_with_context` variants that
+accept `RequestContext`. Close is in-memory session cleanup and has no request
+context.
+
+`PrepareRequest` owns four explicit inputs:
+
+- a valid `LogicalDatabaseId` present in the current catalog;
+- one `SqlDialect` (`Sqlite`, `PostgreSql`, or `MySql`);
+- one `SqlTranslationMode`; and
+- the original SQL string.
+
+There is no dialect detection and no default translation mode. The request's
+`Debug` representation reports only the database, dialect, translation mode,
+and SQL byte count; it never renders SQL text.
+
+Preparation runs the same ordered frontend pipeline for every protocol:
+
+```text
+parse -> exact-one top-level statement check -> common-subset validation ->
+placeholder normalization -> explicit translation -> transient SQLite compile
+```
+
+The request must contain exactly one top-level SQL statement. Empty,
+comment-only, and multi-statement input returns `InvalidArgument`. This is a
+prepared-handle cardinality rule, not the general request classifier: issue
+#27 remains authoritative for empty and multi-statement request policy and for
+read/write/schema/session behavior.
+
+## Logical cache and handle ownership
+
+Every `Session` owns an independent bounded logical cache. A cached statement
+contains BriskDB-owned `TranslatedSql` and owned description metadata. It never
+retains a `rusqlite::Statement`, `rusqlite::Rows`, SQLite connection, pooled
+handle, protocol buffer, or adapter object. Preparation transiently compiles
+the translated SQLite SQL on physical shard 0, copies its metadata, drops the
+SQLite statement, and only then publishes the logical cache entry.
+
+`PreparedStatementId` and `PortalId` are opaque, session-scoped handles. Each
+contains its owning process-unique session identity and a monotonically
+increasing nonzero sequence. Sequences are never reused, including after a
+close. A handle from another session or engine cannot resolve in the receiving
+session.
+
+The cache never evicts a client-visible handle implicitly. When a configured
+count or byte limit is full, the new prepare or bind fails with
+`LimitExceeded`; every existing handle remains valid. Explicit close releases
+capacity:
+
+- `close_portal` removes one portal and returns `true`; closing it again in the
+  same session returns `false`;
+- `close_prepared_statement` removes one statement and every portal bound from
+  it, releases all of their retained-value bytes, and returns `true`; a second
+  same-session close returns `false`; and
+- `Session::close` is terminal and idempotent and clears routing context,
+  prepared statements, portals, and retained-byte accounting.
+
+Describing, binding, or executing an absent same-session handle returns
+`FailedPrecondition`. Closing a statement invalidates all dependent portals.
+An ordinary statement, bind, description, planning, or execution error does not
+evict unrelated valid handles or poison the session.
+
+## Description metadata
+
+Preparation compiles canonical `TranslatedSql::sqlite_sql()` on deterministic
+physical shard 0 under the normal schema-operation, pool, worker, cancellation,
+deadline, connection-isolation, and SQLite cleanup boundaries. Shard 0 is the
+metadata authority because every usable application schema is generation-bound
+and verified to match across shards.
+
+`PreparedStatementDescription` is owned, cloneable, `Send`, and `Sync`. It
+reports:
+
+- one `DataType::Unknown` entry for every normalized one-based parameter index;
+- ordered result `Column` values copied from SQLite, preserving duplicate and
+  empty names;
+- `DataType::Unknown` for every result column;
+- the application-schema generation used for compilation; and
+- `returns_rows()`, derived from whether SQLite reported result columns.
+
+BriskDB deliberately does not infer PostgreSQL or MySQL wire types from SQLite
+affinity in this milestone. An adapter decodes its parameter representation to
+a concrete protocol-neutral `Value` before bind and maps `Unknown` metadata
+according to its own documented wire rules.
+
+`DescribeTarget::Statement` describes a statement;
+`DescribeTarget::Portal` describes its underlying statement. A description at
+the current schema generation is returned from owned memory. After a completed
+schema migration changes the generation, describe recompiles the SQL on shard
+0 and atomically replaces the cached metadata. A normalized-versus-SQLite
+parameter-count mismatch is an `Internal` invariant failure and does not
+publish mismatched metadata.
+
+## Binding and portals
+
+Binding happens only after concrete typed values exist. It validates the exact
+parameter count and every value's lossless SQLite binding, then invokes the
+same bound-statement planner documented in [SQL planning](SQL_PLANNING.md).
+The planner receives statement index 0, the prepared statement's selected
+logical database and retained normalized SQL, the complete value slice, and
+the session's routing key at that instant.
+
+A successful bind creates an immutable logical portal that owns:
+
+- its parent `PreparedStatementId`;
+- the complete protocol-neutral bound values;
+- a byte-for-byte snapshot of the session routing key, when present.
+
+The bind-time `BoundStatementPlan` is validation only and is discarded before
+the portal is published. A portal never retains inferred route bytes, an
+explicit planned route, schema/routing provenance, or another hidden planning
+allocation. This keeps its retained-byte accounting equal to the documented
+values-plus-route model.
+
+Changing or clearing the session routing key after bind does not change an
+existing portal. A later bind observes the later routing context. This lets an
+adapter map PostgreSQL named and unnamed portals, MySQL statement executions,
+or another protocol's equivalent operation onto one engine rule without
+retaining frontend buffers. Portal `Debug` output reports only counts,
+whether a route exists, and retained bytes; it does not render parameter values
+or routing bytes.
+
+Portals are reusable and are not consumed by execution. Multiple portals may
+refer to one prepared statement, subject to the per-session limits. Portal row
+suspension and protocol cursor semantics are not implemented; each execution
+materializes one complete bounded result or returns an error.
+
+## Cache limits and exact byte accounting
+
+`PreparedStatementLimits` validates three independent finite per-session
+limits:
+
+| Limit | Default | Configurable range | CLI / environment |
+| --- | ---: | ---: | --- |
+| Prepared statements | 128 | 1–1,024 | `--max-prepared-statements-per-session` / `BRISKDB_MAX_PREPARED_STATEMENTS_PER_SESSION` |
+| Bound portals | 128 | 1–1,024 | `--max-portals-per-session` / `BRISKDB_MAX_PORTALS_PER_SESSION` |
+| Retained logical-accounted value/per-bind planning bytes | 16 MiB | 1 byte–1 GiB | `--max-retained-bound-value-bytes` / `BRISKDB_MAX_RETAINED_BOUND_VALUE_BYTES` |
+
+Rust embedders configure these with
+`EngineOptions::with_prepared_statement_limits`; `Engine::options()` and
+`EngineStatus::prepared_statement_limits()` expose the effective values. A
+server validates CLI/environment values before listener binding or data-file
+creation.
+
+The `max_retained_bound_value_bytes()` accessor and retained-bound-value
+configuration name expose one ceiling used for two separate comparisons: the
+session aggregate retained by open portals and one bind's transient planning
+preflight. BriskDB does not add those two comparisons together.
+
+The retained-byte limit covers values and captured routing bytes owned by all
+open portals in one session. It is independent of result materialization and
+does not count cached SQL; prepared SQL already has the parser's 65,536-byte
+per-request ceiling and the separate prepared-statement count bound.
+
+For every parameter, the stable protocol-neutral accounting model charges one
+type-tag byte, an eight-byte length, and the payload:
+
+| `Value` | Payload bytes |
+| --- | ---: |
+| `Null` | 0 |
+| `Boolean`, `Int64`, `UInt64`, `Float64` | 8 |
+| `Decimal` | Exact retained decimal-string byte length |
+| `Text` | Exact UTF-8 byte length |
+| `InvalidText`, `Binary` | Exact byte length |
+
+The captured route adds exactly its byte length, with no route envelope, type,
+or length charge. A missing route adds zero. Empty values and an empty captured
+route remain valid and are accounted exactly. This is a logical accounting
+model; BriskDB retains typed `Value` objects, not a serialized accounting or
+wire encoding. All addition and integer conversion is checked. Equality at the
+configured limit succeeds; exceeding it, or an accounting overflow, is
+`LimitExceeded`. Failed binds retain no values and change no counters.
+
+The same configured byte ceiling also bounds one bind's conservative transient
+planning expansion before the planner can allocate inferred values or canonical
+route bytes. The charge starts with one exact copy of the captured routing-key
+bytes, or zero when no route exists. BriskDB then walks
+`StatementParameters::parameter_indices()` in normalized occurrence order. For
+each occurrence, including each appearance of a repeated marker, it charges
+twice the referenced parameter's logical accounted value bytes: one type-tag
+byte, an eight-byte length, and the payload listed above. The two charges cover
+one possible typed-inference copy and one possible canonical-route copy.
+
+This planning charge is a per-bind preflight, not retained cache state. It does
+not include existing portals, is not added to the session's retained-byte
+counter, and disappears when the check returns. Gapped parameters with no
+marker occurrence add no planning charge, although their values are still part
+of the exact retained portal input. Equality succeeds; overflow or a sum above
+the ceiling is `LimitExceeded`. Consequently, a large captured route or
+repeated markers can reject a bind even when its exact retained portal input
+would otherwise fit the remaining session capacity. The planner is not called
+and no portal is published on that failure.
+
+## Execution and provenance
+
+`execute_portal` never hashes a frontend buffer or selects a shard in an
+adapter. It reloads both same-session handles and always creates a new
+`BoundStatementPlan` from the portal's owned values and captured routing
+snapshot under the current schema-operation guard. The new plan necessarily
+contains the current schema generation, routing-map generation, hash version,
+key-encoding version, and bucket-algorithm version. The engine keeps that same
+guard through target selection and SQLite completion, then discards the plan.
+
+Target selection is intentionally narrow:
+
+- accepted cataloged sharded work uses the current plan's one
+  `assigned_shard()`;
+- a safe column-producing statement with `NotApplicable` inference, such as
+  `SELECT 1`, uses deterministic shard 0;
+- a safe column-producing read of a `Global` table uses deterministic shard 0;
+- `Catalog` placement is `PermissionDenied`; and
+- an unassigned sharded read that requires scatter is `Unsupported`.
+
+Shard 0 is valid for the two replicated-schema read cases because every ready
+shard has the same generation-bound application schema and `Global` declares
+replicated lookup placement. This initial path reads one deterministic replica;
+it does not compare replicas.
+
+These paths remain outside issue #26:
+
+- scatter/gather or otherwise multi-shard reads;
+- contradictory reads that might later become an empty result without SQLite;
+- global writes, schema and session-statement execution paths;
+- persistent DDL outside the journaled schema-migration API;
+- complete read/write/schema/session classification and safe batch policy; and
+- explicit transaction state and shard pinning.
+
+Cataloged sharded DML must already satisfy the single-shard policy in
+[SQL planning](SQL_PLANNING.md). A cataloged read with finite inference, or one
+accepted through the bind-time routing fallback, can execute when it has one
+assigned shard. Issue #27 will publish the authoritative statement classifier;
+issue #26 does not infer permission merely from SQLite's ability to compile a
+statement.
+
+SQLite transiently prepares and executes the retained canonical SQLite SQL on
+the selected target. Read-only statements produce
+`Routed<PreparedExecution::Rows(ResultSet)>`; commands produce
+`Routed<PreparedExecution::AffectedRows(usize)>`. Row results preserve ordered
+metadata, duplicate names, positional values, and the normal exact result row
+and logical-byte limits. Row-producing writes are rejected rather than partly
+materialized. The returned `Routed` value always names the physical shard that
+performed the operation.
+
+## Controls, concurrency, close, and shutdown
+
+Prepare, bind, describe, and execute are ordinary engine operations. Their
+`*_with_context` methods apply the caller's sticky cancellation token and
+deadline; the engine default deadline is still an upper bound. Prepare and a
+schema-refreshing describe apply those controls while waiting for shard 0 and
+while SQLite compiles metadata. Execute also applies per-request result limits,
+SQLite interruption, rollback, pool cleanup, and exact-handle retirement.
+
+The engine serializes all concurrent operations borrowing one `Session`. The
+session lock remains owned across pending admission and blocking SQLite work,
+so two successful mutations of one logical cache have one deterministic order.
+Different sessions have independent caches and can progress concurrently,
+subject to the existing schema gate, per-shard pools, and worker limits.
+Cancellation while waiting for the session publishes no statement or portal.
+`Session::close` waits for an admitted same-session operation, then clears all
+state; later prepared operations fail with `FailedPrecondition`.
+
+After `begin_shutdown`, new prepare, bind, describe, and execute admissions
+return `ShuttingDown`; previously admitted work drains under the ordinary
+shutdown contract. `close_prepared_statement`, `close_portal`, and
+`Session::close` are in-memory cleanup and remain available while the engine is
+draining. Prepared state is not persisted and requires no restart recovery.
+
+## Errors and recovery
+
+The lifecycle preserves the existing stable `EngineErrorKind` taxonomy:
+
+| Condition | Kind |
+| --- | --- |
+| Unknown logical database, empty/multi-statement prepare, wrong bind arity, or conflicting explicit/inferred route | `InvalidArgument` |
+| SQL parse/SQLite compile failure or planner write-policy rejection where documented | `InvalidQuery` |
+| Unsupported subset/translation form, unsupported execution target, or row-producing write | `Unsupported` or the narrower documented SQL-path kind |
+| Execution with `Catalog` placement, whether a read or command | `PermissionDenied` |
+| Incompatible key/value type | `TypeMismatch` |
+| Out-of-range unsigned integer or inferred integer | `NumericOutOfRange` |
+| Invalid text value | `InvalidTextEncoding` |
+| Full cache, full portal set, retained-value/planning limit, or sequence/accounting exhaustion | `LimitExceeded` |
+| Closed session, foreign engine/session handle, absent statement/portal, or pending schema migration | `FailedPrecondition` |
+| Pool/schema admission contention | `Busy` |
+| Request cancellation or deadline | `Cancelled` / `DeadlineExceeded` |
+| Degraded storage state | `DataCorruption` |
+| Retained metadata or accounting invariant mismatch | `Internal` |
+
+Parsing, validation, normalization, translation, inference, planning, SQLite,
+request-control, and storage errors retain the precedence and kind defined by
+their normative contracts. Cache-limit failures do not evict older entries.
+Failed prepare does not publish an ID; failed bind does not publish a portal;
+failed describe does not replace valid current metadata; and failed execution
+retains the portal for inspection, retry where independently appropriate, or
+explicit close. Corrected values require binding a new portal.
+
+Adapters map only the stable kind and fixed public text according to
+[the error contract](ERRORS.md); they never serialize an `EngineError` display,
+source chain, or dependency-owned SQLite diagnostic. `PrepareRequest`, cached
+template/state, portal, `BoundStatementPlan`, and
+`PreparedStatementDescription` `Debug` output is deliberately redacted to
+counts, modes, IDs, versions, and route presence. Internal trusted validation
+diagnostics may include a rejected value where an existing value-conversion
+contract says so, including out-of-range unsigned integers or decimals.
+`PreparedExecution` `Debug` intentionally renders its user-visible affected-row
+count or result values. Operators must therefore apply their normal result/log
+handling to that type.
+
+## Dialect and adapter compatibility
+
+The lifecycle is implemented as a Rust engine API, not yet as a PostgreSQL or
+MySQL listener. All three input paths share the same planning and result path:
+
+| Input | Required mode and parameter form | Prepared execution result |
+| --- | --- | --- |
+| SQLite | `StrictSqlite` for exact normalized SQLite, or explicit finite `Compatibility`; `?` / `?N` | Protocol-neutral routed rows or affected-row count |
+| PostgreSQL | `Compatibility`; `$N` identities, including repeats and gaps | Same protocol-neutral routed rows or affected-row count |
+| MySQL | `Compatibility`; each `?` numbered left-to-right | Same protocol-neutral routed rows or affected-row count |
+
+Future adapters own message framing, authentication, statement/portal naming,
+wire parameter decoding, result type encoding, close acknowledgement, and
+protocol resynchronization. They must call this lifecycle rather than retain a
+SQLite handle, implement a second cache, interpolate values into SQL, or choose
+a physical shard themselves.
+
+## Storage-format boundary
+
+Issue #26 adds only process-memory session state and execution orchestration.
+It does not change manifest version 7, a manifest table, routing encoding,
+shard identity, schema fingerprint, migration journal, SQLite header field,
+WAL/synchronous mode, or filename. Prepared statements and portals disappear
+when their owning process/session ends. Preparing or describing changes no
+application data; executing a supported command has only its ordinary
+single-shard SQLite row effects.
+
+Canonical translated SQL is never a schema-migration identity. Persistent
+application schema changes continue to require the journaled migration path,
+which retains the caller's exact submitted SQL. No storage upgrade, downgrade,
+or prepared-cache recovery step is required.
+
+## Verification obligations
+
+Tests cover the complete SQLite/PostgreSQL/MySQL typed lifecycle; exact
+single-statement enforcement; unknown databases; transient shard-0 metadata;
+parameter and column descriptions; schema-generation refresh; fresh planning
+after schema/routing changes; routing snapshots; affected-row and row results;
+result limits; session ownership; statement, portal, and retained-byte limits without
+eviction; repeated-marker planning expansion before allocation; exact close and
+cascading invalidation; invalid arity/value recovery; unassigned execution;
+deterministic concurrent capacity races; cancellation while waiting for a
+session; session close during admitted work; diagnostics and safe protocol
+mapping; targeted request/cache/portal/plan/description `Debug` redaction;
+result visibility; CLI/environment validation; public owned types; and raw
+HTTP/storage-format regressions.

--- a/docs/SQL_SHARD_KEYS.md
+++ b/docs/SQL_SHARD_KEYS.md
@@ -166,10 +166,14 @@ The implemented synchronous
 bind/execute time and turns every inferred value into an owned route. It
 retains optional explicit routing separately, compares finite physical targets,
 rejects unroutable sharded DML, and records a valid single-shard assignment.
-The result is still not executable. The implemented issue #25 translator is a
-separate opt-in operation over the same normalized SQL; it does not change an
-inference result. Later work owns prepared-statement lifecycle, authoritative
-statement classification, and wire-protocol integration.
+The plan by itself is not execution permission. The implemented issue #25
+translator is a separate opt-in operation over the same normalized SQL; it does
+not change an inference result. The implemented
+[prepared lifecycle](SQL_PREPARED_STATEMENTS.md) validates a transient
+bind-time plan, retains the typed values and routing snapshot, and repeats
+planning under the current execution guard to select a supported target. Later
+work owns authoritative statement classification, scatter/gather, and
+wire-protocol integration.
 
 ## Verification obligations
 

--- a/docs/SQL_SUBSET.md
+++ b/docs/SQL_SUBSET.md
@@ -46,10 +46,11 @@ A successful `CommonSql` does not mean that the SQL:
 
 Those responsibilities remain with the implemented issue #21 normalization,
 issue #22 inference, issues #23/#24 bound planning and routing-policy layers,
-the separate issue #25 translation layer, issues #26/#27, and the later wire
-frontends. Validation never consults parameters, a session, the logical
-catalog, storage, routing state, the filesystem, or SQLite. It never formats or
-searches SQL text to make a structural decision.
+the separate issue #25 translation layer, the implemented issue #26 prepared
+lifecycle, issue #27 classification/batch policy, and the later wire frontends.
+Validation never consults parameters, a session, the logical catalog, storage,
+routing state, the filesystem, or SQLite. It never formats or searches SQL text
+to make a structural decision.
 
 Empty and comment-only parsed batches validate successfully. Every statement in
 a mixed batch is checked independently and source order is retained, but that

--- a/docs/SQL_TRANSLATION.md
+++ b/docs/SQL_TRANSLATION.md
@@ -181,11 +181,14 @@ decision, SQLite execution call, manifest migration, shard-file change, or
 storage-format version. The current HTTP execute/query/migration paths continue
 to send caller-provided SQLite SQL directly to their existing engine paths.
 
-Issue #26 owns protocol-neutral prepare/bind/describe/execute state and adoption
-of `sqlite_sql()`. Issue #27 owns authoritative statement behavior and empty,
-single-, or multi-statement request policy. Schema execution must still use the
-journaled migration path, and later execution must revalidate planning
-provenance before consuming an assigned shard.
+The implemented protocol-neutral [prepared lifecycle](SQL_PREPARED_STATEMENTS.md)
+owns prepare/bind/describe/execute state and adopts `sqlite_sql()` only after
+requiring exactly one top-level statement. It transiently compiles metadata,
+caches BriskDB-owned SQL rather than a SQLite handle, and creates a fresh
+current plan from each portal's bind snapshot at execution. Issue #27 still
+owns authoritative statement behavior and general empty, single-, or
+multi-statement request policy. Schema execution must still use the journaled
+migration path.
 
 ## Verification obligations
 

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -254,10 +254,13 @@ describes manifest-owned metadata rather than a user shard table.
 
 The loaded `Catalog` is read-only to callers and remains advisory in version 7:
 the opt-in SQL inference API may consult its database, table placement, and key
-metadata, but there is no table-catalog mutation API, execution-plan
-integration, routing enforcement, or enforcement against physical shard
-schemas. The engine publishes a newly committed schema generation into its
-shared catalog snapshot only after every shard has reached that generation.
+metadata, but there is no table-catalog mutation API or automatic proof that a
+catalog row matches a physical application table. The prepared lifecycle now
+uses catalog placement and keys for its bind-time plan and supported execution
+target; the raw explicit-key execute/query API remains independent of that
+opt-in integration. The engine publishes a newly committed schema generation
+into its shared catalog snapshot only after every shard has reached that
+generation.
 Fresh initialization and every v1/v2/v3 upgrade leave `briskdb_tables` empty;
 a v4-to-v5 upgrade retains every validated v4 catalog row. Schema migration
 does not inspect, infer, or mutate `briskdb_tables` from the journaled SQL; the
@@ -877,6 +880,14 @@ does not change the manifest version, shard files, stored schema text, migration
 digest, or migration identity. Schema migration continues to retain and compare
 the caller's exact submitted SQL; canonical compatibility output is never used
 as storage identity.
+
+Issue #26's prepared statements, descriptions, bound portals, captured routing
+bytes, and transient plans are also process-memory state. Portals retain no
+plan. These objects add no manifest or shard table, header value, routing
+version, schema fingerprint, journal record, or recovery step.
+Prepare/describe do not write application data. A supported portal command has
+only its ordinary one-shard SQLite row effects; persistent schema changes
+remain exclusive to the exact-text journaled migration path.
 
 The checksums are corruption detectors, not authentication. Both use unkeyed
 BLAKE3 and are writable by anyone who can modify the data directory. The

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -13,9 +13,11 @@ use tokio::{sync::OwnedMutexGuard, task::JoinHandle};
 
 use super::{
     BlockingPool, BoundStatementPlan, CancelOnDrop, CancellationReason, CancellationToken,
-    Database, EngineError, EngineErrorKind, EngineOptions, EngineResult, EngineState, Lifecycle,
-    LogicalDatabaseId, OperationControl, OperationLease, RequestContext, ResultLimits, ResultSet,
-    Routed, Session, SessionInner, ShutdownReport, Value, wait_for_cancellation, wait_pending,
+    Database, DescribeTarget, EngineError, EngineErrorKind, EngineOptions, EngineResult,
+    EngineState, Lifecycle, LogicalDatabaseId, OperationControl, OperationLease, PortalId,
+    PrepareRequest, PreparedExecution, PreparedStatementDescription, PreparedStatementId,
+    PreparedStatementLimits, RequestContext, ResultLimits, ResultSet, Routed, Session,
+    SessionInner, ShutdownReport, TablePlacement, Value, wait_for_cancellation, wait_pending,
 };
 use crate::{
     sql,
@@ -65,6 +67,7 @@ pub struct EngineStatus {
     queue_capacity_per_shard: usize,
     max_result_rows: u64,
     max_result_bytes: u64,
+    prepared_statement_limits: PreparedStatementLimits,
     request_timeout: Option<Duration>,
     shutdown_grace: Duration,
 }
@@ -99,6 +102,11 @@ impl EngineStatus {
     /// Return the maximum protocol-neutral logical bytes retained by one query.
     pub const fn max_result_bytes(&self) -> u64 {
         self.max_result_bytes
+    }
+
+    /// Return the finite per-session prepared-statement and portal limits.
+    pub const fn prepared_statement_limits(&self) -> PreparedStatementLimits {
+        self.prepared_statement_limits
     }
 
     /// Return the engine-wide request timeout, if enabled.
@@ -276,7 +284,10 @@ impl Engine {
 
     /// Create a new frontend-owned session.
     pub fn session(&self) -> Session {
-        Session::new(self.inner.id)
+        Session::new(
+            self.inner.id,
+            self.inner.options.prepared_statement_limits(),
+        )
     }
 
     /// Return the configured physical shard count.
@@ -305,6 +316,23 @@ impl Engine {
         explicit_routing_key: Option<&[u8]>,
     ) -> EngineResult<BoundStatementPlan> {
         let _schema_operation = self.inner.database.storage.enter_schema_operation()?;
+        self.plan_bound_statement_admitted(
+            database,
+            normalized,
+            statement_index,
+            parameters,
+            explicit_routing_key,
+        )
+    }
+
+    fn plan_bound_statement_admitted(
+        &self,
+        database: LogicalDatabaseId,
+        normalized: &sql::NormalizedSql,
+        statement_index: usize,
+        parameters: &[Value],
+        explicit_routing_key: Option<&[u8]>,
+    ) -> EngineResult<BoundStatementPlan> {
         let (hash_version, key_encoding_version, bucket_algorithm_version, map_generation) =
             self.inner.database.routing_provenance();
         super::planner::plan_bound_statement(
@@ -481,12 +509,331 @@ impl Engine {
                 queue_capacity_per_shard: self.inner.options.queue_capacity_per_shard(),
                 max_result_rows: result_limits.max_rows(),
                 max_result_bytes: result_limits.max_bytes(),
+                prepared_statement_limits: self.inner.options.prepared_statement_limits(),
                 request_timeout: self.inner.options.request_timeout(),
                 shutdown_grace: self.inner.options.shutdown_grace(),
             })
         }
         .await;
         operation.finish(result)
+    }
+
+    /// Parse, validate, translate, and transiently compile one prepared statement.
+    pub async fn prepare_statement(
+        &self,
+        session: &Session,
+        request: PrepareRequest,
+    ) -> EngineResult<PreparedStatementId> {
+        self.prepare_statement_with_context(session, request, RequestContext::new())
+            .await
+    }
+
+    /// Prepare one statement with explicit cancellation and deadline controls.
+    pub async fn prepare_statement_with_context(
+        &self,
+        session: &Session,
+        request: PrepareRequest,
+        context: RequestContext,
+    ) -> EngineResult<PreparedStatementId> {
+        let mut operation = self.operation(context)?;
+        let schema_operation = match self.inner.database.storage.enter_schema_operation() {
+            Ok(guard) => guard,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let guard = match operation.wait_pending(self.ready_session(session)).await {
+            Ok(guard) => guard,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        if self.catalog().database_by_id(request.database()).is_none() {
+            return operation.finish(Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "selected logical database does not exist",
+            )));
+        }
+        let (database, translated) = match prepare_translated_request(request) {
+            Ok(prepared) => prepared,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        if let Err(error) = guard.prepared().ensure_statement_capacity() {
+            return operation.finish(Err(error));
+        }
+        let parameter_count = translated.statement_parameters()[0].parameter_count();
+        let sqlite_sql = translated.sqlite_sql().to_owned();
+        let schema_generation = self.catalog().schema_generation();
+        let owner = ConnectionOwner::new(session.id().get());
+
+        let result = self
+            .run_on_shard(
+                &mut operation,
+                0,
+                owner,
+                schema_operation,
+                guard,
+                move |connection, session, control| {
+                    connection.isolate_foreign_sql_controlled(Arc::clone(&control), &sqlite_sql)?;
+                    let metadata = connection.run_controlled(control, |connection| {
+                        sql::describe_statement(connection, &sqlite_sql)
+                    })?;
+                    ensure_parameter_metadata(parameter_count, metadata.parameter_count())?;
+                    let description = PreparedStatementDescription::new(
+                        parameter_count,
+                        metadata.columns().to_vec(),
+                        schema_generation,
+                    );
+                    session
+                        .prepared_mut()
+                        .insert_statement(database, translated, description)
+                },
+            )
+            .await;
+        operation.finish_started(result)
+    }
+
+    /// Bind typed values and the session's current routing context into a portal.
+    pub async fn bind_statement(
+        &self,
+        session: &Session,
+        statement: PreparedStatementId,
+        parameters: Vec<Value>,
+    ) -> EngineResult<PortalId> {
+        self.bind_statement_with_context(session, statement, parameters, RequestContext::new())
+            .await
+    }
+
+    /// Bind a prepared statement with explicit cancellation and deadline controls.
+    pub async fn bind_statement_with_context(
+        &self,
+        session: &Session,
+        statement: PreparedStatementId,
+        parameters: Vec<Value>,
+        context: RequestContext,
+    ) -> EngineResult<PortalId> {
+        let mut operation = self.operation(context)?;
+        let schema_operation = match self.inner.database.storage.enter_schema_operation() {
+            Ok(guard) => guard,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let mut guard = match operation.wait_pending(self.ready_session(session)).await {
+            Ok(guard) => guard,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let result = (|| {
+            let routing_key = guard.routing_key().map(str::as_bytes);
+            let template = guard.prepared().statement(statement)?;
+            let parameter_layout = &template.translated().statement_parameters()[0];
+            let expected_parameters = parameter_layout.parameter_count();
+            if parameters.len() != expected_parameters {
+                return Err(EngineError::new(
+                    EngineErrorKind::InvalidArgument,
+                    format!(
+                        "prepared statement requires exactly {expected_parameters} bound parameters"
+                    ),
+                ));
+            }
+            sql::validate_parameters(&parameters)?;
+            guard
+                .prepared()
+                .ensure_portal_capacity(&parameters, routing_key)?;
+            guard.prepared().ensure_planning_capacity(
+                &parameters,
+                parameter_layout.parameter_indices(),
+                routing_key,
+            )?;
+            self.plan_bound_statement_admitted(
+                template.database(),
+                template.translated().normalized_sql(),
+                0,
+                &parameters,
+                routing_key,
+            )?;
+            operation.check_before_start()?;
+            let routing_key = routing_key.map(<[u8]>::to_vec);
+            guard
+                .prepared_mut()
+                .insert_portal(statement, parameters, routing_key)
+        })();
+        drop(schema_operation);
+        operation.finish(result)
+    }
+
+    /// Describe one prepared statement or bound portal.
+    pub async fn describe_prepared(
+        &self,
+        session: &Session,
+        target: DescribeTarget,
+    ) -> EngineResult<PreparedStatementDescription> {
+        self.describe_prepared_with_context(session, target, RequestContext::new())
+            .await
+    }
+
+    /// Describe a prepared object with explicit cancellation and deadline controls.
+    pub async fn describe_prepared_with_context(
+        &self,
+        session: &Session,
+        target: DescribeTarget,
+        context: RequestContext,
+    ) -> EngineResult<PreparedStatementDescription> {
+        let mut operation = self.operation(context)?;
+        let schema_operation = match self.inner.database.storage.enter_schema_operation() {
+            Ok(guard) => guard,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let guard = match operation.wait_pending(self.ready_session(session)).await {
+            Ok(guard) => guard,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let statement = match target {
+            DescribeTarget::Statement(statement) => statement,
+            DescribeTarget::Portal(portal) => match guard.prepared().portal(portal) {
+                Ok(portal) => portal.statement(),
+                Err(error) => return operation.finish(Err(error)),
+            },
+        };
+        let template = match guard.prepared().statement(statement) {
+            Ok(template) => template,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let schema_generation = self.catalog().schema_generation();
+        if template.description().schema_generation() == schema_generation {
+            let result = operation
+                .check_before_start()
+                .map(|()| template.description().clone());
+            drop(guard);
+            drop(schema_operation);
+            return operation.finish(result);
+        }
+
+        let parameter_count = template.translated().statement_parameters()[0].parameter_count();
+        let sqlite_sql = template.translated().sqlite_sql().to_owned();
+        let owner = ConnectionOwner::new(session.id().get());
+        let result = self
+            .run_on_shard(
+                &mut operation,
+                0,
+                owner,
+                schema_operation,
+                guard,
+                move |connection, session, control| {
+                    connection.isolate_foreign_sql_controlled(Arc::clone(&control), &sqlite_sql)?;
+                    let metadata = connection.run_controlled(control, |connection| {
+                        sql::describe_statement(connection, &sqlite_sql)
+                    })?;
+                    ensure_parameter_metadata(parameter_count, metadata.parameter_count())?;
+                    let description = PreparedStatementDescription::new(
+                        parameter_count,
+                        metadata.columns().to_vec(),
+                        schema_generation,
+                    );
+                    session
+                        .prepared_mut()
+                        .statement_mut(statement)?
+                        .replace_description(description.clone());
+                    Ok(description)
+                },
+            )
+            .await;
+        operation.finish_started(result)
+    }
+
+    /// Execute one immutable bound portal on the shard selected by a fresh plan.
+    pub async fn execute_portal(
+        &self,
+        session: &Session,
+        portal: PortalId,
+    ) -> EngineResult<Routed<PreparedExecution>> {
+        self.execute_portal_with_context(session, portal, RequestContext::new())
+            .await
+    }
+
+    /// Execute a bound portal with explicit request and result-budget controls.
+    pub async fn execute_portal_with_context(
+        &self,
+        session: &Session,
+        portal: PortalId,
+        context: RequestContext,
+    ) -> EngineResult<Routed<PreparedExecution>> {
+        let mut operation = self.operation(context)?;
+        let schema_operation = match self.inner.database.storage.enter_schema_operation() {
+            Ok(guard) => guard,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let guard = match operation.wait_pending(self.ready_session(session)).await {
+            Ok(guard) => guard,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let portal_snapshot = match guard.prepared().portal(portal) {
+            Ok(portal) => portal.clone(),
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let template = match guard.prepared().statement(portal_snapshot.statement()) {
+            Ok(template) => template,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let plan = match self.plan_bound_statement_admitted(
+            template.database(),
+            template.translated().normalized_sql(),
+            0,
+            portal_snapshot.parameters(),
+            portal_snapshot.routing_key(),
+        ) {
+            Ok(plan) => plan,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let sqlite_sql = template.translated().sqlite_sql().to_owned();
+        let shard = match prepared_execution_shard(&plan, template.description(), self.catalog()) {
+            Ok(shard) => shard,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let result_limits = operation.result_limits;
+        let owner = ConnectionOwner::new(session.id().get());
+        let result = self
+            .run_on_shard(
+                &mut operation,
+                shard,
+                owner,
+                schema_operation,
+                guard,
+                move |connection, _session, control| {
+                    connection.isolate_foreign_sql_controlled(Arc::clone(&control), &sqlite_sql)?;
+                    connection.run_controlled(control, |connection| {
+                        sql::execute_statement_with_limits(
+                            connection,
+                            &sqlite_sql,
+                            portal_snapshot.parameters(),
+                            result_limits,
+                        )
+                        .map(|execution| match execution {
+                            sql::StatementExecution::Rows(rows) => PreparedExecution::Rows(rows),
+                            sql::StatementExecution::AffectedRows(rows) => {
+                                PreparedExecution::AffectedRows(rows)
+                            }
+                        })
+                    })
+                },
+            )
+            .await;
+        let value = operation.finish_started(result)?;
+        Ok(Routed { shard, value })
+    }
+
+    /// Close a prepared statement and every portal bound from it.
+    ///
+    /// This in-memory cleanup remains available while the engine is draining.
+    pub async fn close_prepared_statement(
+        &self,
+        session: &Session,
+        statement: PreparedStatementId,
+    ) -> EngineResult<bool> {
+        let mut guard = self.ready_session(session).await?;
+        guard.prepared_mut().close_statement(statement)
+    }
+
+    /// Close one bound portal without closing its prepared statement.
+    ///
+    /// This in-memory cleanup remains available while the engine is draining.
+    pub async fn close_portal(&self, session: &Session, portal: PortalId) -> EngineResult<bool> {
+        let mut guard = self.ready_session(session).await?;
+        guard.prepared_mut().close_portal(portal)
     }
 
     /// Execute a routed statement and return its selected shard.
@@ -530,7 +877,7 @@ impl Engine {
                 owner,
                 schema_operation,
                 guard,
-                move |connection, control| {
+                move |connection, _session, control| {
                     connection.isolate_foreign_sql_controlled(Arc::clone(&control), &sql)?;
                     connection.run_controlled(control, |connection| {
                         sql::execute(connection, &sql, &params)
@@ -585,7 +932,7 @@ impl Engine {
                 owner,
                 schema_operation,
                 guard,
-                move |connection, control| {
+                move |connection, _session, control| {
                     connection.isolate_foreign_sql_controlled(Arc::clone(&control), &sql)?;
                     connection.run_controlled(control, |connection| {
                         sql::query_with_limits(connection, &sql, &params, limits)
@@ -676,12 +1023,18 @@ impl Engine {
         shard: u16,
         owner: ConnectionOwner,
         schema_operation: SchemaOperationGuard,
-        session: OwnedMutexGuard<SessionInner>,
+        mut session: OwnedMutexGuard<SessionInner>,
         work: F,
     ) -> EngineResult<T>
     where
         T: Send + 'static,
-        F: FnOnce(&mut PooledConnection, Arc<OperationControl>) -> EngineResult<T> + Send + 'static,
+        F: FnOnce(
+                &mut PooledConnection,
+                &mut SessionInner,
+                Arc<OperationControl>,
+            ) -> EngineResult<T>
+            + Send
+            + 'static,
     {
         let permit = match operation
             .wait_pending(self.inner.connections.acquire_for_owner(shard, owner))
@@ -703,12 +1056,11 @@ impl Engine {
         let storage = self.inner.database.storage.clone();
         let join = worker.spawn(move || {
             let _lease = lease;
-            let _session = session;
             let _schema_operation = schema_operation;
             let result = permit
                 .checkout_controlled(Arc::clone(&worker_control))
                 .and_then(|mut connection| {
-                    let result = work(&mut connection, Arc::clone(&worker_control));
+                    let result = work(&mut connection, &mut session, Arc::clone(&worker_control));
                     retire_if_broken(&mut connection, &result);
                     result
                 });
@@ -764,7 +1116,7 @@ impl Engine {
                 owner,
                 schema_operation,
                 guard,
-                move |_, _| {
+                move |_, _, _| {
                     let _ = started.send(());
                     release.recv().expect("test releases the blocking worker");
                     Ok(())
@@ -790,7 +1142,7 @@ impl Engine {
                 owner,
                 schema_operation,
                 guard,
-                move |_, _| panic!("intentional blocking worker panic"),
+                move |_, _, _| panic!("intentional blocking worker panic"),
             )
             .await;
         operation.finish_started(result)
@@ -816,7 +1168,7 @@ impl Engine {
                 owner,
                 schema_operation,
                 guard,
-                move |_, _| {
+                move |_, _, _| {
                     Err(EngineError::new(
                         EngineErrorKind::DataCorruption,
                         "injected SQLite data corruption",
@@ -847,7 +1199,7 @@ impl Engine {
                 owner,
                 schema_operation,
                 guard,
-                move |connection, control| {
+                move |connection, _session, control| {
                     connection.run_controlled(control, |_connection| -> EngineResult<()> {
                         panic!("intentional controlled SQLite worker panic")
                     })
@@ -884,11 +1236,89 @@ impl Engine {
                 owner,
                 schema_operation,
                 guard,
-                move |connection, _| Ok(connection.connection_id()),
+                move |connection, _, _| Ok(connection.connection_id()),
             )
             .await;
         operation.finish_started(result)
     }
+}
+
+fn prepare_translated_request(
+    request: PrepareRequest,
+) -> EngineResult<(LogicalDatabaseId, sql::TranslatedSql)> {
+    let (database, dialect, translation_mode, source) = request.into_parts();
+    let parsed = sql::parse(dialect, source)?;
+    if parsed.statement_count() != 1 {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            "a prepared statement must contain exactly one top-level SQL statement",
+        ));
+    }
+    let common = sql::validate_common_subset(parsed)?;
+    let normalized = sql::normalize_placeholders(common)?;
+    let translated = sql::translate_sql(normalized, translation_mode)?;
+    Ok((database, translated))
+}
+
+fn ensure_parameter_metadata(expected: usize, actual: usize) -> EngineResult<()> {
+    if expected == actual {
+        Ok(())
+    } else {
+        Err(EngineError::new(
+            EngineErrorKind::Internal,
+            "normalized and SQLite prepared-parameter counts disagree",
+        ))
+    }
+}
+
+fn prepared_execution_shard(
+    plan: &BoundStatementPlan,
+    description: &PreparedStatementDescription,
+    catalog: &super::Catalog,
+) -> EngineResult<u16> {
+    if let Some(shard) = plan.assigned_shard() {
+        return Ok(shard);
+    }
+
+    match plan.inference().kind() {
+        sql::ShardKeyInferenceKind::NotApplicable if description.returns_rows() => Ok(0),
+        sql::ShardKeyInferenceKind::NotApplicable => Err(unassigned_prepared_statement()),
+        sql::ShardKeyInferenceKind::NotSharded => {
+            let table = plan
+                .inference()
+                .table_id()
+                .and_then(|table| catalog.table_by_id(table))
+                .ok_or_else(|| {
+                    EngineError::new(
+                        EngineErrorKind::Internal,
+                        "non-sharded prepared planning lost its catalog table",
+                    )
+                })?;
+            match table.placement() {
+                TablePlacement::Global if description.returns_rows() => Ok(0),
+                TablePlacement::Global => Err(unassigned_prepared_statement()),
+                TablePlacement::Catalog => Err(EngineError::new(
+                    EngineErrorKind::PermissionDenied,
+                    "catalog-placed tables cannot execute as client SQL",
+                )),
+                TablePlacement::Sharded(_) => Err(EngineError::new(
+                    EngineErrorKind::Internal,
+                    "non-sharded prepared planning resolved a sharded table",
+                )),
+            }
+        }
+        sql::ShardKeyInferenceKind::Unconstrained
+        | sql::ShardKeyInferenceKind::Contradiction
+        | sql::ShardKeyInferenceKind::Exact
+        | sql::ShardKeyInferenceKind::Multiple => Err(unassigned_prepared_statement()),
+    }
+}
+
+fn unassigned_prepared_statement() -> EngineError {
+    EngineError::new(
+        EngineErrorKind::Unsupported,
+        "the bound statement does not have one executable physical shard",
+    )
 }
 
 fn flatten_join<T>(result: Result<EngineResult<T>, tokio::task::JoinError>) -> EngineResult<T> {
@@ -958,6 +1388,61 @@ mod tests {
         (temp, engine)
     }
 
+    fn engine_with_prepared_catalog(
+        options: EngineOptions,
+    ) -> (tempfile::TempDir, Engine, LogicalDatabaseId) {
+        let temp = tempfile::tempdir().unwrap();
+        drop(Database::open(temp.path(), 4).unwrap());
+        let manifest = rusqlite::Connection::open(temp.path().join("manifest.sqlite")).unwrap();
+        manifest
+            .execute_batch(
+                "PRAGMA foreign_keys = ON;
+                 BEGIN IMMEDIATE;
+                 DROP TABLE briskdb_integrity;
+                 DROP TABLE briskdb_metadata;
+                 CREATE TABLE briskdb_metadata (
+                     requires_manifest_version INTEGER NOT NULL
+                         CHECK (requires_manifest_version >= 6)
+                 ) STRICT;
+                 INSERT INTO briskdb_metadata VALUES (6);
+                 INSERT INTO briskdb_tables (
+                    table_id,
+                    database_id,
+                    table_name,
+                    placement,
+                    shard_key_column,
+                    shard_key_type
+                 ) VALUES
+                    (4, 1, 'events', 1, 'tenant_id', 1),
+                    (5, 1, 'global_events', 2, NULL, NULL),
+                    (6, 1, 'catalog_records', 3, NULL, NULL),
+                    (7, 1, 'text_events', 1, 'tenant_key', 2);
+                 PRAGMA user_version = 6;
+                 COMMIT;",
+            )
+            .unwrap();
+        drop(manifest);
+
+        let database = Arc::new(Database::open(temp.path(), 4).unwrap());
+        database
+            .broadcast(
+                "CREATE TABLE events (
+                    tenant_id INTEGER PRIMARY KEY,
+                    payload TEXT NOT NULL
+                 );
+                 CREATE TABLE global_events (code INTEGER NOT NULL);
+                 CREATE TABLE catalog_records (code INTEGER NOT NULL);
+                 CREATE TABLE text_events (
+                    tenant_key TEXT PRIMARY KEY,
+                    payload TEXT NOT NULL
+                 );",
+            )
+            .unwrap();
+        let logical_database = database.catalog().default_database().id();
+        let engine = Engine::from_database_with_options(database, options).unwrap();
+        (temp, engine, logical_database)
+    }
+
     fn routing_key_for_shard(engine: &Engine, expected: u16) -> String {
         (0_u64..)
             .map(|value| format!("shard-{value}"))
@@ -1010,6 +1495,12 @@ mod tests {
     fn owned_public_types_have_expected_thread_safety_and_accessors() {
         assert_send_sync::<Engine>();
         assert_send_sync::<Session>();
+        assert_send_sync::<PrepareRequest>();
+        assert_send_sync::<PreparedStatementId>();
+        assert_send_sync::<PortalId>();
+        assert_send_sync::<DescribeTarget>();
+        assert_send_sync::<PreparedStatementDescription>();
+        assert_send_sync::<PreparedExecution>();
 
         let statement = Statement::new("SELECT ?1", vec![Value::from(42_i64)]);
         assert_eq!(statement.sql(), "SELECT ?1");
@@ -1036,6 +1527,10 @@ mod tests {
         assert_eq!(status.max_blocking_workers(), 16);
         assert_eq!(status.connections_per_shard(), 4);
         assert_eq!(status.queue_capacity_per_shard(), 32);
+        assert_eq!(
+            status.prepared_statement_limits(),
+            PreparedStatementLimits::default()
+        );
         assert_eq!(session.state().await, SessionState::Ready);
     }
 
@@ -1096,6 +1591,1077 @@ mod tests {
                 active_operations: 0,
             }
         );
+    }
+
+    #[tokio::test]
+    async fn prepared_lifecycle_returns_the_same_typed_result_for_every_sql_dialect() {
+        let (_temp, engine, database) = engine_with_prepared_catalog(EngineOptions::default());
+        let session = engine.session();
+
+        let insert = engine
+            .prepare_statement(
+                &session,
+                PrepareRequest::new(
+                    database,
+                    sql::SqlDialect::Sqlite,
+                    sql::SqlTranslationMode::StrictSqlite,
+                    "INSERT INTO events (tenant_id, payload) VALUES (?1, ?2)",
+                ),
+            )
+            .await
+            .unwrap();
+        let insert_description = engine
+            .describe_prepared(&session, DescribeTarget::Statement(insert))
+            .await
+            .unwrap();
+        assert_eq!(
+            insert_description.parameter_types(),
+            [DataType::Unknown, DataType::Unknown]
+        );
+        assert!(insert_description.columns().is_empty());
+        assert!(!insert_description.returns_rows());
+
+        let insert_portal = engine
+            .bind_statement(
+                &session,
+                insert,
+                vec![Value::from(7_i64), Value::from("seven")],
+            )
+            .await
+            .unwrap();
+        let inserted = engine
+            .execute_portal(&session, insert_portal)
+            .await
+            .unwrap();
+        assert_eq!(inserted.value, PreparedExecution::AffectedRows(1));
+        assert_eq!(inserted.shard, engine.inner.database.shard_for_key(b"7"));
+
+        let requests = [
+            (
+                sql::SqlDialect::Sqlite,
+                sql::SqlTranslationMode::StrictSqlite,
+                "SELECT tenant_id, payload FROM events WHERE tenant_id = ?1",
+            ),
+            (
+                sql::SqlDialect::PostgreSql,
+                sql::SqlTranslationMode::Compatibility,
+                "SELECT tenant_id, payload FROM events WHERE tenant_id = $1",
+            ),
+            (
+                sql::SqlDialect::MySql,
+                sql::SqlTranslationMode::Compatibility,
+                "SELECT tenant_id, payload FROM events WHERE tenant_id = ?",
+            ),
+        ];
+        let expected = ResultSet::new(
+            vec![
+                Column::new("tenant_id", DataType::Unknown),
+                Column::new("payload", DataType::Unknown),
+            ],
+            vec![Row::new(vec![Value::from(7_i64), Value::from("seven")])],
+        )
+        .unwrap();
+        let mut observed = Vec::new();
+        for (dialect, mode, source) in requests {
+            let statement = engine
+                .prepare_statement(
+                    &session,
+                    PrepareRequest::new(database, dialect, mode, source),
+                )
+                .await
+                .unwrap();
+            let description = engine
+                .describe_prepared(&session, DescribeTarget::Statement(statement))
+                .await
+                .unwrap();
+            assert_eq!(description.parameter_types(), [DataType::Unknown]);
+            assert_eq!(description.columns(), expected.columns());
+            assert!(description.returns_rows());
+            let portal = engine
+                .bind_statement(&session, statement, vec![Value::from(7_i64)])
+                .await
+                .unwrap();
+            assert_eq!(
+                engine
+                    .describe_prepared(&session, DescribeTarget::Portal(portal))
+                    .await
+                    .unwrap(),
+                description
+            );
+            observed.push(engine.execute_portal(&session, portal).await.unwrap());
+            assert!(engine.close_portal(&session, portal).await.unwrap());
+            assert!(
+                engine
+                    .close_prepared_statement(&session, statement)
+                    .await
+                    .unwrap()
+            );
+        }
+        assert!(observed.windows(2).all(|pair| pair[0] == pair[1]));
+        assert_eq!(observed[0].value, PreparedExecution::Rows(expected));
+
+        assert!(engine.close_portal(&session, insert_portal).await.unwrap());
+        assert!(
+            engine
+                .close_prepared_statement(&session, insert)
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn prepared_cache_and_portal_limits_are_session_local_without_eviction() {
+        let limits = PreparedStatementLimits::new(1, 1, 64).unwrap();
+        let options = EngineOptions::default().with_prepared_statement_limits(limits);
+        let (_temp, engine, database) = engine_with_prepared_catalog(options);
+        let first_session = engine.session();
+        let second_session = engine.session();
+        let request = || {
+            PrepareRequest::new(
+                database,
+                sql::SqlDialect::Sqlite,
+                sql::SqlTranslationMode::StrictSqlite,
+                "SELECT payload FROM events WHERE tenant_id = ?1",
+            )
+        };
+
+        let first = engine
+            .prepare_statement(&first_session, request())
+            .await
+            .unwrap();
+        let duplicate_error = engine
+            .prepare_statement(&first_session, request())
+            .await
+            .unwrap_err();
+        assert_eq!(duplicate_error.kind(), EngineErrorKind::LimitExceeded);
+        assert!(
+            engine
+                .describe_prepared(&first_session, DescribeTarget::Statement(first))
+                .await
+                .is_ok()
+        );
+
+        let independent = engine
+            .prepare_statement(&second_session, request())
+            .await
+            .unwrap();
+        assert_ne!(first, independent);
+        assert_eq!(
+            engine
+                .describe_prepared(&second_session, DescribeTarget::Statement(first))
+                .await
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+
+        let first_portal = engine
+            .bind_statement(&first_session, first, vec![Value::from(1_i64)])
+            .await
+            .unwrap();
+        assert_eq!(
+            engine
+                .bind_statement(&first_session, first, vec![Value::from(2_i64)])
+                .await
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::LimitExceeded
+        );
+        assert!(
+            engine
+                .describe_prepared(&first_session, DescribeTarget::Portal(first_portal))
+                .await
+                .is_ok()
+        );
+        assert!(
+            engine
+                .close_portal(&first_session, first_portal)
+                .await
+                .unwrap()
+        );
+        assert!(
+            !engine
+                .close_portal(&first_session, first_portal)
+                .await
+                .unwrap()
+        );
+        let replacement_portal = engine
+            .bind_statement(&first_session, first, vec![Value::from(2_i64)])
+            .await
+            .unwrap();
+
+        assert!(
+            engine
+                .close_prepared_statement(&first_session, first)
+                .await
+                .unwrap()
+        );
+        assert_eq!(
+            engine
+                .execute_portal(&first_session, replacement_portal)
+                .await
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+        assert!(
+            !engine
+                .close_prepared_statement(&first_session, first)
+                .await
+                .unwrap()
+        );
+        let replacement = engine
+            .prepare_statement(&first_session, request())
+            .await
+            .unwrap();
+        assert!(replacement > first);
+
+        assert!(
+            engine
+                .close_prepared_statement(&first_session, replacement)
+                .await
+                .unwrap()
+        );
+        assert!(
+            engine
+                .close_prepared_statement(&second_session, independent)
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn repeated_markers_are_bounded_before_planning_and_bind_recovers() {
+        let limits = PreparedStatementLimits::new(2, 2, 64).unwrap();
+        let options = EngineOptions::default().with_prepared_statement_limits(limits);
+        let (_temp, engine, database) = engine_with_prepared_catalog(options);
+        let session = engine.session();
+        let statement = engine
+            .prepare_statement(
+                &session,
+                PrepareRequest::new(
+                    database,
+                    sql::SqlDialect::Sqlite,
+                    sql::SqlTranslationMode::StrictSqlite,
+                    "INSERT INTO text_events (tenant_key, payload) VALUES (?1, ?1)",
+                ),
+            )
+            .await
+            .unwrap();
+
+        let error = engine
+            .bind_statement(
+                &session,
+                statement,
+                vec![Value::from("abcdefghijklmnopqrst")],
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+        assert_eq!(session.inner.lock().await.prepared().portal_count(), 0);
+
+        let portal = engine
+            .bind_statement(&session, statement, vec![Value::from("a")])
+            .await
+            .unwrap();
+        assert_eq!(session.inner.lock().await.prepared().portal_count(), 1);
+        assert_eq!(
+            engine.execute_portal(&session, portal).await.unwrap().value,
+            PreparedExecution::AffectedRows(1)
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_physical_prepare_does_not_consume_statement_capacity() {
+        let limits = PreparedStatementLimits::new(1, 1, 64).unwrap();
+        let options = EngineOptions::default().with_prepared_statement_limits(limits);
+        let (_temp, engine, database) = engine_with_prepared_catalog(options);
+        let session = engine.session();
+
+        let error = engine
+            .prepare_statement(
+                &session,
+                PrepareRequest::new(
+                    database,
+                    sql::SqlDialect::Sqlite,
+                    sql::SqlTranslationMode::StrictSqlite,
+                    "SELECT * FROM missing_table",
+                ),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::InvalidQuery);
+        assert_eq!(session.inner.lock().await.prepared().statement_count(), 0);
+
+        engine
+            .prepare_statement(
+                &session,
+                PrepareRequest::new(
+                    database,
+                    sql::SqlDialect::Sqlite,
+                    sql::SqlTranslationMode::StrictSqlite,
+                    "SELECT 1",
+                ),
+            )
+            .await
+            .unwrap();
+        assert_eq!(session.inner.lock().await.prepared().statement_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn prepared_errors_are_atomic_and_recover_without_losing_valid_handles() {
+        let (_temp, engine, database) = engine_with_prepared_catalog(EngineOptions::default());
+        let session = engine.session();
+
+        for source in [
+            "",
+            "SELECT 1; SELECT 2",
+            "SELECT 1; PRAGMA user_version",
+            "SELECT 1; SELECT ?0",
+        ] {
+            let error = engine
+                .prepare_statement(
+                    &session,
+                    PrepareRequest::new(
+                        database,
+                        sql::SqlDialect::Sqlite,
+                        sql::SqlTranslationMode::StrictSqlite,
+                        source,
+                    ),
+                )
+                .await
+                .unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::InvalidArgument);
+            assert_eq!(
+                error.diagnostic(),
+                "a prepared statement must contain exactly one top-level SQL statement"
+            );
+        }
+        let unknown_database = LogicalDatabaseId::new(999).unwrap();
+        assert_eq!(
+            engine
+                .prepare_statement(
+                    &session,
+                    PrepareRequest::new(
+                        unknown_database,
+                        sql::SqlDialect::Sqlite,
+                        sql::SqlTranslationMode::StrictSqlite,
+                        "SELECT 1",
+                    ),
+                )
+                .await
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::InvalidArgument
+        );
+
+        let statement = engine
+            .prepare_statement(
+                &session,
+                PrepareRequest::new(
+                    database,
+                    sql::SqlDialect::Sqlite,
+                    sql::SqlTranslationMode::StrictSqlite,
+                    "SELECT payload FROM events WHERE tenant_id = ?1 AND payload = ?2",
+                ),
+            )
+            .await
+            .unwrap();
+        for parameters in [
+            vec![Value::from(1_i64)],
+            vec![Value::from(1_i64), Value::from("value"), Value::Null],
+        ] {
+            assert_eq!(
+                engine
+                    .bind_statement(&session, statement, parameters)
+                    .await
+                    .unwrap_err()
+                    .kind(),
+                EngineErrorKind::InvalidArgument
+            );
+        }
+        let too_large = u64::try_from(i64::MAX).unwrap() + 1;
+        assert_eq!(
+            engine
+                .bind_statement(
+                    &session,
+                    statement,
+                    vec![Value::from(1_i64), Value::from(too_large)],
+                )
+                .await
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::NumericOutOfRange
+        );
+        let portal = engine
+            .bind_statement(
+                &session,
+                statement,
+                vec![Value::from(1_i64), Value::from("missing")],
+            )
+            .await
+            .unwrap();
+        assert!(matches!(
+            engine.execute_portal(&session, portal).await.unwrap().value,
+            PreparedExecution::Rows(result) if result.is_empty()
+        ));
+
+        let scalar = engine
+            .prepare_statement(
+                &session,
+                PrepareRequest::new(
+                    database,
+                    sql::SqlDialect::Sqlite,
+                    sql::SqlTranslationMode::StrictSqlite,
+                    "SELECT 1 AS value",
+                ),
+            )
+            .await
+            .unwrap();
+        let scalar_portal = engine
+            .bind_statement(&session, scalar, vec![])
+            .await
+            .unwrap();
+        let scalar_result = engine
+            .execute_portal(&session, scalar_portal)
+            .await
+            .unwrap();
+        assert_eq!(scalar_result.shard, 0);
+        assert!(matches!(
+            scalar_result.value,
+            PreparedExecution::Rows(result)
+                if result.rows()[0].get(0) == Some(&Value::from(1_i64))
+        ));
+
+        let global = engine
+            .prepare_statement(
+                &session,
+                PrepareRequest::new(
+                    database,
+                    sql::SqlDialect::Sqlite,
+                    sql::SqlTranslationMode::StrictSqlite,
+                    "SELECT code FROM global_events ORDER BY code",
+                ),
+            )
+            .await
+            .unwrap();
+        let global_portal = engine
+            .bind_statement(&session, global, vec![])
+            .await
+            .unwrap();
+        let global_result = engine
+            .execute_portal(&session, global_portal)
+            .await
+            .unwrap();
+        assert_eq!(global_result.shard, 0);
+        assert!(matches!(
+            global_result.value,
+            PreparedExecution::Rows(result) if result.is_empty()
+        ));
+
+        let catalog_statement = engine
+            .prepare_statement(
+                &session,
+                PrepareRequest::new(
+                    database,
+                    sql::SqlDialect::Sqlite,
+                    sql::SqlTranslationMode::StrictSqlite,
+                    "SELECT code FROM catalog_records",
+                ),
+            )
+            .await
+            .unwrap();
+        let catalog_portal = engine
+            .bind_statement(&session, catalog_statement, vec![])
+            .await
+            .unwrap();
+        assert_eq!(
+            engine
+                .execute_portal(&session, catalog_portal)
+                .await
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::PermissionDenied
+        );
+        let catalog_update = engine
+            .prepare_statement(
+                &session,
+                PrepareRequest::new(
+                    database,
+                    sql::SqlDialect::Sqlite,
+                    sql::SqlTranslationMode::StrictSqlite,
+                    "UPDATE catalog_records SET code = 1",
+                ),
+            )
+            .await
+            .unwrap();
+        let catalog_update_portal = engine
+            .bind_statement(&session, catalog_update, vec![])
+            .await
+            .unwrap();
+        assert_eq!(
+            engine
+                .execute_portal(&session, catalog_update_portal)
+                .await
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::PermissionDenied
+        );
+
+        let scatter = engine
+            .prepare_statement(
+                &session,
+                PrepareRequest::new(
+                    database,
+                    sql::SqlDialect::Sqlite,
+                    sql::SqlTranslationMode::StrictSqlite,
+                    "SELECT payload FROM events",
+                ),
+            )
+            .await
+            .unwrap();
+        let scatter_portal = engine
+            .bind_statement(&session, scatter, vec![])
+            .await
+            .unwrap();
+        assert_eq!(
+            engine
+                .execute_portal(&session, scatter_portal)
+                .await
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::Unsupported
+        );
+        assert!(
+            engine
+                .describe_prepared(&session, DescribeTarget::Statement(statement))
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn execution_replans_and_description_refreshes_after_schema_migration() {
+        let (_temp, engine, database) = engine_with_prepared_catalog(EngineOptions::default());
+        let session = engine.session();
+        session.set_routing_key("7").await.unwrap();
+        engine
+            .execute(
+                &session,
+                Statement::new(
+                    "INSERT INTO events (tenant_id, payload) VALUES (?1, ?2)",
+                    vec![Value::from(7_i64), Value::from("seven")],
+                ),
+            )
+            .await
+            .unwrap();
+        session.clear_routing_key().await.unwrap();
+
+        let statement = engine
+            .prepare_statement(
+                &session,
+                PrepareRequest::new(
+                    database,
+                    sql::SqlDialect::Sqlite,
+                    sql::SqlTranslationMode::StrictSqlite,
+                    "SELECT * FROM events WHERE tenant_id = ?1",
+                ),
+            )
+            .await
+            .unwrap();
+        let before = engine
+            .describe_prepared(&session, DescribeTarget::Statement(statement))
+            .await
+            .unwrap();
+        assert_eq!(before.columns().len(), 2);
+        let portal = engine
+            .bind_statement(&session, statement, vec![Value::from(7_i64)])
+            .await
+            .unwrap();
+
+        engine
+            .broadcast(
+                &session,
+                "ALTER TABLE events ADD COLUMN extra TEXT".to_owned(),
+            )
+            .await
+            .unwrap();
+
+        let executed = engine.execute_portal(&session, portal).await.unwrap();
+        assert_eq!(executed.shard, engine.inner.database.shard_for_key(b"7"));
+        let PreparedExecution::Rows(rows) = executed.value else {
+            panic!("the prepared SELECT must return rows");
+        };
+        assert_eq!(rows.columns().len(), 3);
+        assert_eq!(
+            rows.rows()[0].values(),
+            [Value::from(7_i64), Value::from("seven"), Value::Null,]
+        );
+
+        let after = engine
+            .describe_prepared(&session, DescribeTarget::Portal(portal))
+            .await
+            .unwrap();
+        assert_eq!(after.columns().len(), 3);
+        assert!(after.schema_generation() > before.schema_generation());
+        assert_eq!(rows.columns(), after.columns());
+        assert_eq!(
+            engine
+                .describe_prepared(&session, DescribeTarget::Portal(portal))
+                .await
+                .unwrap()
+                .schema_generation(),
+            after.schema_generation()
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_description_refresh_preserves_cached_metadata_and_can_retry() {
+        let (_temp, engine, database) = engine_with_prepared_catalog(EngineOptions::default());
+        let session = engine.session();
+        let statement = engine
+            .prepare_statement(
+                &session,
+                PrepareRequest::new(
+                    database,
+                    sql::SqlDialect::Sqlite,
+                    sql::SqlTranslationMode::StrictSqlite,
+                    "SELECT * FROM events",
+                ),
+            )
+            .await
+            .unwrap();
+        let before = engine
+            .describe_prepared(&session, DescribeTarget::Statement(statement))
+            .await
+            .unwrap();
+        assert_eq!(before.columns().len(), 2);
+
+        engine
+            .broadcast(&session, "DROP TABLE events".to_owned())
+            .await
+            .unwrap();
+        let error = engine
+            .describe_prepared(&session, DescribeTarget::Statement(statement))
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::InvalidQuery);
+        let cached = session
+            .inner
+            .lock()
+            .await
+            .prepared()
+            .statement(statement)
+            .unwrap()
+            .description()
+            .clone();
+        assert_eq!(cached, before);
+
+        engine
+            .broadcast(
+                &session,
+                "CREATE TABLE events (
+                    tenant_id INTEGER PRIMARY KEY,
+                    payload TEXT NOT NULL,
+                    restored TEXT
+                 )"
+                .to_owned(),
+            )
+            .await
+            .unwrap();
+        let refreshed = engine
+            .describe_prepared(&session, DescribeTarget::Statement(statement))
+            .await
+            .unwrap();
+        assert_eq!(refreshed.columns().len(), 3);
+        assert!(refreshed.schema_generation() > before.schema_generation());
+    }
+
+    #[tokio::test]
+    async fn portal_execution_result_limit_failure_is_retryable_with_the_same_handle() {
+        let (_temp, engine, database) = engine_with_prepared_catalog(EngineOptions::default());
+        let session = engine.session();
+        engine
+            .broadcast(
+                &session,
+                "INSERT INTO global_events (code) VALUES (1), (2)".to_owned(),
+            )
+            .await
+            .unwrap();
+        let statement = engine
+            .prepare_statement(
+                &session,
+                PrepareRequest::new(
+                    database,
+                    sql::SqlDialect::Sqlite,
+                    sql::SqlTranslationMode::StrictSqlite,
+                    "SELECT code FROM global_events ORDER BY code",
+                ),
+            )
+            .await
+            .unwrap();
+
+        let portal = engine
+            .bind_statement(&session, statement, vec![])
+            .await
+            .unwrap();
+
+        let narrow = RequestContext::new().with_result_limits(ResultLimits::new(1, 1_024).unwrap());
+        let error = engine
+            .execute_portal_with_context(&session, portal, narrow)
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+        assert_eq!(session.inner.lock().await.prepared().portal_count(), 1);
+
+        let first = engine.execute_portal(&session, portal).await.unwrap();
+        let second = engine.execute_portal(&session, portal).await.unwrap();
+        assert_eq!(first, second);
+        assert!(matches!(
+            first.value,
+            PreparedExecution::Rows(result)
+                if result.rows().len() == 2
+                    && result.rows()[0].get(0) == Some(&Value::from(1_i64))
+                    && result.rows()[1].get(0) == Some(&Value::from(2_i64))
+        ));
+    }
+
+    #[tokio::test]
+    async fn cancelled_bind_publishes_no_portal_and_normal_bind_recovers() {
+        let (_temp, engine, database) = engine_with_prepared_catalog(EngineOptions::default());
+        let session = Arc::new(engine.session());
+        let statement = engine
+            .prepare_statement(
+                &session,
+                PrepareRequest::new(
+                    database,
+                    sql::SqlDialect::Sqlite,
+                    sql::SqlTranslationMode::StrictSqlite,
+                    "SELECT payload FROM events WHERE tenant_id = ?1",
+                ),
+            )
+            .await
+            .unwrap();
+        let (holder_started_tx, holder_started_rx) = oneshot::channel();
+        let (holder_release_tx, holder_release_rx) = mpsc::channel();
+        let holder_engine = engine.clone();
+        let holder_session = Arc::clone(&session);
+        let holder = tokio::spawn(async move {
+            holder_engine
+                .hold_session_for_test(&holder_session, 0, holder_started_tx, holder_release_rx)
+                .await
+        });
+        holder_started_rx.await.unwrap();
+
+        let cancellation = CancellationToken::new();
+        let context = RequestContext::new().with_cancellation_token(cancellation.clone());
+        let waiting_engine = engine.clone();
+        let waiting_session = Arc::clone(&session);
+        let waiting = tokio::spawn(async move {
+            waiting_engine
+                .bind_statement_with_context(
+                    &waiting_session,
+                    statement,
+                    vec![Value::from(1_i64)],
+                    context,
+                )
+                .await
+        });
+        timeout(Duration::from_secs(2), async {
+            while engine.active_operations_for_test() != 2 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        cancellation.cancel();
+        assert_eq!(
+            waiting.await.unwrap().unwrap_err().kind(),
+            EngineErrorKind::Cancelled
+        );
+        holder_release_tx.send(()).unwrap();
+        holder.await.unwrap().unwrap();
+        assert_eq!(session.inner.lock().await.prepared().portal_count(), 0);
+
+        engine
+            .bind_statement(&session, statement, vec![Value::from(1_i64)])
+            .await
+            .unwrap();
+        assert_eq!(session.inner.lock().await.prepared().portal_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn bound_portals_keep_their_routing_snapshot_when_session_context_changes() {
+        let (_temp, engine, database) = engine_with_prepared_catalog(EngineOptions::default());
+        let session = engine.session();
+        session.set_routing_key("7").await.unwrap();
+        engine
+            .execute(
+                &session,
+                Statement::new(
+                    "INSERT INTO events (tenant_id, payload) VALUES (?1, ?2)",
+                    vec![Value::from(7_i64), Value::from("delete-me")],
+                ),
+            )
+            .await
+            .unwrap();
+
+        let statement = engine
+            .prepare_statement(
+                &session,
+                PrepareRequest::new(
+                    database,
+                    sql::SqlDialect::Sqlite,
+                    sql::SqlTranslationMode::StrictSqlite,
+                    "DELETE FROM events WHERE payload = ?1",
+                ),
+            )
+            .await
+            .unwrap();
+        let portal = engine
+            .bind_statement(&session, statement, vec![Value::from("delete-me")])
+            .await
+            .unwrap();
+        let expected_shard = engine.inner.database.shard_for_key(b"7");
+        let different_route = (8_u64..)
+            .map(|value| value.to_string())
+            .find(|key| engine.inner.database.shard_for_key(key.as_bytes()) != expected_shard)
+            .unwrap();
+        session.set_routing_key(different_route).await.unwrap();
+
+        let deleted = engine.execute_portal(&session, portal).await.unwrap();
+        assert_eq!(deleted.shard, expected_shard);
+        assert_eq!(deleted.value, PreparedExecution::AffectedRows(1));
+        session.set_routing_key("7").await.unwrap();
+        let remaining = engine
+            .query(
+                &session,
+                Statement::new(
+                    "SELECT tenant_id FROM events WHERE tenant_id = ?1",
+                    vec![Value::from(7_i64)],
+                ),
+            )
+            .await
+            .unwrap();
+        assert!(remaining.value.is_empty());
+    }
+
+    #[tokio::test]
+    async fn prepared_session_concurrency_cancellation_and_close_are_linearized() {
+        let limits = PreparedStatementLimits::new(1, 2, 1_024).unwrap();
+        let options = EngineOptions::new(1, 2)
+            .unwrap()
+            .with_prepared_statement_limits(limits)
+            .with_request_timeout(None)
+            .unwrap();
+        let (_temp, engine, database) = engine_with_prepared_catalog(options);
+        let session = Arc::new(engine.session());
+        let barrier = Arc::new(tokio::sync::Barrier::new(3));
+        let prepares = ["SELECT 1 FROM events", "SELECT 2 FROM events"]
+            .into_iter()
+            .map(|source| {
+                let engine = engine.clone();
+                let session = Arc::clone(&session);
+                let barrier = Arc::clone(&barrier);
+                tokio::spawn(async move {
+                    barrier.wait().await;
+                    engine
+                        .prepare_statement(
+                            &session,
+                            PrepareRequest::new(
+                                database,
+                                sql::SqlDialect::Sqlite,
+                                sql::SqlTranslationMode::StrictSqlite,
+                                source,
+                            ),
+                        )
+                        .await
+                })
+            })
+            .collect::<Vec<_>>();
+        barrier.wait().await;
+        let mut prepared = Vec::new();
+        let mut failures = Vec::new();
+        for task in prepares {
+            match task.await.unwrap() {
+                Ok(statement) => prepared.push(statement),
+                Err(error) => failures.push(error.kind()),
+            }
+        }
+        assert_eq!(prepared.len(), 1);
+        assert_eq!(failures, [EngineErrorKind::LimitExceeded]);
+        assert!(
+            engine
+                .close_prepared_statement(&session, prepared[0])
+                .await
+                .unwrap()
+        );
+
+        let (holder_started_tx, holder_started_rx) = oneshot::channel();
+        let (holder_release_tx, holder_release_rx) = mpsc::channel();
+        let holder_engine = engine.clone();
+        let holder_session = Arc::clone(&session);
+        let holder = tokio::spawn(async move {
+            holder_engine
+                .hold_session_for_test(&holder_session, 0, holder_started_tx, holder_release_rx)
+                .await
+        });
+        holder_started_rx.await.unwrap();
+
+        let cancellation = CancellationToken::new();
+        let context = RequestContext::new().with_cancellation_token(cancellation.clone());
+        let waiting_engine = engine.clone();
+        let waiting_session = Arc::clone(&session);
+        let waiting = tokio::spawn(async move {
+            waiting_engine
+                .prepare_statement_with_context(
+                    &waiting_session,
+                    PrepareRequest::new(
+                        database,
+                        sql::SqlDialect::Sqlite,
+                        sql::SqlTranslationMode::StrictSqlite,
+                        "SELECT 3 FROM events",
+                    ),
+                    context,
+                )
+                .await
+        });
+        timeout(Duration::from_secs(2), async {
+            while engine.active_operations_for_test() != 2 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        cancellation.cancel();
+        assert_eq!(
+            waiting.await.unwrap().unwrap_err().kind(),
+            EngineErrorKind::Cancelled
+        );
+        holder_release_tx.send(()).unwrap();
+        holder.await.unwrap().unwrap();
+        assert_eq!(session.inner.lock().await.prepared().statement_count(), 0);
+
+        let statement = engine
+            .prepare_statement(
+                &session,
+                PrepareRequest::new(
+                    database,
+                    sql::SqlDialect::Sqlite,
+                    sql::SqlTranslationMode::StrictSqlite,
+                    "SELECT payload FROM events WHERE tenant_id = ?1",
+                ),
+            )
+            .await
+            .unwrap();
+        let portal = engine
+            .bind_statement(&session, statement, vec![Value::from(1_i64)])
+            .await
+            .unwrap();
+        assert_eq!(session.inner.lock().await.prepared().portal_count(), 1);
+
+        let (close_holder_started_tx, close_holder_started_rx) = oneshot::channel();
+        let (close_holder_release_tx, close_holder_release_rx) = mpsc::channel();
+        let holder_engine = engine.clone();
+        let holder_session = Arc::clone(&session);
+        let holder = tokio::spawn(async move {
+            holder_engine
+                .hold_session_for_test(
+                    &holder_session,
+                    0,
+                    close_holder_started_tx,
+                    close_holder_release_rx,
+                )
+                .await
+        });
+        close_holder_started_rx.await.unwrap();
+        let closing_session = Arc::clone(&session);
+        let mut close = tokio::spawn(async move { closing_session.close().await });
+        assert!(
+            timeout(Duration::from_millis(20), &mut close)
+                .await
+                .is_err()
+        );
+        close_holder_release_tx.send(()).unwrap();
+        holder.await.unwrap().unwrap();
+        close.await.unwrap().unwrap();
+        assert_eq!(session.state().await, SessionState::Closed);
+        let guard = session.inner.lock().await;
+        assert_eq!(guard.prepared().statement_count(), 0);
+        assert_eq!(guard.prepared().portal_count(), 0);
+        drop(guard);
+        assert_eq!(
+            engine
+                .execute_portal(&session, portal)
+                .await
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+    }
+
+    #[tokio::test]
+    async fn draining_rejects_prepared_work_but_allows_explicit_cleanup() {
+        let (_temp, engine, database) = engine_with_prepared_catalog(EngineOptions::default());
+        let session = engine.session();
+        let request = || {
+            PrepareRequest::new(
+                database,
+                sql::SqlDialect::Sqlite,
+                sql::SqlTranslationMode::StrictSqlite,
+                "SELECT 1",
+            )
+        };
+        let statement = engine.prepare_statement(&session, request()).await.unwrap();
+        let portal = engine
+            .bind_statement(&session, statement, vec![])
+            .await
+            .unwrap();
+
+        assert_eq!(engine.begin_shutdown(), EngineState::Draining);
+        assert_eq!(
+            engine
+                .prepare_statement(&session, request())
+                .await
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::ShuttingDown
+        );
+        assert_eq!(
+            engine
+                .bind_statement(&session, statement, vec![])
+                .await
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::ShuttingDown
+        );
+        assert_eq!(
+            engine
+                .describe_prepared(&session, DescribeTarget::Statement(statement))
+                .await
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::ShuttingDown
+        );
+        assert_eq!(
+            engine
+                .execute_portal(&session, portal)
+                .await
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::ShuttingDown
+        );
+
+        assert!(engine.close_portal(&session, portal).await.unwrap());
+        assert!(
+            engine
+                .close_prepared_statement(&session, statement)
+                .await
+                .unwrap()
+        );
+        session.close().await.unwrap();
+        engine.shutdown().await.unwrap();
+        assert_eq!(engine.state(), EngineState::Stopped);
     }
 
     #[tokio::test]

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -10,6 +10,7 @@ mod error;
 mod lifecycle;
 mod options;
 mod planner;
+mod prepared;
 mod routing;
 mod session;
 mod types;
@@ -32,12 +33,20 @@ pub use error::{EngineError, EngineErrorKind, EngineResult};
 pub use lifecycle::{EngineState, ShutdownReport};
 pub(crate) use lifecycle::{Lifecycle, OperationLease};
 pub use options::{
-    DEFAULT_CONNECTIONS_PER_SHARD, DEFAULT_MAX_RESULT_BYTES, DEFAULT_MAX_RESULT_ROWS,
-    DEFAULT_QUEUE_CAPACITY_PER_SHARD, DEFAULT_REQUEST_TIMEOUT_MS, DEFAULT_SHUTDOWN_GRACE_MS,
-    EngineOptions, MAX_CONNECTIONS_PER_SHARD, MAX_QUEUE_CAPACITY_PER_SHARD, MAX_REQUEST_TIMEOUT_MS,
-    MAX_RESULT_BYTES, MAX_RESULT_ROWS, MAX_SHUTDOWN_GRACE_MS, ResultLimits,
+    DEFAULT_CONNECTIONS_PER_SHARD, DEFAULT_MAX_PORTALS_PER_SESSION,
+    DEFAULT_MAX_PREPARED_STATEMENTS_PER_SESSION, DEFAULT_MAX_RESULT_BYTES, DEFAULT_MAX_RESULT_ROWS,
+    DEFAULT_MAX_RETAINED_BOUND_VALUE_BYTES, DEFAULT_QUEUE_CAPACITY_PER_SHARD,
+    DEFAULT_REQUEST_TIMEOUT_MS, DEFAULT_SHUTDOWN_GRACE_MS, EngineOptions,
+    MAX_CONNECTIONS_PER_SHARD, MAX_PORTALS_PER_SESSION, MAX_PREPARED_STATEMENTS_PER_SESSION,
+    MAX_QUEUE_CAPACITY_PER_SHARD, MAX_REQUEST_TIMEOUT_MS, MAX_RESULT_BYTES, MAX_RESULT_ROWS,
+    MAX_RETAINED_BOUND_VALUE_BYTES, MAX_SHUTDOWN_GRACE_MS, PreparedStatementLimits, ResultLimits,
 };
 pub use planner::{BoundStatementPlan, PlannedRoute};
+pub(crate) use prepared::PreparedState;
+pub use prepared::{
+    DescribeTarget, PortalId, PrepareRequest, PreparedExecution, PreparedStatementDescription,
+    PreparedStatementId,
+};
 pub(crate) use routing::{
     BUCKET_ALGORITHM_VERSION, HASH_VERSION, INITIAL_MAP_GENERATION, KEY_ENCODING_VERSION,
     RoutingCatalog, VIRTUAL_BUCKET_COUNT, initial_physical_shard,

--- a/src/core/options.rs
+++ b/src/core/options.rs
@@ -22,6 +22,15 @@ pub const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 30_000;
 /// Default graceful-shutdown drain period in milliseconds.
 pub const DEFAULT_SHUTDOWN_GRACE_MS: u64 = 30_000;
 
+/// Default maximum number of prepared statements retained by one session.
+pub const DEFAULT_MAX_PREPARED_STATEMENTS_PER_SESSION: usize = 128;
+
+/// Default maximum number of bound portals retained by one session.
+pub const DEFAULT_MAX_PORTALS_PER_SESSION: usize = 128;
+
+/// Default maximum accounted bound-value bytes retained by one session (16 MiB).
+pub const DEFAULT_MAX_RETAINED_BOUND_VALUE_BYTES: u64 = 16 * 1024 * 1024;
+
 /// Maximum configurable connections per shard.
 pub const MAX_CONNECTIONS_PER_SHARD: usize = 16;
 
@@ -39,6 +48,15 @@ pub const MAX_REQUEST_TIMEOUT_MS: u64 = 24 * 60 * 60 * 1_000;
 
 /// Maximum configured graceful-shutdown period (24 hours).
 pub const MAX_SHUTDOWN_GRACE_MS: u64 = 24 * 60 * 60 * 1_000;
+
+/// Maximum configurable prepared statements retained by one session.
+pub const MAX_PREPARED_STATEMENTS_PER_SESSION: usize = 1_024;
+
+/// Maximum configurable bound portals retained by one session.
+pub const MAX_PORTALS_PER_SESSION: usize = 1_024;
+
+/// Maximum configurable accounted bound-value bytes retained by one session (1 GiB).
+pub const MAX_RETAINED_BOUND_VALUE_BYTES: u64 = 1024 * 1024 * 1024;
 
 const MAX_TOTAL_ACTIVE_CONNECTIONS: usize = 512;
 
@@ -98,16 +116,101 @@ impl Default for ResultLimits {
     }
 }
 
+/// Validated per-session limits for prepared statements and bound portals.
+///
+/// The retained byte limit accounts for protocol-neutral logical values owned
+/// by all portals in a session. The same ceiling conservatively bounds one
+/// bind's planning expansion by charging the captured route once and every
+/// normalized marker occurrence twice, once for typed inference and once for
+/// canonical routing. It is independent of the materialized query-result byte
+/// limit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PreparedStatementLimits {
+    max_statements_per_session: usize,
+    max_portals_per_session: usize,
+    max_retained_bound_value_bytes: u64,
+}
+
+impl PreparedStatementLimits {
+    /// Construct validated finite per-session prepared-statement limits.
+    pub fn new(
+        max_statements_per_session: usize,
+        max_portals_per_session: usize,
+        max_retained_bound_value_bytes: u64,
+    ) -> EngineResult<Self> {
+        if !(1..=MAX_PREPARED_STATEMENTS_PER_SESSION).contains(&max_statements_per_session) {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                format!(
+                    "maximum prepared statements per session must be between 1 and \
+                     {MAX_PREPARED_STATEMENTS_PER_SESSION}"
+                ),
+            ));
+        }
+        if !(1..=MAX_PORTALS_PER_SESSION).contains(&max_portals_per_session) {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                format!(
+                    "maximum portals per session must be between 1 and \
+                     {MAX_PORTALS_PER_SESSION}"
+                ),
+            ));
+        }
+        if !(1..=MAX_RETAINED_BOUND_VALUE_BYTES).contains(&max_retained_bound_value_bytes) {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                format!(
+                    "maximum retained bound-value bytes must be between 1 and \
+                     {MAX_RETAINED_BOUND_VALUE_BYTES}"
+                ),
+            ));
+        }
+
+        Ok(Self {
+            max_statements_per_session,
+            max_portals_per_session,
+            max_retained_bound_value_bytes,
+        })
+    }
+
+    /// Return the maximum prepared statements retained by one session.
+    pub const fn max_statements_per_session(self) -> usize {
+        self.max_statements_per_session
+    }
+
+    /// Return the maximum bound portals retained by one session.
+    pub const fn max_portals_per_session(self) -> usize {
+        self.max_portals_per_session
+    }
+
+    /// Return the maximum accounted retained and per-bind planning bytes.
+    pub const fn max_retained_bound_value_bytes(self) -> u64 {
+        self.max_retained_bound_value_bytes
+    }
+}
+
+impl Default for PreparedStatementLimits {
+    fn default() -> Self {
+        Self {
+            max_statements_per_session: DEFAULT_MAX_PREPARED_STATEMENTS_PER_SESSION,
+            max_portals_per_session: DEFAULT_MAX_PORTALS_PER_SESSION,
+            max_retained_bound_value_bytes: DEFAULT_MAX_RETAINED_BOUND_VALUE_BYTES,
+        }
+    }
+}
+
 /// Resource limits for the asynchronous engine.
 ///
 /// These limits bound active SQLite connections, admitted work, materialized
-/// results, request duration, and graceful-shutdown draining. A caller can
-/// narrow the result and time limits for one request through `RequestContext`.
+/// results, session-owned prepared state, request duration, and
+/// graceful-shutdown draining. A caller can narrow the result and time limits
+/// for one request through `RequestContext`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EngineOptions {
     connections_per_shard: usize,
     queue_capacity_per_shard: usize,
     result_limits: ResultLimits,
+    prepared_statement_limits: PreparedStatementLimits,
     request_timeout: Option<Duration>,
     shutdown_grace: Duration,
 }
@@ -137,6 +240,7 @@ impl EngineOptions {
             connections_per_shard,
             queue_capacity_per_shard,
             result_limits: ResultLimits::default(),
+            prepared_statement_limits: PreparedStatementLimits::default(),
             request_timeout: Some(Duration::from_millis(DEFAULT_REQUEST_TIMEOUT_MS)),
             shutdown_grace: Duration::from_millis(DEFAULT_SHUTDOWN_GRACE_MS),
         })
@@ -161,6 +265,21 @@ impl EngineOptions {
     #[must_use]
     pub const fn with_result_limits(mut self, result_limits: ResultLimits) -> Self {
         self.result_limits = result_limits;
+        self
+    }
+
+    /// Return the finite per-session prepared-statement limits.
+    pub const fn prepared_statement_limits(&self) -> PreparedStatementLimits {
+        self.prepared_statement_limits
+    }
+
+    /// Replace the finite per-session prepared-statement limits.
+    #[must_use]
+    pub const fn with_prepared_statement_limits(
+        mut self,
+        prepared_statement_limits: PreparedStatementLimits,
+    ) -> Self {
+        self.prepared_statement_limits = prepared_statement_limits;
         self
     }
 
@@ -222,6 +341,11 @@ impl Default for EngineOptions {
                 max_rows: DEFAULT_MAX_RESULT_ROWS,
                 max_bytes: DEFAULT_MAX_RESULT_BYTES,
             },
+            prepared_statement_limits: PreparedStatementLimits {
+                max_statements_per_session: DEFAULT_MAX_PREPARED_STATEMENTS_PER_SESSION,
+                max_portals_per_session: DEFAULT_MAX_PORTALS_PER_SESSION,
+                max_retained_bound_value_bytes: DEFAULT_MAX_RETAINED_BOUND_VALUE_BYTES,
+            },
             request_timeout: Some(Duration::from_millis(DEFAULT_REQUEST_TIMEOUT_MS)),
             shutdown_grace: Duration::from_millis(DEFAULT_SHUTDOWN_GRACE_MS),
         }
@@ -261,6 +385,28 @@ mod tests {
         assert_eq!(options.result_limits(), ResultLimits::default());
         assert_eq!(options.result_limits().max_rows(), 10_000);
         assert_eq!(options.result_limits().max_bytes(), 16 * 1024 * 1024);
+        assert_eq!(
+            options.prepared_statement_limits(),
+            PreparedStatementLimits::default()
+        );
+        assert_eq!(
+            options
+                .prepared_statement_limits()
+                .max_statements_per_session(),
+            128
+        );
+        assert_eq!(
+            options
+                .prepared_statement_limits()
+                .max_portals_per_session(),
+            128
+        );
+        assert_eq!(
+            options
+                .prepared_statement_limits()
+                .max_retained_bound_value_bytes(),
+            16 * 1024 * 1024
+        );
         assert_eq!(options.request_timeout(), Some(Duration::from_secs(30)));
         assert_eq!(options.shutdown_grace(), Duration::from_secs(30));
         assert_eq!(options.worker_limit(2).unwrap(), 8);
@@ -296,6 +442,14 @@ mod tests {
         assert_eq!(maximum.queue_capacity_per_shard(), 1_024);
         assert_eq!(minimum.result_limits(), ResultLimits::default());
         assert_eq!(maximum.result_limits(), ResultLimits::default());
+        assert_eq!(
+            minimum.prepared_statement_limits(),
+            PreparedStatementLimits::default()
+        );
+        assert_eq!(
+            maximum.prepared_statement_limits(),
+            PreparedStatementLimits::default()
+        );
     }
 
     #[test]
@@ -323,6 +477,40 @@ mod tests {
     }
 
     #[test]
+    fn prepared_statement_limit_constructor_preserves_inclusive_boundaries() {
+        let minimum = PreparedStatementLimits::new(1, 1, 1).unwrap();
+        assert_eq!(minimum.max_statements_per_session(), 1);
+        assert_eq!(minimum.max_portals_per_session(), 1);
+        assert_eq!(minimum.max_retained_bound_value_bytes(), 1);
+
+        let maximum = PreparedStatementLimits::new(
+            MAX_PREPARED_STATEMENTS_PER_SESSION,
+            MAX_PORTALS_PER_SESSION,
+            MAX_RETAINED_BOUND_VALUE_BYTES,
+        )
+        .unwrap();
+        assert_eq!(maximum.max_statements_per_session(), 1_024);
+        assert_eq!(maximum.max_portals_per_session(), 1_024);
+        assert_eq!(maximum.max_retained_bound_value_bytes(), 1024 * 1024 * 1024);
+    }
+
+    #[test]
+    fn prepared_statement_limit_constructor_rejects_each_invalid_value() {
+        for (max_statements, max_portals, max_bound_bytes) in [
+            (0, 1, 1),
+            (MAX_PREPARED_STATEMENTS_PER_SESSION + 1, 1, 1),
+            (1, 0, 1),
+            (1, MAX_PORTALS_PER_SESSION + 1, 1),
+            (1, 1, 0),
+            (1, 1, MAX_RETAINED_BOUND_VALUE_BYTES + 1),
+        ] {
+            let error = PreparedStatementLimits::new(max_statements, max_portals, max_bound_bytes)
+                .unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::InvalidArgument);
+        }
+    }
+
+    #[test]
     fn engine_options_builder_replaces_only_result_limits() {
         let limits = ResultLimits::new(37, 4_096).unwrap();
         let options = EngineOptions::new(2, 7).unwrap().with_result_limits(limits);
@@ -330,6 +518,25 @@ mod tests {
         assert_eq!(options.connections_per_shard(), 2);
         assert_eq!(options.queue_capacity_per_shard(), 7);
         assert_eq!(options.result_limits(), limits);
+        assert_eq!(
+            options.prepared_statement_limits(),
+            PreparedStatementLimits::default()
+        );
+        assert_eq!(options.request_timeout(), Some(Duration::from_secs(30)));
+        assert_eq!(options.shutdown_grace(), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn engine_options_builder_replaces_only_prepared_statement_limits() {
+        let limits = PreparedStatementLimits::new(37, 41, 4_096).unwrap();
+        let options = EngineOptions::new(2, 7)
+            .unwrap()
+            .with_prepared_statement_limits(limits);
+
+        assert_eq!(options.connections_per_shard(), 2);
+        assert_eq!(options.queue_capacity_per_shard(), 7);
+        assert_eq!(options.result_limits(), ResultLimits::default());
+        assert_eq!(options.prepared_statement_limits(), limits);
         assert_eq!(options.request_timeout(), Some(Duration::from_secs(30)));
         assert_eq!(options.shutdown_grace(), Duration::from_secs(30));
     }

--- a/src/core/prepared.rs
+++ b/src/core/prepared.rs
@@ -1,0 +1,870 @@
+//! Protocol-neutral prepared-statement and bound-portal state.
+
+use std::{collections::BTreeMap, fmt, num::NonZeroU64, sync::Arc};
+
+use crate::sql::{SqlDialect, SqlTranslationMode, TranslatedSql};
+
+use super::{
+    Column, DataType, EngineError, EngineErrorKind, EngineResult, LogicalDatabaseId,
+    PreparedStatementLimits, ResultSet, SessionId, Value,
+};
+
+/// A request to prepare exactly one protocol-neutral SQL statement.
+#[derive(Clone, PartialEq, Eq)]
+pub struct PrepareRequest {
+    database: LogicalDatabaseId,
+    dialect: SqlDialect,
+    translation_mode: SqlTranslationMode,
+    sql: String,
+}
+
+impl PrepareRequest {
+    /// Construct a request with an explicit logical database, source dialect,
+    /// and translation policy.
+    pub fn new(
+        database: LogicalDatabaseId,
+        dialect: SqlDialect,
+        translation_mode: SqlTranslationMode,
+        sql: impl Into<String>,
+    ) -> Self {
+        Self {
+            database,
+            dialect,
+            translation_mode,
+            sql: sql.into(),
+        }
+    }
+
+    /// Return the selected logical database.
+    pub const fn database(&self) -> LogicalDatabaseId {
+        self.database
+    }
+
+    /// Return the explicitly selected source dialect.
+    pub const fn dialect(&self) -> SqlDialect {
+        self.dialect
+    }
+
+    /// Return the explicitly selected translation policy.
+    pub const fn translation_mode(&self) -> SqlTranslationMode {
+        self.translation_mode
+    }
+
+    /// Return the original SQL text.
+    pub fn sql(&self) -> &str {
+        &self.sql
+    }
+
+    pub(crate) fn into_parts(self) -> (LogicalDatabaseId, SqlDialect, SqlTranslationMode, String) {
+        (self.database, self.dialect, self.translation_mode, self.sql)
+    }
+}
+
+impl fmt::Debug for PrepareRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PrepareRequest")
+            .field("database", &self.database)
+            .field("dialect", &self.dialect)
+            .field("translation_mode", &self.translation_mode)
+            .field("sql_bytes", &self.sql.len())
+            .finish()
+    }
+}
+
+/// An opaque handle for one prepared statement in one session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct PreparedStatementId {
+    session: SessionId,
+    sequence: NonZeroU64,
+}
+
+impl PreparedStatementId {
+    const fn new(session: SessionId, sequence: NonZeroU64) -> Self {
+        Self { session, sequence }
+    }
+
+    pub(crate) const fn session(self) -> SessionId {
+        self.session
+    }
+
+    const fn sequence(self) -> NonZeroU64 {
+        self.sequence
+    }
+}
+
+/// An opaque handle for one immutable bound portal in one session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct PortalId {
+    session: SessionId,
+    sequence: NonZeroU64,
+}
+
+impl PortalId {
+    const fn new(session: SessionId, sequence: NonZeroU64) -> Self {
+        Self { session, sequence }
+    }
+
+    pub(crate) const fn session(self) -> SessionId {
+        self.session
+    }
+
+    const fn sequence(self) -> NonZeroU64 {
+        self.sequence
+    }
+}
+
+/// Select the prepared statement or bound portal whose metadata is requested.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DescribeTarget {
+    /// Describe a prepared statement before or after binding.
+    Statement(PreparedStatementId),
+    /// Describe the statement underlying one bound portal.
+    Portal(PortalId),
+}
+
+/// Owned parameter and result metadata for a prepared statement.
+#[derive(Clone, PartialEq, Eq)]
+pub struct PreparedStatementDescription {
+    parameter_types: Box<[DataType]>,
+    columns: Box<[Column]>,
+    schema_generation: u64,
+}
+
+impl PreparedStatementDescription {
+    pub(crate) fn new(
+        parameter_count: usize,
+        columns: Vec<Column>,
+        schema_generation: u64,
+    ) -> Self {
+        Self {
+            parameter_types: vec![DataType::Unknown; parameter_count].into_boxed_slice(),
+            columns: columns.into_boxed_slice(),
+            schema_generation,
+        }
+    }
+
+    /// Return one protocol-neutral type for every normalized parameter index.
+    ///
+    /// Types are currently `Unknown`; wire adapters decode their own parameter
+    /// representation into a concrete [`Value`] before binding.
+    pub fn parameter_types(&self) -> &[DataType] {
+        &self.parameter_types
+    }
+
+    /// Return ordered result-column metadata. Commands have no columns.
+    pub fn columns(&self) -> &[Column] {
+        &self.columns
+    }
+
+    /// Return the application-schema generation used to compile the metadata.
+    pub const fn schema_generation(&self) -> u64 {
+        self.schema_generation
+    }
+
+    /// Return whether SQLite reported result columns for the statement.
+    pub fn returns_rows(&self) -> bool {
+        !self.columns.is_empty()
+    }
+}
+
+impl fmt::Debug for PreparedStatementDescription {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedStatementDescription")
+            .field("parameter_count", &self.parameter_types.len())
+            .field("column_count", &self.columns.len())
+            .field("schema_generation", &self.schema_generation)
+            .finish()
+    }
+}
+
+/// The result of executing one bound portal.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub enum PreparedExecution {
+    /// A command completed and changed this many rows.
+    AffectedRows(usize),
+    /// A read-only statement returned a bounded materialized result.
+    Rows(ResultSet),
+}
+
+#[derive(Clone)]
+pub(crate) struct PreparedTemplate {
+    database: LogicalDatabaseId,
+    translated: TranslatedSql,
+    description: PreparedStatementDescription,
+}
+
+impl PreparedTemplate {
+    pub(crate) const fn database(&self) -> LogicalDatabaseId {
+        self.database
+    }
+
+    pub(crate) const fn translated(&self) -> &TranslatedSql {
+        &self.translated
+    }
+
+    pub(crate) const fn description(&self) -> &PreparedStatementDescription {
+        &self.description
+    }
+
+    pub(crate) fn replace_description(&mut self, description: PreparedStatementDescription) {
+        self.description = description;
+    }
+}
+
+impl fmt::Debug for PreparedTemplate {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedTemplate")
+            .field("database", &self.database)
+            .field("dialect", &self.translated.dialect())
+            .field("translation_mode", &self.translated.mode())
+            .field("source_bytes", &self.translated.source().len())
+            .field("sqlite_sql_bytes", &self.translated.sqlite_sql().len())
+            .field("parameter_count", &self.description.parameter_types.len())
+            .field("column_count", &self.description.columns.len())
+            .field("schema_generation", &self.description.schema_generation)
+            .finish()
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct PreparedPortal {
+    statement: PreparedStatementId,
+    parameters: Arc<[Value]>,
+    routing_key: Option<Arc<[u8]>>,
+    retained_bytes: u64,
+}
+
+impl PreparedPortal {
+    pub(crate) const fn statement(&self) -> PreparedStatementId {
+        self.statement
+    }
+
+    pub(crate) fn parameters(&self) -> &[Value] {
+        &self.parameters
+    }
+
+    pub(crate) fn routing_key(&self) -> Option<&[u8]> {
+        self.routing_key.as_deref()
+    }
+}
+
+impl fmt::Debug for PreparedPortal {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedPortal")
+            .field("statement", &self.statement)
+            .field("parameter_count", &self.parameters.len())
+            .field("has_routing_key", &self.routing_key.is_some())
+            .field("retained_bytes", &self.retained_bytes)
+            .finish()
+    }
+}
+
+pub(crate) struct PreparedState {
+    session: SessionId,
+    limits: PreparedStatementLimits,
+    next_statement_sequence: u64,
+    next_portal_sequence: u64,
+    statements: BTreeMap<NonZeroU64, PreparedTemplate>,
+    portals: BTreeMap<NonZeroU64, PreparedPortal>,
+    retained_bound_value_bytes: u64,
+}
+
+impl PreparedState {
+    pub(crate) fn new(session: SessionId, limits: PreparedStatementLimits) -> Self {
+        Self {
+            session,
+            limits,
+            next_statement_sequence: 1,
+            next_portal_sequence: 1,
+            statements: BTreeMap::new(),
+            portals: BTreeMap::new(),
+            retained_bound_value_bytes: 0,
+        }
+    }
+
+    pub(crate) fn ensure_statement_capacity(&self) -> EngineResult<()> {
+        if self.statements.len() >= self.limits.max_statements_per_session() {
+            Err(EngineError::new(
+                EngineErrorKind::LimitExceeded,
+                "the session prepared-statement cache is full",
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(crate) fn insert_statement(
+        &mut self,
+        database: LogicalDatabaseId,
+        translated: TranslatedSql,
+        description: PreparedStatementDescription,
+    ) -> EngineResult<PreparedStatementId> {
+        self.ensure_statement_capacity()?;
+        let sequence = next_sequence(
+            &mut self.next_statement_sequence,
+            "the session exhausted prepared-statement identifiers",
+        )?;
+        let id = PreparedStatementId::new(self.session, sequence);
+        let previous = self.statements.insert(
+            sequence,
+            PreparedTemplate {
+                database,
+                translated,
+                description,
+            },
+        );
+        debug_assert!(
+            previous.is_none(),
+            "prepared-statement IDs are never reused"
+        );
+        Ok(id)
+    }
+
+    pub(crate) fn statement(&self, id: PreparedStatementId) -> EngineResult<&PreparedTemplate> {
+        self.ensure_statement_owner(id)?;
+        self.statements
+            .get(&id.sequence())
+            .ok_or_else(missing_statement)
+    }
+
+    pub(crate) fn statement_mut(
+        &mut self,
+        id: PreparedStatementId,
+    ) -> EngineResult<&mut PreparedTemplate> {
+        self.ensure_statement_owner(id)?;
+        self.statements
+            .get_mut(&id.sequence())
+            .ok_or_else(missing_statement)
+    }
+
+    pub(crate) fn close_statement(&mut self, id: PreparedStatementId) -> EngineResult<bool> {
+        self.ensure_statement_owner(id)?;
+        if self.statements.remove(&id.sequence()).is_none() {
+            return Ok(false);
+        }
+
+        let released = self
+            .portals
+            .values()
+            .filter(|portal| portal.statement == id)
+            .try_fold(0_u64, |total, portal| {
+                total.checked_add(portal.retained_bytes).ok_or_else(|| {
+                    EngineError::new(
+                        EngineErrorKind::Internal,
+                        "bound-portal byte accounting overflowed while closing a statement",
+                    )
+                })
+            })?;
+        self.portals.retain(|_, portal| portal.statement != id);
+        self.retained_bound_value_bytes = self
+            .retained_bound_value_bytes
+            .checked_sub(released)
+            .expect("retained portal bytes include every dependent portal");
+        Ok(true)
+    }
+
+    pub(crate) fn insert_portal(
+        &mut self,
+        statement: PreparedStatementId,
+        parameters: Vec<Value>,
+        routing_key: Option<Vec<u8>>,
+    ) -> EngineResult<PortalId> {
+        self.statement(statement)?;
+        let (retained_bytes, next_retained) =
+            self.ensure_portal_capacity(&parameters, routing_key.as_deref())?;
+        let sequence = next_sequence(
+            &mut self.next_portal_sequence,
+            "the session exhausted bound-portal identifiers",
+        )?;
+        let id = PortalId::new(self.session, sequence);
+        let previous = self.portals.insert(
+            sequence,
+            PreparedPortal {
+                statement,
+                parameters: Arc::from(parameters),
+                routing_key: routing_key.map(Arc::from),
+                retained_bytes,
+            },
+        );
+        debug_assert!(previous.is_none(), "bound-portal IDs are never reused");
+        self.retained_bound_value_bytes = next_retained;
+        Ok(id)
+    }
+
+    pub(crate) fn ensure_portal_capacity(
+        &self,
+        parameters: &[Value],
+        routing_key: Option<&[u8]>,
+    ) -> EngineResult<(u64, u64)> {
+        if self.portals.len() >= self.limits.max_portals_per_session() {
+            return Err(EngineError::new(
+                EngineErrorKind::LimitExceeded,
+                "the session bound-portal cache is full",
+            ));
+        }
+        let retained_bytes = retained_bound_value_bytes(parameters, routing_key)?;
+        let next_retained = self
+            .retained_bound_value_bytes
+            .checked_add(retained_bytes)
+            .filter(|bytes| *bytes <= self.limits.max_retained_bound_value_bytes())
+            .ok_or_else(|| {
+                EngineError::new(
+                    EngineErrorKind::LimitExceeded,
+                    "bound portals exceed the session retained-value byte limit",
+                )
+            })?;
+        Ok((retained_bytes, next_retained))
+    }
+
+    pub(crate) fn ensure_planning_capacity(
+        &self,
+        parameters: &[Value],
+        parameter_indices: &[usize],
+        routing_key: Option<&[u8]>,
+    ) -> EngineResult<()> {
+        // The planner owns one canonical copy of an explicit route while it
+        // validates the bind. Account for that allocation as part of the same
+        // per-bind ceiling as expanded parameter occurrences.
+        let mut planning_bytes = match routing_key {
+            Some(key) => usize_to_u64(key.len())?,
+            None => 0,
+        };
+        if planning_bytes > self.limits.max_retained_bound_value_bytes() {
+            return Err(planning_bytes_exceeded());
+        }
+        for index in parameter_indices {
+            let parameter = index
+                .checked_sub(1)
+                .and_then(|index| parameters.get(index))
+                .ok_or_else(|| {
+                    EngineError::new(
+                        EngineErrorKind::Internal,
+                        "normalized parameter layout is outside the validated bind",
+                    )
+                })?;
+            // Inference may retain one typed payload and routing may retain one
+            // canonical payload for the same occurrence. Conservatively budget
+            // both before the planner can allocate either copy.
+            let occurrence_bytes = retained_value_bytes(parameter)?
+                .checked_mul(2)
+                .ok_or_else(retained_bytes_overflow)?;
+            planning_bytes = planning_bytes
+                .checked_add(occurrence_bytes)
+                .filter(|bytes| *bytes <= self.limits.max_retained_bound_value_bytes())
+                .ok_or_else(planning_bytes_exceeded)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn portal(&self, id: PortalId) -> EngineResult<&PreparedPortal> {
+        self.ensure_portal_owner(id)?;
+        self.portals.get(&id.sequence()).ok_or_else(missing_portal)
+    }
+
+    pub(crate) fn close_portal(&mut self, id: PortalId) -> EngineResult<bool> {
+        self.ensure_portal_owner(id)?;
+        let Some(portal) = self.portals.remove(&id.sequence()) else {
+            return Ok(false);
+        };
+        self.retained_bound_value_bytes = self
+            .retained_bound_value_bytes
+            .checked_sub(portal.retained_bytes)
+            .expect("retained portal bytes include the removed portal");
+        Ok(true)
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.statements.clear();
+        self.portals.clear();
+        self.retained_bound_value_bytes = 0;
+    }
+
+    fn ensure_statement_owner(&self, id: PreparedStatementId) -> EngineResult<()> {
+        if id.session() == self.session {
+            Ok(())
+        } else {
+            Err(foreign_handle("prepared statement"))
+        }
+    }
+
+    fn ensure_portal_owner(&self, id: PortalId) -> EngineResult<()> {
+        if id.session() == self.session {
+            Ok(())
+        } else {
+            Err(foreign_handle("bound portal"))
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn statement_count(&self) -> usize {
+        self.statements.len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn portal_count(&self) -> usize {
+        self.portals.len()
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn retained_bound_value_bytes_for_test(&self) -> u64 {
+        self.retained_bound_value_bytes
+    }
+}
+
+impl fmt::Debug for PreparedState {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedState")
+            .field("session", &self.session)
+            .field("limits", &self.limits)
+            .field("statement_count", &self.statements.len())
+            .field("portal_count", &self.portals.len())
+            .field(
+                "retained_bound_value_bytes",
+                &self.retained_bound_value_bytes,
+            )
+            .finish()
+    }
+}
+
+fn next_sequence(counter: &mut u64, diagnostic: &'static str) -> EngineResult<NonZeroU64> {
+    let sequence = NonZeroU64::new(*counter)
+        .ok_or_else(|| EngineError::new(EngineErrorKind::LimitExceeded, diagnostic))?;
+    *counter = counter
+        .checked_add(1)
+        .ok_or_else(|| EngineError::new(EngineErrorKind::LimitExceeded, diagnostic))?;
+    Ok(sequence)
+}
+
+fn retained_bound_value_bytes(
+    parameters: &[Value],
+    routing_key: Option<&[u8]>,
+) -> EngineResult<u64> {
+    let mut total = match routing_key {
+        Some(key) => usize_to_u64(key.len())?,
+        None => 0,
+    };
+    for parameter in parameters {
+        total = total
+            .checked_add(retained_value_bytes(parameter)?)
+            .ok_or_else(retained_bytes_overflow)?;
+    }
+    Ok(total)
+}
+
+fn retained_value_bytes(parameter: &Value) -> EngineResult<u64> {
+    const TYPE_BYTES: u64 = 1;
+    const LENGTH_BYTES: u64 = 8;
+    const FIXED_VALUE_BYTES: u64 = 8;
+
+    let payload = match parameter {
+        Value::Null => 0,
+        Value::Boolean(_) | Value::Int64(_) | Value::UInt64(_) | Value::Float64(_) => {
+            FIXED_VALUE_BYTES
+        }
+        Value::Decimal(value) => usize_to_u64(value.as_str().len())?,
+        Value::Text(value) => usize_to_u64(value.len())?,
+        Value::InvalidText(value) | Value::Binary(value) => usize_to_u64(value.len())?,
+    };
+    TYPE_BYTES
+        .checked_add(LENGTH_BYTES)
+        .and_then(|bytes| bytes.checked_add(payload))
+        .ok_or_else(retained_bytes_overflow)
+}
+
+fn usize_to_u64(value: usize) -> EngineResult<u64> {
+    u64::try_from(value).map_err(|_| retained_bytes_overflow())
+}
+
+fn retained_bytes_overflow() -> EngineError {
+    EngineError::new(
+        EngineErrorKind::LimitExceeded,
+        "bound portal retained-value byte accounting overflowed",
+    )
+}
+
+fn planning_bytes_exceeded() -> EngineError {
+    EngineError::new(
+        EngineErrorKind::LimitExceeded,
+        "bound parameters exceed the session planning byte limit",
+    )
+}
+
+fn missing_statement() -> EngineError {
+    EngineError::new(
+        EngineErrorKind::FailedPrecondition,
+        "the prepared statement is not open in this session",
+    )
+}
+
+fn missing_portal() -> EngineError {
+    EngineError::new(
+        EngineErrorKind::FailedPrecondition,
+        "the bound portal is not open in this session",
+    )
+}
+
+fn foreign_handle(entity: &str) -> EngineError {
+    EngineError::new(
+        EngineErrorKind::FailedPrecondition,
+        format!("the {entity} belongs to a different session"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sql::{normalize_placeholders, parse, translate_sql, validate_common_subset};
+
+    fn translated(sql: &str) -> TranslatedSql {
+        let parsed = parse(SqlDialect::Sqlite, sql).unwrap();
+        let common = validate_common_subset(parsed).unwrap();
+        let normalized = normalize_placeholders(common).unwrap();
+        translate_sql(normalized, SqlTranslationMode::StrictSqlite).unwrap()
+    }
+
+    fn description(parameters: usize) -> PreparedStatementDescription {
+        PreparedStatementDescription::new(parameters, vec![Column::new("v", DataType::Unknown)], 0)
+    }
+
+    fn state(max_statements: usize, max_portals: usize, max_bytes: u64) -> PreparedState {
+        let limits = PreparedStatementLimits::new(max_statements, max_portals, max_bytes).unwrap();
+        PreparedState::new(SessionId::for_test(99), limits)
+    }
+
+    #[test]
+    fn prepare_request_accessors_and_debug_are_owned_and_redacted() {
+        let database = LogicalDatabaseId::new(1).unwrap();
+        let request = PrepareRequest::new(
+            database,
+            SqlDialect::PostgreSql,
+            SqlTranslationMode::Compatibility,
+            "SELECT 'private' WHERE id = $1",
+        );
+        assert_eq!(request.database(), database);
+        assert_eq!(request.dialect(), SqlDialect::PostgreSql);
+        assert_eq!(
+            request.translation_mode(),
+            SqlTranslationMode::Compatibility
+        );
+        assert_eq!(request.sql(), "SELECT 'private' WHERE id = $1");
+        let debug = format!("{request:?}");
+        assert!(debug.contains("sql_bytes"));
+        assert!(!debug.contains("private"));
+    }
+
+    #[test]
+    fn statement_cache_is_bounded_distinct_monotonic_and_has_no_eviction() {
+        let database = LogicalDatabaseId::new(1).unwrap();
+        let mut state = state(2, 2, 1_024);
+        let first = state
+            .insert_statement(database, translated("SELECT 1"), description(0))
+            .unwrap();
+        let second = state
+            .insert_statement(database, translated("SELECT 1"), description(0))
+            .unwrap();
+        assert_ne!(first, second);
+        assert_eq!(state.statement_count(), 2);
+        assert_eq!(
+            state.ensure_statement_capacity().unwrap_err().kind(),
+            EngineErrorKind::LimitExceeded
+        );
+        assert_eq!(state.statement(first).unwrap().database(), database);
+
+        assert!(state.close_statement(first).unwrap());
+        assert!(!state.close_statement(first).unwrap());
+        let third = state
+            .insert_statement(database, translated("SELECT 2"), description(0))
+            .unwrap();
+        assert!(third > second);
+        assert_eq!(state.statement_count(), 2);
+        assert!(state.statement(second).is_ok());
+    }
+
+    #[test]
+    fn portals_are_bounded_accounted_and_statement_close_cascades() {
+        let database = LogicalDatabaseId::new(1).unwrap();
+        let mut state = state(2, 2, 128);
+        let sql = translated("SELECT 1");
+        let statement = state
+            .insert_statement(database, sql, description(0))
+            .unwrap();
+        let first = state
+            .insert_portal(statement, vec![Value::from("abc")], Some(b"route".to_vec()))
+            .unwrap();
+        let second = state
+            .insert_portal(statement, vec![Value::from(7_i64)], None)
+            .unwrap();
+        assert_ne!(first, second);
+        assert_eq!(state.portal_count(), 2);
+        assert_eq!(state.retained_bound_value_bytes_for_test(), 34);
+        assert_eq!(
+            state
+                .insert_portal(statement, vec![], None)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::LimitExceeded
+        );
+
+        assert!(state.close_statement(statement).unwrap());
+        assert_eq!(state.portal_count(), 0);
+        assert_eq!(state.retained_bound_value_bytes_for_test(), 0);
+        assert_eq!(
+            state.portal(first).unwrap_err().kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+    }
+
+    #[test]
+    fn portal_byte_failure_is_atomic_and_close_releases_exact_capacity() {
+        let database = LogicalDatabaseId::new(1).unwrap();
+        let mut state = state(1, 2, 20);
+        let sql = translated("SELECT 1");
+        let statement = state
+            .insert_statement(database, sql, description(0))
+            .unwrap();
+        let too_large = state
+            .insert_portal(statement, vec![Value::from("twelve-bytes")], None)
+            .unwrap_err();
+        assert_eq!(too_large.kind(), EngineErrorKind::LimitExceeded);
+        assert_eq!(state.portal_count(), 0);
+        assert_eq!(state.retained_bound_value_bytes_for_test(), 0);
+
+        let portal = state
+            .insert_portal(statement, vec![Value::from("abc")], None)
+            .unwrap();
+        assert_eq!(state.retained_bound_value_bytes_for_test(), 12);
+        assert!(state.close_portal(portal).unwrap());
+        assert!(!state.close_portal(portal).unwrap());
+        assert_eq!(state.retained_bound_value_bytes_for_test(), 0);
+    }
+
+    #[test]
+    fn repeated_parameter_occurrences_are_bounded_before_planning_allocates() {
+        let state = state(1, 1, 30);
+        let parameters = vec![Value::from("abc")];
+        assert!(state.ensure_portal_capacity(&parameters, None).is_ok());
+        assert!(
+            state
+                .ensure_planning_capacity(&parameters, &[1], Some(b"123456"))
+                .is_ok()
+        );
+        assert_eq!(
+            state
+                .ensure_planning_capacity(&parameters, &[1, 1], None)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::LimitExceeded
+        );
+        assert_eq!(
+            state
+                .ensure_planning_capacity(&parameters, &[1], Some(b"1234567"))
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::LimitExceeded
+        );
+        assert_eq!(state.portal_count(), 0);
+        assert_eq!(state.retained_bound_value_bytes_for_test(), 0);
+    }
+
+    #[test]
+    fn retained_value_accounting_covers_every_type_and_exact_boundaries() {
+        let cases = [
+            (Value::Null, 9),
+            (Value::from(false), 17),
+            (Value::from(i64::MIN), 17),
+            (Value::from(u64::MAX), 17),
+            (Value::from(1.5_f64), 17),
+            (Value::decimal("12.3").unwrap(), 13),
+            (Value::from("é"), 11),
+            (Value::from(""), 9),
+            (Value::InvalidText(vec![0x80]), 10),
+            (Value::from(vec![0_u8, 255]), 11),
+            (Value::from(Vec::<u8>::new()), 9),
+        ];
+        for (value, expected) in cases {
+            assert_eq!(
+                retained_bound_value_bytes(&[value], None).unwrap(),
+                expected
+            );
+        }
+        assert_eq!(retained_bound_value_bytes(&[], Some(b"route")).unwrap(), 5);
+
+        let state = state(1, 1, 12);
+        let parameters = vec![Value::from("abc")];
+        assert_eq!(
+            state.ensure_portal_capacity(&parameters, None).unwrap(),
+            (12, 12)
+        );
+        assert_eq!(
+            state
+                .ensure_portal_capacity(&parameters, Some(b"x"))
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::LimitExceeded
+        );
+        assert_eq!(state.portal_count(), 0);
+        assert_eq!(state.retained_bound_value_bytes_for_test(), 0);
+    }
+
+    #[test]
+    fn handles_are_session_scoped_and_debug_omits_cached_contents() {
+        let database = LogicalDatabaseId::new(1).unwrap();
+        let mut first = state(1, 1, 128);
+        let sql = translated("SELECT 'private'");
+        let statement = first
+            .insert_statement(database, sql.clone(), description(0))
+            .unwrap();
+        let portal = first
+            .insert_portal(
+                statement,
+                vec![Value::from("private")],
+                Some(b"private-route".to_vec()),
+            )
+            .unwrap();
+        let second = PreparedState::new(
+            SessionId::for_test(100),
+            PreparedStatementLimits::new(1, 1, 128).unwrap(),
+        );
+
+        assert_eq!(
+            second.statement(statement).unwrap_err().kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+        assert_eq!(
+            second.portal(portal).unwrap_err().kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+        let debug = format!("{first:?} {:?}", first.portal(portal).unwrap());
+        assert!(!debug.contains("private"));
+        assert!(!debug.contains("private-route"));
+    }
+
+    #[test]
+    fn description_accessors_preserve_counts_and_redact_column_names() {
+        let description = PreparedStatementDescription::new(
+            2,
+            vec![
+                Column::new("private_a", DataType::Unknown),
+                Column::new("private_b", DataType::Unknown),
+            ],
+            7,
+        );
+        assert_eq!(
+            description.parameter_types(),
+            [DataType::Unknown, DataType::Unknown]
+        );
+        assert_eq!(description.columns().len(), 2);
+        assert_eq!(description.schema_generation(), 7);
+        assert!(description.returns_rows());
+        let debug = format!("{description:?}");
+        assert!(!debug.contains("private_a"));
+        assert!(!debug.contains("private_b"));
+    }
+}

--- a/src/core/session.rs
+++ b/src/core/session.rs
@@ -8,7 +8,7 @@ use std::{
 
 use tokio::sync::Mutex;
 
-use super::{EngineError, EngineErrorKind, EngineResult};
+use super::{EngineError, EngineErrorKind, EngineResult, PreparedState, PreparedStatementLimits};
 
 static NEXT_SESSION_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -20,6 +20,11 @@ impl SessionId {
     /// Return the numeric session identifier.
     pub const fn get(self) -> u64 {
         self.0
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn for_test(value: u64) -> Self {
+        Self(value)
     }
 }
 
@@ -43,10 +48,10 @@ pub enum SessionState {
     Closed,
 }
 
-#[derive(Debug)]
 pub(crate) struct SessionInner {
     state: SessionState,
     routing_key: Option<String>,
+    prepared: PreparedState,
 }
 
 impl SessionInner {
@@ -60,6 +65,25 @@ impl SessionInner {
 
     pub(crate) fn routing_key(&self) -> Option<&str> {
         self.routing_key.as_deref()
+    }
+
+    pub(crate) const fn prepared(&self) -> &PreparedState {
+        &self.prepared
+    }
+
+    pub(crate) fn prepared_mut(&mut self) -> &mut PreparedState {
+        &mut self.prepared
+    }
+}
+
+impl fmt::Debug for SessionInner {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SessionInner")
+            .field("state", &self.state)
+            .field("has_routing_key", &self.routing_key.is_some())
+            .field("prepared", &self.prepared)
+            .finish()
     }
 }
 
@@ -75,13 +99,15 @@ pub struct Session {
 }
 
 impl Session {
-    pub(crate) fn new(owner: u64) -> Self {
+    pub(crate) fn new(owner: u64, prepared_limits: PreparedStatementLimits) -> Self {
+        let id = SessionId(NEXT_SESSION_ID.fetch_add(1, Ordering::Relaxed));
         Self {
-            id: SessionId(NEXT_SESSION_ID.fetch_add(1, Ordering::Relaxed)),
+            id,
             owner,
             inner: Arc::new(Mutex::new(SessionInner {
                 state: SessionState::Ready,
                 routing_key: None,
+                prepared: PreparedState::new(id, prepared_limits),
             })),
         }
     }
@@ -120,11 +146,13 @@ impl Session {
 
     /// Close the session.
     ///
-    /// Closing is terminal and idempotent. It also clears routing context.
+    /// Closing is terminal and idempotent. It also clears routing context,
+    /// prepared statements, and bound portals.
     pub async fn close(&self) -> EngineResult<()> {
         let mut inner = self.inner.lock().await;
         inner.state = SessionState::Closed;
         inner.routing_key = None;
+        inner.prepared.clear();
         Ok(())
     }
 }
@@ -148,8 +176,8 @@ mod tests {
 
     #[tokio::test]
     async fn sessions_have_unique_ids_and_start_ready_without_routing_context() {
-        let first = Session::new(7);
-        let second = Session::new(7);
+        let first = Session::new(7, PreparedStatementLimits::default());
+        let second = Session::new(7, PreparedStatementLimits::default());
 
         assert_ne!(first.id(), second.id());
         assert!(first.id().get() > 0);
@@ -160,7 +188,7 @@ mod tests {
 
     #[tokio::test]
     async fn routing_context_can_be_set_replaced_and_cleared() {
-        let session = Session::new(7);
+        let session = Session::new(7, PreparedStatementLimits::default());
 
         session.set_routing_key("tenant-a").await.unwrap();
         assert_eq!(session.routing_key().await.as_deref(), Some("tenant-a"));
@@ -173,7 +201,7 @@ mod tests {
 
     #[tokio::test]
     async fn close_is_idempotent_terminal_and_clears_routing_context() {
-        let session = Session::new(7);
+        let session = Session::new(7, PreparedStatementLimits::default());
         session.set_routing_key("tenant-a").await.unwrap();
 
         session.close().await.unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,11 @@ use std::{net::SocketAddr, path::PathBuf, time::Duration};
 
 use briskdb::{
     core::{
-        DEFAULT_CONNECTIONS_PER_SHARD, DEFAULT_MAX_RESULT_BYTES, DEFAULT_MAX_RESULT_ROWS,
+        DEFAULT_CONNECTIONS_PER_SHARD, DEFAULT_MAX_PORTALS_PER_SESSION,
+        DEFAULT_MAX_PREPARED_STATEMENTS_PER_SESSION, DEFAULT_MAX_RESULT_BYTES,
+        DEFAULT_MAX_RESULT_ROWS, DEFAULT_MAX_RETAINED_BOUND_VALUE_BYTES,
         DEFAULT_QUEUE_CAPACITY_PER_SHARD, DEFAULT_REQUEST_TIMEOUT_MS, DEFAULT_SHUTDOWN_GRACE_MS,
-        EngineOptions, EngineResult, ResultLimits,
+        EngineOptions, EngineResult, PreparedStatementLimits, ResultLimits,
     },
     server::{self, Config},
 };
@@ -58,6 +60,30 @@ struct Args {
     )]
     max_result_bytes: u64,
 
+    /// Maximum prepared statements retained by one session (1-1024).
+    #[arg(
+        long,
+        env = "BRISKDB_MAX_PREPARED_STATEMENTS_PER_SESSION",
+        default_value_t = DEFAULT_MAX_PREPARED_STATEMENTS_PER_SESSION
+    )]
+    max_prepared_statements_per_session: usize,
+
+    /// Maximum bound portals retained by one session (1-1024).
+    #[arg(
+        long,
+        env = "BRISKDB_MAX_PORTALS_PER_SESSION",
+        default_value_t = DEFAULT_MAX_PORTALS_PER_SESSION
+    )]
+    max_portals_per_session: usize,
+
+    /// Maximum retained portal and per-bind route/marker planning bytes (1-1 GiB).
+    #[arg(
+        long,
+        env = "BRISKDB_MAX_RETAINED_BOUND_VALUE_BYTES",
+        default_value_t = DEFAULT_MAX_RETAINED_BOUND_VALUE_BYTES
+    )]
+    max_retained_bound_value_bytes: u64,
+
     /// Engine request timeout in milliseconds; zero disables the default deadline.
     #[arg(
         long,
@@ -82,11 +108,17 @@ impl Args {
     /// ensures invalid limits cannot bind a listener or create database files.
     fn into_server_parts(self) -> EngineResult<(Config, EngineOptions)> {
         let result_limits = ResultLimits::new(self.max_result_rows, self.max_result_bytes)?;
+        let prepared_statement_limits = PreparedStatementLimits::new(
+            self.max_prepared_statements_per_session,
+            self.max_portals_per_session,
+            self.max_retained_bound_value_bytes,
+        )?;
         let request_timeout =
             (self.request_timeout_ms != 0).then(|| Duration::from_millis(self.request_timeout_ms));
         let options =
             EngineOptions::new(self.connections_per_shard, self.queue_capacity_per_shard)?
                 .with_result_limits(result_limits)
+                .with_prepared_statement_limits(prepared_statement_limits)
                 .with_request_timeout(request_timeout)?
                 .with_shutdown_grace(Duration::from_millis(self.shutdown_grace_ms))?;
         let config = Config {
@@ -132,6 +164,18 @@ mod tests {
         );
         assert_eq!(args.max_result_rows, DEFAULT_MAX_RESULT_ROWS);
         assert_eq!(args.max_result_bytes, DEFAULT_MAX_RESULT_BYTES);
+        assert_eq!(
+            args.max_prepared_statements_per_session,
+            DEFAULT_MAX_PREPARED_STATEMENTS_PER_SESSION
+        );
+        assert_eq!(
+            args.max_portals_per_session,
+            DEFAULT_MAX_PORTALS_PER_SESSION
+        );
+        assert_eq!(
+            args.max_retained_bound_value_bytes,
+            DEFAULT_MAX_RETAINED_BOUND_VALUE_BYTES
+        );
         assert_eq!(args.request_timeout_ms, DEFAULT_REQUEST_TIMEOUT_MS);
         assert_eq!(args.shutdown_grace_ms, DEFAULT_SHUTDOWN_GRACE_MS);
     }
@@ -154,6 +198,12 @@ mod tests {
             "321",
             "--max-result-bytes",
             "654321",
+            "--max-prepared-statements-per-session",
+            "43",
+            "--max-portals-per-session",
+            "47",
+            "--max-retained-bound-value-bytes",
+            "7654321",
             "--request-timeout-ms",
             "2500",
             "--shutdown-grace-ms",
@@ -168,6 +218,9 @@ mod tests {
         assert_eq!(args.queue_capacity_per_shard, 17);
         assert_eq!(args.max_result_rows, 321);
         assert_eq!(args.max_result_bytes, 654_321);
+        assert_eq!(args.max_prepared_statements_per_session, 43);
+        assert_eq!(args.max_portals_per_session, 47);
+        assert_eq!(args.max_retained_bound_value_bytes, 7_654_321);
         assert_eq!(args.request_timeout_ms, 2_500);
         assert_eq!(args.shutdown_grace_ms, 4_000);
     }
@@ -190,6 +243,12 @@ mod tests {
             "321",
             "--max-result-bytes",
             "654321",
+            "--max-prepared-statements-per-session",
+            "43",
+            "--max-portals-per-session",
+            "47",
+            "--max-retained-bound-value-bytes",
+            "7654321",
             "--request-timeout-ms",
             "2500",
             "--shutdown-grace-ms",
@@ -211,6 +270,10 @@ mod tests {
         assert_eq!(
             options.result_limits(),
             ResultLimits::new(321, 654_321).unwrap()
+        );
+        assert_eq!(
+            options.prepared_statement_limits(),
+            PreparedStatementLimits::new(43, 47, 7_654_321).unwrap()
         );
         assert_eq!(
             options.request_timeout(),
@@ -240,6 +303,12 @@ mod tests {
             vec!["briskdb", "--max-result-rows", "1000001"],
             vec!["briskdb", "--max-result-bytes", "0"],
             vec!["briskdb", "--max-result-bytes", "1073741825"],
+            vec!["briskdb", "--max-prepared-statements-per-session", "0"],
+            vec!["briskdb", "--max-prepared-statements-per-session", "1025"],
+            vec!["briskdb", "--max-portals-per-session", "0"],
+            vec!["briskdb", "--max-portals-per-session", "1025"],
+            vec!["briskdb", "--max-retained-bound-value-bytes", "0"],
+            vec!["briskdb", "--max-retained-bound-value-bytes", "1073741825"],
             vec!["briskdb", "--request-timeout-ms", "86400001"],
             vec!["briskdb", "--shutdown-grace-ms", "0"],
             vec!["briskdb", "--shutdown-grace-ms", "86400001"],
@@ -281,6 +350,18 @@ mod tests {
             .get_arguments()
             .find(|argument| argument.get_id() == "max_result_bytes")
             .unwrap();
+        let prepared_statements = command
+            .get_arguments()
+            .find(|argument| argument.get_id() == "max_prepared_statements_per_session")
+            .unwrap();
+        let portals = command
+            .get_arguments()
+            .find(|argument| argument.get_id() == "max_portals_per_session")
+            .unwrap();
+        let retained_bound_value_bytes = command
+            .get_arguments()
+            .find(|argument| argument.get_id() == "max_retained_bound_value_bytes")
+            .unwrap();
         let timeout = command
             .get_arguments()
             .find(|argument| argument.get_id() == "request_timeout_ms")
@@ -304,6 +385,18 @@ mod tests {
             Some(OsStr::new("BRISKDB_MAX_RESULT_BYTES"))
         );
         assert_eq!(
+            prepared_statements.get_env(),
+            Some(OsStr::new("BRISKDB_MAX_PREPARED_STATEMENTS_PER_SESSION"))
+        );
+        assert_eq!(
+            portals.get_env(),
+            Some(OsStr::new("BRISKDB_MAX_PORTALS_PER_SESSION"))
+        );
+        assert_eq!(
+            retained_bound_value_bytes.get_env(),
+            Some(OsStr::new("BRISKDB_MAX_RETAINED_BOUND_VALUE_BYTES"))
+        );
+        assert_eq!(
             timeout.get_env(),
             Some(OsStr::new("BRISKDB_REQUEST_TIMEOUT_MS"))
         );
@@ -323,6 +416,9 @@ mod tests {
             assert_eq!(args.queue_capacity_per_shard, 41);
             assert_eq!(args.max_result_rows, 500);
             assert_eq!(args.max_result_bytes, 65_536);
+            assert_eq!(args.max_prepared_statements_per_session, 29);
+            assert_eq!(args.max_portals_per_session, 31);
+            assert_eq!(args.max_retained_bound_value_bytes, 98_304);
             assert_eq!(args.request_timeout_ms, 1_250);
             assert_eq!(args.shutdown_grace_ms, 2_750);
             return;
@@ -341,6 +437,9 @@ mod tests {
             .env("BRISKDB_QUEUE_CAPACITY_PER_SHARD", "41")
             .env("BRISKDB_MAX_RESULT_ROWS", "500")
             .env("BRISKDB_MAX_RESULT_BYTES", "65536")
+            .env("BRISKDB_MAX_PREPARED_STATEMENTS_PER_SESSION", "29")
+            .env("BRISKDB_MAX_PORTALS_PER_SESSION", "31")
+            .env("BRISKDB_MAX_RETAINED_BOUND_VALUE_BYTES", "98304")
             .env("BRISKDB_REQUEST_TIMEOUT_MS", "1250")
             .env("BRISKDB_SHUTDOWN_GRACE_MS", "2750")
             .status()

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -73,6 +73,18 @@ pub async fn run_with_engine_options(config: Config, options: EngineOptions) -> 
         queue_capacity_per_shard = engine.options().queue_capacity_per_shard(),
         max_result_rows = engine.options().result_limits().max_rows(),
         max_result_bytes = engine.options().result_limits().max_bytes(),
+        max_prepared_statements_per_session = engine
+            .options()
+            .prepared_statement_limits()
+            .max_statements_per_session(),
+        max_portals_per_session = engine
+            .options()
+            .prepared_statement_limits()
+            .max_portals_per_session(),
+        max_retained_bound_value_bytes = engine
+            .options()
+            .prepared_statement_limits()
+            .max_retained_bound_value_bytes(),
         request_timeout_ms = engine
             .options()
             .request_timeout()

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -28,7 +28,7 @@ pub use subset::{CommonSql, MAX_COMMON_SQL_EXPRESSION_DEPTH, validate_common_sub
 pub use translator::{SqlTranslationMode, TranslatedSql, translate_sql};
 
 use rusqlite::{
-    Connection, params_from_iter,
+    Connection, Statement as SqlStatement, params_from_iter,
     types::{Value as SqlValue, ValueRef},
 };
 
@@ -46,15 +46,143 @@ const LENGTH_BYTES: u64 = 8;
 const ROW_FRAME_BYTES: u64 = 8;
 const FIXED_VALUE_PAYLOAD_BYTES: u64 = 8;
 
+/// Owned metadata collected while SQLite transiently prepares a statement.
+///
+/// SQLite's statement and column metadata borrow their connection. Keeping an
+/// owned protocol-neutral copy lets prepared-statement callers release that
+/// borrow before storing the description in a session.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct StatementMetadata {
+    parameter_count: usize,
+    columns: Vec<Column>,
+    readonly: bool,
+}
+
+impl StatementMetadata {
+    pub(crate) const fn parameter_count(&self) -> usize {
+        self.parameter_count
+    }
+
+    pub(crate) fn columns(&self) -> &[Column] {
+        &self.columns
+    }
+
+    pub(crate) const fn readonly(&self) -> bool {
+        self.readonly
+    }
+
+    pub(crate) fn produces_columns(&self) -> bool {
+        !self.columns.is_empty()
+    }
+}
+
+/// The result of executing one transiently prepared SQLite statement.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum StatementExecution {
+    Rows(ResultSet),
+    AffectedRows(usize),
+}
+
+/// Transiently prepares a statement and copies all metadata needed by the
+/// protocol-neutral prepared-statement lifecycle.
+pub(crate) fn describe_statement(
+    connection: &Connection,
+    statement: &str,
+) -> EngineResult<StatementMetadata> {
+    let statement = connection
+        .prepare(statement)
+        .map_err(sqlite_error::statement)?;
+    Ok(statement_metadata(&statement))
+}
+
+/// Transiently prepares and executes exactly one statement.
+///
+/// Column-producing writes (for example DML with `RETURNING`) are rejected
+/// before SQLite is stepped. Supporting those safely requires a result and
+/// transaction policy that the protocol-neutral engine does not yet expose.
+pub(crate) fn execute_statement_with_limits(
+    connection: &Connection,
+    statement: &str,
+    params: &[Value],
+    limits: ResultLimits,
+) -> EngineResult<StatementExecution> {
+    let params = sqlite_parameters(params)?;
+    let mut statement = connection
+        .prepare(statement)
+        .map_err(sqlite_error::statement)?;
+    let metadata = statement_metadata(&statement);
+
+    if metadata.produces_columns() {
+        if !metadata.readonly() {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidQuery,
+                "row-producing write statements are not supported",
+            ));
+        }
+        return materialize_rows(&mut statement, metadata.columns, params, limits)
+            .map(StatementExecution::Rows);
+    }
+
+    statement
+        .execute(params_from_iter(params))
+        .map(StatementExecution::AffectedRows)
+        .map_err(sqlite_error::statement)
+}
+
+/// Validates that every protocol-neutral parameter has a lossless SQLite
+/// binding without allocating converted text or binary payloads.
+pub(crate) fn validate_parameters(params: &[Value]) -> EngineResult<()> {
+    params.iter().try_for_each(validate_parameter)
+}
+
+fn validate_parameter(value: &Value) -> EngineResult<()> {
+    match value {
+        Value::UInt64(value) => i64::try_from(*value).map(|_| ()).map_err(|error| {
+            EngineError::from_source(
+                EngineErrorKind::NumericOutOfRange,
+                format!("unsigned integer {value} exceeds SQLite INTEGER range"),
+                error,
+            )
+        }),
+        Value::Float64(value) if value.is_nan() => Err(EngineError::new(
+            EngineErrorKind::Unsupported,
+            "NaN has no lossless SQLite binding because SQLite converts it to NULL",
+        )),
+        Value::Decimal(value) => Err(EngineError::new(
+            EngineErrorKind::Unsupported,
+            format!("decimal value {value} has no lossless SQLite binding"),
+        )),
+        Value::InvalidText(_) => Err(EngineError::new(
+            EngineErrorKind::InvalidTextEncoding,
+            "non-UTF-8 text has no lossless SQLite binding",
+        )),
+        Value::Null
+        | Value::Boolean(_)
+        | Value::Int64(_)
+        | Value::Float64(_)
+        | Value::Text(_)
+        | Value::Binary(_) => Ok(()),
+    }
+}
+
+fn statement_metadata(statement: &SqlStatement<'_>) -> StatementMetadata {
+    StatementMetadata {
+        parameter_count: statement.parameter_count(),
+        columns: statement
+            .column_names()
+            .into_iter()
+            .map(|name| Column::new(name, DataType::Unknown))
+            .collect(),
+        readonly: statement.readonly(),
+    }
+}
+
 pub(crate) fn execute(
     connection: &Connection,
     statement: &str,
     params: &[Value],
 ) -> EngineResult<usize> {
-    let params = params
-        .iter()
-        .map(value_to_sql)
-        .collect::<EngineResult<Vec<_>>>()?;
+    let params = sqlite_parameters(params)?;
     connection
         .execute(statement, params_from_iter(params))
         .map_err(sqlite_error::statement)
@@ -74,10 +202,7 @@ pub(crate) fn query_with_limits(
     params: &[Value],
     limits: ResultLimits,
 ) -> EngineResult<ResultSet> {
-    let params = params
-        .iter()
-        .map(value_to_sql)
-        .collect::<EngineResult<Vec<_>>>()?;
+    let params = sqlite_parameters(params)?;
     let mut statement = connection
         .prepare(statement)
         .map_err(sqlite_error::statement)?;
@@ -88,18 +213,26 @@ pub(crate) fn query_with_limits(
         ));
     }
 
-    let column_names = statement.column_names();
+    let metadata = statement_metadata(&statement);
+    materialize_rows(&mut statement, metadata.columns, params, limits)
+}
+
+fn materialize_rows(
+    statement: &mut SqlStatement<'_>,
+    columns: Vec<Column>,
+    params: Vec<SqlValue>,
+    limits: ResultLimits,
+) -> EngineResult<ResultSet> {
     let mut logical_bytes = account_bytes(0, RESULT_ENVELOPE_BYTES, limits.max_bytes())?;
-    for name in &column_names {
+    for column in &columns {
         logical_bytes = account_bytes(logical_bytes, TYPE_TAG_BYTES, limits.max_bytes())?;
         logical_bytes = account_bytes(logical_bytes, LENGTH_BYTES, limits.max_bytes())?;
-        logical_bytes =
-            account_bytes(logical_bytes, usize_to_u64(name.len())?, limits.max_bytes())?;
+        logical_bytes = account_bytes(
+            logical_bytes,
+            usize_to_u64(column.name.len())?,
+            limits.max_bytes(),
+        )?;
     }
-    let columns = column_names
-        .into_iter()
-        .map(|name| Column::new(name, DataType::Unknown))
-        .collect::<Vec<_>>();
     let mut sqlite_rows = statement
         .query(params_from_iter(params))
         .map_err(sqlite_error::statement)?;
@@ -134,6 +267,10 @@ pub(crate) fn query_with_limits(
             error,
         )
     })
+}
+
+fn sqlite_parameters(params: &[Value]) -> EngineResult<Vec<SqlValue>> {
+    params.iter().map(value_to_sql).collect()
 }
 
 fn account_row(current: u64, maximum: u64) -> EngineResult<u64> {
@@ -245,6 +382,297 @@ mod tests {
     use super::*;
 
     #[test]
+    fn statement_metadata_preserves_exact_parameter_and_column_layouts() {
+        let connection = Connection::open_in_memory().unwrap();
+        let metadata = describe_statement(
+            &connection,
+            "SELECT ?1 AS duplicate,
+                    ?3 AS \"\",
+                    ? AS middle,
+                    :named AS duplicate,
+                    :named AS repeated",
+        )
+        .unwrap();
+
+        // SQLite reports the greatest assigned parameter index. That includes
+        // the unused ?2 gap and does not allocate a second slot for a repeated
+        // named parameter.
+        assert_eq!(metadata.parameter_count(), 5);
+        assert_eq!(
+            metadata.columns(),
+            [
+                Column::new("duplicate", DataType::Unknown),
+                Column::new("", DataType::Unknown),
+                Column::new("middle", DataType::Unknown),
+                Column::new("duplicate", DataType::Unknown),
+                Column::new("repeated", DataType::Unknown),
+            ]
+        );
+        assert!(metadata.readonly());
+        assert!(metadata.produces_columns());
+    }
+
+    #[test]
+    fn statement_metadata_distinguishes_commands_from_row_producers() {
+        let connection = Connection::open_in_memory().unwrap();
+        execute_batch(
+            &connection,
+            "CREATE TABLE metadata_test (id INTEGER PRIMARY KEY, value TEXT NOT NULL);",
+        )
+        .unwrap();
+
+        let command = describe_statement(
+            &connection,
+            "INSERT INTO metadata_test (id, value) VALUES (?1, ?2)",
+        )
+        .unwrap();
+        assert_eq!(command.parameter_count(), 2);
+        assert!(command.columns().is_empty());
+        assert!(!command.readonly());
+        assert!(!command.produces_columns());
+
+        let returning = describe_statement(
+            &connection,
+            "INSERT INTO metadata_test (id, value) VALUES (?1, ?2) RETURNING id, value",
+        )
+        .unwrap();
+        assert_eq!(returning.parameter_count(), 2);
+        assert_eq!(
+            returning.columns(),
+            [
+                Column::new("id", DataType::Unknown),
+                Column::new("value", DataType::Unknown),
+            ]
+        );
+        assert!(!returning.readonly());
+        assert!(returning.produces_columns());
+    }
+
+    #[test]
+    fn transient_execution_returns_rows_with_ordered_typed_values() {
+        let connection = Connection::open_in_memory().unwrap();
+        let result = execute_statement_with_limits(
+            &connection,
+            "SELECT ?1 AS duplicate,
+                    ?2 AS duplicate,
+                    ?3 AS \"\",
+                    ?4 AS blob_value,
+                    NULL AS optional_value",
+            &[
+                Value::from(7_i64),
+                Value::from(1.5_f64),
+                Value::from("text"),
+                Value::from(vec![0_u8, 255]),
+            ],
+            ResultLimits::default(),
+        )
+        .unwrap();
+
+        let StatementExecution::Rows(result) = result else {
+            panic!("SELECT must produce rows");
+        };
+        assert_eq!(
+            result.columns(),
+            [
+                Column::new("duplicate", DataType::Unknown),
+                Column::new("duplicate", DataType::Unknown),
+                Column::new("", DataType::Unknown),
+                Column::new("blob_value", DataType::Unknown),
+                Column::new("optional_value", DataType::Unknown),
+            ]
+        );
+        assert_eq!(
+            result.rows(),
+            [Row::new(vec![
+                Value::from(7_i64),
+                Value::from(1.5_f64),
+                Value::from("text"),
+                Value::from(vec![0_u8, 255]),
+                Value::Null,
+            ])]
+        );
+    }
+
+    #[test]
+    fn transient_execution_returns_affected_rows_for_commands() {
+        let connection = Connection::open_in_memory().unwrap();
+        execute_batch(
+            &connection,
+            "CREATE TABLE execution_test (id INTEGER PRIMARY KEY, value TEXT NOT NULL);",
+        )
+        .unwrap();
+
+        assert_eq!(
+            execute_statement_with_limits(
+                &connection,
+                "INSERT INTO execution_test (id, value) VALUES (1, 'one'), (2, 'two')",
+                &[],
+                ResultLimits::default(),
+            )
+            .unwrap(),
+            StatementExecution::AffectedRows(2)
+        );
+        assert_eq!(
+            execute_statement_with_limits(
+                &connection,
+                "UPDATE execution_test SET value = ?1 WHERE id = ?2",
+                &[Value::from("updated"), Value::from(2_i64)],
+                ResultLimits::default(),
+            )
+            .unwrap(),
+            StatementExecution::AffectedRows(1)
+        );
+        assert_eq!(
+            connection
+                .query_row("SELECT value FROM execution_test WHERE id = 2", [], |row| {
+                    row.get::<_, String>(0)
+                },)
+                .unwrap(),
+            "updated"
+        );
+    }
+
+    #[test]
+    fn transient_execution_classifies_arity_and_value_errors_without_mutation() {
+        let connection = Connection::open_in_memory().unwrap();
+        execute_batch(
+            &connection,
+            "CREATE TABLE binding_test (id INTEGER PRIMARY KEY, value INTEGER NOT NULL);",
+        )
+        .unwrap();
+
+        for params in [Vec::new(), vec![Value::from(1_i64), Value::from(2_i64)]] {
+            let error = execute_statement_with_limits(
+                &connection,
+                "INSERT INTO binding_test (id, value) VALUES (1, ?1)",
+                &params,
+                ResultLimits::default(),
+            )
+            .unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::InvalidArgument);
+        }
+
+        let too_large = u64::try_from(i64::MAX).unwrap() + 1;
+        let error = execute_statement_with_limits(
+            &connection,
+            "INSERT INTO binding_test (id, value) VALUES (1, ?1)",
+            &[Value::from(too_large)],
+            ResultLimits::default(),
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::NumericOutOfRange);
+
+        let error = execute_statement_with_limits(
+            &connection,
+            "INSERT INTO binding_test (id, value) VALUES (1, ?1)",
+            &[Value::from(f64::NAN)],
+            ResultLimits::default(),
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Unsupported);
+
+        assert_eq!(
+            connection
+                .query_row("SELECT COUNT(*) FROM binding_test", [], |row| {
+                    row.get::<_, i64>(0)
+                })
+                .unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn transient_execution_rejects_row_producing_writes_before_mutation() {
+        let connection = Connection::open_in_memory().unwrap();
+        execute_batch(
+            &connection,
+            "CREATE TABLE returning_test (id INTEGER PRIMARY KEY, value TEXT NOT NULL);
+             INSERT INTO returning_test (id, value) VALUES (1, 'original');",
+        )
+        .unwrap();
+
+        for statement in [
+            "INSERT INTO returning_test (id, value) VALUES (2, 'inserted') RETURNING id",
+            "UPDATE returning_test SET value = 'updated' WHERE id = 1 RETURNING id",
+            "DELETE FROM returning_test WHERE id = 1 RETURNING id",
+        ] {
+            let error =
+                execute_statement_with_limits(&connection, statement, &[], ResultLimits::default())
+                    .unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::InvalidQuery);
+            assert_eq!(
+                error.to_string(),
+                "row-producing write statements are not supported"
+            );
+        }
+
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT COUNT(*), MIN(value) FROM returning_test",
+                    [],
+                    |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+                )
+                .unwrap(),
+            (1, "original".to_owned())
+        );
+    }
+
+    #[test]
+    fn transient_execution_uses_the_existing_exact_result_limits() {
+        let connection = Connection::open_in_memory().unwrap();
+        // Metadata is 26 bytes. Each integer row is 25 bytes.
+        let exact = ResultLimits::new(2, 76).unwrap();
+        let result = execute_statement_with_limits(
+            &connection,
+            "SELECT 1 AS v UNION ALL SELECT 2",
+            &[],
+            exact,
+        )
+        .unwrap();
+        assert!(matches!(result, StatementExecution::Rows(result) if result.len() == 2));
+
+        for (limits, message) in [
+            (
+                ResultLimits::new(1, 76).unwrap(),
+                "query result exceeds the configured row limit",
+            ),
+            (
+                ResultLimits::new(2, 75).unwrap(),
+                "query result exceeds the configured logical byte limit",
+            ),
+        ] {
+            let error = execute_statement_with_limits(
+                &connection,
+                "SELECT 1 AS v UNION ALL SELECT 2",
+                &[],
+                limits,
+            )
+            .unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+            assert_eq!(error.to_string(), message);
+        }
+    }
+
+    #[test]
+    fn transient_prepare_and_execution_classify_invalid_sql() {
+        let connection = Connection::open_in_memory().unwrap();
+
+        for error in [
+            describe_statement(&connection, "SELECT FROM").unwrap_err(),
+            execute_statement_with_limits(
+                &connection,
+                "SELECT * FROM missing_table",
+                &[],
+                ResultLimits::default(),
+            )
+            .unwrap_err(),
+        ] {
+            assert_eq!(error.kind(), EngineErrorKind::InvalidQuery);
+        }
+    }
+
+    #[test]
     fn protocol_values_bind_to_the_expected_sqlite_storage_classes() {
         assert_eq!(value_to_sql(&Value::Null).unwrap(), SqlValue::Null);
         assert_eq!(
@@ -279,6 +707,48 @@ mod tests {
             value_to_sql(&Value::from(vec![0_u8, 255])).unwrap(),
             SqlValue::Blob(vec![0, 255])
         );
+    }
+
+    #[test]
+    fn parameter_validation_accepts_every_lossless_sqlite_binding() {
+        validate_parameters(&[
+            Value::Null,
+            Value::from(false),
+            Value::from(true),
+            Value::from(i64::MIN),
+            Value::from(i64::MAX),
+            Value::from(0_u64),
+            Value::from(u64::try_from(i64::MAX).unwrap()),
+            Value::from(f64::NEG_INFINITY),
+            Value::from(-0.0_f64),
+            Value::from(f64::INFINITY),
+            Value::from(String::new()),
+            Value::from("text"),
+            Value::from(Vec::<u8>::new()),
+            Value::from(vec![0_u8, 255]),
+        ])
+        .unwrap();
+    }
+
+    #[test]
+    fn parameter_validation_preserves_precise_rejection_kinds() {
+        let too_large = u64::try_from(i64::MAX).unwrap() + 1;
+        let cases = [
+            (Value::from(too_large), EngineErrorKind::NumericOutOfRange),
+            (
+                Value::decimal("12.3400").unwrap(),
+                EngineErrorKind::Unsupported,
+            ),
+            (
+                Value::InvalidText(vec![0x80]),
+                EngineErrorKind::InvalidTextEncoding,
+            ),
+            (Value::from(f64::NAN), EngineErrorKind::Unsupported),
+        ];
+
+        for (value, expected) in cases {
+            assert_eq!(validate_parameters(&[value]).unwrap_err().kind(), expected);
+        }
     }
 
     #[test]

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -44,6 +44,33 @@ fn insert_catalog_fixture(root: &Path) {
         .unwrap();
 }
 
+fn insert_prepared_catalog_fixture(root: &Path) {
+    let manifest = rusqlite::Connection::open(root.join("manifest.sqlite")).unwrap();
+    manifest
+        .execute_batch(
+            "PRAGMA foreign_keys = ON;
+             BEGIN IMMEDIATE;
+             DROP TABLE briskdb_integrity;
+             DROP TABLE briskdb_metadata;
+             CREATE TABLE briskdb_metadata (
+                 requires_manifest_version INTEGER NOT NULL
+                     CHECK (requires_manifest_version >= 6)
+             ) STRICT;
+             INSERT INTO briskdb_metadata VALUES (6);
+             INSERT INTO briskdb_tables (
+                table_id,
+                database_id,
+                table_name,
+                placement,
+                shard_key_column,
+                shard_key_type
+             ) VALUES (50, 1, 'prepared_events', 1, 'tenant_id', 1);
+             PRAGMA user_version = 6;
+             COMMIT;",
+        )
+        .unwrap();
+}
+
 fn assert_catalog_fixture(catalog: &core::Catalog) {
     assert_eq!(catalog.identifier_encoding_version(), 1);
     assert_eq!(catalog.schema_generation(), 0);
@@ -107,6 +134,7 @@ fn legacy_and_explicit_module_paths_are_both_available() {
     let _engine_status: Option<core::EngineStatus> = None;
     let _engine_options: core::EngineOptions = core::EngineOptions::default();
     let _result_limits: core::ResultLimits = core::ResultLimits::default();
+    let _prepared_limits: core::PreparedStatementLimits = core::PreparedStatementLimits::default();
     let _request_context: core::RequestContext = core::RequestContext::new();
     let _cancellation_token: core::CancellationToken = core::CancellationToken::new();
     let _running = core::EngineState::Running;
@@ -115,6 +143,11 @@ fn legacy_and_explicit_module_paths_are_both_available() {
     let _ready = core::SessionState::Ready;
     let _closed = core::SessionState::Closed;
     let _statement = core::Statement::new("SELECT ?1", vec![core::Value::from(42_i64)]);
+    let _prepared_statement_id: Option<core::PreparedStatementId> = None;
+    let _portal_id: Option<core::PortalId> = None;
+    let _describe_target: Option<core::DescribeTarget> = None;
+    let _description: Option<core::PreparedStatementDescription> = None;
+    let _prepared_execution: Option<core::PreparedExecution> = None;
     let _legacy_router: fn(Arc<storage::Database>) -> Router = api::router;
     let _http_router: fn(Arc<core::Database>) -> Router = http::router;
     let _engine_router: fn(core::Engine) -> Router = http::router_with_engine;
@@ -743,6 +776,15 @@ fn engine_options_are_public_validated_and_have_stable_defaults() {
         .unwrap()
     );
     assert_eq!(
+        defaults.prepared_statement_limits(),
+        core::PreparedStatementLimits::new(
+            core::DEFAULT_MAX_PREPARED_STATEMENTS_PER_SESSION,
+            core::DEFAULT_MAX_PORTALS_PER_SESSION,
+            core::DEFAULT_MAX_RETAINED_BOUND_VALUE_BYTES,
+        )
+        .unwrap()
+    );
+    assert_eq!(
         defaults.request_timeout(),
         Some(Duration::from_millis(core::DEFAULT_REQUEST_TIMEOUT_MS))
     );
@@ -783,14 +825,49 @@ fn engine_options_are_public_validated_and_have_stable_defaults() {
         );
     }
 
+    let maximum_prepared = core::PreparedStatementLimits::new(
+        core::MAX_PREPARED_STATEMENTS_PER_SESSION,
+        core::MAX_PORTALS_PER_SESSION,
+        core::MAX_RETAINED_BOUND_VALUE_BYTES,
+    )
+    .unwrap();
+    assert_eq!(
+        maximum_prepared.max_statements_per_session(),
+        core::MAX_PREPARED_STATEMENTS_PER_SESSION
+    );
+    assert_eq!(
+        maximum_prepared.max_portals_per_session(),
+        core::MAX_PORTALS_PER_SESSION
+    );
+    assert_eq!(
+        maximum_prepared.max_retained_bound_value_bytes(),
+        core::MAX_RETAINED_BOUND_VALUE_BYTES
+    );
+    for invalid in [
+        core::PreparedStatementLimits::new(0, 1, 1),
+        core::PreparedStatementLimits::new(core::MAX_PREPARED_STATEMENTS_PER_SESSION + 1, 1, 1),
+        core::PreparedStatementLimits::new(1, 0, 1),
+        core::PreparedStatementLimits::new(1, core::MAX_PORTALS_PER_SESSION + 1, 1),
+        core::PreparedStatementLimits::new(1, 1, 0),
+        core::PreparedStatementLimits::new(1, 1, core::MAX_RETAINED_BOUND_VALUE_BYTES + 1),
+    ] {
+        assert_eq!(
+            invalid.unwrap_err().kind(),
+            core::EngineErrorKind::InvalidArgument
+        );
+    }
+
     let limits = core::ResultLimits::new(37, 4_096).unwrap();
+    let prepared_limits = core::PreparedStatementLimits::new(17, 19, 8_192).unwrap();
     let configured = minimum
         .with_result_limits(limits)
+        .with_prepared_statement_limits(prepared_limits)
         .with_request_timeout(None)
         .unwrap()
         .with_shutdown_grace(Duration::from_millis(250))
         .unwrap();
     assert_eq!(configured.result_limits(), limits);
+    assert_eq!(configured.prepared_statement_limits(), prepared_limits);
     assert_eq!(configured.request_timeout(), None);
     assert_eq!(configured.shutdown_grace(), Duration::from_millis(250));
 }
@@ -799,9 +876,11 @@ fn engine_options_are_public_validated_and_have_stable_defaults() {
 async fn protocol_neutral_async_engine_surface_is_available() {
     let temp = tempfile::tempdir().unwrap();
     let limits = core::ResultLimits::new(50, 8_192).unwrap();
+    let prepared_limits = core::PreparedStatementLimits::new(13, 17, 32_768).unwrap();
     let options = core::EngineOptions::new(2, 7)
         .unwrap()
         .with_result_limits(limits)
+        .with_prepared_statement_limits(prepared_limits)
         .with_request_timeout(Some(Duration::from_secs(5)))
         .unwrap()
         .with_shutdown_grace(Duration::from_millis(100))
@@ -820,6 +899,7 @@ async fn protocol_neutral_async_engine_surface_is_available() {
     assert_eq!(status.queue_capacity_per_shard(), 7);
     assert_eq!(status.max_result_rows(), 50);
     assert_eq!(status.max_result_bytes(), 8_192);
+    assert_eq!(status.prepared_statement_limits(), prepared_limits);
     assert_eq!(status.request_timeout(), Some(Duration::from_secs(5)));
     assert_eq!(status.shutdown_grace(), Duration::from_millis(100));
 
@@ -842,6 +922,137 @@ async fn protocol_neutral_async_engine_surface_is_available() {
     let report = engine.shutdown().await.unwrap();
     assert!(!report.forced());
     assert_eq!(engine.state(), core::EngineState::Stopped);
+}
+
+#[tokio::test]
+async fn prepared_lifecycle_is_public_owned_and_protocol_neutral() {
+    fn assert_owned<T: Send + Sync + 'static>() {}
+    assert_owned::<core::PrepareRequest>();
+    assert_owned::<core::PreparedStatementId>();
+    assert_owned::<core::PortalId>();
+    assert_owned::<core::DescribeTarget>();
+    assert_owned::<core::PreparedStatementDescription>();
+    assert_owned::<core::PreparedExecution>();
+
+    let temp = tempfile::tempdir().unwrap();
+    drop(core::Database::open(temp.path(), 4).unwrap());
+    insert_prepared_catalog_fixture(temp.path());
+    let database = Arc::new(core::Database::open(temp.path(), 4).unwrap());
+    database
+        .broadcast(
+            "CREATE TABLE prepared_events (
+                tenant_id INTEGER PRIMARY KEY,
+                payload TEXT NOT NULL
+             )",
+        )
+        .unwrap();
+    let logical_database = database.catalog().default_database().id();
+    let engine = core::Engine::from_database(database);
+    let session = engine.session();
+
+    let private_request = core::PrepareRequest::new(
+        logical_database,
+        sql::SqlDialect::MySql,
+        sql::SqlTranslationMode::Compatibility,
+        "INSERT INTO prepared_events (tenant_id, payload) VALUES (?, 'private-literal')",
+    );
+    assert_eq!(private_request.database(), logical_database);
+    assert_eq!(private_request.dialect(), sql::SqlDialect::MySql);
+    assert_eq!(
+        private_request.translation_mode(),
+        sql::SqlTranslationMode::Compatibility
+    );
+    assert!(private_request.sql().contains("private-literal"));
+    assert!(!format!("{private_request:?}").contains("private-literal"));
+
+    let insert = engine
+        .prepare_statement(&session, private_request)
+        .await
+        .unwrap();
+    let insert_description = engine
+        .describe_prepared(&session, core::DescribeTarget::Statement(insert))
+        .await
+        .unwrap();
+    assert_eq!(
+        insert_description.parameter_types(),
+        [core::DataType::Unknown]
+    );
+    assert!(insert_description.columns().is_empty());
+    let insert_portal = engine
+        .bind_statement(&session, insert, vec![core::Value::from(42_i64)])
+        .await
+        .unwrap();
+    let inserted = engine
+        .execute_portal(&session, insert_portal)
+        .await
+        .unwrap();
+    assert_eq!(inserted.value, core::PreparedExecution::AffectedRows(1));
+
+    let select = engine
+        .prepare_statement(
+            &session,
+            core::PrepareRequest::new(
+                logical_database,
+                sql::SqlDialect::PostgreSql,
+                sql::SqlTranslationMode::Compatibility,
+                "SELECT tenant_id, payload FROM prepared_events WHERE tenant_id = $1",
+            ),
+        )
+        .await
+        .unwrap();
+    let select_portal = engine
+        .bind_statement(&session, select, vec![core::Value::from(42_i64)])
+        .await
+        .unwrap();
+    let description = engine
+        .describe_prepared(&session, core::DescribeTarget::Portal(select_portal))
+        .await
+        .unwrap();
+    assert_eq!(description.parameter_types(), [core::DataType::Unknown]);
+    assert_eq!(
+        description.columns(),
+        [
+            core::Column::new("tenant_id", core::DataType::Unknown),
+            core::Column::new("payload", core::DataType::Unknown),
+        ]
+    );
+    assert!(description.returns_rows());
+    let selected = engine
+        .execute_portal(&session, select_portal)
+        .await
+        .unwrap();
+    let core::PreparedExecution::Rows(rows) = selected.value else {
+        panic!("the public prepared SELECT should return rows");
+    };
+    assert_eq!(
+        rows.rows()[0].values(),
+        [
+            core::Value::from(42_i64),
+            core::Value::from("private-literal")
+        ]
+    );
+
+    assert!(engine.close_portal(&session, select_portal).await.unwrap());
+    assert!(
+        engine
+            .close_prepared_statement(&session, select)
+            .await
+            .unwrap()
+    );
+    assert!(
+        engine
+            .close_prepared_statement(&session, insert)
+            .await
+            .unwrap()
+    );
+    assert_eq!(
+        engine
+            .execute_portal(&session, insert_portal)
+            .await
+            .unwrap_err()
+            .kind(),
+        core::EngineErrorKind::FailedPrecondition
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add protocol-neutral prepare, bind, describe, execute, and close APIs
- add bounded per-session statement and portal state with exact value accounting
- replan portals for every execution and refresh descriptions across schema generations
- expose validated engine, CLI, environment, and status limits
- document dialect, execution, compatibility, and storage-format behavior

## Verification
- cargo fmt --all --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-targets --all-features
- cargo test --locked --doc --all-features
- cargo +1.85.0 test --locked --all-targets --all-features
- cargo +1.85.0 test --locked --doc --all-features

Closes #26