### PR TITLE
Add browser-based admin data explorer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,7 @@ dependencies = [
  "blake3",
  "clap",
  "criterion",
+ "getrandom",
  "hyper",
  "hyper-util",
  "psm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = "1.0"
 axum = "0.8.9"
 blake3 = "1.8"
 clap = { version = "4.6.6", features = ["derive", "env"] }
+getrandom = "=0.4.3"
 hyper = { version = "1.11", features = ["http1", "server"] }
 hyper-util = { version = "0.1.20", features = ["service", "tokio"] }
 rusqlite = { version = "0.39.0", features = ["bundled", "hooks"] }

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ HTTP problem details, and the mappings reserved for future PostgreSQL and MySQL
 wire adapters.
 The [request-control contract](docs/REQUEST_CONTROLS.md) defines cancellation,
 deadlines, materialized-result budgets, and graceful shutdown.
+The [admin data-browser contract](docs/ADMIN_BROWSER.md) defines the embedded
+read-only per-shard explorer, its temporary login, finite pages, and live-view
+boundaries.
 The [manifest storage-format contract](docs/STORAGE_FORMAT.md) defines versioned
 startup migrations, downgrade behavior, and recovery boundaries.
 Contributions follow the repository's [test-first completion policy](CONTRIBUTING.md).
@@ -66,6 +69,8 @@ minimum supported Rust version (MSRV) and the latest stable toolchain.
 - Explicit graceful drain, forced cancellation, and blocking handle cleanup
 - Independently configured HTTP and PostgreSQL TCP listeners; the PostgreSQL
   listener currently accepts and closes connections pending wire-adapter work
+- An embedded read-only browser at `/admin` for inspecting user tables and
+  bounded row pages on one explicitly selected physical shard
 - Protocol-neutral typed values, ordered columns, positional rows, and results
 - A bounded per-session prepared-statement and immutable bound-portal lifecycle
   with transient shard-0 metadata compilation, bind-time routing snapshots,
@@ -126,6 +131,16 @@ Issue #28 supplies only the separately managed TCP endpoint. Until the
 PostgreSQL wire adapter lands, every accepted connection is closed immediately
 without reading or writing protocol bytes, and no PostgreSQL driver can execute
 a request through it. See the [listener contract](docs/POSTGRES_LISTENER.md).
+
+The HTTP listener also serves the embedded data explorer at
+<http://127.0.0.1:7654/admin>. Its temporary credentials are `admin` / `admin`.
+The explorer is read-only: select one physical shard and an ordinary user table,
+then move through live offset-based pages of at most 200 rows. Browser sessions
+are held only in process memory, expire after eight hours, and disappear on
+restart. The fixed credentials are a development convenience; keep this
+experimental HTTP service on a trusted network. Existing `/health` and `/v1/*`
+behavior is unchanged. See the [admin browser contract](docs/ADMIN_BROWSER.md)
+for the route, table-filtering, pagination, and session boundaries.
 
 Rust embedders can customize pool sizing through the public `EngineOptions`
 type. Existing engine constructors and server startup keep the defaults of four
@@ -296,6 +311,8 @@ are retired rather than reused by another session. Clean read handles can be
 shared for ordinary SQL, but a deny-only authorizer probe moves connection-local
 SQL such as `PRAGMA data_version`, plus any cross-owner write, to a fresh
 disposable handle before execution.
+The read-only `table_list` metadata PRAGMA is an explicit tested exception: it
+does not change connection state and remains reusable for admin discovery.
 BriskDB-owned shard metadata and storage-control PRAGMA mutations, including
 `application_id`, `user_version`, `journal_mode`, `schema_version`, and
 `writable_schema`, are denied through every client SQL surface rather than
@@ -390,9 +407,10 @@ Independent `Database` and `Engine` handles in one process that resolve to the
 same canonical data directory share schema coordination. Separate BriskDB
 server processes must not use the same data directory.
 
-Near-term work includes authentication, richer migration administration and
-status APIs in issue #53, scatter/gather reads, observability, and backup
-tooling.
+The `/admin` browser's fixed development login is separate from the planned
+authentication and role model. Near-term work includes that model, richer
+migration administration and status APIs in issue #53, scatter/gather reads,
+observability, and backup tooling.
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -292,6 +292,10 @@ protocol-specific golden tests only for encoding and state-machine behavior.
 
 ### 6. HTTP data and administration APIs
 
+- [x] Serve an early embedded, read-only data explorer at `/admin` with a
+  temporary fixed login and bounded per-physical-shard row pages (issue #106).
+  This preview does not complete the versioned admin API, listener separation,
+  authentication/role, pagination, or scatter/gather items below.
 - [ ] Replace the experimental endpoints with a versioned `/v1` contract built
   on the shared session/engine types.
 - [ ] Return ordered columns and row arrays so duplicate names and binary values

--- a/docs/ADMIN_BROWSER.md
+++ b/docs/ADMIN_BROWSER.md
@@ -1,0 +1,115 @@
+# Admin data browser
+
+Status: implemented for roadmap issue #106
+
+BriskDB serves a small read-only data explorer from the existing HTTP listener.
+Open `/admin` (or `/admin/`) to use the embedded application. Its HTML, CSS,
+and JavaScript are compiled into the server binary; loading the page does not
+contact a package CDN, font service, analytics service, or other third party.
+
+## Temporary login
+
+The first implementation has one exact built-in credential pair:
+
+- username: `admin`
+- password: `admin`
+
+This is a temporary development convenience, not the user/role, password
+rotation, or transport-encryption work described by roadmap issues #56 and #64.
+Anyone who can reach the HTTP listener knows these credentials. Keep the current
+HTTP service on a trusted network and do not treat this login as a production
+identity boundary. The existing `/health` and `/v1/*` endpoints retain their
+previous behavior and are not made authenticated by issue #106.
+
+A successful login creates an opaque session from 32 operating-system-random
+bytes and sends its lowercase 64-character hexadecimal token only in the
+`briskdb_admin_session` cookie. The cookie is `HttpOnly`, `SameSite=Strict`, has
+`Path=/admin`, and has an absolute eight-hour lifetime (`Max-Age=28800`). It is
+not persisted in the manifest, shards, or any other file. Restarting BriskDB
+invalidates every browser session.
+
+At most 128 sessions are retained in process memory. A successful login at that
+capacity evicts the earliest-expiring session, with the token as a deterministic
+tie-break. Logout invalidates only the presented session and always clears its
+cookie; other authenticated browsers remain independent. Logout is idempotent
+even when the cookie is absent or already unusable. Protected session,
+discovery, and row calls with a missing, malformed, unknown, expired, or
+logged-out cookie receive HTTP 401 with fixed JSON and a cookie-clearing header.
+Session-cookie state is separate from a core `Session`: every inspection
+request still creates a short-lived engine session, and login does not create a
+multi-request SQL transaction.
+
+## Routes
+
+| Surface | Contract |
+| --- | --- |
+| `GET /admin`, `GET /admin/` | Embedded application shell |
+| `GET /admin/assets/styles.css` | Embedded stylesheet |
+| `GET /admin/assets/app.js` | Embedded application code |
+| `POST /admin/api/login` | Accept JSON `{"username":"admin","password":"admin"}`; return `{"authenticated":true}` and set the session cookie |
+| `GET /admin/api/session` | Return `{"authenticated":true,"username":"admin"}` for a live cookie; otherwise return HTTP 401 |
+| `POST /admin/api/logout` | Revoke a presented live token if any, always clear the cookie, and return `{"authenticated":false}` |
+| `GET /admin/api/overview?shard=N` | Return `shard_count`, `selected_shard`, and the selected shard's binary-ordered `tables`; omitted `shard` selects zero |
+| `GET /admin/api/rows?shard=N&table=T&limit=L&offset=O` | Return one page as `shard`, `table`, `limit`, `offset`, `has_more`, ordered `columns`, and positional `rows`; limit defaults to 50 and offset to zero |
+
+The shell and its two assets are public so the application can render its login
+state. Session, overview, and row calls require the server-side session check;
+logout remains an idempotent cookie-clearing operation. Hiding controls in
+JavaScript is not the access check.
+
+## Physical-shard view
+
+The explorer intentionally selects a physical shard number. This differs from
+normal `/v1/query` routing, which hashes a caller-provided logical `shard_key`.
+The overview accepts only `0 <= shard < shard_count`. It discovers ordinary
+tables in SQLite's `main` schema and excludes SQLite-owned names beginning with
+`sqlite_` plus the exact BriskDB-owned name `briskdb` and names beginning with
+`briskdb_`, using ASCII-case-insensitive prefix checks. Views and internal tables
+are not presented. Names have a stable binary ordering in the response.
+
+Discovery describes the tables physically present on the selected shard. It is
+not the advisory logical `briskdb_tables` catalog, and it makes no claim that a
+table exists on another shard. Guessing an excluded or absent name does not make
+it browseable.
+
+The browser offers page sizes 25, 50, 100, and 200 rows and initially selects
+50. The JSON endpoint accepts only limits from 1 through 200 and offsets from 0
+through 1,000,000. BriskDB validates the shard, table identity, limit, offset,
+and checked pagination arithmetic before running the row read. The continuation
+indicator is derived by reading at most one row beyond the requested page; that
+extra row is not included in the returned page. It remains false when the next
+offset would exceed 1,000,000, even if more physical rows exist.
+
+Each page is a separate read of the selected shard. Offset pagination is
+therefore a live view, not a retained snapshot: inserts or deletes between page
+requests can move or repeat rows, and SQLite's table scan supplies no general
+ordering guarantee. The explorer does not merge shards, compute a global row
+count, or implement the later scatter/gather roadmap.
+
+## Engine and JSON boundaries
+
+The HTTP adapter does not open shard files or call `rusqlite`. Discovery and row
+reads use BriskDB's bounded explicit-shard inspection operation. That operation
+uses the ordinary engine lifecycle, schema gate, per-shard pool and worker
+admission, cancellation, deadline, and effective result limits. SQLite must
+classify its generated statement as read-only before it is stepped.
+
+Results retain the existing HTTP representation: ordered column metadata and
+positional row arrays. Duplicate or empty column names remain representable.
+Nulls, integers, finite floats, and valid text use direct JSON values; blobs are
+arrays of byte-valued integers; decimals use strings; invalid UTF-8 text is
+rendered lossily; and non-finite floats become JSON `null`.
+
+Engine failures use the same fixed, redacted HTTP problem details as other HTTP
+operations. Login or session rejection returns HTTP 401 without echoing the
+submitted password or session token. A failed discovery or page read does not
+invalidate a valid browser session, and a later valid request can continue.
+
+## Deliberate non-goals
+
+Issue #106 does not add editing, arbitrary SQL, schema migration, backup,
+maintenance, query cancellation, a separate admin listener, stable pagination
+across concurrent writes, scatter/gather browsing, durable users or roles,
+credential configuration, or TLS. Those remain separate roadmap work. The
+browser adds no manifest table, file, version, checksum input, migration, or
+recovery step.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,6 +10,9 @@ binary (main)
     |
     v
 server ---------> protocol::http
+    |               |    |
+    |               |    v
+    |               +-> embedded admin browser
     |                    |
     |                    v
     +-----------------> core
@@ -23,10 +26,10 @@ server ---------> protocol::http
 
 | Module | Responsibility | Must not own |
 | --- | --- | --- |
-| `core` | Protocol-neutral `Engine`, `Session`, statements, immutable bound portals, values, results, errors, read-only logical catalog, synchronous bound-value-aware plans, prepared lifecycle, and sharded routing policy; stable key routing; bounded per-session and per-shard admission; routed execution and journaled schema migration | JSON/HTTP types, listeners, or Axum handlers |
+| `core` | Protocol-neutral `Engine`, `Session`, statements, immutable bound portals, values, results, errors, read-only logical catalog, synchronous bound-value-aware plans, prepared lifecycle, explicit-shard read-only inspection, and sharded routing policy; stable key routing; bounded per-session and per-shard admission; routed execution and journaled schema migration | JSON/HTTP types, listeners, or Axum handlers |
 | `storage` | Versioned routing/logical manifest, shard layout, migration journal and recovery, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
 | `sql` | Dialect-explicit SQL syntax parsing, recursive common-subset validation, protocol-neutral statement/batch classification, source-preserving placeholder normalization, explicit strict/compatibility translation, catalog-aware typed shard-key inference, and narrow crate-private DML-shape inspection behind BriskDB-owned boundaries; exact source retention; SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, key hashing or shard selection, mutable session state, physical write-routing policy, filesystem layout, protocol responses, protocol-buffer ownership, or protocol-specific support policy |
-| `protocol::http` | HTTP request extraction plus JSON/BriskDB value and RFC 9457 problem-detail encoding | BLAKE3 routing, shard files, or rusqlite calls |
+| `protocol::http` | Existing HTTP request extraction, shared JSON/BriskDB value and RFC 9457 problem-detail encoding, and the embedded admin shell/assets, temporary browser sessions, discovery, and page handlers | BLAKE3 routing, shard files, direct SQLite access, or rusqlite calls |
 | `protocol::error` | Exhaustive HTTP, PostgreSQL, and MySQL mappings from stable engine error kinds | SQLite errors, routing decisions, or wire-protocol session state |
 | `server` | Process configuration, database assembly, separate HTTP/PostgreSQL listener binding, tracked Axum HTTP/1 connection lifecycle, and the temporary PostgreSQL accept/close loop | SQL parsing, PostgreSQL wire messages, or storage implementation details |
 
@@ -63,9 +66,10 @@ of `anyhow::Result<T>`; this intentional pre-1.0 source migration gives callers
 stable error identity while retaining automatic `?` conversion into `anyhow`.
 
 Automated HTTP contract tests cover health, schema broadcast, routed writes,
-routed reads, and structured problem-detail serialization through the shared
-engine. Unit tests remain colocated with sessions, engine orchestration,
-routing, storage, SQL conversion, CLI, and server assembly.
+routed reads, structured problem-detail serialization, admin login/session
+lifecycle, embedded assets, physical-shard discovery, and bounded row pages
+through the shared engine. Unit tests remain colocated with sessions, engine
+orchestration, routing, storage, SQL conversion, CLI, and server assembly.
 
 Issue #17 intentionally changed the behavior behind the preserved
 `/v1/admin/broadcast`, `Database::broadcast`, and `Engine::broadcast` shapes.
@@ -100,6 +104,36 @@ lifecycle placeholder: it accepts and immediately drops each stream without
 reading bytes, writing a PostgreSQL frame, opening a session, or calling the
 engine. This keeps binding, concurrent acceptance, startup cleanup, and shared
 shutdown testable without moving protocol behavior into `server`.
+
+## Admin browser boundary
+
+Issue #106 adds an embedded application under `/admin` on the existing HTTP
+listener. The public shell, stylesheet, and JavaScript are static bytes compiled
+into the binary. Same-origin JSON handlers validate the temporary `admin` /
+`admin` login, retain at most 128 opaque sessions in process memory for an
+absolute eight hours, and enforce the cookie on session, discovery, and row-page
+operations. Logout revokes a presented token when possible and always clears
+the cookie, so repeating it is harmless. These browser sessions are adapter
+state, not core SQL sessions, and are neither written to storage nor recovered
+after restart.
+
+The adapter may select a validated physical shard only through the engine's
+crate-private inspection boundary. `Engine::inspect_shard` retains ordinary
+lifecycle admission, schema coordination, session serialization, per-shard pool
+and worker bounds, request controls, read-only SQLite validation, and typed
+`ResultSet` output. It does not require or synthesize a logical routing key.
+This deliberately narrow path exists for administration; it is not a public
+general-purpose direct-shard execution API.
+
+Table discovery reads SQLite's physical `main` schema through that boundary,
+returns only ordinary application tables, and excludes ASCII-case-insensitive
+`sqlite_`, `briskdb`, and `briskdb_` names. The page handler accepts no SQL from
+the browser. It validates the returned table identity, safely quotes that
+identifier, binds finite limit/offset values, and exposes at most 200 rows from
+one shard. It never opens a database file or imports `rusqlite` in the adapter.
+Separate offset pages are live reads, not a transaction, stable ordering, or a
+cross-shard snapshot. The complete route and representation contract is in the
+[admin data browser](ADMIN_BROWSER.md).
 
 ## SQL parser boundary
 
@@ -517,11 +551,14 @@ later session change cannot retarget an existing portal. `EngineStatus` exposes
 the shard count and prepared-state limits needed by health/configuration
 reporting without exposing the storage implementation.
 
-HTTP is stateless at this stage: each execute or query request creates a fresh
-session and initializes its routing context from the request's `shard_key`.
-Consequently, session settings and transactions cannot span HTTP requests.
-Schema-migration broadcast and status calls also go through the shared engine,
-but do not perform a routing decision in the adapter.
+HTTP SQL state remains request-local: each execute or query request creates a
+fresh session and initializes its routing context from the request's
+`shard_key`. Each admin inspection likewise creates a fresh core session but
+selects a validated physical shard through the dedicated read-only boundary.
+Consequently, session settings and transactions cannot span HTTP requests. The
+eight-hour browser cookie authenticates the admin JSON calls; it does not retain
+SQL session state. Schema-migration broadcast and status calls also go through
+the shared engine, but do not perform a routing decision in the adapter.
 
 ### Bounded worker and connection-pool boundary
 
@@ -593,6 +630,10 @@ probe. The first connection-local or write action is rejected before it can
 run—even for PRAGMAs with prepare-time effects—and the real statement is then
 executed once on a fresh handle. This also gives every cross-owner write clean
 SQLite counter state.
+The read-only `table_list` metadata PRAGMA is the narrow exception to PRAGMA
+tainting. It changes no connection-local state, remains reusable under an exact
+pool regression test, and lets the admin explorer distinguish ordinary tables
+from virtual-table shadow objects.
 The expected probe error is never exposed to the caller. Any other probe error
 also fails closed to a fresh handle. Opening that replacement can surface its own
 storage error; otherwise only the real execution determines the caller-visible
@@ -629,12 +670,13 @@ retired, preventing a late signal from affecting the next request.
 deadline, and optional narrower result limits. The engine default deadline and
 result budget are owned by `EngineOptions`, so protocol adapters contain no
 SQLite control policy. Prepare, bind, describe, and portal execution expose the
-same `*_with_context` boundary as raw operations. Queries and prepared row
-results account a stable logical representation while stepping SQLite and
-before cloning payloads. A row or byte overflow returns no partial
-`ResultSet`; row-producing writes are rejected so early termination cannot hide
-DML effects. The exact accounting contract is documented in
-[request controls](REQUEST_CONTROLS.md).
+same `*_with_context` boundary as raw operations; explicit-shard inspection has
+the same controlled form. Queries, inspection pages, and prepared row results
+account a stable logical representation while stepping SQLite and before
+cloning payloads. A row or byte overflow returns no partial `ResultSet`;
+row-producing writes are rejected so early termination cannot hide DML effects.
+The exact accounting contract is documented in [request
+controls](REQUEST_CONTROLS.md).
 
 All engine clones share one mutex-protected lifecycle. The mutex makes the
 `Running` admission check and active-operation increment atomic with
@@ -713,10 +755,12 @@ to another SQLite storage class. SQLite `TEXT` results preserve invalid bytes as
 `Value::InvalidText` inside the core.
 
 The experimental HTTP adapter is the only JSON conversion boundary.
-`/v1/query` returns `shard`, an ordered `columns` array of `name` and
-`data_type` metadata objects, and positional arrays in `rows`. Column and row
-indices correspond exactly. Duplicate and empty names are valid, and metadata
-is returned even when there are zero rows.
+`/v1/query` and the admin row-page response use the same ordered `columns` array
+of `name` and `data_type` metadata objects plus positional arrays in `rows`.
+Column and row indices correspond exactly. Duplicate and empty names are valid,
+and metadata is returned even when there are zero rows. The admin response adds
+physical-shard, table, and finite pagination metadata without altering the cell
+conversion.
 
 The adapter renders exact decimals as JSON strings, converts `InvalidText` to a
 JSON string with invalid byte sequences replaced by U+FFFD, and maps non-finite

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -128,6 +128,33 @@ the public response stable while preserving the original cause for operators.
 Malformed JSON can still be rejected by the HTTP framework before a request
 reaches the engine; that decoding rejection is outside this taxonomy.
 
+### Admin-browser responses
+
+The embedded `/admin` application's login and cookie checks happen in the HTTP
+adapter before an engine operation exists. Wrong credentials and a missing,
+malformed, unknown, expired, or logged-out `briskdb_admin_session` therefore use
+HTTP 401 rather than inventing an `EngineErrorKind`. A protected call with an
+unusable session returns a fixed JSON response and a cookie-clearing header.
+Logout itself is idempotent: it returns success and clears the cookie even when
+no live token is present. These responses never echo the submitted password or
+cookie token. The public application shell and embedded assets remain loadable
+so the browser can render its login state.
+
+After session validation, overview and row-page failures use the established
+HTTP problem representation whenever they have an engine kind. An out-of-range
+physical shard, absent or excluded table identity, page limit outside 1 through
+200, offset above 1,000,000, or pagination arithmetic overflow is an invalid
+argument. A page that exceeds the effective engine row or logical-byte budget
+is `LimitExceeded` and contains no partial rows. Pool admission, request
+deadline, shutdown, schema-gate, storage, and integrity failures retain their
+normal mappings.
+
+SQLite messages, table contents, filesystem paths, submitted credentials, and
+session tokens remain internal in every case. A failed admin request does not
+invalidate a valid browser session; a subsequent valid request can recover.
+The complete browser route and live-pagination contract is in the [admin data
+browser](ADMIN_BROWSER.md).
+
 ## Classification boundary
 
 The SQL and storage layers classify SQLite failures from primary and extended

--- a/docs/REQUEST_CONTROLS.md
+++ b/docs/REQUEST_CONTROLS.md
@@ -7,12 +7,12 @@ PostgreSQL TCP placeholder never creates an engine request.
 
 ## Per-request context
 
-The existing `Engine::execute`, `query`, `broadcast`, and `status` methods, plus
-`prepare_statement`, `bind_statement`, `describe_prepared`, and
-`execute_portal`, use a default `RequestContext`. `broadcast` now means a
-journaled application-schema migration. Frontends that have their own
-cancellation or deadline source can call the corresponding `*_with_context`
-method:
+The existing `Engine::execute`, `query`, `broadcast`, and `status` methods, the
+crate-private explicit-shard inspection operation, plus `prepare_statement`,
+`bind_statement`, `describe_prepared`, and `execute_portal`, use a default
+`RequestContext`. `broadcast` now means a journaled application-schema
+migration. Frontends that have their own cancellation or deadline source can
+call the corresponding `*_with_context` method:
 
 ```rust
 use std::time::Duration;
@@ -94,13 +94,23 @@ and SQLite can still allocate its current row internally. The logical limit is
 not an HTTP encoded-body limit; for example, the current JSON representation of
 a blob expands bytes into JSON integers.
 
-The raw query path accepts only SQLite statements reported as read-only. The
-prepared executor likewise rejects row-producing writes. These rules prevent
-an early result-budget failure from accompanying a partially consumed DML
-`RETURNING` statement. Raw execute, prepared affected-row results, and schema
-migration do not materialize a `ResultSet` and are unaffected by query result
-budgets. A future scatter/gather implementation must apply one budget to the
-combined result, not a fresh budget for every shard.
+The raw query and explicit-shard inspection paths accept only SQLite statements
+reported as read-only. The prepared executor likewise rejects row-producing
+writes. These rules prevent an early result-budget failure from accompanying a
+partially consumed DML `RETURNING` statement. Raw execute, prepared affected-row
+results, and schema migration do not materialize a `ResultSet` and are
+unaffected by query result budgets. A future scatter/gather implementation must
+apply one budget to the combined result, not a fresh budget for every shard.
+
+The `/admin` browser independently caps a requested page at 200 returned rows
+and validates offsets no greater than 1,000,000. It may inspect one additional
+row to decide whether another page exists; that row is not serialized. The
+inspection still uses the engine's effective logical-byte and row budgets, so a
+lower configured engine limit or a byte-heavy page can return `LimitExceeded`
+with no partial page. Every offset page is a separate request and consumes
+capacity only from its selected physical shard. It is not a global budget,
+cross-shard read, or multi-page snapshot. The continuation flag is false if the
+next calculated offset would exceed the browser's 1,000,000 cap.
 
 ## Prepared-session limits
 
@@ -126,6 +136,27 @@ length, and its payload), once for a possible typed-inference copy and once for
 a possible canonical-route copy. Repeated markers are charged again. The
 transient sum is not retained or added to existing portal bytes. A failure
 returns `LimitExceeded` before planning and publishes no portal.
+
+## Browser-session limits
+
+Admin-browser authentication state is protocol-adapter memory, not an engine
+`Session` or prepared cache. A successful temporary `admin` / `admin` login
+creates one opaque cookie token with an absolute eight-hour lifetime. The HTTP
+adapter retains at most 128 live browser sessions. Logout removes the presented
+session, expiration makes it unusable, and process restart removes all of them.
+A successful login at capacity evicts the earliest-expiring session, using its
+token only as a deterministic tie-break; it never grows the store past 128. No
+browser-session data is charged to a shard pool, written to the data directory,
+or recovered at startup.
+
+Each authenticated discovery or row-page call separately creates a core
+`Session`. Discovery uses one engine operation. A row page uses one operation to
+verify the exact visible table identity, followed by a separately bounded page
+read that repeats the visibility predicate before returning data. Cancelling,
+failing, or completing either operation does not extend the cookie lifetime or
+invalidate an otherwise valid browser session. Conversely, logging out prevents
+later admin requests but does not retroactively cancel an inspection already
+admitted to the engine.
 
 ## Schema-migration controls
 

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -82,6 +82,7 @@ path; they do not pass through these opt-in SQL layers.
 | HTTP `/v1/execute` | Experimental | One SQLite statement with positional parameters | Required caller-provided `shard_key` |
 | HTTP `/v1/query` | Experimental | One raw SQLite statement prepared transiently by the row-returning path; no session cache | Required caller-provided `shard_key` |
 | HTTP `/v1/admin/broadcast` | Experimental | A journaled parameterless SQLite schema batch | Preflight on every shard, then ascending resumable apply |
+| HTTP `/admin` browser | Experimental, read-only | No caller SQL; server-generated physical table discovery and bounded `SELECT *` pages | Required validated physical shard number; never a routed or scatter query |
 | PostgreSQL wire protocol | TCP lifecycle scaffold; wire protocol planned | Rust parsing, validation, classification, placeholder normalization, finite compatibility translation, and prepared lifecycle implemented; placeholder listener accepts then closes without protocol bytes | Core batch/write policy, bind validation, routing snapshots, current execute-time planning, and supported target execution implemented; wire mapping planned |
 | MySQL wire protocol | Planned | Rust parsing, validation, classification, placeholder normalization, finite compatibility translation, and prepared lifecycle implemented; listener adoption planned | Core batch/write policy, bind validation, routing snapshots, current execute-time planning, and supported target execution implemented; wire mapping planned |
 
@@ -91,12 +92,41 @@ lifecycle are implemented Rust APIs, not PostgreSQL or MySQL network
 interfaces. The PostgreSQL socket scaffold does not connect those APIs to the
 network. They do not change any current HTTP row in this table.
 
-Every HTTP operation now calls the same protocol-neutral async engine intended
-for future PostgreSQL and MySQL adapters. Execute and query requests create a
-fresh `Ready` session, put the request's `shard_key` in its routing context, and
-submit an owned statement. The engine, rather than the HTTP adapter, selects the
-shard and acquires a pooled SQLite connection. The session is discarded when
-that HTTP request finishes, so a transaction cannot span requests.
+Every HTTP database operation now calls the same protocol-neutral async engine
+intended for future PostgreSQL and MySQL adapters. Execute and query requests
+create a fresh `Ready` session, put the request's `shard_key` in its routing
+context, and submit an owned statement. The engine, rather than the HTTP
+adapter, selects the shard and acquires a pooled SQLite connection. Admin
+inspection requests also create a fresh `Ready` session, but use a bounded
+read-only engine operation with an already validated physical shard. The
+session is discarded when that HTTP request finishes, so a transaction cannot
+span requests.
+
+### Admin browser inspection
+
+The `/admin` application is an early operational view rather than another SQL
+compatibility mode. The browser never submits SQL. Its overview selects one
+physical shard from the configured range and discovers ordinary `main`-schema
+tables through SQLite's typed `table_list` metadata. ASCII-case-insensitive `sqlite_`,
+the exact name `briskdb`, and `briskdb_` prefixes are excluded, as are non-table
+objects. This is a physical schema view, not a promise that advisory logical
+catalog metadata describes the table or that another shard has an equal table.
+
+Row browsing generates one safely quoted `SELECT *` for a table returned by
+discovery. Page limits are 1 through 200 and offsets are 0 through 1,000,000;
+the interface reads at most one extra row to decide whether another page is
+available. The user interface offers 25, 50, 100, and 200 and starts at 50.
+Shard, table, limit, offset, and checked arithmetic are validated before
+execution. The engine still requires SQLite to classify the statement as
+read-only and applies its schema gate, pool/worker admission, cancellation,
+deadline, and effective result-byte and row budgets.
+
+Each offset page is a new committed read. No order is promised for a general
+SQLite table scan, and concurrent changes may move rows between pages. The
+browser does not merge physical shards, preserve a multi-page snapshot, accept
+arbitrary filters or SQL, or implement the planned scatter/gather query path.
+The full route, login, and live-view contract is in the [admin data
+browser](ADMIN_BROWSER.md).
 
 The asynchronous boundary admits work to an independent bounded pool for each
 shard before dispatching blocking SQLite work. The default pool permits four
@@ -232,8 +262,10 @@ positional rows are preserved inside `ResultSet`; SQLite result-column metadata
 is marked `Unknown` because dynamic SQLite values do not guarantee one static
 type.
 
-The experimental `/v1/query` response exposes the ordered result directly. For
-example:
+The experimental `/v1/query` response exposes the ordered result directly. The
+admin row-page endpoint reuses the same column and cell conversion and wraps it
+with physical-shard and pagination metadata. For example, the existing query
+shape is:
 
 ```json
 {
@@ -264,9 +296,10 @@ JSON number through binary floating point must also account for precision loss
 when reading large `uint64` cells.
 
 This ordered response intentionally replaces the earlier experimental
-object-per-row shape, which collapsed duplicate names. It changes only HTTP
-query serialization; request fields, routing, configuration, the manifest,
-shard files, and stored data are unchanged.
+object-per-row shape, which collapsed duplicate names. Admin pages preserve the
+same indexed relationship instead of converting rows into name-keyed objects.
+The conversion changes only HTTP serialization; request fields, routing,
+configuration, the manifest, shard files, and stored data are unchanged.
 
 ### Current error contract
 

--- a/docs/SUPPORTED_PLATFORMS.md
+++ b/docs/SUPPORTED_PLATFORMS.md
@@ -39,6 +39,15 @@ PostgreSQL endpoint is currently an accept/close lifecycle scaffold, not a wire
 compatibility claim. Its exact process behavior is documented in
 [PostgreSQL listener lifecycle](POSTGRES_LISTENER.md).
 
+The same runner exercises the embedded `/admin` shell and assets, temporary
+login/session lifecycle, physical-shard table discovery, and bounded row-page
+JSON contract without contacting third-party asset hosts. These are HTTP and
+content contract tests, not a named desktop/mobile browser compatibility
+matrix, visual-regression suite, or accessibility certification. The interface
+uses ordinary HTML, CSS, browser JavaScript, and same-origin requests; an
+unlisted browser remains best-effort until it has repeatable automated coverage.
+See the [admin data-browser contract](ADMIN_BROWSER.md).
+
 ## Development-tested targets
 
 Maintainers also develop and run the full suite on `aarch64-apple-darwin`.
@@ -71,6 +80,9 @@ Only a single BriskDB server process per data directory is supported. The
 process-wide registry makes independent `Database` and `Engine` handles that
 resolve to the same canonical root share schema admission and catalog
 publication. It does not coordinate separate server processes.
+Admin browser sessions likewise belong to one process, but are not part of that
+data-directory registry: their absolute eight-hour state is memory-only and is
+discarded on restart.
 Do not copy, move, edit, or separately open the manifest, shard, WAL, or shared
 memory files while the server is running. Backup, restore, multi-process
 access, filesystem-fault behavior, and crash-recovery guarantees will become

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -943,6 +943,72 @@ impl Engine {
         Ok(Routed { shard, value })
     }
 
+    /// Run one read-only inspection statement on an explicit physical shard.
+    ///
+    /// This crate-private boundary exists for administrative surfaces that
+    /// need to describe one shard honestly rather than manufacturing a routing
+    /// key. It retains the ordinary engine lifecycle, schema gate, session,
+    /// pool, worker, cancellation, and result-budget behavior. The SQL adapter
+    /// verifies that the prepared SQLite statement is read-only before it is
+    /// stepped.
+    pub(crate) async fn inspect_shard(
+        &self,
+        session: &Session,
+        shard: u16,
+        statement: Statement,
+    ) -> EngineResult<ResultSet> {
+        self.inspect_shard_with_context(session, shard, statement, RequestContext::new())
+            .await
+    }
+
+    /// Run an explicit-shard inspection with request-scoped controls.
+    pub(crate) async fn inspect_shard_with_context(
+        &self,
+        session: &Session,
+        shard: u16,
+        statement: Statement,
+        context: RequestContext,
+    ) -> EngineResult<ResultSet> {
+        let mut operation = self.operation(context)?;
+        let schema_operation = match self.inner.database.storage.enter_schema_operation() {
+            Ok(guard) => guard,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let guard = match operation.wait_pending(self.ready_session(session)).await {
+            Ok(guard) => guard,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        if shard >= self.shard_count() {
+            return operation.finish(Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                format!(
+                    "physical shard {shard} is outside the configured range 0..{}",
+                    self.shard_count()
+                ),
+            )));
+        }
+        let owner = ConnectionOwner::new(session.id().get());
+        let (sql, params) = statement.into_parts();
+        let limits = operation.result_limits;
+
+        let result = self
+            .run_on_shard(
+                &mut operation,
+                shard,
+                owner,
+                schema_operation,
+                guard,
+                move |connection, _session, control| {
+                    connection.isolate_foreign_sql_controlled(Arc::clone(&control), &sql)?;
+                    connection.run_controlled(control, |connection| {
+                        sql::query_with_limits(connection, &sql, &params, limits)
+                    })
+                },
+            )
+            .await;
+        operation.finish_started(result)
+    }
+
     /// Apply a parameterless SQL migration batch through the durable shard journal.
     pub async fn broadcast(&self, session: &Session, sql: String) -> EngineResult<Vec<u16>> {
         self.broadcast_with_context(session, sql, RequestContext::new())
@@ -3134,6 +3200,182 @@ mod tests {
             }
             assert_eq!(shard.retired, 0);
         }
+    }
+
+    #[tokio::test]
+    async fn explicit_shard_inspection_reads_only_the_selected_physical_shard() {
+        let (_temp, engine) = engine_with_options(2, 2, 2);
+        let setup = engine.session();
+        engine
+            .broadcast(
+                &setup,
+                "CREATE TABLE inspection_rows (id INTEGER PRIMARY KEY, label TEXT NOT NULL)"
+                    .to_owned(),
+            )
+            .await
+            .unwrap();
+
+        let writer = engine.session();
+        for shard in 0..engine.shard_count() {
+            writer
+                .set_routing_key(routing_key_for_shard(&engine, shard))
+                .await
+                .unwrap();
+            let written = engine
+                .execute(
+                    &writer,
+                    Statement::new(
+                        "INSERT INTO inspection_rows (id, label) VALUES (?1, ?2)",
+                        vec![
+                            Value::from(i64::from(shard)),
+                            Value::from(format!("shard-{shard}")),
+                        ],
+                    ),
+                )
+                .await
+                .unwrap();
+            assert_eq!(written.shard, shard);
+        }
+
+        let inspector = engine.session();
+        for shard in 0..engine.shard_count() {
+            let result = engine
+                .inspect_shard(
+                    &inspector,
+                    shard,
+                    Statement::new("SELECT id, label FROM inspection_rows ORDER BY id", vec![]),
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                result,
+                ResultSet::new(
+                    vec![
+                        Column::new("id", DataType::Unknown),
+                        Column::new("label", DataType::Unknown),
+                    ],
+                    vec![Row::new(vec![
+                        Value::from(i64::from(shard)),
+                        Value::from(format!("shard-{shard}")),
+                    ])],
+                )
+                .unwrap()
+            );
+        }
+        assert_eq!(inspector.routing_key().await, None);
+        assert_eq!(inspector.state().await, SessionState::Ready);
+
+        let pools = engine.inner.connections.snapshot().unwrap();
+        assert!(
+            pools
+                .shards
+                .iter()
+                .all(|shard| shard.active == 0 && shard.queued == 0 && shard.checkouts >= 2)
+        );
+    }
+
+    #[tokio::test]
+    async fn explicit_shard_inspection_rejects_invalid_shards_without_pool_work_and_recovers() {
+        let (_temp, engine) = engine_with_options(2, 1, 1);
+        let session = engine.session();
+
+        let (_other_temp, other_engine) = engine_with_options(2, 1, 1);
+        let foreign_session = other_engine.session();
+        let foreign_error = engine
+            .inspect_shard(
+                &foreign_session,
+                u16::MAX,
+                Statement::new("SELECT 1", vec![]),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(foreign_error.kind(), EngineErrorKind::FailedPrecondition);
+
+        for invalid in [engine.shard_count(), u16::MAX] {
+            let error = engine
+                .inspect_shard(&session, invalid, Statement::new("SELECT 1", vec![]))
+                .await
+                .unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::InvalidArgument);
+            assert_eq!(
+                error.to_string(),
+                format!(
+                    "physical shard {invalid} is outside the configured range 0..{}",
+                    engine.shard_count()
+                )
+            );
+        }
+        assert!(
+            engine
+                .inner
+                .connections
+                .snapshot()
+                .unwrap()
+                .shards
+                .iter()
+                .all(|shard| shard.checkouts == 0)
+        );
+
+        let recovered = engine
+            .inspect_shard(
+                &session,
+                0,
+                Statement::new("SELECT ?1 AS value", vec![Value::from(7_i64)]),
+            )
+            .await
+            .unwrap();
+        assert_eq!(recovered.rows()[0].get(0), Some(&Value::from(7_i64)));
+        assert_eq!(session.state().await, SessionState::Ready);
+    }
+
+    #[tokio::test]
+    async fn explicit_shard_inspection_rejects_writes_and_result_overflow_without_poisoning() {
+        let (_temp, engine) = engine_with_options(2, 1, 1);
+        let setup = engine.session();
+        engine
+            .broadcast(
+                &setup,
+                "CREATE TABLE inspected_write (id INTEGER PRIMARY KEY)".to_owned(),
+            )
+            .await
+            .unwrap();
+        let session = engine.session();
+
+        let write_error = engine
+            .inspect_shard(
+                &session,
+                0,
+                Statement::new("INSERT INTO inspected_write (id) VALUES (1)", vec![]),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(write_error.kind(), EngineErrorKind::InvalidQuery);
+
+        let narrow = RequestContext::new().with_result_limits(ResultLimits::new(1, 1_024).unwrap());
+        let limit_error = engine
+            .inspect_shard_with_context(
+                &session,
+                0,
+                Statement::new("SELECT 1 AS value UNION ALL SELECT 2", vec![]),
+                narrow,
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(limit_error.kind(), EngineErrorKind::LimitExceeded);
+
+        let recovered = engine
+            .inspect_shard(
+                &session,
+                0,
+                Statement::new("SELECT COUNT(*) AS count FROM inspected_write", vec![]),
+            )
+            .await
+            .unwrap();
+        assert_eq!(recovered.rows()[0].get(0), Some(&Value::from(0_i64)));
+        assert_eq!(session.state().await, SessionState::Ready);
+        let shard = engine.inner.connections.snapshot().unwrap().shards[0];
+        assert_eq!(shard.active, 0);
+        assert_eq!(shard.queued, 0);
     }
 
     #[tokio::test]

--- a/src/protocol/http.rs
+++ b/src/protocol/http.rs
@@ -1,5 +1,7 @@
 //! Experimental HTTP adapter.
 
+mod admin;
+
 use std::sync::Arc;
 
 use axum::{
@@ -28,15 +30,27 @@ pub fn router(database: Arc<Database>) -> Router {
 
 /// Build an HTTP router backed by the protocol-neutral asynchronous engine.
 pub fn router_with_engine(engine: Engine) -> Router {
+    let state = HttpState {
+        engine,
+        admin_sessions: admin::SessionStore::new(),
+    };
     Router::new()
         .route("/health", get(health))
         .route("/v1/execute", post(execute))
         .route("/v1/query", post(query))
         .route("/v1/admin/broadcast", post(broadcast))
-        .with_state(engine)
+        .merge(admin::routes(state.clone()))
+        .with_state(state)
 }
 
-async fn health(State(engine): State<Engine>) -> Result<Json<JsonValue>, ApiError> {
+#[derive(Clone)]
+struct HttpState {
+    engine: Engine,
+    admin_sessions: admin::SessionStore,
+}
+
+async fn health(State(state): State<HttpState>) -> Result<Json<JsonValue>, ApiError> {
+    let engine = state.engine;
     let session = engine.session();
     let status = engine.status(&session).await?;
 
@@ -79,9 +93,10 @@ struct QueryColumn {
 }
 
 async fn execute(
-    State(engine): State<Engine>,
+    State(state): State<HttpState>,
     Json(request): Json<RoutedSqlRequest>,
 ) -> Result<Json<ExecuteResponse>, ApiError> {
+    let engine = state.engine;
     let params = request
         .params
         .into_iter()
@@ -103,9 +118,10 @@ async fn execute(
 }
 
 async fn query(
-    State(engine): State<Engine>,
+    State(state): State<HttpState>,
     Json(request): Json<RoutedSqlRequest>,
 ) -> Result<Json<QueryResponse>, ApiError> {
+    let engine = state.engine;
     let params = request
         .params
         .into_iter()
@@ -125,9 +141,10 @@ async fn query(
 }
 
 async fn broadcast(
-    State(engine): State<Engine>,
+    State(state): State<HttpState>,
     Json(request): Json<BroadcastRequest>,
 ) -> Result<Json<JsonValue>, ApiError> {
+    let engine = state.engine;
     let session = engine.session();
     let shards = engine.broadcast(&session, request.sql).await?;
     Ok(Json(json!({"completed_shards": shards})))

--- a/src/protocol/http/admin.rs
+++ b/src/protocol/http/admin.rs
@@ -1,0 +1,1243 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex, MutexGuard},
+    time::{Duration, Instant},
+};
+
+use axum::{
+    Json, Router,
+    extract::{DefaultBodyLimit, Query, Request, State},
+    http::{
+        HeaderMap, HeaderName, HeaderValue, StatusCode,
+        header::{CACHE_CONTROL, CONTENT_TYPE, COOKIE, SET_COOKIE},
+    },
+    middleware::{self, Next},
+    response::{IntoResponse, Response},
+    routing::{get, post},
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value as JsonValue, json};
+
+use super::HttpState;
+use crate::core::{EngineError, EngineErrorKind, ResultSet, Statement, Value};
+
+const INDEX_HTML: &str = include_str!("admin/index.html");
+const STYLES_CSS: &str = include_str!("admin/styles.css");
+const APP_JS: &str = include_str!("admin/app.js");
+
+const ADMIN_USERNAME: &str = "admin";
+const ADMIN_PASSWORD: &str = "admin";
+const SESSION_COOKIE: &str = "briskdb_admin_session";
+const SESSION_LIFETIME: Duration = Duration::from_secs(8 * 60 * 60);
+const MAX_SESSIONS: usize = 128;
+const DEFAULT_PAGE_LIMIT: u16 = 50;
+const MAX_PAGE_LIMIT: u16 = 200;
+const MAX_PAGE_OFFSET: u64 = 1_000_000;
+const TABLE_DISCOVERY_SQL: &str = "SELECT name FROM pragma_table_list \
+     WHERE schema = 'main' AND type = 'table' \
+       AND lower(name) NOT GLOB 'sqlite_*' \
+       AND lower(name) != 'briskdb' \
+       AND lower(name) NOT GLOB 'briskdb_*' \
+     ORDER BY name COLLATE BINARY";
+const TABLE_LOOKUP_SQL: &str = "SELECT name FROM pragma_table_list \
+     WHERE schema = 'main' AND type = 'table' \
+       AND name = ?1 COLLATE BINARY \
+       AND lower(name) NOT GLOB 'sqlite_*' \
+       AND lower(name) != 'briskdb' \
+       AND lower(name) NOT GLOB 'briskdb_*' \
+     LIMIT 1";
+const NO_STORE: HeaderValue = HeaderValue::from_static("no-store");
+const CSP: HeaderValue = HeaderValue::from_static(
+    "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'; form-action 'self'",
+);
+
+#[derive(Clone)]
+pub(super) struct SessionStore {
+    inner: Arc<Mutex<Sessions>>,
+}
+
+#[derive(Default)]
+struct Sessions {
+    by_token: HashMap<String, Instant>,
+}
+
+impl SessionStore {
+    pub(super) fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Sessions::default())),
+        }
+    }
+
+    fn issue(&self) -> Result<String, getrandom::Error> {
+        let mut bytes = [0_u8; 32];
+        getrandom::fill(&mut bytes)?;
+        let token = hex_token(&bytes);
+        self.issue_at(token.clone(), Instant::now());
+        Ok(token)
+    }
+
+    fn issue_at(&self, token: String, now: Instant) {
+        let mut sessions = self.lock();
+        sessions.purge_expired(now);
+        if sessions.by_token.len() >= MAX_SESSIONS {
+            let evicted = sessions
+                .by_token
+                .iter()
+                .min_by(|(left_token, left_expiry), (right_token, right_expiry)| {
+                    left_expiry
+                        .cmp(right_expiry)
+                        .then_with(|| left_token.cmp(right_token))
+                })
+                .map(|(token, _)| token.clone());
+            if let Some(token) = evicted {
+                sessions.by_token.remove(&token);
+            }
+        }
+        sessions.by_token.insert(token, now + SESSION_LIFETIME);
+    }
+
+    fn validate(&self, token: &str) -> bool {
+        self.validate_at(token, Instant::now())
+    }
+
+    fn validate_at(&self, token: &str, now: Instant) -> bool {
+        let mut sessions = self.lock();
+        sessions.purge_expired(now);
+        sessions.by_token.contains_key(token)
+    }
+
+    fn revoke(&self, token: &str) -> bool {
+        self.lock().by_token.remove(token).is_some()
+    }
+
+    fn lock(&self) -> MutexGuard<'_, Sessions> {
+        self.inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
+impl Sessions {
+    fn purge_expired(&mut self, now: Instant) {
+        self.by_token.retain(|_, expiry| *expiry > now);
+    }
+}
+
+pub(super) fn routes(state: HttpState) -> Router<HttpState> {
+    let protected = Router::new()
+        .route("/admin/api/session", get(session))
+        .route("/admin/api/overview", get(overview))
+        .route("/admin/api/rows", get(rows))
+        .route_layer(middleware::from_fn_with_state(state, require_authenticated));
+
+    Router::new()
+        .route("/admin", get(index))
+        .route("/admin/", get(index))
+        .route("/admin/assets/styles.css", get(styles))
+        .route("/admin/assets/app.js", get(script))
+        .route("/admin/api/login", post(login))
+        .route("/admin/api/logout", post(logout))
+        .merge(protected)
+        .layer(DefaultBodyLimit::max(1_024))
+        .layer(middleware::from_fn(add_no_store))
+}
+
+async fn require_authenticated(
+    State(state): State<HttpState>,
+    headers: HeaderMap,
+    request: Request,
+    next: Next,
+) -> Response {
+    if authenticate(&headers, &state.admin_sessions).is_err() {
+        authentication_required()
+    } else {
+        next.run(request).await
+    }
+}
+
+async fn add_no_store(request: Request, next: Next) -> Response {
+    no_store(next.run(request).await)
+}
+
+async fn index() -> Response {
+    let mut response = static_response("text/html; charset=utf-8", INDEX_HTML);
+    response.headers_mut().insert(
+        HeaderName::from_static("content-security-policy"),
+        CSP.clone(),
+    );
+    response
+}
+
+async fn styles() -> Response {
+    static_response("text/css; charset=utf-8", STYLES_CSS)
+}
+
+async fn script() -> Response {
+    static_response("text/javascript; charset=utf-8", APP_JS)
+}
+
+#[derive(Deserialize)]
+struct LoginRequest {
+    username: String,
+    password: String,
+}
+
+async fn login(
+    State(state): State<HttpState>,
+    headers: HeaderMap,
+    Json(request): Json<LoginRequest>,
+) -> Response {
+    if request.username != ADMIN_USERNAME || request.password != ADMIN_PASSWORD {
+        return auth_json(
+            StatusCode::UNAUTHORIZED,
+            json!({
+                "code": "invalid_credentials",
+                "message": "Invalid username or password."
+            }),
+            None,
+        );
+    }
+
+    for token in presented_valid_tokens(&headers) {
+        state.admin_sessions.revoke(&token);
+    }
+    let token = match state.admin_sessions.issue() {
+        Ok(token) => token,
+        Err(error) => {
+            tracing::error!(error = ?error, "could not create an admin browser session");
+            return auth_json(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                json!({"code": "internal", "message": "The request could not be completed."}),
+                None,
+            );
+        }
+    };
+    auth_json(
+        StatusCode::OK,
+        json!({"authenticated": true}),
+        Some(session_cookie(&token)),
+    )
+}
+
+async fn logout(State(state): State<HttpState>, headers: HeaderMap) -> Response {
+    for token in presented_valid_tokens(&headers) {
+        state.admin_sessions.revoke(&token);
+    }
+    auth_json(
+        StatusCode::OK,
+        json!({"authenticated": false}),
+        Some(clear_session_cookie()),
+    )
+}
+
+async fn session() -> Response {
+    auth_json(
+        StatusCode::OK,
+        json!({"authenticated": true, "username": ADMIN_USERNAME}),
+        None,
+    )
+}
+
+#[derive(Deserialize)]
+struct OverviewQuery {
+    #[serde(default)]
+    shard: Option<u16>,
+}
+
+#[derive(Serialize)]
+struct OverviewResponse {
+    shard_count: u16,
+    selected_shard: u16,
+    tables: Vec<String>,
+}
+
+async fn overview(State(state): State<HttpState>, Query(query): Query<OverviewQuery>) -> Response {
+    let shard = query.shard.unwrap_or(0);
+    let session = state.engine.session();
+    let result = state
+        .engine
+        .inspect_shard(&session, shard, Statement::new(TABLE_DISCOVERY_SQL, vec![]))
+        .await;
+
+    match result.and_then(table_names) {
+        Ok(tables) => admin_json(
+            StatusCode::OK,
+            &OverviewResponse {
+                shard_count: state.engine.shard_count(),
+                selected_shard: shard,
+                tables,
+            },
+        ),
+        Err(error) => admin_engine_error(error),
+    }
+}
+
+#[derive(Deserialize)]
+struct RowsQuery {
+    shard: u16,
+    table: String,
+    #[serde(default)]
+    limit: Option<u16>,
+    #[serde(default)]
+    offset: Option<u64>,
+}
+
+#[derive(Serialize)]
+struct RowsResponse {
+    shard: u16,
+    table: String,
+    limit: u16,
+    offset: u64,
+    has_more: bool,
+    columns: Vec<super::QueryColumn>,
+    rows: Vec<Vec<JsonValue>>,
+}
+
+async fn rows(State(state): State<HttpState>, Query(query): Query<RowsQuery>) -> Response {
+    let limit = query.limit.unwrap_or(DEFAULT_PAGE_LIMIT);
+    let offset = query.offset.unwrap_or(0);
+    if !(1..=MAX_PAGE_LIMIT).contains(&limit) {
+        return invalid_argument("admin page limit is outside the supported range");
+    }
+    if offset > MAX_PAGE_OFFSET {
+        return invalid_argument("admin page offset is outside the supported range");
+    }
+    if !is_visible_table_name(&query.table) {
+        return invalid_argument("admin table name is not browseable");
+    }
+
+    let session = state.engine.session();
+    let verified = state
+        .engine
+        .inspect_shard(
+            &session,
+            query.shard,
+            Statement::new(TABLE_LOOKUP_SQL, vec![Value::Text(query.table.clone())]),
+        )
+        .await;
+    let verified = match verified.and_then(table_names) {
+        Ok(tables) if tables.as_slice() == [query.table.as_str()] => true,
+        Ok(_) => false,
+        Err(error) => return admin_engine_error(error),
+    };
+    if !verified {
+        return invalid_argument("admin table name is not browseable");
+    }
+
+    let quoted_table = quote_identifier(&query.table);
+    let result = state
+        .engine
+        .inspect_shard(
+            &session,
+            query.shard,
+            Statement::new(
+                format!(
+                    "SELECT browse.* FROM {quoted_table} AS browse \
+                     WHERE EXISTS (\
+                         SELECT 1 FROM pragma_table_list \
+                         WHERE schema = 'main' AND type = 'table' \
+                           AND name = ?1 COLLATE BINARY \
+                           AND lower(name) NOT GLOB 'sqlite_*' \
+                           AND lower(name) != 'briskdb' \
+                           AND lower(name) NOT GLOB 'briskdb_*'\
+                     ) \
+                     LIMIT ?2 OFFSET ?3"
+                ),
+                vec![
+                    Value::Text(query.table.clone()),
+                    Value::Int64(i64::from(limit) + 1),
+                    Value::Int64(offset as i64),
+                ],
+            ),
+        )
+        .await;
+
+    match result {
+        Ok(result) => page_response(query.shard, query.table, limit, offset, result),
+        Err(error) => admin_engine_error(error),
+    }
+}
+
+fn page_response(
+    shard: u16,
+    table: String,
+    limit: u16,
+    offset: u64,
+    result: ResultSet,
+) -> Response {
+    let super::QueryResponse {
+        columns, mut rows, ..
+    } = super::result_set_to_query_response(shard, result);
+    let has_more = rows.len() > usize::from(limit)
+        && offset
+            .checked_add(u64::from(limit))
+            .is_some_and(|next_offset| next_offset <= MAX_PAGE_OFFSET);
+    rows.truncate(usize::from(limit));
+    admin_json(
+        StatusCode::OK,
+        &RowsResponse {
+            shard,
+            table,
+            limit,
+            offset,
+            has_more,
+            columns,
+            rows,
+        },
+    )
+}
+
+fn table_names(result: ResultSet) -> Result<Vec<String>, EngineError> {
+    result
+        .into_parts()
+        .1
+        .into_iter()
+        .map(|row| match row.into_values().into_iter().next() {
+            Some(Value::Text(name)) if is_visible_table_name(&name) => Ok(name),
+            _ => Err(EngineError::new(
+                EngineErrorKind::Internal,
+                "admin table discovery returned an unexpected value",
+            )),
+        })
+        .collect()
+}
+
+fn is_visible_table_name(name: &str) -> bool {
+    if name.contains('\0') {
+        return false;
+    }
+    let lower = name.to_ascii_lowercase();
+    lower != "briskdb" && !lower.starts_with("briskdb_") && !lower.starts_with("sqlite_")
+}
+
+fn quote_identifier(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
+}
+
+fn hex_token(bytes: &[u8; 32]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut token = String::with_capacity(64);
+    for byte in bytes {
+        token.push(char::from(HEX[usize::from(byte >> 4)]));
+        token.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    token
+}
+
+enum PresentedSession {
+    Missing,
+    ValidFormat(String),
+    Invalid,
+}
+
+fn presented_session(headers: &HeaderMap) -> PresentedSession {
+    let mut found = None;
+    for header in headers.get_all(COOKIE) {
+        let Ok(header) = header.to_str() else {
+            return PresentedSession::Invalid;
+        };
+        for pair in header.split(';') {
+            let Some((name, value)) = pair.trim().split_once('=') else {
+                continue;
+            };
+            if name.trim() != SESSION_COOKIE {
+                continue;
+            }
+            if found.is_some() || !valid_token_format(value.trim()) {
+                return PresentedSession::Invalid;
+            }
+            found = Some(value.trim().to_owned());
+        }
+    }
+    found.map_or(PresentedSession::Missing, PresentedSession::ValidFormat)
+}
+
+fn presented_valid_tokens(headers: &HeaderMap) -> Vec<String> {
+    headers
+        .get_all(COOKIE)
+        .iter()
+        .filter_map(|header| header.to_str().ok())
+        .flat_map(|header| header.split(';'))
+        .filter_map(|pair| pair.trim().split_once('='))
+        .filter_map(|(name, value)| {
+            let value = value.trim();
+            (name.trim() == SESSION_COOKIE && valid_token_format(value)).then(|| value.to_owned())
+        })
+        .collect()
+}
+
+fn valid_token_format(token: &str) -> bool {
+    token.len() == 64
+        && token
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn authenticate(headers: &HeaderMap, sessions: &SessionStore) -> Result<String, ()> {
+    match presented_session(headers) {
+        PresentedSession::ValidFormat(token) if sessions.validate(&token) => Ok(token),
+        PresentedSession::Missing
+        | PresentedSession::ValidFormat(_)
+        | PresentedSession::Invalid => Err(()),
+    }
+}
+
+fn session_cookie(token: &str) -> HeaderValue {
+    HeaderValue::from_str(&format!(
+        "{SESSION_COOKIE}={token}; Path=/admin; HttpOnly; SameSite=Strict; Max-Age=28800"
+    ))
+    .expect("a lowercase hexadecimal token is a valid cookie value")
+}
+
+fn clear_session_cookie() -> HeaderValue {
+    HeaderValue::from_static(
+        "briskdb_admin_session=; Path=/admin; HttpOnly; SameSite=Strict; Max-Age=0",
+    )
+}
+
+fn static_response(content_type: &'static str, body: &'static str) -> Response {
+    let mut response = body.into_response();
+    response
+        .headers_mut()
+        .insert(CONTENT_TYPE, HeaderValue::from_static(content_type));
+    no_store(response)
+}
+
+fn admin_json(status: StatusCode, body: &impl Serialize) -> Response {
+    no_store((status, Json(body)).into_response())
+}
+
+fn auth_json(status: StatusCode, body: JsonValue, cookie: Option<HeaderValue>) -> Response {
+    let mut response = admin_json(status, &body);
+    if let Some(cookie) = cookie {
+        response.headers_mut().insert(SET_COOKIE, cookie);
+    }
+    response
+}
+
+fn authentication_required() -> Response {
+    auth_json(
+        StatusCode::UNAUTHORIZED,
+        json!({
+            "code": "authentication_required",
+            "message": "Log in to continue."
+        }),
+        Some(clear_session_cookie()),
+    )
+}
+
+fn invalid_argument(diagnostic: &'static str) -> Response {
+    admin_engine_error(EngineError::new(
+        EngineErrorKind::InvalidArgument,
+        diagnostic,
+    ))
+}
+
+fn admin_engine_error(error: EngineError) -> Response {
+    no_store(super::ApiError(error).into_response())
+}
+
+fn no_store(mut response: Response) -> Response {
+    response
+        .headers_mut()
+        .insert(CACHE_CONTROL, NO_STORE.clone());
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::Arc, thread};
+
+    use axum::{
+        body::{Body, to_bytes},
+        http::{Method, Request},
+    };
+    use tower::ServiceExt;
+
+    use super::*;
+    use crate::core::{Column, DataType, Database, Row};
+
+    fn token(character: char) -> String {
+        std::iter::repeat_n(character, 64).collect()
+    }
+
+    fn application() -> (tempfile::TempDir, Router) {
+        let temp = tempfile::tempdir().unwrap();
+        let database = Arc::new(Database::open(temp.path(), 2).unwrap());
+        let router = super::super::router(database);
+        (temp, router)
+    }
+
+    async fn request(
+        app: &Router,
+        method: Method,
+        uri: &str,
+        cookie: Option<&str>,
+        body: Option<JsonValue>,
+    ) -> Response {
+        let mut builder = Request::builder().method(method).uri(uri);
+        if let Some(cookie) = cookie {
+            builder = builder.header(COOKIE, cookie);
+        }
+        let body = if let Some(body) = body {
+            builder = builder.header(CONTENT_TYPE, "application/json");
+            Body::from(serde_json::to_vec(&body).unwrap())
+        } else {
+            Body::empty()
+        };
+        app.clone()
+            .oneshot(builder.body(body).unwrap())
+            .await
+            .unwrap()
+    }
+
+    async fn body_json(response: Response) -> JsonValue {
+        let bytes = to_bytes(response.into_body(), 1_048_576).await.unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    async fn login_cookie(app: &Router) -> HeaderValue {
+        let response = request(
+            app,
+            Method::POST,
+            "/admin/api/login",
+            None,
+            Some(json!({"username": "admin", "password": "admin"})),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        response.headers()[SET_COOKIE].clone()
+    }
+
+    #[test]
+    fn token_encoding_is_exact_lowercase_hex() {
+        let bytes = std::array::from_fn(|index| index as u8);
+        assert_eq!(
+            hex_token(&bytes),
+            "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        );
+    }
+
+    #[test]
+    fn session_expiry_capacity_eviction_and_revocation_are_deterministic() {
+        let sessions = SessionStore::new();
+        let now = Instant::now();
+        let first = token('0');
+        sessions.issue_at(first.clone(), now);
+        assert!(sessions.validate_at(&first, now + SESSION_LIFETIME - Duration::from_nanos(1)));
+        assert!(!sessions.validate_at(&first, now + SESSION_LIFETIME));
+
+        for index in 0..MAX_SESSIONS {
+            sessions.issue_at(
+                format!("{index:064x}"),
+                now + Duration::from_nanos(index as u64),
+            );
+        }
+        assert_eq!(sessions.lock().by_token.len(), MAX_SESSIONS);
+        sessions.issue_at(token('f'), now + Duration::from_secs(1));
+        assert_eq!(sessions.lock().by_token.len(), MAX_SESSIONS);
+        assert!(!sessions.validate_at(&format!("{:064x}", 0), now));
+        assert!(sessions.revoke(&token('f')));
+        assert!(!sessions.revoke(&token('f')));
+    }
+
+    #[test]
+    fn cloned_store_is_safe_for_independent_concurrent_sessions() {
+        let sessions = SessionStore::new();
+        let now = Instant::now();
+        let mut workers = Vec::new();
+        for index in 0..32 {
+            let sessions = sessions.clone();
+            workers.push(thread::spawn(move || {
+                let token = format!("{index:064x}");
+                sessions.issue_at(token.clone(), now);
+                assert!(sessions.validate_at(&token, now));
+            }));
+        }
+        for worker in workers {
+            worker.join().unwrap();
+        }
+        assert_eq!(sessions.lock().by_token.len(), 32);
+    }
+
+    #[test]
+    fn cookie_parser_accepts_one_token_and_rejects_malformed_or_duplicate_values() {
+        let value = token('a');
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            COOKIE,
+            HeaderValue::from_str(&format!("theme=dark; {SESSION_COOKIE}={value}; x=1")).unwrap(),
+        );
+        assert!(matches!(
+            presented_session(&headers),
+            PresentedSession::ValidFormat(found) if found == value
+        ));
+
+        headers.insert(
+            COOKIE,
+            HeaderValue::from_str(&format!(
+                "{SESSION_COOKIE}={value}; {SESSION_COOKIE}={value}"
+            ))
+            .unwrap(),
+        );
+        assert!(matches!(
+            presented_session(&headers),
+            PresentedSession::Invalid
+        ));
+        headers.insert(
+            COOKIE,
+            HeaderValue::from_static("briskdb_admin_session=UPPERCASE"),
+        );
+        assert!(matches!(
+            presented_session(&headers),
+            PresentedSession::Invalid
+        ));
+    }
+
+    #[test]
+    fn table_names_are_filtered_and_identifiers_are_quoted() {
+        for hidden in ["briskdb", "BriskDB_meta", "SQLITE_sequence", "bad\0name"] {
+            assert!(!is_visible_table_name(hidden));
+        }
+        assert!(is_visible_table_name(""));
+        assert!(is_visible_table_name("orders"));
+        assert!(is_visible_table_name("snowman_☃"));
+        assert_eq!(quote_identifier("a\"b"), "\"a\"\"b\"");
+    }
+
+    #[test]
+    fn typed_table_discovery_excludes_virtual_and_shadow_objects() {
+        let connection = rusqlite::Connection::open_in_memory().unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE ordinary (id INTEGER); \
+                 CREATE VIRTUAL TABLE docs USING fts5(body);",
+            )
+            .unwrap();
+        let mut statement = connection.prepare(TABLE_DISCOVERY_SQL).unwrap();
+        let names = statement
+            .query_map([], |row| row.get::<_, String>(0))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(names, ["ordinary"]);
+    }
+
+    #[tokio::test]
+    async fn embedded_shell_and_assets_are_public_deterministic_and_same_origin() {
+        let (_temp, app) = application();
+        for (uri, content_type, marker) in [
+            ("/admin", "text/html; charset=utf-8", "BriskDB Data Browser"),
+            (
+                "/admin/assets/styles.css",
+                "text/css; charset=utf-8",
+                "--accent",
+            ),
+            (
+                "/admin/assets/app.js",
+                "text/javascript; charset=utf-8",
+                "textContent",
+            ),
+        ] {
+            let response = request(&app, Method::GET, uri, None, None).await;
+            assert_eq!(response.status(), StatusCode::OK);
+            assert_eq!(response.headers()[CONTENT_TYPE], content_type);
+            assert_eq!(response.headers()[CACHE_CONTROL], "no-store");
+            let text = String::from_utf8(
+                to_bytes(response.into_body(), 1_048_576)
+                    .await
+                    .unwrap()
+                    .to_vec(),
+            )
+            .unwrap();
+            assert!(text.contains(marker));
+            assert!(!text.contains("https://"));
+            assert!(!text.contains("http://"));
+        }
+
+        for id in [
+            "login-form",
+            "browser-view",
+            "shard-select",
+            "table-list",
+            "status",
+            "data-head",
+            "data-body",
+            "previous-page",
+            "next-page",
+        ] {
+            assert!(INDEX_HTML.contains(&format!("id=\"{id}\"")));
+            assert!(APP_JS.contains(&format!("#{id}")));
+        }
+        assert!(!APP_JS.contains("innerHTML"));
+        assert!(APP_JS.contains("(empty table name)"));
+        assert!(APP_JS.contains("(whitespace-only table name)"));
+        assert!(APP_JS.contains("state.table === null"));
+    }
+
+    #[tokio::test]
+    async fn exact_login_session_and_idempotent_logout_flow() {
+        let (_temp, app) = application();
+        for credentials in [
+            json!({"username": "Admin", "password": "admin"}),
+            json!({"username": "admin", "password": "Admin"}),
+            json!({"username": "", "password": ""}),
+        ] {
+            let response = request(
+                &app,
+                Method::POST,
+                "/admin/api/login",
+                None,
+                Some(credentials),
+            )
+            .await;
+            assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+            assert!(response.headers().get(SET_COOKIE).is_none());
+            assert_eq!(
+                body_json(response).await,
+                json!({"code":"invalid_credentials","message":"Invalid username or password."})
+            );
+        }
+
+        let set_cookie = login_cookie(&app).await;
+        let set_cookie = set_cookie.to_str().unwrap();
+        assert!(set_cookie.contains("Path=/admin"));
+        assert!(set_cookie.contains("HttpOnly"));
+        assert!(set_cookie.contains("SameSite=Strict"));
+        assert!(set_cookie.contains("Max-Age=28800"));
+        let cookie = set_cookie.split(';').next().unwrap();
+        assert!(valid_token_format(cookie.split_once('=').unwrap().1));
+
+        let response = request(&app, Method::GET, "/admin/api/session", Some(cookie), None).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            body_json(response).await,
+            json!({"authenticated":true,"username":"admin"})
+        );
+
+        let response = request(&app, Method::POST, "/admin/api/logout", Some(cookie), None).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(
+            response.headers()[SET_COOKIE]
+                .to_str()
+                .unwrap()
+                .contains("Max-Age=0")
+        );
+
+        let rejected = request(&app, Method::GET, "/admin/api/session", Some(cookie), None).await;
+        assert_eq!(rejected.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            body_json(rejected).await,
+            json!({"code":"authentication_required","message":"Log in to continue."})
+        );
+
+        let response = request(&app, Method::POST, "/admin/api/logout", None, None).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(body_json(response).await, json!({"authenticated":false}));
+    }
+
+    #[tokio::test]
+    async fn overview_and_rows_require_authentication_and_validate_bounds() {
+        let (_temp, app) = application();
+        for uri in [
+            "/admin/api/session",
+            "/admin/api/overview?shard=0",
+            "/admin/api/rows?shard=0&table=widgets",
+            "/admin/api/overview?shard=not-a-number",
+            "/admin/api/rows?shard=not-a-number",
+        ] {
+            let response = request(&app, Method::GET, uri, None, None).await;
+            assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+            assert!(
+                response.headers()[SET_COOKIE]
+                    .to_str()
+                    .unwrap()
+                    .contains("Max-Age=0")
+            );
+        }
+
+        let set_cookie = login_cookie(&app).await;
+        let cookie = set_cookie.to_str().unwrap().split(';').next().unwrap();
+        for uri in [
+            "/admin/api/rows?shard=0&table=widgets&limit=0",
+            "/admin/api/rows?shard=0&table=widgets&limit=201",
+            "/admin/api/rows?shard=0&table=widgets&offset=1000001",
+            "/admin/api/rows?shard=2&table=widgets",
+        ] {
+            let response = request(&app, Method::GET, uri, Some(cookie), None).await;
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{uri}");
+        }
+    }
+
+    fn routing_key_for_shard(database: &Database, target: u16) -> String {
+        (0_u64..)
+            .map(|candidate| format!("admin-browser-{candidate}"))
+            .find(|candidate| database.shard_for_key(candidate.as_bytes()) == target)
+            .unwrap()
+    }
+
+    async fn response_json(response: Response) -> (StatusCode, JsonValue) {
+        let status = response.status();
+        (status, body_json(response).await)
+    }
+
+    #[tokio::test]
+    async fn authenticated_browser_discovers_and_pages_only_the_selected_shard() {
+        let temp = tempfile::tempdir().unwrap();
+        let database = Arc::new(Database::open(temp.path(), 2).unwrap());
+        database
+            .broadcast(
+                "CREATE TABLE widgets (\
+                    id INTEGER PRIMARY KEY, \
+                    label TEXT NOT NULL, \
+                    payload BLOB, \
+                    note TEXT\
+                 ); \
+                 CREATE TABLE \"\" (value TEXT); \
+                 CREATE TABLE \" \" (value TEXT); \
+                 CREATE TABLE \"odd\"\"table\" (value TEXT); \
+                 CREATE VIEW widget_view AS SELECT id FROM widgets;",
+            )
+            .unwrap();
+        for shard in 0..2 {
+            let routing_key = routing_key_for_shard(&database, shard);
+            for id in 1..=3_i64 {
+                database
+                    .execute(
+                        &routing_key,
+                        "INSERT INTO widgets (id, label, payload, note) VALUES (?1, ?2, ?3, ?4)",
+                        &[
+                            Value::Int64(id),
+                            Value::Text(format!("shard-{shard}-row-{id}")),
+                            Value::Binary(vec![shard as u8, id as u8]),
+                            Value::Null,
+                        ],
+                    )
+                    .unwrap();
+            }
+        }
+        let app = super::super::router(database);
+        let set_cookie = login_cookie(&app).await;
+        let cookie = set_cookie.to_str().unwrap().split(';').next().unwrap();
+
+        assert_eq!(
+            response_json(
+                request(
+                    &app,
+                    Method::GET,
+                    "/admin/api/overview?shard=1",
+                    Some(cookie),
+                    None,
+                )
+                .await
+            )
+            .await,
+            (
+                StatusCode::OK,
+                json!({
+                    "shard_count": 2,
+                    "selected_shard": 1,
+                    "tables": ["", " ", "odd\"table", "widgets"]
+                })
+            )
+        );
+
+        let (status, first_page) = response_json(
+            request(
+                &app,
+                Method::GET,
+                "/admin/api/rows?shard=1&table=widgets&limit=2&offset=0",
+                Some(cookie),
+                None,
+            )
+            .await,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(first_page["shard"], 1);
+        assert_eq!(first_page["table"], "widgets");
+        assert_eq!(first_page["limit"], 2);
+        assert_eq!(first_page["offset"], 0);
+        assert_eq!(first_page["has_more"], true);
+        assert_eq!(
+            first_page["columns"],
+            json!([
+                {"name":"id","data_type":"unknown"},
+                {"name":"label","data_type":"unknown"},
+                {"name":"payload","data_type":"unknown"},
+                {"name":"note","data_type":"unknown"}
+            ])
+        );
+        assert_eq!(
+            first_page["rows"],
+            json!([
+                [1, "shard-1-row-1", [1, 1], null],
+                [2, "shard-1-row-2", [1, 2], null]
+            ])
+        );
+
+        assert_eq!(
+            response_json(
+                request(
+                    &app,
+                    Method::GET,
+                    "/admin/api/rows?shard=1&table=widgets&limit=2&offset=2",
+                    Some(cookie),
+                    None,
+                )
+                .await
+            )
+            .await,
+            (
+                StatusCode::OK,
+                json!({
+                    "shard": 1,
+                    "table": "widgets",
+                    "limit": 2,
+                    "offset": 2,
+                    "has_more": false,
+                    "columns": [
+                        {"name":"id","data_type":"unknown"},
+                        {"name":"label","data_type":"unknown"},
+                        {"name":"payload","data_type":"unknown"},
+                        {"name":"note","data_type":"unknown"}
+                    ],
+                    "rows": [[3, "shard-1-row-3", [1, 3], null]]
+                })
+            )
+        );
+
+        let odd_table = "/admin/api/rows?shard=0&table=odd%22table&limit=50&offset=0";
+        let (status, empty) =
+            response_json(request(&app, Method::GET, odd_table, Some(cookie), None).await).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(empty["rows"], json!([]));
+        assert_eq!(empty["has_more"], false);
+
+        let empty_name = "/admin/api/rows?shard=0&table=&limit=50&offset=0";
+        let (status, empty) =
+            response_json(request(&app, Method::GET, empty_name, Some(cookie), None).await).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(empty["table"], "");
+        assert_eq!(empty["rows"], json!([]));
+
+        let whitespace_name = "/admin/api/rows?shard=0&table=%20&limit=50&offset=0";
+        let (status, whitespace) =
+            response_json(request(&app, Method::GET, whitespace_name, Some(cookie), None).await)
+                .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(whitespace["table"], " ");
+
+        let shard_zero = request(
+            &app,
+            Method::GET,
+            "/admin/api/rows?shard=0&table=widgets&limit=1&offset=0",
+            Some(cookie),
+            None,
+        );
+        let shard_one = request(
+            &app,
+            Method::GET,
+            "/admin/api/rows?shard=1&table=widgets&limit=1&offset=0",
+            Some(cookie),
+            None,
+        );
+        let (shard_zero, shard_one) = tokio::join!(shard_zero, shard_one);
+        let (_, shard_zero) = response_json(shard_zero).await;
+        let (_, shard_one) = response_json(shard_one).await;
+        assert_eq!(shard_zero["rows"][0][1], "shard-0-row-1");
+        assert_eq!(shard_one["rows"][0][1], "shard-1-row-1");
+
+        for table in ["briskdb_shard_metadata", "widget_view", "guessed_table"] {
+            let uri = format!("/admin/api/rows?shard=0&table={table}");
+            let response = request(&app, Method::GET, &uri, Some(cookie), None).await;
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{table}");
+        }
+        let recovered = request(
+            &app,
+            Method::GET,
+            "/admin/api/rows?shard=0&table=widgets&limit=1&offset=0",
+            Some(cookie),
+            None,
+        )
+        .await;
+        assert_eq!(recovered.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn browser_sessions_are_independent_and_unknown_tokens_are_cleared() {
+        let (_temp, app) = application();
+        let first = login_cookie(&app).await;
+        let second = login_cookie(&app).await;
+        let first = first.to_str().unwrap().split(';').next().unwrap();
+        let second = second.to_str().unwrap().split(';').next().unwrap();
+        assert_ne!(first, second);
+
+        let duplicate_first = format!("{first}; {first}");
+        let logged_out = request(
+            &app,
+            Method::POST,
+            "/admin/api/logout",
+            Some(&duplicate_first),
+            None,
+        )
+        .await;
+        assert_eq!(logged_out.status(), StatusCode::OK);
+        assert_eq!(
+            request(&app, Method::GET, "/admin/api/session", Some(first), None,)
+                .await
+                .status(),
+            StatusCode::UNAUTHORIZED
+        );
+        assert_eq!(
+            request(&app, Method::GET, "/admin/api/session", Some(second), None,)
+                .await
+                .status(),
+            StatusCode::OK
+        );
+
+        for invalid in [
+            "briskdb_admin_session=short",
+            "briskdb_admin_session=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "briskdb_admin_session=ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        ] {
+            let response =
+                request(&app, Method::GET, "/admin/api/session", Some(invalid), None).await;
+            assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+            assert!(
+                response.headers()[SET_COOKIE]
+                    .to_str()
+                    .unwrap()
+                    .contains("Max-Age=0")
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn framework_login_rejections_are_never_cached() {
+        let (_temp, app) = application();
+        for (content_type, body) in [
+            ("application/json", "{".to_owned()),
+            ("text/plain", "username=admin&password=admin".to_owned()),
+            ("application/json", "x".repeat(1_025)),
+        ] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method(Method::POST)
+                        .uri("/admin/api/login")
+                        .header(CONTENT_TYPE, content_type)
+                        .body(Body::from(body))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert!(response.status().is_client_error());
+            assert_eq!(response.headers()[CACHE_CONTROL], "no-store");
+            assert!(response.headers().get(SET_COOKIE).is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn maximum_offset_never_advertises_an_unrequestable_next_page() {
+        let result = ResultSet::new(
+            vec![Column::new("value", DataType::Unknown)],
+            vec![
+                Row::new(vec![Value::Int64(1)]),
+                Row::new(vec![Value::Int64(2)]),
+            ],
+        )
+        .unwrap();
+        let body = body_json(page_response(
+            0,
+            "widgets".to_owned(),
+            1,
+            MAX_PAGE_OFFSET,
+            result,
+        ))
+        .await;
+        assert_eq!(body["rows"], json!([[1]]));
+        assert_eq!(body["has_more"], false);
+    }
+
+    #[tokio::test]
+    async fn expired_session_is_rejected_and_successful_relogin_replaces_presented_session() {
+        let temp = tempfile::tempdir().unwrap();
+        let sessions = SessionStore::new();
+        let expired = token('e');
+        sessions.issue_at(
+            expired.clone(),
+            Instant::now() - SESSION_LIFETIME - Duration::from_secs(1),
+        );
+        let state = HttpState {
+            engine: crate::core::Engine::from_database(Arc::new(
+                Database::open(temp.path(), 2).unwrap(),
+            )),
+            admin_sessions: sessions,
+        };
+        let app = routes(state.clone()).with_state(state);
+        let expired_cookie = format!("{SESSION_COOKIE}={expired}");
+        let response = request(
+            &app,
+            Method::GET,
+            "/admin/api/session",
+            Some(&expired_cookie),
+            None,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+        let first = login_cookie(&app).await;
+        let first = first.to_str().unwrap().split(';').next().unwrap();
+        let replacement = request(
+            &app,
+            Method::POST,
+            "/admin/api/login",
+            Some(first),
+            Some(json!({"username":"admin","password":"admin"})),
+        )
+        .await;
+        assert_eq!(replacement.status(), StatusCode::OK);
+        let replacement_cookie = replacement.headers()[SET_COOKIE]
+            .to_str()
+            .unwrap()
+            .split(';')
+            .next()
+            .unwrap();
+        assert_ne!(first, replacement_cookie);
+        assert_eq!(
+            request(&app, Method::GET, "/admin/api/session", Some(first), None,)
+                .await
+                .status(),
+            StatusCode::UNAUTHORIZED
+        );
+        assert_eq!(
+            request(
+                &app,
+                Method::GET,
+                "/admin/api/session",
+                Some(replacement_cookie),
+                None,
+            )
+            .await
+            .status(),
+            StatusCode::OK
+        );
+    }
+
+    #[test]
+    fn admin_adapter_source_stays_above_storage_and_routing_internals() {
+        let source = include_str!("admin.rs");
+        let production = source.split_once("#[cfg(test)]").unwrap().0;
+        for pieces in [
+            ["rusi", "qlite"],
+            ["crate::", "storage"],
+            ["std::", "fs"],
+            ["shard_", "for_key"],
+        ] {
+            let forbidden = pieces.concat();
+            assert!(!production.contains(&forbidden), "found {forbidden}");
+        }
+    }
+}

--- a/src/protocol/http/admin/app.js
+++ b/src/protocol/http/admin/app.js
@@ -1,0 +1,324 @@
+(() => {
+  "use strict";
+
+  const state = {
+    shard: 0,
+    shardCount: 0,
+    table: null,
+    limit: 50,
+    offset: 0,
+    hasMore: false,
+    overviewRequest: 0,
+    rowsRequest: 0,
+  };
+
+  const elements = {
+    loginView: document.querySelector("#login-view"),
+    browserView: document.querySelector("#browser-view"),
+    loginForm: document.querySelector("#login-form"),
+    loginError: document.querySelector("#login-error"),
+    username: document.querySelector("#username"),
+    password: document.querySelector("#password"),
+    logout: document.querySelector("#logout-button"),
+    shard: document.querySelector("#shard-select"),
+    shardKicker: document.querySelector("#shard-kicker"),
+    tableList: document.querySelector("#table-list"),
+    tableCount: document.querySelector("#table-count"),
+    tableTitle: document.querySelector("#table-title"),
+    tableSubtitle: document.querySelector("#table-subtitle"),
+    pageSize: document.querySelector("#page-size"),
+    status: document.querySelector("#status"),
+    empty: document.querySelector("#empty-state"),
+    tableWrap: document.querySelector("#table-wrap"),
+    tableCaption: document.querySelector("#table-caption"),
+    dataHead: document.querySelector("#data-head"),
+    dataBody: document.querySelector("#data-body"),
+    summary: document.querySelector("#page-summary"),
+    previous: document.querySelector("#previous-page"),
+    next: document.querySelector("#next-page"),
+  };
+
+  async function api(path, options = {}) {
+    const response = await fetch(path, {
+      credentials: "same-origin",
+      ...options,
+      headers: {
+        ...(options.body ? { "Content-Type": "application/json" } : {}),
+        ...(options.headers || {}),
+      },
+    });
+    const contentType = response.headers.get("content-type") || "";
+    const body = contentType.includes("json") ? await response.json() : null;
+    if (response.status === 401) {
+      showLogin(body && body.message ? body.message : "Log in to continue.");
+      throw new Error("authentication_required");
+    }
+    if (!response.ok) {
+      throw new Error(body && (body.detail || body.message) ? (body.detail || body.message) : `Request failed (${response.status})`);
+    }
+    return body;
+  }
+
+  function setStatus(message, isError = false) {
+    elements.status.textContent = message;
+    elements.status.classList.toggle("error", isError);
+  }
+
+  function showLogin(message = "") {
+    state.overviewRequest += 1;
+    state.rowsRequest += 1;
+    elements.browserView.classList.add("hidden");
+    elements.loginView.classList.remove("hidden");
+    elements.loginError.textContent = message;
+    elements.password.value = "";
+    elements.username.focus();
+  }
+
+  function showBrowser() {
+    elements.loginView.classList.add("hidden");
+    elements.browserView.classList.remove("hidden");
+    elements.loginError.textContent = "";
+  }
+
+  function clearPage(title, message, summary = "No rows loaded") {
+    elements.empty.classList.remove("hidden");
+    elements.empty.querySelector("h2").textContent = title;
+    elements.empty.querySelector("p").textContent = message;
+    elements.tableWrap.classList.add("hidden");
+    elements.dataHead.replaceChildren();
+    elements.dataBody.replaceChildren();
+    elements.summary.textContent = summary;
+    elements.previous.disabled = true;
+    elements.next.disabled = true;
+  }
+
+  function resetTable(message = "Select an application table to inspect its rows.") {
+    state.rowsRequest += 1;
+    state.table = null;
+    state.offset = 0;
+    state.hasMore = false;
+    elements.tableTitle.textContent = "Choose a table";
+    elements.tableSubtitle.textContent = message;
+    clearPage("No table selected", "Choose a table from the sidebar to browse a bounded, read-only page.");
+  }
+
+  function renderShardOptions(count, selected) {
+    elements.shard.replaceChildren();
+    for (let shard = 0; shard < count; shard += 1) {
+      const option = document.createElement("option");
+      option.value = String(shard);
+      option.textContent = `Shard ${shard}`;
+      option.selected = shard === selected;
+      elements.shard.append(option);
+    }
+  }
+
+  function displayTableName(table) {
+    if (table.length === 0) return "(empty table name)";
+    if (table.trim().length === 0) return "(whitespace-only table name)";
+    return table;
+  }
+
+  function renderTables(tables) {
+    elements.tableList.replaceChildren();
+    elements.tableCount.textContent = String(tables.length);
+    if (tables.length === 0) {
+      const note = document.createElement("p");
+      note.className = "no-tables";
+      note.textContent = "No application tables on this shard.";
+      elements.tableList.append(note);
+      resetTable("This physical shard has no browseable application tables.");
+      return;
+    }
+    for (const table of tables) {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "table-button";
+      button.textContent = displayTableName(table);
+      button.title = displayTableName(table);
+      button.addEventListener("click", () => selectTable(table, button));
+      elements.tableList.append(button);
+    }
+    resetTable();
+  }
+
+  async function loadOverview(shard) {
+    const requestId = ++state.overviewRequest;
+    state.rowsRequest += 1;
+    state.shard = shard;
+    state.table = null;
+    state.offset = 0;
+    elements.tableList.replaceChildren();
+    elements.tableCount.textContent = "…";
+    elements.shardKicker.textContent = `Physical shard ${shard}`;
+    resetTable(`Loading application tables from physical shard ${shard}.`);
+    setStatus(`Loading tables from physical shard ${shard}…`);
+    try {
+      const overview = await api(`/admin/api/overview?shard=${encodeURIComponent(shard)}`);
+      if (requestId !== state.overviewRequest) return;
+      state.shardCount = overview.shard_count;
+      state.shard = overview.selected_shard;
+      renderShardOptions(overview.shard_count, overview.selected_shard);
+      renderTables(overview.tables);
+      setStatus(`${overview.tables.length} application table${overview.tables.length === 1 ? "" : "s"} on physical shard ${overview.selected_shard}.`);
+    } catch (error) {
+      if (requestId !== state.overviewRequest) return;
+      if (error.message !== "authentication_required") {
+        resetTable("The table list could not be loaded.");
+        setStatus(error.message, true);
+      }
+    }
+  }
+
+  async function selectTable(table, button) {
+    state.table = table;
+    state.offset = 0;
+    for (const item of elements.tableList.querySelectorAll(".table-button")) {
+      item.classList.toggle("active", item === button);
+    }
+    elements.tableTitle.textContent = displayTableName(table);
+    elements.tableSubtitle.textContent = `Read-only rows from physical shard ${state.shard}.`;
+    await loadRows();
+  }
+
+  function renderCell(value) {
+    const cell = document.createElement("td");
+    const content = document.createElement("span");
+    if (value === null) {
+      content.className = "null-value";
+      content.textContent = "NULL";
+    } else if (Array.isArray(value)) {
+      content.className = "binary-value";
+      content.textContent = value.length === 0 ? "0x" : `0x${value.map((byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+    } else if (typeof value === "string") {
+      content.textContent = value;
+    } else {
+      content.textContent = JSON.stringify(value);
+    }
+    cell.append(content);
+    return cell;
+  }
+
+  function renderPage(page) {
+    elements.dataHead.replaceChildren();
+    elements.dataBody.replaceChildren();
+    const headingRow = document.createElement("tr");
+    for (const column of page.columns) {
+      const heading = document.createElement("th");
+      heading.scope = "col";
+      const name = document.createElement("span");
+      name.textContent = column.name || "(unnamed)";
+      const type = document.createElement("span");
+      type.className = "column-type";
+      type.textContent = column.data_type;
+      heading.append(name, type);
+      headingRow.append(heading);
+    }
+    elements.dataHead.append(headingRow);
+    for (const row of page.rows) {
+      const tableRow = document.createElement("tr");
+      for (const value of row) {
+        tableRow.append(renderCell(value));
+      }
+      elements.dataBody.append(tableRow);
+    }
+
+    state.hasMore = page.has_more;
+    elements.tableCaption.textContent = `${displayTableName(page.table)} rows from physical shard ${page.shard}`;
+    elements.empty.classList.toggle("hidden", page.rows.length !== 0);
+    elements.tableWrap.classList.toggle("hidden", page.rows.length === 0);
+    if (page.rows.length === 0) {
+      elements.empty.querySelector("h2").textContent = page.offset === 0 ? "This table is empty" : "No rows on this page";
+      elements.empty.querySelector("p").textContent = "Try the previous page or select another table.";
+    }
+    const first = page.rows.length === 0 ? 0 : page.offset + 1;
+    const last = page.offset + page.rows.length;
+    elements.summary.textContent = page.rows.length === 0 ? "No rows" : `Showing rows ${first}–${last}`;
+    elements.previous.disabled = page.offset === 0;
+    elements.next.disabled = !page.has_more;
+  }
+
+  async function loadRows() {
+    if (state.table === null) return;
+    const requestId = ++state.rowsRequest;
+    const displayTable = displayTableName(state.table);
+    clearPage("Loading rows…", `Reading ${displayTable} from physical shard ${state.shard}.`, "Loading…");
+    setStatus(`Loading ${displayTable} from physical shard ${state.shard}…`);
+    elements.previous.disabled = true;
+    elements.next.disabled = true;
+    const query = new URLSearchParams({
+      shard: String(state.shard),
+      table: state.table,
+      limit: String(state.limit),
+      offset: String(state.offset),
+    });
+    try {
+      const page = await api(`/admin/api/rows?${query.toString()}`);
+      if (requestId !== state.rowsRequest) return;
+      renderPage(page);
+      setStatus(`${page.rows.length} row${page.rows.length === 1 ? "" : "s"} loaded from physical shard ${page.shard}.`);
+    } catch (error) {
+      if (requestId !== state.rowsRequest) return;
+      if (error.message !== "authentication_required") {
+        clearPage("Rows unavailable", error.message, "No rows loaded");
+        setStatus(error.message, true);
+      }
+    }
+  }
+
+  elements.loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    elements.loginError.textContent = "";
+    const submit = elements.loginForm.querySelector("button[type='submit']");
+    submit.disabled = true;
+    try {
+      await api("/admin/api/login", {
+        method: "POST",
+        body: JSON.stringify({ username: elements.username.value, password: elements.password.value }),
+      });
+      showBrowser();
+      await loadOverview(0);
+    } catch (error) {
+      if (error.message !== "authentication_required") {
+        elements.loginError.textContent = error.message;
+      }
+    } finally {
+      submit.disabled = false;
+    }
+  });
+
+  elements.logout.addEventListener("click", async () => {
+    try {
+      await api("/admin/api/logout", { method: "POST" });
+    } catch (_) {
+      // The local page still returns to login when the server already forgot the session.
+    }
+    showLogin();
+  });
+
+  elements.shard.addEventListener("change", () => loadOverview(Number(elements.shard.value)));
+  elements.pageSize.addEventListener("change", () => {
+    state.limit = Number(elements.pageSize.value);
+    state.offset = 0;
+    loadRows();
+  });
+  elements.previous.addEventListener("click", () => {
+    state.offset = Math.max(0, state.offset - state.limit);
+    loadRows();
+  });
+  elements.next.addEventListener("click", () => {
+    if (state.hasMore) {
+      state.offset += state.limit;
+      loadRows();
+    }
+  });
+
+  api("/admin/api/session")
+    .then(() => {
+      showBrowser();
+      return loadOverview(0);
+    })
+    .catch((error) => {
+      if (error.message !== "authentication_required") showLogin(error.message);
+    });
+})();

--- a/src/protocol/http/admin/index.html
+++ b/src/protocol/http/admin/index.html
@@ -1,0 +1,108 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="dark">
+  <title>BriskDB Data Browser</title>
+  <link rel="stylesheet" href="/admin/assets/styles.css">
+  <script src="/admin/assets/app.js" defer></script>
+</head>
+<body>
+  <div class="ambient ambient-one"></div>
+  <div class="ambient ambient-two"></div>
+
+  <main id="login-view" class="login-shell">
+    <section class="login-card" aria-labelledby="login-title">
+      <div class="brand-mark" aria-hidden="true">B</div>
+      <p class="eyebrow">BriskDB</p>
+      <h1 id="login-title">Open the data browser</h1>
+      <p class="muted">Inspect tables and rows on one physical shard at a time.</p>
+      <form id="login-form">
+        <label for="username">Username</label>
+        <input id="username" name="username" autocomplete="username" required>
+        <label for="password">Password</label>
+        <input id="password" name="password" type="password" autocomplete="current-password" required>
+        <button class="button primary" type="submit">Log in</button>
+      </form>
+      <p id="login-error" class="form-error" role="alert"></p>
+    </section>
+  </main>
+
+  <div id="browser-view" class="app-shell hidden">
+    <header class="topbar">
+      <div class="brand-lockup">
+        <div class="brand-mark small" aria-hidden="true">B</div>
+        <div>
+          <strong>BriskDB</strong>
+          <span>Data Browser</span>
+        </div>
+      </div>
+      <div class="topbar-actions">
+        <span class="connection-state"><i></i> Connected</span>
+        <button id="logout-button" class="button ghost" type="button">Log out</button>
+      </div>
+    </header>
+
+    <div class="workspace">
+      <aside class="sidebar" aria-label="Database navigation">
+        <div class="sidebar-section">
+          <label for="shard-select" class="section-label">Physical shard</label>
+          <select id="shard-select"></select>
+          <p class="sidebar-note">Each table list and row page comes from this shard only.</p>
+        </div>
+        <div class="sidebar-section tables-section">
+          <div class="section-heading">
+            <span class="section-label">Application tables</span>
+            <span id="table-count" class="count-badge">0</span>
+          </div>
+          <nav id="table-list" class="table-list" aria-label="Application tables"></nav>
+        </div>
+      </aside>
+
+      <main class="content">
+        <div class="content-header">
+          <div>
+            <p id="shard-kicker" class="eyebrow">Physical shard 0</p>
+            <h1 id="table-title">Choose a table</h1>
+            <p id="table-subtitle" class="muted">Select an application table to inspect its rows.</p>
+          </div>
+          <div class="page-size-control">
+            <label for="page-size">Rows per page</label>
+            <select id="page-size">
+              <option value="25">25</option>
+              <option value="50" selected>50</option>
+              <option value="100">100</option>
+              <option value="200">200</option>
+            </select>
+          </div>
+        </div>
+
+        <div id="status" class="status" aria-live="polite">Loading session…</div>
+
+        <section class="data-card" aria-labelledby="table-title">
+          <div id="empty-state" class="empty-state">
+            <div class="empty-icon" aria-hidden="true">▦</div>
+            <h2>No table selected</h2>
+            <p>Choose a table from the sidebar to browse a bounded, read-only page.</p>
+          </div>
+          <div id="table-wrap" class="table-wrap hidden">
+            <table>
+              <caption id="table-caption">Rows from the selected physical shard</caption>
+              <thead id="data-head"></thead>
+              <tbody id="data-body"></tbody>
+            </table>
+          </div>
+          <div class="pager">
+            <span id="page-summary">No rows loaded</span>
+            <div>
+              <button id="previous-page" class="button ghost" type="button" disabled>Previous</button>
+              <button id="next-page" class="button ghost" type="button" disabled>Next</button>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/protocol/http/admin/styles.css
+++ b/src/protocol/http/admin/styles.css
@@ -1,0 +1,217 @@
+:root {
+  color-scheme: dark;
+  --bg: #07100f;
+  --panel: rgba(14, 28, 26, 0.92);
+  --panel-solid: #0e1c1a;
+  --panel-raised: #132522;
+  --border: rgba(153, 196, 185, 0.16);
+  --border-strong: rgba(153, 196, 185, 0.28);
+  --text: #edf8f5;
+  --muted: #91aaa4;
+  --accent: #56e0ac;
+  --accent-strong: #2bc78f;
+  --accent-ink: #04130e;
+  --error: #ff8f84;
+  --shadow: 0 24px 80px rgba(0, 0, 0, 0.38);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  min-width: 320px;
+  min-height: 100vh;
+  margin: 0;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 8% 0%, rgba(58, 170, 132, 0.12), transparent 35rem),
+    linear-gradient(145deg, #07100f 0%, #091513 52%, #07100f 100%);
+}
+
+button, input, select { font: inherit; }
+
+button, select { cursor: pointer; }
+
+button:focus-visible, input:focus-visible, select:focus-visible {
+  outline: 3px solid rgba(86, 224, 172, 0.38);
+  outline-offset: 2px;
+}
+
+.hidden { display: none !important; }
+.muted { color: var(--muted); }
+.eyebrow, .section-label {
+  margin: 0 0 0.45rem;
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 750;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.ambient {
+  position: fixed;
+  width: 28rem;
+  height: 28rem;
+  border-radius: 50%;
+  filter: blur(110px);
+  opacity: 0.11;
+  pointer-events: none;
+}
+.ambient-one { top: -15rem; right: 8%; background: var(--accent); }
+.ambient-two { bottom: -20rem; left: 4%; background: #3f8fc8; }
+
+.login-shell {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 1.5rem;
+}
+
+.login-card {
+  width: min(100%, 28rem);
+  padding: 2.5rem;
+  border: 1px solid var(--border-strong);
+  border-radius: 1.25rem;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(18px);
+}
+
+.brand-mark {
+  display: grid;
+  width: 3.25rem;
+  height: 3.25rem;
+  margin-bottom: 1.25rem;
+  place-items: center;
+  border-radius: 0.9rem;
+  color: var(--accent-ink);
+  background: linear-gradient(145deg, #7af4c4, var(--accent-strong));
+  box-shadow: 0 12px 32px rgba(43, 199, 143, 0.22);
+  font-size: 1.35rem;
+  font-weight: 850;
+}
+
+.brand-mark.small { width: 2.35rem; height: 2.35rem; margin: 0; border-radius: 0.68rem; font-size: 1rem; }
+.login-card h1 { margin: 0.2rem 0 0.6rem; font-size: clamp(1.65rem, 6vw, 2.2rem); letter-spacing: -0.035em; }
+.login-card > .muted { margin: 0 0 1.8rem; line-height: 1.55; }
+.login-card form { display: grid; gap: 0.6rem; }
+.login-card label, .page-size-control label { color: #c7d8d3; font-size: 0.82rem; font-weight: 650; }
+
+input, select {
+  width: 100%;
+  border: 1px solid var(--border-strong);
+  border-radius: 0.65rem;
+  color: var(--text);
+  background: rgba(3, 13, 11, 0.72);
+}
+input { height: 2.9rem; margin-bottom: 0.45rem; padding: 0 0.85rem; }
+select { min-height: 2.55rem; padding: 0 2.2rem 0 0.75rem; }
+
+.button {
+  min-height: 2.55rem;
+  padding: 0 1rem;
+  border: 1px solid transparent;
+  border-radius: 0.65rem;
+  font-weight: 720;
+}
+.button.primary { margin-top: 0.7rem; color: var(--accent-ink); background: var(--accent); }
+.button.primary:hover { background: #79edc1; }
+.button.ghost { border-color: var(--border-strong); color: #dceae6; background: rgba(255, 255, 255, 0.025); }
+.button.ghost:hover:not(:disabled) { border-color: rgba(86, 224, 172, 0.5); color: var(--accent); }
+.button:disabled { cursor: not-allowed; opacity: 0.4; }
+.form-error { min-height: 1.3rem; margin: 1rem 0 0; color: var(--error); font-size: 0.88rem; }
+
+.app-shell { position: relative; z-index: 1; min-height: 100vh; }
+.topbar {
+  position: sticky;
+  z-index: 4;
+  top: 0;
+  display: flex;
+  height: 4.5rem;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 1.5rem;
+  border-bottom: 1px solid var(--border);
+  background: rgba(7, 16, 15, 0.88);
+  backdrop-filter: blur(18px);
+}
+.brand-lockup, .topbar-actions { display: flex; align-items: center; gap: 0.8rem; }
+.brand-lockup div:last-child { display: grid; gap: 0.1rem; }
+.brand-lockup span { color: var(--muted); font-size: 0.74rem; }
+.connection-state { display: flex; align-items: center; gap: 0.45rem; color: var(--muted); font-size: 0.78rem; }
+.connection-state i { width: 0.48rem; height: 0.48rem; border-radius: 50%; background: var(--accent); box-shadow: 0 0 12px var(--accent); }
+
+.workspace { display: grid; min-height: calc(100vh - 4.5rem); grid-template-columns: 17rem minmax(0, 1fr); }
+.sidebar { padding: 1.5rem 1rem; border-right: 1px solid var(--border); background: rgba(8, 20, 18, 0.56); }
+.sidebar-section { padding: 0 0.35rem 1.5rem; }
+.sidebar-note { margin: 0.75rem 0 0; color: var(--muted); font-size: 0.75rem; line-height: 1.5; }
+.tables-section { border-top: 1px solid var(--border); padding-top: 1.4rem; }
+.section-heading { display: flex; align-items: center; justify-content: space-between; }
+.count-badge { min-width: 1.5rem; padding: 0.15rem 0.4rem; border-radius: 99px; color: var(--muted); background: var(--panel-raised); text-align: center; font-size: 0.7rem; }
+.table-list { display: grid; gap: 0.25rem; margin-top: 0.65rem; }
+.table-button {
+  overflow: hidden;
+  width: 100%;
+  padding: 0.65rem 0.7rem;
+  border: 1px solid transparent;
+  border-radius: 0.55rem;
+  color: #b7cbc5;
+  background: transparent;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.table-button:hover { color: var(--text); background: rgba(255, 255, 255, 0.035); }
+.table-button.active { border-color: rgba(86, 224, 172, 0.18); color: var(--accent); background: rgba(86, 224, 172, 0.09); }
+.no-tables { padding: 0.8rem 0.7rem; color: var(--muted); font-size: 0.8rem; }
+
+.content { min-width: 0; padding: clamp(1.25rem, 3vw, 2.5rem); }
+.content-header { display: flex; align-items: end; justify-content: space-between; gap: 1rem; margin-bottom: 1rem; }
+.content-header h1 { margin: 0.15rem 0 0.4rem; font-size: clamp(1.5rem, 3vw, 2.1rem); letter-spacing: -0.035em; }
+.content-header p { margin-top: 0; }
+.page-size-control { display: grid; width: 8.5rem; gap: 0.35rem; }
+.status { min-height: 1.5rem; margin-bottom: 0.7rem; color: var(--muted); font-size: 0.82rem; }
+.status.error { color: var(--error); }
+
+.data-card { overflow: hidden; border: 1px solid var(--border); border-radius: 0.9rem; background: var(--panel); box-shadow: 0 20px 60px rgba(0, 0, 0, 0.18); }
+.empty-state { display: grid; min-height: 22rem; place-items: center; align-content: center; padding: 2rem; text-align: center; }
+.empty-state h2 { margin: 0.8rem 0 0.3rem; font-size: 1.1rem; }
+.empty-state p { max-width: 30rem; margin: 0; color: var(--muted); line-height: 1.55; }
+.empty-icon { display: grid; width: 3.5rem; height: 3.5rem; place-items: center; border: 1px solid var(--border-strong); border-radius: 1rem; color: var(--accent); background: rgba(86, 224, 172, 0.06); font-size: 1.45rem; }
+.table-wrap { overflow: auto; max-height: calc(100vh - 18rem); }
+table { width: 100%; border-collapse: collapse; font-size: 0.82rem; white-space: nowrap; }
+caption { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); }
+th, td { max-width: 30rem; overflow: hidden; padding: 0.78rem 1rem; border-bottom: 1px solid var(--border); text-align: left; text-overflow: ellipsis; }
+th { position: sticky; z-index: 2; top: 0; color: #aec4bd; background: var(--panel-solid); font-size: 0.72rem; font-weight: 750; letter-spacing: 0.035em; }
+tbody tr:hover { background: rgba(86, 224, 172, 0.035); }
+.column-type { display: block; margin-top: 0.18rem; color: #607b74; font-size: 0.62rem; font-weight: 500; text-transform: uppercase; }
+.null-value { color: #7e9891; font-style: italic; }
+.binary-value { color: #9cc8bc; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+.pager { display: flex; min-height: 4rem; align-items: center; justify-content: space-between; gap: 1rem; padding: 0.7rem 1rem; color: var(--muted); background: rgba(5, 14, 12, 0.6); font-size: 0.78rem; }
+.pager > div { display: flex; gap: 0.5rem; }
+
+@media (max-width: 760px) {
+  .connection-state { display: none; }
+  .workspace { grid-template-columns: 1fr; }
+  .sidebar { position: static; border-right: 0; border-bottom: 1px solid var(--border); }
+  .tables-section { padding-bottom: 0; }
+  .table-list { display: flex; overflow-x: auto; }
+  .table-button { width: auto; max-width: 14rem; flex: 0 0 auto; }
+  .content-header { align-items: start; }
+}
+
+@media (max-width: 520px) {
+  .login-card { padding: 1.5rem; }
+  .topbar { padding: 0 0.8rem; }
+  .content { padding: 1rem; }
+  .content-header { display: grid; }
+  .page-size-control { width: 100%; }
+  .pager { align-items: start; flex-direction: column; }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .login-card, .data-card { animation: rise 320ms ease-out both; }
+  @keyframes rise { from { opacity: 0; transform: translateY(8px); } }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -868,25 +868,34 @@ pub(crate) fn validate_shard_count(requested_shards: u16) -> EngineResult<()> {
 }
 
 fn action_taints_connection(action: AuthAction<'_>) -> bool {
-    matches!(
-        action,
-        AuthAction::Unknown { .. }
-            | AuthAction::CreateTempIndex { .. }
-            | AuthAction::CreateTempTable { .. }
-            | AuthAction::CreateTempTrigger { .. }
-            | AuthAction::CreateTempView { .. }
-            | AuthAction::DropTempIndex { .. }
-            | AuthAction::DropTempTable { .. }
-            | AuthAction::DropTempTrigger { .. }
-            | AuthAction::DropTempView { .. }
-            | AuthAction::Pragma { .. }
-            | AuthAction::Transaction { .. }
-            | AuthAction::Attach { .. }
-            | AuthAction::Detach { .. }
-            | AuthAction::CreateVtable { .. }
-            | AuthAction::DropVtable { .. }
-            | AuthAction::Savepoint { .. }
-    )
+    match action {
+        // SQLite reports table-valued PRAGMAs through the authorizer as a
+        // PRAGMA action. `table_list` is a read-only schema inventory with no
+        // connection-local state, so it is safe for the admin inspector to use
+        // without forcing a pooled handle to retire after every page.
+        AuthAction::Pragma {
+            pragma_name,
+            pragma_value,
+        } => pragma_value.is_some() || !pragma_name.eq_ignore_ascii_case("table_list"),
+        _ => matches!(
+            action,
+            AuthAction::Unknown { .. }
+                | AuthAction::CreateTempIndex { .. }
+                | AuthAction::CreateTempTable { .. }
+                | AuthAction::CreateTempTrigger { .. }
+                | AuthAction::CreateTempView { .. }
+                | AuthAction::DropTempIndex { .. }
+                | AuthAction::DropTempTable { .. }
+                | AuthAction::DropTempTrigger { .. }
+                | AuthAction::DropTempView { .. }
+                | AuthAction::Transaction { .. }
+                | AuthAction::Attach { .. }
+                | AuthAction::Detach { .. }
+                | AuthAction::CreateVtable { .. }
+                | AuthAction::DropVtable { .. }
+                | AuthAction::Savepoint { .. }
+        ),
+    }
 }
 
 fn action_writes_connection(action: AuthAction<'_>) -> bool {

--- a/src/storage/pool.rs
+++ b/src/storage/pool.rs
@@ -1850,6 +1850,18 @@ mod tests {
         ];
 
         assert!(actions.into_iter().all(action_taints_connection));
+        assert!(!action_taints_connection(AuthAction::Pragma {
+            pragma_name: "table_list",
+            pragma_value: None,
+        }));
+        assert!(!action_taints_connection(AuthAction::Pragma {
+            pragma_name: "TABLE_LIST",
+            pragma_value: None,
+        }));
+        assert!(action_taints_connection(AuthAction::Pragma {
+            pragma_name: "table_list",
+            pragma_value: Some("unexpected"),
+        }));
         assert!(!action_taints_connection(AuthAction::Select));
         assert!(!action_taints_connection(AuthAction::Insert {
             table_name: "widgets"
@@ -1885,6 +1897,32 @@ mod tests {
                 .tainted
                 .load(Ordering::Relaxed)
         );
+    }
+
+    #[tokio::test]
+    async fn read_only_table_list_metadata_keeps_a_pooled_connection_reusable() {
+        let (_temp, pools) = pools(1, 0);
+        let connection = pools.acquire(0).await.unwrap().checkout().unwrap();
+        let id = connection.connection_id();
+        let tables = connection
+            .query_row("SELECT COUNT(*) FROM pragma_table_list", [], |row| {
+                row.get::<_, i64>(0)
+            })
+            .unwrap();
+        assert!(tables >= 1);
+        assert!(
+            !connection
+                .managed
+                .as_ref()
+                .unwrap()
+                .hygiene
+                .tainted
+                .load(Ordering::Relaxed)
+        );
+        drop(connection);
+
+        let reused = pools.acquire(0).await.unwrap().checkout().unwrap();
+        assert_eq!(reused.connection_id(), id);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- serve an embedded responsive data browser at `/admin`
- add temporary `admin` / `admin` login with bounded eight-hour in-memory cookie sessions and logout
- discover ordinary tables and browse bounded live row pages on one explicit physical shard
- route inspection through the existing engine lifecycle, pools, workers, cancellation, and result budgets
- preserve existing `/health` and `/v1/*` behavior and document the complete browser contract
- cover engine, storage metadata, authentication, assets, discovery, pagination, concurrency, recovery, and compatibility behavior

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- stable `cargo test --locked --all-targets --all-features` (529 library, 13 binary, 6 workload, 16 public API tests, benchmark targets)
- stable `cargo test --locked --doc --all-features`
- Rust 1.85.0 target and documentation test matrix
- `node --check src/protocol/http/admin/app.js`
- live HTTP login, asset, discovery, logout, and revoked-session flow
- three independent final reviews with no remaining findings

Closes #106