### PR TITLE
Classify SQL statement behavior and batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ The [SQL parser decision record](docs/SQL_PARSER.md) defines the shared,
 dialect-explicit syntax boundary and its resource and dependency limits.
 The [common SQL subset contract](docs/SQL_SUBSET.md) defines the opt-in,
 protocol-neutral structural validator and its exact accepted statement forms.
+The [statement-classification contract](docs/SQL_STATEMENT_CLASSIFICATION.md)
+defines the shared read/write/schema/session taxonomy, conservative batch gate,
+and behavior metadata consumed by planning and prepared execution.
 The [SQL parameter-normalization contract](docs/SQL_PARAMETERS.md) defines the
 opt-in dialect-specific rewrite to canonical SQLite positional parameters and
 its per-statement binding metadata.
@@ -60,13 +63,14 @@ minimum supported Rust version (MSRV) and the latest stable toolchain.
 - Protocol-neutral typed values, ordered columns, positional rows, and results
 - A bounded per-session prepared-statement and immutable bound-portal lifecycle
   with transient shard-0 metadata compilation, bind-time routing snapshots,
-  fresh execute-time planning, and supported physical-target execution
+  retained logical behavior, fresh execute-time planning, and supported
+  physical-target execution
 - A bounded SQL AST parser plus recursive common-subset validator for explicit
   SQLite, PostgreSQL, and MySQL dialects, followed by opt-in source-preserving
-  placeholder normalization, per-statement binding metadata, and catalog-aware
-  typed shard-key inference plus synchronous bound-value-aware routing plans
-  with single-shard write policy, all isolated from the current raw SQLite HTTP
-  execution path
+  statement/batch classification, placeholder normalization, per-statement
+  binding metadata, and catalog-aware typed shard-key inference plus
+  synchronous bound-value-aware routing plans with single-shard write policy,
+  all isolated from the current raw SQLite HTTP execution path
 - A transactionally versioned `manifest.sqlite` with durable 4,096-bucket
   routing plus logical-database and table metadata
 - Identity-bound, WAL-enabled SQLite shard files that are never silently
@@ -202,7 +206,11 @@ connections rather than reserving every shard pool.
 
 Rust callers may explicitly parse SQL and consume the result with
 `validate_common_subset(ParsedSql)`, receiving an owned opaque `CommonSql` on
-success. They may then opt into `normalize_placeholders(CommonSql)`, receiving
+success. Before consuming it, callers may borrow it with
+`classify_statements(&CommonSql)`, receiving an ordered, source-redacted
+read/write/schema/session classification. Empty input is `InvalidArgument`;
+multi-statement input is accepted only when every statement is a read. They may
+then opt into `normalize_placeholders(CommonSql)`, receiving
 canonical SQLite `?N` text and per-statement occurrence-to-index metadata
 without supplying parameter values. Callers can consume that result with
 `translate_sql(NormalizedSql, SqlTranslationMode)`: explicit compatibility mode
@@ -221,27 +229,30 @@ parameters, explicit_routing_key)` to retain the inference and produce one
 owned canonical route per inferred value plus an independent explicit route.
 That call compares finite inferred and explicit routes by physical shard,
 rejects cross-shard or otherwise unroutable cataloged sharded DML, prevents
-shard-key updates, and exposes the accepted `assigned_shard()`. The synchronous
-plan API records schema and routing provenance but does not classify complete
-request behavior or execute anything.
+shard-key updates, applies the complete batch gate, and exposes both the
+selected `behavior()` and accepted `assigned_shard()`. The synchronous plan API
+records schema and routing provenance but does not execute anything. Direct
+shard-key inference remains statement-local and does not grant batch permission.
 
 Rust callers can instead create a `PrepareRequest` with an explicit logical
 database, dialect, translation mode, and SQL string. `Engine::prepare_statement`
 runs the complete frontend pipeline, requires exactly one top-level statement,
-transiently compiles metadata on shard 0, and caches only BriskDB-owned SQL and
-metadata in the session. `bind_statement` snapshots typed values and the
-session's current route into an immutable portal after transiently validating a
-plan from those concrete values. `describe_prepared` returns owned `Unknown`
-parameter/result types and refreshes column metadata after a schema-generation
-change.
+classifies it, transiently compiles metadata on shard 0, and caches only
+BriskDB-owned SQL, behavior, and metadata in the session. Persistent schema SQL
+is denied during that compile and publishes no handle. `bind_statement`
+snapshots typed values and the session's current route into an immutable portal
+after transiently validating a plan from those concrete values.
+`describe_prepared` returns owned `Unknown` parameter/result types and refreshes
+column metadata after a schema-generation change.
 `execute_portal` always plans again from the retained values and route snapshot
-under the current schema guard. It runs accepted sharded work on its assigned
-shard and safe column-producing `NotApplicable`/`Global` reads on deterministic
-shard 0, returning routed rows or an affected-row count. There is no implicit
-cache eviction, no retained plan, `rusqlite` statement, or connection, and
-closing a statement closes all of its portals. Complete statement behavior and
-batch classification remain issue #27; sharded reads requiring scatter do not
-execute through this lifecycle.
+under the current schema guard. Logical behavior, rather than SQLite result
+columns, decides whether the target is a read, write, schema change, or session
+control. It runs accepted sharded work on its assigned shard and safe
+`NotApplicable`/`Global` reads on deterministic shard 0, returning routed rows
+or an affected-row count. Schema/session execution and sharded reads requiring
+scatter remain unsupported. There is no implicit cache eviction, no retained
+plan, `rusqlite` statement, or connection, and closing a statement closes all
+of its portals.
 
 Translation and planning remain independently callable branches over the same
 normalized request. The HTTP execute, query, and migration endpoints invoke
@@ -353,9 +364,9 @@ Independent `Database` and `Engine` handles in one process that resolve to the
 same canonical data directory share schema coordination. Separate BriskDB
 server processes must not use the same data directory.
 
-Near-term work includes authoritative statement and batch classification,
-authentication, richer migration administration and status APIs in issue #53,
-scatter/gather reads, observability, and backup tooling.
+Near-term work includes authentication, richer migration administration and
+status APIs in issue #53, scatter/gather reads, observability, and backup
+tooling.
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -215,7 +215,7 @@ interrupted schema migration can be diagnosed and resumed.
   preserve a strict mode that exposes SQLite SQL directly.
 - [x] Implement protocol-neutral prepare/bind/describe/execute lifecycle and a
   bounded per-session prepared-statement cache.
-- [ ] Classify statements by read/write/schema/session behavior and block unsafe
+- [x] Classify statements by read/write/schema/session behavior and block unsafe
   multi-statement combinations.
 
 Exit criterion: the same typed request produces the same plan and result through

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,7 +23,7 @@ server ---------> protocol::http
 | --- | --- | --- |
 | `core` | Protocol-neutral `Engine`, `Session`, statements, immutable bound portals, values, results, errors, read-only logical catalog, synchronous bound-value-aware plans, prepared lifecycle, and sharded routing policy; stable key routing; bounded per-session and per-shard admission; routed execution and journaled schema migration | JSON/HTTP types, listeners, or Axum handlers |
 | `storage` | Versioned routing/logical manifest, shard layout, migration journal and recovery, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
-| `sql` | Dialect-explicit SQL syntax parsing, recursive common-subset validation, source-preserving placeholder normalization, explicit strict/compatibility translation, catalog-aware typed shard-key inference, and narrow crate-private DML-shape inspection behind BriskDB-owned boundaries; exact source retention; SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, key hashing or shard selection, session/write policy, filesystem layout, protocol responses, protocol-buffer ownership, or protocol-specific support policy |
+| `sql` | Dialect-explicit SQL syntax parsing, recursive common-subset validation, protocol-neutral statement/batch classification, source-preserving placeholder normalization, explicit strict/compatibility translation, catalog-aware typed shard-key inference, and narrow crate-private DML-shape inspection behind BriskDB-owned boundaries; exact source retention; SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, key hashing or shard selection, mutable session state, physical write-routing policy, filesystem layout, protocol responses, protocol-buffer ownership, or protocol-specific support policy |
 | `protocol::http` | HTTP request extraction plus JSON/BriskDB value and RFC 9457 problem-detail encoding | BLAKE3 routing, shard files, or rusqlite calls |
 | `protocol::error` | Exhaustive HTTP, PostgreSQL, and MySQL mappings from stable engine error kinds | SQLite errors, routing decisions, or wire-protocol session state |
 | `server` | Process configuration, database assembly, listener binding, and tracked Axum HTTP/1 connection lifecycle | SQL parsing or storage implementation details |
@@ -92,11 +92,11 @@ deterministic and keeps the dependency replaceable.
 
 Parsing is syntax recognition, not support validation or planning. The parser
 has no session, parameter, catalog, storage, or routing access. The separate
-common-subset validator, placeholder normalizer, shard-key inference layer, and
-later planner layers consume structural syntax through BriskDB-owned
-interfaces; shard-key inference does not inspect raw or formatted SQL with
-regular expressions. Exact input remains authoritative because AST formatting
-is lossy and is never executed.
+common-subset validator, statement classifier, placeholder normalizer,
+shard-key inference layer, and later planner layers consume structural syntax
+through BriskDB-owned interfaces; shard-key inference does not inspect raw or
+formatted SQL with regular expressions. Exact input remains authoritative
+because AST formatting is lossy and is never executed.
 
 Inputs are bounded to 65,536 UTF-8 bytes, 256 statements, and recursion depth
 32. The dependency's recursive-protection feature remains enabled. Parse and
@@ -116,18 +116,43 @@ failures retain their existing kinds.
 Validation is structural and stateless. It does not normalize placeholders,
 translate type names or syntax, inspect parameters or the catalog, infer a
 shard, build a plan, classify statement behavior, authorize an endpoint, or
-execute SQL. Empty and mixed batches can validate because issue #27 owns
-request-level batch policy. Recursive expression validation has an independent
-depth limit of 128 so iteratively parsed flat operator chains remain bounded.
+execute SQL. Empty and mixed batches can validate because the separate
+classifier owns request-level batch policy. Recursive expression validation has
+an independent depth limit of 128 so iteratively parsed flat operator chains remain bounded.
 The normative accepted forms and exclusions are in the [common SQL subset
 contract](SQL_SUBSET.md).
 
 The current HTTP execute/query and migration paths deliberately remain raw
-SQLite pass-through and call none of the parser, subset validator, placeholder
-normalizer, translator, shard-key inference, bound statement-planning, or
-prepared-lifecycle layers. Issues #19 through #26 therefore change no HTTP
-shape, SQL acceptance, execution routing, or storage behavior. Rust callers can
-now invoke those layers together through the separate prepared API.
+SQLite pass-through and call none of the parser, subset validator, statement
+classifier, placeholder normalizer, translator, shard-key inference, bound
+statement-planning, or prepared-lifecycle layers. Issues #19 through #27
+therefore change no HTTP shape, SQL acceptance, execution routing, or storage
+behavior. Rust callers can now invoke those layers together through the
+separate prepared API.
+
+### Statement-classification boundary
+
+`classify_statements(&CommonSql)` borrows the validated opaque AST and returns
+an owned ordered `StatementBatchClassification`. Each top-level statement is
+classified as `Read`, a precise `Write` (`Insert`, `Update`, or `Delete`), a
+precise `Schema` change (`CreateTable` or `CreateIndex`), or a precise `Session`
+control (`Begin`, `Commit`, or `Rollback`). The result exposes ordered behavior,
+count, indexed lookup, and whether the accepted batch is wholly read-only,
+without exposing or rendering SQL or the dependency-owned AST.
+
+Empty input is `InvalidArgument`. A singleton of any behavior is classified,
+but a batch of two or more statements is accepted only when every member is a
+read; the first non-read member makes the whole batch `Unsupported`. This is
+logical request policy, not execution permission. The classifier has no
+catalog, parameters, routing, session, storage, or SQLite access and opens no
+connection.
+
+The general planner applies this complete batch gate before planning a selected
+member and retains that member's behavior. Direct shard-key inference remains
+statement-local. Prepared statements keep their stricter exact-one rule, then
+retain the singleton behavior for descriptions and execution target policy.
+The normative taxonomy, matrix, errors, integration, and tests are in [SQL
+statement and batch classification](SQL_STATEMENT_CLASSIFICATION.md).
 
 ### Placeholder-normalization boundary
 
@@ -152,7 +177,7 @@ expressions or AST formatting. Every non-marker byte remains exact, including
 comments, literals, whitespace, and UTF-8 text. SQLite named parameters are
 deliberately unsupported. The layer has no session, catalog, storage, routing,
 filesystem, or execution access and does not decide whether a statement batch
-may execute; issue #27 owns that policy. The normative API, dialect rules,
+may execute; the classifier owns that policy. The normative API, dialect rules,
 limits, errors, and tests are in the [SQL parameter-normalization
 contract](SQL_PARAMETERS.md).
 
@@ -207,14 +232,16 @@ contract](SQL_SHARD_KEYS.md).
 
 ### Bound statement-planning boundary
 
-Synchronous `Engine::plan_bound_statement` accepts one `NormalizedSql`
-statement, its complete bound `Value` slice, the selected logical database, and
-an optional explicit routing byte sequence. It invokes inference only after
-the bound values exist, encodes every inferred value, and looks each occurrence
-up through the validated routing catalog. The returned `BoundStatementPlan`
-owns the inference and one `PlannedRoute` per inferred value in matching order,
-including duplicate multi-row values and distinct keys that happen to select
-the same physical shard.
+Synchronous `Engine::plan_bound_statement` accepts a `NormalizedSql` batch, one
+selected statement's complete bound `Value` slice, the selected logical
+database, and an optional explicit routing byte sequence. It first applies the
+complete statement/batch classifier, then invokes statement-local inference
+only after the bound values exist, encodes every inferred value, and looks each
+occurrence up through the validated routing catalog. The returned
+`BoundStatementPlan` owns the selected `StatementBehavior`, inference, and one
+`PlannedRoute` per inferred value in matching order, including duplicate
+multi-row values and distinct keys that happen to select the same physical
+shard.
 
 Canonical version-1 inferred bytes are the shortest signed decimal ASCII form
 for `Int64`, exact UTF-8 for `Text`, and exact bytes for `Binary`. Explicit
@@ -224,12 +251,11 @@ never by opaque bytes, and records `assigned_shard()` when one valid target
 exists. Distinct logical keys co-located on one shard remain separate route
 occurrences but form one physical assignment.
 
-The SQL layer exposes only a crate-private inspection of whether the selected
-AST is `INSERT`, `UPDATE`, or `DELETE` and whether an `UPDATE` targets the
-cataloged shard-key column. Core uses that shape to reject unproven inserts,
-multi-shard writes, broad updates/deletes without explicit fallback, and every
-shard-key assignment. Full read/write/schema/session behavior and batch
-classification remain issue #27.
+The public classifier supplies the precise selected read/write/schema/session
+behavior. SQL also exposes a narrow crate-private DML shape, including whether
+an `UPDATE` targets the cataloged shard-key column. Core uses those shapes to
+reject unproven inserts, multi-shard writes, broad updates/deletes without
+explicit fallback, and every shard-key assignment.
 
 Planning holds the existing schema-operation guard while it reads logical and
 routing state. The owned result records schema generation, map generation, and
@@ -240,21 +266,23 @@ owned bind snapshot under its current schema-operation guard.
 
 The public planner remains stateless and its assignment alone is not execution
 permission. It does not invoke translation, mutate a session, cache a prepared
-statement, apply batch policy, open a shard connection, scatter reads, or
-execute anything. The normative API, assignment matrix, encoding, provenance,
-error, boundary, and testing rules are in the
+statement, open a shard connection, scatter reads, or execute anything. It does
+apply the shared batch gate so a mutating multi-statement request cannot reach
+later planning through this boundary. The normative API, assignment matrix,
+encoding, provenance, error, boundary, and testing rules are in the
 [bound statement-planning and routing-policy
 contract](SQL_PLANNING.md). Translation is the separate implemented issue #25
-branch over the same `NormalizedSql`; issue #26's prepared lifecycle consumes
-both layers, while issue #27 still owns authoritative statement/batch policy.
+branch over the same `NormalizedSql`; the prepared lifecycle consumes the
+classifier, translation, and planning layers.
 
 ### Prepared-statement and portal boundary
 
 `Engine::prepare_statement` accepts an owned `PrepareRequest` with one logical
 database, source dialect, explicit translation mode, and SQL string. It runs
-parse, exact-one top-level validation, subset validation, placeholder
-normalization, and translation, then transiently compiles metadata on shard 0.
-The session cache retains only BriskDB-owned `TranslatedSql` plus owned
+parse, exact-one top-level validation, subset validation, statement
+classification, placeholder normalization, and translation, then transiently
+compiles metadata on shard 0. The session cache retains only BriskDB-owned
+`TranslatedSql`, the precise singleton `StatementBehavior`, and owned
 parameter/column metadata. No `rusqlite::Statement`, rows iterator, SQLite
 connection, pool handle, or protocol buffer crosses the operation boundary.
 
@@ -265,10 +293,13 @@ only that snapshot and the values in an immutable logical portal. Later
 session-route changes do not affect it. Describing after a schema-generation
 change recompiles owned metadata on shard 0. Every execution plans again from
 the portal snapshot under the current schema/routing guard before choosing the
-supported physical target. Safe
-column-producing `NotApplicable` and `Global` reads may use deterministic shard
-0; a sharded read that still needs scatter remains unsupported. Catalog
-placement is never exposed as an application read target.
+supported physical target. Logical behavior, not SQLite result-column metadata,
+distinguishes reads from writes, schema changes, and session control. Safe
+`NotApplicable` and `Global` reads may use deterministic shard 0; a sharded
+read that still needs scatter remains unsupported. Schema/session execution is
+not implemented, and Catalog placement is never exposed as an application
+target. `PreparedStatementDescription::behavior()` gives adapters the same
+retained behavior.
 
 Per-session limits independently bound statement count, portal count, and the
 logical accounted value bytes plus routing bytes retained by all portals. Full
@@ -283,12 +314,12 @@ expansion by charging its captured route once and each normalized marker
 occurrence twice; repeated markers cannot cause unbounded inference/route
 allocation before the check.
 
-The prepared lifecycle integrates the previously independent SQL and planning
-layers but deliberately does not publish the complete statement classifier,
-execute a multi-statement batch, scatter reads, or implement transactions.
-Those remain issue #27 and the later planner/transaction milestones. The
-complete API, accounting, execution, error, adapter, and persistence contract
-is in [prepared statements and bound portals](SQL_PREPARED_STATEMENTS.md).
+The prepared lifecycle integrates the classifier, translation, and planning
+layers but deliberately does not execute a multi-statement batch, scatter
+reads, execute schema/session statements, or implement transactions. Those
+remain later planner/transaction milestones. The complete API, accounting,
+execution, error, adapter, and persistence contract is in [prepared statements
+and bound portals](SQL_PREPARED_STATEMENTS.md).
 
 ## Manifest storage boundary
 

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -143,8 +143,18 @@ internal diagnostic contains the one-based statement position and a fixed
 feature category, never the submitted SQL, a literal, formatted AST output, or
 a parser diagnostic. Its independent recursive expression-depth limit is 128;
 exceeding that limit is `LimitExceeded`. Empty and mixed batches can pass
-structural validation; later request-level classification decides whether they
-may execute. See the [common SQL subset contract](SQL_SUBSET.md).
+structural validation; the separate request-level classifier decides whether
+they pass batch policy. See the [common SQL subset
+contract](SQL_SUBSET.md).
+
+The statement/batch classifier reports an empty or comment-only validated
+batch as `InvalidArgument`. A batch of two or more statements containing any
+non-read behavior is `Unsupported`; its diagnostic identifies only the first
+such one-based statement ordinal and a fixed coarse behavior category. A
+validated AST family without a classifier mapping is an `Internal` invariant
+failure. Submitted SQL, identifiers, literals, nested behavior details, and AST
+output are never included. See the [statement and batch classification
+contract](SQL_STATEMENT_CLASSIFICATION.md).
 
 The opt-in placeholder normalizer classifies a zero positional index or marker
 spelling incompatible with the selected PostgreSQL or MySQL dialect as
@@ -180,8 +190,10 @@ locations. See the [shard-key inference contract](SQL_SHARD_KEYS.md).
 The synchronous bound statement planner preserves those inference error kinds
 and diagnostics. Before inference it also acquires ordinary schema-operation
 admission, so a migrating gate returns `Busy`, a pending migration returns
-`FailedPrecondition`, and a degraded gate returns `DataCorruption`. Routing
-policy reports an explicit physical-shard conflict, or a sharded
+`FailedPrecondition`, and a degraded gate returns `DataCorruption`. It then
+applies complete batch policy: empty is `InvalidArgument`, a mutating
+multi-statement batch is `Unsupported`, and an out-of-range selected index in
+an accepted batch is `InvalidArgument`. Routing policy reports an explicit physical-shard conflict, or a sharded
 `UPDATE`/`DELETE` missing both finite inference and explicit fallback, as
 `InvalidArgument`. A shard-key `UPDATE`, an `INSERT` without a proven key for
 every row, or a finite write spanning physical shards is `InvalidQuery`.
@@ -194,8 +206,9 @@ contract](SQL_PLANNING.md).
 The prepared lifecycle preserves each earlier frontend/planner kind. Prepare
 adds `InvalidArgument` for an unknown logical database and for anything other
 than exactly one top-level statement, `LimitExceeded` for a full session
-statement cache, and `InvalidQuery` when SQLite cannot transiently compile the
-translated SQL on shard 0. Bind preserves parameter-count, value-conversion,
+statement cache, `PermissionDenied` when ordinary shard policy denies a
+persistent schema statement, and `InvalidQuery` when SQLite otherwise cannot
+transiently compile the translated SQL on shard 0. Bind preserves parameter-count, value-conversion,
 inference, and planning errors, and adds `LimitExceeded` for a full portal cache
 or retained-value byte budget, or when the captured route and repeated
 normalized occurrences exceed the conservative per-bind planning ceiling
@@ -208,11 +221,12 @@ session/engine, a closed session, or an absent statement/portal is
 `FailedPrecondition`; closing an already absent same-session handle instead
 returns `false`. Portal execution reports `PermissionDenied` for catalog
 placement and `Unsupported` for a sharded read that still needs scatter or
-another unimplemented target. Safe column-producing `NotApplicable` and
-`Global` reads use deterministic shard 0; accepted sharded work uses its
-current assigned shard. Cancellation, deadlines, pool admission, schema-gate
-state, SQLite execution, constraints, and result limits retain their existing
-kinds.
+another unimplemented target, including session behavior. Classified safe
+`NotApplicable` and `Global` reads use deterministic shard 0; accepted sharded
+work uses its current assigned shard. A disagreement between retained behavior
+and SQLite execution metadata is `Internal`. Cancellation, deadlines, pool
+admission, schema-gate state, SQLite execution, constraints, and result limits
+retain their existing kinds.
 
 A failed prepare or bind publishes no handle, full caches evict nothing, and an
 execution failure retains its portal. Protocol adapters still serialize only

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -16,12 +16,14 @@ document defines the SQL and behavioral contract separately from connectivity.
 - **Unsupported** means BriskDB rejects the behavior or makes no compatibility
   promise for it.
 
-The syntax parser, recursive common-subset validator, placeholder normalizer,
-finite SQL translator, catalog-aware shard-key inference API, and synchronous
-engine bound-statement planner are now available behind BriskDB-owned types.
+The syntax parser, recursive common-subset validator, statement/batch
+classifier, placeholder normalizer, finite SQL translator, catalog-aware
+shard-key inference API, and synchronous engine bound-statement planner are now
+available behind BriskDB-owned types.
 Validation is explicit and returns `Unsupported` for a parsed form outside the
 subset; parser acceptance alone is not product support. Translation,
-normalization, inference, bound planning, and routing policy are also explicit.
+classification, normalization, inference, bound planning, and routing policy
+are also explicit.
 The current experimental HTTP interface is still a raw SQLite pass-through and
 can execute uncontracted SQLite syntax because it calls none of these layers.
 That behavior is not a compatibility promise.
@@ -46,7 +48,8 @@ than claiming to be a drop-in PostgreSQL or MySQL replacement.
 Only the experimental HTTP network interface is implemented today. There is no
 PostgreSQL or MySQL listener. The public Rust SQL facade can parse an explicitly
 selected SQLite, PostgreSQL, or MySQL dialect, consume that result with
-`validate_common_subset(ParsedSql)`, and then opt into
+`validate_common_subset(ParsedSql)`, borrow the result with
+`classify_statements(&CommonSql)`, and then opt into
 `normalize_placeholders(CommonSql)`. That step yields source-preserving SQLite
 `?N` text and per-statement parameter metadata. A caller can consume the owned
 normalized result with `translate_sql`, explicitly selecting either finite
@@ -62,26 +65,27 @@ explicit routing byte sequence, retains the inference, and produces owned
 physical routes with schema and routing provenance. It compares finite inferred
 and explicit routes by physical shard, rejects unroutable cataloged sharded
 DML, and records a valid single-shard assignment. The planner does not invoke
-translation, authorize, enforce batch policy, or execute a statement. The
+translation, authorize, or execute a statement; it does enforce the common
+batch gate and exposes the selected statement behavior. The
 protocol-neutral prepared lifecycle composes these SQL stages for exactly one
-statement, binds typed values into a session-scoped portal, refreshes stale
-description metadata, plans freshly at every execution, and executes supported
-physical targets. HTTP requests still send caller-provided SQLite SQL directly
-to the raw engine path; they do not
-pass through these opt-in SQL layers.
+statement, exposes retained behavior in description metadata, binds typed
+values into a session-scoped portal, refreshes stale description metadata,
+plans freshly at every execution, and executes supported physical targets.
+HTTP requests still send caller-provided SQLite SQL directly to the raw engine
+path; they do not pass through these opt-in SQL layers.
 
 | Interface | Status | SQL accepted | Routing |
 | --- | --- | --- | --- |
 | HTTP `/v1/execute` | Experimental | One SQLite statement with positional parameters | Required caller-provided `shard_key` |
 | HTTP `/v1/query` | Experimental | One raw SQLite statement prepared transiently by the row-returning path; no session cache | Required caller-provided `shard_key` |
 | HTTP `/v1/admin/broadcast` | Experimental | A journaled parameterless SQLite schema batch | Preflight on every shard, then ascending resumable apply |
-| PostgreSQL wire protocol | Planned | Rust parsing, validation, placeholder normalization, finite compatibility translation, and prepared lifecycle implemented; listener adoption planned | Core bind validation, routing snapshots, current execute-time planning, and supported target execution implemented; wire mapping planned |
-| MySQL wire protocol | Planned | Rust parsing, validation, placeholder normalization, finite compatibility translation, and prepared lifecycle implemented; listener adoption planned | Core bind validation, routing snapshots, current execute-time planning, and supported target execution implemented; wire mapping planned |
+| PostgreSQL wire protocol | Planned | Rust parsing, validation, classification, placeholder normalization, finite compatibility translation, and prepared lifecycle implemented; listener adoption planned | Core batch/write policy, bind validation, routing snapshots, current execute-time planning, and supported target execution implemented; wire mapping planned |
+| MySQL wire protocol | Planned | Rust parsing, validation, classification, placeholder normalization, finite compatibility translation, and prepared lifecycle implemented; listener adoption planned | Core batch/write policy, bind validation, routing snapshots, current execute-time planning, and supported target execution implemented; wire mapping planned |
 
-The parser, subset validator, placeholder normalizer, SQL translator, shard-key
-inference function, engine planner, and prepared lifecycle are implemented Rust
-APIs, not PostgreSQL or MySQL network interfaces. They do not change any
-current HTTP row in this table.
+The parser, subset validator, statement classifier, placeholder normalizer, SQL
+translator, shard-key inference function, engine planner, and prepared
+lifecycle are implemented Rust APIs, not PostgreSQL or MySQL network
+interfaces. They do not change any current HTTP row in this table.
 
 Every HTTP operation now calls the same protocol-neutral async engine intended
 for future PostgreSQL and MySQL adapters. Execute and query requests create a
@@ -291,14 +295,16 @@ make a statement part of BriskDB's supported common subset or establish that
 its behavior matches SQLite. Inputs are bounded to 65,536 UTF-8 bytes, 256
 statements, and recursion depth 32. The parser can represent an ordered batch,
 but the current execution surfaces retain their existing endpoint-specific
-single-statement and migration rules; later classification will decide which
-multi-statement combinations are safe.
+single-statement and migration rules. The implemented classifier supplies the
+shared common-SQL batch rule described below.
 
 `validate_common_subset(ParsedSql)` is the separate support-validation step. It
 consumes the opaque parsed result and returns an owned opaque `CommonSql` only
 when every top-level statement and nested form is in the first subset. Empty
-and mixed batches may validate because request-level batch policy remains issue
-#27. `normalize_placeholders(CommonSql)` then returns an owned `NormalizedSql`
+and mixed batches may validate because classification is a separate step.
+`classify_statements(&CommonSql)` borrows that marker and returns ordered
+behavior only when the complete batch passes policy.
+`normalize_placeholders(CommonSql)` then returns an owned `NormalizedSql`
 with canonical SQLite parameter text and one parameter record per statement.
 `translate_sql` can consume it and return an owned `TranslatedSql` containing a
 separate SQLite representation while retaining the complete normalized result.
@@ -321,8 +327,11 @@ the [SQL translation contract](SQL_TRANSLATION.md) for modes and the finite
 type and syntax matrix. The [shard-key inference contract](SQL_SHARD_KEYS.md)
 defines the supported proof grammar and typed result. The [bound
 statement-planning and routing-policy contract](SQL_PLANNING.md) defines
-canonical route bytes, occurrence ordering, physical-target comparison, write
-rejection, provenance, and the non-executable planning boundary.
+canonical route bytes, occurrence ordering, complete batch admission,
+physical-target comparison, write rejection, selected behavior, provenance,
+and the non-executable planning boundary. The [statement and batch
+classification contract](SQL_STATEMENT_CLASSIFICATION.md) defines the precise
+taxonomy and request matrix.
 The [prepared statements and bound portals
 contract](SQL_PREPARED_STATEMENTS.md) defines the composed exact-one-statement
 lifecycle, session limits, metadata, routing snapshots, current execution
@@ -399,9 +408,9 @@ typed key extraction is the implemented issue #22 layer. Synchronous bind-time
 route construction is the implemented issue #23 layer, and issue #24 adds
 physical-target comparison, assigned shards, and rejection of conflicting or
 unroutable cataloged sharded writes.
-Issue #26 adds the prepared/bind/describe/execute state described below. Empty
-or multi-statement request policy remains issue #27; a prepared handle requires
-exactly one statement as its own cardinality rule.
+Issue #26 adds the prepared/bind/describe/execute state described below. The
+implemented classifier adds general behavior and batch policy; a prepared
+handle retains its stricter exactly-one-statement cardinality rule.
 
 The validator independently caps recursive expression AST depth at 128. This
 also bounds flat operator chains that parse iteratively; exceeding the limit is
@@ -411,8 +420,36 @@ The driver-capable Rust execution path now consumes accepted sharded writes and
 supported read targets and creates a fresh plan under every execution's current
 schema guard. Persistent `CREATE TABLE` and `CREATE INDEX` must still use
 journaled schema migrations, and real transactions still require
-protocol-neutral transaction state. Unsafe statement combinations and
-cross-shard transactions remain later request/session policy.
+protocol-neutral transaction state. Cross-shard transactions remain later
+request/session policy.
+
+### Implemented statement and batch classification
+
+The public Rust function `classify_statements(&CommonSql)` borrows the opaque
+validated AST and returns an owned ordered `StatementBatchClassification`.
+Behavior is derived structurally and is the same for SQLite, PostgreSQL, and
+MySQL source:
+
+| Statement | Behavior |
+| --- | --- |
+| `SELECT` | `Read` |
+| `INSERT`, `UPDATE`, `DELETE` | `Write(Insert)`, `Write(Update)`, `Write(Delete)` |
+| `CREATE TABLE`, `CREATE INDEX` | `Schema(CreateTable)`, `Schema(CreateIndex)` |
+| `BEGIN`, `COMMIT`, `ROLLBACK` | `Session(Begin)`, `Session(Commit)`, `Session(Rollback)` |
+
+Empty/comment-only input is `InvalidArgument`. Every singleton behavior can be
+classified, but a batch of two or more is accepted only when all members are
+`Read`; the first non-read member makes the whole batch `Unsupported`. This
+classification is not by itself execution permission. Diagnostics and `Debug`
+metadata never expose submitted SQL, literals, identifiers, or AST output.
+
+`Engine::plan_bound_statement` applies that complete batch gate before it
+selects a statement index and exposes the selected `behavior()` in its owned
+plan. Direct shard-key inference remains statement-local. The prepared pipeline
+uses the same classifier after its exact-one check and exposes behavior in
+`PreparedStatementDescription`. The exact matrix, precedence, and boundary are
+normative in [SQL statement and batch
+classification](SQL_STATEMENT_CLASSIFICATION.md).
 
 ### Implemented placeholder normalization
 
@@ -492,8 +529,9 @@ that policy.
 
 The synchronous public Rust method `Engine::plan_bound_statement` accepts a
 logical database, `NormalizedSql`, zero-based statement index, exact bound
-`Value` slice, and optional explicit routing bytes. It runs inference only
-after those concrete values exist and returns an owned `BoundStatementPlan`.
+`Value` slice, and optional explicit routing bytes. It applies the complete
+batch gate before selecting the member, then runs inference only after those
+concrete values exist and returns an owned `BoundStatementPlan`.
 
 Each inferred `Int64` becomes shortest signed decimal ASCII, `Text` becomes
 exact UTF-8, and `Binary` remains exact bytes. Explicit routing bytes also
@@ -508,36 +546,40 @@ not required. Multiple logical keys are accepted for a write only when they
 co-locate on one physical shard. `INSERT` must prove every row's key;
 unconstrained or contradictory `UPDATE`/`DELETE` requires explicit fallback;
 and every assignment to a cataloged shard-key column is rejected. A successful
-single-shard plan exposes `assigned_shard()`.
+plan exposes the selected `behavior()`; a successful single-shard plan also
+exposes `assigned_shard()`.
 
 Planning holds the schema-operation guard while consulting the catalog. The
 result records schema generation, routing-map generation, and hash,
 key-encoding, and bucket-algorithm versions. Those fields describe the snapshot
 used to build the plan; they do not reserve that snapshot for future execution.
 The method does not translate SQL, mutate a session, cache a prepared
-statement, apply complete statement/batch policy, scatter reads, or execute
-SQLite. The exact matrix and error precedence are in [bound statement planning
-and routing policy](SQL_PLANNING.md).
+statement, scatter reads, or execute SQLite. It does apply complete
+statement/batch policy; direct `infer_shard_keys` remains statement-local. The
+exact matrix and error precedence are in [bound statement planning and routing
+policy](SQL_PLANNING.md).
 
 ### Implemented prepared-statement lifecycle
 
 The public async Rust engine accepts a `PrepareRequest` with one logical
 database, explicit source dialect, explicit translation mode, and SQL string.
-Prepare runs parsing through translation, requires exactly one top-level
-statement, and transiently compiles parameter/column metadata on shard 0. A
-session retains only BriskDB-owned translated SQL and owned metadata; no SQLite
-statement or connection is cached.
+Prepare runs parsing through classification and translation, requires exactly
+one top-level statement, and transiently compiles parameter/column metadata on
+shard 0. A session retains only BriskDB-owned translated SQL, precise logical
+behavior, and owned metadata; no SQLite statement or connection is cached.
 
 Binding validates a complete typed `Value` slice with a transient plan,
 snapshots the session's current routing key, and returns an opaque
 session-scoped `PortalId`. The portal retains the values and routing snapshot,
 not a plan. Describe returns ordered columns and one `Unknown` type per
-parameter/result column and refreshes metadata after schema migration. Every
-execution creates a fresh plan under its current schema guard. It runs accepted
-sharded work on its assigned shard and safe
-column-producing `NotApplicable`/`Global` reads on deterministic shard 0;
-catalog reads and sharded reads requiring scatter remain unsupported. Results
-are the same protocol-neutral routed rowset or affected-row count for SQLite,
+parameter/result column, exposes the classified behavior, and refreshes column
+metadata after schema migration without changing that behavior. Every execution
+creates a fresh plan under its current schema guard. It runs accepted sharded
+work on its assigned shard and classified safe `NotApplicable`/`Global` reads
+on deterministic shard 0; catalog access and sharded reads requiring scatter
+remain unavailable. Persistent schema prepare is denied before a handle is
+published, and session behavior cannot execute through a portal. Results are
+the same protocol-neutral routed rowset or affected-row count for SQLite,
 PostgreSQL, and MySQL source.
 
 Per-session statement, portal, retained-bound-value, and per-bind planning

--- a/docs/SQL_PARAMETERS.md
+++ b/docs/SQL_PARAMETERS.md
@@ -21,8 +21,10 @@ normalizer, and values are never rendered or interpolated into SQL text. The
 current HTTP execute, query, and migration endpoints do not invoke this opt-in
 layer; they retain their existing raw SQLite behavior. The asynchronous
 prepared lifecycle does invoke it and requires exactly one statement before it
-creates a prepared handle. Issue #27 still owns general empty-batch and
-multi-statement request policy.
+creates a prepared handle. Before consuming `CommonSql`, callers can borrow it
+with the implemented [statement/batch
+classifier](SQL_STATEMENT_CLASSIFICATION.md). That separate layer owns general
+empty and multi-statement request policy.
 
 The separate [SQL translation layer](SQL_TRANSLATION.md) can consume the
 result and either expose the normalized SQLite text exactly in strict mode or
@@ -166,7 +168,8 @@ A successful `NormalizedSql` does not establish that:
 - catalog names and types exist or are compatible;
 - non-placeholder PostgreSQL or MySQL syntax has been translated to SQLite
   until the separate `translate_sql` call succeeds;
-- a statement or batch is permitted by an endpoint or session;
+- a statement or batch passed classification, unless it is consumed by the
+  policy-bearing planner or prepared pipeline;
 - a prepared statement has been described, cached, bound, or executed; or
 - execution would preserve all source-dialect semantics.
 
@@ -178,8 +181,10 @@ unroutable cataloged sharded writes, and records a valid single-shard
 assignment. The implemented issue #25 translation layer is separate from this
 normalizer. The implemented
 [prepared-statement lifecycle](SQL_PREPARED_STATEMENTS.md) runs normalization
-during prepare, retains its metadata, and uses it again at bind. Issue #27 owns
-request-level statement classification.
+during prepare after exact-one classification, retains its metadata, and uses
+it again at bind. The planner applies complete batch policy before planning a
+selected normalized statement; direct shard-key inference remains
+statement-local.
 
 ## Verification obligations
 

--- a/docs/SQL_PARSER.md
+++ b/docs/SQL_PARSER.md
@@ -75,24 +75,26 @@ In particular, this layer does not:
   `translate_sql(NormalizedSql, SqlTranslationMode)` layer;
 - implement prepare/bind/describe/execute state or caches (issue #26 provides
   those as a separate core layer); or
-- classify statement behavior or reject unsafe multi-statement combinations
-  (issue #27).
+- classify statement behavior or apply request-level batch policy; issue #27
+  implements that as the separate
+  `classify_statements(&CommonSql)` layer.
 
 The parser may return several statements in source order. The 256-statement
 limit below is a resource bound, not permission to execute a batch. Whether a
-particular surface accepts one statement or a safe combination remains issue
-#27. The implemented subset validator checks each ordered statement
-independently and returns `Unsupported` for a parsed form outside its contract;
-that still does not grant permission to execute an empty or mixed batch.
+particular surface accepts one statement or a combination is decided by the
+[statement classifier](SQL_STATEMENT_CLASSIFICATION.md): empty input is
+`InvalidArgument`, and a batch of two or more is accepted only when every
+statement is a read. The subset validator first checks each ordered statement
+independently and returns `Unsupported` for a parsed form outside its contract.
 
 The existing HTTP execute, query, and migration paths remain raw SQLite
 pass-through surfaces with their existing authorizer and endpoint-specific
 rules. They call neither this parser, the opt-in common-subset validator,
-placeholder normalizer, translator, shard-key inference, nor bound statement
-planner. The separate Rust
+statement classifier, placeholder normalizer, translator, shard-key inference,
+nor bound statement planner. The separate Rust
 [prepared lifecycle](SQL_PREPARED_STATEMENTS.md) now connects those layers for
 an exact-one-statement handle without changing the experimental HTTP SQL
-surface. Request-level statement and batch policy remains issue #27.
+surface.
 
 ## Resource and error boundaries
 
@@ -106,13 +108,14 @@ work:
 | Parser recursion depth | 32 | `LimitExceeded` |
 
 Empty, whitespace-only, and comment-only input successfully produces an empty
-AST; whether a later request surface permits that is classification policy for
-issue #27. NUL input, malformed tokens, incomplete syntax, and other parse
-failures are `InvalidQuery`. A syntactically valid statement that is outside
-BriskDB's common subset is not a parse failure; `validate_common_subset`
-classifies it as `Unsupported`. Public protocol errors continue to use the fixed
-safe text for the error kind and must not serialize SQL text, parser diagnostics,
-source locations, or internal error chains.
+AST. The general classifier later returns `InvalidArgument` for that empty AST;
+prepared statements apply their own exact-one check, while raw HTTP surfaces
+retain endpoint-specific rules. NUL input, malformed tokens, incomplete syntax,
+and other parse failures are `InvalidQuery`. A syntactically valid statement
+that is outside BriskDB's common subset is not a parse failure;
+`validate_common_subset` classifies it as `Unsupported`. Public protocol errors
+continue to use the fixed safe text for the error kind and must not serialize
+SQL text, parser diagnostics, source locations, or internal error chains.
 
 The parser is stateless and has no catalog, storage, session, parameters,
 filesystem, or routing access. Routing will consume structural AST information

--- a/docs/SQL_PLANNING.md
+++ b/docs/SQL_PLANNING.md
@@ -1,6 +1,6 @@
 # Bound statement planning and routing policy
 
-Status: implemented for roadmap issues #23 and #24
+Status: implemented for roadmap issues #23, #24, and #27 integration
 
 BriskDB exposes one synchronous, protocol-neutral engine call that plans a
 normalized statement from the values actually bound for that execution:
@@ -27,7 +27,8 @@ a new portal and again for every execution.
 The call performs protocol-neutral analysis only. It infers typed shard-key
 values, converts them to canonical routing bytes, looks up physical shards,
 compares optional explicit routing context, applies the first single-shard DML
-rules, and records an assigned shard when one is valid. It does not prepare,
+rules, and records an assigned shard when one is valid. Before selecting a
+statement, it applies the shared complete-batch classifier. It does not prepare,
 translate, authorize, or execute SQL.
 
 ## Result contract
@@ -36,6 +37,8 @@ translate, authorize, or execute SQL.
 
 - `database()`: the logical database used for catalog resolution;
 - `statement_index()`: the selected statement in the normalized batch;
+- `behavior()`: the selected statement's authoritative logical
+  `StatementBehavior`;
 - `inference()`: the complete owned `ShardKeyInference` result;
 - `inferred_routes()`: one `PlannedRoute` for every entry returned by
   `inference().values()`, in the same order;
@@ -60,7 +63,7 @@ The [prepared execution lifecycle](SQL_PREPARED_STATEMENTS.md) consumes this
 result only after values are bound. Bind validates then discards one plan;
 execution creates another under its current schema guard. Execution uses an
 assigned shard for cataloged sharded work and may select deterministic shard 0
-for a safe column-producing `NotApplicable` or `Global` read. It still rejects
+for a classified safe `NotApplicable` or `Global` read. It still rejects
 catalog placement and sharded reads that need scatter. That target-selection
 integration does not change this planner's meaning of `assigned_shard()`.
 
@@ -90,10 +93,10 @@ This preserves their provenance for later session and execution work.
 
 ## Read assignment
 
-This issue deliberately does not publish a full statement-behavior classifier;
-issue #27 owns that API. At this boundary, the retained normalized AST is
-inspected only far enough to identify `INSERT`, `UPDATE`, and `DELETE`. Other
-sharded statements follow the read/deferred-assignment rules:
+The implemented [statement classifier](SQL_STATEMENT_CLASSIFICATION.md)
+publishes the precise read/write/schema/session behavior. Planning applies its
+full batch rule before selecting an index and retains the selected behavior.
+Only statements classified as `Read` follow these deferred-assignment rules:
 
 | Inference result | No explicit route | Compatible explicit route |
 | --- | --- | --- |
@@ -134,8 +137,9 @@ Row movement between shards is not implemented.
 `NotApplicable` and `NotSharded` statements do not become successful sharded
 writes. Global and Catalog placement, plus schema/session statements, retain
 `assigned_shard() == None` at this planning layer. Downstream execution policy
-decides whether a specific unassigned statement can run; the prepared lifecycle
-currently reads Global data on shard 0 and rejects Catalog placement.
+decides whether a specific unassigned singleton can run; the prepared lifecycle
+currently reads Global data on shard 0, rejects Catalog placement, and does not
+execute schema/session behavior.
 
 ## Canonical routing-key bytes
 
@@ -202,11 +206,15 @@ the catalog.
 ## Errors and recovery
 
 The caller reaches this API only after parsing, subset validation, and
-normalization succeed. Planning preserves shard-key inference errors and can
-also return:
+normalization succeed. Planning first classifies the complete retained batch,
+then preserves shard-key inference errors for the selected member and can also
+return:
 
 | Condition | `EngineErrorKind` |
 | --- | --- |
+| Empty normalized batch | `InvalidArgument` |
+| Multi-statement batch containing any non-read behavior | `Unsupported` |
+| Selected statement index is outside an otherwise accepted batch | `InvalidArgument` |
 | Explicit physical shard conflicts with any finite inferred route | `InvalidArgument` |
 | `UPDATE` or `DELETE` has no finite route and no explicit fallback | `InvalidArgument` |
 | A sharded `UPDATE` assigns the cataloged shard-key column | `InvalidQuery` |
@@ -218,12 +226,14 @@ Schema-gate errors retain their existing `Busy`, `FailedPrecondition`, and
 `DataCorruption` classifications. No new error kind or protocol mapping is
 introduced.
 
-Error precedence is deterministic: schema admission and inference happen
-first; an attempted shard-key update is rejected next; finite explicit-route
-conflicts are checked next; remaining write routability is checked last. Thus
-a shard-key update wins over a conflicting explicit key, while a multi-target
-write with an explicit route that disagrees with part of its finite inference
-is `InvalidArgument`.
+Error precedence is deterministic: public engine schema admission happens
+first; complete batch policy is next; the selected index is checked next;
+inference follows; an attempted shard-key update is rejected next; finite
+explicit-route conflicts are checked next; remaining write routability is
+checked last. Thus a blocked mutating batch wins over member-specific parameter
+or route errors. Within an accepted singleton, a shard-key update wins over a
+conflicting explicit key, while a multi-target write with an explicit route
+that disagrees with part of its finite inference is `InvalidArgument`.
 
 Policy diagnostics use fixed categories. They contain no submitted SQL,
 identifier spelling, literal, parameter value, routing-key bytes, or formatted
@@ -250,18 +260,17 @@ path. In particular:
   session cache or `PreparedStatementLimits` to consult;
 - planning does not invoke the separate PostgreSQL/MySQL-to-SQLite translation
   layer;
-- no complete read/write/schema/session or batch classifier is published; and
 - the current HTTP execute, query, and migration paths do not invoke parsing,
-  validation, normalization, inference, or planning.
+  validation, classification, normalization, inference, or planning.
 
 The implemented issue #25 translation API can independently consume the same
 normalized statement, but it neither changes nor executes a bound plan. The
 implemented issue #26 protocol-neutral prepare/bind/describe/execute lifecycle
 integrates translation and planning, validates transiently at bind, and plans
-again from the bounded session portal's snapshot at every execution. Issue #27
-owns the authoritative statement-behavior and empty, single-, and
-multi-statement request policy. Later query-planner work owns scatter/gather
-execution.
+again from the bounded session portal's snapshot at every execution. The
+implemented classifier supplies authoritative statement behavior and the
+empty/single/multi-statement gate. Direct inference remains statement-local;
+later query-planner work owns scatter/gather execution.
 
 ## Verification obligations
 
@@ -273,6 +282,7 @@ contradictory `UPDATE`/`DELETE`; immutable shard-key assignments under all
 source dialects and statement indexes; read deferral; error precedence and
 redaction; policy-error retries; deterministic valid and rejected concurrent
 calls; schema-gate precedence and recovery; owned
-public results; provenance; and equivalent SQLite, PostgreSQL, and MySQL typed
-requests. Raw HTTP regressions prove that opt-in planning still does not change
-existing execution behavior.
+public results; selected behavior; empty, all-read, and rejected mutating batch
+policy; provenance; and equivalent SQLite, PostgreSQL, and MySQL typed requests.
+Raw HTTP regressions prove that opt-in planning still does not change existing
+execution behavior.

--- a/docs/SQL_PREPARED_STATEMENTS.md
+++ b/docs/SQL_PREPARED_STATEMENTS.md
@@ -94,14 +94,16 @@ Preparation runs the same ordered frontend pipeline for every protocol:
 
 ```text
 parse -> exact-one top-level statement check -> common-subset validation ->
-placeholder normalization -> explicit translation -> transient SQLite compile
+statement classification -> placeholder normalization -> explicit translation
+-> transient SQLite compile
 ```
 
 The request must contain exactly one top-level SQL statement. Empty,
 comment-only, and multi-statement input returns `InvalidArgument`. This is a
-prepared-handle cardinality rule, not the general request classifier: issue
-#27 remains authoritative for empty and multi-statement request policy and for
-read/write/schema/session behavior.
+prepared-handle cardinality rule, not the general request classifier. The
+implemented [statement/batch classifier](SQL_STATEMENT_CLASSIFICATION.md)
+accepts a general multi-statement request only when every member is a read and
+supplies the singleton's precise read/write/schema/session behavior here.
 
 ## Logical cache and handle ownership
 
@@ -147,6 +149,7 @@ and verified to match across shards.
 `PreparedStatementDescription` is owned, cloneable, `Send`, and `Sync`. It
 reports:
 
+- the authoritative parsed `StatementBehavior` retained at prepare time;
 - one `DataType::Unknown` entry for every normalized one-based parameter index;
 - ordered result `Column` values copied from SQLite, preserving duplicate and
   empty names;
@@ -163,7 +166,8 @@ according to its own documented wire rules.
 `DescribeTarget::Portal` describes its underlying statement. A description at
 the current schema generation is returned from owned memory. After a completed
 schema migration changes the generation, describe recompiles the SQL on shard
-0 and atomically replaces the cached metadata. A normalized-versus-SQLite
+0 and atomically replaces the cached column metadata while preserving the
+classified behavior. A normalized-versus-SQLite
 parameter-count mismatch is an `Internal` invariant failure and does not
 publish mismatched metadata.
 
@@ -277,41 +281,49 @@ contains the current schema generation, routing-map generation, hash version,
 key-encoding version, and bucket-algorithm version. The engine keeps that same
 guard through target selection and SQLite completion, then discards the plan.
 
-Target selection is intentionally narrow:
+Target selection is intentionally narrow and starts from the retained logical
+behavior rather than SQLite result-column metadata:
 
-- accepted cataloged sharded work uses the current plan's one
+- accepted cataloged sharded reads and writes use the current plan's one
   `assigned_shard()`;
-- a safe column-producing statement with `NotApplicable` inference, such as
-  `SELECT 1`, uses deterministic shard 0;
-- a safe column-producing read of a `Global` table uses deterministic shard 0;
+- a classified `Read` with `NotApplicable` inference, such as `SELECT 1`, uses
+  deterministic shard 0;
+- a classified `Read` of a `Global` table uses deterministic shard 0;
 - `Catalog` placement is `PermissionDenied`; and
-- an unassigned sharded read that requires scatter is `Unsupported`.
+- an unassigned sharded read, a `Global` write, or `Session` behavior is
+  `Unsupported`.
 
 Shard 0 is valid for the two replicated-schema read cases because every ready
 shard has the same generation-bound application schema and `Global` declares
 replicated lookup placement. This initial path reads one deterministic replica;
 it does not compare replicas.
 
-These paths remain outside issue #26:
+These paths remain outside the current lifecycle:
 
 - scatter/gather or otherwise multi-shard reads;
 - contradictory reads that might later become an empty result without SQLite;
 - global writes, schema and session-statement execution paths;
 - persistent DDL outside the journaled schema-migration API;
-- complete read/write/schema/session classification and safe batch policy; and
 - explicit transaction state and shard pinning.
 
 Cataloged sharded DML must already satisfy the single-shard policy in
 [SQL planning](SQL_PLANNING.md). A cataloged read with finite inference, or one
 accepted through the bind-time routing fallback, can execute when it has one
-assigned shard. Issue #27 will publish the authoritative statement classifier;
-issue #26 does not infer permission merely from SQLite's ability to compile a
-statement.
+assigned shard. The shared classifier is authoritative; SQLite's ability to
+compile a statement or report columns never grants execution permission.
+
+Persistent `CREATE TABLE` and `CREATE INDEX` are classified as `Schema`, but
+ordinary shard authorizer policy denies them during transient preparation with
+`PermissionDenied`, so no prepared handle or description is published. A
+session-control singleton can be prepared and described, but portal execution
+returns `Unsupported` before SQLite is stepped and leaves the session usable.
 
 SQLite transiently prepares and executes the retained canonical SQLite SQL on
-the selected target. Read-only statements produce
+the selected target. Classified reads must produce
 `Routed<PreparedExecution::Rows(ResultSet)>`; commands produce
-`Routed<PreparedExecution::AffectedRows(usize)>`. Row results preserve ordered
+`Routed<PreparedExecution::AffectedRows(usize)>` only for classified writes. A
+disagreement between classified behavior and SQLite execution metadata is an
+`Internal` invariant failure. Row results preserve ordered
 metadata, duplicate names, positional values, and the normal exact result row
 and logical-byte limits. Row-producing writes are rejected rather than partly
 materialized. The returned `Routed` value always names the physical shard that
@@ -349,8 +361,8 @@ The lifecycle preserves the existing stable `EngineErrorKind` taxonomy:
 | --- | --- |
 | Unknown logical database, empty/multi-statement prepare, wrong bind arity, or conflicting explicit/inferred route | `InvalidArgument` |
 | SQL parse/SQLite compile failure or planner write-policy rejection where documented | `InvalidQuery` |
-| Unsupported subset/translation form, unsupported execution target, or row-producing write | `Unsupported` or the narrower documented SQL-path kind |
-| Execution with `Catalog` placement, whether a read or command | `PermissionDenied` |
+| Unsupported subset/translation form, session execution, unsupported physical target, or row-producing write | `Unsupported` or the narrower documented SQL-path kind |
+| Persistent schema prepare, or execution with `Catalog` placement | `PermissionDenied` |
 | Incompatible key/value type | `TypeMismatch` |
 | Out-of-range unsigned integer or inferred integer | `NumericOutOfRange` |
 | Invalid text value | `InvalidTextEncoding` |
@@ -359,11 +371,11 @@ The lifecycle preserves the existing stable `EngineErrorKind` taxonomy:
 | Pool/schema admission contention | `Busy` |
 | Request cancellation or deadline | `Cancelled` / `DeadlineExceeded` |
 | Degraded storage state | `DataCorruption` |
-| Retained metadata or accounting invariant mismatch | `Internal` |
+| Retained metadata/accounting mismatch, or classified behavior disagreeing with SQLite execution metadata | `Internal` |
 
-Parsing, validation, normalization, translation, inference, planning, SQLite,
-request-control, and storage errors retain the precedence and kind defined by
-their normative contracts. Cache-limit failures do not evict older entries.
+Parsing, validation, classification, normalization, translation, inference,
+planning, SQLite, request-control, and storage errors retain the precedence and
+kind defined by their normative contracts. Cache-limit failures do not evict older entries.
 Failed prepare does not publish an ID; failed bind does not publish a portal;
 failed describe does not replace valid current metadata; and failed execution
 retains the portal for inspection, retry where independently appropriate, or
@@ -417,11 +429,14 @@ or prepared-cache recovery step is required.
 
 Tests cover the complete SQLite/PostgreSQL/MySQL typed lifecycle; exact
 single-statement enforcement; unknown databases; transient shard-0 metadata;
-parameter and column descriptions; schema-generation refresh; fresh planning
+classified behavior and parameter/column descriptions; schema-generation
+behavior preservation; fresh planning
 after schema/routing changes; routing snapshots; affected-row and row results;
 result limits; session ownership; statement, portal, and retained-byte limits without
 eviction; repeated-marker planning expansion before allocation; exact close and
-cascading invalidation; invalid arity/value recovery; unassigned execution;
+cascading invalidation; invalid arity/value recovery; behavior-based unassigned
+execution; schema-prepare denial and session-execution rejection without state
+changes;
 deterministic concurrent capacity races; cancellation while waiting for a
 session; session close during admitted work; diagnostics and safe protocol
 mapping; targeted request/cache/portal/plan/description `Debug` redaction;

--- a/docs/SQL_SHARD_KEYS.md
+++ b/docs/SQL_SHARD_KEYS.md
@@ -25,6 +25,9 @@ indices; values are never interpolated into SQL text.
 This API performs catalog-aware analysis only. It does not encode or hash a
 key, select a virtual bucket or physical shard, build an execution plan,
 authorize a statement, enforce write policy, or execute SQL.
+It is also statement-local: the separate [statement/batch
+classifier](SQL_STATEMENT_CLASSIFICATION.md) owns logical behavior and complete
+request policy.
 
 ## Result contract
 
@@ -171,9 +174,9 @@ translator is a separate opt-in operation over the same normalized SQL; it does
 not change an inference result. The implemented
 [prepared lifecycle](SQL_PREPARED_STATEMENTS.md) validates a transient
 bind-time plan, retains the typed values and routing snapshot, and repeats
-planning under the current execution guard to select a supported target. Later
-work owns authoritative statement classification, scatter/gather, and
-wire-protocol integration.
+planning under the current execution guard to select a supported target. The
+planner applies the implemented batch gate and retains the selected statement's
+behavior; later work still owns scatter/gather and wire-protocol integration.
 
 ## Verification obligations
 

--- a/docs/SQL_STATEMENT_CLASSIFICATION.md
+++ b/docs/SQL_STATEMENT_CLASSIFICATION.md
@@ -1,0 +1,260 @@
+# SQL statement and batch classification
+
+Status: implemented for roadmap issue #27
+
+BriskDB classifies the already validated common SQL AST into a small,
+protocol-neutral behavior taxonomy. The classifier is the shared request gate
+for future PostgreSQL, MySQL, and other adapters; a frontend must not infer
+behavior from SQL text, a wire command, SQLite result columns, or whether
+SQLite reports a statement as read-only.
+
+```rust
+classify_statements(
+    common: &CommonSql,
+) -> EngineResult<StatementBatchClassification>
+```
+
+The call borrows `CommonSql`. It neither consumes nor rewrites the caller's
+source, so the same validated value can independently continue to placeholder
+normalization. `StatementBatchClassification` is an owned, ordered result and
+exposes:
+
+- `behaviors()`, with one entry per top-level statement in source order;
+- `behavior(index)`, using a zero-based index and returning `None` outside the
+  batch;
+- `statement_count()`; and
+- `is_read_only()`, which is true only for an accepted nonempty batch whose
+  entries are all `Read`.
+
+The result does not expose the parser dependency's AST. Its `Debug`
+representation contains behavior metadata only and never renders submitted SQL,
+comments, identifiers, literals, placeholders, or source locations.
+
+## Behavior taxonomy
+
+`StatementBehavior` is protocol neutral and deliberately more precise than a
+single read/write Boolean:
+
+| Common-subset statement | `StatementBehavior` |
+| --- | --- |
+| `SELECT` | `Read` |
+| `INSERT` | `Write(WriteBehavior::Insert)` |
+| `UPDATE` | `Write(WriteBehavior::Update)` |
+| `DELETE` | `Write(WriteBehavior::Delete)` |
+| `CREATE TABLE` | `Schema(SchemaBehavior::CreateTable)` |
+| `CREATE INDEX` | `Schema(SchemaBehavior::CreateIndex)` |
+| `BEGIN` | `Session(SessionBehavior::Begin)` |
+| `COMMIT` | `Session(SessionBehavior::Commit)` |
+| `ROLLBACK` | `Session(SessionBehavior::Rollback)` |
+
+The public enums are non-exhaustive so a future common-subset expansion can add
+behavior without exposing dependency-owned syntax types. The pinned parser can
+map several accepted spellings to the same semantic AST. For example,
+`ROLLBACK`, accepted rollback suffix aliases, and PostgreSQL `ABORT` all classify
+as `Session(Rollback)`. Classification follows that semantic AST rather than
+searching retained source text.
+
+This taxonomy describes logical behavior; it is not execution permission. In
+particular, a successfully classified singleton schema statement is denied by
+ordinary prepared-compile policy, a session statement cannot execute through a
+portal, and a classified write must still satisfy catalog, routing, and target
+policy.
+
+## Batch policy
+
+Classification is all-or-nothing. A caller receives the complete ordered
+classification only when the batch passes this table:
+
+| Top-level statements | Result |
+| --- | --- |
+| Zero, including whitespace or comments only | `InvalidArgument` |
+| Exactly one `Read`, `Write`, `Schema`, or `Session` | Accepted |
+| Two or more, all `Read` | Accepted in source order |
+| Two or more containing any `Write`, `Schema`, or `Session` | `Unsupported` |
+
+Equivalently, the complete pairwise rule is:
+
+| First / second | `Read` | `Write` | `Schema` | `Session` |
+| --- | --- | --- | --- | --- |
+| `Read` | Accept | Reject | Reject | Reject |
+| `Write` | Reject | Reject | Reject | Reject |
+| `Schema` | Reject | Reject | Reject | Reject |
+| `Session` | Reject | Reject | Reject | Reject |
+
+The rule is conservative because BriskDB does not yet expose a general batch
+result or atomic multi-statement data-execution contract. It prevents a
+frontend from partially applying a mutating batch or hiding a session/schema
+transition among otherwise read-only work. A future relaxation requires an
+explicit result, transaction, routing, and adapter contract; it must not be
+implemented independently in one wire frontend.
+
+The first non-`Read` statement in a rejected multi-statement batch determines
+the diagnostic. The one-based ordinal and coarse behavior name are trusted
+diagnostic metadata; the nested subtype and caller SQL are omitted. No partial
+classification is returned.
+
+The parser's maximum of 256 statements remains a resource ceiling rather than
+permission. A 256-statement all-read batch can classify successfully. A 257th
+statement is rejected by parsing before classification.
+
+## Pipeline and error precedence
+
+The general SQL analysis pipeline is:
+
+```text
+explicit-dialect parse -> common-subset validation -> batch classification
+                                               |-> placeholder normalization
+                                               |-> later analysis branches
+```
+
+Classification borrows `CommonSql`; normalization continues to consume it.
+Callers that need both must classify first and then pass the same validated
+value to normalization. The ordering establishes these rules:
+
+1. parser syntax and parser limits win before subset or batch policy;
+2. common-subset validation checks every statement in order, so its first
+   unsupported form or expression-depth error wins before batch policy;
+3. empty and mutating multi-statement policy runs before placeholder
+   normalization, SQL translation, planning, or execution; and
+4. after an all-read or singleton batch passes, later layers retain their own
+   documented errors.
+
+The classifier itself returns:
+
+| Condition | `EngineErrorKind` |
+| --- | --- |
+| Empty/comment-only validated batch | `InvalidArgument` |
+| Multi-statement batch whose first non-read entry is at ordinal N | `Unsupported` |
+| A validated AST family has no classifier mapping | `Internal` |
+
+Diagnostics never contain submitted SQL, identifiers, comments, literal or
+parameter values, formatted AST output, source locations, or parser messages.
+Adapters map only the stable `EngineErrorKind` and fixed public text from
+[the error contract](ERRORS.md).
+
+A failed classification does not mutate `CommonSql`, allocate session state,
+or poison a later call. Because the classifier borrows an immutable validated
+AST and uses no shared mutable state, concurrent classifications of equal input
+produce equal results or equal stable errors.
+
+## Planning integration
+
+`Engine::plan_bound_statement` is the generic policy-bearing planning boundary.
+Before selecting its requested `statement_index`, it applies the complete batch
+classifier to the retained `CommonSql` inside `NormalizedSql`. Consequently:
+
+- an empty normalized batch is `InvalidArgument`;
+- a multi-statement batch containing a write, schema change, or session control
+  is `Unsupported`, even when the selected member alone could be routed;
+- an all-read multi-statement batch may be planned one member at a time; and
+- a successful `BoundStatementPlan` exposes the selected member through
+  `behavior()`.
+
+Shard-key inference remains deliberately statement-local. Direct
+`infer_shard_keys` callers select one normalized statement and receive a key
+classification without granting batch permission. Planning composes that
+statement-local inference with the complete batch gate and retains the selected
+logical behavior alongside routing provenance.
+
+Routing policy retains its narrow crate-private DML shape, including the extra
+detail needed to detect shard-key assignments, while the plan exposes the
+matching public `WriteBehavior`. Downstream execution no longer infers that an
+absent DML shape or SQLite result columns imply a read. This preserves the
+existing single-shard write rules while making schema and session behavior
+explicit.
+`BoundStatementPlan::Debug` may report behavior metadata but continues to omit
+SQL, bound values, and routing-key bytes.
+
+## Prepared-statement integration
+
+Prepared statements keep their stricter cardinality contract. Their frontend
+pipeline is:
+
+```text
+parse -> exact-one check -> common-subset validation -> classification ->
+placeholder normalization -> explicit translation -> transient SQLite compile
+```
+
+Empty input and any input with more than one parsed statement return
+`InvalidArgument` immediately after parsing. Thus a two-`SELECT` batch can pass
+the general classifier but cannot become one prepared handle. The exact-one
+error also precedes a later member's subset, marker, or translation error.
+
+The prepared cache retains the singleton `StatementBehavior` as owned template
+metadata. `PreparedStatementDescription::behavior()` exposes it to adapters;
+the value is unchanged by binding, schema-generation metadata refresh, or
+portal execution. Bind and execute plans expose the same selected behavior.
+
+Prepared target selection uses this logical classification rather than
+`PreparedStatementDescription::returns_rows()`:
+
+- an assigned cataloged `Read` or `Write` uses its planned shard;
+- an unassigned `Read` with `NotApplicable` inference, such as `SELECT 1`, uses
+  deterministic shard 0;
+- a `Read` of a `Global` table uses deterministic shard 0;
+- a write to `Global` placement, an unassigned sharded read, and other targets
+  without one implemented physical execution path are `Unsupported`;
+- `Catalog` placement remains `PermissionDenied`; and
+- persistent `Schema` behavior is denied with `PermissionDenied` during
+  transient preparation, so no handle is published, while `Session` behavior
+  is `Unsupported` at portal target selection.
+
+SQLite column metadata still describes protocol results, but it does not grant
+read permission or decide logical behavior. Persistent schema changes continue
+through the journaled migration API, and real transaction state and shard
+pinning remain later transaction work.
+
+## Adapter and raw-surface boundary
+
+Future PostgreSQL and MySQL adapters must pass their explicitly selected
+dialect through the shared parser, subset validator, and classifier. They may
+map the nested behavior to protocol command tags or status handling, but must
+not implement a second keyword classifier or loosen batch policy on their own.
+The same typed common SQL produces the same classification regardless of its
+wire protocol.
+
+Issue #27 adds no PostgreSQL or MySQL listener and no new HTTP route, request
+field, response body, or configuration option. The experimental HTTP execute,
+query, and migration endpoints remain raw SQLite surfaces and do not invoke the
+opt-in common frontend. In particular, the journaled migration endpoint keeps
+its own bounded, parameterless SQLite batch contract and can accept a schema
+batch that the general common-SQL classifier deliberately rejects.
+
+## Storage-format and configuration boundary
+
+Classification is process-memory analysis over an already owned AST. It does
+not change manifest format version 7, manifest tables, logical catalog rows,
+routing-key encoding, virtual buckets, shard identity, SQLite headers,
+application-schema fingerprints, migration-journal records, WAL/synchronous
+mode, or filenames. It opens no database connection and performs no recovery
+work.
+
+No CLI flag, environment variable, `EngineOptions` field, or cache limit is
+added. Classification input remains bounded by the parser's SQL byte,
+statement-count, and recursion limits and the common subset's expression-depth
+limit. A classification result is ordinary owned memory and is not persisted
+across process restart.
+
+Canonical translated SQL is still not a migration identity. The migration
+coordinator continues to retain and digest the caller's exact submitted SQL,
+independently of common-SQL classification.
+
+## Verification obligations
+
+Tests cover every nested behavior in SQLite, PostgreSQL, and MySQL; accepted
+transaction aliases; AST-only handling of behavior words and semicolons in
+comments, strings, aliases, and quoted identifiers; empty input; the complete
+pairwise batch matrix in both source orders; first/middle/last rejected
+ordinals; all-read batches and the exact parser statement limit; error
+precedence; ordered accessors; out-of-range lookup; read-only status; owned
+public types; diagnostics and `Debug` redaction; deterministic concurrent calls;
+and successful calls after independent errors.
+
+Planner tests cover the complete batch gate, selected behavior, all-read member
+planning, inference's separate statement-local boundary, and behavior retained
+across equivalent dialect inputs. Prepared tests cover exact-one precedence,
+description behavior, schema refresh, behavior-based physical target policy,
+denied schema prepare and rejected session execution without side effects, and
+later valid work in the same session. Raw HTTP and storage regressions prove
+that classification does not alter the existing migration or pass-through
+contracts.

--- a/docs/SQL_SUBSET.md
+++ b/docs/SQL_SUBSET.md
@@ -47,15 +47,18 @@ A successful `CommonSql` does not mean that the SQL:
 Those responsibilities remain with the implemented issue #21 normalization,
 issue #22 inference, issues #23/#24 bound planning and routing-policy layers,
 the separate issue #25 translation layer, the implemented issue #26 prepared
-lifecycle, issue #27 classification/batch policy, and the later wire frontends.
+lifecycle, the implemented issue #27
+[statement/batch classifier](SQL_STATEMENT_CLASSIFICATION.md), and the later
+wire frontends.
 Validation never consults parameters, a session, the logical catalog, storage,
 routing state, the filesystem, or SQLite. It never formats or searches SQL text
 to make a structural decision.
 
 Empty and comment-only parsed batches validate successfully. Every statement in
 a mixed batch is checked independently and source order is retained, but that
-is not permission to execute the batch. Issue #27 owns empty-request policy,
-statement behavior classification, and safe statement combinations.
+is not permission to execute the batch. The separate classifier returns
+`InvalidArgument` for empty input, precisely classifies each accepted family,
+and accepts a multi-statement request only when every member is a read.
 
 ## Statement forms
 
@@ -87,8 +90,9 @@ validation does not inspect whether an assignment changes a shard-key column.
 The separate inference layer classifies the supported predicate proof. The
 implemented [bound planning and routing-policy layer](SQL_PLANNING.md) performs
 the narrow catalog-aware `UPDATE` target check and rejects conflicting or
-unroutable sharded DML. That does not broaden structural validation or replace
-the complete statement classifier owned by issue #27.
+unroutable sharded DML. That does not broaden structural validation; the
+separate statement classifier supplies the complete logical behavior and batch
+gate.
 
 ### Names, aliases, and types
 

--- a/docs/SQL_TRANSLATION.md
+++ b/docs/SQL_TRANSLATION.md
@@ -19,7 +19,9 @@ contains a separate `sqlite_sql()` string for a later SQLite prepare step.
 
 Translation is pure SQL analysis. It accepts no catalog, session, routing key,
 bound values, storage handle, or protocol object. It does not prepare,
-authorize, classify a request batch, route, or execute a statement.
+authorize, classify a request batch, route, or execute a statement. The
+separate [statement classifier](SQL_STATEMENT_CLASSIFICATION.md) borrows
+`CommonSql` before normalization and owns logical behavior and batch policy.
 
 ## Explicit modes
 
@@ -183,12 +185,12 @@ to send caller-provided SQLite SQL directly to their existing engine paths.
 
 The implemented protocol-neutral [prepared lifecycle](SQL_PREPARED_STATEMENTS.md)
 owns prepare/bind/describe/execute state and adopts `sqlite_sql()` only after
-requiring exactly one top-level statement. It transiently compiles metadata,
-caches BriskDB-owned SQL rather than a SQLite handle, and creates a fresh
-current plan from each portal's bind snapshot at execution. Issue #27 still
-owns authoritative statement behavior and general empty, single-, or
-multi-statement request policy. Schema execution must still use the journaled
-migration path.
+requiring and classifying exactly one top-level statement. It transiently
+compiles metadata, caches BriskDB-owned SQL and behavior rather than a SQLite
+handle, and creates a fresh current plan from each portal's bind snapshot at
+execution. The general planner applies the classifier's batch gate before
+planning; translation remains an independently callable syntax branch. Schema
+execution must still use the journaled migration path.
 
 ## Verification obligations
 

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -889,6 +889,15 @@ Prepare/describe do not write application data. A supported portal command has
 only its ordinary one-shard SQLite row effects; persistent schema changes
 remain exclusive to the exact-text journaled migration path.
 
+Issue #27's `StatementBatchClassification`, nested behavior enums, and behavior
+retained by plans/descriptions are likewise process-memory analysis metadata.
+They add no manifest or shard table, format version, header value, routing/key
+encoding, virtual-bucket map, schema fingerprint, journal record, CLI setting,
+or restart-recovery step. The raw migration endpoint keeps its separate
+parameterless schema-batch contract: it still digests and retains the caller's
+exact submitted SQL and does not substitute classified, normalized, or
+translated text as migration identity.
+
 The checksums are corruption detectors, not authentication. Both use unkeyed
 BLAKE3 and are writable by anyone who can modify the data directory. The
 manifest root covers canonical control-plane values, not raw SQLite pages. The

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -550,7 +550,7 @@ impl Engine {
                 "selected logical database does not exist",
             )));
         }
-        let (database, translated) = match prepare_translated_request(request) {
+        let (database, behavior, translated) = match prepare_translated_request(request) {
             Ok(prepared) => prepared,
             Err(error) => return operation.finish(Err(error)),
         };
@@ -576,6 +576,7 @@ impl Engine {
                     })?;
                     ensure_parameter_metadata(parameter_count, metadata.parameter_count())?;
                     let description = PreparedStatementDescription::new(
+                        behavior,
                         parameter_count,
                         metadata.columns().to_vec(),
                         schema_generation,
@@ -704,6 +705,7 @@ impl Engine {
         }
 
         let parameter_count = template.translated().statement_parameters()[0].parameter_count();
+        let behavior = template.description().behavior();
         let sqlite_sql = template.translated().sqlite_sql().to_owned();
         let owner = ConnectionOwner::new(session.id().get());
         let result = self
@@ -720,6 +722,7 @@ impl Engine {
                     })?;
                     ensure_parameter_metadata(parameter_count, metadata.parameter_count())?;
                     let description = PreparedStatementDescription::new(
+                        behavior,
                         parameter_count,
                         metadata.columns().to_vec(),
                         schema_generation,
@@ -780,10 +783,11 @@ impl Engine {
             Err(error) => return operation.finish(Err(error)),
         };
         let sqlite_sql = template.translated().sqlite_sql().to_owned();
-        let shard = match prepared_execution_shard(&plan, template.description(), self.catalog()) {
+        let shard = match prepared_execution_shard(&plan, self.catalog()) {
             Ok(shard) => shard,
             Err(error) => return operation.finish(Err(error)),
         };
+        let behavior = plan.behavior();
         let result_limits = operation.result_limits;
         let owner = ConnectionOwner::new(session.id().get());
         let result = self
@@ -802,12 +806,7 @@ impl Engine {
                             portal_snapshot.parameters(),
                             result_limits,
                         )
-                        .map(|execution| match execution {
-                            sql::StatementExecution::Rows(rows) => PreparedExecution::Rows(rows),
-                            sql::StatementExecution::AffectedRows(rows) => {
-                                PreparedExecution::AffectedRows(rows)
-                            }
-                        })
+                        .and_then(|execution| prepared_execution(behavior, execution))
                     })
                 },
             )
@@ -1245,7 +1244,11 @@ impl Engine {
 
 fn prepare_translated_request(
     request: PrepareRequest,
-) -> EngineResult<(LogicalDatabaseId, sql::TranslatedSql)> {
+) -> EngineResult<(
+    LogicalDatabaseId,
+    sql::StatementBehavior,
+    sql::TranslatedSql,
+)> {
     let (database, dialect, translation_mode, source) = request.into_parts();
     let parsed = sql::parse(dialect, source)?;
     if parsed.statement_count() != 1 {
@@ -1255,9 +1258,16 @@ fn prepare_translated_request(
         ));
     }
     let common = sql::validate_common_subset(parsed)?;
+    let classification = sql::classify_statements(&common)?;
+    let behavior = classification.behavior(0).ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::Internal,
+            "prepared statement classification lost its only statement",
+        )
+    })?;
     let normalized = sql::normalize_placeholders(common)?;
     let translated = sql::translate_sql(normalized, translation_mode)?;
-    Ok((database, translated))
+    Ok((database, behavior, translated))
 }
 
 fn ensure_parameter_metadata(expected: usize, actual: usize) -> EngineResult<()> {
@@ -1273,45 +1283,92 @@ fn ensure_parameter_metadata(expected: usize, actual: usize) -> EngineResult<()>
 
 fn prepared_execution_shard(
     plan: &BoundStatementPlan,
-    description: &PreparedStatementDescription,
     catalog: &super::Catalog,
 ) -> EngineResult<u16> {
-    if let Some(shard) = plan.assigned_shard() {
-        return Ok(shard);
+    if matches!(
+        plan.behavior(),
+        sql::StatementBehavior::Schema(_) | sql::StatementBehavior::Session(_)
+    ) {
+        return Err(unsupported_prepared_behavior());
     }
 
-    match plan.inference().kind() {
-        sql::ShardKeyInferenceKind::NotApplicable if description.returns_rows() => Ok(0),
-        sql::ShardKeyInferenceKind::NotApplicable => Err(unassigned_prepared_statement()),
-        sql::ShardKeyInferenceKind::NotSharded => {
-            let table = plan
-                .inference()
-                .table_id()
-                .and_then(|table| catalog.table_by_id(table))
-                .ok_or_else(|| {
-                    EngineError::new(
-                        EngineErrorKind::Internal,
-                        "non-sharded prepared planning lost its catalog table",
-                    )
-                })?;
-            match table.placement() {
-                TablePlacement::Global if description.returns_rows() => Ok(0),
-                TablePlacement::Global => Err(unassigned_prepared_statement()),
-                TablePlacement::Catalog => Err(EngineError::new(
+    let is_global = if plan.inference().kind() == sql::ShardKeyInferenceKind::NotSharded {
+        let table = plan
+            .inference()
+            .table_id()
+            .and_then(|table| catalog.table_by_id(table))
+            .ok_or_else(|| {
+                EngineError::new(
+                    EngineErrorKind::Internal,
+                    "non-sharded prepared planning lost its catalog table",
+                )
+            })?;
+        match table.placement() {
+            TablePlacement::Catalog => {
+                return Err(EngineError::new(
                     EngineErrorKind::PermissionDenied,
                     "catalog-placed tables cannot execute as client SQL",
-                )),
-                TablePlacement::Sharded(_) => Err(EngineError::new(
+                ));
+            }
+            TablePlacement::Global => true,
+            TablePlacement::Sharded(_) => {
+                return Err(EngineError::new(
                     EngineErrorKind::Internal,
                     "non-sharded prepared planning resolved a sharded table",
-                )),
+                ));
             }
         }
-        sql::ShardKeyInferenceKind::Unconstrained
-        | sql::ShardKeyInferenceKind::Contradiction
-        | sql::ShardKeyInferenceKind::Exact
-        | sql::ShardKeyInferenceKind::Multiple => Err(unassigned_prepared_statement()),
+    } else {
+        false
+    };
+
+    match plan.behavior() {
+        sql::StatementBehavior::Read => {
+            if let Some(shard) = plan.assigned_shard() {
+                return Ok(shard);
+            }
+            match plan.inference().kind() {
+                sql::ShardKeyInferenceKind::NotApplicable => Ok(0),
+                sql::ShardKeyInferenceKind::NotSharded if is_global => Ok(0),
+                sql::ShardKeyInferenceKind::NotSharded
+                | sql::ShardKeyInferenceKind::Unconstrained
+                | sql::ShardKeyInferenceKind::Contradiction
+                | sql::ShardKeyInferenceKind::Exact
+                | sql::ShardKeyInferenceKind::Multiple => Err(unassigned_prepared_statement()),
+            }
+        }
+        sql::StatementBehavior::Write(_) => plan
+            .assigned_shard()
+            .ok_or_else(unassigned_prepared_statement),
+        sql::StatementBehavior::Schema(_) | sql::StatementBehavior::Session(_) => {
+            Err(unsupported_prepared_behavior())
+        }
     }
+}
+
+fn prepared_execution(
+    behavior: sql::StatementBehavior,
+    execution: sql::StatementExecution,
+) -> EngineResult<PreparedExecution> {
+    match (behavior, execution) {
+        (sql::StatementBehavior::Read, sql::StatementExecution::Rows(rows)) => {
+            Ok(PreparedExecution::Rows(rows))
+        }
+        (sql::StatementBehavior::Write(_), sql::StatementExecution::AffectedRows(rows)) => {
+            Ok(PreparedExecution::AffectedRows(rows))
+        }
+        _ => Err(EngineError::new(
+            EngineErrorKind::Internal,
+            "classified statement behavior disagrees with SQLite execution metadata",
+        )),
+    }
+}
+
+fn unsupported_prepared_behavior() -> EngineError {
+    EngineError::new(
+        EngineErrorKind::Unsupported,
+        "schema and session statements require a dedicated engine operation",
+    )
 }
 
 fn unassigned_prepared_statement() -> EngineError {
@@ -1448,6 +1505,42 @@ mod tests {
             .map(|value| format!("shard-{value}"))
             .find(|key| engine.inner.database.shard_for_key(key.as_bytes()) == expected)
             .expect("the finite shard layout has a routing key")
+    }
+
+    #[test]
+    fn prepared_execution_shape_must_match_classified_behavior() {
+        let rows = ResultSet::new(vec![Column::new("value", DataType::Int64)], vec![]).unwrap();
+        assert_eq!(
+            prepared_execution(
+                sql::StatementBehavior::Read,
+                sql::StatementExecution::Rows(rows.clone()),
+            )
+            .unwrap(),
+            PreparedExecution::Rows(rows.clone())
+        );
+        assert_eq!(
+            prepared_execution(
+                sql::StatementBehavior::Write(sql::WriteBehavior::Update),
+                sql::StatementExecution::AffectedRows(2),
+            )
+            .unwrap(),
+            PreparedExecution::AffectedRows(2)
+        );
+
+        for error in [
+            prepared_execution(
+                sql::StatementBehavior::Read,
+                sql::StatementExecution::AffectedRows(0),
+            )
+            .unwrap_err(),
+            prepared_execution(
+                sql::StatementBehavior::Write(sql::WriteBehavior::Delete),
+                sql::StatementExecution::Rows(rows),
+            )
+            .unwrap_err(),
+        ] {
+            assert_eq!(error.kind(), EngineErrorKind::Internal);
+        }
     }
 
     async fn wait_for_pool_occupancy(engine: &Engine, shard: u16, active: usize, queued: usize) {
@@ -1598,43 +1691,84 @@ mod tests {
         let (_temp, engine, database) = engine_with_prepared_catalog(EngineOptions::default());
         let session = engine.session();
 
-        let insert = engine
-            .prepare_statement(
-                &session,
-                PrepareRequest::new(
-                    database,
-                    sql::SqlDialect::Sqlite,
-                    sql::SqlTranslationMode::StrictSqlite,
-                    "INSERT INTO events (tenant_id, payload) VALUES (?1, ?2)",
-                ),
-            )
-            .await
-            .unwrap();
-        let insert_description = engine
-            .describe_prepared(&session, DescribeTarget::Statement(insert))
-            .await
-            .unwrap();
-        assert_eq!(
-            insert_description.parameter_types(),
-            [DataType::Unknown, DataType::Unknown]
-        );
-        assert!(insert_description.columns().is_empty());
-        assert!(!insert_description.returns_rows());
+        let insert_requests = [
+            (
+                sql::SqlDialect::Sqlite,
+                sql::SqlTranslationMode::StrictSqlite,
+                "INSERT INTO events (tenant_id, payload) VALUES (?1, ?2)",
+                7_i64,
+                "seven",
+            ),
+            (
+                sql::SqlDialect::PostgreSql,
+                sql::SqlTranslationMode::Compatibility,
+                "INSERT INTO events (tenant_id, payload) VALUES ($1, $2)",
+                8_i64,
+                "eight",
+            ),
+            (
+                sql::SqlDialect::MySql,
+                sql::SqlTranslationMode::Compatibility,
+                "INSERT INTO events (tenant_id, payload) VALUES (?, ?)",
+                9_i64,
+                "nine",
+            ),
+        ];
+        let mut insert_descriptions = Vec::new();
+        for (dialect, mode, source, tenant_id, payload) in insert_requests {
+            let statement = engine
+                .prepare_statement(
+                    &session,
+                    PrepareRequest::new(database, dialect, mode, source),
+                )
+                .await
+                .unwrap();
+            let description = engine
+                .describe_prepared(&session, DescribeTarget::Statement(statement))
+                .await
+                .unwrap();
+            assert_eq!(
+                description.parameter_types(),
+                [DataType::Unknown, DataType::Unknown]
+            );
+            assert_eq!(
+                description.behavior(),
+                sql::StatementBehavior::Write(sql::WriteBehavior::Insert)
+            );
+            assert!(description.columns().is_empty());
+            assert!(!description.returns_rows());
+            insert_descriptions.push(description);
 
-        let insert_portal = engine
-            .bind_statement(
-                &session,
-                insert,
-                vec![Value::from(7_i64), Value::from("seven")],
-            )
-            .await
-            .unwrap();
-        let inserted = engine
-            .execute_portal(&session, insert_portal)
-            .await
-            .unwrap();
-        assert_eq!(inserted.value, PreparedExecution::AffectedRows(1));
-        assert_eq!(inserted.shard, engine.inner.database.shard_for_key(b"7"));
+            let portal = engine
+                .bind_statement(
+                    &session,
+                    statement,
+                    vec![Value::from(tenant_id), Value::from(payload)],
+                )
+                .await
+                .unwrap();
+            let inserted = engine.execute_portal(&session, portal).await.unwrap();
+            assert_eq!(inserted.value, PreparedExecution::AffectedRows(1));
+            assert_eq!(
+                inserted.shard,
+                engine
+                    .inner
+                    .database
+                    .shard_for_key(tenant_id.to_string().as_bytes())
+            );
+            assert!(engine.close_portal(&session, portal).await.unwrap());
+            assert!(
+                engine
+                    .close_prepared_statement(&session, statement)
+                    .await
+                    .unwrap()
+            );
+        }
+        assert!(
+            insert_descriptions
+                .windows(2)
+                .all(|pair| pair[0] == pair[1])
+        );
 
         let requests = [
             (
@@ -1674,6 +1808,7 @@ mod tests {
                 .describe_prepared(&session, DescribeTarget::Statement(statement))
                 .await
                 .unwrap();
+            assert_eq!(description.behavior(), sql::StatementBehavior::Read);
             assert_eq!(description.parameter_types(), [DataType::Unknown]);
             assert_eq!(description.columns(), expected.columns());
             assert!(description.returns_rows());
@@ -1699,14 +1834,144 @@ mod tests {
         }
         assert!(observed.windows(2).all(|pair| pair[0] == pair[1]));
         assert_eq!(observed[0].value, PreparedExecution::Rows(expected));
+    }
 
-        assert!(engine.close_portal(&session, insert_portal).await.unwrap());
-        assert!(
+    #[tokio::test]
+    async fn prepared_schema_and_session_statements_are_blocked_without_state_changes_and_recover()
+    {
+        let (temp, engine, database) = engine_with_prepared_catalog(EngineOptions::default());
+        let session = engine.session();
+
+        for (source, expected, object_name) in [
+            (
+                "CREATE TABLE blocked_prepared_schema_table (id INTEGER)",
+                sql::SchemaBehavior::CreateTable,
+                "blocked_prepared_schema_table",
+            ),
+            (
+                "CREATE INDEX blocked_prepared_schema_index ON events (payload)",
+                sql::SchemaBehavior::CreateIndex,
+                "blocked_prepared_schema_index",
+            ),
+        ] {
+            let schema_sql = sql::normalize_placeholders(
+                sql::validate_common_subset(sql::parse(sql::SqlDialect::Sqlite, source).unwrap())
+                    .unwrap(),
+            )
+            .unwrap();
+            let schema_plan = engine
+                .plan_bound_statement(database, &schema_sql, 0, &[], None)
+                .unwrap();
+            assert_eq!(
+                schema_plan.behavior(),
+                sql::StatementBehavior::Schema(expected)
+            );
+            assert_eq!(
+                prepared_execution_shard(&schema_plan, engine.catalog())
+                    .unwrap_err()
+                    .kind(),
+                EngineErrorKind::Unsupported
+            );
+
+            let schema_error = engine
+                .prepare_statement(
+                    &session,
+                    PrepareRequest::new(
+                        database,
+                        sql::SqlDialect::Sqlite,
+                        sql::SqlTranslationMode::StrictSqlite,
+                        source,
+                    ),
+                )
+                .await
+                .unwrap_err();
+            assert_eq!(schema_error.kind(), EngineErrorKind::PermissionDenied);
+            assert_eq!(session.inner.lock().await.prepared().statement_count(), 0);
+            for shard in 0..engine.shard_count() {
+                let connection = rusqlite::Connection::open(
+                    temp.path().join(format!("shards/{shard:04}.sqlite")),
+                )
+                .unwrap();
+                let count = connection
+                    .query_row(
+                        "SELECT COUNT(*) FROM sqlite_schema WHERE name = ?1",
+                        [object_name],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .unwrap();
+                assert_eq!(count, 0);
+            }
+        }
+
+        for (source, expected) in [
+            ("BEGIN", sql::SessionBehavior::Begin),
+            ("COMMIT", sql::SessionBehavior::Commit),
+            ("ROLLBACK", sql::SessionBehavior::Rollback),
+        ] {
+            let statement = engine
+                .prepare_statement(
+                    &session,
+                    PrepareRequest::new(
+                        database,
+                        sql::SqlDialect::Sqlite,
+                        sql::SqlTranslationMode::StrictSqlite,
+                        source,
+                    ),
+                )
+                .await
+                .unwrap();
+            let description = engine
+                .describe_prepared(&session, DescribeTarget::Statement(statement))
+                .await
+                .unwrap();
+            assert_eq!(
+                description.behavior(),
+                sql::StatementBehavior::Session(expected)
+            );
+            assert!(description.columns().is_empty());
+
+            let portal = engine
+                .bind_statement(&session, statement, vec![])
+                .await
+                .unwrap();
+            let error = engine.execute_portal(&session, portal).await.unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::Unsupported);
+            assert_eq!(session.state().await, SessionState::Ready);
+            assert_eq!(session.routing_key().await, None);
+            assert!(engine.close_portal(&session, portal).await.unwrap());
+            assert!(
+                engine
+                    .close_prepared_statement(&session, statement)
+                    .await
+                    .unwrap()
+            );
+        }
+
+        let recovered = engine
+            .prepare_statement(
+                &session,
+                PrepareRequest::new(
+                    database,
+                    sql::SqlDialect::Sqlite,
+                    sql::SqlTranslationMode::StrictSqlite,
+                    "SELECT 1",
+                ),
+            )
+            .await
+            .unwrap();
+        let recovered_portal = engine
+            .bind_statement(&session, recovered, vec![])
+            .await
+            .unwrap();
+        assert!(matches!(
             engine
-                .close_prepared_statement(&session, insert)
+                .execute_portal(&session, recovered_portal)
                 .await
                 .unwrap()
-        );
+                .value,
+            PreparedExecution::Rows(rows)
+                if rows.rows()[0].get(0) == Some(&Value::from(1_i64))
+        ));
     }
 
     #[tokio::test]
@@ -1910,7 +2175,7 @@ mod tests {
 
     #[tokio::test]
     async fn prepared_errors_are_atomic_and_recover_without_losing_valid_handles() {
-        let (_temp, engine, database) = engine_with_prepared_catalog(EngineOptions::default());
+        let (temp, engine, database) = engine_with_prepared_catalog(EngineOptions::default());
         let session = engine.session();
 
         for source in [
@@ -2059,6 +2324,52 @@ mod tests {
             PreparedExecution::Rows(result) if result.is_empty()
         ));
 
+        let global_update = engine
+            .prepare_statement(
+                &session,
+                PrepareRequest::new(
+                    database,
+                    sql::SqlDialect::Sqlite,
+                    sql::SqlTranslationMode::StrictSqlite,
+                    "UPDATE global_events SET code = 1",
+                ),
+            )
+            .await
+            .unwrap();
+        let global_update_description = engine
+            .describe_prepared(&session, DescribeTarget::Statement(global_update))
+            .await
+            .unwrap();
+        assert_eq!(
+            global_update_description.behavior(),
+            sql::StatementBehavior::Write(sql::WriteBehavior::Update)
+        );
+        let global_update_portal = engine
+            .bind_statement(&session, global_update, vec![])
+            .await
+            .unwrap();
+        assert_eq!(
+            engine
+                .execute_portal(&session, global_update_portal)
+                .await
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::Unsupported
+        );
+        for shard in 0..engine.shard_count() {
+            let connection =
+                rusqlite::Connection::open(temp.path().join(format!("shards/{shard:04}.sqlite")))
+                    .unwrap();
+            assert_eq!(
+                connection
+                    .query_row("SELECT COUNT(*) FROM global_events", [], |row| {
+                        row.get::<_, i64>(0)
+                    })
+                    .unwrap(),
+                0
+            );
+        }
+
         let catalog_statement = engine
             .prepare_statement(
                 &session,
@@ -2173,6 +2484,7 @@ mod tests {
             .describe_prepared(&session, DescribeTarget::Statement(statement))
             .await
             .unwrap();
+        assert_eq!(before.behavior(), sql::StatementBehavior::Read);
         assert_eq!(before.columns().len(), 2);
         let portal = engine
             .bind_statement(&session, statement, vec![Value::from(7_i64)])
@@ -2202,6 +2514,7 @@ mod tests {
             .describe_prepared(&session, DescribeTarget::Portal(portal))
             .await
             .unwrap();
+        assert_eq!(after.behavior(), sql::StatementBehavior::Read);
         assert_eq!(after.columns().len(), 3);
         assert!(after.schema_generation() > before.schema_generation());
         assert_eq!(rows.columns(), after.columns());
@@ -2235,6 +2548,7 @@ mod tests {
             .describe_prepared(&session, DescribeTarget::Statement(statement))
             .await
             .unwrap();
+        assert_eq!(before.behavior(), sql::StatementBehavior::Read);
         assert_eq!(before.columns().len(), 2);
 
         engine
@@ -2273,6 +2587,7 @@ mod tests {
             .describe_prepared(&session, DescribeTarget::Statement(statement))
             .await
             .unwrap();
+        assert_eq!(refreshed.behavior(), sql::StatementBehavior::Read);
         assert_eq!(refreshed.columns().len(), 3);
         assert!(refreshed.schema_generation() > before.schema_generation());
     }

--- a/src/core/planner.rs
+++ b/src/core/planner.rs
@@ -4,7 +4,7 @@ use std::{collections::HashMap, fmt, sync::Arc};
 
 use crate::sql::{
     NormalizedSql, RoutedDml, ShardKeyInference, ShardKeyInferenceKind, ShardKeyValue,
-    infer_shard_keys, routed_dml_shape,
+    StatementBehavior, classify_normalized_statements, infer_shard_keys, routed_dml_shape,
 };
 
 use super::{
@@ -46,8 +46,9 @@ impl fmt::Debug for PlannedRoute {
 /// [`ShardKeyInference::values`], including duplicate `INSERT` row values. An
 /// explicit route is retained independently even after routing policy compares
 /// it with inferred routes. A successful plan records the one assigned shard
-/// when the statement has a valid single-shard route. It does not translate SQL
-/// or execute anything.
+/// when the statement has a valid single-shard route and retains its classified
+/// behavior. The complete normalized batch must first satisfy statement-batch
+/// policy. A plan does not translate SQL or execute anything.
 #[derive(Clone, PartialEq, Eq)]
 pub struct BoundStatementPlan {
     database: LogicalDatabaseId,
@@ -57,6 +58,7 @@ pub struct BoundStatementPlan {
     bucket_algorithm_version: u32,
     map_generation: u64,
     statement_index: usize,
+    behavior: StatementBehavior,
     inference: ShardKeyInference,
     inferred_routes: Vec<PlannedRoute>,
     explicit_route: Option<PlannedRoute>,
@@ -99,6 +101,11 @@ impl BoundStatementPlan {
         self.statement_index
     }
 
+    /// Return the authoritative behavior of the selected statement.
+    pub const fn behavior(&self) -> StatementBehavior {
+        self.behavior
+    }
+
     /// Return the typed shard-key inference retained by this plan.
     pub const fn inference(&self) -> &ShardKeyInference {
         &self.inference
@@ -135,6 +142,7 @@ impl fmt::Debug for BoundStatementPlan {
             .field("bucket_algorithm_version", &self.bucket_algorithm_version)
             .field("map_generation", &self.map_generation)
             .field("statement_index", &self.statement_index)
+            .field("behavior", &self.behavior)
             .field("inference", &self.inference)
             .field("inferred_route_count", &self.inferred_routes.len())
             .field("has_explicit_route", &self.explicit_route.is_some())
@@ -212,6 +220,13 @@ where
         parameters,
         explicit_routing_key,
     } = input;
+    let classification = classify_normalized_statements(normalized)?;
+    let behavior = classification.behavior(statement_index).ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            "SQL statement index is outside the normalized batch",
+        )
+    })?;
     let schema_generation = catalog.schema_generation();
     let inference = infer_shard_keys(catalog, database, normalized, statement_index, parameters)?;
     validate_inference_shape(&inference)?;
@@ -277,6 +292,7 @@ where
         bucket_algorithm_version: provenance.bucket_algorithm_version,
         map_generation: provenance.map_generation,
         statement_index,
+        behavior,
         inference,
         inferred_routes,
         explicit_route,
@@ -654,6 +670,10 @@ mod tests {
         )
         .unwrap();
         assert_eq!(plan.clone(), plan);
+        assert_eq!(
+            plan.behavior(),
+            StatementBehavior::Write(crate::sql::WriteBehavior::Insert)
+        );
         assert_eq!(plan.inferred_routes()[0].key_bytes(), b"private-tenant");
         assert_eq!(
             plan.explicit_route().unwrap().key_bytes(),
@@ -1348,7 +1368,7 @@ mod tests {
             "UPDATE events SET payload = 1 WHERE tenant_id = 7; \
              UPDATE events SET tenant_id = 8 WHERE tenant_id = 7",
         );
-        let first = plan_with_router(
+        let batch_error = plan_with_router(
             &catalog,
             DEFAULT_DATABASE,
             &batch,
@@ -1357,14 +1377,35 @@ mod tests {
             None,
             split_test_router,
         )
+        .unwrap_err();
+        assert_eq!(batch_error.kind(), EngineErrorKind::Unsupported);
+
+        let first_update = normalize(
+            SqlDialect::Sqlite,
+            "UPDATE events SET payload = 1 WHERE tenant_id = 7",
+        );
+        let first = plan_with_router(
+            &catalog,
+            DEFAULT_DATABASE,
+            &first_update,
+            0,
+            &[],
+            None,
+            split_test_router,
+        )
         .unwrap();
         assert_eq!(first.assigned_shard(), Some(1));
+
+        let shard_key_update = normalize(
+            SqlDialect::Sqlite,
+            "UPDATE events SET tenant_id = 8 WHERE tenant_id = 7",
+        );
         assert_eq!(
             plan_with_router(
                 &catalog,
                 DEFAULT_DATABASE,
-                &batch,
-                1,
+                &shard_key_update,
+                0,
                 &[],
                 None,
                 split_test_router,
@@ -1606,6 +1647,118 @@ mod tests {
     }
 
     #[test]
+    fn whole_batch_policy_precedes_member_planning_and_allows_read_batches() {
+        let catalog = sample_catalog();
+
+        let empty = normalize(SqlDialect::Sqlite, "-- no statements");
+        let empty_error = plan(&catalog, DEFAULT_DATABASE, &empty, 0, &[], None).unwrap_err();
+        assert_eq!(empty_error.kind(), EngineErrorKind::InvalidArgument);
+        assert_eq!(
+            empty_error.diagnostic(),
+            "a SQL request must contain at least one top-level statement"
+        );
+
+        let schema_batch = normalize(
+            SqlDialect::Sqlite,
+            "SELECT 1; CREATE TABLE later_table (id INTEGER)",
+        );
+        let schema_error = plan(
+            &catalog,
+            DEFAULT_DATABASE,
+            &schema_batch,
+            usize::MAX,
+            &[],
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(schema_error.kind(), EngineErrorKind::Unsupported);
+        assert_eq!(
+            schema_error.diagnostic(),
+            "statement 2 has schema behavior; multi-statement requests may contain only read statements"
+        );
+
+        let session_batch = normalize(
+            SqlDialect::Sqlite,
+            "SELECT payload FROM events WHERE tenant_id = ?1; BEGIN",
+        );
+        let parameter_error = plan_with_router(
+            &catalog,
+            DEFAULT_DATABASE,
+            &session_batch,
+            0,
+            &[],
+            None,
+            split_test_router,
+        )
+        .unwrap_err();
+        assert_eq!(parameter_error.kind(), EngineErrorKind::Unsupported);
+        assert_eq!(
+            parameter_error.diagnostic(),
+            "statement 2 has session behavior; multi-statement requests may contain only read statements"
+        );
+
+        let routing_error = plan_with_router(
+            &catalog,
+            DEFAULT_DATABASE,
+            &session_batch,
+            0,
+            &[Value::Int64(7)],
+            Some(b"8"),
+            split_test_router,
+        )
+        .unwrap_err();
+        assert_eq!(routing_error.kind(), EngineErrorKind::Unsupported);
+        assert_eq!(routing_error.diagnostic(), parameter_error.diagnostic());
+
+        let read_batch = normalize(
+            SqlDialect::Sqlite,
+            "SELECT payload FROM events WHERE tenant_id = ?1; \
+             SELECT payload FROM events WHERE tenant_id = ?1",
+        );
+        let first = plan_with_router(
+            &catalog,
+            DEFAULT_DATABASE,
+            &read_batch,
+            0,
+            &[Value::Int64(7)],
+            None,
+            split_test_router,
+        )
+        .unwrap();
+        let second = plan_with_router(
+            &catalog,
+            DEFAULT_DATABASE,
+            &read_batch,
+            1,
+            &[Value::Int64(8)],
+            None,
+            split_test_router,
+        )
+        .unwrap();
+        assert_eq!(first.behavior(), StatementBehavior::Read);
+        assert_eq!(second.behavior(), StatementBehavior::Read);
+        assert_eq!(first.statement_index(), 0);
+        assert_eq!(second.statement_index(), 1);
+        assert_eq!(first.assigned_shard(), Some(1));
+        assert_eq!(second.assigned_shard(), Some(2));
+
+        let index_error = plan(
+            &catalog,
+            DEFAULT_DATABASE,
+            &read_batch,
+            2,
+            &[Value::Int64(7)],
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(index_error.kind(), EngineErrorKind::InvalidArgument);
+        assert_eq!(
+            index_error.diagnostic(),
+            "SQL statement index is outside the normalized batch"
+        );
+    }
+
+    #[test]
     fn statement_local_batch_indexes_use_statement_local_parameters() {
         let catalog = sample_catalog();
         let normalized = normalize(
@@ -1633,6 +1786,8 @@ mod tests {
         .unwrap();
         assert_eq!(first.statement_index(), 0);
         assert_eq!(second.statement_index(), 1);
+        assert_eq!(first.behavior(), StatementBehavior::Read);
+        assert_eq!(second.behavior(), StatementBehavior::Read);
         assert_eq!(first.inferred_routes()[0].key_bytes(), b"12");
         assert_eq!(second.inferred_routes()[0].key_bytes(), b"34");
 

--- a/src/core/prepared.rs
+++ b/src/core/prepared.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::BTreeMap, fmt, num::NonZeroU64, sync::Arc};
 
-use crate::sql::{SqlDialect, SqlTranslationMode, TranslatedSql};
+use crate::sql::{SqlDialect, SqlTranslationMode, StatementBehavior, TranslatedSql};
 
 use super::{
     Column, DataType, EngineError, EngineErrorKind, EngineResult, LogicalDatabaseId,
@@ -124,9 +124,10 @@ pub enum DescribeTarget {
     Portal(PortalId),
 }
 
-/// Owned parameter and result metadata for a prepared statement.
+/// Owned behavior, parameter, and result metadata for a prepared statement.
 #[derive(Clone, PartialEq, Eq)]
 pub struct PreparedStatementDescription {
+    behavior: StatementBehavior,
     parameter_types: Box<[DataType]>,
     columns: Box<[Column]>,
     schema_generation: u64,
@@ -134,15 +135,22 @@ pub struct PreparedStatementDescription {
 
 impl PreparedStatementDescription {
     pub(crate) fn new(
+        behavior: StatementBehavior,
         parameter_count: usize,
         columns: Vec<Column>,
         schema_generation: u64,
     ) -> Self {
         Self {
+            behavior,
             parameter_types: vec![DataType::Unknown; parameter_count].into_boxed_slice(),
             columns: columns.into_boxed_slice(),
             schema_generation,
         }
+    }
+
+    /// Return the authoritative parsed behavior of this statement.
+    pub const fn behavior(&self) -> StatementBehavior {
+        self.behavior
     }
 
     /// Return one protocol-neutral type for every normalized parameter index.
@@ -173,6 +181,7 @@ impl fmt::Debug for PreparedStatementDescription {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("PreparedStatementDescription")
+            .field("behavior", &self.behavior)
             .field("parameter_count", &self.parameter_types.len())
             .field("column_count", &self.columns.len())
             .field("schema_generation", &self.schema_generation)
@@ -224,6 +233,7 @@ impl fmt::Debug for PreparedTemplate {
             .field("translation_mode", &self.translated.mode())
             .field("source_bytes", &self.translated.source().len())
             .field("sqlite_sql_bytes", &self.translated.sqlite_sql().len())
+            .field("behavior", &self.description.behavior)
             .field("parameter_count", &self.description.parameter_types.len())
             .field("column_count", &self.description.columns.len())
             .field("schema_generation", &self.description.schema_generation)
@@ -630,7 +640,12 @@ mod tests {
     }
 
     fn description(parameters: usize) -> PreparedStatementDescription {
-        PreparedStatementDescription::new(parameters, vec![Column::new("v", DataType::Unknown)], 0)
+        PreparedStatementDescription::new(
+            StatementBehavior::Read,
+            parameters,
+            vec![Column::new("v", DataType::Unknown)],
+            0,
+        )
     }
 
     fn state(max_statements: usize, max_portals: usize, max_bytes: u64) -> PreparedState {
@@ -849,6 +864,7 @@ mod tests {
     #[test]
     fn description_accessors_preserve_counts_and_redact_column_names() {
         let description = PreparedStatementDescription::new(
+            StatementBehavior::Read,
             2,
             vec![
                 Column::new("private_a", DataType::Unknown),
@@ -862,9 +878,23 @@ mod tests {
         );
         assert_eq!(description.columns().len(), 2);
         assert_eq!(description.schema_generation(), 7);
+        assert_eq!(description.behavior(), StatementBehavior::Read);
         assert!(description.returns_rows());
         let debug = format!("{description:?}");
         assert!(!debug.contains("private_a"));
         assert!(!debug.contains("private_b"));
+
+        let command = PreparedStatementDescription::new(
+            StatementBehavior::Write(crate::sql::WriteBehavior::Update),
+            0,
+            vec![],
+            7,
+        );
+        assert_eq!(
+            command.behavior(),
+            StatementBehavior::Write(crate::sql::WriteBehavior::Update)
+        );
+        assert!(!command.returns_rows());
+        assert_ne!(command, description);
     }
 }

--- a/src/sql/classifier.rs
+++ b/src/sql/classifier.rs
@@ -1,0 +1,599 @@
+//! Protocol-neutral statement behavior and request-batch classification.
+
+use std::fmt;
+
+use sqlparser::ast::Statement as AstStatement;
+
+use super::{CommonSql, NormalizedSql};
+use crate::core::{EngineError, EngineErrorKind, EngineResult};
+
+/// The data-changing operation performed by a supported write statement.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum WriteBehavior {
+    /// Insert one or more rows.
+    Insert,
+    /// Update existing rows.
+    Update,
+    /// Delete existing rows.
+    Delete,
+}
+
+/// The schema-changing operation performed by a supported schema statement.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SchemaBehavior {
+    /// Create a table.
+    CreateTable,
+    /// Create an index.
+    CreateIndex,
+}
+
+/// The session operation represented by a supported transaction statement.
+///
+/// This is syntax classification only. Transaction state and shard pinning are
+/// owned by the later protocol-neutral session state machine.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SessionBehavior {
+    /// Begin a transaction.
+    Begin,
+    /// Commit the current transaction.
+    Commit,
+    /// Roll back the current transaction.
+    Rollback,
+}
+
+/// The protocol-neutral behavior of one validated top-level SQL statement.
+///
+/// The behavior comes only from BriskDB's opaque validated AST. It is
+/// independent of source dialect, SQLite compile metadata, routing, catalog
+/// placement, authorization, and the eventual wire protocol.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum StatementBehavior {
+    /// Read rows without changing data, schema, or session state.
+    Read,
+    /// Change application data.
+    Write(WriteBehavior),
+    /// Change the application schema.
+    Schema(SchemaBehavior),
+    /// Change transaction or other session state.
+    Session(SessionBehavior),
+}
+
+impl StatementBehavior {
+    /// Return whether the statement has no data, schema, or session side
+    /// effect according to the validated common SQL subset.
+    pub const fn is_read_only(self) -> bool {
+        matches!(self, Self::Read)
+    }
+
+    const fn category(self) -> &'static str {
+        match self {
+            Self::Read => "read",
+            Self::Write(_) => "write",
+            Self::Schema(_) => "schema",
+            Self::Session(_) => "session",
+        }
+    }
+}
+
+/// Owned ordered behavior metadata for one accepted SQL request batch.
+///
+/// A successful classification is always nonempty. A multi-statement result is
+/// always read-only; batches containing any data, schema, or session change are
+/// rejected atomically by [`classify_statements`]. This result grants no
+/// catalog, routing, authorization, or execution permission.
+#[derive(Clone, PartialEq, Eq)]
+pub struct StatementBatchClassification {
+    behaviors: Box<[StatementBehavior]>,
+}
+
+impl StatementBatchClassification {
+    /// Return one behavior for every top-level statement in source order.
+    pub fn behaviors(&self) -> &[StatementBehavior] {
+        &self.behaviors
+    }
+
+    /// Return the behavior at one zero-based top-level statement index.
+    pub fn behavior(&self, statement_index: usize) -> Option<StatementBehavior> {
+        self.behaviors.get(statement_index).copied()
+    }
+
+    /// Return the number of classified top-level statements.
+    pub fn statement_count(&self) -> usize {
+        self.behaviors.len()
+    }
+
+    /// Return whether every statement in this nonempty accepted batch is
+    /// read-only.
+    pub fn is_read_only(&self) -> bool {
+        self.behaviors
+            .iter()
+            .copied()
+            .all(StatementBehavior::is_read_only)
+    }
+}
+
+impl fmt::Debug for StatementBatchClassification {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StatementBatchClassification")
+            .field("statement_count", &self.statement_count())
+            .field("behaviors", &self.behaviors)
+            .finish()
+    }
+}
+
+/// Classify a validated request and enforce BriskDB's general batch policy.
+///
+/// Empty requests are invalid. Every supported statement family may appear as
+/// a singleton. A request with two or more statements is accepted only when
+/// every statement is read-only. The first non-read statement determines the
+/// deterministic rejection diagnostic; no SQL text or AST formatting is
+/// included.
+pub fn classify_statements(common: &CommonSql) -> EngineResult<StatementBatchClassification> {
+    classify_statement_slice(common.statements())
+}
+
+/// Apply the same whole-request classifier to retained normalized SQL.
+///
+/// Core planning and execution use this helper so normalization cannot become
+/// a path around the public batch policy.
+pub(crate) fn classify_normalized_statements(
+    normalized: &NormalizedSql,
+) -> EngineResult<StatementBatchClassification> {
+    classify_statement_slice(normalized.common().statements())
+}
+
+fn classify_statement_slice(
+    statements: &[AstStatement],
+) -> EngineResult<StatementBatchClassification> {
+    if statements.is_empty() {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            "a SQL request must contain at least one top-level statement",
+        ));
+    }
+
+    let behaviors = statements
+        .iter()
+        .map(classify_statement)
+        .collect::<EngineResult<Box<[_]>>>()?;
+
+    if let Some((index, behavior)) = first_disallowed_batch_behavior(&behaviors) {
+        return Err(EngineError::new(
+            EngineErrorKind::Unsupported,
+            format!(
+                "statement {} has {} behavior; multi-statement requests may contain only read statements",
+                index + 1,
+                behavior.category()
+            ),
+        ));
+    }
+
+    Ok(StatementBatchClassification { behaviors })
+}
+
+fn first_disallowed_batch_behavior(
+    behaviors: &[StatementBehavior],
+) -> Option<(usize, StatementBehavior)> {
+    if behaviors.len() <= 1 {
+        return None;
+    }
+    behaviors
+        .iter()
+        .copied()
+        .enumerate()
+        .find(|(_, behavior)| !behavior.is_read_only())
+}
+
+fn classify_statement(statement: &AstStatement) -> EngineResult<StatementBehavior> {
+    let behavior = match statement {
+        AstStatement::Query(_) => StatementBehavior::Read,
+        AstStatement::Insert(_) => StatementBehavior::Write(WriteBehavior::Insert),
+        AstStatement::Update(_) => StatementBehavior::Write(WriteBehavior::Update),
+        AstStatement::Delete(_) => StatementBehavior::Write(WriteBehavior::Delete),
+        AstStatement::CreateTable(_) => StatementBehavior::Schema(SchemaBehavior::CreateTable),
+        AstStatement::CreateIndex(_) => StatementBehavior::Schema(SchemaBehavior::CreateIndex),
+        AstStatement::StartTransaction { .. } => StatementBehavior::Session(SessionBehavior::Begin),
+        AstStatement::Commit { .. } => StatementBehavior::Session(SessionBehavior::Commit),
+        AstStatement::Rollback { .. } => StatementBehavior::Session(SessionBehavior::Rollback),
+        _ => return Err(classification_invariant()),
+    };
+    Ok(behavior)
+}
+
+fn classification_invariant() -> EngineError {
+    EngineError::new(
+        EngineErrorKind::Internal,
+        "validated SQL contains an unclassified statement type",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{Arc, Barrier},
+        thread,
+    };
+
+    use super::*;
+    use crate::sql::{
+        MAX_PARSED_SQL_STATEMENTS, SqlDialect, normalize_placeholders, parse,
+        validate_common_subset,
+    };
+
+    fn common(dialect: SqlDialect, source: &str) -> EngineResult<CommonSql> {
+        validate_common_subset(parse(dialect, source)?)
+    }
+
+    fn classify(dialect: SqlDialect, source: &str) -> EngineResult<StatementBatchClassification> {
+        classify_statements(&common(dialect, source)?)
+    }
+
+    #[test]
+    fn every_supported_family_has_dialect_independent_behavior() {
+        let cases = [
+            ("SELECT 1", StatementBehavior::Read),
+            (
+                "INSERT INTO widgets (id) VALUES (1)",
+                StatementBehavior::Write(WriteBehavior::Insert),
+            ),
+            (
+                "UPDATE widgets SET id = 1",
+                StatementBehavior::Write(WriteBehavior::Update),
+            ),
+            (
+                "DELETE FROM widgets",
+                StatementBehavior::Write(WriteBehavior::Delete),
+            ),
+            (
+                "CREATE TABLE widgets (id INTEGER)",
+                StatementBehavior::Schema(SchemaBehavior::CreateTable),
+            ),
+            (
+                "CREATE INDEX widgets_id ON widgets (id)",
+                StatementBehavior::Schema(SchemaBehavior::CreateIndex),
+            ),
+            ("BEGIN", StatementBehavior::Session(SessionBehavior::Begin)),
+            (
+                "COMMIT",
+                StatementBehavior::Session(SessionBehavior::Commit),
+            ),
+            (
+                "ROLLBACK",
+                StatementBehavior::Session(SessionBehavior::Rollback),
+            ),
+        ];
+
+        for dialect in SqlDialect::ALL.iter().copied() {
+            for (source, expected) in cases {
+                let classified = classify(dialect, source)
+                    .unwrap_or_else(|error| panic!("{dialect} rejected {source}: {error}"));
+                assert_eq!(classified.behaviors(), [expected], "{dialect}: {source}");
+                assert_eq!(classified.behavior(0), Some(expected));
+                assert_eq!(classified.behavior(1), None);
+                assert_eq!(classified.statement_count(), 1);
+                assert_eq!(classified.is_read_only(), expected.is_read_only());
+            }
+        }
+    }
+
+    #[test]
+    fn transaction_aliases_keep_their_semantic_session_behavior() {
+        for source in ["BEGIN", "BEGIN TRANSACTION", "BEGIN WORK"] {
+            assert_eq!(
+                classify(SqlDialect::PostgreSql, source)
+                    .unwrap()
+                    .behaviors(),
+                [StatementBehavior::Session(SessionBehavior::Begin)]
+            );
+        }
+        for source in [
+            "COMMIT",
+            "COMMIT TRANSACTION",
+            "COMMIT WORK",
+            "COMMIT TRAN",
+            "COMMIT AND NO CHAIN",
+        ] {
+            assert_eq!(
+                classify(SqlDialect::PostgreSql, source)
+                    .unwrap()
+                    .behaviors(),
+                [StatementBehavior::Session(SessionBehavior::Commit)]
+            );
+        }
+        for source in [
+            "ROLLBACK",
+            "ROLLBACK TRANSACTION",
+            "ROLLBACK WORK",
+            "ROLLBACK TRAN",
+            "ROLLBACK AND NO CHAIN",
+            "ABORT",
+            "ABORT AND NO CHAIN",
+        ] {
+            assert_eq!(
+                classify(SqlDialect::PostgreSql, source)
+                    .unwrap()
+                    .behaviors(),
+                [StatementBehavior::Session(SessionBehavior::Rollback)]
+            );
+        }
+    }
+
+    #[test]
+    fn behavior_words_and_semicolons_in_lexical_content_do_not_change_classification() {
+        for (dialect, quoted_alias) in [
+            (SqlDialect::Sqlite, "\"DELETE\""),
+            (SqlDialect::PostgreSql, "\"DELETE\""),
+            (SqlDialect::MySql, "`DELETE`"),
+        ] {
+            let source = format!(
+                "SELECT 'INSERT; UPDATE' AS {quoted_alias} \
+                 /* CREATE TABLE; BEGIN */; \
+                 SELECT 2 AS session_behavior -- COMMIT; ROLLBACK\n"
+            );
+            let classified = classify(dialect, &source).unwrap();
+            assert_eq!(
+                classified.behaviors(),
+                [StatementBehavior::Read, StatementBehavior::Read],
+                "{dialect}: {source}"
+            );
+        }
+    }
+
+    #[test]
+    fn empty_requests_are_invalid_but_every_singleton_behavior_is_accepted() {
+        for source in ["", " ", "-- comment only\n", "/* comment only */"] {
+            let error = classify(SqlDialect::Sqlite, source).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::InvalidArgument);
+            assert_eq!(
+                error.to_string(),
+                "a SQL request must contain at least one top-level statement"
+            );
+        }
+
+        for source in [
+            "SELECT 1",
+            "INSERT INTO widgets (id) VALUES (1)",
+            "CREATE TABLE widgets (id INTEGER)",
+            "BEGIN",
+        ] {
+            assert_eq!(
+                classify(SqlDialect::Sqlite, source)
+                    .unwrap()
+                    .statement_count(),
+                1,
+                "{source}"
+            );
+        }
+    }
+
+    #[test]
+    fn every_pair_of_coarse_behaviors_obeys_the_read_only_batch_matrix() {
+        let representatives = [
+            ("SELECT 1", "read"),
+            ("INSERT INTO widgets (id) VALUES (1)", "write"),
+            ("CREATE TABLE widgets (id INTEGER)", "schema"),
+            ("BEGIN", "session"),
+        ];
+
+        for dialect in SqlDialect::ALL.iter().copied() {
+            for (left, left_category) in representatives.iter().copied() {
+                for (right, right_category) in representatives.iter().copied() {
+                    let source = format!("{left}; {right}");
+                    if left_category == "read" && right_category == "read" {
+                        let classified = classify(dialect, &source).unwrap();
+                        assert_eq!(classified.behaviors(), [StatementBehavior::Read; 2]);
+                        assert!(classified.is_read_only());
+                        continue;
+                    }
+
+                    let (ordinal, category) = if left_category == "read" {
+                        (2, right_category)
+                    } else {
+                        (1, left_category)
+                    };
+                    let error = classify(dialect, &source).unwrap_err();
+                    assert_eq!(
+                        error.kind(),
+                        EngineErrorKind::Unsupported,
+                        "{dialect}: {source}"
+                    );
+                    assert_eq!(
+                        error.to_string(),
+                        format!(
+                            "statement {ordinal} has {category} behavior; multi-statement requests may contain only read statements"
+                        )
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn first_non_read_statement_deterministically_controls_rejection() {
+        for (source, ordinal, category) in [
+            (
+                "UPDATE widgets SET id = 1; CREATE TABLE later (id INTEGER); BEGIN",
+                1,
+                "write",
+            ),
+            (
+                "SELECT 1; CREATE TABLE later (id INTEGER); DELETE FROM widgets",
+                2,
+                "schema",
+            ),
+            (
+                "SELECT 1; SELECT 2; COMMIT; INSERT INTO widgets (id) VALUES (1)",
+                3,
+                "session",
+            ),
+        ] {
+            let error = classify(SqlDialect::Sqlite, source).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::Unsupported);
+            assert!(error.diagnostic().contains(&format!("statement {ordinal}")));
+            assert!(error.diagnostic().contains(category));
+        }
+    }
+
+    #[test]
+    fn parser_statement_boundaries_remain_exact() {
+        let maximum = std::iter::repeat_n("SELECT 1", MAX_PARSED_SQL_STATEMENTS)
+            .collect::<Vec<_>>()
+            .join(";");
+        let classified = classify(SqlDialect::Sqlite, &maximum).unwrap();
+        assert_eq!(classified.statement_count(), MAX_PARSED_SQL_STATEMENTS);
+        assert!(classified.is_read_only());
+
+        let last_write = format!(
+            "{}; UPDATE widgets SET id = 1",
+            std::iter::repeat_n("SELECT 1", MAX_PARSED_SQL_STATEMENTS - 1)
+                .collect::<Vec<_>>()
+                .join(";")
+        );
+        let error = classify(SqlDialect::Sqlite, &last_write).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Unsupported);
+        assert!(
+            error
+                .diagnostic()
+                .contains(&format!("statement {MAX_PARSED_SQL_STATEMENTS}"))
+        );
+
+        let over_limit = format!("{maximum}; SELECT 1");
+        let error = classify(SqlDialect::Sqlite, &over_limit).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+    }
+
+    #[test]
+    fn earlier_frontend_errors_precede_batch_policy_and_later_normalization() {
+        let unsupported = parse(
+            SqlDialect::Sqlite,
+            "SELECT 1; CREATE VIEW private_view AS SELECT 2",
+        )
+        .and_then(validate_common_subset)
+        .and_then(|common| classify_statements(&common))
+        .unwrap_err();
+        assert_eq!(unsupported.kind(), EngineErrorKind::Unsupported);
+        assert!(unsupported.diagnostic().contains("statement 2"));
+        assert!(unsupported.diagnostic().contains("common SQL subset"));
+
+        let common = common(
+            SqlDialect::Sqlite,
+            "SELECT 1; UPDATE widgets SET id = :private_marker",
+        )
+        .unwrap();
+        let batch_error = classify_statements(&common).unwrap_err();
+        assert_eq!(batch_error.kind(), EngineErrorKind::Unsupported);
+        assert!(batch_error.diagnostic().contains("statement 2"));
+        let marker_error = normalize_placeholders(common).unwrap_err();
+        assert_eq!(marker_error.kind(), EngineErrorKind::Unsupported);
+    }
+
+    #[test]
+    fn an_impossible_unvalidated_statement_family_is_an_internal_invariant() {
+        let parsed = parse(SqlDialect::Sqlite, "DROP TABLE private_table").unwrap();
+        let error = classify_statement(&parsed.statements()[0]).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Internal);
+        assert_eq!(
+            error.to_string(),
+            "validated SQL contains an unclassified statement type"
+        );
+        assert!(!error.diagnostic().contains("private_table"));
+    }
+
+    #[test]
+    fn diagnostics_and_debug_never_render_source_sql() {
+        let source = "SELECT 'private literal'; UPDATE private_table SET private_column = 1";
+        let error = classify(SqlDialect::Sqlite, source).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Unsupported);
+        for private in [source, "private literal", "private_table", "private_column"] {
+            assert!(!error.diagnostic().contains(private));
+        }
+
+        let classified = classify(
+            SqlDialect::Sqlite,
+            "SELECT 'private literal'; SELECT private_column FROM private_table",
+        )
+        .unwrap();
+        let debug = format!("{classified:?}");
+        assert!(debug.contains("statement_count"));
+        assert!(debug.contains("Read"));
+        for private in ["private literal", "private_table", "private_column"] {
+            assert!(!debug.contains(private));
+        }
+    }
+
+    #[test]
+    fn classification_is_owned_thread_safe_deterministic_and_recoverable() {
+        fn assert_owned<T: Clone + Send + Sync + 'static>() {}
+        assert_owned::<StatementBatchClassification>();
+        assert_owned::<StatementBehavior>();
+        assert_owned::<WriteBehavior>();
+        assert_owned::<SchemaBehavior>();
+        assert_owned::<SessionBehavior>();
+
+        let shared_common =
+            Arc::new(common(SqlDialect::PostgreSql, "SELECT $1; SELECT $2; SELECT $1").unwrap());
+        let expected = classify_statements(&shared_common).unwrap();
+        let workers = (0..24)
+            .map(|_| {
+                let common = Arc::clone(&shared_common);
+                thread::spawn(move || classify_statements(&common).unwrap())
+            })
+            .collect::<Vec<_>>();
+        for worker in workers {
+            assert_eq!(worker.join().unwrap(), expected);
+        }
+
+        let rejected =
+            Arc::new(common(SqlDialect::Sqlite, "SELECT 1; DELETE FROM private_table").unwrap());
+        let expected_error = classify_statements(&rejected).unwrap_err();
+        assert_eq!(expected_error.kind(), EngineErrorKind::Unsupported);
+        let barrier = Arc::new(Barrier::new(25));
+        let workers = (0..24)
+            .map(|_| {
+                let common = Arc::clone(&rejected);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    classify_statements(&common).unwrap_err()
+                })
+            })
+            .collect::<Vec<_>>();
+        barrier.wait();
+        for worker in workers {
+            let error = worker.join().unwrap();
+            assert_eq!(error.kind(), EngineErrorKind::Unsupported);
+            assert_eq!(error.diagnostic(), expected_error.diagnostic());
+        }
+
+        assert_eq!(
+            classify(SqlDialect::Sqlite, "SELECT 1; SELECT 2")
+                .unwrap()
+                .behaviors(),
+            [StatementBehavior::Read; 2]
+        );
+    }
+
+    #[test]
+    fn normalized_helper_applies_the_identical_whole_batch_policy() {
+        let read_common = common(SqlDialect::MySql, "SELECT ?; SELECT ?").unwrap();
+        let public = classify_statements(&read_common).unwrap();
+        let normalized = normalize_placeholders(read_common).unwrap();
+        assert_eq!(classify_normalized_statements(&normalized).unwrap(), public);
+
+        let mixed_common = common(
+            SqlDialect::MySql,
+            "SELECT ?; INSERT INTO widgets (id) VALUES (?)",
+        )
+        .unwrap();
+        let public_error = classify_statements(&mixed_common).unwrap_err();
+        let normalized = normalize_placeholders(mixed_common).unwrap();
+        let helper_error = classify_normalized_statements(&normalized).unwrap_err();
+        assert_eq!(helper_error.kind(), public_error.kind());
+        assert_eq!(helper_error.diagnostic(), public_error.diagnostic());
+    }
+}

--- a/src/sql/dml.rs
+++ b/src/sql/dml.rs
@@ -15,7 +15,9 @@ pub(crate) enum RoutedDml {
 
 /// Inspect only the DML details needed by single-shard routing policy.
 ///
-/// Full statement behavior and batch classification remain a separate layer.
+/// Full statement behavior and batch policy live in the separate public
+/// classifier; this helper retains the extra assignment detail needed only by
+/// sharded-write planning.
 pub(crate) fn routed_dml_shape(
     normalized: &NormalizedSql,
     statement_index: usize,

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -2,11 +2,13 @@
 //!
 //! The parser facade produces a bounded, dialect-explicit opaque AST. The
 //! common-subset validator recursively admits only protocol-neutral SQL shapes,
-//! and the placeholder normalizer produces a separate source-preserving SQLite
-//! parameter representation for later planning work. Current execution remains
-//! deliberate SQLite pass-through; these opt-in layers do not gate, route, or
-//! execute statements.
+//! the statement classifier identifies protocol-neutral behavior and enforces
+//! read-only multi-statement batches, and the placeholder normalizer produces a
+//! separate source-preserving SQLite parameter representation for later
+//! planning work. Current HTTP execution remains deliberate SQLite pass-through;
+//! these opt-in layers do not route or execute statements.
 
+mod classifier;
 mod dml;
 mod inference;
 mod normalizer;
@@ -14,8 +16,13 @@ mod parser;
 mod subset;
 mod translator;
 
+pub(crate) use classifier::classify_normalized_statements;
 pub(crate) use dml::{RoutedDml, routed_dml_shape};
 
+pub use classifier::{
+    SchemaBehavior, SessionBehavior, StatementBatchClassification, StatementBehavior,
+    WriteBehavior, classify_statements,
+};
 pub use inference::{ShardKeyInference, ShardKeyInferenceKind, ShardKeyValue, infer_shard_keys};
 pub use normalizer::{
     MAX_SQL_PARAMETERS, NormalizedSql, StatementParameters, normalize_placeholders,

--- a/src/sql/subset.rs
+++ b/src/sql/subset.rs
@@ -83,7 +83,7 @@ impl fmt::Debug for CommonSql {
 ///
 /// The batch is validated atomically and retains its exact source and order.
 /// Empty batches and otherwise-valid statement combinations are accepted here;
-/// a later classification layer owns request-level batch policy.
+/// [`super::classify_statements`] separately owns request-level batch policy.
 pub fn validate_common_subset(parsed: ParsedSql) -> EngineResult<CommonSql> {
     let mut statement_placeholders = Vec::with_capacity(parsed.statement_count());
     for (index, statement) in parsed.statements().iter().enumerate() {

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -260,6 +260,106 @@ fn common_sql_subset_validation_is_public_owned_and_opt_in() {
 }
 
 #[test]
+fn statement_classification_is_public_typed_ordered_and_conservative() {
+    fn assert_owned_public<T: Clone + Send + Sync + 'static>() {}
+    fn assert_copy_public<T: Copy + Eq + std::hash::Hash + Send + Sync + 'static>() {}
+
+    assert_owned_public::<sql::StatementBatchClassification>();
+    assert_copy_public::<sql::StatementBehavior>();
+    assert_copy_public::<sql::WriteBehavior>();
+    assert_copy_public::<sql::SchemaBehavior>();
+    assert_copy_public::<sql::SessionBehavior>();
+
+    let families = [
+        ("SELECT 1", sql::StatementBehavior::Read),
+        (
+            "INSERT INTO widgets (id) VALUES (1)",
+            sql::StatementBehavior::Write(sql::WriteBehavior::Insert),
+        ),
+        (
+            "UPDATE widgets SET id = 2 WHERE id = 1",
+            sql::StatementBehavior::Write(sql::WriteBehavior::Update),
+        ),
+        (
+            "DELETE FROM widgets WHERE id = 1",
+            sql::StatementBehavior::Write(sql::WriteBehavior::Delete),
+        ),
+        (
+            "CREATE TABLE widgets (id INTEGER)",
+            sql::StatementBehavior::Schema(sql::SchemaBehavior::CreateTable),
+        ),
+        (
+            "CREATE INDEX widgets_id ON widgets (id)",
+            sql::StatementBehavior::Schema(sql::SchemaBehavior::CreateIndex),
+        ),
+        (
+            "BEGIN",
+            sql::StatementBehavior::Session(sql::SessionBehavior::Begin),
+        ),
+        (
+            "COMMIT",
+            sql::StatementBehavior::Session(sql::SessionBehavior::Commit),
+        ),
+        (
+            "ROLLBACK",
+            sql::StatementBehavior::Session(sql::SessionBehavior::Rollback),
+        ),
+    ];
+
+    for dialect in sql::SqlDialect::ALL.iter().copied() {
+        for &(source, expected) in &families {
+            let common = sql::validate_common_subset(sql::parse(dialect, source).unwrap()).unwrap();
+            let classification = sql::classify_statements(&common).unwrap();
+            assert_eq!(classification.statement_count(), 1);
+            assert_eq!(classification.behaviors(), [expected]);
+            assert_eq!(classification.behavior(0), Some(expected));
+            assert_eq!(classification.behavior(1), None);
+            assert_eq!(
+                classification.is_read_only(),
+                expected == sql::StatementBehavior::Read
+            );
+            assert_eq!(
+                expected.is_read_only(),
+                expected == sql::StatementBehavior::Read
+            );
+        }
+
+        let private_source =
+            "SELECT 'private-read-one' AS value; SELECT 'private-read-two' AS value";
+        let common =
+            sql::validate_common_subset(sql::parse(dialect, private_source).unwrap()).unwrap();
+        let classification = sql::classify_statements(&common).unwrap();
+        assert_eq!(
+            classification.behaviors(),
+            [sql::StatementBehavior::Read, sql::StatementBehavior::Read]
+        );
+        assert!(classification.is_read_only());
+        let debug = format!("{classification:?}");
+        assert!(!debug.contains("private-read-one"));
+        assert!(!debug.contains("private-read-two"));
+
+        let blocked_source =
+            "SELECT 'private-batch-value'; INSERT INTO private_table (id) VALUES (1)";
+        let blocked_common =
+            sql::validate_common_subset(sql::parse(dialect, blocked_source).unwrap()).unwrap();
+        let blocked = sql::classify_statements(&blocked_common).unwrap_err();
+        assert_eq!(blocked.kind(), core::EngineErrorKind::Unsupported);
+        assert!(blocked.diagnostic().contains("statement 2"));
+        assert!(!blocked.diagnostic().contains("private-batch-value"));
+        assert!(!blocked.diagnostic().contains("private_table"));
+        assert_eq!(blocked_common.source(), blocked_source);
+    }
+
+    let empty = sql::validate_common_subset(
+        sql::parse(sql::SqlDialect::Sqlite, "-- private empty batch").unwrap(),
+    )
+    .unwrap();
+    let error = sql::classify_statements(&empty).unwrap_err();
+    assert_eq!(error.kind(), core::EngineErrorKind::InvalidArgument);
+    assert!(!error.diagnostic().contains("private empty batch"));
+}
+
+#[test]
 fn placeholder_normalization_is_public_owned_bounded_and_opt_in() {
     fn assert_owned_public<T: Clone + Send + Sync + 'static>() {}
     assert_owned_public::<sql::NormalizedSql>();
@@ -569,6 +669,10 @@ async fn bound_statement_planning_is_public_owned_value_aware_and_opt_in() {
     assert_eq!(plan.bucket_algorithm_version(), 1);
     assert_eq!(plan.map_generation(), 1);
     assert_eq!(plan.statement_index(), 0);
+    assert_eq!(
+        plan.behavior(),
+        sql::StatementBehavior::Write(sql::WriteBehavior::Insert)
+    );
     assert_eq!(
         plan.inference().kind(),
         sql::ShardKeyInferenceKind::Multiple
@@ -974,6 +1078,10 @@ async fn prepared_lifecycle_is_public_owned_and_protocol_neutral() {
         .await
         .unwrap();
     assert_eq!(
+        insert_description.behavior(),
+        sql::StatementBehavior::Write(sql::WriteBehavior::Insert)
+    );
+    assert_eq!(
         insert_description.parameter_types(),
         [core::DataType::Unknown]
     );
@@ -1008,6 +1116,7 @@ async fn prepared_lifecycle_is_public_owned_and_protocol_neutral() {
         .describe_prepared(&session, core::DescribeTarget::Portal(select_portal))
         .await
         .unwrap();
+    assert_eq!(description.behavior(), sql::StatementBehavior::Read);
     assert_eq!(description.parameter_types(), [core::DataType::Unknown]);
     assert_eq!(
         description.columns(),


### PR DESCRIPTION
## Summary

- add a protocol-neutral read/write/schema/session taxonomy with precise write, schema, and session subtypes
- reject empty requests and permit multi-statement batches only when every member is a read
- retain behavior in bound plans and prepared descriptions, and use it for prepared target/result decisions
- document the classifier, error precedence, compatibility, storage, and raw HTTP boundaries

## Tests

- [x] Unit tests were added or updated for behavior-changing code.
- [x] Boundary/integration tests cover planning, prepared execution, every source dialect, concurrent calls, and recovery.
- [x] `cargo fmt --all --check` passes.
- [x] `cargo test --locked --all-targets --all-features` passes.
- [x] `cargo test --locked --doc --all-features` passes.
- [x] `cargo clippy --locked --all-targets --all-features -- -D warnings` passes.
- [x] Rust 1.85 all-target and doc-test suites pass.

## Compatibility and operations

- [x] Public behavior and compatibility documentation were updated.
- [x] Storage-format, migration, and recovery effects were considered; no format or configuration changes are introduced.
- [x] Existing raw HTTP execute/query/migration behavior remains unchanged.

Closes #27