### PR TITLE
Harden admin browser data fidelity

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,8 +39,14 @@ CI update in the same pull request.
 
 Run these before publishing a branch:
 
+Admin-browser script checks require Node.js 18 or newer. The all-target Rust
+suite invokes the same script checks so both CI Rust lanes exercise them.
+
 ```bash
 cargo fmt --all --check
+node --check src/protocol/http/admin/logic.js
+node --check src/protocol/http/admin/app.js
+node --test tests/admin_browser_logic.test.js
 cargo test --locked --all-targets --all-features
 cargo test --locked --doc --all-features
 cargo clippy --locked --all-targets --all-features -- -D warnings

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -294,7 +294,9 @@ protocol-specific golden tests only for encoding and state-machine behavior.
 ### 6. HTTP data and administration APIs
 
 - [x] Serve an early embedded, read-only data explorer at `/admin` with a
-  temporary fixed login and bounded per-physical-shard row pages (issue #106).
+  temporary fixed login and bounded per-physical-shard row pages (issue #106),
+  including exact large-integer display and ordered login responses (issue
+  #110).
   This preview does not complete the versioned admin API, listener separation,
   authentication/role, pagination, or scatter/gather items below.
 - [ ] Replace the experimental endpoints with a versioned `/v1` contract built

--- a/docs/ADMIN_BROWSER.md
+++ b/docs/ADMIN_BROWSER.md
@@ -1,6 +1,6 @@
 # Admin data browser
 
-Status: implemented for roadmap issue #106
+Status: implemented for roadmap issue #106 and hardened by issue #110
 
 BriskDB serves a small read-only data explorer from the existing HTTP listener.
 Open `/admin` (or `/admin/`) to use the embedded application. Its HTML, CSS,
@@ -34,7 +34,11 @@ tie-break. Logout invalidates only the presented session and always clears its
 cookie; other authenticated browsers remain independent. Logout is idempotent
 even when the cookie is absent or already unusable. Protected session,
 discovery, and row calls with a missing, malformed, unknown, expired, or
-logged-out cookie receive HTTP 401 with fixed JSON and a cookie-clearing header.
+logged-out cookie receive HTTP 401 with fixed JSON and no `Set-Cookie` header.
+Only explicit logout clears the cookie. This means an older unauthorized
+response cannot clear a session issued by a newer login. The application also
+tracks an authentication generation so an older response cannot replace a
+newer logged-in view.
 Session-cookie state is separate from a core `Session`: every inspection
 request still creates a short-lived engine session, and login does not create a
 multi-request SQL transaction.
@@ -45,6 +49,7 @@ multi-request SQL transaction.
 | --- | --- |
 | `GET /admin`, `GET /admin/` | Embedded application shell |
 | `GET /admin/assets/styles.css` | Embedded stylesheet |
+| `GET /admin/assets/logic.js` | Embedded, independently tested display and authentication-order logic |
 | `GET /admin/assets/app.js` | Embedded application code |
 | `POST /admin/api/login` | Accept JSON `{"username":"admin","password":"admin"}`; return `{"authenticated":true}` and set the session cookie |
 | `GET /admin/api/session` | Return `{"authenticated":true,"username":"admin"}` for a live cookie; otherwise return HTTP 401 |
@@ -52,10 +57,16 @@ multi-request SQL transaction.
 | `GET /admin/api/overview?shard=N` | Return `shard_count`, `selected_shard`, and the selected shard's binary-ordered `tables`; omitted `shard` selects zero |
 | `GET /admin/api/rows?shard=N&table=T&limit=L&offset=O` | Return one page as `shard`, `table`, `limit`, `offset`, `has_more`, ordered `columns`, and positional `rows`; limit defaults to 50 and offset to zero |
 
-The shell and its two assets are public so the application can render its login
+The shell and its three assets are public so the application can render its login
 state. Session, overview, and row calls require the server-side session check;
 logout remains an idempotent cookie-clearing operation. Hiding controls in
 JavaScript is not the access check.
+
+Display conversion and authentication-order transitions live in the small
+`logic.js` asset. Executable Node.js tests cover that pure logic, while a Rust
+integration test syntax-checks both scripts and runs the logic suite as part of
+the existing all-target CI command. Node.js is needed only for development
+tests; serving the embedded browser has no frontend build step.
 
 ## Physical-shard view
 
@@ -94,11 +105,17 @@ uses the ordinary engine lifecycle, schema gate, per-shard pool and worker
 admission, cancellation, deadline, and effective result limits. SQLite must
 classify its generated statement as read-only before it is stepped.
 
-Results retain the existing HTTP representation: ordered column metadata and
-positional row arrays. Duplicate or empty column names remain representable.
-Nulls, integers, finite floats, and valid text use direct JSON values; blobs are
+Results retain ordered column metadata and positional row arrays. Duplicate or
+empty column names remain representable. Nulls, finite floats, valid text, and
+integers in JavaScript's inclusive exact range
+`-9007199254740991..=9007199254740991` use direct JSON values. Larger signed or
+unsigned integers use
+`{"$briskdb_type":"int64","value":"exact decimal text"}` or the equivalent
+`uint64` tag in this admin-only response so the browser never rounds the
+displayed value. Blobs are
 arrays of byte-valued integers; decimals use strings; invalid UTF-8 text is
-rendered lossily; and non-finite floats become JSON `null`.
+rendered lossily; and non-finite floats become JSON `null`. This tagged integer
+addition does not change the experimental `/v1/query` response.
 
 Engine failures use the same fixed, redacted HTTP problem details as other HTTP
 operations. Login or session rejection returns HTTP 401 without echoing the

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -777,8 +777,10 @@ The experimental HTTP adapter is the only JSON conversion boundary.
 of `name` and `data_type` metadata objects plus positional arrays in `rows`.
 Column and row indices correspond exactly. Duplicate and empty names are valid,
 and metadata is returned even when there are zero rows. The admin response adds
-physical-shard, table, and finite pagination metadata without altering the cell
-conversion.
+physical-shard, table, and finite pagination metadata. It also tags signed or
+unsigned integers outside JavaScript's exact range with their decimal text so
+the browser cannot round them; the experimental `/v1/query` cell encoding is
+unchanged.
 
 The adapter renders exact decimals as JSON strings, converts `InvalidText` to a
 JSON string with invalid byte sequences replaced by U+FFFD, and maps non-finite

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -144,7 +144,8 @@ The embedded `/admin` application's login and cookie checks happen in the HTTP
 adapter before an engine operation exists. Wrong credentials and a missing,
 malformed, unknown, expired, or logged-out `briskdb_admin_session` therefore use
 HTTP 401 rather than inventing an `EngineErrorKind`. A protected call with an
-unusable session returns a fixed JSON response and a cookie-clearing header.
+unusable session returns a fixed JSON response without changing cookies, so an
+older unauthorized response cannot clear a newer login.
 Logout itself is idempotent: it returns success and clears the cookie even when
 no live token is present. These responses never echo the submitted password or
 cookie token. The public application shell and embedded assets remain loadable

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -269,8 +269,9 @@ is marked `Unknown` because dynamic SQLite values do not guarantee one static
 type.
 
 The experimental `/v1/query` response exposes the ordered result directly. The
-admin row-page endpoint reuses the same column and cell conversion and wraps it
-with physical-shard and pagination metadata. For example, the existing query
+admin row-page endpoint reuses the same ordered columns and positional rows and
+wraps them with physical-shard and pagination metadata. Its large-integer
+display encoding differs as described below. For example, the existing query
 shape is:
 
 ```json
@@ -292,14 +293,21 @@ ordered column metadata with `"rows": []`. The `data_type` label is one of
 or `binary`. SQLite result columns currently report `unknown` because SQLite
 does not guarantee one static result type.
 
-Cell encoding retains the existing HTTP policy: nulls, booleans, signed and
-unsigned integers, finite floats, and valid text use their direct JSON forms;
-binary data is an array of byte-valued JSON integers; and exact decimals are
-JSON strings. `InvalidText` is rendered lossily with invalid UTF-8 byte
-sequences replaced by U+FFFD. Because JSON has no non-finite number syntax,
+The `/v1/query` cell encoding retains the existing HTTP policy: nulls, booleans,
+signed and unsigned integers, finite floats, and valid text use their direct
+JSON forms; binary data is an array of byte-valued JSON integers; and exact
+decimals are JSON strings. `InvalidText` is rendered lossily with invalid UTF-8
+byte sequences replaced by U+FFFD. Because JSON has no non-finite number syntax,
 infinite or `NaN` `Float64` values become `null`. Consumers that decode every
-JSON number through binary floating point must also account for precision loss
-when reading large `uint64` cells.
+`/v1/query` JSON number through binary floating point must also account for
+precision loss when reading large integer cells.
+
+The admin row-page response keeps direct JSON integers within
+`-9007199254740991..=9007199254740991`. It represents larger signed or unsigned
+values as
+`{"$briskdb_type":"int64","value":"exact decimal text"}` or the equivalent
+`uint64` tag, and the embedded browser displays that text verbatim. This
+admin-only tag avoids JavaScript rounding without changing `/v1/query`.
 
 This ordered response intentionally replaces the earlier experimental
 object-per-row shape, which collapsed duplicate names. Admin pages preserve the

--- a/docs/SUPPORTED_PLATFORMS.md
+++ b/docs/SUPPORTED_PLATFORMS.md
@@ -48,12 +48,16 @@ session-lifecycle policy; see the [adapter decision record](POSTGRES_ADAPTER.md)
 
 The same runner exercises the embedded `/admin` shell and assets, temporary
 login/session lifecycle, physical-shard table discovery, and bounded row-page
-JSON contract without contacting third-party asset hosts. These are HTTP and
-content contract tests, not a named desktop/mobile browser compatibility
-matrix, visual-regression suite, or accessibility certification. The interface
-uses ordinary HTML, CSS, browser JavaScript, and same-origin requests; an
-unlisted browser remains best-effort until it has repeatable automated coverage.
-See the [admin data-browser contract](ADMIN_BROWSER.md).
+JSON contract without contacting third-party asset hosts. The all-target test
+suite also uses the pinned runner's Node.js executable to syntax-check both
+embedded scripts and run the pure display/authentication-order logic tests.
+Node.js is a development-test dependency, not a BriskDB runtime or frontend
+build dependency. These are HTTP, content, and logic contract tests, not a named
+desktop/mobile browser compatibility matrix, visual-regression suite, or
+accessibility certification. The interface uses ordinary HTML, CSS, browser
+JavaScript, and same-origin requests; an unlisted browser remains best-effort
+until it has repeatable automated coverage. See the
+[admin data-browser contract](ADMIN_BROWSER.md).
 
 ## Development-tested targets
 

--- a/src/protocol/http/admin.rs
+++ b/src/protocol/http/admin.rs
@@ -23,6 +23,7 @@ use crate::core::{EngineError, EngineErrorKind, ResultSet, Statement, Value};
 
 const INDEX_HTML: &str = include_str!("admin/index.html");
 const STYLES_CSS: &str = include_str!("admin/styles.css");
+const LOGIC_JS: &str = include_str!("admin/logic.js");
 const APP_JS: &str = include_str!("admin/app.js");
 
 const ADMIN_USERNAME: &str = "admin";
@@ -33,6 +34,7 @@ const MAX_SESSIONS: usize = 128;
 const DEFAULT_PAGE_LIMIT: u16 = 50;
 const MAX_PAGE_LIMIT: u16 = 200;
 const MAX_PAGE_OFFSET: u64 = 1_000_000;
+const MAX_JAVASCRIPT_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
 const TABLE_DISCOVERY_SQL: &str = "SELECT name FROM pragma_table_list \
      WHERE schema = 'main' AND type = 'table' \
        AND lower(name) NOT GLOB 'sqlite_*' \
@@ -134,6 +136,7 @@ pub(super) fn routes(state: HttpState) -> Router<HttpState> {
         .route("/admin", get(index))
         .route("/admin/", get(index))
         .route("/admin/assets/styles.css", get(styles))
+        .route("/admin/assets/logic.js", get(logic))
         .route("/admin/assets/app.js", get(script))
         .route("/admin/api/login", post(login))
         .route("/admin/api/logout", post(logout))
@@ -170,6 +173,10 @@ async fn index() -> Response {
 
 async fn styles() -> Response {
     static_response("text/css; charset=utf-8", STYLES_CSS)
+}
+
+async fn logic() -> Response {
+    static_response("text/javascript; charset=utf-8", LOGIC_JS)
 }
 
 async fn script() -> Response {
@@ -365,9 +372,23 @@ fn page_response(
     offset: u64,
     result: ResultSet,
 ) -> Response {
-    let super::QueryResponse {
-        columns, mut rows, ..
-    } = super::result_set_to_query_response(shard, result);
+    let (columns, rows) = result.into_parts();
+    let columns = columns
+        .into_iter()
+        .map(|column| super::QueryColumn {
+            name: column.name,
+            data_type: super::data_type_name(column.data_type),
+        })
+        .collect();
+    let mut rows = rows
+        .into_iter()
+        .map(|row| {
+            row.into_values()
+                .into_iter()
+                .map(admin_value_to_json)
+                .collect()
+        })
+        .collect::<Vec<_>>();
     let has_more = rows.len() > usize::from(limit)
         && offset
             .checked_add(u64::from(limit))
@@ -385,6 +406,25 @@ fn page_response(
             rows,
         },
     )
+}
+
+fn admin_value_to_json(value: Value) -> JsonValue {
+    match value {
+        Value::Int64(value) if value.unsigned_abs() > MAX_JAVASCRIPT_SAFE_INTEGER => {
+            tagged_integer("int64", value)
+        }
+        Value::UInt64(value) if value > MAX_JAVASCRIPT_SAFE_INTEGER => {
+            tagged_integer("uint64", value)
+        }
+        value => super::value_to_json(value),
+    }
+}
+
+fn tagged_integer(kind: &'static str, value: impl ToString) -> JsonValue {
+    json!({
+        "$briskdb_type": kind,
+        "value": value.to_string(),
+    })
 }
 
 fn table_names(result: ResultSet) -> Result<Vec<String>, EngineError> {
@@ -522,7 +562,7 @@ fn authentication_required() -> Response {
             "code": "authentication_required",
             "message": "Log in to continue."
         }),
-        Some(clear_session_cookie()),
+        None,
     )
 }
 
@@ -734,6 +774,11 @@ mod tests {
                 "--accent",
             ),
             (
+                "/admin/assets/logic.js",
+                "text/javascript; charset=utf-8",
+                "createAuthEpoch",
+            ),
+            (
                 "/admin/assets/app.js",
                 "text/javascript; charset=utf-8",
                 "textContent",
@@ -773,6 +818,15 @@ mod tests {
         assert!(APP_JS.contains("(empty table name)"));
         assert!(APP_JS.contains("(whitespace-only table name)"));
         assert!(APP_JS.contains("state.table === null"));
+        assert!(APP_JS.contains("logic.acceptAuthenticationFailure"));
+        assert!(APP_JS.contains("logic.cellPresentation"));
+        let logic_position = INDEX_HTML
+            .find("/admin/assets/logic.js")
+            .expect("the shell loads the tested browser logic");
+        let app_position = INDEX_HTML
+            .find("/admin/assets/app.js")
+            .expect("the shell loads the application script");
+        assert!(logic_position < app_position);
     }
 
     #[tokio::test]
@@ -848,12 +902,7 @@ mod tests {
         ] {
             let response = request(&app, Method::GET, uri, None, None).await;
             assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
-            assert!(
-                response.headers()[SET_COOKIE]
-                    .to_str()
-                    .unwrap()
-                    .contains("Max-Age=0")
-            );
+            assert!(response.headers().get(SET_COOKIE).is_none());
         }
 
         let set_cookie = login_cookie(&app).await;
@@ -1065,7 +1114,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn browser_sessions_are_independent_and_unknown_tokens_are_cleared() {
+    async fn browser_sessions_are_independent_and_unknown_tokens_are_rejected() {
         let (_temp, app) = application();
         let first = login_cookie(&app).await;
         let second = login_cookie(&app).await;
@@ -1104,13 +1153,32 @@ mod tests {
             let response =
                 request(&app, Method::GET, "/admin/api/session", Some(invalid), None).await;
             assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
-            assert!(
-                response.headers()[SET_COOKIE]
-                    .to_str()
-                    .unwrap()
-                    .contains("Max-Age=0")
-            );
+            assert!(response.headers().get(SET_COOKIE).is_none());
         }
+    }
+
+    #[tokio::test]
+    async fn stale_authentication_failure_cannot_clear_a_newer_login_cookie() {
+        let (_temp, app) = application();
+        let stale = request(
+            &app,
+            Method::GET,
+            "/admin/api/session",
+            Some("briskdb_admin_session=ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+            None,
+        )
+        .await;
+        let current = login_cookie(&app).await;
+        let current = current.to_str().unwrap().split(';').next().unwrap();
+
+        assert_eq!(stale.status(), StatusCode::UNAUTHORIZED);
+        assert!(stale.headers().get(SET_COOKIE).is_none());
+        assert_eq!(
+            request(&app, Method::GET, "/admin/api/session", Some(current), None,)
+                .await
+                .status(),
+            StatusCode::OK
+        );
     }
 
     #[tokio::test]
@@ -1159,6 +1227,74 @@ mod tests {
         .await;
         assert_eq!(body["rows"], json!([[1]]));
         assert_eq!(body["has_more"], false);
+    }
+
+    #[tokio::test]
+    async fn admin_page_response_preserves_extreme_integer_text() {
+        let result = ResultSet::new(
+            vec![
+                Column::new("minimum", DataType::Int64),
+                Column::new("maximum", DataType::Int64),
+                Column::new("unsigned", DataType::UInt64),
+            ],
+            vec![Row::new(vec![
+                Value::Int64(i64::MIN),
+                Value::Int64(i64::MAX),
+                Value::UInt64(u64::MAX),
+            ])],
+        )
+        .unwrap();
+        let body = body_json(page_response(0, "numbers".to_owned(), 50, 0, result)).await;
+
+        assert_eq!(
+            body["rows"],
+            json!([[{
+                "$briskdb_type": "int64",
+                "value": "-9223372036854775808"
+            }, {
+                "$briskdb_type": "int64",
+                "value": "9223372036854775807"
+            }, {
+                "$briskdb_type": "uint64",
+                "value": "18446744073709551615"
+            }]])
+        );
+    }
+
+    #[test]
+    fn admin_integer_encoding_is_exact_at_javascript_boundaries() {
+        let safe = MAX_JAVASCRIPT_SAFE_INTEGER as i64;
+        for value in [-safe, safe] {
+            assert_eq!(admin_value_to_json(Value::Int64(value)), json!(value));
+        }
+        assert_eq!(
+            admin_value_to_json(Value::Int64(-safe - 1)),
+            json!({"$briskdb_type":"int64","value":"-9007199254740992"})
+        );
+        assert_eq!(
+            admin_value_to_json(Value::Int64(safe + 1)),
+            json!({"$briskdb_type":"int64","value":"9007199254740992"})
+        );
+        assert_eq!(
+            admin_value_to_json(Value::Int64(i64::MIN)),
+            json!({"$briskdb_type":"int64","value":"-9223372036854775808"})
+        );
+        assert_eq!(
+            admin_value_to_json(Value::Int64(i64::MAX)),
+            json!({"$briskdb_type":"int64","value":"9223372036854775807"})
+        );
+        assert_eq!(
+            admin_value_to_json(Value::UInt64(MAX_JAVASCRIPT_SAFE_INTEGER)),
+            json!(MAX_JAVASCRIPT_SAFE_INTEGER)
+        );
+        assert_eq!(
+            admin_value_to_json(Value::UInt64(MAX_JAVASCRIPT_SAFE_INTEGER + 1)),
+            json!({"$briskdb_type":"uint64","value":"9007199254740992"})
+        );
+        assert_eq!(
+            admin_value_to_json(Value::UInt64(u64::MAX)),
+            json!({"$briskdb_type":"uint64","value":"18446744073709551615"})
+        );
     }
 
     #[tokio::test]

--- a/src/protocol/http/admin/app.js
+++ b/src/protocol/http/admin/app.js
@@ -1,6 +1,9 @@
 (() => {
   "use strict";
 
+  const logic = globalThis.BriskDbAdminLogic;
+  const authEpoch = logic.createAuthEpoch();
+
   const state = {
     shard: 0,
     shardCount: 0,
@@ -39,6 +42,7 @@
   };
 
   async function api(path, options = {}) {
+    const requestAuthEpoch = authEpoch.current();
     const response = await fetch(path, {
       credentials: "same-origin",
       ...options,
@@ -50,7 +54,9 @@
     const contentType = response.headers.get("content-type") || "";
     const body = contentType.includes("json") ? await response.json() : null;
     if (response.status === 401) {
-      showLogin(body && body.message ? body.message : "Log in to continue.");
+      if (logic.acceptAuthenticationFailure(authEpoch, requestAuthEpoch)) {
+        showLogin(body && body.message ? body.message : "Log in to continue.");
+      }
       throw new Error("authentication_required");
     }
     if (!response.ok) {
@@ -78,6 +84,7 @@
     elements.loginView.classList.add("hidden");
     elements.browserView.classList.remove("hidden");
     elements.loginError.textContent = "";
+    elements.browserView.focus();
   }
 
   function clearPage(title, message, summary = "No rows loaded") {
@@ -136,6 +143,7 @@
       button.className = "table-button";
       button.textContent = displayTableName(table);
       button.title = displayTableName(table);
+      button.setAttribute("aria-pressed", "false");
       button.addEventListener("click", () => selectTable(table, button));
       elements.tableList.append(button);
     }
@@ -174,7 +182,9 @@
     state.table = table;
     state.offset = 0;
     for (const item of elements.tableList.querySelectorAll(".table-button")) {
-      item.classList.toggle("active", item === button);
+      const active = item === button;
+      item.classList.toggle("active", active);
+      item.setAttribute("aria-pressed", String(active));
     }
     elements.tableTitle.textContent = displayTableName(table);
     elements.tableSubtitle.textContent = `Read-only rows from physical shard ${state.shard}.`;
@@ -184,17 +194,10 @@
   function renderCell(value) {
     const cell = document.createElement("td");
     const content = document.createElement("span");
-    if (value === null) {
-      content.className = "null-value";
-      content.textContent = "NULL";
-    } else if (Array.isArray(value)) {
-      content.className = "binary-value";
-      content.textContent = value.length === 0 ? "0x" : `0x${value.map((byte) => byte.toString(16).padStart(2, "0")).join("")}`;
-    } else if (typeof value === "string") {
-      content.textContent = value;
-    } else {
-      content.textContent = JSON.stringify(value);
-    }
+    const presentation = logic.cellPresentation(value);
+    content.className = presentation.className;
+    content.textContent = presentation.text;
+    content.title = presentation.title;
     cell.append(content);
     return cell;
   }
@@ -268,6 +271,8 @@
 
   elements.loginForm.addEventListener("submit", async (event) => {
     event.preventDefault();
+    authEpoch.advance();
+    const loginAuthEpoch = authEpoch.current();
     elements.loginError.textContent = "";
     const submit = elements.loginForm.querySelector("button[type='submit']");
     submit.disabled = true;
@@ -276,10 +281,11 @@
         method: "POST",
         body: JSON.stringify({ username: elements.username.value, password: elements.password.value }),
       });
+      if (!authEpoch.isCurrent(loginAuthEpoch)) return;
       showBrowser();
       await loadOverview(0);
     } catch (error) {
-      if (error.message !== "authentication_required") {
+      if (authEpoch.isCurrent(loginAuthEpoch) && error.message !== "authentication_required") {
         elements.loginError.textContent = error.message;
       }
     } finally {
@@ -288,12 +294,18 @@
   });
 
   elements.logout.addEventListener("click", async () => {
+    authEpoch.advance();
+    const logoutAuthEpoch = authEpoch.current();
     try {
       await api("/admin/api/logout", { method: "POST" });
     } catch (_) {
       // The local page still returns to login when the server already forgot the session.
+    } finally {
+      if (authEpoch.isCurrent(logoutAuthEpoch)) {
+        authEpoch.advance();
+        showLogin();
+      }
     }
-    showLogin();
   });
 
   elements.shard.addEventListener("change", () => loadOverview(Number(elements.shard.value)));
@@ -313,12 +325,18 @@
     }
   });
 
+  const sessionAuthEpoch = authEpoch.current();
   api("/admin/api/session")
     .then(() => {
+      if (!authEpoch.isCurrent(sessionAuthEpoch)) return undefined;
       showBrowser();
       return loadOverview(0);
     })
     .catch((error) => {
-      if (error.message !== "authentication_required") showLogin(error.message);
+      if (!authEpoch.isCurrent(sessionAuthEpoch)) return;
+      if (error.message !== "authentication_required") {
+        authEpoch.advance();
+        showLogin(error.message);
+      }
     });
 })();

--- a/src/protocol/http/admin/index.html
+++ b/src/protocol/http/admin/index.html
@@ -6,6 +6,7 @@
   <meta name="color-scheme" content="dark">
   <title>BriskDB Data Browser</title>
   <link rel="stylesheet" href="/admin/assets/styles.css">
+  <script src="/admin/assets/logic.js" defer></script>
   <script src="/admin/assets/app.js" defer></script>
 </head>
 <body>
@@ -29,7 +30,7 @@
     </section>
   </main>
 
-  <div id="browser-view" class="app-shell hidden">
+  <div id="browser-view" class="app-shell hidden" tabindex="-1">
     <header class="topbar">
       <div class="brand-lockup">
         <div class="brand-mark small" aria-hidden="true">B</div>

--- a/src/protocol/http/admin/logic.js
+++ b/src/protocol/http/admin/logic.js
@@ -1,0 +1,63 @@
+(() => {
+  "use strict";
+
+  const INTEGER_KINDS = new Set(["int64", "uint64"]);
+
+  function taggedInteger(value) {
+    return value !== null
+      && typeof value === "object"
+      && !Array.isArray(value)
+      && INTEGER_KINDS.has(value.$briskdb_type)
+      && typeof value.value === "string"
+      && /^-?[0-9]+$/.test(value.value);
+  }
+
+  function cellPresentation(value) {
+    if (value === null) {
+      return { text: "NULL", className: "null-value", title: "NULL" };
+    }
+    if (Array.isArray(value)) {
+      const text = value.length === 0
+        ? "0x"
+        : `0x${value.map((byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+      return { text, className: "binary-value", title: text };
+    }
+    if (taggedInteger(value)) {
+      return {
+        text: value.value,
+        className: "integer-value",
+        title: `${value.$briskdb_type}: ${value.value}`,
+      };
+    }
+    if (typeof value === "string") {
+      return { text: value, className: "", title: value };
+    }
+    const text = JSON.stringify(value);
+    return { text, className: "", title: text };
+  }
+
+  function createAuthEpoch() {
+    let current = 0;
+    return Object.freeze({
+      current: () => current,
+      advance: () => {
+        current += 1;
+        return current;
+      },
+      isCurrent: (candidate) => candidate === current,
+    });
+  }
+
+  function acceptAuthenticationFailure(epochs, requestEpoch) {
+    if (!epochs.isCurrent(requestEpoch)) return false;
+    epochs.advance();
+    return true;
+  }
+
+  globalThis.BriskDbAdminLogic = Object.freeze({
+    acceptAuthenticationFailure,
+    cellPresentation,
+    createAuthEpoch,
+    taggedInteger,
+  });
+})();

--- a/src/protocol/http/admin/styles.css
+++ b/src/protocol/http/admin/styles.css
@@ -124,6 +124,7 @@ select { min-height: 2.55rem; padding: 0 2.2rem 0 0.75rem; }
 .form-error { min-height: 1.3rem; margin: 1rem 0 0; color: var(--error); font-size: 0.88rem; }
 
 .app-shell { position: relative; z-index: 1; min-height: 100vh; }
+.app-shell:focus { outline: none; }
 .topbar {
   position: sticky;
   z-index: 4;
@@ -186,9 +187,9 @@ caption { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: r
 th, td { max-width: 30rem; overflow: hidden; padding: 0.78rem 1rem; border-bottom: 1px solid var(--border); text-align: left; text-overflow: ellipsis; }
 th { position: sticky; z-index: 2; top: 0; color: #aec4bd; background: var(--panel-solid); font-size: 0.72rem; font-weight: 750; letter-spacing: 0.035em; }
 tbody tr:hover { background: rgba(86, 224, 172, 0.035); }
-.column-type { display: block; margin-top: 0.18rem; color: #607b74; font-size: 0.62rem; font-weight: 500; text-transform: uppercase; }
+.column-type { display: block; margin-top: 0.18rem; color: #8aa79f; font-size: 0.62rem; font-weight: 500; text-transform: uppercase; }
 .null-value { color: #7e9891; font-style: italic; }
-.binary-value { color: #9cc8bc; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+.binary-value, .integer-value { color: #9cc8bc; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
 .pager { display: flex; min-height: 4rem; align-items: center; justify-content: space-between; gap: 1rem; padding: 0.7rem 1rem; color: var(--muted); background: rgba(5, 14, 12, 0.6); font-size: 0.78rem; }
 .pager > div { display: flex; gap: 0.5rem; }
 

--- a/tests/admin_browser_js.rs
+++ b/tests/admin_browser_js.rs
@@ -1,0 +1,24 @@
+use std::process::Command;
+
+fn assert_node_success(arguments: &[&str]) {
+    let output = Command::new("node")
+        .args(arguments)
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .expect("the supported CI and admin-browser development environment provides Node.js");
+
+    assert!(
+        output.status.success(),
+        "node {} failed\nstdout:\n{}\nstderr:\n{}",
+        arguments.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+fn embedded_admin_browser_scripts_are_valid_and_logic_tests_pass() {
+    assert_node_success(&["--check", "src/protocol/http/admin/logic.js"]);
+    assert_node_success(&["--check", "src/protocol/http/admin/app.js"]);
+    assert_node_success(&["--test", "tests/admin_browser_logic.test.js"]);
+}

--- a/tests/admin_browser_logic.test.js
+++ b/tests/admin_browser_logic.test.js
@@ -1,0 +1,68 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+
+const source = fs.readFileSync(
+  path.join(__dirname, "..", "src", "protocol", "http", "admin", "logic.js"),
+  "utf8",
+);
+const context = {};
+vm.runInNewContext(source, context, { filename: "logic.js" });
+const logic = context.BriskDbAdminLogic;
+
+test("tagged signed and unsigned integers retain their exact text", () => {
+  for (const [kind, value] of [
+    ["int64", "-9223372036854775808"],
+    ["int64", "9007199254740992"],
+    ["uint64", "18446744073709551615"],
+  ]) {
+    const cell = { $briskdb_type: kind, value };
+    assert.equal(logic.taggedInteger(cell), true);
+    const presentation = logic.cellPresentation(cell);
+    assert.equal(presentation.text, value);
+    assert.equal(presentation.className, "integer-value");
+    assert.equal(presentation.title, `${kind}: ${value}`);
+  }
+});
+
+test("malformed integer tags are never interpreted as BriskDB integers", () => {
+  for (const value of [
+    { $briskdb_type: "decimal", value: "1" },
+    { $briskdb_type: "int64", value: "1.5" },
+    { $briskdb_type: "int64", value: 1 },
+    { value: "1" },
+    null,
+    [],
+  ]) {
+    assert.equal(logic.taggedInteger(value), false);
+  }
+});
+
+test("ordinary cells keep their existing browser presentation", () => {
+  assert.equal(logic.cellPresentation(null).text, "NULL");
+  assert.equal(logic.cellPresentation("hello").text, "hello");
+  assert.equal(logic.cellPresentation(9007199254740991).text, "9007199254740991");
+  assert.equal(logic.cellPresentation([0, 15, 255]).text, "0x000fff");
+});
+
+test("authentication epochs reject stale responses after login or logout starts", () => {
+  const epochs = logic.createAuthEpoch();
+  const initialSession = epochs.current();
+  const login = epochs.advance();
+
+  assert.equal(epochs.isCurrent(initialSession), false);
+  assert.equal(epochs.isCurrent(login), true);
+  assert.equal(logic.acceptAuthenticationFailure(epochs, initialSession), false);
+  assert.equal(epochs.current(), login);
+  assert.equal(logic.acceptAuthenticationFailure(epochs, login), true);
+  assert.equal(epochs.isCurrent(login), false);
+
+  const oldDataRequest = epochs.current();
+  const logout = epochs.advance();
+  assert.equal(epochs.isCurrent(oldDataRequest), false);
+  assert.equal(epochs.isCurrent(logout), true);
+});


### PR DESCRIPTION
## Summary

- preserve exact Int64 and UInt64 display in the admin row browser outside the JavaScript safe-integer range
- prevent stale unauthorized responses from replacing a newer logged-in view or clearing its cookie
- isolate browser display and authentication-order logic behind executable Node tests
- run script syntax and logic tests through the existing all-target Rust test lanes
- update admin, architecture, compatibility, error, platform, roadmap, and contributor documentation

## Verification

- cargo fmt --all --check
- node --check src/protocol/http/admin/logic.js
- node --check src/protocol/http/admin/app.js
- node --test tests/admin_browser_logic.test.js
- cargo test --locked --all-targets --all-features
- cargo test --locked --doc --all-features
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo +1.85.0 test --locked --all-targets --all-features
- cargo +1.85.0 test --locked --doc --all-features
- live HTTP smoke test for admin login, extreme integer rows, and unauthorized cookie behavior

Closes #110