### PR TITLE
Select PostgreSQL wire adapter library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "array-init"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,6 +99,17 @@ name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -159,6 +176,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,17 +202,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "briskdb"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "blake3",
  "clap",
  "criterion",
- "getrandom",
+ "futures",
+ "getrandom 0.4.3",
  "hyper",
  "hyper-util",
+ "pgwire",
  "psm",
  "rusqlite",
  "serde",
@@ -207,6 +242,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -235,6 +276,17 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "ciborium"
@@ -304,10 +356,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "constant_time_eq"
@@ -362,6 +426,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "derive-new"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "ctutils",
+]
+
+[[package]]
 name = "either"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,6 +481,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fallible-iterator"
@@ -417,12 +528,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -430,6 +557,40 @@ name = "futures-core"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
@@ -443,10 +604,27 @@ version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
 ]
 
 [[package]]
@@ -457,7 +635,8 @@ checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -494,6 +673,21 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -539,6 +733,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -607,6 +810,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy-regex"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4994ba703f78b083e2f7946dac9251abd83fd43a0365f030e99b69be5b4b9ef9"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex-lite",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd97232314824e6dbef1918a871bb93f51070455e3715bf26e19a6d01aa977a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,6 +890,22 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
+name = "md5"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
 
 [[package]]
 name = "memchr"
@@ -763,6 +1005,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pgwire"
+version = "0.36.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a2bcdcc4b20a88e0648778ecf00415bbd5b447742275439c22176835056f99"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "derive-new",
+ "futures",
+ "hex",
+ "lazy-regex",
+ "md5",
+ "postgres-types",
+ "rand 0.9.5",
+ "ryu",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,6 +1036,45 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand 0.10.2",
+ "sha2",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
+dependencies = [
+ "array-init",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "postgres-protocol",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -804,9 +1106,61 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "recursive"
@@ -861,6 +1215,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -883,7 +1243,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
 dependencies = [
  "bitflags",
- "fallible-iterator",
+ "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
@@ -998,6 +1358,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1090,6 +1461,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1130,7 +1512,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1176,6 +1558,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1201,6 +1598,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "libc",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1294,10 +1705,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "utf8parse"
@@ -1332,6 +1770,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1401,6 +1848,12 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,17 @@ publish = false
 
 [dependencies]
 anyhow = "1.0"
+async-trait = "0.1"
 axum = "0.8.9"
 blake3 = "1.8"
 clap = { version = "4.6.6", features = ["derive", "env"] }
 getrandom = "=0.4.3"
 hyper = { version = "1.11", features = ["http1", "server"] }
 hyper-util = { version = "0.1.20", features = ["service", "tokio"] }
+# 0.36.3 is the newest pgwire release that supports BriskDB's Rust 1.85
+# baseline. Keep the pre-1.0 dependency exact and enable only the plaintext
+# server surface; later roadmap work owns TLS and extended type adapters.
+pgwire = { version = "=0.36.3", default-features = false, features = ["server-api"] }
 rusqlite = { version = "0.39.0", features = ["bundled", "hooks"] }
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0"
@@ -36,6 +41,7 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 
 [dev-dependencies]
 criterion = { version = "0.7", default-features = false }
+futures = "0.3"
 tempfile = "3.23"
 
 [[bench]]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ planned PostgreSQL/MySQL wire compatibility.
 The [PostgreSQL listener contract](docs/POSTGRES_LISTENER.md) defines its
 address configuration, disabled state, startup order, placeholder connection
 behavior, and shared shutdown lifecycle.
+The [PostgreSQL adapter decision record](docs/POSTGRES_ADAPTER.md) selects the
+exact wire-library version and features, defines the BriskDB-owned connection
+boundary, and records the work that remains before that listener speaks the
+protocol.
 The [SQL parser decision record](docs/SQL_PARSER.md) defines the shared,
 dialect-explicit syntax boundary and its resource and dependency limits.
 The [common SQL subset contract](docs/SQL_SUBSET.md) defines the opt-in,
@@ -40,8 +44,8 @@ protocol-neutral prepare/bind/describe/execute lifecycle, session-scoped
 statement and portal caches, exact resource limits, metadata refresh, and
 supported physical-target execution boundary shared by future adapters.
 The [error contract](docs/ERRORS.md) defines stable engine error kinds, safe
-HTTP problem details, and the mappings reserved for future PostgreSQL and MySQL
-wire adapters.
+HTTP problem details, the mapping consumed by the private PostgreSQL adapter
+probe, and the mapping reserved for a future MySQL wire adapter.
 The [request-control contract](docs/REQUEST_CONTROLS.md) defines cancellation,
 deadlines, materialized-result budgets, and graceful shutdown.
 The [admin data-browser contract](docs/ADMIN_BROWSER.md) defines the embedded
@@ -67,8 +71,9 @@ minimum supported Rust version (MSRV) and the latest stable toolchain.
 - Request cancellation and deadlines that interrupt SQLite and await cleanup
 - Finite per-query row/logical-byte budgets with no partial results
 - Explicit graceful drain, forced cancellation, and blocking handle cleanup
-- Independently configured HTTP and PostgreSQL TCP listeners; the PostgreSQL
-  listener currently accepts and closes connections pending wire-adapter work
+- Independently configured HTTP and PostgreSQL TCP listeners; `pgwire` 0.36.3
+  is pinned behind a BriskDB-owned adapter seam while the PostgreSQL listener
+  continues to accept and close connections pending startup/session work
 - An embedded read-only browser at `/admin` for inspecting user tables and
   bounded row pages on one explicitly selected physical shard
 - Protocol-neutral typed values, ordered columns, positional rows, and results
@@ -127,10 +132,12 @@ cargo run -- --postgres-listen disabled
 BRISKDB_POSTGRES_LISTEN=disabled cargo run
 ```
 
-Issue #28 supplies only the separately managed TCP endpoint. Until the
-PostgreSQL wire adapter lands, every accepted connection is closed immediately
-without reading or writing protocol bytes, and no PostgreSQL driver can execute
-a request through it. See the [listener contract](docs/POSTGRES_LISTENER.md).
+Issue #28 supplies the separately managed TCP endpoint, and issue #29 selects
+the wire library without activating it on that endpoint. Until startup/session
+support lands, every accepted connection is closed immediately without reading
+or writing protocol bytes, and no PostgreSQL driver can execute a request
+through it. See the [listener contract](docs/POSTGRES_LISTENER.md) and
+[adapter decision record](docs/POSTGRES_ADAPTER.md).
 
 The HTTP listener also serves the embedded data explorer at
 <http://127.0.0.1:7654/admin>. Its temporary credentials are `admin` / `admin`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -225,10 +225,10 @@ the engine regardless of its eventual wire protocol.
 
 - [x] Run a separate configurable listener, initially
   `--postgres-listen 127.0.0.1:5433`; allow it to be disabled.
-- [ ] Spike the current `pgwire` crate against the core interfaces before
-  committing to it; `pgwire` 0.40.5 is the leading candidate as of this roadmap.
-  Pin the selected pre-1.0 version and keep protocol code behind a BriskDB-owned
-  adapter boundary.
+- [x] Spike `pgwire` against the core interfaces and select exact version
+  `0.36.3`, the newest release compatible with BriskDB's Rust 1.85 baseline.
+  Enable only `server-api`, pin the pre-1.0 version, and keep its types behind
+  the BriskDB-owned `protocol::postgres` adapter boundary.
 - [ ] Support startup, database/user selection, parameter status, clean
   termination, and useful server-version identification.
 - [ ] Support simple query flow and extended Parse/Bind/Describe/Execute/Sync,
@@ -421,7 +421,8 @@ The first buildable slices should be small and merge independently:
   <https://www.postgresql.org/docs/current/protocol-flow.html>
 - MySQL client/server protocol:
   <https://dev.mysql.com/doc/dev/mysql-server/latest/PAGE_PROTOCOL.html>
-- PostgreSQL server library candidate: <https://crates.io/crates/pgwire>
+- Selected PostgreSQL server library: exact `pgwire` 0.36.3; see the
+  [adapter decision record](docs/POSTGRES_ADAPTER.md)
 - MySQL server library candidates: <https://crates.io/crates/mysql-mimic> and
   <https://crates.io/crates/opensrv-mysql>
 - SQL parser candidate: <https://crates.io/crates/sqlparser>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,6 +22,9 @@ server ---------> protocol::http
     |
     +-- PostgreSQL TCP lifecycle
         (accept/close placeholder; no core request)
+
+protocol::postgres ---------> core
+    (selected pgwire seam; not connected to the listener yet)
 ```
 
 | Module | Responsibility | Must not own |
@@ -30,6 +33,7 @@ server ---------> protocol::http
 | `storage` | Versioned routing/logical manifest, shard layout, migration journal and recovery, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
 | `sql` | Dialect-explicit SQL syntax parsing, recursive common-subset validation, protocol-neutral statement/batch classification, source-preserving placeholder normalization, explicit strict/compatibility translation, catalog-aware typed shard-key inference, and narrow crate-private DML-shape inspection behind BriskDB-owned boundaries; exact source retention; SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, key hashing or shard selection, mutable session state, physical write-routing policy, filesystem layout, protocol responses, protocol-buffer ownership, or protocol-specific support policy |
 | `protocol::http` | Existing HTTP request extraction, shared JSON/BriskDB value and RFC 9457 problem-detail encoding, and the embedded admin shell/assets, temporary browser sessions, discovery, and page handlers | BLAKE3 routing, shard files, direct SQLite access, or rusqlite calls |
+| `protocol::postgres` | BriskDB-owned adapter and per-connection core-session boundary around the exactly pinned `pgwire` library; private compile/query-parser and fixed-error conversion proof | Listener binding, direct SQLite access, routing, unbounded authoritative prepared state, or public dependency-owned types |
 | `protocol::error` | Exhaustive HTTP, PostgreSQL, and MySQL mappings from stable engine error kinds | SQLite errors, routing decisions, or wire-protocol session state |
 | `server` | Process configuration, database assembly, separate HTTP/PostgreSQL listener binding, tracked Axum HTTP/1 connection lifecycle, and the temporary PostgreSQL accept/close loop | SQL parsing, PostgreSQL wire messages, or storage implementation details |
 
@@ -99,11 +103,19 @@ option. The process default enables loopback `127.0.0.1:5433`. See the
 [PostgreSQL listener contract](POSTGRES_LISTENER.md) for the full grammar and
 startup order.
 
-Until the subsequent wire-adapter work, the PostgreSQL listener is a server
-lifecycle placeholder: it accepts and immediately drops each stream without
+Issue #29 selects exact `pgwire` 0.36.3 with only `server-api` and adds the
+BriskDB-owned `protocol::postgres::{Adapter, Connection}` seam. Each connection
+created through that seam owns one core `Session`; a private parser bridge and
+loopback compatibility test prove that the selected handler/socket API can call
+the engine without exposing dependency types to core or server contracts. See
+the [adapter decision record](POSTGRES_ADAPTER.md).
+
+The production PostgreSQL listener remains a server-lifecycle placeholder: it
+accepts and immediately drops each stream without constructing that adapter,
 reading bytes, writing a PostgreSQL frame, opening a session, or calling the
-engine. This keeps binding, concurrent acceptance, startup cleanup, and shared
-shutdown testable without moving protocol behavior into `server`.
+engine. Issue #30 owns that wiring and startup behavior. This keeps binding,
+concurrent acceptance, startup cleanup, and shared shutdown testable without
+moving protocol behavior into `server`.
 
 ## Admin browser boundary
 
@@ -719,9 +731,11 @@ response type. SQL and storage classify SQLite failures from primary and
 extended result codes plus operation context; they never parse SQLite error
 messages. Protocol-owned tables map each kind to an HTTP status and safe RFC
 9457 problem, a PostgreSQL SQLSTATE, and a MySQL error number/SQLSTATE pair.
-The PostgreSQL and MySQL entries are mapping contracts for future wire
-adapters. The PostgreSQL TCP placeholder emits no protocol frame and therefore
-does not encode the PostgreSQL mapping yet; no MySQL listener exists yet.
+The selected PostgreSQL adapter probe consumes the PostgreSQL mapping behind a
+private dependency boundary; the MySQL entry remains a contract for its future
+adapter. The PostgreSQL TCP placeholder emits no protocol frame and therefore
+does not expose the PostgreSQL mapping on the network yet; no MySQL listener
+exists yet.
 
 Client responses use fixed, safe text for the error kind. Diagnostic display
 text and source chains stay available internally but are never serialized, so

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -3,9 +3,11 @@
 BriskDB classifies failures once, at the protocol-neutral engine boundary. An
 `EngineErrorKind` is stable error identity; protocol adapters translate that
 identity without inspecting an error message. The HTTP adapter uses the mapping
-today. The PostgreSQL and MySQL columns below are contracts for their planned
-wire adapters. The current PostgreSQL TCP placeholder accepts and closes
-without emitting an error frame, and there is no MySQL listener yet.
+today. The selected PostgreSQL adapter seam also converts every engine kind
+through the PostgreSQL column in its compatibility tests, but the current
+PostgreSQL TCP placeholder accepts and closes without emitting an error frame.
+The MySQL column remains a contract for its planned adapter, and there is no
+MySQL listener yet.
 
 Malformed listener configuration is rejected by the binary before server
 startup. Listener bind/accept failures terminate the shared server lifecycle
@@ -274,6 +276,13 @@ contract](SQL_PREPARED_STATEMENTS.md).
 The core contains no HTTP, PostgreSQL, or MySQL response types. Conversely,
 protocol adapters do not inspect SQLite errors. This lets every frontend share
 one error identity while retaining its own response encoding.
+
+Issue #29's private `pgwire` bridge constructs `ErrorInfo` only from
+`postgres_error(error.kind())`: severity `ERROR`, the fixed SQLSTATE, and the
+fixed public message. Its exhaustive test uses a private diagnostic sentinel
+for every kind and proves that sentinel is absent. This is a library-fit
+contract, not live listener behavior; issue #30 and later transaction work own
+production severity, connection-fatal policy, and failed-transaction state.
 
 Manifest compatibility uses the same protocol-neutral kinds. A foreign file,
 a manifest newer than the running binary, or a requested shard-count mismatch

--- a/docs/POSTGRES_ADAPTER.md
+++ b/docs/POSTGRES_ADAPTER.md
@@ -1,0 +1,205 @@
+# PostgreSQL adapter decision record
+
+Status: accepted for roadmap issue #29
+
+BriskDB needs a PostgreSQL frontend library that can own protocol framing and
+message dispatch without becoming the database engine, routing policy,
+prepared-object store, or public error taxonomy. This record selects that
+library, fixes its dependency boundary, and documents the compatibility probe.
+It does not activate PostgreSQL wire behavior on the configured listener.
+
+## Decision
+
+BriskDB pins `pgwire` exactly at version `0.36.3`:
+
+```toml
+pgwire = { version = "=0.36.3", default-features = false, features = ["server-api"] }
+```
+
+`0.36.3` is the newest published `pgwire` release whose package metadata
+declares Rust 1.85 support. The roadmap's original `0.40.5` candidate, the
+current `0.40.6` release at the time of this spike, and every checked release
+from `0.37.0` onward declare Rust 1.89. Raising BriskDB's compiler baseline for
+one frontend dependency would contradict the existing Rust 1.85 support
+contract, so those versions were not selected.
+
+The exact requirement is intentional. `pgwire` is pre-1.0, and a normal caret
+requirement would allow Cargo to select a later 0.36 patch without a deliberate
+adapter review. A version change must be an explicit source, feature, API,
+behavior, and MSRV decision followed by the complete verification matrix.
+
+## Selected feature surface
+
+Only `server-api` is enabled. That supplies the Tokio socket entrypoint,
+frontend/backend messages, handler traits, PostgreSQL type descriptors, and
+row encoders needed by the planned server adapter.
+
+The dependency's defaults are disabled because they additionally select an
+AWS-LC TLS backend and extended chrono, decimal, and JSON adapters. BriskDB does
+not need those dependencies for the issue-29 fit check:
+
+| `pgwire` feature area | Issue #29 decision | Owning follow-up |
+| --- | --- | --- |
+| Plain server API | Enabled | Foundation for issues #30 and #31 |
+| AWS-LC or ring TLS provider | Not enabled | TLS and SCRAM issue #36 |
+| Chrono type adapter | Not enabled | Type mapping issue #33 |
+| Rust-decimal adapter | Not enabled | Type mapping issue #33 |
+| Serde-JSON adapter | Not enabled | Type mapping issue #33 |
+| Client API | Not enabled | Named external-client matrix issue #38 |
+
+The resolved graph uses the repository's existing Tokio 1.53.1 rather than a
+second Tokio version. `cargo tree -e features -i pgwire` reports only the
+`server-api` feature. The selected graph contains no `aws-lc`, `ring`,
+`tokio-rustls`, `chrono`, or `rust_decimal` package through `pgwire`.
+
+## BriskDB-owned boundary
+
+All production imports of the selected library are confined to
+`protocol::postgres`. Neither `core`, `storage`, `sql`, `server`, nor the HTTP
+adapter accepts or returns a `pgwire` type.
+
+The public BriskDB seam consists of two owned types:
+
+- `protocol::postgres::Adapter` holds a clone of the protocol-neutral `Engine`
+  and the current default logical-database identifier. Constructing it has no
+  network or session side effect.
+- `protocol::postgres::Connection` owns exactly one non-cloneable core
+  `Session`, exposes its `SessionId`, can read controlled engine status, and can
+  close that session idempotently. Separate connections never share session
+  state.
+
+The connection retains a private implementation of `pgwire`'s `QueryParser`
+trait as the compile-time bridge. Its probe path prepares PostgreSQL-dialect
+SQL through `Engine::prepare_statement` with compatibility translation and
+describes the resulting BriskDB handle. It neither opens SQLite directly nor
+computes a route. PostgreSQL parameter OID lists are rejected as `Unsupported`
+until issue #33 defines their exact mapping. Because `pgwire`
+collapses both raw OID zero and unknown/custom OIDs to `None` before invoking
+`QueryParser`, the probe rejects every nonempty parameter-type list rather than
+guessing which raw value produced it.
+
+The private prepared wrapper contains only a BriskDB
+`PreparedStatementId` and `PreparedStatementDescription`. It does not expose
+the dependency's statement, portal, message, or type objects through a BriskDB
+signature. Production Parse/Bind name management and cleanup do not use this
+probe yet; issue #31 owns that state machine.
+
+## Compatibility probe
+
+Automated tests exercise both sides of the boundary without changing the live
+server:
+
+1. one shared adapter creates independent connection contexts and unique core
+   sessions;
+2. concurrent contexts call `Engine::status` through their own sessions;
+3. closing one context is terminal and idempotent while another remains usable;
+4. the private `QueryParser` prepares and describes a PostgreSQL statement
+   through the bounded core prepared lifecycle;
+5. every `EngineErrorKind` becomes `pgwire::ErrorInfo` through BriskDB's fixed
+   SQLSTATE and safe-message table, never through `EngineError::diagnostic`;
+6. a test-only handler factory drives `pgwire::tokio::process_socket` over a
+   loopback TCP connection, completes a startup/query probe, reaches core
+   status, returns after client EOF, and explicitly closes its core session;
+7. a rejected startup returns promptly, closes its core session, and leaves a
+   later adapter connection usable; and
+8. the existing server tests continue to prove that the configured production
+   PostgreSQL listener writes zero bytes and immediately closes each stream.
+
+The loopback command and its response tag exist only inside the unit test. They
+are not supported SQL, public protocol behavior, or a claim that a PostgreSQL
+driver can use BriskDB today.
+
+## Library fit and retained ownership
+
+The selected version provides the protocol pieces required by the roadmap:
+
+- a Tokio `process_socket` entrypoint with an optional TLS acceptor;
+- startup, simple-query, extended-query, copy, error, and cancellation handler
+  traits selected by a per-socket factory;
+- Parse/Bind/Describe/Execute/Flush/Sync/Close message dispatch;
+- text and binary field descriptors and row encoders; and
+- PostgreSQL connection and transaction-status tracking.
+
+Those conveniences do not transfer product ownership to the library. In
+particular:
+
+- `pgwire`'s default startup handler advertises dependency-owned version and
+  parameter values. Issue #30 must replace it with BriskDB values before the
+  production listener calls `process_socket`.
+- Its default in-memory statement/portal store is unbounded, replacement does
+  not return the old object for cleanup, and statement removal does not cascade
+  into BriskDB handles. Issue #31 must keep the engine's existing finite
+  per-session prepared-statement, portal, and retained-value budgets
+  authoritative.
+- The default Bind path retains dependency-owned raw parameter bytes and does
+  not call `Engine::bind_statement`. The production adapter must decode into
+  BriskDB `Value` objects and bind at Bind time so the route snapshot is
+  immutable before Execute.
+- The socket loop has no BriskDB session-close callback. The production wrapper
+  must close its `Connection` on every ordinary, error, EOF, cancellation, and
+  shutdown return path.
+- The selected version understands protocol 3.0 and 3.2 and defaults its own
+  client state to 3.2. Issue #32 must apply BriskDB's deliberate baseline and
+  minor-version negotiation policy.
+- Dependency message-size ceilings are not BriskDB retention limits. SQL,
+  names, raw parameters, prepared objects, rows, and connection tasks still
+  require BriskDB-owned finite limits.
+- Portal suspension in the dependency cannot cause a BriskDB portal to execute
+  twice. The core currently returns a complete bounded materialized result;
+  issue #31 must retain and resume the already produced response or provide a
+  separately reviewed streaming contract.
+
+These are adapter requirements, not reasons to move protocol state into core.
+The library remains replaceable as long as the BriskDB seam and conformance
+tests remain authoritative.
+
+## Current listener behavior
+
+The configured PostgreSQL TCP listener still performs issue #28's exact
+accept-and-close behavior. It does not construct an `Adapter` or `Connection`,
+call `process_socket`, read a startup packet, emit a response, open a core
+session, or run SQL. Selecting a library must not accidentally ship its default
+startup behavior before BriskDB's production session policy is implemented.
+
+Issue #30 owns production wiring plus startup, logical database/user selection,
+BriskDB parameter status, termination, and server-version identification.
+Issue #31 owns simple and extended query flow. Later roadmap issues retain
+their existing protocol-version, type, transaction, cancellation, TLS/SCRAM,
+client-matrix, and row-streaming scopes.
+
+## Errors, configuration, and storage
+
+The compile bridge converts an `EngineError` only by calling
+`protocol::error::postgres_error(error.kind())`. It creates severity `ERROR`,
+the table's five-character SQLSTATE, and the fixed safe message. Trusted SQL,
+SQLite text, paths, and source chains in `diagnostic()` are never serialized.
+Production severity, failed-transaction state, and connection-fatal policy
+remain part of the later wire/session work.
+
+This decision adds no CLI or environment setting and does not change listener
+defaults, HTTP routes, JSON, SQL support, routing, engine limits, manifest or
+shard schemas, storage versions, migration journals, file headers, checksums,
+or recovery behavior. Adapter and connection state exist only in process
+memory and disappear on close or restart.
+
+## Upgrade and verification policy
+
+A `pgwire` update must remain exact and must verify, at minimum:
+
+- package MSRV and the complete resolved graph on Rust 1.85;
+- enabled features and absence of unintended providers/type adapters;
+- handler factory, startup, query, error, cancellation, portal, and socket-loop
+  API changes;
+- message limits and connection-state behavior;
+- independent per-connection BriskDB sessions and cleanup on every return path;
+- fixed SQLSTATE/safe-message conversion for every engine error kind;
+- the production listener's expected behavior for the roadmap issue being
+  implemented; and
+- formatting, Clippy, all targets, documentation tests, and the named stable
+  and Rust 1.85 CI matrices with the locked dependency graph.
+
+Primary upstream references:
+
+- [`pgwire` 0.36.3 package metadata](https://crates.io/crates/pgwire/0.36.3)
+- [`pgwire` server API documentation](https://docs.rs/pgwire/0.36.3/pgwire/)
+- [PostgreSQL frontend/backend protocol](https://www.postgresql.org/docs/current/protocol.html)

--- a/docs/POSTGRES_LISTENER.md
+++ b/docs/POSTGRES_LISTENER.md
@@ -1,8 +1,10 @@
 # PostgreSQL listener lifecycle
 
 Issue #28 adds the process and TCP-lifecycle boundary for a future PostgreSQL
-wire adapter. It deliberately does not implement a PostgreSQL startup packet,
-authentication, query flow, error response, or any other wire message.
+wire adapter. Issue #29 subsequently selects the adapter library without
+activating it here. The listener deliberately does not implement a PostgreSQL
+startup packet, authentication, query flow, error response, or any other wire
+message.
 
 ## Process configuration
 
@@ -67,8 +69,8 @@ the supported retry.
 
 ## Placeholder connection behavior
 
-While issue #28 is the latest completed PostgreSQL item, the listener accepts
-each TCP connection and immediately drops the stream:
+After issue #29, the listener still accepts each TCP connection and immediately
+drops the stream:
 
 - it reads no client bytes;
 - it writes no server bytes or PostgreSQL error frame;
@@ -79,9 +81,9 @@ each TCP connection and immediately drops the stream:
 
 Continuously accepting and closing prevents the operating-system backlog from
 filling while making the incomplete wire behavior deterministic. Emitting even
-a nominal PostgreSQL frame is deferred to the BriskDB-owned adapter selected by
-the following roadmap work. This TCP scaffold must not be described as a
-usable PostgreSQL interface.
+a nominal PostgreSQL frame is deferred to production activation of the
+selected BriskDB-owned adapter in issue #30. This TCP scaffold must not be
+described as a usable PostgreSQL interface.
 
 HTTP acceptance and placeholder PostgreSQL acceptance share one server
 lifecycle. Neither listener implements routing, parsing, planning, or SQLite
@@ -101,15 +103,18 @@ the server future closes both listener sockets and enters the same resumable
 
 ## Compatibility and storage boundary
 
-This issue adds no dependency on `pgwire` or another PostgreSQL implementation.
-It changes no HTTP route, JSON body, SQL subset, planner rule, typed result,
-engine error mapping, manifest table, shard header, migration journal, stored
-row, or storage-format version. Listener settings are process configuration and
-are not persisted in `manifest.sqlite` or a shard.
+Issue #28 itself adds no wire dependency. Issue #29 pins `pgwire` 0.36.3 behind
+`protocol::postgres`, with default features disabled and only `server-api`
+enabled. That selection changes no HTTP route, JSON body, SQL subset, planner
+rule, typed result, engine error mapping, manifest table, shard header,
+migration journal, stored row, or storage-format version. Listener settings and
+the inactive adapter seam are not persisted in `manifest.sqlite` or a shard.
 
-The PostgreSQL SQLSTATE table remains a tested mapping for the future adapter;
-the placeholder emits none of those mappings. The next roadmap items own the
-adapter dependency and PostgreSQL startup/session messages.
+The PostgreSQL SQLSTATE table is consumed by the adapter compatibility probe;
+the placeholder emits none of those mappings. The next roadmap item owns
+PostgreSQL startup/session messages and production socket integration. Library
+selection details and constraints are normative in the
+[PostgreSQL adapter decision record](POSTGRES_ADAPTER.md).
 
 ## Verification contract
 

--- a/docs/REQUEST_CONTROLS.md
+++ b/docs/REQUEST_CONTROLS.md
@@ -1,9 +1,10 @@
 # Request controls and shutdown
 
 BriskDB applies cancellation, deadlines, result budgets, and shutdown at the
-protocol-neutral `Engine` boundary. HTTP and future PostgreSQL/MySQL wire
-adapters therefore share the same resource and cleanup semantics. The current
-PostgreSQL TCP placeholder never creates an engine request.
+protocol-neutral `Engine` boundary. HTTP, the selected PostgreSQL adapter seam,
+and a future MySQL adapter therefore share the same resource and cleanup
+semantics. The current PostgreSQL TCP placeholder never creates an engine
+request.
 
 ## Per-request context
 

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -46,9 +46,10 @@ than claiming to be a drop-in PostgreSQL or MySQL replacement.
 ## Current implementation
 
 Only the experimental HTTP network interface can execute network requests
-today. A separately configured PostgreSQL TCP listener now accepts and
-immediately closes streams as a lifecycle scaffold; it implements no
-PostgreSQL wire message. There is no MySQL listener. The public Rust SQL facade
+today. `pgwire` 0.36.3 is selected and pinned behind a BriskDB-owned adapter
+seam, while the separately configured PostgreSQL TCP listener still accepts
+and immediately closes streams; it implements no PostgreSQL wire message.
+There is no MySQL listener. The public Rust SQL facade
 can parse an explicitly selected SQLite, PostgreSQL, or MySQL dialect, consume
 that result with
 `validate_common_subset(ParsedSql)`, borrow the result with
@@ -83,13 +84,14 @@ path; they do not pass through these opt-in SQL layers.
 | HTTP `/v1/query` | Experimental | One raw SQLite statement prepared transiently by the row-returning path; no session cache | Required caller-provided `shard_key` |
 | HTTP `/v1/admin/broadcast` | Experimental | A journaled parameterless SQLite schema batch | Preflight on every shard, then ascending resumable apply |
 | HTTP `/admin` browser | Experimental, read-only | No caller SQL; server-generated physical table discovery and bounded `SELECT *` pages | Required validated physical shard number; never a routed or scatter query |
-| PostgreSQL wire protocol | TCP lifecycle scaffold; wire protocol planned | Rust parsing, validation, classification, placeholder normalization, finite compatibility translation, and prepared lifecycle implemented; placeholder listener accepts then closes without protocol bytes | Core batch/write policy, bind validation, routing snapshots, current execute-time planning, and supported target execution implemented; wire mapping planned |
+| PostgreSQL wire protocol | `pgwire` 0.36.3 selected behind a BriskDB-owned core-session seam; production TCP listener remains an accept/close scaffold | Rust parsing, validation, classification, placeholder normalization, finite compatibility translation, and prepared lifecycle implemented; private parser compatibility probe only | Core batch/write policy, bind validation, routing snapshots, current execute-time planning, and supported target execution implemented; production wire mapping planned |
 | MySQL wire protocol | Planned | Rust parsing, validation, classification, placeholder normalization, finite compatibility translation, and prepared lifecycle implemented; listener adoption planned | Core batch/write policy, bind validation, routing snapshots, current execute-time planning, and supported target execution implemented; wire mapping planned |
 
 The parser, subset validator, statement classifier, placeholder normalizer, SQL
-translator, shard-key inference function, engine planner, and prepared
-lifecycle are implemented Rust APIs, not PostgreSQL or MySQL network
-interfaces. The PostgreSQL socket scaffold does not connect those APIs to the
+translator, shard-key inference function, engine planner, prepared lifecycle,
+and PostgreSQL adapter seam are implemented Rust APIs, not PostgreSQL or MySQL
+network interfaces. The private issue-29 probe composes the selected library
+with those APIs, but the PostgreSQL socket scaffold does not connect them to the
 network. They do not change any current HTTP row in this table.
 
 Every HTTP database operation now calls the same protocol-neutral async engine
@@ -310,10 +312,12 @@ SQLite result codes and operation context; error-message text is never parsed
 to choose an error kind.
 
 The same kinds already have defined PostgreSQL SQLSTATE and MySQL error
-number/SQLSTATE mappings, but those are contracts for the planned adapters.
-The PostgreSQL TCP placeholder emits no error frame, and no MySQL listener is
-available. See the complete [error taxonomy and mapping table](ERRORS.md) and
-the [PostgreSQL listener lifecycle](POSTGRES_LISTENER.md).
+number/SQLSTATE mappings. The private selected-adapter probe consumes the
+PostgreSQL mapping; the MySQL mapping remains a contract for its future
+adapter. The PostgreSQL TCP placeholder emits no error frame, and no MySQL
+listener is available. See the complete
+[error taxonomy and mapping table](ERRORS.md) and the
+[PostgreSQL listener lifecycle](POSTGRES_LISTENER.md).
 
 ## SQL surface
 
@@ -630,12 +634,15 @@ boundary are normative in
 
 ## PostgreSQL differences
 
-The bound PostgreSQL TCP scaffold will host an adapter targeting the
-frontend/backend wire protocol and a deliberately small SQL compatibility
-surface. It currently accepts and closes without a handshake; PostgreSQL-
-specific behavior is not implemented unless listed as implemented in this
-document. Configuration and lifecycle semantics are normative in the
-[PostgreSQL listener contract](POSTGRES_LISTENER.md).
+The bound PostgreSQL TCP scaffold will host the selected `pgwire` 0.36.3
+adapter targeting the frontend/backend protocol and a deliberately small SQL
+compatibility surface. The BriskDB-owned adapter/core-session boundary and a
+private parser/socket fit probe exist, but the listener currently accepts and
+closes without a handshake. PostgreSQL-specific behavior is not implemented
+unless listed as implemented in this document. Configuration and lifecycle
+semantics are normative in the [PostgreSQL listener
+contract](POSTGRES_LISTENER.md); dependency and adapter constraints are
+normative in the [adapter decision record](POSTGRES_ADAPTER.md).
 
 | Area | PostgreSQL | BriskDB contract |
 | --- | --- | --- |

--- a/docs/SQL_PREPARED_STATEMENTS.md
+++ b/docs/SQL_PREPARED_STATEMENTS.md
@@ -395,10 +395,12 @@ handling to that type.
 
 ## Dialect and adapter compatibility
 
-The lifecycle is implemented as a Rust engine API and is not yet connected to
-a wire adapter. The PostgreSQL TCP scaffold accepts and closes without creating
-a session; there is no MySQL listener. All three typed input paths share the
-same planning and result path:
+The lifecycle is implemented as a Rust engine API. The selected PostgreSQL
+adapter seam privately proves that wire preparation can enter that lifecycle,
+but no wire-message path is connected to the production listener yet. The
+PostgreSQL TCP scaffold accepts and closes without creating a session; there is
+no MySQL listener. All three typed input paths share the same planning and
+result path:
 
 | Input | Required mode and parameter form | Prepared execution result |
 | --- | --- | --- |

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -906,6 +906,14 @@ open and its existing recovery precede listener binding, a later bind failure
 does not undo a migration or recovery transaction that already committed; a
 subsequent startup revalidates the same version-7 layout normally.
 
+Issue #29's pinned `pgwire` dependency, `protocol::postgres::Adapter`, and
+per-connection core `Session` seam are also process-only code and memory state.
+They add no manifest or shard table, header value, format version, digest input,
+routing metadata, schema fingerprint, journal record, file, or recovery step.
+The production PostgreSQL listener does not construct that state yet. A probe
+prepare is transient prepared metadata and is explicitly closed in tests; it
+does not write application rows or schema.
+
 The checksums are corruption detectors, not authentication. Both use unkeyed
 BLAKE3 and are writable by anyone who can modify the data directory. The
 manifest root covers canonical control-plane values, not raw SQLite pages. The

--- a/docs/SUPPORTED_PLATFORMS.md
+++ b/docs/SUPPORTED_PLATFORMS.md
@@ -39,6 +39,13 @@ PostgreSQL endpoint is currently an accept/close lifecycle scaffold, not a wire
 compatibility claim. Its exact process behavior is documented in
 [PostgreSQL listener lifecycle](POSTGRES_LISTENER.md).
 
+The selected PostgreSQL library is pinned to `pgwire` 0.36.3 with only its
+`server-api` feature. It is the newest release declaring compatibility with the
+project's Rust 1.85 minimum; 0.37 and newer require Rust 1.89. CI compiles the
+locked adapter/core compatibility probe on Rust 1.85 and stable. This library
+selection does not change the production endpoint's placeholder behavior; see
+the [adapter decision record](POSTGRES_ADAPTER.md).
+
 The same runner exercises the embedded `/admin` shell and assets, temporary
 login/session lifecycle, physical-shard table discovery, and bounded row-page
 JSON contract without contacting third-party asset hosts. These are HTTP and

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -2,3 +2,4 @@
 
 pub mod error;
 pub mod http;
+pub mod postgres;

--- a/src/protocol/postgres.rs
+++ b/src/protocol/postgres.rs
@@ -1,0 +1,581 @@
+//! BriskDB-owned boundary for the selected PostgreSQL wire library.
+//!
+//! This module deliberately does not serve the configured PostgreSQL listener
+//! yet. It owns the selected library integration and one protocol-neutral core
+//! session per future wire connection so `server`, `core`, and public BriskDB
+//! contracts do not depend on `pgwire` types.
+
+use std::{fmt, sync::Arc};
+
+use async_trait::async_trait;
+use pgwire::{
+    api::{ClientInfo, Type, stmt::QueryParser},
+    error::{ErrorInfo, PgWireError, PgWireResult},
+};
+
+use crate::{
+    core::{
+        DescribeTarget, Engine, EngineError, EngineResult, EngineStatus, LogicalDatabaseId,
+        PrepareRequest, PreparedStatementDescription, PreparedStatementId, Session, SessionId,
+    },
+    protocol::error::postgres_error,
+    sql::{SqlDialect, SqlTranslationMode},
+};
+
+/// A PostgreSQL protocol adapter backed only by BriskDB's public engine API.
+///
+/// Constructing an adapter does not bind a socket, accept a connection, create
+/// a session, or alter the current listener behavior. A distinct core session
+/// is allocated only by [`Adapter::open_connection`].
+#[derive(Clone)]
+pub struct Adapter {
+    engine: Engine,
+    default_database: LogicalDatabaseId,
+}
+
+impl Adapter {
+    /// Construct the BriskDB-owned PostgreSQL adapter boundary.
+    pub fn new(engine: Engine) -> Self {
+        let default_database = engine.catalog().default_database().id();
+        Self {
+            engine,
+            default_database,
+        }
+    }
+
+    /// Allocate independent protocol state for one future wire connection.
+    ///
+    /// The returned value owns exactly one non-cloneable BriskDB [`Session`].
+    /// No socket is opened and no wire handshake is performed.
+    pub fn open_connection(&self) -> Connection {
+        let state = Arc::new(ConnectionState {
+            engine: self.engine.clone(),
+            session: self.engine.session(),
+            database: self.default_database,
+        });
+        let wire_parser = Arc::new(PgWireQueryParser {
+            state: Arc::clone(&state),
+        });
+        Connection { state, wire_parser }
+    }
+}
+
+impl fmt::Debug for Adapter {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("Adapter")
+            .field("default_database", &self.default_database)
+            .field("shard_count", &self.engine.shard_count())
+            .finish_non_exhaustive()
+    }
+}
+
+struct ConnectionState {
+    engine: Engine,
+    session: Session,
+    database: LogicalDatabaseId,
+}
+
+/// Protocol-owned state for one future PostgreSQL wire connection.
+///
+/// This type exposes only BriskDB values. The selected wire crate remains an
+/// implementation detail inside this module.
+#[must_use = "a PostgreSQL connection context should be explicitly closed"]
+pub struct Connection {
+    state: Arc<ConnectionState>,
+    // Retaining the parser here makes the selected pgwire trait contract part
+    // of every connection without exposing that dependency in BriskDB's API.
+    wire_parser: Arc<PgWireQueryParser>,
+}
+
+impl Connection {
+    /// Return the process-unique core session identifier for this connection.
+    pub fn session_id(&self) -> SessionId {
+        self.state.session.id()
+    }
+
+    /// Read engine status through this connection's protocol-neutral session.
+    ///
+    /// This small operation is the issue-29 proof that the selected wire
+    /// adapter composes with the controlled async engine boundary. Query and
+    /// prepared execution remain later roadmap work.
+    pub async fn status(&self) -> EngineResult<EngineStatus> {
+        self.state.engine.status(&self.state.session).await
+    }
+
+    /// Close this connection's core session.
+    ///
+    /// Closing is terminal and idempotent. Future production socket wrappers
+    /// must call this on every return path from the wire library.
+    pub async fn close(&self) -> EngineResult<()> {
+        self.state.session.close().await
+    }
+}
+
+impl fmt::Debug for Connection {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("Connection")
+            .field("session_id", &self.session_id())
+            .field("database", &self.state.database)
+            .field("wire_parser", &self.wire_parser)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Clone)]
+struct PgWirePrepared {
+    id: PreparedStatementId,
+    description: PreparedStatementDescription,
+}
+
+impl fmt::Debug for PgWirePrepared {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PgWirePrepared")
+            .field("id", &self.id)
+            .field("description", &self.description)
+            .finish()
+    }
+}
+
+struct PgWireQueryParser {
+    state: Arc<ConnectionState>,
+}
+
+impl fmt::Debug for PgWireQueryParser {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PgWireQueryParser")
+            .field("session_id", &self.state.session.id())
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl QueryParser for PgWireQueryParser {
+    type Statement = PgWirePrepared;
+
+    async fn parse_sql<C>(
+        &self,
+        _client: &C,
+        sql: &str,
+        types: &[Option<Type>],
+    ) -> PgWireResult<Self::Statement>
+    where
+        C: ClientInfo + Unpin + Send + Sync,
+    {
+        // pgwire has already converted raw OIDs by this point. Both the
+        // inference marker (OID 0) and an unknown/custom OID arrive as `None`,
+        // so this boundary cannot safely distinguish them. Reject every
+        // nonempty type list until BriskDB owns raw Parse-message validation.
+        if !types.is_empty() {
+            return Err(engine_error_to_pgwire(EngineError::new(
+                crate::core::EngineErrorKind::Unsupported,
+                "PostgreSQL parameter OID lists are deferred to type mapping",
+            )));
+        }
+
+        let request = PrepareRequest::new(
+            self.state.database,
+            SqlDialect::PostgreSql,
+            SqlTranslationMode::Compatibility,
+            sql,
+        );
+        let id = self
+            .state
+            .engine
+            .prepare_statement(&self.state.session, request)
+            .await
+            .map_err(engine_error_to_pgwire)?;
+        let description = match self
+            .state
+            .engine
+            .describe_prepared(&self.state.session, DescribeTarget::Statement(id))
+            .await
+        {
+            Ok(description) => description,
+            Err(error) => {
+                let _ = self
+                    .state
+                    .engine
+                    .close_prepared_statement(&self.state.session, id)
+                    .await;
+                return Err(engine_error_to_pgwire(error));
+            }
+        };
+
+        Ok(PgWirePrepared { id, description })
+    }
+}
+
+fn engine_error_to_pgwire(error: EngineError) -> PgWireError {
+    let mapping = postgres_error(error.kind());
+    PgWireError::UserError(Box::new(ErrorInfo::new(
+        "ERROR".to_owned(),
+        mapping.sqlstate.to_owned(),
+        mapping.message.to_owned(),
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fmt::Debug, net::SocketAddr, sync::Arc, time::Duration};
+
+    use async_trait::async_trait;
+    use futures::Sink;
+    use pgwire::{
+        api::{
+            ClientInfo, ClientPortalStore, DefaultClient, PgWireServerHandlers,
+            auth::{StartupHandler, noop::NoopStartupHandler},
+            query::SimpleQueryHandler,
+            results::{Response, Tag},
+            stmt::QueryParser,
+        },
+        error::{PgWireError, PgWireResult},
+        messages::{PgWireBackendMessage, PgWireFrontendMessage},
+        tokio::process_socket,
+    };
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::{TcpListener, TcpStream},
+    };
+
+    use super::*;
+    use crate::core::{EngineErrorKind, SessionState};
+
+    struct ProbeHandler {
+        connection: Arc<Connection>,
+    }
+
+    #[async_trait]
+    impl NoopStartupHandler for ProbeHandler {
+        async fn post_startup<C>(
+            &self,
+            _client: &mut C,
+            _message: PgWireFrontendMessage,
+        ) -> PgWireResult<()>
+        where
+            C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send,
+            C::Error: Debug,
+            PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+        {
+            self.connection
+                .status()
+                .await
+                .map(|_| ())
+                .map_err(engine_error_to_pgwire)
+        }
+    }
+
+    #[async_trait]
+    impl SimpleQueryHandler for ProbeHandler {
+        async fn do_query<C>(&self, _client: &mut C, query: &str) -> PgWireResult<Vec<Response>>
+        where
+            C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+            C::Error: Debug,
+            PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+        {
+            if query != "BRISKDB SPIKE" {
+                return Err(engine_error_to_pgwire(EngineError::new(
+                    EngineErrorKind::Unsupported,
+                    "the compatibility probe accepts one sentinel command",
+                )));
+            }
+            let status = self
+                .connection
+                .status()
+                .await
+                .map_err(engine_error_to_pgwire)?;
+            Ok(vec![Response::Execution(
+                Tag::new("BRISKDB SPIKE").with_rows(usize::from(status.shard_count())),
+            )])
+        }
+    }
+
+    struct ProbeFactory {
+        handler: Arc<ProbeHandler>,
+    }
+
+    impl PgWireServerHandlers for ProbeFactory {
+        fn startup_handler(&self) -> Arc<impl StartupHandler> {
+            Arc::clone(&self.handler)
+        }
+
+        fn simple_query_handler(&self) -> Arc<impl SimpleQueryHandler> {
+            Arc::clone(&self.handler)
+        }
+    }
+
+    async fn engine(shards: u16) -> (tempfile::TempDir, Engine) {
+        let temp = tempfile::tempdir().unwrap();
+        let engine = Engine::open(temp.path(), shards).await.unwrap();
+        (temp, engine)
+    }
+
+    fn test_client() -> DefaultClient<String> {
+        DefaultClient::new("127.0.0.1:7654".parse().unwrap(), false)
+    }
+
+    fn startup_packet() -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(&196_608_u32.to_be_bytes());
+        body.extend_from_slice(b"user\0briskdb\0database\0default\0\0");
+        let length = u32::try_from(body.len() + 4).unwrap();
+        let mut packet = Vec::with_capacity(body.len() + 4);
+        packet.extend_from_slice(&length.to_be_bytes());
+        packet.extend_from_slice(&body);
+        packet
+    }
+
+    fn typed_packet(message_type: u8, body: &[u8]) -> Vec<u8> {
+        let length = u32::try_from(body.len() + 4).unwrap();
+        let mut packet = Vec::with_capacity(body.len() + 5);
+        packet.push(message_type);
+        packet.extend_from_slice(&length.to_be_bytes());
+        packet.extend_from_slice(body);
+        packet
+    }
+
+    async fn read_frame(stream: &mut TcpStream) -> (u8, Vec<u8>) {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            let mut header = [0_u8; 5];
+            stream.read_exact(&mut header).await.unwrap();
+            let length = u32::from_be_bytes(header[1..].try_into().unwrap());
+            assert!((4..=1_048_576).contains(&length));
+            let mut body = vec![0_u8; usize::try_from(length - 4).unwrap()];
+            stream.read_exact(&mut body).await.unwrap();
+            (header[0], body)
+        })
+        .await
+        .expect("the pgwire compatibility probe returned a frame")
+    }
+
+    async fn read_until_ready(stream: &mut TcpStream) -> Vec<(u8, Vec<u8>)> {
+        let mut frames = Vec::new();
+        loop {
+            let frame = read_frame(stream).await;
+            let ready = frame.0 == b'Z';
+            frames.push(frame);
+            if ready {
+                return frames;
+            }
+            assert!(frames.len() < 64, "bounded startup response frame count");
+        }
+    }
+
+    #[tokio::test]
+    async fn adapter_connections_are_independent_and_close_idempotently() {
+        let (_temp, engine) = engine(3).await;
+        let adapter = Adapter::new(engine.clone());
+        let first = Arc::new(adapter.open_connection());
+        let second = Arc::new(adapter.open_connection());
+
+        assert_ne!(first.session_id(), second.session_id());
+        let (first_status, second_status) = tokio::join!(first.status(), second.status());
+        assert_eq!(first_status.unwrap().shard_count(), 3);
+        assert_eq!(second_status.unwrap().shard_count(), 3);
+
+        first.close().await.unwrap();
+        first.close().await.unwrap();
+        assert_eq!(first.state().await, SessionState::Closed);
+        assert_eq!(
+            first.status().await.unwrap_err().kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+        assert_eq!(second.status().await.unwrap().shard_count(), 3);
+
+        second.close().await.unwrap();
+        engine.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn selected_query_parser_prepares_through_core_and_rejects_all_oid_lists() {
+        let (_temp, engine) = engine(2).await;
+        let adapter = Adapter::new(engine.clone());
+        let connection = adapter.open_connection();
+        let client = test_client();
+
+        let prepared = connection
+            .wire_parser
+            .parse_sql(&client, "SELECT 1", &[])
+            .await
+            .unwrap();
+        assert_eq!(prepared.description.parameter_types(), []);
+        assert_eq!(prepared.description.columns().len(), 1);
+        assert!(
+            connection
+                .state
+                .engine
+                .close_prepared_statement(&connection.state.session, prepared.id)
+                .await
+                .unwrap()
+        );
+
+        let inferred_or_unknown = connection
+            .wire_parser
+            .parse_sql(&client, "SELECT $1", &[None])
+            .await
+            .unwrap_err();
+        let PgWireError::UserError(info) = inferred_or_unknown else {
+            panic!("expected a BriskDB-owned PostgreSQL error")
+        };
+        assert_eq!(info.code, "0A000");
+        assert_eq!(
+            info.message,
+            postgres_error(EngineErrorKind::Unsupported).message
+        );
+
+        let recognized = connection
+            .wire_parser
+            .parse_sql(&client, "SELECT $1", &[Some(Type::INT8)])
+            .await
+            .unwrap_err();
+        let PgWireError::UserError(info) = recognized else {
+            panic!("expected a BriskDB-owned PostgreSQL error")
+        };
+        assert_eq!(info.code, "0A000");
+        assert_eq!(
+            info.message,
+            postgres_error(EngineErrorKind::Unsupported).message
+        );
+
+        let invalid = connection
+            .wire_parser
+            .parse_sql(&client, "SELECT 'private adapter literal' +", &[])
+            .await
+            .unwrap_err();
+        let PgWireError::UserError(info) = invalid else {
+            panic!("expected a classified parser error")
+        };
+        assert_eq!(info.code, "42000");
+        assert_eq!(
+            info.message,
+            postgres_error(EngineErrorKind::InvalidQuery).message
+        );
+        assert!(!info.message.contains("private adapter literal"));
+        assert_eq!(connection.status().await.unwrap().shard_count(), 2);
+
+        connection.close().await.unwrap();
+        engine.shutdown().await.unwrap();
+    }
+
+    #[test]
+    fn every_engine_error_uses_the_fixed_postgres_mapping() {
+        for kind in EngineErrorKind::ALL.iter().copied() {
+            let wire = engine_error_to_pgwire(EngineError::new(
+                kind,
+                "private SQL, path, and SQLite diagnostic",
+            ));
+            let PgWireError::UserError(info) = wire else {
+                panic!("{kind:?} did not produce a user error")
+            };
+            let expected = postgres_error(kind);
+            assert_eq!(info.severity, "ERROR");
+            assert_eq!(info.code, expected.sqlstate);
+            assert_eq!(info.message, expected.message);
+            assert!(!info.message.contains("private"));
+            assert!(info.detail.is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn selected_pgwire_entrypoint_can_reach_core_without_enabling_the_listener() {
+        let (_temp, engine) = engine(3).await;
+        let adapter = Adapter::new(engine.clone());
+        let connection = Arc::new(adapter.open_connection());
+        let observed = Arc::clone(&connection);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address: SocketAddr = listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            let (socket, _) = listener.accept().await.unwrap();
+            let factory = ProbeFactory {
+                handler: Arc::new(ProbeHandler {
+                    connection: Arc::clone(&connection),
+                }),
+            };
+            let result = process_socket(socket, None, factory).await;
+            connection.close().await.unwrap();
+            result
+        });
+
+        let mut client = TcpStream::connect(address).await.unwrap();
+        client.write_all(&startup_packet()).await.unwrap();
+        let startup = read_until_ready(&mut client).await;
+        assert!(startup.iter().any(|frame| frame.0 == b'R'));
+        assert!(startup.iter().any(|frame| frame.0 == b'S'));
+        assert!(startup.iter().any(|frame| frame.0 == b'K'));
+        assert_eq!(startup.last().unwrap().0, b'Z');
+
+        client
+            .write_all(&typed_packet(b'Q', b"BRISKDB SPIKE\0"))
+            .await
+            .unwrap();
+        let query = read_until_ready(&mut client).await;
+        let command = query.iter().find(|frame| frame.0 == b'C').unwrap();
+        assert_eq!(command.1, b"BRISKDB SPIKE 3\0");
+        assert_eq!(query.last().unwrap().0, b'Z');
+
+        client.write_all(&typed_packet(b'X', &[])).await.unwrap();
+        drop(client);
+        tokio::time::timeout(Duration::from_secs(2), server)
+            .await
+            .expect("the pgwire probe returned after client EOF")
+            .unwrap()
+            .unwrap();
+        assert_eq!(observed.state().await, SessionState::Closed);
+
+        engine.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn rejected_startup_cleans_up_and_a_later_connection_remains_usable() {
+        let (_temp, engine) = engine(2).await;
+        let adapter = Adapter::new(engine.clone());
+        let connection = Arc::new(adapter.open_connection());
+        let observed = Arc::clone(&connection);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            let (socket, _) = listener.accept().await.unwrap();
+            let factory = ProbeFactory {
+                handler: Arc::new(ProbeHandler {
+                    connection: Arc::clone(&connection),
+                }),
+            };
+            let result = process_socket(socket, None, factory).await;
+            connection.close().await.unwrap();
+            result
+        });
+
+        let mut client = TcpStream::connect(address).await.unwrap();
+        let mut unsupported = startup_packet();
+        unsupported[4..8].copy_from_slice(&0x0009_0009_u32.to_be_bytes());
+        client.write_all(&unsupported).await.unwrap();
+        let mut byte = [0_u8; 1];
+        let read = tokio::time::timeout(Duration::from_secs(2), client.read(&mut byte))
+            .await
+            .expect("the rejected startup closed promptly")
+            .unwrap();
+        assert_eq!(read, 0);
+        tokio::time::timeout(Duration::from_secs(2), server)
+            .await
+            .expect("the rejected startup task returned")
+            .unwrap()
+            .unwrap();
+        assert_eq!(observed.state().await, SessionState::Closed);
+
+        let recovered = adapter.open_connection();
+        assert_eq!(recovered.status().await.unwrap().shard_count(), 2);
+        recovered.close().await.unwrap();
+        engine.shutdown().await.unwrap();
+    }
+
+    impl Connection {
+        async fn state(&self) -> SessionState {
+            self.state.session.state().await
+        }
+    }
+}

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -8,7 +8,7 @@ use std::{
 use axum::Router;
 use briskdb::{
     api, core,
-    protocol::{error, http},
+    protocol::{error, http, postgres},
     server, sql, storage,
 };
 
@@ -232,6 +232,34 @@ fn protocol_neutral_sql_parser_facade_is_public_bounded_and_opt_in() {
     raw_sql.push_str(&" ".repeat(sql::MAX_PARSED_SQL_BYTES));
     let result = database.query("parser-opt-in", &raw_sql, &[]).unwrap();
     assert_eq!(result.rows()[0].get(0), Some(&core::Value::Int64(1)));
+}
+
+#[tokio::test]
+async fn postgres_adapter_boundary_is_public_session_scoped_and_not_a_listener() {
+    fn assert_send_sync<T: Send + Sync + 'static>() {}
+    assert_send_sync::<postgres::Adapter>();
+    assert_send_sync::<postgres::Connection>();
+
+    let temp = tempfile::tempdir().unwrap();
+    let engine = core::Engine::open(temp.path(), 2).await.unwrap();
+    let adapter = postgres::Adapter::new(engine.clone());
+    let first = adapter.open_connection();
+    let second = adapter.open_connection();
+
+    assert_ne!(first.session_id(), second.session_id());
+    assert_eq!(first.status().await.unwrap().shard_count(), 2);
+    assert_eq!(second.status().await.unwrap().shard_count(), 2);
+    assert!(format!("{adapter:?}").contains("shard_count"));
+    assert!(format!("{first:?}").contains("session_id"));
+
+    first.close().await.unwrap();
+    assert_eq!(
+        first.status().await.unwrap_err().kind(),
+        core::EngineErrorKind::FailedPrecondition
+    );
+    assert_eq!(second.status().await.unwrap().shard_count(), 2);
+    second.close().await.unwrap();
+    engine.shutdown().await.unwrap();
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Pin `pgwire` exactly at 0.36.3, the newest release compatible with Rust 1.85, with only `server-api` enabled.
- Add a BriskDB-owned adapter and per-connection core-session boundary with private parser and fixed error-mapping probes.
- Cover independent sessions, cleanup, parser behavior, all engine error mappings, actual loopback socket startup/query flow, and recovery after rejected startup.
- Keep the production PostgreSQL listener at its existing accept-and-close behavior and document the remaining adapter work.

## Validation

- `cargo +stable fmt --all -- --check`
- `cargo +stable clippy --locked --all-targets --all-features -- -D warnings`
- `cargo +stable test --locked --all-targets --all-features`
- `cargo +stable test --locked --doc --all-features`
- `cargo +1.85.0 test --locked --all-targets --all-features`
- `cargo +1.85.0 test --locked --doc --all-features`
- `cargo +1.85.0 tree --locked -e features -i pgwire`

Closes #29.