### PR TITLE
Support PostgreSQL startup sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,6 +232,7 @@ dependencies = [
  "sqlparser",
  "tempfile",
  "tokio",
+ "tokio-util",
  "tower",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ axum = "0.8.9"
 blake3 = "1.8"
 clap = { version = "4.6.6", features = ["derive", "env"] }
 getrandom = "=0.4.3"
+futures = "0.3"
 hyper = { version = "1.11", features = ["http1", "server"] }
 hyper-util = { version = "0.1.20", features = ["service", "tokio"] }
 # 0.36.3 is the newest pgwire release that supports BriskDB's Rust 1.85
@@ -35,13 +36,13 @@ sqlparser = { version = "=0.62.0", git = "https://github.com/apache/datafusion-s
 # both this repository and downstream consumers until that graph is corrected.
 psm = "=0.1.28"
 tokio = { version = "1.53.1", features = ["full"] }
+tokio-util = { version = "0.7", features = ["codec"] }
 tower = { version = "0.5", features = ["util"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 
 [dev-dependencies]
 criterion = { version = "0.7", default-features = false }
-futures = "0.3"
 tempfile = "3.23"
 
 [[bench]]

--- a/README.md
+++ b/README.md
@@ -13,15 +13,14 @@ The [architecture map](docs/ARCHITECTURE.md) defines the crate's module
 boundaries and dependency direction.
 
 The [SQL compatibility contract](docs/SQL_COMPATIBILITY.md) distinguishes the
-current SQLite pass-through API from the PostgreSQL TCP-listener scaffold and
-planned PostgreSQL/MySQL wire compatibility.
+current SQLite pass-through API from PostgreSQL startup support and planned
+PostgreSQL/MySQL query compatibility.
 The [PostgreSQL listener contract](docs/POSTGRES_LISTENER.md) defines its
-address configuration, disabled state, startup order, placeholder connection
-behavior, and shared shutdown lifecycle.
+address configuration, startup/session behavior, parameter status, deferred
+query boundary, and shared shutdown lifecycle.
 The [PostgreSQL adapter decision record](docs/POSTGRES_ADAPTER.md) selects the
 exact wire-library version and features, defines the BriskDB-owned connection
-boundary, and records the work that remains before that listener speaks the
-protocol.
+boundary, and records the work that remains for query execution.
 The [SQL parser decision record](docs/SQL_PARSER.md) defines the shared,
 dialect-explicit syntax boundary and its resource and dependency limits.
 The [common SQL subset contract](docs/SQL_SUBSET.md) defines the opt-in,
@@ -44,8 +43,9 @@ protocol-neutral prepare/bind/describe/execute lifecycle, session-scoped
 statement and portal caches, exact resource limits, metadata refresh, and
 supported physical-target execution boundary shared by future adapters.
 The [error contract](docs/ERRORS.md) defines stable engine error kinds, safe
-HTTP problem details, the mapping consumed by the private PostgreSQL adapter
-probe, and the mapping reserved for a future MySQL wire adapter.
+HTTP problem details, the mapping consumed by PostgreSQL startup/query deferral
+and the private adapter probe, and the mapping reserved for a future MySQL wire
+adapter.
 The [request-control contract](docs/REQUEST_CONTROLS.md) defines cancellation,
 deadlines, materialized-result budgets, and graceful shutdown.
 The [admin data-browser contract](docs/ADMIN_BROWSER.md) defines the embedded
@@ -71,9 +71,10 @@ minimum supported Rust version (MSRV) and the latest stable toolchain.
 - Request cancellation and deadlines that interrupt SQLite and await cleanup
 - Finite per-query row/logical-byte budgets with no partial results
 - Explicit graceful drain, forced cancellation, and blocking handle cleanup
-- Independently configured HTTP and PostgreSQL TCP listeners; `pgwire` 0.36.3
-  is pinned behind a BriskDB-owned adapter seam while the PostgreSQL listener
-  continues to accept and close connections pending startup/session work
+- Independently configured HTTP and PostgreSQL TCP listeners; the loopback
+  PostgreSQL endpoint supports protocol 3.0 startup, logical database/user
+  selection, BriskDB parameter status, and clean connection termination through
+  a BriskDB-owned `pgwire` 0.36.3 boundary
 - An embedded read-only browser at `/admin` for inspecting user tables and
   bounded row pages on one explicitly selected physical shard
 - Protocol-neutral typed values, ordered columns, positional rows, and results
@@ -124,6 +125,10 @@ precedence over the environment, which takes precedence over the default. The
 HTTP address, data directory, and shard count can also be supplied with
 `BRISKDB_LISTEN`, `BRISKDB_DATA_DIR`, and `BRISKDB_SHARDS`.
 
+An enabled PostgreSQL address must be IPv4 or IPv6 loopback in the current
+phase. A non-loopback value is rejected before the engine opens or either
+listener binds.
+
 ```bash
 # Keep the existing HTTP service and do not bind the PostgreSQL port.
 cargo run -- --postgres-listen disabled
@@ -132,11 +137,11 @@ cargo run -- --postgres-listen disabled
 BRISKDB_POSTGRES_LISTEN=disabled cargo run
 ```
 
-Issue #28 supplies the separately managed TCP endpoint, and issue #29 selects
-the wire library without activating it on that endpoint. Until startup/session
-support lands, every accepted connection is closed immediately without reading
-or writing protocol bytes, and no PostgreSQL driver can execute a request
-through it. See the [listener contract](docs/POSTGRES_LISTENER.md) and
+The PostgreSQL listener currently accepts only loopback addresses. It supports
+protocol 3.0 startup and session selection, then reports fixed `0A000` errors
+for SQL until issue #31 adds simple and extended query execution. It is not yet
+a query-capable PostgreSQL interface. See the
+[listener contract](docs/POSTGRES_LISTENER.md) and
 [adapter decision record](docs/POSTGRES_ADAPTER.md).
 
 The HTTP listener also serves the embedded data explorer at
@@ -165,10 +170,14 @@ shutdown allows 30 seconds before cancelling admitted work and is configured by
 `--shutdown-grace-ms` / `BRISKDB_SHUTDOWN_GRACE_MS`. Ctrl-C and, on Unix,
 SIGTERM stop new admissions, drain or cancel admitted SQLite work, close idle
 handles, and then stop the process. Core admission closes before both listener
-sockets are dropped. Accepted HTTP connections are tracked; connections
-that outlive the grace window are force-closed and joined before the server
-returns. Placeholder PostgreSQL connections have already been closed at
-accept time and retain no engine work to drain.
+sockets are dropped. Accepted HTTP and PostgreSQL connections are tracked;
+connections that outlive the grace window are force-closed. HTTP task joins are
+awaited; PostgreSQL task joins and retained-session closes get one additional
+grace interval. If that second interval expires, remaining PostgreSQL session
+closes are scheduled as best-effort runtime cleanup rather than delaying server
+return. Every completed PostgreSQL startup owns one core session that is closed
+on `Terminate`, EOF, or protocol failure; server shutdown applies the bounded
+cleanup described above.
 
 Each session defaults to at most 128 prepared statements, 128 bound portals,
 and a 16 MiB ceiling for retained bound values/captured routing bytes and one

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -229,19 +229,20 @@ the engine regardless of its eventual wire protocol.
   `0.36.3`, the newest release compatible with BriskDB's Rust 1.85 baseline.
   Enable only `server-api`, pin the pre-1.0 version, and keep its types behind
   the BriskDB-owned `protocol::postgres` adapter boundary.
-- [ ] Support startup, database/user selection, parameter status, clean
-  termination, and useful server-version identification.
+- [x] Support protocol 3.0 startup, exact logical database/user selection,
+  BriskDB-owned parameter status, clean termination and session cleanup, and
+  useful `<package-version>-briskdb` server identification on loopback.
 - [ ] Support simple query flow and extended Parse/Bind/Describe/Execute/Sync,
   including named and unnamed statements/portals, Flush/Close, protocol error
   resynchronization, and portal suspension.
-- [ ] Baseline protocol 3.0 and negotiate newer minor versions rather than
-  assuming that wire version and server marketing version are identical.
+- [ ] Negotiate explicitly supported newer protocol minor versions from the
+  exact 3.0 baseline rather than conflating protocol and server versions.
 - [ ] Map BriskDB types to PostgreSQL OIDs and support text format first, then
   the binary formats required by tested drivers.
 - [ ] Implement `BEGIN`/`COMMIT`/`ROLLBACK`, failed-transaction state, and shard
   pinning. Report PostgreSQL's idle/in-transaction/failed (`I`/`T`/`E`) states
   even where SQLite's native behavior differs.
-- [ ] Support cancellation requests and connection cleanup.
+- [ ] Support `CancelRequest`/backend keys and wire cancellation to the core.
 - [ ] Add TLS and SCRAM-SHA-256 before non-loopback use; never ship cleartext
   password authentication on an unencrypted listener.
 - [ ] Add compatibility shims for `SELECT version()`, common `SHOW` commands,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,8 +2,8 @@
 
 BriskDB is organized so network protocols can share one routing and execution
 core. The module layout preserves the experimental HTTP contract and existing
-Rust module paths while making future PostgreSQL and MySQL adapters explicit
-peers.
+Rust module paths while making the active PostgreSQL startup adapter and the
+planned MySQL adapter explicit peers.
 
 ```text
 binary (main)
@@ -20,11 +20,11 @@ server ---------> protocol::http
     |                v      v
     |            storage    sql
     |
-    +-- PostgreSQL TCP lifecycle
-        (accept/close placeholder; no core request)
-
-protocol::postgres ---------> core
-    (selected pgwire seam; not connected to the listener yet)
+    +---------> protocol::postgres
+                    |
+                    v
+                  core
+        (startup/session active; SQL deferred)
 ```
 
 | Module | Responsibility | Must not own |
@@ -33,9 +33,9 @@ protocol::postgres ---------> core
 | `storage` | Versioned routing/logical manifest, shard layout, migration journal and recovery, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
 | `sql` | Dialect-explicit SQL syntax parsing, recursive common-subset validation, protocol-neutral statement/batch classification, source-preserving placeholder normalization, explicit strict/compatibility translation, catalog-aware typed shard-key inference, and narrow crate-private DML-shape inspection behind BriskDB-owned boundaries; exact source retention; SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, key hashing or shard selection, mutable session state, physical write-routing policy, filesystem layout, protocol responses, protocol-buffer ownership, or protocol-specific support policy |
 | `protocol::http` | Existing HTTP request extraction, shared JSON/BriskDB value and RFC 9457 problem-detail encoding, and the embedded admin shell/assets, temporary browser sessions, discovery, and page handlers | BLAKE3 routing, shard files, direct SQLite access, or rusqlite calls |
-| `protocol::postgres` | BriskDB-owned adapter and per-connection core-session boundary around the exactly pinned `pgwire` library; private compile/query-parser and fixed-error conversion proof | Listener binding, direct SQLite access, routing, unbounded authoritative prepared state, or public dependency-owned types |
+| `protocol::postgres` | BriskDB-owned bounded protocol-3.0 framing, finite parameter validation, selected identity/status, per-connection core-session ownership, query-deferral responses, and private compile/query-parser seam around the exactly pinned `pgwire` library | Listener binding, direct SQLite access, routing, unbounded authoritative prepared state, or public dependency-owned types |
 | `protocol::error` | Exhaustive HTTP, PostgreSQL, and MySQL mappings from stable engine error kinds | SQLite errors, routing decisions, or wire-protocol session state |
-| `server` | Process configuration, database assembly, separate HTTP/PostgreSQL listener binding, tracked Axum HTTP/1 connection lifecycle, and the temporary PostgreSQL accept/close loop | SQL parsing, PostgreSQL wire messages, or storage implementation details |
+| `server` | Process configuration, database assembly, loopback validation, separate HTTP/PostgreSQL listener binding, finite connection-task supervision, and shared graceful/forced draining | SQL parsing, PostgreSQL wire framing, or storage implementation details |
 
 Implementation dependencies flow one way: adapters call the async `Engine` in
 `core`; the engine coordinates routing, `storage`, and `sql`. An adapter supplies
@@ -90,7 +90,7 @@ bounded per-session caches, bounded per-shard pools, request controls, and
 explicit shutdown lifecycle are now in place. The synchronous `Database` API
 remains available as a Rust compatibility surface; existing engine and server
 function signatures remain in place and delegate to the controlled defaults.
-Issue #28 adds `Config::postgres_listen: Option<SocketAddr>`, so pre-1.0 Rust
+Issue #28 added `Config::postgres_listen: Option<SocketAddr>`, so pre-1.0 Rust
 callers constructing `Config` with a struct literal must now choose an enabled
 address or `None`.
 
@@ -104,18 +104,17 @@ option. The process default enables loopback `127.0.0.1:5433`. See the
 startup order.
 
 Issue #29 selects exact `pgwire` 0.36.3 with only `server-api` and adds the
-BriskDB-owned `protocol::postgres::{Adapter, Connection}` seam. Each connection
-created through that seam owns one core `Session`; a private parser bridge and
-loopback compatibility test prove that the selected handler/socket API can call
-the engine without exposing dependency types to core or server contracts. See
-the [adapter decision record](POSTGRES_ADAPTER.md).
-
-The production PostgreSQL listener remains a server-lifecycle placeholder: it
-accepts and immediately drops each stream without constructing that adapter,
-reading bytes, writing a PostgreSQL frame, opening a session, or calling the
-engine. Issue #30 owns that wiring and startup behavior. This keeps binding,
-concurrent acceptance, startup cleanup, and shared shutdown testable without
-moving protocol behavior into `server`.
+BriskDB-owned `protocol::postgres::{Adapter, Connection}` seam. Issue #30
+connects the production loopback listener to that adapter for exact protocol
+3.0 startup. Parameter validation, logical database/user selection, fixed
+status/error frames, and terminal session cleanup stay in
+`protocol::postgres`; socket binding, the 256-task cap, and task draining stay
+in `server`. A successful startup creates one core `Session` only after
+validation. `Terminate`, EOF, and protocol failure close it; shutdown hands it
+to the bounded cleanup lifecycle described below. No dependency-owned type
+crosses into core or the public server contract. SQL message execution remains
+issue #31. See the
+[adapter decision record](POSTGRES_ADAPTER.md).
 
 ## Admin browser boundary
 
@@ -701,15 +700,20 @@ this explicit asynchronous path. Prepared statement/portal close and terminal
 session close remain available as in-memory cleanup while draining; no
 prepared state is persisted for restart recovery.
 
-The server owns accepted HTTP/1 connections in a tracked task set and manages a
-separate optional PostgreSQL socket in the same accept lifecycle. It stops
-engine admission before dropping both listeners, starts HTTP and core draining
-together, and aborts then joins any HTTP connection that exceeds the HTTP grace
-deadline. Placeholder PostgreSQL streams are already closed at accept time and
-therefore own no drain task. Signal receivers are installed only after every
-configured listener binds and before readiness is logged. Dropping the server
-future closes both listeners, aborts its tracked HTTP connection set, and
-synchronously enters `Draining`; a surviving embedder-owned `Engine` clone can
+The server owns accepted HTTP/1 and PostgreSQL connections in separate tracked
+task sets under one accept lifecycle. It stops engine admission before dropping
+both listeners, signals both task sets, and starts connection/core draining
+together. Tasks that exceed the common grace deadline are aborted. HTTP task
+joins are awaited, while the PostgreSQL supervisor gets one additional grace
+interval to join aborted tasks and attempt to close each selected core session.
+If that second interval expires, server return does not await the remaining
+PostgreSQL session closes; they are scheduled on the runtime as best-effort
+cleanup.
+Partial startup sockets own a task but no session. Signal receivers are
+installed only after every configured listener binds and before readiness is
+logged. Dropping the server future closes both listeners, aborts both task
+sets, synchronously enters `Draining`, and schedules best-effort terminal
+PostgreSQL session cleanup; a surviving embedder-owned `Engine` clone can
 resume asynchronous cleanup with `shutdown()`.
 
 Real multi-call `BEGIN`/`COMMIT`/`ROLLBACK`, failed-transaction state, and
@@ -731,11 +735,11 @@ response type. SQL and storage classify SQLite failures from primary and
 extended result codes plus operation context; they never parse SQLite error
 messages. Protocol-owned tables map each kind to an HTTP status and safe RFC
 9457 problem, a PostgreSQL SQLSTATE, and a MySQL error number/SQLSTATE pair.
-The selected PostgreSQL adapter probe consumes the PostgreSQL mapping behind a
-private dependency boundary; the MySQL entry remains a contract for its future
-adapter. The PostgreSQL TCP placeholder emits no protocol frame and therefore
-does not expose the PostgreSQL mapping on the network yet; no MySQL listener
-exists yet.
+Production PostgreSQL startup emits fixed fatal validation/protocol errors and
+the pre-issue-31 query boundary emits the fixed `Unsupported` mapping. The
+private adapter probe also consumes the engine mapping behind the same
+dependency boundary. The MySQL entry remains a contract for its future adapter;
+no MySQL listener exists yet.
 
 Client responses use fixed, safe text for the error kind. Diagnostic display
 text and source chains stay available internally but are never serialized, so

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -3,17 +3,16 @@
 BriskDB classifies failures once, at the protocol-neutral engine boundary. An
 `EngineErrorKind` is stable error identity; protocol adapters translate that
 identity without inspecting an error message. The HTTP adapter uses the mapping
-today. The selected PostgreSQL adapter seam also converts every engine kind
-through the PostgreSQL column in its compatibility tests, but the current
-PostgreSQL TCP placeholder accepts and closes without emitting an error frame.
-The MySQL column remains a contract for its planned adapter, and there is no
-MySQL listener yet.
+today. PostgreSQL startup and the deliberate pre-query boundary emit fixed
+wire errors through the same safe-message policy, and the adapter converts
+every engine kind through the PostgreSQL column. The MySQL column remains a
+contract for its planned adapter, and there is no MySQL listener yet.
 
 Malformed listener configuration is rejected by the binary before server
 startup. Listener bind/accept failures terminate the shared server lifecycle
 with process-level diagnostics after cleanup; they are not `EngineErrorKind`
-values and are not encoded as HTTP or PostgreSQL responses. A placeholder
-PostgreSQL peer receives only a no-byte connection close.
+values and are not encoded as HTTP or PostgreSQL responses. A PostgreSQL
+startup timeout closes without a frame because no session was established.
 
 ## Taxonomy and protocol mappings
 
@@ -46,6 +45,15 @@ the human-readable text to identify an error.
 | <a id="storage-unavailable"></a>`StorageUnavailable` | `storage_unavailable` | 503 | Storage unavailable | The storage is unavailable. | `58030` | 1105 | `HY000` | No |
 | <a id="data-corruption"></a>`DataCorruption` | `data_corruption` | 500 | Data corruption | Stored data failed an integrity check. | `XX001` | 1105 | `HY000` | No |
 | <a id="internal"></a>`Internal` | `internal` | 500 | Internal error | An internal engine error occurred. | `XX000` | 1105 | `HY000` | No |
+
+PostgreSQL startup also has a finite protocol-specific table: invalid user
+labels use `28000`, unknown logical databases use `3D000`, invalid startup
+values use `22023`, unsupported startup features use `0A000`, and malformed or
+unsupported protocol versions use `08P01`. These are fixed `FATAL` responses
+followed by socket close, without `ReadyForQuery`. Before issue #31, simple
+queries and extended `Parse` use the engine `Unsupported` mapping (`0A000`) and
+never include query text. The complete sequencing is in
+[PostgreSQL startup and listener](POSTGRES_LISTENER.md).
 
 Only `Busy` is retryable. A caller should retry it with bounded exponential
 backoff and jitter. No other HTTP status, SQLSTATE, or MySQL error number
@@ -280,9 +288,10 @@ one error identity while retaining its own response encoding.
 Issue #29's private `pgwire` bridge constructs `ErrorInfo` only from
 `postgres_error(error.kind())`: severity `ERROR`, the fixed SQLSTATE, and the
 fixed public message. Its exhaustive test uses a private diagnostic sentinel
-for every kind and proves that sentinel is absent. This is a library-fit
-contract, not live listener behavior; issue #30 and later transaction work own
-production severity, connection-fatal policy, and failed-transaction state.
+for every kind and proves that sentinel is absent. Issue #30 applies fixed
+`FATAL` startup errors plus terminal close and fixed `ERROR` / `0A000` query
+deferral. Later transaction work owns failed-transaction state and the complete
+execution-error policy.
 
 Manifest compatibility uses the same protocol-neutral kinds. A foreign file,
 a manifest newer than the running binary, or a requested shard-count mismatch

--- a/docs/POSTGRES_ADAPTER.md
+++ b/docs/POSTGRES_ADAPTER.md
@@ -1,12 +1,14 @@
 # PostgreSQL adapter decision record
 
-Status: accepted for roadmap issue #29
+Status: accepted for roadmap issue #29; amended by issue #30 production startup
+activation
 
 BriskDB needs a PostgreSQL frontend library that can own protocol framing and
 message dispatch without becoming the database engine, routing policy,
 prepared-object store, or public error taxonomy. This record selects that
-library, fixes its dependency boundary, and documents the compatibility probe.
-It does not activate PostgreSQL wire behavior on the configured listener.
+library, fixes its dependency boundary, documents the compatibility probe, and
+records the BriskDB-owned startup constraints applied when issue #30 activated
+the configured loopback listener.
 
 ## Decision
 
@@ -32,7 +34,7 @@ behavior, and MSRV decision followed by the complete verification matrix.
 
 Only `server-api` is enabled. That supplies the Tokio socket entrypoint,
 frontend/backend messages, handler traits, PostgreSQL type descriptors, and
-row encoders needed by the planned server adapter.
+row encoders used by startup and the planned query adapter.
 
 The dependency's defaults are disabled because they additionally select an
 AWS-LC TLS backend and extended chrono, decimal, and JSON adapters. BriskDB does
@@ -64,9 +66,9 @@ The public BriskDB seam consists of two owned types:
   and the current default logical-database identifier. Constructing it has no
   network or session side effect.
 - `protocol::postgres::Connection` owns exactly one non-cloneable core
-  `Session`, exposes its `SessionId`, can read controlled engine status, and can
-  close that session idempotently. Separate connections never share session
-  state.
+  `Session`, exposes its `SessionId` plus selected user/database identity, can
+  read controlled engine status, and can close that session idempotently.
+  Separate connections never share session state.
 
 The connection retains a private implementation of `pgwire`'s `QueryParser`
 trait as the compile-time bridge. Its probe path prepares PostgreSQL-dialect
@@ -102,12 +104,13 @@ server:
    status, returns after client EOF, and explicitly closes its core session;
 7. a rejected startup returns promptly, closes its core session, and leaves a
    later adapter connection usable; and
-8. the existing server tests continue to prove that the configured production
-   PostgreSQL listener writes zero bytes and immediately closes each stream.
+8. production server tests independently prove exact startup frames, concurrent
+   HTTP/PostgreSQL service, tracked termination, and shutdown cleanup.
 
-The loopback command and its response tag exist only inside the unit test. They
-are not supported SQL, public protocol behavior, or a claim that a PostgreSQL
-driver can use BriskDB today.
+The issue-29 loopback command and its response tag remain only a private unit
+probe. They are not supported SQL or public protocol behavior. Production
+startup has separate raw-wire contract tests and deliberately returns `0A000`
+for queries until issue #31.
 
 ## Library fit and retained ownership
 
@@ -124,8 +127,9 @@ Those conveniences do not transfer product ownership to the library. In
 particular:
 
 - `pgwire`'s default startup handler advertises dependency-owned version and
-  parameter values. Issue #30 must replace it with BriskDB values before the
-  production listener calls `process_socket`.
+  parameter values. Production startup therefore uses BriskDB-owned handlers,
+  validates protocol 3.0 and a finite parameter set, and emits only the status
+  documented in `POSTGRES_LISTENER.md`.
 - Its default in-memory statement/portal store is unbounded, replacement does
   not return the old object for cleanup, and statement removal does not cascade
   into BriskDB handles. Issue #31 must keep the engine's existing finite
@@ -135,15 +139,31 @@ particular:
   not call `Engine::bind_statement`. The production adapter must decode into
   BriskDB `Value` objects and bind at Bind time so the route snapshot is
   immutable before Execute.
-- The socket loop has no BriskDB session-close callback. The production wrapper
-  must close its `Connection` on every ordinary, error, EOF, cancellation, and
-  shutdown return path.
+- The selected socket loop does not treat `Terminate` as terminal and has no
+  BriskDB session-close callback. Production uses a narrow BriskDB-owned loop
+  around the library's public decoder/dispatcher and closes its `Connection`
+  on `Terminate`, error, and EOF. Shutdown signals the loop; forced task cleanup
+  hands retained connections to the server's bounded cleanup supervisor.
+- The selected decoder assumes complete, correctly bounded frames. A
+  BriskDB-owned raw-frame gate therefore runs before dependency decoding and
+  releases exactly one validated frame at a time. BriskDB also owns plaintext
+  negotiation: `SSLRequest` and `GSSENCRequest` must each be exactly eight bytes
+  before the dependency identifies them, so a malformed negotiation cannot
+  consume a following startup. Startup frames have a maximum declared length
+  of 10,000 bytes. After startup, only `Query`, `Parse`, `Sync`, and `Terminate`
+  are admitted, with a maximum declared length of 65,541 bytes; strings must be
+  valid UTF-8 and each frame must satisfy its exact structural boundary. Other
+  frontend message types are rejected until their owning roadmap issues.
+  Malformed or oversized input receives BriskDB's fixed `08P01` response when a
+  response can be sent, the socket closes, and an already-selected core session
+  is still closed. Raw-frame regression tests cover malformed input both before
+  and after successful startup.
 - The selected version understands protocol 3.0 and 3.2 and defaults its own
-  client state to 3.2. Issue #32 must apply BriskDB's deliberate baseline and
-  minor-version negotiation policy.
-- Dependency message-size ceilings are not BriskDB retention limits. SQL,
-  names, raw parameters, prepared objects, rows, and connection tasks still
-  require BriskDB-owned finite limits.
+  client state to 3.2. BriskDB now overrides that state with an exact 3.0
+  baseline; issue #32 owns explicit newer-minor negotiation.
+- The raw-frame caps are transport-retention boundaries, not budgets for SQL,
+  names, raw parameters, prepared objects, or rows. Those values and connection
+  tasks still require their BriskDB-owned finite limits.
 - Portal suspension in the dependency cannot cause a BriskDB portal to execute
   twice. The core currently returns a complete bounded materialized result;
   issue #31 must retain and resume the already produced response or provide a
@@ -155,17 +175,19 @@ tests remain authoritative.
 
 ## Current listener behavior
 
-The configured PostgreSQL TCP listener still performs issue #28's exact
-accept-and-close behavior. It does not construct an `Adapter` or `Connection`,
-call `process_socket`, read a startup packet, emit a response, open a core
-session, or run SQL. Selecting a library must not accidentally ship its default
-startup behavior before BriskDB's production session policy is implemented.
+Issue #30 activates production protocol 3.0 startup on configured loopback
+addresses. The listener validates a finite startup parameter set, resolves an
+exact logical database through the core catalog, creates one session only after
+validation, emits BriskDB-owned status, and tracks that session through
+termination and server shutdown. It does not use the dependency's default
+startup values or protocol-version state.
 
-Issue #30 owns production wiring plus startup, logical database/user selection,
-BriskDB parameter status, termination, and server-version identification.
-Issue #31 owns simple and extended query flow. Later roadmap issues retain
-their existing protocol-version, type, transaction, cancellation, TLS/SCRAM,
-client-matrix, and row-streaming scopes.
+Issue #31 owns simple and extended query flow. Until then, every simple query
+and extended `Parse` receives a fixed `0A000` error with protocol recovery and
+no retained statement. Later roadmap issues retain their existing
+minor-version negotiation, type, transaction, cancellation, TLS/SCRAM,
+client-matrix, and row-streaming scopes. The exact live contract is in the
+[PostgreSQL listener document](POSTGRES_LISTENER.md).
 
 ## Errors, configuration, and storage
 
@@ -173,8 +195,9 @@ The compile bridge converts an `EngineError` only by calling
 `protocol::error::postgres_error(error.kind())`. It creates severity `ERROR`,
 the table's five-character SQLSTATE, and the fixed safe message. Trusted SQL,
 SQLite text, paths, and source chains in `diagnostic()` are never serialized.
-Production severity, failed-transaction state, and connection-fatal policy
-remain part of the later wire/session work.
+Startup applies fixed fatal severity and closes after its error; pre-query
+errors use fixed ordinary severity. Failed-transaction state remains part of
+the later transaction work.
 
 This decision adds no CLI or environment setting and does not change listener
 defaults, HTTP routes, JSON, SQL support, routing, engine limits, manifest or
@@ -190,7 +213,8 @@ A `pgwire` update must remain exact and must verify, at minimum:
 - enabled features and absence of unintended providers/type adapters;
 - handler factory, startup, query, error, cancellation, portal, and socket-loop
   API changes;
-- message limits and connection-state behavior;
+- raw-frame gate/decoder boundaries, exact message limits, and connection-state
+  behavior;
 - independent per-connection BriskDB sessions and cleanup on every return path;
 - fixed SQLSTATE/safe-message conversion for every engine error kind;
 - the production listener's expected behavior for the roadmap issue being

--- a/docs/POSTGRES_LISTENER.md
+++ b/docs/POSTGRES_LISTENER.md
@@ -1,10 +1,10 @@
-# PostgreSQL listener lifecycle
+# PostgreSQL startup and listener contract
 
-Issue #28 adds the process and TCP-lifecycle boundary for a future PostgreSQL
-wire adapter. Issue #29 subsequently selects the adapter library without
-activating it here. The listener deliberately does not implement a PostgreSQL
-startup packet, authentication, query flow, error response, or any other wire
-message.
+BriskDB serves PostgreSQL protocol 3.0 startup on a separately configured
+loopback TCP listener. A successful startup selects one logical database,
+creates one protocol-neutral core session, publishes BriskDB-owned parameter
+status, and keeps the socket alive until `Terminate`, EOF, server shutdown, or
+a protocol failure. SQL query execution begins in roadmap issue #31.
 
 ## Process configuration
 
@@ -12,108 +12,174 @@ The binary exposes one value with one grammar:
 
 | Source | Default | Enabled value | Disabled value |
 | --- | --- | --- | --- |
-| CLI | `--postgres-listen 127.0.0.1:5433` | numeric `SocketAddr`, such as `127.0.0.1:6543` or `[::1]:6543` | `--postgres-listen disabled` |
-| Environment | `BRISKDB_POSTGRES_LISTEN=127.0.0.1:5433` | the same numeric `SocketAddr` grammar | `BRISKDB_POSTGRES_LISTEN=disabled` |
+| CLI | `--postgres-listen 127.0.0.1:5433` | numeric loopback `SocketAddr`, such as `127.0.0.1:6543` or `[::1]:6543` | `--postgres-listen disabled` |
+| Environment | `BRISKDB_POSTGRES_LISTEN=127.0.0.1:5433` | the same numeric loopback grammar | `BRISKDB_POSTGRES_LISTEN=disabled` |
 
 An explicit command-line value wins over the environment; the environment wins
 over the default. `disabled` is the exact lowercase sentinel. Empty values,
-hostnames, address strings without a port, and aliases such as `off` or `none`
-are rejected during command-line parsing. Port zero retains the standard
+hostnames, values without a port, and aliases such as `off` or `none` are
+rejected during command-line parsing. Port zero retains the standard
 `SocketAddr` meaning of asking the operating system to select a port.
 
-The existing `--listen` / `BRISKDB_LISTEN` setting remains the always-enabled
-HTTP address and retains its `127.0.0.1:7654` default. The two listeners are
-configured independently; this issue does not rename the HTTP option or add an
-HTTP-disabled mode.
-
-## Rust server configuration
+Only IPv4 or IPv6 loopback addresses may activate the PostgreSQL wire endpoint
+until the TLS and SCRAM work in issue #36. `server::Config` applies that rule
+before opening the data directory or binding either listener. The existing
+HTTP listener remains independently configured and always enabled.
 
 `server::Config::postgres_listen` is `Option<SocketAddr>`:
 
-- `Some(address)` binds and serves the placeholder PostgreSQL listener;
+- `Some(address)` validates, binds, and serves PostgreSQL startup;
 - `None` skips its bind, accept branch, and shutdown work.
 
-The process-only `disabled` spelling is converted to `None` before calling the
-server library, so embedders never parse a command-line sentinel. Adding this
-field to the public pre-1.0 `Config` struct is a source-shape change for callers
-that construct it with a literal; those callers must choose `Some(address)` or
-`None`. The signatures of `server::run` and
-`server::run_with_engine_options` are unchanged.
+The process-only `disabled` spelling is converted to `None` before entering the
+server library. `server::run` and `server::run_with_engine_options` retain their
+existing signatures.
 
 ## Startup and failure order
 
 Startup has one deterministic order:
 
-1. clap parses every CLI/environment value and `Args::into_server_parts`
-   validates resource options;
-2. the engine opens the configured data directory, including existing startup
-   recovery and shard validation;
-3. the HTTP listener binds;
-4. the PostgreSQL listener binds when configured;
-5. process signal receivers are installed; and
-6. readiness is logged and the accept loop starts.
+1. clap parses CLI/environment values and resource options are validated;
+2. a configured PostgreSQL address is required to be loopback;
+3. the engine opens the data directory and completes startup recovery;
+4. the HTTP listener binds;
+5. the PostgreSQL listener binds when configured;
+6. process signal receivers are installed; and
+7. readiness is logged and the shared accept loop starts.
 
-The server never logs readiness after only one of two configured listeners has
-bound. Preserving HTTP-first binding means an HTTP bind conflict is reported
-before a PostgreSQL bind is attempted. If the PostgreSQL bind fails, the
-already-bound HTTP listener is dropped, the engine enters its normal shutdown
-path, cleanup is awaited, and the original PostgreSQL bind error is returned.
-The same cleanup applies if signal setup fails. A disabled PostgreSQL listener
-cannot cause a bind failure, even if the default port is already in use.
+The server never logs readiness after only one configured listener has bound.
+An HTTP bind failure precedes a PostgreSQL bind attempt. If the PostgreSQL bind
+or signal setup fails, the HTTP listener is released and engine shutdown is
+awaited before the original error is returned. Disabled mode cannot cause a
+PostgreSQL bind failure.
 
-Engine open precedes network binding to retain BriskDB's existing startup
-ordering. Consequently, an open may finish an already-recorded storage recovery
-before a later listener bind fails. That durable recovery is not rolled back;
-after the address becomes available, starting the same data directory again is
-the supported retry.
+Engine open still precedes network binding, so a recorded storage recovery can
+finish before a later bind failure. That completed recovery is durable; after
+the address becomes available, reopening the same data directory is the
+supported retry.
 
-## Placeholder connection behavior
+## Startup protocol
 
-After issue #29, the listener still accepts each TCP connection and immediately
-drops the stream:
+The listener accepts PostgreSQL protocol version 3.0 exactly. Newer minor
+version negotiation belongs to issue #32. `SSLRequest` and `GSSENCRequest` must
+each be an exact eight-byte frame and receive `N`, after which the client may
+send a plaintext startup packet on the loopback socket. Malformed negotiation
+lengths cannot consume bytes from a following startup packet. No TLS or GSS
+session is accepted in the current phase. The listener waits at most 60 seconds
+for negotiation and a startup packet; that timeout closes the socket without
+creating a core session.
 
-- it reads no client bytes;
-- it writes no server bytes or PostgreSQL error frame;
-- the peer observes EOF/connection close;
-- no `Engine` session, prepared statement, portal, route, or SQLite operation
-  is created; and
-- accepted placeholder connections are not retained as background tasks.
+For the startup packet and subsequent typed messages, a BriskDB-owned raw-frame
+gate runs before general dependency decoding and releases exactly one complete
+frame at a time. A startup packet's declared length may not exceed 10,000
+bytes. After successful startup, only `Query`, `Parse`, `Sync`, and `Terminate`
+frontend messages are admitted, and their declared length may not exceed 65,541
+bytes (the one-byte message type is outside that declared length). Query and
+Parse strings must be valid UTF-8, all four message types must match their exact
+structural boundaries, and startup key/value pairs must be structurally
+complete valid UTF-8 with no duplicate key. Other frontend message types are
+rejected until their owning roadmap issues. Malformed and oversized frames
+follow the fixed `08P01` protocol-failure path when a response can be sent.
 
-Continuously accepting and closing prevents the operating-system backlog from
-filling while making the incomplete wire behavior deterministic. Emitting even
-a nominal PostgreSQL frame is deferred to production activation of the
-selected BriskDB-owned adapter in issue #30. This TCP scaffold must not be
-described as a usable PostgreSQL interface.
+The accepted startup keys are finite:
 
-HTTP acceptance and placeholder PostgreSQL acceptance share one server
-lifecycle. Neither listener implements routing, parsing, planning, or SQLite
-access; those remain behind the protocol-neutral `Engine` boundary.
+| Key | Contract |
+| --- | --- |
+| `user` | Required session label: 1–63 bytes; first byte lowercase ASCII or `_`; remaining bytes lowercase ASCII, digits, or `_` |
+| `database` | Optional exact logical-database name; omission selects the database whose name equals `user` |
+| `client_encoding` | Optional `UTF8` or `UTF-8`; both become `UTF8` |
+| `application_name` | Optional, at most 63 UTF-8 bytes, with no control or replacement character |
+| `replication` | Optional literal `false`; other values are unsupported |
 
-## Shutdown and recovery
+Every other key is rejected. The `user` value is a bounded connection label,
+not a role lookup or credential check. Authentication and role catalogs are
+separate later work; it is also unrelated to the HTTP browser's temporary
+login. Database selection is an exact lookup through the protocol-neutral
+catalog. Startup creates a core session only after every parameter and the
+database selection have passed validation.
 
-SIGINT and, on supported Unix hosts, SIGTERM first stop new engine admissions.
-Both TCP listeners are then dropped. Existing HTTP connection tasks drain under
-the configured grace period alongside core shutdown. PostgreSQL placeholder
-streams need no drain because they are closed as soon as they are accepted.
+Successful startup emits these frames in order:
 
-An accept failure on either listener ends the shared server: both listeners
-close, HTTP tasks drain, and the engine completes its normal shutdown. Dropping
-the server future closes both listener sockets and enters the same resumable
-`Draining` engine state already documented for HTTP-only operation.
+1. `AuthenticationOk`;
+2. `ParameterStatus(server_version, <BriskDB package version>-briskdb)`;
+3. `ParameterStatus(server_encoding, UTF8)`;
+4. `ParameterStatus(client_encoding, UTF8)`;
+5. `ParameterStatus(standard_conforming_strings, on)`;
+6. `ParameterStatus(integer_datetimes, on)`;
+7. optional validated `ParameterStatus(application_name, ...)`; and
+8. `ReadyForQuery(I)`.
+
+The values and ordering are BriskDB-owned rather than dependency defaults.
+`BackendKeyData` is omitted until cancellation identifiers are implemented in
+issue #35.
+
+## Startup errors
+
+Decoded startup validation/protocol rejections send one fixed `FATAL`
+`ErrorResponse` and then close the socket; they do not append `ReadyForQuery`
+or echo rejected values. A read timeout, server shutdown, or peer disconnect
+can instead close without a response.
+
+| Condition | SQLSTATE |
+| --- | --- |
+| Missing or invalid `user` | `28000` |
+| Empty, invalid, or unknown logical database | `3D000` |
+| Invalid client encoding or application name | `22023` |
+| Unknown startup key or unsupported replication value | `0A000` |
+| Unsupported protocol version or malformed startup message | `08P01` |
+
+A failed startup creates no retained core session, statement, portal, route, or
+SQLite operation. A later connection can start normally.
+
+## Query boundary before issue #31
+
+Startup support does not claim SQL execution. Every simple-query message,
+including an empty query, receives BriskDB's fixed `ERROR` / `0A000` mapping
+followed by `ReadyForQuery(I)`; the same connection remains reusable. An
+extended `Parse` receives the same fixed error before a dependency-owned
+statement is stored, and `Sync` restores `ReadyForQuery(I)`. Query text is
+never included in the response. Issue #31 replaces this deliberate boundary
+with the complete simple and extended query state machine.
+
+## Connection ownership and shutdown
+
+Each accepted socket runs in a tracked task. At most 256 PostgreSQL socket
+tasks are retained; a connection accepted while that limit is full is closed.
+HTTP and PostgreSQL tasks share the process lifecycle but are tracked
+separately. A PostgreSQL socket that completes startup owns exactly one core
+session and tracks it for closure on every terminal path:
+
+- `Terminate` closes promptly without waiting for client EOF;
+- client EOF or a wire failure closes the session;
+- ordinary server shutdown signals both HTTP and PostgreSQL tasks, then drains
+  them concurrently with core shutdown;
+- tasks that exceed the configured shutdown grace are aborted, then get one
+  additional grace interval for their joins and retained-session closes;
+- if that second interval expires, server return does not await the remaining
+  PostgreSQL session closes and schedules them as best-effort runtime cleanup;
+  and
+- dropping the outer server future closes both listener sockets, aborts owned
+  connection tasks, begins the resumable engine drain, and schedules
+  best-effort terminal session cleanup.
+
+Partial startup sockets are tracked and close during shutdown even though they
+have not created a core session. An accept failure on either listener ends the
+shared server and enters the same cleanup path.
 
 ## Compatibility and storage boundary
 
-Issue #28 itself adds no wire dependency. Issue #29 pins `pgwire` 0.36.3 behind
-`protocol::postgres`, with default features disabled and only `server-api`
-enabled. That selection changes no HTTP route, JSON body, SQL subset, planner
-rule, typed result, engine error mapping, manifest table, shard header,
-migration journal, stored row, or storage-format version. Listener settings and
-the inactive adapter seam are not persisted in `manifest.sqlite` or a shard.
+`pgwire` remains pinned exactly at 0.36.3 with default features disabled and
+only `server-api` enabled. Production framing is contained in
+`protocol::postgres`; `core`, `storage`, `sql`, `server`, and the public API do
+not accept or return dependency types. The adapter uses BriskDB's catalog,
+session lifecycle, fixed SQLSTATE table, and safe messages.
 
-The PostgreSQL SQLSTATE table is consumed by the adapter compatibility probe;
-the placeholder emits none of those mappings. The next roadmap item owns
-PostgreSQL startup/session messages and production socket integration. Library
-selection details and constraints are normative in the
+This startup work changes no HTTP route, JSON body, SQL subset, planner rule,
+typed result, manifest table, shard header, migration journal, stored row, or
+storage-format version. Startup identity, parameter metadata, and connection
+tasks exist only in process memory.
+
+Library selection details and upgrade constraints are normative in the
 [PostgreSQL adapter decision record](POSTGRES_ADAPTER.md).
 
 ## Verification contract
@@ -121,11 +187,23 @@ selection details and constraints are normative in the
 Automated coverage includes:
 
 - default, explicit IPv4/IPv6, environment, CLI-over-environment, disabled, and
-  malformed configuration cases;
-- both listeners serving concurrently while the HTTP health path remains live;
-- immediate close for one and many concurrent placeholder clients;
-- disabled mode skipping PostgreSQL binding;
-- PostgreSQL bind-failure cleanup and a clean retry of the data directory;
-- ordinary graceful shutdown and dropped-server-future recovery with both
-  listeners configured; and
+  malformed configuration values;
+- loopback validation before database or listener creation;
+- dual-listener binding, bind-failure cleanup, and clean retry;
+- exact `SSLRequest`/`GSSENCRequest` refusal and boundary handling, startup frame
+  order, selected identity, omitted-database behavior, and useful BriskDB server
+  identification;
+- the 60-second production startup timeout through an accelerated timer test;
+- startup and typed-message size boundaries, exact frame isolation, UTF-8 and
+  structural validation, duplicate startup keys, and unsupported message types;
+- fixed failures for protocol, user, database, encoding, application-name,
+  unknown-key, replication, and truncated-message cases before and after
+  session creation, followed by successful recovery;
+- simple-query recovery and extended-query `Sync` recovery without retaining a
+  dependency statement;
+- immediate `Terminate`, client EOF, partial startup, normal shutdown, forced
+  server-task cancellation, and core-session cleanup;
+- the 256-task admission boundary, deterministic overflow close, and slot reuse
+  after a tracked task completes;
+- many concurrent PostgreSQL sessions while HTTP health remains live; and
 - unchanged public HTTP behavior and unchanged storage version.

--- a/docs/REQUEST_CONTROLS.md
+++ b/docs/REQUEST_CONTROLS.md
@@ -1,10 +1,10 @@
 # Request controls and shutdown
 
 BriskDB applies cancellation, deadlines, result budgets, and shutdown at the
-protocol-neutral `Engine` boundary. HTTP, the selected PostgreSQL adapter seam,
-and a future MySQL adapter therefore share the same resource and cleanup
-semantics. The current PostgreSQL TCP placeholder never creates an engine
-request.
+protocol-neutral `Engine` boundary. HTTP, PostgreSQL sessions, and a future
+MySQL adapter therefore share the same resource and cleanup semantics. Current
+PostgreSQL startup performs one bounded status operation; SQL request flow is
+deferred to issue #31.
 
 ## Per-request context
 
@@ -221,12 +221,16 @@ persisted or recovered after process shutdown.
 The server constructs its SIGINT/SIGTERM receivers after every configured
 listener binds and before logging readiness on supported Unix hosts. It
 transitions the engine to `Draining` before dropping both the HTTP listener and
-the optional PostgreSQL listener and signaling each tracked HTTP/1 connection.
-HTTP draining and core shutdown start together. A connection still active at
-the HTTP grace deadline is aborted and joined before server shutdown returns;
-accepted PostgreSQL placeholder streams were closed immediately and own no
-task to drain. Core cleanup may continue through its separately documented
-forced-cleanup grace. A forced cancellation cannot erase committed
+the optional PostgreSQL listener and signaling every tracked HTTP/PostgreSQL
+connection. Connection draining and core shutdown start together. A connection
+still active at the grace deadline is aborted. HTTP task joins are awaited;
+PostgreSQL task joins and retained-session closes get one additional grace
+interval. If that second interval expires, server return does not await the
+remaining PostgreSQL session closes and schedules them as best-effort runtime
+cleanup. Completed PostgreSQL startups retain one core session; normal and
+completed forced-task cleanup close it, while partial startups own no session.
+Core cleanup may continue through its separately documented forced-cleanup
+grace. A forced cancellation cannot erase committed
 schema-migration progress: the current shard transaction rolls back if still
 running, the retained prefix remains resumable, and the next startup finishes
 it before serving ordinary work.

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -1,9 +1,10 @@
 # SQL compatibility
 
 BriskDB stores data in SQLite and is designed to expose the same database
-engine through HTTP, PostgreSQL, MySQL, and future protocol adapters. A wire
-protocol does not change SQLite into that protocol's namesake database. This
-document defines the SQL and behavioral contract separately from connectivity.
+engine through HTTP, the active PostgreSQL startup adapter, and planned SQL
+flows for PostgreSQL, MySQL, and other future protocol adapters. A wire protocol
+does not change SQLite into that protocol's namesake database. This document
+defines the SQL and behavioral contract separately from connectivity.
 
 ## Status vocabulary
 
@@ -39,17 +40,19 @@ BriskDB tracks three independent compatibility layers:
 3. **Behavioral compatibility** emulates the metadata, type, error, transaction,
    and session behavior needed by specifically tested clients and tools.
 
-Passing a PostgreSQL or MySQL handshake will establish only wire compatibility.
-BriskDB will publish behavioral compatibility per tested driver or tool rather
-than claiming to be a drop-in PostgreSQL or MySQL replacement.
+Completing only a PostgreSQL or MySQL handshake establishes startup
+compatibility, not the full wire compatibility defined above. BriskDB will
+publish wire and behavioral compatibility per tested driver or tool rather than
+claiming to be a drop-in PostgreSQL or MySQL replacement.
 
 ## Current implementation
 
-Only the experimental HTTP network interface can execute network requests
-today. `pgwire` 0.36.3 is selected and pinned behind a BriskDB-owned adapter
-seam, while the separately configured PostgreSQL TCP listener still accepts
-and immediately closes streams; it implements no PostgreSQL wire message.
-There is no MySQL listener. The public Rust SQL facade
+Only the experimental HTTP network interface can execute SQL network requests
+today. The separately configured loopback PostgreSQL listener implements exact
+protocol-3.0 startup, logical database/user selection, BriskDB parameter
+status, and tracked session termination through a pinned `pgwire` 0.36.3
+boundary. It rejects SQL with fixed `0A000` responses until issue #31. There is
+no MySQL listener. The public Rust SQL facade
 can parse an explicitly selected SQLite, PostgreSQL, or MySQL dialect, consume
 that result with
 `validate_common_subset(ParsedSql)`, borrow the result with
@@ -84,25 +87,26 @@ path; they do not pass through these opt-in SQL layers.
 | HTTP `/v1/query` | Experimental | One raw SQLite statement prepared transiently by the row-returning path; no session cache | Required caller-provided `shard_key` |
 | HTTP `/v1/admin/broadcast` | Experimental | A journaled parameterless SQLite schema batch | Preflight on every shard, then ascending resumable apply |
 | HTTP `/admin` browser | Experimental, read-only | No caller SQL; server-generated physical table discovery and bounded `SELECT *` pages | Required validated physical shard number; never a routed or scatter query |
-| PostgreSQL wire protocol | `pgwire` 0.36.3 selected behind a BriskDB-owned core-session seam; production TCP listener remains an accept/close scaffold | Rust parsing, validation, classification, placeholder normalization, finite compatibility translation, and prepared lifecycle implemented; private parser compatibility probe only | Core batch/write policy, bind validation, routing snapshots, current execute-time planning, and supported target execution implemented; production wire mapping planned |
+| PostgreSQL wire protocol | Protocol-3.0 startup/session only on loopback; SQL flow deferred | No SQL accepted over the wire; simple `Query` and extended `Parse` return fixed `0A000` responses | Startup selects an exact logical database; no wire SQL request reaches planning or routing |
 | MySQL wire protocol | Planned | Rust parsing, validation, classification, placeholder normalization, finite compatibility translation, and prepared lifecycle implemented; listener adoption planned | Core batch/write policy, bind validation, routing snapshots, current execute-time planning, and supported target execution implemented; wire mapping planned |
 
 The parser, subset validator, statement classifier, placeholder normalizer, SQL
-translator, shard-key inference function, engine planner, prepared lifecycle,
-and PostgreSQL adapter seam are implemented Rust APIs, not PostgreSQL or MySQL
-network interfaces. The private issue-29 probe composes the selected library
-with those APIs, but the PostgreSQL socket scaffold does not connect them to the
-network. They do not change any current HTTP row in this table.
+translator, shard-key inference function, engine planner, and prepared
+lifecycle are implemented Rust APIs, not PostgreSQL or MySQL query interfaces.
+PostgreSQL production startup connects only identity, catalog selection,
+status, and session cleanup; the historical private issue-29 parser probe does
+not make that prepared pipeline public wire behavior. These changes do not
+alter any HTTP row in this table.
 
 Every HTTP database operation now calls the same protocol-neutral async engine
-intended for future PostgreSQL and MySQL adapters. Execute and query requests
-create a fresh `Ready` session, put the request's `shard_key` in its routing
-context, and submit an owned statement. The engine, rather than the HTTP
-adapter, selects the shard and acquires a pooled SQLite connection. Admin
-inspection requests also create a fresh `Ready` session, but use a bounded
-read-only engine operation with an already validated physical shard. The
-session is discarded when that HTTP request finishes, so a transaction cannot
-span requests.
+used by PostgreSQL startup status and intended for issue-31 PostgreSQL SQL flow
+and the future MySQL adapter. Execute and query requests create a fresh `Ready`
+session, put the request's `shard_key` in its routing context, and submit an
+owned statement. The engine, rather than the HTTP adapter, selects the shard
+and acquires a pooled SQLite connection. Admin inspection requests also create
+a fresh `Ready` session, but use a bounded read-only engine operation with an
+already validated physical shard. The session is discarded when that HTTP
+request finishes, so a transaction cannot span requests.
 
 ### Admin browser inspection
 
@@ -312,9 +316,10 @@ SQLite result codes and operation context; error-message text is never parsed
 to choose an error kind.
 
 The same kinds already have defined PostgreSQL SQLSTATE and MySQL error
-number/SQLSTATE mappings. The private selected-adapter probe consumes the
-PostgreSQL mapping; the MySQL mapping remains a contract for its future
-adapter. The PostgreSQL TCP placeholder emits no error frame, and no MySQL
+number/SQLSTATE mappings. PostgreSQL startup emits a finite fixed fatal-error
+table, and its current query boundary emits `Unsupported` / `0A000` without
+query text; the private selected-adapter probe also consumes the engine mapping.
+The MySQL mapping remains a contract for its future adapter, and no MySQL
 listener is available. See the complete
 [error taxonomy and mapping table](ERRORS.md) and the
 [PostgreSQL listener lifecycle](POSTGRES_LISTENER.md).
@@ -634,13 +639,13 @@ boundary are normative in
 
 ## PostgreSQL differences
 
-The bound PostgreSQL TCP scaffold will host the selected `pgwire` 0.36.3
-adapter targeting the frontend/backend protocol and a deliberately small SQL
-compatibility surface. The BriskDB-owned adapter/core-session boundary and a
-private parser/socket fit probe exist, but the listener currently accepts and
-closes without a handshake. PostgreSQL-specific behavior is not implemented
-unless listed as implemented in this document. Configuration and lifecycle
-semantics are normative in the [PostgreSQL listener
+The PostgreSQL TCP listener hosts the selected `pgwire` 0.36.3 boundary for
+exact protocol-3.0 startup on loopback. It validates a finite parameter set,
+selects one logical database and user label, advertises BriskDB-owned status,
+and tracks the selected core session through termination. SQL messages remain
+at a fixed error/resynchronization boundary until issue #31. PostgreSQL-specific
+behavior is not implemented unless listed as implemented in this document.
+Configuration and lifecycle semantics are normative in the [PostgreSQL listener
 contract](POSTGRES_LISTENER.md); dependency and adapter constraints are
 normative in the [adapter decision record](POSTGRES_ADAPTER.md).
 
@@ -659,7 +664,7 @@ normative in the [adapter decision record](POSTGRES_ADAPTER.md).
 | `ON CONFLICT` | PostgreSQL upsert syntax | Outside the initial common subset and unsupported |
 | Functions/operators | PostgreSQL catalog | SQLite functions/operators unless an explicit shim is documented |
 | System catalogs | `pg_catalog`, `information_schema` | Only queries required by named, tested clients will be emulated |
-| Error behavior | SQLSTATE and failed transaction state | Stable error-kind-to-SQLSTATE mapping defined; wire encoding and `I`/`T`/`E` transaction states planned |
+| Error behavior | SQLSTATE and failed transaction state | Startup and query-deferral errors are encoded now; the complete execution mapping and `I`/`T`/`E` transaction states remain planned |
 | `COPY`, replication, `LISTEN/NOTIFY` | PostgreSQL subprotocols/features | Deferred and unsupported initially |
 
 PostgreSQL's static result metadata does not always have an exact equivalent in

--- a/docs/SQL_PREPARED_STATEMENTS.md
+++ b/docs/SQL_PREPARED_STATEMENTS.md
@@ -395,12 +395,12 @@ handling to that type.
 
 ## Dialect and adapter compatibility
 
-The lifecycle is implemented as a Rust engine API. The selected PostgreSQL
-adapter seam privately proves that wire preparation can enter that lifecycle,
-but no wire-message path is connected to the production listener yet. The
-PostgreSQL TCP scaffold accepts and closes without creating a session; there is
-no MySQL listener. All three typed input paths share the same planning and
-result path:
+The lifecycle is implemented as a Rust engine API. Production PostgreSQL
+startup now validates identity and creates one selected core session, but every
+simple query and extended `Parse` stops at a fixed `0A000` response. That wire
+boundary creates no prepared statement or portal and does not yet enter this
+lifecycle. There is no MySQL listener. All three typed Rust input paths share
+the same planning and result path:
 
 | Input | Required mode and parameter form | Prepared execution result |
 | --- | --- | --- |
@@ -408,11 +408,12 @@ result path:
 | PostgreSQL | `Compatibility`; `$N` identities, including repeats and gaps | Same protocol-neutral routed rows or affected-row count |
 | MySQL | `Compatibility`; each `?` numbered left-to-right | Same protocol-neutral routed rows or affected-row count |
 
-Future adapters own message framing, authentication, statement/portal naming,
-wire parameter decoding, result type encoding, close acknowledgement, and
-protocol resynchronization. They must call this lifecycle rather than retain a
-SQLite handle, implement a second cache, interpolate values into SQL, or choose
-a physical shard themselves.
+Each protocol adapter owns its message framing, authentication,
+statement/portal naming, wire parameter decoding, result type encoding, close
+acknowledgement, and protocol resynchronization. PostgreSQL startup framing and
+session ownership are implemented; issue #31 must map its query messages into
+this lifecycle rather than retain a SQLite handle, implement a second cache,
+interpolate values into SQL, or choose a physical shard itself.
 
 ## Storage-format boundary
 

--- a/docs/SQL_STATEMENT_CLASSIFICATION.md
+++ b/docs/SQL_STATEMENT_CLASSIFICATION.md
@@ -4,9 +4,10 @@ Status: implemented for roadmap issue #27
 
 BriskDB classifies the already validated common SQL AST into a small,
 protocol-neutral behavior taxonomy. The classifier is the shared request gate
-for future PostgreSQL, MySQL, and other adapters; a frontend must not infer
-behavior from SQL text, a wire command, SQLite result columns, or whether
-SQLite reports a statement as read-only.
+for the PostgreSQL adapter's deferred SQL flow, the planned MySQL adapter, and
+other future adapters; a frontend must not infer behavior from SQL text, a wire
+command, SQLite result columns, or whether SQLite reports a statement as
+read-only.
 
 ```rust
 classify_statements(
@@ -206,12 +207,12 @@ pinning remain later transaction work.
 
 ## Adapter and raw-surface boundary
 
-Future PostgreSQL and MySQL adapters must pass their explicitly selected
-dialect through the shared parser, subset validator, and classifier. They may
-map the nested behavior to protocol command tags or status handling, but must
-not implement a second keyword classifier or loosen batch policy on their own.
-The same typed common SQL produces the same classification regardless of its
-wire protocol.
+The PostgreSQL adapter's issue-31 SQL flow and the future MySQL adapter must
+pass their explicitly selected dialect through the shared parser, subset
+validator, and classifier. They may map the nested behavior to protocol command
+tags or status handling, but must not implement a second keyword classifier or
+loosen batch policy on their own. The same typed common SQL produces the same
+classification regardless of its wire protocol.
 
 Issue #27 adds no PostgreSQL or MySQL listener and no new HTTP route, request
 field, response body, or configuration option. The experimental HTTP execute,
@@ -219,8 +220,10 @@ query, and migration endpoints remain raw SQLite surfaces and do not invoke the
 opt-in common frontend. In particular, the journaled migration endpoint keeps
 its own bounded, parameterless SQLite batch contract and can accept a schema
 batch that the general common-SQL classifier deliberately rejects.
-Issue #28 subsequently adds only the PostgreSQL TCP accept/close scaffold; it
-does not connect that socket to classification or any other SQL layer.
+At the issue-28 milestone, the PostgreSQL endpoint was only an accept/close
+scaffold. Issue #30 connected startup, catalog selection, status, and session
+cleanup, but SQL messages still stop before classification or any other shared
+SQL layer until issue #31.
 
 ## Storage-format and configuration boundary
 

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -898,21 +898,24 @@ parameterless schema-batch contract: it still digests and retains the caller's
 exact submitted SQL and does not substitute classified, normalized, or
 translated text as migration identity.
 
-Issue #28's optional PostgreSQL socket address and accept/close listener are
-process configuration only. They add no manifest or shard table, header value,
-format version, digest input, routing metadata, schema fingerprint, journal
-record, or recovery step. Listener settings are not persisted. Because engine
-open and its existing recovery precede listener binding, a later bind failure
-does not undo a migration or recovery transaction that already committed; a
-subsequent startup revalidates the same version-7 layout normally.
+Issue #28's optional PostgreSQL socket address and accept/close listener were
+process-configuration changes only. They added no manifest or shard table,
+header value, format version, digest input, routing metadata, schema
+fingerprint, journal record, or recovery step. Listener settings are not
+persisted. Because engine open and its existing recovery precede listener
+binding, a later bind failure does not undo a migration or recovery transaction
+that already committed; a subsequent startup revalidates the same version-7
+layout normally.
 
-Issue #29's pinned `pgwire` dependency, `protocol::postgres::Adapter`, and
-per-connection core `Session` seam are also process-only code and memory state.
-They add no manifest or shard table, header value, format version, digest input,
-routing metadata, schema fingerprint, journal record, file, or recovery step.
-The production PostgreSQL listener does not construct that state yet. A probe
-prepare is transient prepared metadata and is explicitly closed in tests; it
-does not write application rows or schema.
+Issue #29's pinned `pgwire` dependency and issue #30's production startup,
+`protocol::postgres::Adapter`, selected identity, and per-connection core
+`Session` are also process-only code and memory state. They add no manifest or
+shard table, header value, format version, digest input, routing metadata,
+schema fingerprint, journal record, file, or recovery step. Startup performs a
+read-only engine-status operation; current wire queries are rejected before
+preparation, routing, or SQLite execution. The historical private probe's
+prepared metadata is transient and explicitly closed in tests. None of these
+paths writes application rows or schema.
 
 The checksums are corruption detectors, not authentication. Both use unkeyed
 BLAKE3 and are writable by anyone who can modify the data directory. The

--- a/docs/SUPPORTED_PLATFORMS.md
+++ b/docs/SUPPORTED_PLATFORMS.md
@@ -31,20 +31,20 @@ service-manager integration beyond those signals is not yet part of the support
 contract.
 
 The supported runner tests separate Tokio TCP listeners on numeric IPv4
-loopback addresses, concurrent HTTP and PostgreSQL-placeholder acceptance,
-disabled PostgreSQL binding, bind-failure cleanup, and shutdown of both
-listeners. Numeric IPv6 `SocketAddr` parsing is part of the CLI contract; an
-individual host must still provide the requested address family. The
-PostgreSQL endpoint is currently an accept/close lifecycle scaffold, not a wire
-compatibility claim. Its exact process behavior is documented in
+loopback addresses, concurrent HTTP and PostgreSQL startup sessions, disabled
+PostgreSQL binding, bind-failure cleanup, and shutdown of both listeners.
+Numeric IPv6 `SocketAddr` parsing is part of the CLI contract; an individual
+host must still provide the requested address family. The PostgreSQL endpoint
+currently supports startup and session lifecycle but not SQL execution. Its
+exact process behavior is documented in
 [PostgreSQL listener lifecycle](POSTGRES_LISTENER.md).
 
 The selected PostgreSQL library is pinned to `pgwire` 0.36.3 with only its
 `server-api` feature. It is the newest release declaring compatibility with the
 project's Rust 1.85 minimum; 0.37 and newer require Rust 1.89. CI compiles the
 locked adapter/core compatibility probe on Rust 1.85 and stable. This library
-selection does not change the production endpoint's placeholder behavior; see
-the [adapter decision record](POSTGRES_ADAPTER.md).
+selection is active only behind BriskDB-owned startup, status, error, and
+session-lifecycle policy; see the [adapter decision record](POSTGRES_ADAPTER.md).
 
 The same runner exercises the embedded `/admin` shell and assets, temporary
 login/session lifecycle, physical-shard table discovery, and bounded row-page

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ struct Args {
     #[arg(long, env = "BRISKDB_LISTEN", default_value = "127.0.0.1:7654")]
     listen: SocketAddr,
 
-    /// PostgreSQL TCP listener address, or `disabled` to turn it off.
+    /// Loopback PostgreSQL TCP listener address, or `disabled` to turn it off.
     #[arg(
         long,
         env = "BRISKDB_POSTGRES_LISTEN",

--- a/src/protocol/error.rs
+++ b/src/protocol/error.rs
@@ -1,8 +1,8 @@
 //! Safe protocol representations of protocol-neutral engine errors.
 //!
-//! The PostgreSQL TCP placeholder emits no wire messages, and no MySQL listener
-//! exists yet. These records are the tested compatibility contract their wire
-//! adapters will consume.
+//! PostgreSQL startup and deferred-query responses use these fixed mappings.
+//! No MySQL listener exists yet; its mapping remains the tested contract for
+//! that later wire adapter.
 
 use crate::core::EngineErrorKind;
 

--- a/src/protocol/postgres.rs
+++ b/src/protocol/postgres.rs
@@ -1,17 +1,47 @@
 //! BriskDB-owned boundary for the selected PostgreSQL wire library.
 //!
-//! This module deliberately does not serve the configured PostgreSQL listener
-//! yet. It owns the selected library integration and one protocol-neutral core
-//! session per future wire connection so `server`, `core`, and public BriskDB
-//! contracts do not depend on `pgwire` types.
+//! The configured loopback listener delegates startup framing and dispatch to
+//! this module. Each successfully started wire connection owns one
+//! protocol-neutral core session; `server`, `core`, and BriskDB's public API do
+//! not accept or return `pgwire` types.
 
-use std::{fmt, sync::Arc};
+use std::{
+    collections::BTreeSet,
+    fmt, io,
+    pin::Pin,
+    sync::{Arc, OnceLock},
+    task::{Context, Poll},
+    time::Duration,
+};
 
 use async_trait::async_trait;
+use futures::{Sink, SinkExt, StreamExt};
 use pgwire::{
-    api::{ClientInfo, Type, stmt::QueryParser},
+    api::{
+        ClientInfo, ClientPortalStore, DefaultClient, ErrorHandler, PgWireConnectionState,
+        PgWireServerHandlers, Type,
+        auth::StartupHandler,
+        portal::Portal,
+        query::{ExtendedQueryHandler, SimpleQueryHandler},
+        results::{DescribePortalResponse, DescribeStatementResponse, Response},
+        stmt::{NoopQueryParser, QueryParser, StoredStatement},
+        store::PortalStore,
+    },
     error::{ErrorInfo, PgWireError, PgWireResult},
+    messages::{
+        PgWireBackendMessage, PgWireFrontendMessage, ProtocolVersion, SslNegotiationMetaMessage,
+        extendedquery::Parse,
+        response::{GssEncResponse, ReadyForQuery, SslResponse, TransactionStatus},
+        simplequery::Query,
+        startup::{Authentication, ParameterStatus},
+    },
+    tokio::server::{PgWireMessageServerCodec, process_error, process_message},
 };
+use tokio::{
+    io::{AsyncRead, AsyncWrite, ReadBuf},
+    net::TcpStream,
+};
+use tokio_util::codec::Framed;
 
 use crate::{
     core::{
@@ -19,44 +49,411 @@ use crate::{
         PrepareRequest, PreparedStatementDescription, PreparedStatementId, Session, SessionId,
     },
     protocol::error::postgres_error,
-    sql::{SqlDialect, SqlTranslationMode},
+    sql::{MAX_PARSED_SQL_BYTES, SqlDialect, SqlTranslationMode},
 };
+
+const POSTGRES_PROTOCOL_MAJOR: u16 = 3;
+const POSTGRES_PROTOCOL_MINOR: u16 = 0;
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(60);
+const MAX_STARTUP_NAME_BYTES: usize = 63;
+const MAX_STARTUP_PACKET_LENGTH: usize = 10_000;
+const MAX_FRONTEND_MESSAGE_LENGTH: usize = MAX_PARSED_SQL_BYTES + 5;
+const CANCEL_REQUEST_CODE: i32 = 80_877_102;
+const SSL_REQUEST_CODE: i32 = 80_877_103;
+const GSSENC_REQUEST_CODE: i32 = 80_877_104;
+const SERVER_VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), "-briskdb");
+const PARAMETER_STATUS: [(&str, &str); 5] = [
+    ("server_version", SERVER_VERSION),
+    ("server_encoding", "UTF8"),
+    ("client_encoding", "UTF8"),
+    ("standard_conforming_strings", "on"),
+    ("integer_datetimes", "on"),
+];
+
+#[derive(Clone, Copy)]
+enum FrontendFramePhase {
+    Startup,
+    Typed,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum StartupFrameKind {
+    Negotiation,
+    Startup,
+}
+
+/// Bounded raw-frame gate in front of the pinned dependency decoder.
+///
+/// It releases exactly one complete validated frame at a time. That keeps a
+/// declared oversized body out of the dependency buffer and prevents one
+/// frame's decoder from consuming bytes belonging to the next frame.
+struct GuardedPgStream<S> {
+    inner: S,
+    phase: FrontendFramePhase,
+    pending: Vec<u8>,
+    ready: Option<Vec<u8>>,
+    ready_offset: usize,
+}
+
+impl<S> GuardedPgStream<S> {
+    fn new(inner: S, pending: Vec<u8>) -> Self {
+        Self {
+            inner,
+            phase: FrontendFramePhase::Startup,
+            pending,
+            ready: None,
+            ready_offset: 0,
+        }
+    }
+
+    fn expected_frame_length(&self) -> io::Result<Option<usize>> {
+        let (length_offset, header_length, minimum, maximum, type_length) = match self.phase {
+            FrontendFramePhase::Startup => (0, 4, 8, MAX_STARTUP_PACKET_LENGTH, 0),
+            FrontendFramePhase::Typed => (1, 5, 4, MAX_FRONTEND_MESSAGE_LENGTH, 1),
+        };
+        if self.pending.len() < header_length {
+            return Ok(None);
+        }
+        let declared = i32::from_be_bytes(
+            self.pending[length_offset..length_offset + 4]
+                .try_into()
+                .expect("the guarded frame header length was checked"),
+        );
+        if declared < minimum {
+            return Err(invalid_frontend_frame());
+        }
+        if matches!(self.phase, FrontendFramePhase::Startup) && self.pending.len() >= 8 {
+            let code = i32::from_be_bytes(
+                self.pending[4..8]
+                    .try_into()
+                    .expect("the guarded startup preamble length was checked"),
+            );
+            if code == CANCEL_REQUEST_CODE
+                || (matches!(code, SSL_REQUEST_CODE | GSSENC_REQUEST_CODE) && declared != 8)
+            {
+                return Err(invalid_frontend_frame());
+            }
+        }
+        let declared = usize::try_from(declared).map_err(|_| invalid_frontend_frame())?;
+        if declared > maximum {
+            return Err(invalid_frontend_frame());
+        }
+        Ok(Some(declared + type_length))
+    }
+
+    fn prepare_frame(&mut self) -> io::Result<bool> {
+        if self.ready.is_some() {
+            return Ok(true);
+        }
+        let Some(frame_length) = self.expected_frame_length()? else {
+            return Ok(false);
+        };
+        if self.pending.len() < frame_length {
+            return Ok(false);
+        }
+
+        let remainder = self.pending.split_off(frame_length);
+        let frame = std::mem::replace(&mut self.pending, remainder);
+        match self.phase {
+            FrontendFramePhase::Startup => {
+                if validate_startup_frame(&frame)? == StartupFrameKind::Startup {
+                    self.phase = FrontendFramePhase::Typed;
+                }
+            }
+            FrontendFramePhase::Typed => validate_typed_frame(&frame)?,
+        }
+        self.ready = Some(frame);
+        Ok(true)
+    }
+}
+
+impl<S> AsyncRead for GuardedPgStream<S>
+where
+    S: AsyncRead + Unpin,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+        output: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        if output.remaining() == 0 {
+            return Poll::Ready(Ok(()));
+        }
+        loop {
+            if let Some(ready) = &this.ready {
+                let available = &ready[this.ready_offset..];
+                let count = available.len().min(output.remaining());
+                output.put_slice(&available[..count]);
+                this.ready_offset += count;
+                if this.ready_offset == ready.len() {
+                    this.ready = None;
+                    this.ready_offset = 0;
+                }
+                return Poll::Ready(Ok(()));
+            }
+
+            match this.prepare_frame() {
+                Ok(true) => continue,
+                Ok(false) => {}
+                Err(error) => return Poll::Ready(Err(error)),
+            }
+
+            let needed = match this.expected_frame_length() {
+                Ok(Some(frame_length)) => frame_length.saturating_sub(this.pending.len()),
+                Ok(None) => match this.phase {
+                    FrontendFramePhase::Startup => 4 - this.pending.len(),
+                    FrontendFramePhase::Typed => 5 - this.pending.len(),
+                },
+                Err(error) => return Poll::Ready(Err(error)),
+            };
+            let mut scratch = [0_u8; 4_096];
+            let read_length = needed.min(scratch.len());
+            let mut read = ReadBuf::new(&mut scratch[..read_length]);
+            match Pin::new(&mut this.inner).poll_read(context, &mut read) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Err(error)) => return Poll::Ready(Err(error)),
+                Poll::Ready(Ok(())) if read.filled().is_empty() => {
+                    return if this.pending.is_empty() {
+                        Poll::Ready(Ok(()))
+                    } else {
+                        Poll::Ready(Err(invalid_frontend_frame()))
+                    };
+                }
+                Poll::Ready(Ok(())) => this.pending.extend_from_slice(read.filled()),
+            }
+        }
+    }
+}
+
+impl<S> AsyncWrite for GuardedPgStream<S>
+where
+    S: AsyncWrite + Unpin,
+{
+    fn poll_write(
+        self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+        buffer: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.get_mut().inner).poll_write(context, buffer)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_flush(context)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_shutdown(context)
+    }
+}
+
+fn validate_startup_frame(frame: &[u8]) -> io::Result<StartupFrameKind> {
+    if frame.len() < 8
+        || frame.len() > MAX_STARTUP_PACKET_LENGTH
+        || !declared_frame_length_matches(frame, 0, 0)
+    {
+        return Err(invalid_frontend_frame());
+    }
+    let code = i32::from_be_bytes(
+        frame[4..8]
+            .try_into()
+            .expect("the guarded startup frame length was checked"),
+    );
+    if matches!(code, SSL_REQUEST_CODE | GSSENC_REQUEST_CODE) {
+        return if frame.len() == 8 {
+            Ok(StartupFrameKind::Negotiation)
+        } else {
+            Err(invalid_frontend_frame())
+        };
+    }
+    if code == CANCEL_REQUEST_CODE {
+        // Backend cancellation identifiers are introduced by roadmap issue
+        // #35. Until then, a CancelRequest is a well-framed but unsupported
+        // startup packet and must not reach the dependency's no-op handler.
+        return Err(invalid_frontend_frame());
+    }
+    if frame.len() < 9 {
+        return Err(invalid_frontend_frame());
+    }
+
+    let mut cursor = 8;
+    let mut keys = BTreeSet::new();
+    loop {
+        let (key, next) = consume_utf8_cstring(frame, cursor).ok_or_else(invalid_frontend_frame)?;
+        cursor = next;
+        if key.is_empty() {
+            return if cursor == frame.len() {
+                Ok(StartupFrameKind::Startup)
+            } else {
+                Err(invalid_frontend_frame())
+            };
+        }
+        if !keys.insert(key) {
+            return Err(invalid_frontend_frame());
+        }
+        let (_, next) = consume_utf8_cstring(frame, cursor).ok_or_else(invalid_frontend_frame)?;
+        cursor = next;
+    }
+}
+
+fn validate_typed_frame(frame: &[u8]) -> io::Result<()> {
+    if frame.len() < 5
+        || frame.len() > MAX_FRONTEND_MESSAGE_LENGTH + 1
+        || !declared_frame_length_matches(frame, 1, 1)
+    {
+        return Err(invalid_frontend_frame());
+    }
+    let body = frame.get(5..).ok_or_else(invalid_frontend_frame)?;
+    match frame.first().copied() {
+        Some(b'Q') => {
+            if body.last() == Some(&0)
+                && !body[..body.len() - 1].contains(&0)
+                && std::str::from_utf8(&body[..body.len() - 1]).is_ok()
+            {
+                Ok(())
+            } else {
+                Err(invalid_frontend_frame())
+            }
+        }
+        Some(b'P') => {
+            let (_, mut cursor) =
+                consume_utf8_cstring(body, 0).ok_or_else(invalid_frontend_frame)?;
+            let (_, next) =
+                consume_utf8_cstring(body, cursor).ok_or_else(invalid_frontend_frame)?;
+            cursor = next;
+            let count_end = cursor.checked_add(2).ok_or_else(invalid_frontend_frame)?;
+            let count_bytes = body
+                .get(cursor..count_end)
+                .ok_or_else(invalid_frontend_frame)?;
+            let count = usize::from(u16::from_be_bytes(
+                count_bytes
+                    .try_into()
+                    .expect("the guarded Parse count length was checked"),
+            ));
+            let oid_bytes = count.checked_mul(4).ok_or_else(invalid_frontend_frame)?;
+            let expected_end = count_end
+                .checked_add(oid_bytes)
+                .ok_or_else(invalid_frontend_frame)?;
+            if expected_end == body.len() {
+                Ok(())
+            } else {
+                Err(invalid_frontend_frame())
+            }
+        }
+        Some(b'S') | Some(b'X') if body.is_empty() => Ok(()),
+        _ => Err(invalid_frontend_frame()),
+    }
+}
+
+fn declared_frame_length_matches(frame: &[u8], offset: usize, type_length: usize) -> bool {
+    let Some(length_bytes) = frame.get(offset..offset + 4) else {
+        return false;
+    };
+    let declared = i32::from_be_bytes(
+        length_bytes
+            .try_into()
+            .expect("the declared-length slice is exactly four bytes"),
+    );
+    let Ok(declared) = usize::try_from(declared) else {
+        return false;
+    };
+    declared.checked_add(type_length) == Some(frame.len())
+}
+
+fn consume_utf8_cstring(buffer: &[u8], start: usize) -> Option<(&str, usize)> {
+    let tail = buffer.get(start..)?;
+    let offset = tail.iter().position(|byte| *byte == 0)?;
+    let value = std::str::from_utf8(&tail[..offset]).ok()?;
+    let end = start.checked_add(offset)?.checked_add(1)?;
+    Some((value, end))
+}
+
+fn invalid_frontend_frame() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        "invalid bounded PostgreSQL frontend frame",
+    )
+}
 
 /// A PostgreSQL protocol adapter backed only by BriskDB's public engine API.
 ///
-/// Constructing an adapter does not bind a socket, accept a connection, create
-/// a session, or alter the current listener behavior. A distinct core session
-/// is allocated only by [`Adapter::open_connection`].
+/// Constructing an adapter does not bind a socket, accept a connection, or
+/// create a session. A distinct core session is allocated only after an
+/// explicit connection open or a fully validated wire startup.
 #[derive(Clone)]
 pub struct Adapter {
     engine: Engine,
     default_database: LogicalDatabaseId,
+    default_database_name: Box<str>,
 }
 
 impl Adapter {
     /// Construct the BriskDB-owned PostgreSQL adapter boundary.
     pub fn new(engine: Engine) -> Self {
-        let default_database = engine.catalog().default_database().id();
+        let default_metadata = engine.catalog().default_database();
+        let default_database = default_metadata.id();
+        let default_database_name = default_metadata.name().into();
         Self {
             engine,
             default_database,
+            default_database_name,
         }
     }
 
-    /// Allocate independent protocol state for one future wire connection.
+    /// Allocate independent protocol state for a direct adapter probe.
     ///
     /// The returned value owns exactly one non-cloneable BriskDB [`Session`].
     /// No socket is opened and no wire handshake is performed.
     pub fn open_connection(&self) -> Connection {
+        self.connection(None, self.default_database, &self.default_database_name)
+    }
+
+    /// Allocate a connection for one validated PostgreSQL user/database pair.
+    ///
+    /// The user is a bounded session label until the later role-catalog work.
+    /// Database selection is an exact lookup in the protocol-neutral catalog.
+    pub fn open_connection_for(&self, user: &str, database: &str) -> EngineResult<Connection> {
+        if !valid_user_label(user) {
+            return Err(EngineError::new(
+                crate::core::EngineErrorKind::InvalidArgument,
+                "PostgreSQL user labels must be 1 to 63 bytes, start with lowercase ASCII or underscore, and then contain only lowercase ASCII, digits, or underscores",
+            ));
+        }
+        let database = self.engine.catalog().database(database)?.ok_or_else(|| {
+            EngineError::new(
+                crate::core::EngineErrorKind::InvalidArgument,
+                "the selected PostgreSQL logical database does not exist",
+            )
+        })?;
+        Ok(self.connection(Some(user), database.id(), database.name()))
+    }
+
+    fn connection(
+        &self,
+        user: Option<&str>,
+        database: LogicalDatabaseId,
+        database_name: &str,
+    ) -> Connection {
         let state = Arc::new(ConnectionState {
             engine: self.engine.clone(),
             session: self.engine.session(),
-            database: self.default_database,
+            user: user.map(Into::into),
+            database,
+            database_name: database_name.into(),
         });
         let wire_parser = Arc::new(PgWireQueryParser {
             state: Arc::clone(&state),
         });
         Connection { state, wire_parser }
+    }
+
+    pub(crate) fn wire_connection(&self) -> WireConnection {
+        WireConnection {
+            state: Arc::new(WireConnectionState {
+                adapter: self.clone(),
+                connection: OnceLock::new(),
+            }),
+        }
     }
 }
 
@@ -73,10 +470,12 @@ impl fmt::Debug for Adapter {
 struct ConnectionState {
     engine: Engine,
     session: Session,
+    user: Option<Box<str>>,
     database: LogicalDatabaseId,
+    database_name: Box<str>,
 }
 
-/// Protocol-owned state for one future PostgreSQL wire connection.
+/// Protocol-owned state for one PostgreSQL connection.
 ///
 /// This type exposes only BriskDB values. The selected wire crate remains an
 /// implementation detail inside this module.
@@ -94,19 +493,34 @@ impl Connection {
         self.state.session.id()
     }
 
+    /// Return the selected user label, if this connection has an identity.
+    pub fn user(&self) -> Option<&str> {
+        self.state.user.as_deref()
+    }
+
+    /// Return the selected logical-database identity.
+    pub fn database_id(&self) -> LogicalDatabaseId {
+        self.state.database
+    }
+
+    /// Return the selected canonical logical-database name.
+    pub fn database(&self) -> &str {
+        &self.state.database_name
+    }
+
     /// Read engine status through this connection's protocol-neutral session.
     ///
-    /// This small operation is the issue-29 proof that the selected wire
-    /// adapter composes with the controlled async engine boundary. Query and
-    /// prepared execution remain later roadmap work.
+    /// Startup uses this operation to prove that the selected session can enter
+    /// the controlled async engine boundary. Query and prepared execution
+    /// remain later roadmap work.
     pub async fn status(&self) -> EngineResult<EngineStatus> {
         self.state.engine.status(&self.state.session).await
     }
 
     /// Close this connection's core session.
     ///
-    /// Closing is terminal and idempotent. Future production socket wrappers
-    /// must call this on every return path from the wire library.
+    /// Closing is terminal and idempotent. The production socket wrapper calls
+    /// this on ordinary termination, EOF, error, shutdown, and forced cleanup.
     pub async fn close(&self) -> EngineResult<()> {
         self.state.session.close().await
     }
@@ -118,9 +532,535 @@ impl fmt::Debug for Connection {
             .debug_struct("Connection")
             .field("session_id", &self.session_id())
             .field("database", &self.state.database)
+            .field("has_user", &self.state.user.is_some())
             .field("wire_parser", &self.wire_parser)
             .finish_non_exhaustive()
     }
+}
+
+/// One accepted PostgreSQL socket and its optional validated core connection.
+///
+/// The server retains a clone while the socket task runs so it can close the
+/// core session even if the task panics or is forcefully cancelled.
+#[derive(Clone)]
+pub(crate) struct WireConnection {
+    state: Arc<WireConnectionState>,
+}
+
+struct WireConnectionState {
+    adapter: Adapter,
+    connection: OnceLock<Arc<Connection>>,
+}
+
+impl WireConnection {
+    async fn install(&self, user: &str, database: &str) -> PgWireResult<()> {
+        if self.state.connection.get().is_some() {
+            return Err(fatal_wire_error(
+                "08P01",
+                "PostgreSQL startup was already completed",
+            ));
+        }
+
+        let connection = Arc::new(
+            self.state
+                .adapter
+                .open_connection_for(user, database)
+                .map_err(|_| {
+                    fatal_wire_error("3D000", "PostgreSQL database selection is unavailable")
+                })?,
+        );
+        if let Err(connection) = self.state.connection.set(connection) {
+            let _ = connection.close().await;
+            return Err(fatal_wire_error(
+                "08P01",
+                "PostgreSQL startup was already completed",
+            ));
+        }
+        let connection = self
+            .state
+            .connection
+            .get()
+            .expect("the validated PostgreSQL connection was just installed");
+        if let Err(error) = connection.status().await {
+            let _ = connection.close().await;
+            return Err(engine_error_to_pgwire_with_severity(error, "FATAL"));
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn serve<F>(&self, stream: TcpStream, shutdown: F) -> io::Result<()>
+    where
+        F: std::future::Future<Output = ()> + Send,
+    {
+        self.serve_with_startup_timeout(stream, shutdown, STARTUP_TIMEOUT)
+            .await
+    }
+
+    async fn serve_with_startup_timeout<F>(
+        &self,
+        stream: TcpStream,
+        shutdown: F,
+        startup_timeout: Duration,
+    ) -> io::Result<()>
+    where
+        F: std::future::Future<Output = ()> + Send,
+    {
+        let handlers = WireHandlers {
+            connection: self.clone(),
+        };
+        tokio::pin!(shutdown);
+        let wire_result = tokio::select! {
+            biased;
+            _ = &mut shutdown => Ok(()),
+            result = run_socket(stream, handlers, startup_timeout) => result,
+        };
+        let close_result = self.close().await.map_err(io::Error::other);
+        wire_result.and(close_result)
+    }
+
+    pub(crate) async fn close(&self) -> EngineResult<()> {
+        if let Some(connection) = self.state.connection.get() {
+            connection.close().await
+        } else {
+            Ok(())
+        }
+    }
+
+    #[cfg(test)]
+    fn connection(&self) -> Option<&Arc<Connection>> {
+        self.state.connection.get()
+    }
+}
+
+struct WireHandlers {
+    connection: WireConnection,
+}
+
+#[async_trait]
+impl StartupHandler for WireHandlers {
+    async fn on_startup<C>(
+        &self,
+        client: &mut C,
+        message: PgWireFrontendMessage,
+    ) -> PgWireResult<()>
+    where
+        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::Error: fmt::Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        let PgWireFrontendMessage::Startup(startup) = message else {
+            return Err(fatal_wire_error(
+                "08P01",
+                "a PostgreSQL startup message is required",
+            ));
+        };
+        if (startup.protocol_number_major, startup.protocol_number_minor)
+            != (POSTGRES_PROTOCOL_MAJOR, POSTGRES_PROTOCOL_MINOR)
+        {
+            return Err(fatal_wire_error(
+                "08P01",
+                "the PostgreSQL protocol version is unsupported",
+            ));
+        }
+
+        for key in startup.parameters.keys() {
+            if !matches!(
+                key.as_str(),
+                "user" | "database" | "client_encoding" | "application_name" | "replication"
+            ) {
+                return Err(fatal_wire_error(
+                    "0A000",
+                    "the PostgreSQL startup parameter is unsupported",
+                ));
+            }
+        }
+
+        let user = startup.parameters.get("user").ok_or_else(|| {
+            fatal_wire_error("28000", "a valid PostgreSQL user label is required")
+        })?;
+        if !valid_user_label(user) {
+            return Err(fatal_wire_error(
+                "28000",
+                "a valid PostgreSQL user label is required",
+            ));
+        }
+        let database = startup
+            .parameters
+            .get("database")
+            .map(String::as_str)
+            .unwrap_or(user);
+
+        if startup
+            .parameters
+            .get("client_encoding")
+            .is_some_and(|encoding| !matches!(encoding.as_str(), "UTF8" | "UTF-8"))
+        {
+            return Err(fatal_wire_error(
+                "22023",
+                "PostgreSQL client encoding must be UTF8",
+            ));
+        }
+        let application_name = startup.parameters.get("application_name");
+        if application_name.is_some_and(|name| !valid_application_name(name)) {
+            return Err(fatal_wire_error(
+                "22023",
+                "the PostgreSQL application name is invalid",
+            ));
+        }
+        if startup
+            .parameters
+            .get("replication")
+            .is_some_and(|value| value != "false")
+        {
+            return Err(fatal_wire_error(
+                "0A000",
+                "PostgreSQL replication startup is unsupported",
+            ));
+        }
+
+        self.connection.install(user, database).await?;
+        client.set_protocol_version(ProtocolVersion::PROTOCOL3_0);
+        let metadata = client.metadata_mut();
+        metadata.insert("user".to_owned(), user.to_owned());
+        metadata.insert("database".to_owned(), database.to_owned());
+        metadata.insert("client_encoding".to_owned(), "UTF8".to_owned());
+        if let Some(application_name) = application_name {
+            metadata.insert("application_name".to_owned(), application_name.to_owned());
+        }
+
+        client
+            .feed(PgWireBackendMessage::Authentication(Authentication::Ok))
+            .await?;
+        for (name, value) in PARAMETER_STATUS {
+            client
+                .feed(PgWireBackendMessage::ParameterStatus(ParameterStatus::new(
+                    name.to_owned(),
+                    value.to_owned(),
+                )))
+                .await?;
+        }
+        if let Some(application_name) = application_name {
+            client
+                .feed(PgWireBackendMessage::ParameterStatus(ParameterStatus::new(
+                    "application_name".to_owned(),
+                    application_name.to_owned(),
+                )))
+                .await?;
+        }
+        client
+            .send(PgWireBackendMessage::ReadyForQuery(ReadyForQuery::new(
+                TransactionStatus::Idle,
+            )))
+            .await?;
+        client.set_state(PgWireConnectionState::ReadyForQuery);
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl SimpleQueryHandler for WireHandlers {
+    async fn on_query<C>(&self, _client: &mut C, _query: Query) -> PgWireResult<()>
+    where
+        C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::Error: fmt::Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        Err(unsupported_query_error())
+    }
+
+    async fn do_query<C>(&self, _client: &mut C, _query: &str) -> PgWireResult<Vec<Response>>
+    where
+        C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::Error: fmt::Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        Err(unsupported_query_error())
+    }
+}
+
+#[async_trait]
+impl ExtendedQueryHandler for WireHandlers {
+    type Statement = String;
+    type QueryParser = NoopQueryParser;
+
+    fn query_parser(&self) -> Arc<Self::QueryParser> {
+        Arc::new(NoopQueryParser)
+    }
+
+    async fn on_parse<C>(&self, _client: &mut C, _message: Parse) -> PgWireResult<()>
+    where
+        C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::PortalStore: PortalStore<Statement = Self::Statement>,
+        C::Error: fmt::Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        Err(unsupported_query_error())
+    }
+
+    async fn do_describe_statement<C>(
+        &self,
+        _client: &mut C,
+        _target: &StoredStatement<Self::Statement>,
+    ) -> PgWireResult<DescribeStatementResponse>
+    where
+        C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::PortalStore: PortalStore<Statement = Self::Statement>,
+        C::Error: fmt::Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        Err(unsupported_query_error())
+    }
+
+    async fn do_describe_portal<C>(
+        &self,
+        _client: &mut C,
+        _target: &Portal<Self::Statement>,
+    ) -> PgWireResult<DescribePortalResponse>
+    where
+        C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::PortalStore: PortalStore<Statement = Self::Statement>,
+        C::Error: fmt::Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        Err(unsupported_query_error())
+    }
+
+    async fn do_query<C>(
+        &self,
+        _client: &mut C,
+        _portal: &Portal<Self::Statement>,
+        _max_rows: usize,
+    ) -> PgWireResult<Response>
+    where
+        C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::PortalStore: PortalStore<Statement = Self::Statement>,
+        C::Error: fmt::Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        Err(unsupported_query_error())
+    }
+}
+
+impl ErrorHandler for WireHandlers {
+    fn on_error<C>(&self, client: &C, error: &mut PgWireError)
+    where
+        C: ClientInfo,
+    {
+        if matches!(error, PgWireError::UserError(_)) {
+            return;
+        }
+        *error = if matches!(
+            client.state(),
+            PgWireConnectionState::AwaitingStartup
+                | PgWireConnectionState::AuthenticationInProgress
+        ) {
+            fatal_wire_error("08P01", "the PostgreSQL startup message is invalid")
+        } else {
+            unsupported_query_error()
+        };
+    }
+}
+
+impl PgWireServerHandlers for WireHandlers {
+    fn startup_handler(&self) -> Arc<impl StartupHandler> {
+        Arc::new(Self {
+            connection: self.connection.clone(),
+        })
+    }
+
+    fn simple_query_handler(&self) -> Arc<impl SimpleQueryHandler> {
+        Arc::new(Self {
+            connection: self.connection.clone(),
+        })
+    }
+
+    fn extended_query_handler(&self) -> Arc<impl ExtendedQueryHandler> {
+        Arc::new(Self {
+            connection: self.connection.clone(),
+        })
+    }
+
+    fn error_handler(&self) -> Arc<impl ErrorHandler> {
+        Arc::new(Self {
+            connection: self.connection.clone(),
+        })
+    }
+}
+
+type GuardedSocket = Framed<GuardedPgStream<TcpStream>, PgWireMessageServerCodec<String>>;
+
+async fn negotiate_plaintext(stream: TcpStream) -> io::Result<Option<GuardedSocket>> {
+    let peer = stream.peer_addr()?;
+    stream.set_nodelay(true)?;
+
+    // Direct TLS is not enabled for the loopback-only listener. Match the
+    // dependency's existing behavior by closing without interpreting a TLS
+    // ClientHello as PostgreSQL framing.
+    let mut first = [0_u8; 1];
+    if stream.peek(&mut first).await? > 0 && first[0] == 0x16 {
+        return Ok(None);
+    }
+
+    let client = DefaultClient::<String>::new(peer, false);
+    let codec = PgWireMessageServerCodec::new(client);
+    let mut socket = Framed::new(GuardedPgStream::new(stream, Vec::new()), codec);
+
+    loop {
+        match socket.next().await {
+            Some(Ok(PgWireFrontendMessage::SslNegotiation(
+                SslNegotiationMetaMessage::PostgresSsl(_),
+            ))) => {
+                socket
+                    .send(PgWireBackendMessage::SslResponse(SslResponse::Refuse))
+                    .await?;
+            }
+            Some(Ok(PgWireFrontendMessage::SslNegotiation(
+                SslNegotiationMetaMessage::PostgresGss(_),
+            ))) => {
+                socket
+                    .send(PgWireBackendMessage::GssEncResponse(GssEncResponse::Refuse))
+                    .await?;
+            }
+            Some(Ok(PgWireFrontendMessage::SslNegotiation(SslNegotiationMetaMessage::None))) => {
+                socket.set_state(PgWireConnectionState::AwaitingStartup);
+                return Ok(Some(socket));
+            }
+            Some(Ok(_)) | Some(Err(_)) => {
+                send_connection_error(
+                    &mut socket,
+                    fatal_wire_error("08P01", "the PostgreSQL protocol message is invalid"),
+                )
+                .await?;
+                return Ok(None);
+            }
+            None => return Ok(None),
+        }
+    }
+}
+
+async fn run_socket(
+    stream: TcpStream,
+    handlers: WireHandlers,
+    startup_timeout: Duration,
+) -> io::Result<()> {
+    let startup_timeout = tokio::time::sleep(startup_timeout);
+    tokio::pin!(startup_timeout);
+    let socket = tokio::select! {
+        _ = &mut startup_timeout => return Ok(()),
+        socket = negotiate_plaintext(stream) => socket?,
+    };
+    let Some(mut socket) = socket else {
+        return Ok(());
+    };
+
+    let startup_handler = Arc::new(WireHandlers {
+        connection: handlers.connection.clone(),
+    });
+    let simple_query_handler = Arc::new(WireHandlers {
+        connection: handlers.connection.clone(),
+    });
+    let extended_query_handler = Arc::new(WireHandlers {
+        connection: handlers.connection.clone(),
+    });
+    let copy_handler = handlers.copy_handler();
+    let cancel_handler = handlers.cancel_handler();
+    let error_handler = handlers.error_handler();
+
+    loop {
+        let startup_phase = matches!(
+            socket.state(),
+            PgWireConnectionState::AwaitingStartup
+                | PgWireConnectionState::AuthenticationInProgress
+        );
+        let message = if startup_phase {
+            tokio::select! {
+                _ = &mut startup_timeout => None,
+                message = socket.next() => message,
+            }
+        } else {
+            socket.next().await
+        };
+
+        match message {
+            Some(Ok(PgWireFrontendMessage::Terminate(_))) => break,
+            Some(Ok(message)) => {
+                let is_extended_query = match socket.state() {
+                    PgWireConnectionState::CopyInProgress(is_extended_query) => is_extended_query,
+                    _ => message.is_extended_query(),
+                };
+                if let Err(mut error) = process_message(
+                    message,
+                    &mut socket,
+                    Arc::clone(&startup_handler),
+                    Arc::clone(&simple_query_handler),
+                    Arc::clone(&extended_query_handler),
+                    Arc::clone(&copy_handler),
+                    Arc::clone(&cancel_handler),
+                )
+                .await
+                {
+                    error_handler.on_error(&socket, &mut error);
+                    if startup_phase {
+                        send_connection_error(&mut socket, error).await?;
+                        break;
+                    }
+                    process_error(&mut socket, error, is_extended_query).await?;
+                }
+            }
+            Some(Err(_)) => {
+                send_connection_error(
+                    &mut socket,
+                    fatal_wire_error("08P01", "the PostgreSQL protocol message is invalid"),
+                )
+                .await?;
+                break;
+            }
+            None => break,
+        }
+    }
+    Ok(())
+}
+
+async fn send_connection_error<C>(client: &mut C, error: PgWireError) -> io::Result<()>
+where
+    C: Sink<PgWireBackendMessage, Error = io::Error> + Unpin,
+{
+    let info: ErrorInfo = error.into();
+    client
+        .send(PgWireBackendMessage::ErrorResponse(info.into()))
+        .await?;
+    client.close().await
+}
+
+fn fatal_wire_error(code: &'static str, message: &'static str) -> PgWireError {
+    PgWireError::UserError(Box::new(ErrorInfo::new(
+        "FATAL".to_owned(),
+        code.to_owned(),
+        message.to_owned(),
+    )))
+}
+
+fn unsupported_query_error() -> PgWireError {
+    engine_error_to_pgwire(EngineError::new(
+        crate::core::EngineErrorKind::Unsupported,
+        "PostgreSQL query flow is not implemented yet",
+    ))
+}
+
+fn valid_user_label(user: &str) -> bool {
+    let bytes = user.as_bytes();
+    !bytes.is_empty()
+        && bytes.len() <= MAX_STARTUP_NAME_BYTES
+        && matches!(bytes[0], b'a'..=b'z' | b'_')
+        && bytes
+            .iter()
+            .all(|byte| matches!(byte, b'a'..=b'z' | b'0'..=b'9' | b'_'))
+}
+
+fn valid_application_name(name: &str) -> bool {
+    name.len() <= MAX_STARTUP_NAME_BYTES
+        && !name.contains('\u{fffd}')
+        && name.chars().all(|character| !character.is_control())
 }
 
 #[derive(Clone)]
@@ -210,9 +1150,13 @@ impl QueryParser for PgWireQueryParser {
 }
 
 fn engine_error_to_pgwire(error: EngineError) -> PgWireError {
+    engine_error_to_pgwire_with_severity(error, "ERROR")
+}
+
+fn engine_error_to_pgwire_with_severity(error: EngineError, severity: &str) -> PgWireError {
     let mapping = postgres_error(error.kind());
     PgWireError::UserError(Box::new(ErrorInfo::new(
-        "ERROR".to_owned(),
+        severity.to_owned(),
         mapping.sqlstate.to_owned(),
         mapping.message.to_owned(),
     )))
@@ -317,15 +1261,25 @@ mod tests {
         DefaultClient::new("127.0.0.1:7654".parse().unwrap(), false)
     }
 
-    fn startup_packet() -> Vec<u8> {
+    fn startup_packet_with(protocol: u32, parameters: &[(&str, &str)]) -> Vec<u8> {
         let mut body = Vec::new();
-        body.extend_from_slice(&196_608_u32.to_be_bytes());
-        body.extend_from_slice(b"user\0briskdb\0database\0default\0\0");
+        body.extend_from_slice(&protocol.to_be_bytes());
+        for (name, value) in parameters {
+            body.extend_from_slice(name.as_bytes());
+            body.push(0);
+            body.extend_from_slice(value.as_bytes());
+            body.push(0);
+        }
+        body.push(0);
         let length = u32::try_from(body.len() + 4).unwrap();
         let mut packet = Vec::with_capacity(body.len() + 4);
         packet.extend_from_slice(&length.to_be_bytes());
         packet.extend_from_slice(&body);
         packet
+    }
+
+    fn startup_packet() -> Vec<u8> {
+        startup_packet_with(196_608, &[("user", "briskdb"), ("database", "default")])
     }
 
     fn typed_packet(message_type: u8, body: &[u8]) -> Vec<u8> {
@@ -361,6 +1315,860 @@ mod tests {
                 return frames;
             }
             assert!(frames.len() < 64, "bounded startup response frame count");
+        }
+    }
+
+    fn message_fields(body: &[u8]) -> std::collections::BTreeMap<u8, String> {
+        let mut fields = std::collections::BTreeMap::new();
+        let mut index = 0;
+        while index < body.len() && body[index] != 0 {
+            let kind = body[index];
+            index += 1;
+            let end = body[index..]
+                .iter()
+                .position(|byte| *byte == 0)
+                .map(|offset| index + offset)
+                .expect("a backend field is null terminated");
+            fields.insert(
+                kind,
+                std::str::from_utf8(&body[index..end]).unwrap().to_owned(),
+            );
+            index = end + 1;
+        }
+        fields
+    }
+
+    fn parameter_status(body: &[u8]) -> (String, String) {
+        let mut fields = body.split(|byte| *byte == 0);
+        let name = std::str::from_utf8(fields.next().unwrap())
+            .unwrap()
+            .to_owned();
+        let value = std::str::from_utf8(fields.next().unwrap())
+            .unwrap()
+            .to_owned();
+        assert_eq!(fields.next(), Some([].as_slice()));
+        (name, value)
+    }
+
+    async fn assert_eof(stream: &mut TcpStream) {
+        let mut byte = [0_u8; 1];
+        let count = tokio::time::timeout(Duration::from_secs(2), stream.read(&mut byte))
+            .await
+            .expect("the PostgreSQL peer closed promptly")
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    async fn assert_closed_after_invalid_input(stream: &mut TcpStream) {
+        let mut byte = [0_u8; 1];
+        match tokio::time::timeout(Duration::from_secs(2), stream.read(&mut byte))
+            .await
+            .expect("the PostgreSQL peer closed promptly")
+        {
+            Ok(0) => {}
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    io::ErrorKind::ConnectionReset | io::ErrorKind::BrokenPipe
+                ) => {}
+            Ok(count) => panic!("the closed PostgreSQL peer returned {count} unexpected bytes"),
+            Err(error) => panic!("the PostgreSQL peer closed with an unexpected error: {error}"),
+        }
+    }
+
+    async fn assert_protocol_fatal(stream: &mut TcpStream) {
+        let frame = read_frame(stream).await;
+        assert_eq!(frame.0, b'E');
+        let fields = message_fields(&frame.1);
+        assert_eq!(fields.get(&b'S').map(String::as_str), Some("FATAL"));
+        assert_eq!(fields.get(&b'C').map(String::as_str), Some("08P01"));
+        assert_eq!(
+            fields.get(&b'M').map(String::as_str),
+            Some("the PostgreSQL protocol message is invalid")
+        );
+    }
+
+    async fn spawn_wire_server(
+        adapter: &Adapter,
+    ) -> (
+        SocketAddr,
+        WireConnection,
+        tokio::task::JoinHandle<io::Result<()>>,
+    ) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let connection = adapter.wire_connection();
+        let served = connection.clone();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            served.serve(stream, std::future::pending()).await
+        });
+        (address, connection, server)
+    }
+
+    async fn finish_wire_server(
+        client: &mut TcpStream,
+        server: tokio::task::JoinHandle<io::Result<()>>,
+    ) {
+        client.write_all(&typed_packet(b'X', &[])).await.unwrap();
+        assert_eof(client).await;
+        tokio::time::timeout(Duration::from_secs(2), server)
+            .await
+            .expect("the PostgreSQL connection task returned")
+            .unwrap()
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn production_startup_selects_identity_emits_owned_status_and_terminates() {
+        let (_temp, engine) = engine(3).await;
+        let adapter = Adapter::new(engine.clone());
+        let (address, wire, server) = spawn_wire_server(&adapter).await;
+        let mut client = TcpStream::connect(address).await.unwrap();
+
+        let mut ssl_request = Vec::new();
+        ssl_request.extend_from_slice(&8_u32.to_be_bytes());
+        ssl_request.extend_from_slice(&80_877_103_u32.to_be_bytes());
+        client.write_all(&ssl_request).await.unwrap();
+        let mut ssl_response = [0_u8; 1];
+        client.read_exact(&mut ssl_response).await.unwrap();
+        assert_eq!(ssl_response, *b"N");
+
+        client
+            .write_all(&startup_packet_with(
+                196_608,
+                &[
+                    ("user", "client_user"),
+                    ("database", "default"),
+                    ("client_encoding", "UTF-8"),
+                    ("application_name", "adapter-test"),
+                    ("replication", "false"),
+                ],
+            ))
+            .await
+            .unwrap();
+        let frames = read_until_ready(&mut client).await;
+        assert_eq!(frames.first().unwrap(), &(b'R', vec![0, 0, 0, 0]));
+        assert_eq!(frames.last().unwrap(), &(b'Z', vec![b'I']));
+        assert!(!frames.iter().any(|frame| frame.0 == b'K'));
+        assert_eq!(
+            frames.iter().map(|frame| frame.0).collect::<Vec<_>>(),
+            vec![b'R', b'S', b'S', b'S', b'S', b'S', b'S', b'Z']
+        );
+        let statuses = frames
+            .iter()
+            .filter(|frame| frame.0 == b'S')
+            .map(|frame| parameter_status(&frame.1))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            statuses,
+            vec![
+                ("server_version".to_owned(), SERVER_VERSION.to_owned()),
+                ("server_encoding".to_owned(), "UTF8".to_owned()),
+                ("client_encoding".to_owned(), "UTF8".to_owned()),
+                ("standard_conforming_strings".to_owned(), "on".to_owned(),),
+                ("integer_datetimes".to_owned(), "on".to_owned()),
+                ("application_name".to_owned(), "adapter-test".to_owned()),
+            ]
+        );
+        assert!(!statuses.iter().any(|(_, value)| value.contains("pgwire")));
+
+        let core = Arc::clone(wire.connection().unwrap());
+        assert_eq!(core.user(), Some("client_user"));
+        assert_eq!(core.database(), "default");
+        assert_eq!(core.database_id(), engine.catalog().default_database().id());
+        assert_eq!(core.state().await, SessionState::Ready);
+
+        finish_wire_server(&mut client, server).await;
+        assert_eq!(core.state().await, SessionState::Closed);
+        engine.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn negotiation_requests_require_exact_boundaries_before_startup() {
+        let (_temp, engine) = engine(2).await;
+        let adapter = Adapter::new(engine.clone());
+
+        for code in [SSL_REQUEST_CODE, GSSENC_REQUEST_CODE] {
+            let (address, wire, server) = spawn_wire_server(&adapter).await;
+            let mut client = TcpStream::connect(address).await.unwrap();
+            let mut malformed_negotiation = Vec::new();
+            malformed_negotiation.extend_from_slice(&100_u32.to_be_bytes());
+            malformed_negotiation.extend_from_slice(&(code as u32).to_be_bytes());
+            malformed_negotiation.extend_from_slice(&startup_packet());
+            client.write_all(&malformed_negotiation).await.unwrap();
+
+            assert_protocol_fatal(&mut client).await;
+            assert_closed_after_invalid_input(&mut client).await;
+            tokio::time::timeout(Duration::from_secs(2), server)
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap();
+            assert!(wire.connection().is_none());
+        }
+
+        let (address, wire, server) = spawn_wire_server(&adapter).await;
+        let mut client = TcpStream::connect(address).await.unwrap();
+        let mut gss_request = Vec::new();
+        gss_request.extend_from_slice(&8_u32.to_be_bytes());
+        gss_request.extend_from_slice(&(GSSENC_REQUEST_CODE as u32).to_be_bytes());
+        client.write_all(&gss_request).await.unwrap();
+        let mut response = [0_u8; 1];
+        client.read_exact(&mut response).await.unwrap();
+        assert_eq!(response, *b"N");
+
+        client.write_all(&startup_packet()).await.unwrap();
+        assert_eq!(read_until_ready(&mut client).await.last().unwrap().0, b'Z');
+        let core = Arc::clone(wire.connection().unwrap());
+        finish_wire_server(&mut client, server).await;
+        assert_eq!(core.state().await, SessionState::Closed);
+
+        engine.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn startup_rejections_are_fixed_fatal_and_a_later_connection_recovers() {
+        let (_temp, engine) = engine(2).await;
+        let adapter = Adapter::new(engine.clone());
+        let long_user = "a".repeat(MAX_STARTUP_NAME_BYTES + 1);
+        let long_application_name = "a".repeat(MAX_STARTUP_NAME_BYTES + 1);
+        let malformed_startup = vec![0, 0, 0, 12, 0, 3, 0, 0, b'u', b's', b'e', b'r'];
+        let mut malformed_then_pipelined = malformed_startup.clone();
+        malformed_then_pipelined.extend_from_slice(&typed_packet(b'X', &[]));
+        let duplicate_user = startup_packet_with(
+            196_608,
+            &[
+                ("user", "first_user"),
+                ("user", "second_user"),
+                ("database", "default"),
+            ],
+        );
+        let mut invalid_utf8 = startup_packet();
+        let user_value = invalid_utf8
+            .windows(b"briskdb".len())
+            .position(|window| window == b"briskdb")
+            .unwrap();
+        invalid_utf8[user_value] = 0xff;
+        let cases = vec![
+            (
+                malformed_startup,
+                "08P01",
+                "the PostgreSQL protocol message is invalid",
+            ),
+            (
+                malformed_then_pipelined,
+                "08P01",
+                "the PostgreSQL protocol message is invalid",
+            ),
+            (
+                duplicate_user,
+                "08P01",
+                "the PostgreSQL protocol message is invalid",
+            ),
+            (
+                invalid_utf8,
+                "08P01",
+                "the PostgreSQL protocol message is invalid",
+            ),
+            (
+                startup_packet_with(131_072, &[("user", "client_user"), ("database", "default")]),
+                "08P01",
+                "the PostgreSQL protocol message is invalid",
+            ),
+            (
+                startup_packet_with(196_608, &[("database", "default")]),
+                "28000",
+                "a valid PostgreSQL user label is required",
+            ),
+            (
+                startup_packet_with(196_608, &[("user", "Uppercase"), ("database", "default")]),
+                "28000",
+                "a valid PostgreSQL user label is required",
+            ),
+            (
+                startup_packet_with(196_608, &[("user", &long_user), ("database", "default")]),
+                "28000",
+                "a valid PostgreSQL user label is required",
+            ),
+            (
+                startup_packet_with(196_608, &[("user", "client_user"), ("database", "missing")]),
+                "3D000",
+                "PostgreSQL database selection is unavailable",
+            ),
+            (
+                startup_packet_with(196_608, &[("user", "client_user"), ("database", "")]),
+                "3D000",
+                "PostgreSQL database selection is unavailable",
+            ),
+            (
+                startup_packet_with(196_608, &[("user", "client_user")]),
+                "3D000",
+                "PostgreSQL database selection is unavailable",
+            ),
+            (
+                startup_packet_with(
+                    196_608,
+                    &[
+                        ("user", "client_user"),
+                        ("database", "default"),
+                        ("client_encoding", "LATIN1"),
+                    ],
+                ),
+                "22023",
+                "PostgreSQL client encoding must be UTF8",
+            ),
+            (
+                startup_packet_with(
+                    196_608,
+                    &[
+                        ("user", "client_user"),
+                        ("database", "default"),
+                        ("application_name", "line\nbreak"),
+                    ],
+                ),
+                "22023",
+                "the PostgreSQL application name is invalid",
+            ),
+            (
+                startup_packet_with(
+                    196_608,
+                    &[
+                        ("user", "client_user"),
+                        ("database", "default"),
+                        ("application_name", &long_application_name),
+                    ],
+                ),
+                "22023",
+                "the PostgreSQL application name is invalid",
+            ),
+            (
+                startup_packet_with(
+                    196_608,
+                    &[
+                        ("user", "client_user"),
+                        ("database", "default"),
+                        ("options", "private-startup-value"),
+                    ],
+                ),
+                "0A000",
+                "the PostgreSQL startup parameter is unsupported",
+            ),
+            (
+                startup_packet_with(
+                    196_608,
+                    &[
+                        ("user", "client_user"),
+                        ("database", "default"),
+                        ("replication", "database"),
+                    ],
+                ),
+                "0A000",
+                "PostgreSQL replication startup is unsupported",
+            ),
+            (
+                startup_packet_with(196_610, &[("user", "client_user"), ("database", "default")]),
+                "08P01",
+                "the PostgreSQL protocol version is unsupported",
+            ),
+        ];
+
+        for (packet, expected_code, expected_message) in cases {
+            let (address, wire, server) = spawn_wire_server(&adapter).await;
+            let mut client = TcpStream::connect(address).await.unwrap();
+            client.write_all(&packet).await.unwrap();
+            let frame = read_frame(&mut client).await;
+            assert_eq!(frame.0, b'E');
+            let fields = message_fields(&frame.1);
+            assert_eq!(fields.get(&b'S').map(String::as_str), Some("FATAL"));
+            assert_eq!(fields.get(&b'C').map(String::as_str), Some(expected_code));
+            assert_eq!(
+                fields.get(&b'M').map(String::as_str),
+                Some(expected_message)
+            );
+            assert!(!fields.get(&b'M').unwrap().contains("private-startup-value"));
+            assert_closed_after_invalid_input(&mut client).await;
+            tokio::time::timeout(Duration::from_secs(2), server)
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap();
+            assert!(wire.connection().is_none());
+        }
+
+        let (address, wire, server) = spawn_wire_server(&adapter).await;
+        let mut client = TcpStream::connect(address).await.unwrap();
+        client
+            .write_all(&startup_packet_with(196_608, &[("user", "default")]))
+            .await
+            .unwrap();
+        assert_eq!(read_until_ready(&mut client).await.last().unwrap().0, b'Z');
+        let core = Arc::clone(wire.connection().unwrap());
+        assert_eq!(core.user(), Some("default"));
+        assert_eq!(core.database(), "default");
+        finish_wire_server(&mut client, server).await;
+        assert_eq!(core.state().await, SessionState::Closed);
+        engine.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn startup_status_failure_is_fatal_and_closes_the_selected_session() {
+        let (_temp, engine) = engine(2).await;
+        let adapter = Adapter::new(engine.clone());
+        engine.begin_shutdown();
+        let (address, wire, server) = spawn_wire_server(&adapter).await;
+        let mut client = TcpStream::connect(address).await.unwrap();
+        client.write_all(&startup_packet()).await.unwrap();
+
+        let frame = read_frame(&mut client).await;
+        assert_eq!(frame.0, b'E');
+        let fields = message_fields(&frame.1);
+        let expected = postgres_error(crate::core::EngineErrorKind::ShuttingDown);
+        assert_eq!(fields.get(&b'S').map(String::as_str), Some("FATAL"));
+        assert_eq!(
+            fields.get(&b'C').map(String::as_str),
+            Some(expected.sqlstate)
+        );
+        assert_eq!(
+            fields.get(&b'M').map(String::as_str),
+            Some(expected.message)
+        );
+        assert_eof(&mut client).await;
+        tokio::time::timeout(Duration::from_secs(2), server)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            wire.connection().unwrap().state().await,
+            SessionState::Closed
+        );
+        engine.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn simple_query_is_fixed_unsupported_and_connection_remains_reusable() {
+        let (_temp, engine) = engine(2).await;
+        let adapter = Adapter::new(engine.clone());
+        let (address, wire, server) = spawn_wire_server(&adapter).await;
+        let mut client = TcpStream::connect(address).await.unwrap();
+        client.write_all(&startup_packet()).await.unwrap();
+        read_until_ready(&mut client).await;
+        let core = Arc::clone(wire.connection().unwrap());
+
+        for query in [b"SELECT 'private query text'\0".as_slice(), b"\0"] {
+            client.write_all(&typed_packet(b'Q', query)).await.unwrap();
+            let frames = read_until_ready(&mut client).await;
+            assert_eq!(frames.len(), 2);
+            assert_eq!(frames[0].0, b'E');
+            let fields = message_fields(&frames[0].1);
+            assert_eq!(fields.get(&b'S').map(String::as_str), Some("ERROR"));
+            assert_eq!(fields.get(&b'C').map(String::as_str), Some("0A000"));
+            assert_eq!(
+                fields.get(&b'M').map(String::as_str),
+                Some(postgres_error(crate::core::EngineErrorKind::Unsupported).message)
+            );
+            assert!(!fields.get(&b'M').unwrap().contains("private query text"));
+            assert_eq!(frames[1], (b'Z', vec![b'I']));
+            assert_eq!(core.status().await.unwrap().shard_count(), 2);
+        }
+
+        finish_wire_server(&mut client, server).await;
+        assert_eq!(core.state().await, SessionState::Closed);
+        engine.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn extended_query_rejects_before_storage_and_sync_recovers() {
+        let (_temp, engine) = engine(2).await;
+        let adapter = Adapter::new(engine.clone());
+        let (address, wire, server) = spawn_wire_server(&adapter).await;
+        let mut client = TcpStream::connect(address).await.unwrap();
+        client.write_all(&startup_packet()).await.unwrap();
+        read_until_ready(&mut client).await;
+        let core = Arc::clone(wire.connection().unwrap());
+
+        let mut parse = Vec::new();
+        parse.push(0);
+        parse.extend_from_slice(b"SELECT 'private extended text'\0");
+        parse.extend_from_slice(&0_u16.to_be_bytes());
+        client.write_all(&typed_packet(b'P', &parse)).await.unwrap();
+        let error = read_frame(&mut client).await;
+        assert_eq!(error.0, b'E');
+        let fields = message_fields(&error.1);
+        assert_eq!(fields.get(&b'C').map(String::as_str), Some("0A000"));
+        assert_eq!(
+            fields.get(&b'M').map(String::as_str),
+            Some(postgres_error(crate::core::EngineErrorKind::Unsupported).message)
+        );
+        assert!(!fields.get(&b'M').unwrap().contains("private extended text"));
+
+        client.write_all(&typed_packet(b'S', &[])).await.unwrap();
+        assert_eq!(read_frame(&mut client).await, (b'Z', vec![b'I']));
+        assert_eq!(core.status().await.unwrap().shard_count(), 2);
+
+        finish_wire_server(&mut client, server).await;
+        assert_eq!(core.state().await, SessionState::Closed);
+        engine.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn malformed_message_after_startup_is_fatal_and_closes_the_core_session() {
+        let (_temp, engine) = engine(2).await;
+        let adapter = Adapter::new(engine.clone());
+        let (address, wire, server) = spawn_wire_server(&adapter).await;
+        let mut client = TcpStream::connect(address).await.unwrap();
+        client.write_all(&startup_packet()).await.unwrap();
+        read_until_ready(&mut client).await;
+        let core = Arc::clone(wire.connection().unwrap());
+
+        // Parse requires two C strings and a u16 OID count. This complete
+        // frame deliberately ends before the count.
+        client
+            .write_all(&typed_packet(b'P', &[0, 0]))
+            .await
+            .unwrap();
+        let error = read_frame(&mut client).await;
+        assert_eq!(error.0, b'E');
+        let fields = message_fields(&error.1);
+        assert_eq!(fields.get(&b'S').map(String::as_str), Some("FATAL"));
+        assert_eq!(fields.get(&b'C').map(String::as_str), Some("08P01"));
+        assert_eof(&mut client).await;
+        tokio::time::timeout(Duration::from_secs(2), server)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(core.state().await, SessionState::Closed);
+        engine.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn oversized_frame_headers_fail_without_waiting_for_the_declared_body() {
+        let (_temp, engine) = engine(2).await;
+        let adapter = Adapter::new(engine.clone());
+
+        let (address, wire, server) = spawn_wire_server(&adapter).await;
+        let mut client = TcpStream::connect(address).await.unwrap();
+        let mut oversized_startup_header = Vec::new();
+        oversized_startup_header.extend_from_slice(
+            &u32::try_from(MAX_STARTUP_PACKET_LENGTH + 1)
+                .unwrap()
+                .to_be_bytes(),
+        );
+        client.write_all(&oversized_startup_header).await.unwrap();
+        assert_protocol_fatal(&mut client).await;
+        assert_eof(&mut client).await;
+        tokio::time::timeout(Duration::from_secs(2), server)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert!(wire.connection().is_none());
+
+        let (address, wire, server) = spawn_wire_server(&adapter).await;
+        let mut client = TcpStream::connect(address).await.unwrap();
+        client.write_all(&startup_packet()).await.unwrap();
+        read_until_ready(&mut client).await;
+        let core = Arc::clone(wire.connection().unwrap());
+        let mut oversized_query_header = vec![b'Q'];
+        oversized_query_header.extend_from_slice(
+            &u32::try_from(MAX_FRONTEND_MESSAGE_LENGTH + 1)
+                .unwrap()
+                .to_be_bytes(),
+        );
+        client.write_all(&oversized_query_header).await.unwrap();
+        assert_protocol_fatal(&mut client).await;
+        assert_eof(&mut client).await;
+        tokio::time::timeout(Duration::from_secs(2), server)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(core.state().await, SessionState::Closed);
+
+        engine.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn eof_and_server_shutdown_both_close_the_selected_core_session() {
+        let (_temp, engine) = engine(2).await;
+        let adapter = Adapter::new(engine.clone());
+
+        let (address, wire, server) = spawn_wire_server(&adapter).await;
+        let mut client = TcpStream::connect(address).await.unwrap();
+        client.write_all(&startup_packet()).await.unwrap();
+        read_until_ready(&mut client).await;
+        let eof_core = Arc::clone(wire.connection().unwrap());
+        drop(client);
+        tokio::time::timeout(Duration::from_secs(2), server)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(eof_core.state().await, SessionState::Closed);
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let wire = adapter.wire_connection();
+        let served = wire.clone();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            served
+                .serve(stream, async move {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+        });
+        let mut client = TcpStream::connect(address).await.unwrap();
+        client.write_all(&startup_packet()).await.unwrap();
+        read_until_ready(&mut client).await;
+        let shutdown_core = Arc::clone(wire.connection().unwrap());
+        shutdown_tx.send(()).unwrap();
+        assert_eof(&mut client).await;
+        tokio::time::timeout(Duration::from_secs(2), server)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(shutdown_core.state().await, SessionState::Closed);
+
+        engine.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn incomplete_startup_closes_at_the_configured_timeout_without_a_session() {
+        assert_eq!(STARTUP_TIMEOUT, Duration::from_secs(60));
+        let (_temp, engine) = engine(2).await;
+        let adapter = Adapter::new(engine.clone());
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let wire = adapter.wire_connection();
+        let served = wire.clone();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            served
+                .serve_with_startup_timeout(
+                    stream,
+                    std::future::pending(),
+                    Duration::from_millis(20),
+                )
+                .await
+        });
+
+        let mut client = TcpStream::connect(address).await.unwrap();
+        assert_eof(&mut client).await;
+        tokio::time::timeout(Duration::from_secs(2), server)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert!(wire.connection().is_none());
+        engine.shutdown().await.unwrap();
+    }
+
+    #[test]
+    fn raw_frame_validators_enforce_size_structure_boundaries_and_utf8() {
+        let startup = startup_packet();
+        assert_eq!(
+            validate_startup_frame(&startup).unwrap(),
+            StartupFrameKind::Startup
+        );
+
+        for code in [SSL_REQUEST_CODE, GSSENC_REQUEST_CODE] {
+            let mut negotiation = Vec::new();
+            negotiation.extend_from_slice(&8_u32.to_be_bytes());
+            negotiation.extend_from_slice(&(code as u32).to_be_bytes());
+            assert_eq!(
+                validate_startup_frame(&negotiation).unwrap(),
+                StartupFrameKind::Negotiation
+            );
+
+            negotiation[..4].copy_from_slice(&100_u32.to_be_bytes());
+            assert!(validate_startup_frame(&negotiation).is_err());
+        }
+
+        let maximum_value = "a".repeat(MAX_STARTUP_PACKET_LENGTH - 12);
+        let maximum_startup = startup_packet_with(196_608, &[("x", &maximum_value)]);
+        assert_eq!(maximum_startup.len(), MAX_STARTUP_PACKET_LENGTH);
+        assert_eq!(
+            validate_startup_frame(&maximum_startup).unwrap(),
+            StartupFrameKind::Startup
+        );
+
+        let mut oversized_startup = maximum_startup.clone();
+        oversized_startup.insert(oversized_startup.len() - 1, b'a');
+        let oversized_length = u32::try_from(oversized_startup.len()).unwrap();
+        oversized_startup[..4].copy_from_slice(&oversized_length.to_be_bytes());
+        assert!(validate_startup_frame(&oversized_startup).is_err());
+
+        let mut missing_terminal = startup.clone();
+        missing_terminal.pop();
+        let missing_terminal_length = u32::try_from(missing_terminal.len()).unwrap();
+        missing_terminal[..4].copy_from_slice(&missing_terminal_length.to_be_bytes());
+
+        let mut trailing_after_terminal = startup.clone();
+        trailing_after_terminal.push(b'x');
+        let trailing_length = u32::try_from(trailing_after_terminal.len()).unwrap();
+        trailing_after_terminal[..4].copy_from_slice(&trailing_length.to_be_bytes());
+
+        let duplicate = startup_packet_with(
+            196_608,
+            &[
+                ("user", "first"),
+                ("user", "second"),
+                ("database", "default"),
+            ],
+        );
+        let missing_value = vec![0, 0, 0, 14, 0, 3, 0, 0, b'u', b's', b'e', b'r', 0, 0];
+        let mut invalid_utf8 = startup.clone();
+        let user_value = invalid_utf8
+            .windows(b"briskdb".len())
+            .position(|window| window == b"briskdb")
+            .unwrap();
+        invalid_utf8[user_value] = 0xff;
+        let mut wrong_declared_length = startup.clone();
+        wrong_declared_length[..4].copy_from_slice(&8_u32.to_be_bytes());
+        let mut cancel = Vec::new();
+        cancel.extend_from_slice(&16_u32.to_be_bytes());
+        cancel.extend_from_slice(&(CANCEL_REQUEST_CODE as u32).to_be_bytes());
+        cancel.extend_from_slice(&1_u32.to_be_bytes());
+        cancel.extend_from_slice(&2_u32.to_be_bytes());
+
+        for rejected in [
+            missing_terminal,
+            trailing_after_terminal,
+            duplicate,
+            missing_value,
+            invalid_utf8,
+            wrong_declared_length,
+            cancel,
+        ] {
+            assert!(
+                validate_startup_frame(&rejected).is_err(),
+                "rejected startup frame: {rejected:?}"
+            );
+        }
+
+        let mut maximum_query_body = vec![b'a'; MAX_PARSED_SQL_BYTES];
+        maximum_query_body.push(0);
+        let maximum_query = typed_packet(b'Q', &maximum_query_body);
+        assert_eq!(
+            u32::from_be_bytes(maximum_query[1..5].try_into().unwrap()) as usize,
+            MAX_FRONTEND_MESSAGE_LENGTH
+        );
+        validate_typed_frame(&maximum_query).unwrap();
+        validate_typed_frame(&typed_packet(b'Q', &[0])).unwrap();
+
+        let mut parse = Vec::new();
+        parse.extend_from_slice(b"statement\0SELECT 1\0");
+        parse.extend_from_slice(&1_u16.to_be_bytes());
+        parse.extend_from_slice(&23_u32.to_be_bytes());
+        validate_typed_frame(&typed_packet(b'P', &parse)).unwrap();
+        validate_typed_frame(&typed_packet(b'S', &[])).unwrap();
+        validate_typed_frame(&typed_packet(b'X', &[])).unwrap();
+
+        let mut oversized_query_body = vec![b'a'; MAX_PARSED_SQL_BYTES + 1];
+        oversized_query_body.push(0);
+        let invalid_typed_frames = [
+            typed_packet(b'Q', b"SELECT 1"),
+            typed_packet(b'Q', b"SELECT\0trailing\0"),
+            typed_packet(b'Q', &[0xff, 0]),
+            typed_packet(b'Q', &oversized_query_body),
+            typed_packet(b'P', b"statement\0SELECT 1\0"),
+            typed_packet(b'P', b"statement\0SELECT 1\0\0\x01"),
+            typed_packet(b'P', b"statement\0SELECT 1\0\0\x01\0\0\0"),
+            typed_packet(b'S', &[0]),
+            typed_packet(b'X', &[0]),
+            typed_packet(b'B', &[]),
+        ];
+        for rejected in invalid_typed_frames {
+            assert!(
+                validate_typed_frame(&rejected).is_err(),
+                "rejected typed frame: {rejected:?}"
+            );
+        }
+
+        let mut wrong_typed_length = typed_packet(b'Q', b"SELECT 1\0");
+        wrong_typed_length[1..5].copy_from_slice(&4_u32.to_be_bytes());
+        assert!(validate_typed_frame(&wrong_typed_length).is_err());
+    }
+
+    #[tokio::test]
+    async fn raw_frame_guard_handles_fragmented_buffered_and_partial_input() {
+        let startup = startup_packet();
+        let terminate = typed_packet(b'X', &[]);
+        let mut expected = startup.clone();
+        expected.extend_from_slice(&terminate);
+
+        let (mut writer, reader) = tokio::io::duplex(1);
+        let fragmented = expected.clone();
+        let writing = tokio::spawn(async move {
+            writer.write_all(&fragmented).await.unwrap();
+        });
+        let mut guarded = GuardedPgStream::new(reader, Vec::new());
+        let mut received = vec![0; expected.len()];
+        guarded.read_exact(&mut received).await.unwrap();
+        assert_eq!(received, expected);
+        writing.await.unwrap();
+        assert_eq!(guarded.read(&mut [0]).await.unwrap(), 0);
+
+        let (writer, reader) = tokio::io::duplex(1);
+        drop(writer);
+        let mut guarded = GuardedPgStream::new(reader, expected.clone());
+        let mut received = vec![0; expected.len()];
+        guarded.read_exact(&mut received).await.unwrap();
+        assert_eq!(received, expected);
+        assert_eq!(guarded.read(&mut [0]).await.unwrap(), 0);
+
+        let (mut writer, reader) = tokio::io::duplex(8);
+        writer.write_all(&startup[..8]).await.unwrap();
+        writer.shutdown().await.unwrap();
+        let mut guarded = GuardedPgStream::new(reader, Vec::new());
+        assert_eq!(
+            guarded.read(&mut [0]).await.unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+
+    #[test]
+    fn startup_identity_validators_have_exact_byte_and_character_boundaries() {
+        let max_user = "a".repeat(MAX_STARTUP_NAME_BYTES);
+        for user in ["a", "_", "a0", "_0", max_user.as_str()] {
+            assert!(valid_user_label(user), "accepted user boundary: {user:?}");
+        }
+        let too_long_user = "a".repeat(MAX_STARTUP_NAME_BYTES + 1);
+        for user in [
+            "",
+            "0user",
+            "Uppercase",
+            "non_ascii_é",
+            "a-b",
+            &too_long_user,
+        ] {
+            assert!(!valid_user_label(user), "rejected user boundary: {user:?}");
+        }
+
+        let max_utf8_application = format!("{}a", "é".repeat(31));
+        assert_eq!(max_utf8_application.len(), MAX_STARTUP_NAME_BYTES);
+        for application in ["", "client", max_utf8_application.as_str()] {
+            assert!(
+                valid_application_name(application),
+                "accepted application-name boundary: {application:?}"
+            );
+        }
+        let too_long_utf8_application = "é".repeat(32);
+        assert_eq!(too_long_utf8_application.len(), MAX_STARTUP_NAME_BYTES + 1);
+        for application in [
+            "line\nbreak",
+            "replacement_\u{fffd}",
+            too_long_utf8_application.as_str(),
+        ] {
+            assert!(
+                !valid_application_name(application),
+                "rejected application-name boundary: {application:?}"
+            );
         }
     }
 
@@ -480,7 +2288,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn selected_pgwire_entrypoint_can_reach_core_without_enabling_the_listener() {
+    async fn historical_pgwire_entrypoint_probe_remains_isolated_from_production_startup() {
         let (_temp, engine) = engine(3).await;
         let adapter = Adapter::new(engine.clone());
         let connection = Arc::new(adapter.open_connection());

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,6 +1,9 @@
 //! Server process assembly and listener lifecycle.
 
-use std::{future::Future, net::SocketAddr, path::PathBuf, pin::Pin, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap, future::Future, net::SocketAddr, path::PathBuf, pin::Pin, sync::Arc,
+    time::Duration,
+};
 
 use anyhow::Context;
 use axum::body::Body;
@@ -8,15 +11,17 @@ use hyper::{Request, body::Incoming, server::conn::http1};
 use hyper_util::{rt::TokioIo, service::TowerToHyperService};
 use tokio::{
     sync::{Notify, watch},
-    task::JoinSet,
+    task::{Id, JoinSet},
 };
 use tower::ServiceExt;
 use tracing::{debug, info, warn};
 
 use crate::{
     core::{Engine, EngineOptions},
-    protocol::http,
+    protocol::{http, postgres},
 };
+
+const MAX_POSTGRES_CONNECTIONS: usize = 256;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Config {
@@ -67,6 +72,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
 /// [`run`] remains the compatibility entry point and delegates here with
 /// [`EngineOptions::default`].
 pub async fn run_with_engine_options(config: Config, options: EngineOptions) -> anyhow::Result<()> {
+    validate_postgres_listener(&config)?;
     let engine = Engine::open_with_options(&config.data_dir, config.shards, options).await?;
     let listeners = match BoundListeners::bind(&config).await {
         Ok(listeners) => listeners,
@@ -126,6 +132,18 @@ pub async fn run_with_engine_options(config: Config, options: EngineOptions) -> 
     serve_listeners_with_shutdown(listeners, engine, signal).await
 }
 
+fn validate_postgres_listener(config: &Config) -> anyhow::Result<()> {
+    if let Some(address) = config
+        .postgres_listen
+        .filter(|address| !address.ip().is_loopback())
+    {
+        anyhow::bail!(
+            "PostgreSQL wire startup currently requires a loopback listen address; received {address}"
+        );
+    }
+    Ok(())
+}
+
 async fn serve_listeners_with_shutdown<F>(
     listeners: BoundListeners,
     engine: Engine,
@@ -167,8 +185,13 @@ where
 {
     let mut shutdown_guard = ShutdownOnDrop::new(engine.clone());
     let router = http::router_with_engine(engine.clone());
+    let postgres_adapter = listeners
+        .postgres
+        .as_ref()
+        .map(|_| postgres::Adapter::new(engine.clone()));
     let (graceful_tx, _graceful_rx) = watch::channel(false);
-    let mut connections = JoinSet::new();
+    let mut http_connections = JoinSet::new();
+    let mut postgres_connections = PostgresConnections::default();
     let mut server_error = None;
     tokio::pin!(signal);
 
@@ -176,8 +199,13 @@ where
         tokio::select! {
             biased;
             _ = &mut signal => break,
-            Some(result) = connections.join_next(), if !connections.is_empty() => {
-                log_connection_join(result, false);
+            Some(result) = http_connections.join_next(), if !http_connections.is_empty() => {
+                log_http_connection_join(result, false);
+            }
+            result = postgres_connections.join_next_result(), if !postgres_connections.is_empty() => {
+                if let Some(result) = result {
+                    postgres_connections.finish_join(result, false).await;
+                }
             }
             accepted_connection = accept_next_connection(&listeners) => {
                 match accepted_connection {
@@ -192,7 +220,7 @@ where
                             },
                         ));
                         let graceful_rx = graceful_tx.subscribe();
-                        connections.spawn(async move {
+                        http_connections.spawn(async move {
                             serve_http_connection(stream, peer, service, graceful_rx).await;
                         });
                     }
@@ -203,8 +231,21 @@ where
                         break;
                     }
                     ListenerAccept::Postgres(Ok((stream, peer))) => {
-                        debug!(%peer, "closing connection before PostgreSQL wire support is enabled");
-                        drop(stream);
+                        let adapter = postgres_adapter
+                            .as_ref()
+                            .expect("an accepted PostgreSQL socket has an adapter");
+                        if !postgres_connections.spawn(
+                            stream,
+                            peer,
+                            adapter,
+                            graceful_tx.subscribe(),
+                        ) {
+                            debug!(
+                                %peer,
+                                max_connections = postgres_connections.limit(),
+                                "closing PostgreSQL connection because the finite task limit is full"
+                            );
+                        }
                     }
                     ListenerAccept::Postgres(Err(error)) => {
                         server_error = Some(
@@ -224,8 +265,13 @@ where
     drop(listeners);
     let http_grace = engine.options().shutdown_grace();
     let core_shutdown = engine.shutdown();
-    let http_shutdown = drain_http_connections(graceful_tx, &mut connections, http_grace);
-    let (core_result, _) = tokio::join!(core_shutdown, http_shutdown);
+    let connection_shutdown = drain_connections(
+        graceful_tx,
+        &mut http_connections,
+        &mut postgres_connections,
+        http_grace,
+    );
+    let (core_result, _) = tokio::join!(core_shutdown, connection_shutdown);
     let report = core_result?;
     info!(forced = report.forced(), "BriskDB core shutdown completed");
 
@@ -257,6 +303,144 @@ async fn accept_optional(
     }
 }
 
+struct TrackedPostgresConnection {
+    connection: postgres::WireConnection,
+    peer: SocketAddr,
+}
+
+struct PostgresConnections {
+    tasks: JoinSet<std::io::Result<()>>,
+    connections: HashMap<Id, TrackedPostgresConnection>,
+    limit: usize,
+}
+
+impl Default for PostgresConnections {
+    fn default() -> Self {
+        Self {
+            tasks: JoinSet::new(),
+            connections: HashMap::new(),
+            limit: MAX_POSTGRES_CONNECTIONS,
+        }
+    }
+}
+
+impl PostgresConnections {
+    #[cfg(test)]
+    fn with_limit(limit: usize) -> Self {
+        assert!(limit > 0);
+        Self {
+            tasks: JoinSet::new(),
+            connections: HashMap::new(),
+            limit,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.tasks.is_empty()
+    }
+
+    fn len(&self) -> usize {
+        self.tasks.len()
+    }
+
+    const fn limit(&self) -> usize {
+        self.limit
+    }
+
+    fn spawn(
+        &mut self,
+        stream: tokio::net::TcpStream,
+        peer: SocketAddr,
+        adapter: &postgres::Adapter,
+        mut shutdown: watch::Receiver<bool>,
+    ) -> bool {
+        if self.len() >= self.limit {
+            return false;
+        }
+
+        let connection = adapter.wire_connection();
+        let task_connection = connection.clone();
+        let handle = self.tasks.spawn(async move {
+            task_connection
+                .serve(stream, wait_for_connection_shutdown(&mut shutdown))
+                .await
+        });
+        self.connections
+            .insert(handle.id(), TrackedPostgresConnection { connection, peer });
+        true
+    }
+
+    fn abort_all(&mut self) {
+        self.tasks.abort_all();
+    }
+
+    async fn join_next_result(
+        &mut self,
+    ) -> Option<Result<(Id, std::io::Result<()>), tokio::task::JoinError>> {
+        self.tasks.join_next_with_id().await
+    }
+
+    async fn finish_join(
+        &mut self,
+        result: Result<(Id, std::io::Result<()>), tokio::task::JoinError>,
+        forced: bool,
+    ) {
+        let id = match &result {
+            Ok((id, _)) => *id,
+            Err(error) => error.id(),
+        };
+        let tracked = self
+            .connections
+            .get(&id)
+            .map(|tracked| (tracked.connection.clone(), tracked.peer));
+        if let Some((connection, peer)) = &tracked {
+            if let Err(error) = connection.close().await {
+                warn!(%peer, kind = ?error.kind(), "failed to close PostgreSQL core session");
+            }
+        }
+        self.connections.remove(&id);
+
+        match result {
+            Ok((_, Ok(()))) => {}
+            Ok((_, Err(error))) => {
+                if let Some((_, peer)) = tracked {
+                    debug!(%peer, %error, "PostgreSQL connection ended with a protocol error");
+                } else {
+                    debug!(%error, "PostgreSQL connection ended with a protocol error");
+                }
+            }
+            Err(error) if forced && error.is_cancelled() => {}
+            Err(error) => {
+                if let Some((_, peer)) = tracked {
+                    warn!(%peer, %error, "PostgreSQL connection task failed");
+                } else {
+                    warn!(%error, "PostgreSQL connection task failed");
+                }
+            }
+        }
+    }
+}
+
+impl Drop for PostgresConnections {
+    fn drop(&mut self) {
+        self.tasks.abort_all();
+        let connections = std::mem::take(&mut self.connections)
+            .into_values()
+            .map(|tracked| tracked.connection)
+            .collect::<Vec<_>>();
+        if connections.is_empty() {
+            return;
+        }
+        if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+            let _cleanup = runtime.spawn(async move {
+                for connection in connections {
+                    let _ = connection.close().await;
+                }
+            });
+        }
+    }
+}
+
 async fn serve_http_connection<S>(
     stream: tokio::net::TcpStream,
     peer: SocketAddr,
@@ -283,7 +467,7 @@ async fn serve_http_connection<S>(
     } else {
         tokio::select! {
             result = &mut connection => result,
-            _ = wait_for_http_shutdown(&mut graceful_rx) => {
+            _ = wait_for_connection_shutdown(&mut graceful_rx) => {
                 connection.as_mut().graceful_shutdown();
                 connection.await
             }
@@ -294,7 +478,7 @@ async fn serve_http_connection<S>(
     }
 }
 
-async fn wait_for_http_shutdown(graceful_rx: &mut watch::Receiver<bool>) {
+async fn wait_for_connection_shutdown(graceful_rx: &mut watch::Receiver<bool>) {
     loop {
         if *graceful_rx.borrow_and_update() {
             return;
@@ -305,33 +489,63 @@ async fn wait_for_http_shutdown(graceful_rx: &mut watch::Receiver<bool>) {
     }
 }
 
-async fn drain_http_connections(
+async fn drain_connections(
     graceful_tx: watch::Sender<bool>,
-    connections: &mut JoinSet<()>,
+    http_connections: &mut JoinSet<()>,
+    postgres_connections: &mut PostgresConnections,
     grace: Duration,
 ) -> bool {
     let watched_connections = graceful_tx.receiver_count().saturating_sub(1);
     graceful_tx.send_replace(true);
     let graceful_drain = async {
-        while let Some(result) = connections.join_next().await {
-            log_connection_join(result, false);
+        while !http_connections.is_empty() || !postgres_connections.is_empty() {
+            tokio::select! {
+                Some(result) = http_connections.join_next(), if !http_connections.is_empty() => {
+                    log_http_connection_join(result, false);
+                }
+                result = postgres_connections.join_next_result(), if !postgres_connections.is_empty() => {
+                    if let Some(result) = result {
+                        postgres_connections.finish_join(result, false).await;
+                    }
+                }
+            }
         }
     };
 
     if tokio::time::timeout(grace, graceful_drain).await.is_ok() {
         false
     } else {
-        let remaining = connections.len();
+        let remaining_http = http_connections.len();
+        let remaining_postgres = postgres_connections.len();
+        let remaining = remaining_http.saturating_add(remaining_postgres);
         if remaining > 0 {
             warn!(
                 grace_ms = grace.as_millis(),
                 connections = remaining,
+                http_connections = remaining_http,
+                postgres_connections = remaining_postgres,
                 watched_connections,
-                "HTTP connections exceeded the shutdown grace period; force-closing them"
+                "connections exceeded the shutdown grace period; force-closing them"
             );
-            connections.abort_all();
-            while let Some(result) = connections.join_next().await {
-                log_connection_join(result, true);
+            http_connections.abort_all();
+            postgres_connections.abort_all();
+            while let Some(result) = http_connections.join_next().await {
+                log_http_connection_join(result, true);
+            }
+            let postgres_cleanup = async {
+                while !postgres_connections.is_empty() {
+                    let Some(result) = postgres_connections.join_next_result().await else {
+                        break;
+                    };
+                    postgres_connections.finish_join(result, true).await;
+                }
+            };
+            if tokio::time::timeout(grace, postgres_cleanup).await.is_err() {
+                warn!(
+                    grace_ms = grace.as_millis(),
+                    connections = postgres_connections.len(),
+                    "PostgreSQL session cleanup exceeded the forced-close interval"
+                );
             }
         }
         drop(graceful_tx);
@@ -339,7 +553,7 @@ async fn drain_http_connections(
     }
 }
 
-fn log_connection_join(result: Result<(), tokio::task::JoinError>, forced: bool) {
+fn log_http_connection_join(result: Result<(), tokio::task::JoinError>, forced: bool) {
     if let Err(error) = result {
         if !(forced && error.is_cancelled()) {
             warn!(%error, "HTTP connection task failed");
@@ -437,13 +651,68 @@ mod tests {
         .expect("the peer should be closed");
     }
 
-    async fn assert_peer_closes_without_bytes(stream: &mut tokio::net::TcpStream) {
-        let mut buffer = [0_u8; 1_024];
-        match timeout(Duration::from_secs(1), stream.read(&mut buffer)).await {
-            Ok(Ok(0) | Err(_)) => {}
-            Ok(Ok(bytes)) => panic!("the placeholder wrote {bytes} unexpected bytes"),
-            Err(_) => panic!("the placeholder should close without writing bytes"),
+    fn postgres_startup_packet(user: &str) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(&196_608_u32.to_be_bytes());
+        body.extend_from_slice(b"user\0");
+        body.extend_from_slice(user.as_bytes());
+        body.extend_from_slice(b"\0database\0default\0\0");
+        let mut packet = Vec::new();
+        packet.extend_from_slice(&u32::try_from(body.len() + 4).unwrap().to_be_bytes());
+        packet.extend_from_slice(&body);
+        packet
+    }
+
+    fn postgres_typed_packet(kind: u8, body: &[u8]) -> Vec<u8> {
+        let mut packet = Vec::new();
+        packet.push(kind);
+        packet.extend_from_slice(&u32::try_from(body.len() + 4).unwrap().to_be_bytes());
+        packet.extend_from_slice(body);
+        packet
+    }
+
+    async fn read_postgres_frame(stream: &mut tokio::net::TcpStream) -> (u8, Vec<u8>) {
+        timeout(Duration::from_secs(1), async {
+            let mut header = [0_u8; 5];
+            stream.read_exact(&mut header).await.unwrap();
+            let length = u32::from_be_bytes(header[1..].try_into().unwrap());
+            assert!((4..=1_048_576).contains(&length));
+            let mut body = vec![0_u8; usize::try_from(length - 4).unwrap()];
+            stream.read_exact(&mut body).await.unwrap();
+            (header[0], body)
+        })
+        .await
+        .expect("the PostgreSQL server returned a frame")
+    }
+
+    async fn start_postgres_session(address: SocketAddr, user: &str) -> tokio::net::TcpStream {
+        let mut stream = tokio::net::TcpStream::connect(address).await.unwrap();
+        stream
+            .write_all(&postgres_startup_packet(user))
+            .await
+            .unwrap();
+        let mut kinds = Vec::new();
+        loop {
+            let frame = read_postgres_frame(&mut stream).await;
+            kinds.push(frame.0);
+            if frame.0 == b'Z' {
+                assert_eq!(frame.1, vec![b'I']);
+                break;
+            }
+            assert!(kinds.len() < 16);
         }
+        assert_eq!(kinds.first(), Some(&b'R'));
+        assert_eq!(kinds.iter().filter(|kind| **kind == b'S').count(), 5);
+        assert!(!kinds.contains(&b'K'));
+        stream
+    }
+
+    async fn terminate_postgres_session(stream: &mut tokio::net::TcpStream) {
+        stream
+            .write_all(&postgres_typed_packet(b'X', &[]))
+            .await
+            .unwrap();
+        assert_peer_closes(stream).await;
     }
 
     async fn read_http_health(address: SocketAddr) -> Vec<u8> {
@@ -483,6 +752,26 @@ mod tests {
         .unwrap_err();
 
         assert_eq!(error.to_string(), "shard count must be between 2 and 64");
+        assert!(!data_dir.exists());
+    }
+
+    #[tokio::test]
+    async fn non_loopback_postgres_activation_fails_before_database_or_listener_startup() {
+        let temp = tempfile::tempdir().unwrap();
+        let data_dir = temp.path().join("database");
+        let error = run(Config {
+            listen: "127.0.0.1:0".parse().unwrap(),
+            postgres_listen: Some("0.0.0.0:0".parse().unwrap()),
+            data_dir: data_dir.clone(),
+            shards: 2,
+        })
+        .await
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "PostgreSQL wire startup currently requires a loopback listen address; received 0.0.0.0:0"
+        );
         assert!(!data_dir.exists());
     }
 
@@ -537,6 +826,67 @@ mod tests {
         .await
         .unwrap();
         assert!(disabled.postgres.is_none());
+    }
+
+    #[tokio::test]
+    async fn postgres_task_limit_closes_overflow_and_reuses_a_completed_slot() {
+        assert_eq!(MAX_POSTGRES_CONNECTIONS, 256);
+        assert_eq!(
+            PostgresConnections::default().limit(),
+            MAX_POSTGRES_CONNECTIONS
+        );
+        let test_limit = 4;
+        let temp = tempfile::tempdir().unwrap();
+        let engine = Engine::open(temp.path(), 2).await.unwrap();
+        let adapter = postgres::Adapter::new(engine.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (shutdown_tx, _) = watch::channel(false);
+        let mut connections = PostgresConnections::with_limit(test_limit);
+        let mut clients = Vec::with_capacity(test_limit);
+
+        for _ in 0..test_limit {
+            let (client, accepted) =
+                tokio::join!(tokio::net::TcpStream::connect(address), listener.accept());
+            let client = client.unwrap();
+            let (stream, peer) = accepted.unwrap();
+            assert!(connections.spawn(stream, peer, &adapter, shutdown_tx.subscribe()));
+            clients.push(client);
+        }
+        assert_eq!(connections.len(), test_limit);
+
+        let (mut overflow, accepted) =
+            tokio::join!(tokio::net::TcpStream::connect(address), listener.accept());
+        let (stream, peer) = accepted.unwrap();
+        assert!(!connections.spawn(stream, peer, &adapter, shutdown_tx.subscribe()));
+        assert_peer_closes(overflow.as_mut().unwrap()).await;
+
+        drop(clients.pop());
+        let completed = timeout(Duration::from_secs(2), connections.join_next_result())
+            .await
+            .expect("the closed client should release its tracked task")
+            .expect("the task set should return one completion");
+        connections.finish_join(completed, false).await;
+        assert_eq!(connections.len(), test_limit - 1);
+
+        let (replacement, accepted) =
+            tokio::join!(tokio::net::TcpStream::connect(address), listener.accept());
+        let (stream, peer) = accepted.unwrap();
+        assert!(connections.spawn(stream, peer, &adapter, shutdown_tx.subscribe()));
+        clients.push(replacement.unwrap());
+        assert_eq!(connections.len(), test_limit);
+
+        shutdown_tx.send_replace(true);
+        timeout(Duration::from_secs(2), async {
+            while let Some(result) = connections.join_next_result().await {
+                connections.finish_join(result, false).await;
+            }
+        })
+        .await
+        .expect("all bounded PostgreSQL tasks should stop cooperatively");
+        assert!(connections.is_empty());
+        drop(clients);
+        engine.shutdown().await.unwrap();
     }
 
     #[tokio::test]
@@ -648,7 +998,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn postgres_accept_loop_recovers_after_concurrent_connections_and_http_stays_live() {
+    async fn postgres_startup_recovers_after_concurrent_connections_and_http_stays_live() {
         let temp = tempfile::tempdir().unwrap();
         let options = EngineOptions::default()
             .with_shutdown_grace(Duration::from_millis(50))
@@ -674,13 +1024,11 @@ mod tests {
         ));
 
         let clients = (0..32)
-            .map(|_| {
+            .map(|index| {
                 tokio::spawn(async move {
-                    let mut stream = tokio::net::TcpStream::connect(postgres_address)
-                        .await
-                        .unwrap();
-                    let _ = stream.write_all(b"placeholder input").await;
-                    assert_peer_closes_without_bytes(&mut stream).await;
+                    let mut stream =
+                        start_postgres_session(postgres_address, &format!("client_{index}")).await;
+                    terminate_postgres_session(&mut stream).await;
                 })
             })
             .collect::<Vec<_>>();
@@ -690,11 +1038,10 @@ mod tests {
             client.await.unwrap();
         }
 
-        for _ in 0..3 {
-            let mut stream = tokio::net::TcpStream::connect(postgres_address)
-                .await
-                .unwrap();
-            assert_peer_closes_without_bytes(&mut stream).await;
+        for index in 0..3 {
+            let mut stream =
+                start_postgres_session(postgres_address, &format!("recovery_{index}")).await;
+            terminate_postgres_session(&mut stream).await;
         }
         assert!(
             read_http_health(http_address)
@@ -706,6 +1053,55 @@ mod tests {
         timeout(Duration::from_secs(2), server)
             .await
             .expect("both listeners should finish shutdown")
+            .unwrap()
+            .unwrap();
+        assert_eq!(observer.state(), crate::core::EngineState::Stopped);
+    }
+
+    #[tokio::test]
+    async fn graceful_shutdown_closes_idle_and_partial_postgres_connections() {
+        let temp = tempfile::tempdir().unwrap();
+        let options = EngineOptions::default()
+            .with_shutdown_grace(Duration::from_millis(100))
+            .unwrap();
+        let engine = Engine::open_with_options(temp.path(), 2, options)
+            .await
+            .unwrap();
+        let observer = engine.clone();
+        let http = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let postgres = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let postgres_address = postgres.local_addr().unwrap();
+        let (signal_tx, signal_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(serve_listeners_with_shutdown(
+            BoundListeners {
+                http,
+                postgres: Some(postgres),
+            },
+            engine,
+            async move {
+                let _ = signal_rx.await;
+            },
+        ));
+
+        let mut idle = start_postgres_session(postgres_address, "idle_client").await;
+        let mut partial = tokio::net::TcpStream::connect(postgres_address)
+            .await
+            .unwrap();
+        partial
+            .write_all(&[0, 0, 0, 8, 4, 210, 22, 47])
+            .await
+            .unwrap();
+        let mut ssl_response = [0_u8; 1];
+        partial.read_exact(&mut ssl_response).await.unwrap();
+        assert_eq!(ssl_response, *b"N");
+        partial.write_all(&[0, 0, 0, 32]).await.unwrap();
+
+        signal_tx.send(()).unwrap();
+        assert_peer_closes(&mut idle).await;
+        assert_peer_closes(&mut partial).await;
+        timeout(Duration::from_secs(2), server)
+            .await
+            .expect("tracked PostgreSQL connections should drain")
             .unwrap()
             .unwrap();
         assert_eq!(observer.state(), crate::core::EngineState::Stopped);
@@ -833,10 +1229,12 @@ mod tests {
         timeout(Duration::from_secs(1), accepted.notified())
             .await
             .expect("the connection should be owned before aborting the server");
+        let mut postgres_client = start_postgres_session(postgres_address, "abort_client").await;
         server.abort();
         assert!(server.await.unwrap_err().is_cancelled());
         assert_eq!(observer.state(), crate::core::EngineState::Draining);
         assert_peer_closes(&mut client).await;
+        assert_peer_closes(&mut postgres_client).await;
         assert!(tokio::net::TcpStream::connect(address).await.is_err());
         assert!(
             tokio::net::TcpStream::connect(postgres_address)
@@ -854,7 +1252,9 @@ mod tests {
     #[tokio::test]
     async fn active_http_query_drains_through_core_cancellation() {
         let temp = tempfile::tempdir().unwrap();
-        let grace = Duration::from_millis(20);
+        // Leave enough forced-cleanup time for heavily parallel CI while still
+        // proving that the long-running query crosses the grace boundary.
+        let grace = Duration::from_millis(250);
         let options = EngineOptions::new(1, 1)
             .unwrap()
             .with_request_timeout(None)

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -245,12 +245,37 @@ async fn postgres_adapter_boundary_is_public_session_scoped_and_not_a_listener()
     let adapter = postgres::Adapter::new(engine.clone());
     let first = adapter.open_connection();
     let second = adapter.open_connection();
+    let selected = adapter
+        .open_connection_for("public_client", "default")
+        .unwrap();
 
     assert_ne!(first.session_id(), second.session_id());
+    assert_ne!(first.session_id(), selected.session_id());
     assert_eq!(first.status().await.unwrap().shard_count(), 2);
     assert_eq!(second.status().await.unwrap().shard_count(), 2);
+    assert_eq!(selected.user(), Some("public_client"));
+    assert_eq!(selected.database(), "default");
+    assert_eq!(
+        selected.database_id(),
+        engine.catalog().default_database().id()
+    );
     assert!(format!("{adapter:?}").contains("shard_count"));
     assert!(format!("{first:?}").contains("session_id"));
+    assert!(!format!("{selected:?}").contains("public_client"));
+    assert_eq!(
+        adapter
+            .open_connection_for("Invalid", "default")
+            .unwrap_err()
+            .kind(),
+        core::EngineErrorKind::InvalidArgument
+    );
+    assert_eq!(
+        adapter
+            .open_connection_for("public_client", "missing")
+            .unwrap_err()
+            .kind(),
+        core::EngineErrorKind::InvalidArgument
+    );
 
     first.close().await.unwrap();
     assert_eq!(
@@ -259,6 +284,7 @@ async fn postgres_adapter_boundary_is_public_session_scoped_and_not_a_listener()
     );
     assert_eq!(second.status().await.unwrap().shard_count(), 2);
     second.close().await.unwrap();
+    selected.close().await.unwrap();
     engine.shutdown().await.unwrap();
 }
 


### PR DESCRIPTION
Closes #30

## Summary
- activate loopback PostgreSQL protocol 3.0 startup with exact user and logical-database selection
- emit BriskDB-owned authentication, parameter status, server identification, fixed errors, and clean termination
- bound SSL/GSS negotiation, startup, Query, Parse, Sync, and Terminate framing before dependency decoding
- track up to 256 PostgreSQL connection tasks and close selected core sessions across terminal and shutdown paths
- document the current startup-only compatibility boundary and mark the roadmap item complete

## Verification
- cargo fmt --all --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-targets --all-features
- cargo +1.85.0 test --locked --all-targets --all-features
- cargo test --locked --doc --all-features
- cargo +1.85.0 test --locked --doc --all-features
- git diff --check