### PR TITLE
Add configurable PostgreSQL listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ The [architecture map](docs/ARCHITECTURE.md) defines the crate's module
 boundaries and dependency direction.
 
 The [SQL compatibility contract](docs/SQL_COMPATIBILITY.md) distinguishes the
-current SQLite pass-through API from planned PostgreSQL and MySQL compatibility.
+current SQLite pass-through API from the PostgreSQL TCP-listener scaffold and
+planned PostgreSQL/MySQL wire compatibility.
+The [PostgreSQL listener contract](docs/POSTGRES_LISTENER.md) defines its
+address configuration, disabled state, startup order, placeholder connection
+behavior, and shared shutdown lifecycle.
 The [SQL parser decision record](docs/SQL_PARSER.md) defines the shared,
 dialect-explicit syntax boundary and its resource and dependency limits.
 The [common SQL subset contract](docs/SQL_SUBSET.md) defines the opt-in,
@@ -37,7 +41,7 @@ statement and portal caches, exact resource limits, metadata refresh, and
 supported physical-target execution boundary shared by future adapters.
 The [error contract](docs/ERRORS.md) defines stable engine error kinds, safe
 HTTP problem details, and the mappings reserved for future PostgreSQL and MySQL
-adapters.
+wire adapters.
 The [request-control contract](docs/REQUEST_CONTROLS.md) defines cancellation,
 deadlines, materialized-result budgets, and graceful shutdown.
 The [manifest storage-format contract](docs/STORAGE_FORMAT.md) defines versioned
@@ -60,6 +64,8 @@ minimum supported Rust version (MSRV) and the latest stable toolchain.
 - Request cancellation and deadlines that interrupt SQLite and await cleanup
 - Finite per-query row/logical-byte budgets with no partial results
 - Explicit graceful drain, forced cancellation, and blocking handle cleanup
+- Independently configured HTTP and PostgreSQL TCP listeners; the PostgreSQL
+  listener currently accepts and closes connections pending wire-adapter work
 - Protocol-neutral typed values, ordered columns, positional rows, and results
 - A bounded per-session prepared-statement and immutable bound-portal lifecycle
   with transient shard-0 metadata compilation, bind-time routing snapshots,
@@ -100,8 +106,26 @@ briskdb-data/
 cargo run -- --data-dir ./briskdb-data --shards 4
 ```
 
-The default listener is `127.0.0.1:7654`. Configuration can also be supplied
-with `BRISKDB_LISTEN`, `BRISKDB_DATA_DIR`, and `BRISKDB_SHARDS`.
+The HTTP listener defaults to `127.0.0.1:7654`. The separate PostgreSQL TCP
+listener defaults to `127.0.0.1:5433`. Set either an explicit socket address or
+the exact value `disabled` with `--postgres-listen`; the corresponding
+environment variable is `BRISKDB_POSTGRES_LISTEN`. Command-line input takes
+precedence over the environment, which takes precedence over the default. The
+HTTP address, data directory, and shard count can also be supplied with
+`BRISKDB_LISTEN`, `BRISKDB_DATA_DIR`, and `BRISKDB_SHARDS`.
+
+```bash
+# Keep the existing HTTP service and do not bind the PostgreSQL port.
+cargo run -- --postgres-listen disabled
+
+# The environment has the same value grammar.
+BRISKDB_POSTGRES_LISTEN=disabled cargo run
+```
+
+Issue #28 supplies only the separately managed TCP endpoint. Until the
+PostgreSQL wire adapter lands, every accepted connection is closed immediately
+without reading or writing protocol bytes, and no PostgreSQL driver can execute
+a request through it. See the [listener contract](docs/POSTGRES_LISTENER.md).
 
 Rust embedders can customize pool sizing through the public `EngineOptions`
 type. Existing engine constructors and server startup keep the defaults of four
@@ -118,9 +142,11 @@ data. Configure these with `--max-result-rows` / `BRISKDB_MAX_RESULT_ROWS` and
 shutdown allows 30 seconds before cancelling admitted work and is configured by
 `--shutdown-grace-ms` / `BRISKDB_SHUTDOWN_GRACE_MS`. Ctrl-C and, on Unix,
 SIGTERM stop new admissions, drain or cancel admitted SQLite work, close idle
-handles, and then stop the process. Accepted HTTP connections are tracked;
-connections that outlive the grace window are force-closed and joined before
-the server returns.
+handles, and then stop the process. Core admission closes before both listener
+sockets are dropped. Accepted HTTP connections are tracked; connections
+that outlive the grace window are force-closed and joined before the server
+returns. Placeholder PostgreSQL connections have already been closed at
+accept time and retain no engine work to drain.
 
 Each session defaults to at most 128 prepared statements, 128 bound portals,
 and a 16 MiB ceiling for retained bound values/captured routing bytes and one

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -223,7 +223,7 @@ the engine regardless of its eventual wire protocol.
 
 ### 4. PostgreSQL wire-protocol frontend
 
-- [ ] Run a separate configurable listener, initially
+- [x] Run a separate configurable listener, initially
   `--postgres-listen 127.0.0.1:5433`; allow it to be disabled.
 - [ ] Spike the current `pgwire` crate against the core interfaces before
   committing to it; `pgwire` 0.40.5 is the leading candidate as of this roadmap.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,12 +11,14 @@ binary (main)
     v
 server ---------> protocol::http
     |                    |
-    +--------+-----------+
-             v
-            core
-           /    \
-          v      v
-      storage    sql
+    |                    v
+    +-----------------> core
+    |                 /    \
+    |                v      v
+    |            storage    sql
+    |
+    +-- PostgreSQL TCP lifecycle
+        (accept/close placeholder; no core request)
 ```
 
 | Module | Responsibility | Must not own |
@@ -26,7 +28,7 @@ server ---------> protocol::http
 | `sql` | Dialect-explicit SQL syntax parsing, recursive common-subset validation, protocol-neutral statement/batch classification, source-preserving placeholder normalization, explicit strict/compatibility translation, catalog-aware typed shard-key inference, and narrow crate-private DML-shape inspection behind BriskDB-owned boundaries; exact source retention; SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, key hashing or shard selection, mutable session state, physical write-routing policy, filesystem layout, protocol responses, protocol-buffer ownership, or protocol-specific support policy |
 | `protocol::http` | HTTP request extraction plus JSON/BriskDB value and RFC 9457 problem-detail encoding | BLAKE3 routing, shard files, or rusqlite calls |
 | `protocol::error` | Exhaustive HTTP, PostgreSQL, and MySQL mappings from stable engine error kinds | SQLite errors, routing decisions, or wire-protocol session state |
-| `server` | Process configuration, database assembly, listener binding, and tracked Axum HTTP/1 connection lifecycle | SQL parsing or storage implementation details |
+| `server` | Process configuration, database assembly, separate HTTP/PostgreSQL listener binding, tracked Axum HTTP/1 connection lifecycle, and the temporary PostgreSQL accept/close loop | SQL parsing, PostgreSQL wire messages, or storage implementation details |
 
 Implementation dependencies flow one way: adapters call the async `Engine` in
 `core`; the engine coordinates routing, `storage`, and `sql`. An adapter supplies
@@ -79,7 +81,25 @@ already complete. The async engine, session and prepared-object lifecycle,
 bounded per-session caches, bounded per-shard pools, request controls, and
 explicit shutdown lifecycle are now in place. The synchronous `Database` API
 remains available as a Rust compatibility surface; existing engine and server
-entry points retain their signatures and delegate to the controlled defaults.
+function signatures remain in place and delegate to the controlled defaults.
+Issue #28 adds `Config::postgres_listen: Option<SocketAddr>`, so pre-1.0 Rust
+callers constructing `Config` with a struct literal must now choose an enabled
+address or `None`.
+
+## Listener boundary
+
+The HTTP address remains `Config::listen`. The independent
+`Config::postgres_listen` is either a numeric socket address or disabled with
+`None`; the binary maps the exact `disabled` CLI/environment sentinel to that
+option. The process default enables loopback `127.0.0.1:5433`. See the
+[PostgreSQL listener contract](POSTGRES_LISTENER.md) for the full grammar and
+startup order.
+
+Until the subsequent wire-adapter work, the PostgreSQL listener is a server
+lifecycle placeholder: it accepts and immediately drops each stream without
+reading bytes, writing a PostgreSQL frame, opening a session, or calling the
+engine. This keeps binding, concurrent acceptance, startup cleanup, and shared
+shutdown testable without moving protocol behavior into `server`.
 
 ## SQL parser boundary
 
@@ -627,13 +647,16 @@ this explicit asynchronous path. Prepared statement/portal close and terminal
 session close remain available as in-memory cleanup while draining; no
 prepared state is persisted for restart recovery.
 
-The server owns accepted HTTP/1 connections in a tracked task set. It stops
-engine admission before dropping the listener, starts HTTP and core draining
-together, and aborts then joins any connection that exceeds the HTTP grace
-deadline. Signal receivers are installed before readiness is logged. Dropping
-the server future aborts its tracked connection set and synchronously enters
-`Draining`; a surviving embedder-owned `Engine` clone can resume asynchronous
-cleanup with `shutdown()`.
+The server owns accepted HTTP/1 connections in a tracked task set and manages a
+separate optional PostgreSQL socket in the same accept lifecycle. It stops
+engine admission before dropping both listeners, starts HTTP and core draining
+together, and aborts then joins any HTTP connection that exceeds the HTTP grace
+deadline. Placeholder PostgreSQL streams are already closed at accept time and
+therefore own no drain task. Signal receivers are installed only after every
+configured listener binds and before readiness is logged. Dropping the server
+future closes both listeners, aborts its tracked HTTP connection set, and
+synchronously enters `Draining`; a surviving embedder-owned `Engine` clone can
+resume asynchronous cleanup with `shutdown()`.
 
 Real multi-call `BEGIN`/`COMMIT`/`ROLLBACK`, failed-transaction state, and
 single-shard pinning remain deferred to the PostgreSQL and MySQL transaction
@@ -654,8 +677,9 @@ response type. SQL and storage classify SQLite failures from primary and
 extended result codes plus operation context; they never parse SQLite error
 messages. Protocol-owned tables map each kind to an HTTP status and safe RFC
 9457 problem, a PostgreSQL SQLSTATE, and a MySQL error number/SQLSTATE pair.
-The PostgreSQL and MySQL entries are mapping contracts for future adapters, not
-implemented listeners.
+The PostgreSQL and MySQL entries are mapping contracts for future wire
+adapters. The PostgreSQL TCP placeholder emits no protocol frame and therefore
+does not encode the PostgreSQL mapping yet; no MySQL listener exists yet.
 
 Client responses use fixed, safe text for the error kind. Diagnostic display
 text and source chains stay available internally but are never serialized, so

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -4,7 +4,14 @@ BriskDB classifies failures once, at the protocol-neutral engine boundary. An
 `EngineErrorKind` is stable error identity; protocol adapters translate that
 identity without inspecting an error message. The HTTP adapter uses the mapping
 today. The PostgreSQL and MySQL columns below are contracts for their planned
-adapters, not a claim that either wire-protocol listener is implemented.
+wire adapters. The current PostgreSQL TCP placeholder accepts and closes
+without emitting an error frame, and there is no MySQL listener yet.
+
+Malformed listener configuration is rejected by the binary before server
+startup. Listener bind/accept failures terminate the shared server lifecycle
+with process-level diagnostics after cleanup; they are not `EngineErrorKind`
+values and are not encoded as HTTP or PostgreSQL responses. A placeholder
+PostgreSQL peer receives only a no-byte connection close.
 
 ## Taxonomy and protocol mappings
 

--- a/docs/POSTGRES_LISTENER.md
+++ b/docs/POSTGRES_LISTENER.md
@@ -1,0 +1,126 @@
+# PostgreSQL listener lifecycle
+
+Issue #28 adds the process and TCP-lifecycle boundary for a future PostgreSQL
+wire adapter. It deliberately does not implement a PostgreSQL startup packet,
+authentication, query flow, error response, or any other wire message.
+
+## Process configuration
+
+The binary exposes one value with one grammar:
+
+| Source | Default | Enabled value | Disabled value |
+| --- | --- | --- | --- |
+| CLI | `--postgres-listen 127.0.0.1:5433` | numeric `SocketAddr`, such as `127.0.0.1:6543` or `[::1]:6543` | `--postgres-listen disabled` |
+| Environment | `BRISKDB_POSTGRES_LISTEN=127.0.0.1:5433` | the same numeric `SocketAddr` grammar | `BRISKDB_POSTGRES_LISTEN=disabled` |
+
+An explicit command-line value wins over the environment; the environment wins
+over the default. `disabled` is the exact lowercase sentinel. Empty values,
+hostnames, address strings without a port, and aliases such as `off` or `none`
+are rejected during command-line parsing. Port zero retains the standard
+`SocketAddr` meaning of asking the operating system to select a port.
+
+The existing `--listen` / `BRISKDB_LISTEN` setting remains the always-enabled
+HTTP address and retains its `127.0.0.1:7654` default. The two listeners are
+configured independently; this issue does not rename the HTTP option or add an
+HTTP-disabled mode.
+
+## Rust server configuration
+
+`server::Config::postgres_listen` is `Option<SocketAddr>`:
+
+- `Some(address)` binds and serves the placeholder PostgreSQL listener;
+- `None` skips its bind, accept branch, and shutdown work.
+
+The process-only `disabled` spelling is converted to `None` before calling the
+server library, so embedders never parse a command-line sentinel. Adding this
+field to the public pre-1.0 `Config` struct is a source-shape change for callers
+that construct it with a literal; those callers must choose `Some(address)` or
+`None`. The signatures of `server::run` and
+`server::run_with_engine_options` are unchanged.
+
+## Startup and failure order
+
+Startup has one deterministic order:
+
+1. clap parses every CLI/environment value and `Args::into_server_parts`
+   validates resource options;
+2. the engine opens the configured data directory, including existing startup
+   recovery and shard validation;
+3. the HTTP listener binds;
+4. the PostgreSQL listener binds when configured;
+5. process signal receivers are installed; and
+6. readiness is logged and the accept loop starts.
+
+The server never logs readiness after only one of two configured listeners has
+bound. Preserving HTTP-first binding means an HTTP bind conflict is reported
+before a PostgreSQL bind is attempted. If the PostgreSQL bind fails, the
+already-bound HTTP listener is dropped, the engine enters its normal shutdown
+path, cleanup is awaited, and the original PostgreSQL bind error is returned.
+The same cleanup applies if signal setup fails. A disabled PostgreSQL listener
+cannot cause a bind failure, even if the default port is already in use.
+
+Engine open precedes network binding to retain BriskDB's existing startup
+ordering. Consequently, an open may finish an already-recorded storage recovery
+before a later listener bind fails. That durable recovery is not rolled back;
+after the address becomes available, starting the same data directory again is
+the supported retry.
+
+## Placeholder connection behavior
+
+While issue #28 is the latest completed PostgreSQL item, the listener accepts
+each TCP connection and immediately drops the stream:
+
+- it reads no client bytes;
+- it writes no server bytes or PostgreSQL error frame;
+- the peer observes EOF/connection close;
+- no `Engine` session, prepared statement, portal, route, or SQLite operation
+  is created; and
+- accepted placeholder connections are not retained as background tasks.
+
+Continuously accepting and closing prevents the operating-system backlog from
+filling while making the incomplete wire behavior deterministic. Emitting even
+a nominal PostgreSQL frame is deferred to the BriskDB-owned adapter selected by
+the following roadmap work. This TCP scaffold must not be described as a
+usable PostgreSQL interface.
+
+HTTP acceptance and placeholder PostgreSQL acceptance share one server
+lifecycle. Neither listener implements routing, parsing, planning, or SQLite
+access; those remain behind the protocol-neutral `Engine` boundary.
+
+## Shutdown and recovery
+
+SIGINT and, on supported Unix hosts, SIGTERM first stop new engine admissions.
+Both TCP listeners are then dropped. Existing HTTP connection tasks drain under
+the configured grace period alongside core shutdown. PostgreSQL placeholder
+streams need no drain because they are closed as soon as they are accepted.
+
+An accept failure on either listener ends the shared server: both listeners
+close, HTTP tasks drain, and the engine completes its normal shutdown. Dropping
+the server future closes both listener sockets and enters the same resumable
+`Draining` engine state already documented for HTTP-only operation.
+
+## Compatibility and storage boundary
+
+This issue adds no dependency on `pgwire` or another PostgreSQL implementation.
+It changes no HTTP route, JSON body, SQL subset, planner rule, typed result,
+engine error mapping, manifest table, shard header, migration journal, stored
+row, or storage-format version. Listener settings are process configuration and
+are not persisted in `manifest.sqlite` or a shard.
+
+The PostgreSQL SQLSTATE table remains a tested mapping for the future adapter;
+the placeholder emits none of those mappings. The next roadmap items own the
+adapter dependency and PostgreSQL startup/session messages.
+
+## Verification contract
+
+Automated coverage includes:
+
+- default, explicit IPv4/IPv6, environment, CLI-over-environment, disabled, and
+  malformed configuration cases;
+- both listeners serving concurrently while the HTTP health path remains live;
+- immediate close for one and many concurrent placeholder clients;
+- disabled mode skipping PostgreSQL binding;
+- PostgreSQL bind-failure cleanup and a clean retry of the data directory;
+- ordinary graceful shutdown and dropped-server-future recovery with both
+  listeners configured; and
+- unchanged public HTTP behavior and unchanged storage version.

--- a/docs/REQUEST_CONTROLS.md
+++ b/docs/REQUEST_CONTROLS.md
@@ -1,8 +1,9 @@
 # Request controls and shutdown
 
 BriskDB applies cancellation, deadlines, result budgets, and shutdown at the
-protocol-neutral `Engine` boundary. HTTP and future PostgreSQL/MySQL adapters
-therefore share the same resource and cleanup semantics.
+protocol-neutral `Engine` boundary. HTTP and future PostgreSQL/MySQL wire
+adapters therefore share the same resource and cleanup semantics. The current
+PostgreSQL TCP placeholder never creates an engine request.
 
 ## Per-request context
 
@@ -185,12 +186,15 @@ for an admitted same-session operation, then clears every statement, portal,
 captured route/value, and routing context. Nothing in the prepared cache is
 persisted or recovered after process shutdown.
 
-The server constructs its SIGINT/SIGTERM receivers before logging readiness on
-supported Unix hosts. It transitions the engine to `Draining` before dropping
-the listener and signaling each tracked HTTP/1 connection. HTTP draining and
-core shutdown start together. A connection still active at the HTTP grace
-deadline is aborted and joined before server shutdown returns; core cleanup may
-continue through its separately documented forced-cleanup grace. A forced
-cancellation cannot erase committed schema-migration progress: the current
-shard transaction rolls back if still running, the retained prefix remains
-resumable, and the next startup finishes it before serving ordinary work.
+The server constructs its SIGINT/SIGTERM receivers after every configured
+listener binds and before logging readiness on supported Unix hosts. It
+transitions the engine to `Draining` before dropping both the HTTP listener and
+the optional PostgreSQL listener and signaling each tracked HTTP/1 connection.
+HTTP draining and core shutdown start together. A connection still active at
+the HTTP grace deadline is aborted and joined before server shutdown returns;
+accepted PostgreSQL placeholder streams were closed immediately and own no
+task to drain. Core cleanup may continue through its separately documented
+forced-cleanup grace. A forced cancellation cannot erase committed
+schema-migration progress: the current shard transaction rolls back if still
+running, the retained prefix remains resumable, and the next startup finishes
+it before serving ordinary work.

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -45,9 +45,12 @@ than claiming to be a drop-in PostgreSQL or MySQL replacement.
 
 ## Current implementation
 
-Only the experimental HTTP network interface is implemented today. There is no
-PostgreSQL or MySQL listener. The public Rust SQL facade can parse an explicitly
-selected SQLite, PostgreSQL, or MySQL dialect, consume that result with
+Only the experimental HTTP network interface can execute network requests
+today. A separately configured PostgreSQL TCP listener now accepts and
+immediately closes streams as a lifecycle scaffold; it implements no
+PostgreSQL wire message. There is no MySQL listener. The public Rust SQL facade
+can parse an explicitly selected SQLite, PostgreSQL, or MySQL dialect, consume
+that result with
 `validate_common_subset(ParsedSql)`, borrow the result with
 `classify_statements(&CommonSql)`, and then opt into
 `normalize_placeholders(CommonSql)`. That step yields source-preserving SQLite
@@ -79,13 +82,14 @@ path; they do not pass through these opt-in SQL layers.
 | HTTP `/v1/execute` | Experimental | One SQLite statement with positional parameters | Required caller-provided `shard_key` |
 | HTTP `/v1/query` | Experimental | One raw SQLite statement prepared transiently by the row-returning path; no session cache | Required caller-provided `shard_key` |
 | HTTP `/v1/admin/broadcast` | Experimental | A journaled parameterless SQLite schema batch | Preflight on every shard, then ascending resumable apply |
-| PostgreSQL wire protocol | Planned | Rust parsing, validation, classification, placeholder normalization, finite compatibility translation, and prepared lifecycle implemented; listener adoption planned | Core batch/write policy, bind validation, routing snapshots, current execute-time planning, and supported target execution implemented; wire mapping planned |
+| PostgreSQL wire protocol | TCP lifecycle scaffold; wire protocol planned | Rust parsing, validation, classification, placeholder normalization, finite compatibility translation, and prepared lifecycle implemented; placeholder listener accepts then closes without protocol bytes | Core batch/write policy, bind validation, routing snapshots, current execute-time planning, and supported target execution implemented; wire mapping planned |
 | MySQL wire protocol | Planned | Rust parsing, validation, classification, placeholder normalization, finite compatibility translation, and prepared lifecycle implemented; listener adoption planned | Core batch/write policy, bind validation, routing snapshots, current execute-time planning, and supported target execution implemented; wire mapping planned |
 
 The parser, subset validator, statement classifier, placeholder normalizer, SQL
 translator, shard-key inference function, engine planner, and prepared
 lifecycle are implemented Rust APIs, not PostgreSQL or MySQL network
-interfaces. They do not change any current HTTP row in this table.
+interfaces. The PostgreSQL socket scaffold does not connect those APIs to the
+network. They do not change any current HTTP row in this table.
 
 Every HTTP operation now calls the same protocol-neutral async engine intended
 for future PostgreSQL and MySQL adapters. Execute and query requests create a
@@ -274,8 +278,9 @@ to choose an error kind.
 
 The same kinds already have defined PostgreSQL SQLSTATE and MySQL error
 number/SQLSTATE mappings, but those are contracts for the planned adapters.
-They do not make either wire-protocol listener available. See the complete
-[error taxonomy and mapping table](ERRORS.md).
+The PostgreSQL TCP placeholder emits no error frame, and no MySQL listener is
+available. See the complete [error taxonomy and mapping table](ERRORS.md) and
+the [PostgreSQL listener lifecycle](POSTGRES_LISTENER.md).
 
 ## SQL surface
 
@@ -592,9 +597,12 @@ boundary are normative in
 
 ## PostgreSQL differences
 
-The PostgreSQL listener will target the frontend/backend wire protocol and a
-deliberately small SQL compatibility surface. PostgreSQL-specific behavior is
-not implemented unless listed as implemented in this document.
+The bound PostgreSQL TCP scaffold will host an adapter targeting the
+frontend/backend wire protocol and a deliberately small SQL compatibility
+surface. It currently accepts and closes without a handshake; PostgreSQL-
+specific behavior is not implemented unless listed as implemented in this
+document. Configuration and lifecycle semantics are normative in the
+[PostgreSQL listener contract](POSTGRES_LISTENER.md).
 
 | Area | PostgreSQL | BriskDB contract |
 | --- | --- | --- |

--- a/docs/SQL_PREPARED_STATEMENTS.md
+++ b/docs/SQL_PREPARED_STATEMENTS.md
@@ -395,8 +395,10 @@ handling to that type.
 
 ## Dialect and adapter compatibility
 
-The lifecycle is implemented as a Rust engine API, not yet as a PostgreSQL or
-MySQL listener. All three input paths share the same planning and result path:
+The lifecycle is implemented as a Rust engine API and is not yet connected to
+a wire adapter. The PostgreSQL TCP scaffold accepts and closes without creating
+a session; there is no MySQL listener. All three typed input paths share the
+same planning and result path:
 
 | Input | Required mode and parameter form | Prepared execution result |
 | --- | --- | --- |

--- a/docs/SQL_STATEMENT_CLASSIFICATION.md
+++ b/docs/SQL_STATEMENT_CLASSIFICATION.md
@@ -219,6 +219,8 @@ query, and migration endpoints remain raw SQLite surfaces and do not invoke the
 opt-in common frontend. In particular, the journaled migration endpoint keeps
 its own bounded, parameterless SQLite batch contract and can accept a schema
 batch that the general common-SQL classifier deliberately rejects.
+Issue #28 subsequently adds only the PostgreSQL TCP accept/close scaffold; it
+does not connect that socket to classification or any other SQL layer.
 
 ## Storage-format and configuration boundary
 

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -898,6 +898,14 @@ parameterless schema-batch contract: it still digests and retains the caller's
 exact submitted SQL and does not substitute classified, normalized, or
 translated text as migration identity.
 
+Issue #28's optional PostgreSQL socket address and accept/close listener are
+process configuration only. They add no manifest or shard table, header value,
+format version, digest input, routing metadata, schema fingerprint, journal
+record, or recovery step. Listener settings are not persisted. Because engine
+open and its existing recovery precede listener binding, a later bind failure
+does not undo a migration or recovery transaction that already committed; a
+subsequent startup revalidates the same version-7 layout normally.
+
 The checksums are corruption detectors, not authentication. Both use unkeyed
 BLAKE3 and are writable by anyone who can modify the data directory. The
 manifest root covers canonical control-plane values, not raw SQLite pages. The

--- a/docs/SUPPORTED_PLATFORMS.md
+++ b/docs/SUPPORTED_PLATFORMS.md
@@ -30,6 +30,15 @@ tested `Engine` drain/cancel/cleanup lifecycle; platform-specific
 service-manager integration beyond those signals is not yet part of the support
 contract.
 
+The supported runner tests separate Tokio TCP listeners on numeric IPv4
+loopback addresses, concurrent HTTP and PostgreSQL-placeholder acceptance,
+disabled PostgreSQL binding, bind-failure cleanup, and shutdown of both
+listeners. Numeric IPv6 `SocketAddr` parsing is part of the CLI contract; an
+individual host must still provide the requested address family. The
+PostgreSQL endpoint is currently an accept/close lifecycle scaffold, not a wire
+compatibility claim. Its exact process behavior is documented in
+[PostgreSQL listener lifecycle](POSTGRES_LISTENER.md).
+
 ## Development-tested targets
 
 Maintainers also develop and run the full suite on `aarch64-apple-darwin`.
@@ -74,9 +83,10 @@ application-schema migration step; see the
 [manifest storage-format contract](STORAGE_FORMAT.md). After manifest load or
 upgrade, an active schema migration is resumed before ordinary layout
 reconciliation and final strict shard validation. All startup work finishes
-before the server accepts requests. Outside the explicit `Creating` state,
-every shard is opened read-write with SQLite create and symbolic-link following
-disabled. A missing, extra canonical, swapped, foreign, non-WAL, or
+before either server listener accepts requests. Outside the explicit
+`Creating` state, every shard is opened read-write with SQLite create and
+symbolic-link following disabled. A missing, extra canonical, swapped,
+foreign, non-WAL, or
 wrong-generation shard file is rejected, as is a shard cloned into another slot
 or layout. It is not recreated, reassigned, or silently reconfigured. Recovery
 requires restoring the correct complete layout.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::{net::SocketAddr, path::PathBuf, time::Duration};
+use std::{net::SocketAddr, path::PathBuf, str::FromStr, time::Duration};
 
 use briskdb::{
     core::{
@@ -13,12 +13,57 @@ use briskdb::{
 use clap::Parser;
 use tracing_subscriber::EnvFilter;
 
+const DEFAULT_POSTGRES_LISTEN: &str = "127.0.0.1:5433";
+
+/// Command-line representation of an optional TCP listener.
+///
+/// Keeping the `disabled` sentinel at the process boundary means the public
+/// server API can use `Option<SocketAddr>` without carrying CLI spelling into
+/// Rust callers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ListenerSetting {
+    Address(SocketAddr),
+    Disabled,
+}
+
+impl ListenerSetting {
+    const fn into_option(self) -> Option<SocketAddr> {
+        match self {
+            Self::Address(address) => Some(address),
+            Self::Disabled => None,
+        }
+    }
+}
+
+impl FromStr for ListenerSetting {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if value == "disabled" {
+            return Ok(Self::Disabled);
+        }
+
+        value.parse::<SocketAddr>().map(Self::Address).map_err(|_| {
+            format!("expected a socket address or the exact value 'disabled', got '{value}'")
+        })
+    }
+}
+
 #[derive(Debug, Parser)]
 #[command(version, about)]
 struct Args {
     /// Address on which the HTTP server listens.
     #[arg(long, env = "BRISKDB_LISTEN", default_value = "127.0.0.1:7654")]
     listen: SocketAddr,
+
+    /// PostgreSQL TCP listener address, or `disabled` to turn it off.
+    #[arg(
+        long,
+        env = "BRISKDB_POSTGRES_LISTEN",
+        default_value = DEFAULT_POSTGRES_LISTEN,
+        value_name = "SOCKET_ADDR|disabled"
+    )]
+    postgres_listen: ListenerSetting,
 
     /// Directory containing the manifest and shard files.
     #[arg(long, env = "BRISKDB_DATA_DIR", default_value = "./briskdb-data")]
@@ -123,6 +168,7 @@ impl Args {
                 .with_shutdown_grace(Duration::from_millis(self.shutdown_grace_ms))?;
         let config = Config {
             listen: self.listen,
+            postgres_listen: self.postgres_listen.into_option(),
             data_dir: self.data_dir,
             shards: self.shards,
         };
@@ -155,6 +201,10 @@ mod tests {
         let args = Args::try_parse_from(["briskdb"]).unwrap();
 
         assert_eq!(args.listen, "127.0.0.1:7654".parse().unwrap());
+        assert_eq!(
+            args.postgres_listen,
+            ListenerSetting::Address(DEFAULT_POSTGRES_LISTEN.parse().unwrap())
+        );
         assert_eq!(args.data_dir, PathBuf::from("./briskdb-data"));
         assert_eq!(args.shards, 4);
         assert_eq!(args.connections_per_shard, DEFAULT_CONNECTIONS_PER_SHARD);
@@ -186,6 +236,8 @@ mod tests {
             "briskdb",
             "--listen",
             "127.0.0.1:9000",
+            "--postgres-listen",
+            "127.0.0.1:9543",
             "--data-dir",
             "/tmp/briskdb-test-data",
             "--shards",
@@ -212,6 +264,10 @@ mod tests {
         .unwrap();
 
         assert_eq!(args.listen, "127.0.0.1:9000".parse().unwrap());
+        assert_eq!(
+            args.postgres_listen,
+            ListenerSetting::Address("127.0.0.1:9543".parse().unwrap())
+        );
         assert_eq!(args.data_dir, PathBuf::from("/tmp/briskdb-test-data"));
         assert_eq!(args.shards, 8);
         assert_eq!(args.connections_per_shard, 3);
@@ -231,6 +287,8 @@ mod tests {
             "briskdb",
             "--listen",
             "127.0.0.1:9000",
+            "--postgres-listen",
+            "127.0.0.1:9543",
             "--data-dir",
             "/tmp/briskdb-test-data",
             "--shards",
@@ -261,6 +319,7 @@ mod tests {
             config,
             Config {
                 listen: "127.0.0.1:9000".parse().unwrap(),
+                postgres_listen: Some("127.0.0.1:9543".parse().unwrap()),
                 data_dir: PathBuf::from("/tmp/briskdb-test-data"),
                 shards: 8,
             }
@@ -332,8 +391,53 @@ mod tests {
     }
 
     #[test]
+    fn postgres_listener_can_be_disabled_explicitly() {
+        let args = Args::try_parse_from(["briskdb", "--postgres-listen", "disabled"]).unwrap();
+        assert_eq!(args.postgres_listen, ListenerSetting::Disabled);
+
+        let (config, _) = args.into_server_parts().unwrap();
+        assert_eq!(config.postgres_listen, None);
+    }
+
+    #[test]
+    fn postgres_listener_accepts_ipv4_and_ipv6_socket_addresses() {
+        for (input, expected) in [
+            ("127.0.0.1:6543", "127.0.0.1:6543"),
+            ("[::1]:6543", "[::1]:6543"),
+        ] {
+            let args = Args::try_parse_from(["briskdb", "--postgres-listen", input]).unwrap();
+            assert_eq!(
+                args.postgres_listen,
+                ListenerSetting::Address(expected.parse().unwrap())
+            );
+        }
+    }
+
+    #[test]
+    fn malformed_postgres_listener_values_fail_during_cli_parsing() {
+        for value in [
+            "",
+            "off",
+            "none",
+            "DISABLED",
+            "localhost:5433",
+            "127.0.0.1",
+            "127.0.0.1:not-a-port",
+        ] {
+            assert!(
+                Args::try_parse_from(["briskdb", "--postgres-listen", value]).is_err(),
+                "value should be rejected: {value:?}"
+            );
+        }
+    }
+
+    #[test]
     fn resource_flags_are_bound_to_the_documented_environment_variables() {
         let command = Args::command();
+        let postgres_listener = command
+            .get_arguments()
+            .find(|argument| argument.get_id() == "postgres_listen")
+            .unwrap();
         let connections = command
             .get_arguments()
             .find(|argument| argument.get_id() == "connections_per_shard")
@@ -371,6 +475,10 @@ mod tests {
             .find(|argument| argument.get_id() == "shutdown_grace_ms")
             .unwrap();
 
+        assert_eq!(
+            postgres_listener.get_env(),
+            Some(OsStr::new("BRISKDB_POSTGRES_LISTEN"))
+        );
         assert_eq!(
             connections.get_env(),
             Some(OsStr::new("BRISKDB_CONNECTIONS_PER_SHARD"))
@@ -412,6 +520,10 @@ mod tests {
 
         if std::env::var_os(CHILD_MARKER).is_some() {
             let args = Args::try_parse_from(["briskdb"]).unwrap();
+            assert_eq!(
+                args.postgres_listen,
+                ListenerSetting::Address("127.0.0.1:6543".parse().unwrap())
+            );
             assert_eq!(args.connections_per_shard, 6);
             assert_eq!(args.queue_capacity_per_shard, 41);
             assert_eq!(args.max_result_rows, 500);
@@ -431,6 +543,7 @@ mod tests {
             ])
             .env(CHILD_MARKER, "1")
             .env("BRISKDB_LISTEN", "127.0.0.1:7654")
+            .env("BRISKDB_POSTGRES_LISTEN", "127.0.0.1:6543")
             .env("BRISKDB_DATA_DIR", "./briskdb-env-test-data")
             .env("BRISKDB_SHARDS", "4")
             .env("BRISKDB_CONNECTIONS_PER_SHARD", "6")
@@ -446,5 +559,98 @@ mod tests {
             .unwrap();
 
         assert!(status.success());
+    }
+
+    #[test]
+    fn postgres_listener_address_and_disabled_state_parse_from_environment() {
+        const CHILD_MARKER: &str = "BRISKDB_POSTGRES_LISTENER_ENV_TEST_CHILD";
+
+        if let Some(expected) = std::env::var_os(CHILD_MARKER) {
+            let args = Args::try_parse_from(["briskdb"]).unwrap();
+            match expected.to_str().unwrap() {
+                "address" => assert_eq!(
+                    args.postgres_listen,
+                    ListenerSetting::Address("127.0.0.1:7543".parse().unwrap())
+                ),
+                "disabled" => assert_eq!(args.postgres_listen, ListenerSetting::Disabled),
+                unexpected => panic!("unexpected child case {unexpected}"),
+            }
+            return;
+        }
+
+        for (value, expected) in [("127.0.0.1:7543", "address"), ("disabled", "disabled")] {
+            let status = std::process::Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "--exact",
+                    "tests::postgres_listener_address_and_disabled_state_parse_from_environment",
+                ])
+                .env(CHILD_MARKER, expected)
+                .env("BRISKDB_POSTGRES_LISTEN", value)
+                .status()
+                .unwrap();
+            assert!(status.success(), "environment case failed: {expected}");
+        }
+    }
+
+    #[test]
+    fn explicit_postgres_listener_cli_value_overrides_environment() {
+        const CHILD_MARKER: &str = "BRISKDB_POSTGRES_LISTENER_PRECEDENCE_TEST_CHILD";
+
+        if let Some(expected) = std::env::var_os(CHILD_MARKER) {
+            match expected.to_str().unwrap() {
+                "disabled" => {
+                    let args =
+                        Args::try_parse_from(["briskdb", "--postgres-listen", "disabled"]).unwrap();
+                    assert_eq!(args.postgres_listen, ListenerSetting::Disabled);
+                }
+                "address" => {
+                    let args =
+                        Args::try_parse_from(["briskdb", "--postgres-listen", "127.0.0.1:9543"])
+                            .unwrap();
+                    assert_eq!(
+                        args.postgres_listen,
+                        ListenerSetting::Address("127.0.0.1:9543".parse().unwrap())
+                    );
+                }
+                unexpected => panic!("unexpected child case {unexpected}"),
+            }
+            return;
+        }
+
+        for (environment, expected) in [("127.0.0.1:8543", "disabled"), ("disabled", "address")] {
+            let status = std::process::Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "--exact",
+                    "tests::explicit_postgres_listener_cli_value_overrides_environment",
+                ])
+                .env(CHILD_MARKER, expected)
+                .env("BRISKDB_POSTGRES_LISTEN", environment)
+                .status()
+                .unwrap();
+            assert!(status.success(), "precedence case failed: {expected}");
+        }
+    }
+
+    #[test]
+    fn malformed_postgres_listener_environment_value_is_rejected() {
+        const CHILD_MARKER: &str = "BRISKDB_POSTGRES_LISTENER_BAD_ENV_TEST_CHILD";
+
+        if std::env::var_os(CHILD_MARKER).is_some() {
+            assert!(Args::try_parse_from(["briskdb"]).is_err());
+            return;
+        }
+
+        for value in ["", "localhost:5433"] {
+            let status = std::process::Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "--exact",
+                    "tests::malformed_postgres_listener_environment_value_is_rejected",
+                ])
+                .env(CHILD_MARKER, "1")
+                .env("BRISKDB_POSTGRES_LISTEN", value)
+                .status()
+                .unwrap();
+            assert!(status.success(), "environment value should fail: {value:?}");
+        }
     }
 }

--- a/src/protocol/error.rs
+++ b/src/protocol/error.rs
@@ -1,7 +1,8 @@
 //! Safe protocol representations of protocol-neutral engine errors.
 //!
-//! PostgreSQL and MySQL listeners are not implemented yet. Their records here
-//! are the tested compatibility contract those adapters will consume.
+//! The PostgreSQL TCP placeholder emits no wire messages, and no MySQL listener
+//! exists yet. These records are the tested compatibility contract their wire
+//! adapters will consume.
 
 use crate::core::EngineErrorKind;
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -21,8 +21,40 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Config {
     pub listen: SocketAddr,
+    pub postgres_listen: Option<SocketAddr>,
     pub data_dir: PathBuf,
     pub shards: u16,
+}
+
+#[derive(Debug)]
+struct BoundListeners {
+    http: tokio::net::TcpListener,
+    postgres: Option<tokio::net::TcpListener>,
+}
+
+impl BoundListeners {
+    async fn bind(config: &Config) -> anyhow::Result<Self> {
+        let http = tokio::net::TcpListener::bind(config.listen)
+            .await
+            .with_context(|| format!("failed to bind {}", config.listen))?;
+        let postgres = match config.postgres_listen {
+            Some(address) => Some(
+                tokio::net::TcpListener::bind(address)
+                    .await
+                    .with_context(|| format!("failed to bind PostgreSQL listener {address}"))?,
+            ),
+            None => None,
+        };
+        Ok(Self { http, postgres })
+    }
+
+    #[cfg(test)]
+    fn http_only(http: tokio::net::TcpListener) -> Self {
+        Self {
+            http,
+            postgres: None,
+        }
+    }
 }
 
 pub async fn run(config: Config) -> anyhow::Result<()> {
@@ -36,11 +68,8 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
 /// [`EngineOptions::default`].
 pub async fn run_with_engine_options(config: Config, options: EngineOptions) -> anyhow::Result<()> {
     let engine = Engine::open_with_options(&config.data_dir, config.shards, options).await?;
-    let listener = match tokio::net::TcpListener::bind(config.listen)
-        .await
-        .with_context(|| format!("failed to bind {}", config.listen))
-    {
-        Ok(listener) => listener,
+    let listeners = match BoundListeners::bind(&config).await {
+        Ok(listeners) => listeners,
         Err(error) => {
             engine.begin_shutdown();
             if let Err(shutdown_error) = engine.shutdown().await {
@@ -65,6 +94,7 @@ pub async fn run_with_engine_options(config: Config, options: EngineOptions) -> 
 
     info!(
         listen = %config.listen,
+        postgres_listen = ?config.postgres_listen,
         data_dir = %config.data_dir.display(),
         shards = engine.shard_count(),
         max_blocking_workers = engine.options().connections_per_shard()
@@ -93,22 +123,41 @@ pub async fn run_with_engine_options(config: Config, options: EngineOptions) -> 
         "BriskDB is ready"
     );
 
-    serve_with_shutdown(listener, engine, signal).await
+    serve_listeners_with_shutdown(listeners, engine, signal).await
 }
 
-async fn serve_with_shutdown<F>(
-    listener: tokio::net::TcpListener,
+async fn serve_listeners_with_shutdown<F>(
+    listeners: BoundListeners,
     engine: Engine,
     signal: F,
 ) -> anyhow::Result<()>
 where
     F: Future<Output = ()> + Send,
 {
-    serve_with_shutdown_observed(listener, engine, signal, None).await
+    serve_listeners_with_shutdown_observed(listeners, engine, signal, None).await
 }
 
+#[cfg(test)]
 async fn serve_with_shutdown_observed<F>(
     listener: tokio::net::TcpListener,
+    engine: Engine,
+    signal: F,
+    accepted: Option<Arc<Notify>>,
+) -> anyhow::Result<()>
+where
+    F: Future<Output = ()> + Send,
+{
+    serve_listeners_with_shutdown_observed(
+        BoundListeners::http_only(listener),
+        engine,
+        signal,
+        accepted,
+    )
+    .await
+}
+
+async fn serve_listeners_with_shutdown_observed<F>(
+    listeners: BoundListeners,
     engine: Engine,
     signal: F,
     accepted: Option<Arc<Notify>>,
@@ -130,37 +179,49 @@ where
             Some(result) = connections.join_next(), if !connections.is_empty() => {
                 log_connection_join(result, false);
             }
-            accepted_connection = listener.accept() => {
-                let (stream, peer) = match accepted_connection {
-                    Ok(connection) => connection,
-                    Err(error) => {
+            accepted_connection = accept_next_connection(&listeners) => {
+                match accepted_connection {
+                    ListenerAccept::Http(Ok((stream, peer))) => {
+                        let accepted = accepted.clone();
+                        let service = TowerToHyperService::new(router.clone().map_request(
+                            move |request: Request<Incoming>| {
+                                if let Some(accepted) = &accepted {
+                                    accepted.notify_one();
+                                }
+                                request.map(Body::new)
+                            },
+                        ));
+                        let graceful_rx = graceful_tx.subscribe();
+                        connections.spawn(async move {
+                            serve_http_connection(stream, peer, service, graceful_rx).await;
+                        });
+                    }
+                    ListenerAccept::Http(Err(error)) => {
                         server_error = Some(
                             anyhow::Error::from(error).context("HTTP listener accept failed")
                         );
                         break;
                     }
-                };
-                let accepted = accepted.clone();
-                let service = TowerToHyperService::new(router.clone().map_request(
-                    move |request: Request<Incoming>| {
-                        if let Some(accepted) = &accepted {
-                            accepted.notify_one();
-                        }
-                        request.map(Body::new)
-                    },
-                ));
-                let graceful_rx = graceful_tx.subscribe();
-                connections.spawn(async move {
-                    serve_http_connection(stream, peer, service, graceful_rx).await;
-                });
+                    ListenerAccept::Postgres(Ok((stream, peer))) => {
+                        debug!(%peer, "closing connection before PostgreSQL wire support is enabled");
+                        drop(stream);
+                    }
+                    ListenerAccept::Postgres(Err(error)) => {
+                        server_error = Some(
+                            anyhow::Error::from(error)
+                                .context("PostgreSQL listener accept failed")
+                        );
+                        break;
+                    }
+                }
             }
         }
     }
 
-    // Admission must close before the listener and connection signals so an
+    // Admission must close before the listeners and connection signals so an
     // already-accepted request cannot enter the core after draining starts.
     engine.begin_shutdown();
-    drop(listener);
+    drop(listeners);
     let http_grace = engine.options().shutdown_grace();
     let core_shutdown = engine.shutdown();
     let http_shutdown = drain_http_connections(graceful_tx, &mut connections, http_grace);
@@ -173,6 +234,27 @@ where
         return Err(server_error);
     }
     Ok(())
+}
+
+enum ListenerAccept {
+    Http(std::io::Result<(tokio::net::TcpStream, SocketAddr)>),
+    Postgres(std::io::Result<(tokio::net::TcpStream, SocketAddr)>),
+}
+
+async fn accept_next_connection(listeners: &BoundListeners) -> ListenerAccept {
+    tokio::select! {
+        accepted = listeners.http.accept() => ListenerAccept::Http(accepted),
+        accepted = accept_optional(&listeners.postgres) => ListenerAccept::Postgres(accepted),
+    }
+}
+
+async fn accept_optional(
+    listener: &Option<tokio::net::TcpListener>,
+) -> std::io::Result<(tokio::net::TcpStream, SocketAddr)> {
+    match listener {
+        Some(listener) => listener.accept().await,
+        None => std::future::pending().await,
+    }
 }
 
 async fn serve_http_connection<S>(
@@ -352,7 +434,30 @@ mod tests {
             }
         })
         .await
-        .expect("the tracked HTTP peer should be closed");
+        .expect("the peer should be closed");
+    }
+
+    async fn assert_peer_closes_without_bytes(stream: &mut tokio::net::TcpStream) {
+        let mut buffer = [0_u8; 1_024];
+        match timeout(Duration::from_secs(1), stream.read(&mut buffer)).await {
+            Ok(Ok(0) | Err(_)) => {}
+            Ok(Ok(bytes)) => panic!("the placeholder wrote {bytes} unexpected bytes"),
+            Err(_) => panic!("the placeholder should close without writing bytes"),
+        }
+    }
+
+    async fn read_http_health(address: SocketAddr) -> Vec<u8> {
+        let mut stream = tokio::net::TcpStream::connect(address).await.unwrap();
+        stream
+            .write_all(b"GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+            .await
+            .unwrap();
+        let mut response = Vec::new();
+        timeout(Duration::from_secs(1), stream.read_to_end(&mut response))
+            .await
+            .expect("the HTTP health response should complete")
+            .unwrap();
+        response
     }
 
     fn partial_json_request(content_length: usize) -> Vec<u8> {
@@ -370,6 +475,7 @@ mod tests {
         let (_occupied_listener, listen) = unavailable_address();
         let error = run(Config {
             listen,
+            postgres_listen: None,
             data_dir: data_dir.clone(),
             shards: 1,
         })
@@ -389,6 +495,7 @@ mod tests {
         let error = run_with_engine_options(
             Config {
                 listen,
+                postgres_listen: None,
                 data_dir: data_dir.clone(),
                 shards: 64,
             },
@@ -406,7 +513,89 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn injected_signal_stops_the_listener_and_fully_stops_the_engine() {
+    async fn configured_listeners_bind_enabled_and_disabled_postgres_modes() {
+        let temp = tempfile::tempdir().unwrap();
+        let enabled = BoundListeners::bind(&Config {
+            listen: "127.0.0.1:0".parse().unwrap(),
+            postgres_listen: Some("127.0.0.1:0".parse().unwrap()),
+            data_dir: temp.path().to_path_buf(),
+            shards: 2,
+        })
+        .await
+        .unwrap();
+        let http_address = enabled.http.local_addr().unwrap();
+        let postgres_address = enabled.postgres.as_ref().unwrap().local_addr().unwrap();
+        assert_ne!(http_address, postgres_address);
+        drop(enabled);
+
+        let disabled = BoundListeners::bind(&Config {
+            listen: "127.0.0.1:0".parse().unwrap(),
+            postgres_listen: None,
+            data_dir: temp.path().to_path_buf(),
+            shards: 2,
+        })
+        .await
+        .unwrap();
+        assert!(disabled.postgres.is_none());
+    }
+
+    #[tokio::test]
+    async fn http_bind_failure_precedes_postgres_bind_and_cleans_up_the_engine() {
+        let temp = tempfile::tempdir().unwrap();
+        let (_http_reservation, http_address) = unavailable_address();
+        let (_postgres_reservation, postgres_address) = unavailable_address();
+
+        let error = run(Config {
+            listen: http_address,
+            postgres_listen: Some(postgres_address),
+            data_dir: temp.path().to_path_buf(),
+            shards: 2,
+        })
+        .await
+        .unwrap_err();
+        assert_eq!(error.to_string(), format!("failed to bind {http_address}"));
+
+        let reopened = Engine::open(temp.path(), 2)
+            .await
+            .expect("the startup engine should complete cleanup after the HTTP bind failure");
+        reopened.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn postgres_bind_failure_releases_http_listener_and_engine() {
+        let temp = tempfile::tempdir().unwrap();
+        let (http_reservation, http_address) = unavailable_address();
+        drop(http_reservation);
+        let (postgres_reservation, postgres_address) = unavailable_address();
+        let config = Config {
+            listen: http_address,
+            postgres_listen: Some(postgres_address),
+            data_dir: temp.path().to_path_buf(),
+            shards: 2,
+        };
+
+        let error = run(config.clone()).await.unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            format!("failed to bind PostgreSQL listener {postgres_address}")
+        );
+
+        let rebound = std::net::TcpListener::bind(http_address)
+            .expect("the partially started HTTP listener should be released");
+        drop(rebound);
+        let reopened = Engine::open(temp.path(), 2)
+            .await
+            .expect("the startup engine should complete cleanup after the bind failure");
+        drop(postgres_reservation);
+        let rebound = BoundListeners::bind(&config)
+            .await
+            .expect("both listeners should bind on a clean retry");
+        drop(rebound);
+        reopened.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn injected_signal_stops_both_listeners_and_fully_stops_the_engine() {
         let temp = tempfile::tempdir().unwrap();
         let options = EngineOptions::default()
             .with_shutdown_grace(Duration::from_millis(50))
@@ -415,8 +604,10 @@ mod tests {
             .await
             .unwrap();
         let observer = engine.clone();
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let address = listener.local_addr().unwrap();
+        let http = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let http_address = http.local_addr().unwrap();
+        let postgres = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let postgres_address = postgres.local_addr().unwrap();
         let (signal_tx, signal_rx) = tokio::sync::oneshot::channel();
         let send_signal = tokio::spawn(async move {
             // Let the serve and signal futures both register before firing the
@@ -426,9 +617,16 @@ mod tests {
         });
         timeout(
             Duration::from_secs(2),
-            serve_with_shutdown(listener, engine, async move {
-                let _ = signal_rx.await;
-            }),
+            serve_listeners_with_shutdown(
+                BoundListeners {
+                    http,
+                    postgres: Some(postgres),
+                },
+                engine,
+                async move {
+                    let _ = signal_rx.await;
+                },
+            ),
         )
         .await
         .unwrap_or_else(|_| {
@@ -441,11 +639,16 @@ mod tests {
         send_signal.await.unwrap();
 
         assert_eq!(observer.state(), crate::core::EngineState::Stopped);
-        assert!(tokio::net::TcpStream::connect(address).await.is_err());
+        assert!(tokio::net::TcpStream::connect(http_address).await.is_err());
+        assert!(
+            tokio::net::TcpStream::connect(postgres_address)
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]
-    async fn already_ready_shutdown_signal_has_no_startup_lost_wakeup() {
+    async fn postgres_accept_loop_recovers_after_concurrent_connections_and_http_stays_live() {
         let temp = tempfile::tempdir().unwrap();
         let options = EngineOptions::default()
             .with_shutdown_grace(Duration::from_millis(50))
@@ -454,16 +657,96 @@ mod tests {
             .await
             .unwrap();
         let observer = engine.clone();
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let http = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let http_address = http.local_addr().unwrap();
+        let postgres = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let postgres_address = postgres.local_addr().unwrap();
+        let (signal_tx, signal_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(serve_listeners_with_shutdown(
+            BoundListeners {
+                http,
+                postgres: Some(postgres),
+            },
+            engine,
+            async move {
+                let _ = signal_rx.await;
+            },
+        ));
+
+        let clients = (0..32)
+            .map(|_| {
+                tokio::spawn(async move {
+                    let mut stream = tokio::net::TcpStream::connect(postgres_address)
+                        .await
+                        .unwrap();
+                    let _ = stream.write_all(b"placeholder input").await;
+                    assert_peer_closes_without_bytes(&mut stream).await;
+                })
+            })
+            .collect::<Vec<_>>();
+        let response = read_http_health(http_address).await;
+        assert!(response.starts_with(b"HTTP/1.1 200 OK\r\n"));
+        for client in clients {
+            client.await.unwrap();
+        }
+
+        for _ in 0..3 {
+            let mut stream = tokio::net::TcpStream::connect(postgres_address)
+                .await
+                .unwrap();
+            assert_peer_closes_without_bytes(&mut stream).await;
+        }
+        assert!(
+            read_http_health(http_address)
+                .await
+                .starts_with(b"HTTP/1.1 200 OK\r\n")
+        );
+
+        signal_tx.send(()).unwrap();
+        timeout(Duration::from_secs(2), server)
+            .await
+            .expect("both listeners should finish shutdown")
+            .unwrap()
+            .unwrap();
+        assert_eq!(observer.state(), crate::core::EngineState::Stopped);
+    }
+
+    #[tokio::test]
+    async fn already_ready_shutdown_signal_closes_both_listeners_without_lost_wakeup() {
+        let temp = tempfile::tempdir().unwrap();
+        let options = EngineOptions::default()
+            .with_shutdown_grace(Duration::from_millis(50))
+            .unwrap();
+        let engine = Engine::open_with_options(temp.path(), 2, options)
+            .await
+            .unwrap();
+        let observer = engine.clone();
+        let http = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let http_address = http.local_addr().unwrap();
+        let postgres = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let postgres_address = postgres.local_addr().unwrap();
 
         timeout(
             Duration::from_secs(2),
-            serve_with_shutdown(listener, engine, async {}),
+            serve_listeners_with_shutdown(
+                BoundListeners {
+                    http,
+                    postgres: Some(postgres),
+                },
+                engine,
+                async {},
+            ),
         )
         .await
         .expect("ready signal should shut down immediately")
         .unwrap();
         assert_eq!(observer.state(), crate::core::EngineState::Stopped);
+        assert!(tokio::net::TcpStream::connect(http_address).await.is_err());
+        assert!(
+            tokio::net::TcpStream::connect(postgres_address)
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]
@@ -528,10 +811,15 @@ mod tests {
         let observer = engine.clone();
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
+        let postgres = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let postgres_address = postgres.local_addr().unwrap();
         let accepted = Arc::new(Notify::new());
         let accepted_for_server = Arc::clone(&accepted);
-        let server = tokio::spawn(serve_with_shutdown_observed(
-            listener,
+        let server = tokio::spawn(serve_listeners_with_shutdown_observed(
+            BoundListeners {
+                http: listener,
+                postgres: Some(postgres),
+            },
             engine,
             std::future::pending(),
             Some(accepted_for_server),
@@ -550,6 +838,11 @@ mod tests {
         assert_eq!(observer.state(), crate::core::EngineState::Draining);
         assert_peer_closes(&mut client).await;
         assert!(tokio::net::TcpStream::connect(address).await.is_err());
+        assert!(
+            tokio::net::TcpStream::connect(postgres_address)
+                .await
+                .is_err()
+        );
 
         timeout(Duration::from_secs(2), observer.shutdown())
             .await

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -153,6 +153,16 @@ fn legacy_and_explicit_module_paths_are_both_available() {
     let _engine_router: fn(core::Engine) -> Router = http::router_with_engine;
     let _default_server_entry_point = server::run;
     let _configured_server_entry_point = server::run_with_engine_options;
+    let server_config = server::Config {
+        listen: "127.0.0.1:7654".parse().unwrap(),
+        postgres_listen: Some("127.0.0.1:5433".parse().unwrap()),
+        data_dir: std::path::PathBuf::from("./briskdb-data"),
+        shards: 4,
+    };
+    assert_eq!(
+        server_config.postgres_listen,
+        Some("127.0.0.1:5433".parse().unwrap())
+    );
 
     let result = core::ResultSet::new(
         vec![core::Column::new("value", core::DataType::Int64)],


### PR DESCRIPTION
## Summary

- add a separately configured PostgreSQL TCP listener with the default `127.0.0.1:5433`
- support `--postgres-listen disabled` and `BRISKDB_POSTGRES_LISTEN` while keeping `server::Config` protocol-neutral with `Option<SocketAddr>`
- bind HTTP then PostgreSQL before readiness, accept and close PostgreSQL streams without reading or writing bytes, and close both listeners through the shared shutdown lifecycle
- document configuration, startup, compatibility, storage, and placeholder behavior

## Tests

- [x] Unit tests cover defaults, explicit IPv4/IPv6 addresses, disabled mode, environment parsing, CLI precedence, and malformed values.
- [x] Listener tests cover enabled/disabled binding, bind-order failures, cleanup and retry, concurrent accept/close, live HTTP health, already-ready and ordinary shutdown, and dropped-future recovery.
- [x] `cargo fmt --all --check` passes.
- [x] `cargo test --locked --all-targets --all-features` passes: 510 library, 13 binary, 6 workload, and 16 public API tests plus benchmark targets.
- [x] `cargo test --locked --doc` and rustdoc with warnings denied pass.
- [x] `cargo clippy --locked --all-targets --all-features -- -D warnings` passes.
- [x] Rust 1.85 all-target suite passes.
- [x] Two independent reviews completed with no findings.

## Compatibility and operations

- [x] HTTP remains enabled on `--listen`, unchanged by the optional PostgreSQL setting.
- [x] The PostgreSQL socket is a deterministic TCP lifecycle scaffold; wire messages and SQL execution remain deferred to following roadmap issues.
- [x] No dependency or storage-format change is introduced.

Closes #28