### PR TITLE
Show all-shard table row totals in admin browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,9 @@ minimum supported Rust version (MSRV) and the latest stable toolchain.
   PostgreSQL endpoint supports protocol 3.0 startup, logical database/user
   selection, BriskDB parameter status, and clean connection termination through
   a BriskDB-owned `pgwire` 0.36.3 boundary
-- An embedded read-only browser at `/admin` for inspecting user tables and
-  bounded row pages on one explicitly selected physical shard
+- An embedded read-only browser at `/admin` for inspecting user tables, showing
+  exact physical-row totals across all shards, and reading bounded row pages on
+  one explicitly selected physical shard
 - Protocol-neutral typed values, ordered columns, positional rows, and results
 - A bounded per-session prepared-statement and immutable bound-portal lifecycle
   with transient shard-0 metadata compilation, bind-time routing snapshots,
@@ -147,7 +148,8 @@ a query-capable PostgreSQL interface. See the
 The HTTP listener also serves the embedded data explorer at
 <http://127.0.0.1:7654/admin>. Its temporary credentials are `admin` / `admin`.
 The explorer is read-only: select one physical shard and an ordinary user table,
-then move through live offset-based pages of at most 200 rows. Browser sessions
+see its exact physical-row sum across every shard, then move through live
+offset-based pages of at most 200 rows from the selected shard. Browser sessions
 are held only in process memory, expire after eight hours, and disappear on
 restart. The fixed credentials are a development convenience; keep this
 experimental HTTP service on a trusted network. Existing `/health` and `/v1/*`

--- a/docs/ADMIN_BROWSER.md
+++ b/docs/ADMIN_BROWSER.md
@@ -55,10 +55,11 @@ multi-request SQL transaction.
 | `GET /admin/api/session` | Return `{"authenticated":true,"username":"admin"}` for a live cookie; otherwise return HTTP 401 |
 | `POST /admin/api/logout` | Revoke a presented live token if any, always clear the cookie, and return `{"authenticated":false}` |
 | `GET /admin/api/overview?shard=N` | Return `shard_count`, `selected_shard`, and the selected shard's binary-ordered `tables`; omitted `shard` selects zero |
+| `GET /admin/api/count?table=T` | Return the exact physical-row sum for `T` as `table`, `scope: "all_physical_shards"`, `shard_count`, and `total_rows` |
 | `GET /admin/api/rows?shard=N&table=T&limit=L&offset=O` | Return one page as `shard`, `table`, `limit`, `offset`, `has_more`, ordered `columns`, and positional `rows`; limit defaults to 50 and offset to zero |
 
 The shell and its three assets are public so the application can render its login
-state. Session, overview, and row calls require the server-side session check;
+state. Session, overview, count, and row calls require the server-side session check;
 logout remains an idempotent cookie-clearing operation. Hiding controls in
 JavaScript is not the access check.
 
@@ -94,13 +95,37 @@ offset would exceed 1,000,000, even if more physical rows exist.
 Each page is a separate read of the selected shard. Offset pagination is
 therefore a live view, not a retained snapshot: inserts or deletes between page
 requests can move or repeat rows, and SQLite's table scan supplies no general
-ordering guarantee. The explorer does not merge shards, compute a global row
-count, or implement the later scatter/gather roadmap.
+ordering guarantee. The explorer does not merge row pages or implement the
+later general scatter/gather roadmap.
+
+## All-shard physical row total
+
+Selecting a table also starts a separate exact count request. BriskDB verifies
+that the same exact ordinary table is browseable on every configured shard,
+runs a generated read-only `COUNT(*)` through the engine on each shard with at
+most eight shard operations in flight, and checked-adds the results as an
+unsigned 64-bit total. One missing table, shard failure, deadline, completed
+schema migration, or arithmetic overflow fails the whole request; no partial
+total is returned. The count is loaded once per table selection rather than on
+every pagination request.
+
+`scope: "all_physical_shards"` is literal. A properly partitioned table's sum
+is its logical row count. A replicated or global table counts every physical
+copy, so identical rows stored on two shards contribute twice. The physical
+browser cannot safely infer deduplication from the advisory catalog, especially
+for imported uncataloged tables. Each shard count is also a separate live read,
+not one atomic cross-shard snapshot, so concurrent writes can affect which
+instant each shard represents.
+
+`total_rows` uses a direct JSON integer through `9007199254740991`; larger
+values use the admin `uint64` tagged representation described below. The page
+summary continues to state the selected physical shard so the global count is
+not mistaken for globally merged displayed rows.
 
 ## Engine and JSON boundaries
 
-The HTTP adapter does not open shard files or call `rusqlite`. Discovery and row
-reads use BriskDB's bounded explicit-shard inspection operation. That operation
+The HTTP adapter does not open shard files or call `rusqlite`. Discovery, count,
+and row reads use BriskDB's bounded explicit-shard inspection operation. That operation
 uses the ordinary engine lifecycle, schema gate, per-shard pool and worker
 admission, cancellation, deadline, and effective result limits. SQLite must
 classify its generated statement as read-only before it is stepped.
@@ -119,14 +144,15 @@ addition does not change the experimental `/v1/query` response.
 
 Engine failures use the same fixed, redacted HTTP problem details as other HTTP
 operations. Login or session rejection returns HTTP 401 without echoing the
-submitted password or session token. A failed discovery or page read does not
-invalidate a valid browser session, and a later valid request can continue.
+submitted password or session token. A failed discovery, count, or page read
+does not invalidate a valid browser session, and a later valid request can
+continue.
 
 ## Deliberate non-goals
 
 Issue #106 does not add editing, arbitrary SQL, schema migration, backup,
 maintenance, query cancellation, a separate admin listener, stable pagination
-across concurrent writes, scatter/gather browsing, durable users or roles,
+across concurrent writes, general scatter/gather browsing, durable users or roles,
 credential configuration, or TLS. Those remain separate roadmap work. The
 browser adds no manifest table, file, version, checksum input, migration, or
 recovery step.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -32,7 +32,7 @@ server ---------> protocol::http
 | `core` | Protocol-neutral `Engine`, `Session`, statements, immutable bound portals, values, results, errors, read-only logical catalog, synchronous bound-value-aware plans, prepared lifecycle, explicit-shard read-only inspection, and sharded routing policy; stable key routing; bounded per-session and per-shard admission; routed execution and journaled schema migration | JSON/HTTP types, listeners, or Axum handlers |
 | `storage` | Versioned routing/logical manifest, shard layout, migration journal and recovery, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
 | `sql` | Dialect-explicit SQL syntax parsing, recursive common-subset validation, protocol-neutral statement/batch classification, source-preserving placeholder normalization, explicit strict/compatibility translation, catalog-aware typed shard-key inference, and narrow crate-private DML-shape inspection behind BriskDB-owned boundaries; exact source retention; SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, key hashing or shard selection, mutable session state, physical write-routing policy, filesystem layout, protocol responses, protocol-buffer ownership, or protocol-specific support policy |
-| `protocol::http` | Existing HTTP request extraction, shared JSON/BriskDB value and RFC 9457 problem-detail encoding, and the embedded admin shell/assets, temporary browser sessions, discovery, and page handlers | BLAKE3 routing, shard files, direct SQLite access, or rusqlite calls |
+| `protocol::http` | Existing HTTP request extraction, shared JSON/BriskDB value and RFC 9457 problem-detail encoding, and the embedded admin shell/assets, temporary browser sessions, discovery, all-shard physical counts, and page handlers | BLAKE3 routing, shard files, direct SQLite access, or rusqlite calls |
 | `protocol::postgres` | BriskDB-owned bounded protocol-3.0 framing, finite parameter validation, selected identity/status, per-connection core-session ownership, query-deferral responses, and private compile/query-parser seam around the exactly pinned `pgwire` library | Listener binding, direct SQLite access, routing, unbounded authoritative prepared state, or public dependency-owned types |
 | `protocol::error` | Exhaustive HTTP, PostgreSQL, and MySQL mappings from stable engine error kinds | SQLite errors, routing decisions, or wire-protocol session state |
 | `server` | Process configuration, database assembly, loopback validation, separate HTTP/PostgreSQL listener binding, finite connection-task supervision, and shared graceful/forced draining | SQL parsing, PostgreSQL wire framing, or storage implementation details |
@@ -122,8 +122,9 @@ Issue #106 adds an embedded application under `/admin` on the existing HTTP
 listener. The public shell, stylesheet, and JavaScript are static bytes compiled
 into the binary. Same-origin JSON handlers validate the temporary `admin` /
 `admin` login, retain at most 128 opaque sessions in process memory for an
-absolute eight hours, and enforce the cookie on session, discovery, and row-page
-operations. Logout revokes a presented token when possible and always clears
+absolute eight hours, and enforce the cookie on session, discovery, all-shard
+physical-count, and row-page operations. Logout revokes a presented token when
+possible and always clears
 the cookie, so repeating it is harmless. These browser sessions are adapter
 state, not core SQL sessions, and are neither written to storage nor recovered
 after restart.
@@ -142,8 +143,11 @@ returns only ordinary application tables, and excludes ASCII-case-insensitive
 the browser. It validates the returned table identity, safely quotes that
 identifier, binds finite limit/offset values, and exposes at most 200 rows from
 one shard. It never opens a database file or imports `rusqlite` in the adapter.
-Separate offset pages are live reads, not a transaction, stable ordering, or a
-cross-shard snapshot. The complete route and representation contract is in the
+The specialized count handler verifies the table on every shard, runs bounded
+concurrent read-only counts through the same engine boundary, and returns only
+a checked physical-row sum. Separate pages and shard counts are live reads, not
+a transaction, stable ordering, or a cross-shard snapshot. The complete route
+and representation contract is in the
 [admin data browser](ADMIN_BROWSER.md).
 
 ## SQL parser boundary
@@ -565,7 +569,8 @@ reporting without exposing the storage implementation.
 HTTP SQL state remains request-local: each execute or query request creates a
 fresh session and initializes its routing context from the request's
 `shard_key`. Each admin inspection likewise creates a fresh core session but
-selects a validated physical shard through the dedicated read-only boundary.
+selects a validated physical shard through the dedicated read-only boundary;
+the count handler coordinates multiple such explicitly bounded inspections.
 Consequently, session settings and transactions cannot span HTTP requests. The
 eight-hour browser cookie authenticates the admin JSON calls; it does not retain
 SQL session state. Schema-migration broadcast and status calls also go through

--- a/docs/REQUEST_CONTROLS.md
+++ b/docs/REQUEST_CONTROLS.md
@@ -153,11 +153,15 @@ or recovered at startup.
 Each authenticated discovery or row-page call separately creates a core
 `Session`. Discovery uses one engine operation. A row page uses one operation to
 verify the exact visible table identity, followed by a separately bounded page
-read that repeats the visibility predicate before returning data. Cancelling,
-failing, or completing either operation does not extend the cookie lifetime or
-invalidate an otherwise valid browser session. Conversely, logging out prevents
-later admin requests but does not retroactively cancel an inspection already
-admitted to the engine.
+read that repeats the visibility predicate before returning data. The separate
+all-shard count uses at most eight concurrent shard tasks. Each task owns a core
+session, verifies the ordinary table, and runs one exact `COUNT(*)`; all tasks
+share one request deadline and only a checked complete sum is returned. A
+completed schema-generation change makes the request retryable instead of
+mixing generations. Cancelling, failing, or completing any operation does not
+extend the cookie lifetime or invalidate an otherwise valid browser session.
+Conversely, logging out prevents later admin requests but does not retroactively
+cancel an inspection already admitted to the engine.
 
 ## Schema-migration controls
 

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -86,7 +86,7 @@ path; they do not pass through these opt-in SQL layers.
 | HTTP `/v1/execute` | Experimental | One SQLite statement with positional parameters | Required caller-provided `shard_key` |
 | HTTP `/v1/query` | Experimental | One raw SQLite statement prepared transiently by the row-returning path; no session cache | Required caller-provided `shard_key` |
 | HTTP `/v1/admin/broadcast` | Experimental | A journaled parameterless SQLite schema batch | Preflight on every shard, then ascending resumable apply |
-| HTTP `/admin` browser | Experimental, read-only | No caller SQL; server-generated physical table discovery and bounded `SELECT *` pages | Required validated physical shard number; never a routed or scatter query |
+| HTTP `/admin` browser | Experimental, read-only | No caller SQL; server-generated physical table discovery, exact all-shard physical `COUNT(*)`, and bounded `SELECT *` pages | Pages require a validated physical shard; the specialized count fans out with bounded concurrency but is not a general scatter-query surface |
 | PostgreSQL wire protocol | Protocol-3.0 startup/session only on loopback; SQL flow deferred | No SQL accepted over the wire; simple `Query` and extended `Parse` return fixed `0A000` responses | Startup selects an exact logical database; no wire SQL request reaches planning or routing |
 | MySQL wire protocol | Planned | Rust parsing, validation, classification, placeholder normalization, finite compatibility translation, and prepared lifecycle implemented; listener adoption planned | Core batch/write policy, bind validation, routing snapshots, current execute-time planning, and supported target execution implemented; wire mapping planned |
 
@@ -127,10 +127,16 @@ execution. The engine still requires SQLite to classify the statement as
 read-only and applies its schema gate, pool/worker admission, cancellation,
 deadline, and effective result-byte and row budgets.
 
+Table selection separately verifies the exact ordinary table on every shard
+and runs bounded read-only `COUNT(*)` inspections. It returns the checked sum of
+physical rows, so replicated rows count once per shard. The sum is not a
+cross-shard snapshot and does not make arbitrary SQL scatterable.
+
 Each offset page is a new committed read. No order is promised for a general
 SQLite table scan, and concurrent changes may move rows between pages. The
-browser does not merge physical shards, preserve a multi-page snapshot, accept
-arbitrary filters or SQL, or implement the planned scatter/gather query path.
+browser does not merge physical row pages, preserve a multi-page snapshot,
+accept arbitrary filters or SQL, or implement the planned general
+scatter/gather query path.
 The full route, login, and live-view contract is in the [admin data
 browser](ADMIN_BROWSER.md).
 

--- a/src/protocol/http/admin.rs
+++ b/src/protocol/http/admin.rs
@@ -15,11 +15,12 @@ use axum::{
     response::{IntoResponse, Response},
     routing::{get, post},
 };
+use futures::{StreamExt, TryStreamExt, stream};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value as JsonValue, json};
 
 use super::HttpState;
-use crate::core::{EngineError, EngineErrorKind, ResultSet, Statement, Value};
+use crate::core::{EngineError, EngineErrorKind, RequestContext, ResultSet, Statement, Value};
 
 const INDEX_HTML: &str = include_str!("admin/index.html");
 const STYLES_CSS: &str = include_str!("admin/styles.css");
@@ -34,6 +35,7 @@ const MAX_SESSIONS: usize = 128;
 const DEFAULT_PAGE_LIMIT: u16 = 50;
 const MAX_PAGE_LIMIT: u16 = 200;
 const MAX_PAGE_OFFSET: u64 = 1_000_000;
+const MAX_COUNT_CONCURRENCY: usize = 8;
 const MAX_JAVASCRIPT_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
 const TABLE_DISCOVERY_SQL: &str = "SELECT name FROM pragma_table_list \
      WHERE schema = 'main' AND type = 'table' \
@@ -129,6 +131,7 @@ pub(super) fn routes(state: HttpState) -> Router<HttpState> {
     let protected = Router::new()
         .route("/admin/api/session", get(session))
         .route("/admin/api/overview", get(overview))
+        .route("/admin/api/count", get(count))
         .route("/admin/api/rows", get(rows))
         .route_layer(middleware::from_fn_with_state(state, require_authenticated));
 
@@ -280,6 +283,178 @@ async fn overview(State(state): State<HttpState>, Query(query): Query<OverviewQu
 }
 
 #[derive(Deserialize)]
+struct CountQuery {
+    table: String,
+}
+
+#[derive(Serialize)]
+struct CountResponse {
+    table: String,
+    scope: &'static str,
+    shard_count: u16,
+    total_rows: JsonValue,
+}
+
+async fn count(State(state): State<HttpState>, Query(query): Query<CountQuery>) -> Response {
+    if !is_visible_table_name(&query.table) {
+        return invalid_argument("admin table name is not browseable");
+    }
+
+    let shard_count = state.engine.shard_count();
+    match count_table_rows(&state.engine, &query.table).await {
+        Ok(total_rows) => admin_json(
+            StatusCode::OK,
+            &CountResponse {
+                table: query.table,
+                scope: "all_physical_shards",
+                shard_count,
+                total_rows: admin_value_to_json(Value::UInt64(total_rows)),
+            },
+        ),
+        Err(error) => admin_engine_error(error),
+    }
+}
+
+async fn count_table_rows(engine: &crate::core::Engine, table: &str) -> Result<u64, EngineError> {
+    let status_session = engine.session();
+    let status = engine.status(&status_session).await?;
+    let context = match status.request_timeout() {
+        Some(timeout) => RequestContext::new().with_timeout(timeout)?,
+        None => RequestContext::new(),
+    };
+    let schema_generation = engine.catalog().schema_generation();
+    let counts = stream::iter(0..engine.shard_count())
+        .map(|shard| {
+            let engine = engine.clone();
+            let table = table.to_owned();
+            let context = context.clone();
+            async move { count_table_rows_on_shard(&engine, shard, &table, context).await }
+        })
+        .buffer_unordered(MAX_COUNT_CONCURRENCY)
+        .try_collect::<Vec<_>>()
+        .await;
+    finish_row_counts(
+        schema_generation,
+        engine.catalog().schema_generation(),
+        counts,
+    )
+}
+
+fn finish_row_counts(
+    expected_generation: u64,
+    observed_generation: u64,
+    counts: Result<Vec<u64>, EngineError>,
+) -> Result<u64, EngineError> {
+    ensure_schema_generation(expected_generation, observed_generation)?;
+    sum_row_counts(counts?)
+}
+
+fn sum_row_counts(counts: impl IntoIterator<Item = u64>) -> Result<u64, EngineError> {
+    counts.into_iter().try_fold(0_u64, |total, count| {
+        total.checked_add(count).ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::NumericOutOfRange,
+                "admin all-shard row count exceeds the supported unsigned range",
+            )
+        })
+    })
+}
+
+fn ensure_schema_generation(expected: u64, observed: u64) -> Result<(), EngineError> {
+    if observed == expected {
+        Ok(())
+    } else {
+        Err(EngineError::new(
+            EngineErrorKind::Busy,
+            "admin all-shard row count crossed a completed schema migration",
+        ))
+    }
+}
+
+async fn count_table_rows_on_shard(
+    engine: &crate::core::Engine,
+    shard: u16,
+    table: &str,
+    context: RequestContext,
+) -> Result<u64, EngineError> {
+    let session = engine.session();
+    ensure_browseable_table_with_context(engine, &session, shard, table, context.clone()).await?;
+    let result = engine
+        .inspect_shard_with_context(
+            &session,
+            shard,
+            Statement::new(
+                format!(
+                    "SELECT COUNT(*) AS row_count FROM {}",
+                    quote_identifier(table)
+                ),
+                vec![],
+            ),
+            context,
+        )
+        .await?;
+    row_count(result)
+}
+
+async fn ensure_browseable_table(
+    engine: &crate::core::Engine,
+    session: &crate::core::Session,
+    shard: u16,
+    table: &str,
+) -> Result<(), EngineError> {
+    ensure_browseable_table_with_context(engine, session, shard, table, RequestContext::new()).await
+}
+
+async fn ensure_browseable_table_with_context(
+    engine: &crate::core::Engine,
+    session: &crate::core::Session,
+    shard: u16,
+    table: &str,
+    context: RequestContext,
+) -> Result<(), EngineError> {
+    let tables = engine
+        .inspect_shard_with_context(
+            session,
+            shard,
+            Statement::new(TABLE_LOOKUP_SQL, vec![Value::Text(table.to_owned())]),
+            context,
+        )
+        .await
+        .and_then(table_names)?;
+    if tables.as_slice() == [table] {
+        Ok(())
+    } else {
+        Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            format!("admin table is not browseable on physical shard {shard}"),
+        ))
+    }
+}
+
+fn row_count(result: ResultSet) -> Result<u64, EngineError> {
+    let (_, mut rows) = result.into_parts();
+    if rows.len() != 1 {
+        return Err(invalid_count_result());
+    }
+    let values = rows
+        .pop()
+        .expect("the exact row count was checked")
+        .into_values();
+    match values.as_slice() {
+        [Value::Int64(value)] if *value >= 0 => Ok(*value as u64),
+        [Value::UInt64(value)] => Ok(*value),
+        _ => Err(invalid_count_result()),
+    }
+}
+
+fn invalid_count_result() -> EngineError {
+    EngineError::new(
+        EngineErrorKind::Internal,
+        "admin table count returned an unexpected result shape",
+    )
+}
+
+#[derive(Deserialize)]
 struct RowsQuery {
     shard: u16,
     table: String,
@@ -314,21 +489,10 @@ async fn rows(State(state): State<HttpState>, Query(query): Query<RowsQuery>) ->
     }
 
     let session = state.engine.session();
-    let verified = state
-        .engine
-        .inspect_shard(
-            &session,
-            query.shard,
-            Statement::new(TABLE_LOOKUP_SQL, vec![Value::Text(query.table.clone())]),
-        )
-        .await;
-    let verified = match verified.and_then(table_names) {
-        Ok(tables) if tables.as_slice() == [query.table.as_str()] => true,
-        Ok(_) => false,
-        Err(error) => return admin_engine_error(error),
-    };
-    if !verified {
-        return invalid_argument("admin table name is not browseable");
+    if let Err(error) =
+        ensure_browseable_table(&state.engine, &session, query.shard, &query.table).await
+    {
+        return admin_engine_error(error);
     }
 
     let quoted_table = quote_identifier(&query.table);
@@ -805,6 +969,7 @@ mod tests {
             "browser-view",
             "shard-select",
             "table-list",
+            "record-count",
             "status",
             "data-head",
             "data-body",
@@ -819,7 +984,12 @@ mod tests {
         assert!(APP_JS.contains("(whitespace-only table name)"));
         assert!(APP_JS.contains("state.table === null"));
         assert!(APP_JS.contains("logic.acceptAuthenticationFailure"));
+        assert!(APP_JS.contains("logic.acceptsTableResponse"));
         assert!(APP_JS.contains("logic.cellPresentation"));
+        assert!(APP_JS.contains("logic.pageSummary"));
+        assert!(APP_JS.contains("logic.rowCountPresentation"));
+        assert!(APP_JS.contains("state.countRequest"));
+        assert!(APP_JS.contains("/admin/api/count?"));
         let logic_position = INDEX_HTML
             .find("/admin/assets/logic.js")
             .expect("the shell loads the tested browser logic");
@@ -891,11 +1061,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn overview_and_rows_require_authentication_and_validate_bounds() {
+    async fn overview_count_and_rows_require_authentication_and_validate_bounds() {
         let (_temp, app) = application();
         for uri in [
             "/admin/api/session",
             "/admin/api/overview?shard=0",
+            "/admin/api/count?table=widgets",
+            "/admin/api/count",
             "/admin/api/rows?shard=0&table=widgets",
             "/admin/api/overview?shard=not-a-number",
             "/admin/api/rows?shard=not-a-number",
@@ -908,6 +1080,7 @@ mod tests {
         let set_cookie = login_cookie(&app).await;
         let cookie = set_cookie.to_str().unwrap().split(';').next().unwrap();
         for uri in [
+            "/admin/api/count",
             "/admin/api/rows?shard=0&table=widgets&limit=0",
             "/admin/api/rows?shard=0&table=widgets&limit=201",
             "/admin/api/rows?shard=0&table=widgets&offset=1000001",
@@ -950,7 +1123,8 @@ mod tests {
             .unwrap();
         for shard in 0..2 {
             let routing_key = routing_key_for_shard(&database, shard);
-            for id in 1..=3_i64 {
+            let row_count = if shard == 0 { 2 } else { 3 };
+            for id in 1..=row_count {
                 database
                     .execute(
                         &routing_key,
@@ -987,6 +1161,52 @@ mod tests {
                     "shard_count": 2,
                     "selected_shard": 1,
                     "tables": ["", " ", "odd\"table", "widgets"]
+                })
+            )
+        );
+
+        assert_eq!(
+            response_json(
+                request(
+                    &app,
+                    Method::GET,
+                    "/admin/api/count?table=widgets",
+                    Some(cookie),
+                    None,
+                )
+                .await
+            )
+            .await,
+            (
+                StatusCode::OK,
+                json!({
+                    "table": "widgets",
+                    "scope": "all_physical_shards",
+                    "shard_count": 2,
+                    "total_rows": 5
+                })
+            )
+        );
+
+        assert_eq!(
+            response_json(
+                request(
+                    &app,
+                    Method::GET,
+                    "/admin/api/count?table=odd%22table",
+                    Some(cookie),
+                    None,
+                )
+                .await
+            )
+            .await,
+            (
+                StatusCode::OK,
+                json!({
+                    "table": "odd\"table",
+                    "scope": "all_physical_shards",
+                    "shard_count": 2,
+                    "total_rows": 0
                 })
             )
         );
@@ -1101,6 +1321,9 @@ mod tests {
             let uri = format!("/admin/api/rows?shard=0&table={table}");
             let response = request(&app, Method::GET, &uri, Some(cookie), None).await;
             assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{table}");
+            let uri = format!("/admin/api/count?table={table}");
+            let response = request(&app, Method::GET, &uri, Some(cookie), None).await;
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{table}");
         }
         let recovered = request(
             &app,
@@ -1111,6 +1334,72 @@ mod tests {
         )
         .await;
         assert_eq!(recovered.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn all_shard_count_returns_no_partial_total_and_recovers_after_one_shard_failure() {
+        let temp = tempfile::tempdir().unwrap();
+        let database = Arc::new(Database::open(temp.path(), 2).unwrap());
+        database
+            .broadcast(
+                "CREATE TABLE counted (id INTEGER PRIMARY KEY); \
+                 CREATE TABLE control (id INTEGER PRIMARY KEY);",
+            )
+            .unwrap();
+        let app = super::super::router(Arc::clone(&database));
+        let set_cookie = login_cookie(&app).await;
+        let cookie = set_cookie.to_str().unwrap().split(';').next().unwrap();
+
+        let primed = request(
+            &app,
+            Method::GET,
+            "/admin/api/count?table=counted",
+            Some(cookie),
+            None,
+        )
+        .await;
+        assert_eq!(primed.status(), StatusCode::OK);
+
+        rusqlite::Connection::open(temp.path().join("shards/0001.sqlite"))
+            .unwrap()
+            .execute_batch("DROP TABLE counted")
+            .unwrap();
+
+        let failed = request(
+            &app,
+            Method::GET,
+            "/admin/api/count?table=counted",
+            Some(cookie),
+            None,
+        )
+        .await;
+        assert_eq!(failed.status(), StatusCode::BAD_REQUEST);
+        let failed = body_json(failed).await;
+        assert_eq!(failed["code"], "invalid_argument");
+        assert!(failed.get("total_rows").is_none());
+
+        assert_eq!(
+            response_json(
+                request(
+                    &app,
+                    Method::GET,
+                    "/admin/api/count?table=control",
+                    Some(cookie),
+                    None,
+                )
+                .await
+            )
+            .await,
+            (
+                StatusCode::OK,
+                json!({
+                    "table": "control",
+                    "scope": "all_physical_shards",
+                    "shard_count": 2,
+                    "total_rows": 0
+                })
+            )
+        );
     }
 
     #[tokio::test]
@@ -1294,6 +1583,73 @@ mod tests {
         assert_eq!(
             admin_value_to_json(Value::UInt64(u64::MAX)),
             json!({"$briskdb_type":"uint64","value":"18446744073709551615"})
+        );
+    }
+
+    #[test]
+    fn all_shard_count_validates_shapes_overflow_generation_and_exact_json() {
+        let result =
+            |rows| ResultSet::new(vec![Column::new("row_count", DataType::Unknown)], rows).unwrap();
+        assert_eq!(
+            row_count(result(vec![Row::new(vec![Value::Int64(5)])])).unwrap(),
+            5
+        );
+        assert_eq!(
+            row_count(result(vec![Row::new(vec![Value::UInt64(u64::MAX)])])).unwrap(),
+            u64::MAX
+        );
+        for malformed in [
+            result(vec![]),
+            result(vec![Row::new(vec![Value::Int64(-1)])]),
+            result(vec![Row::new(vec![Value::Text("5".to_owned())])]),
+            result(vec![
+                Row::new(vec![Value::Int64(2)]),
+                Row::new(vec![Value::Int64(3)]),
+            ]),
+        ] {
+            assert_eq!(
+                row_count(malformed).unwrap_err().kind(),
+                EngineErrorKind::Internal
+            );
+        }
+
+        assert_eq!(sum_row_counts([2, 3, 5]).unwrap(), 10);
+        assert_eq!(sum_row_counts(std::iter::empty()).unwrap(), 0);
+        assert_eq!(
+            sum_row_counts([u64::MAX, 1]).unwrap_err().kind(),
+            EngineErrorKind::NumericOutOfRange
+        );
+        assert!(ensure_schema_generation(7, 7).is_ok());
+        let changed = ensure_schema_generation(7, 8).unwrap_err();
+        assert_eq!(changed.kind(), EngineErrorKind::Busy);
+        assert!(changed.is_retryable());
+        let shard_error = || {
+            EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "one shard no longer has the table",
+            )
+        };
+        assert_eq!(
+            finish_row_counts(7, 7, Err(shard_error()))
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::InvalidArgument
+        );
+        let changed_wins = finish_row_counts(7, 8, Err(shard_error())).unwrap_err();
+        assert_eq!(changed_wins.kind(), EngineErrorKind::Busy);
+        assert!(changed_wins.is_retryable());
+
+        let body = serde_json::to_value(CountResponse {
+            table: "events".to_owned(),
+            scope: "all_physical_shards",
+            shard_count: 64,
+            total_rows: admin_value_to_json(Value::UInt64(MAX_JAVASCRIPT_SAFE_INTEGER + 1)),
+        })
+        .unwrap();
+        assert_eq!(body["scope"], "all_physical_shards");
+        assert_eq!(
+            body["total_rows"],
+            json!({"$briskdb_type":"uint64","value":"9007199254740992"})
         );
     }
 

--- a/src/protocol/http/admin/app.js
+++ b/src/protocol/http/admin/app.js
@@ -13,6 +13,7 @@
     hasMore: false,
     overviewRequest: 0,
     rowsRequest: 0,
+    countRequest: 0,
   };
 
   const elements = {
@@ -29,6 +30,7 @@
     tableCount: document.querySelector("#table-count"),
     tableTitle: document.querySelector("#table-title"),
     tableSubtitle: document.querySelector("#table-subtitle"),
+    recordCount: document.querySelector("#record-count"),
     pageSize: document.querySelector("#page-size"),
     status: document.querySelector("#status"),
     empty: document.querySelector("#empty-state"),
@@ -73,6 +75,7 @@
   function showLogin(message = "") {
     state.overviewRequest += 1;
     state.rowsRequest += 1;
+    state.countRequest += 1;
     elements.browserView.classList.add("hidden");
     elements.loginView.classList.remove("hidden");
     elements.loginError.textContent = message;
@@ -99,13 +102,22 @@
     elements.next.disabled = true;
   }
 
+  function setRecordCount(message, isError = false, isBusy = false, title = "") {
+    elements.recordCount.textContent = message;
+    elements.recordCount.classList.toggle("error", isError);
+    elements.recordCount.setAttribute("aria-busy", String(isBusy));
+    elements.recordCount.title = title;
+  }
+
   function resetTable(message = "Select an application table to inspect its rows.") {
     state.rowsRequest += 1;
+    state.countRequest += 1;
     state.table = null;
     state.offset = 0;
     state.hasMore = false;
     elements.tableTitle.textContent = "Choose a table";
     elements.tableSubtitle.textContent = message;
+    setRecordCount("No total loaded");
     clearPage("No table selected", "Choose a table from the sidebar to browse a bounded, read-only page.");
   }
 
@@ -188,7 +200,7 @@
     }
     elements.tableTitle.textContent = displayTableName(table);
     elements.tableSubtitle.textContent = `Read-only rows from physical shard ${state.shard}.`;
-    await loadRows();
+    await Promise.all([loadRows(), loadCount()]);
   }
 
   function renderCell(value) {
@@ -234,9 +246,7 @@
       elements.empty.querySelector("h2").textContent = page.offset === 0 ? "This table is empty" : "No rows on this page";
       elements.empty.querySelector("p").textContent = "Try the previous page or select another table.";
     }
-    const first = page.rows.length === 0 ? 0 : page.offset + 1;
-    const last = page.offset + page.rows.length;
-    elements.summary.textContent = page.rows.length === 0 ? "No rows" : `Showing rows ${first}–${last}`;
+    elements.summary.textContent = logic.pageSummary(page);
     elements.previous.disabled = page.offset === 0;
     elements.next.disabled = !page.has_more;
   }
@@ -265,6 +275,28 @@
       if (error.message !== "authentication_required") {
         clearPage("Rows unavailable", error.message, "No rows loaded");
         setStatus(error.message, true);
+      }
+    }
+  }
+
+  async function loadCount() {
+    if (state.table === null) return;
+    const requestedTable = state.table;
+    const requestId = ++state.countRequest;
+    setRecordCount("Calculating total records across all physical shards…", false, true);
+    const query = new URLSearchParams({ table: requestedTable });
+    try {
+      const count = await api(`/admin/api/count?${query.toString()}`);
+      if (!logic.acceptsTableResponse(requestId, state.countRequest, requestedTable, state.table)) return;
+      if (count.table !== requestedTable || count.scope !== "all_physical_shards") {
+        throw new Error("Invalid all-shard row count response.");
+      }
+      const presentation = logic.rowCountPresentation(count.total_rows, count.shard_count);
+      setRecordCount(presentation.text, false, false, presentation.title);
+    } catch (error) {
+      if (!logic.acceptsTableResponse(requestId, state.countRequest, requestedTable, state.table)) return;
+      if (error.message !== "authentication_required") {
+        setRecordCount("Total across all physical shards unavailable", true, false, error.message);
       }
     }
   }

--- a/src/protocol/http/admin/index.html
+++ b/src/protocol/http/admin/index.html
@@ -67,6 +67,7 @@
             <p id="shard-kicker" class="eyebrow">Physical shard 0</p>
             <h1 id="table-title">Choose a table</h1>
             <p id="table-subtitle" class="muted">Select an application table to inspect its rows.</p>
+            <p id="record-count" class="record-count" role="status" aria-live="polite" aria-atomic="true" aria-busy="false">No total loaded</p>
           </div>
           <div class="page-size-control">
             <label for="page-size">Rows per page</label>

--- a/src/protocol/http/admin/logic.js
+++ b/src/protocol/http/admin/logic.js
@@ -36,6 +36,35 @@
     return { text, className: "", title: text };
   }
 
+  function exactRowCount(value) {
+    if (Number.isSafeInteger(value) && value >= 0) return String(value);
+    if (taggedInteger(value) && !value.value.startsWith("-")) return value.value;
+    return null;
+  }
+
+  function rowCountPresentation(value, shardCount) {
+    const exact = exactRowCount(value);
+    if (exact === null || !Number.isInteger(shardCount) || shardCount < 1) {
+      throw new Error("Invalid all-shard row count response.");
+    }
+    const formatted = exact.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+    return {
+      text: `${formatted} total record${exact === "1" ? "" : "s"} across ${shardCount} physical shard${shardCount === 1 ? "" : "s"}`,
+      title: "Exact sum of physical table rows. Replicated records are counted once per shard.",
+    };
+  }
+
+  function acceptsTableResponse(requestId, currentRequestId, requestedTable, currentTable) {
+    return requestId === currentRequestId && requestedTable === currentTable;
+  }
+
+  function pageSummary(page) {
+    if (page.rows.length === 0) return `No rows on physical shard ${page.shard}`;
+    const first = page.offset + 1;
+    const last = page.offset + page.rows.length;
+    return `Showing rows ${first}–${last} on physical shard ${page.shard}`;
+  }
+
   function createAuthEpoch() {
     let current = 0;
     return Object.freeze({
@@ -56,8 +85,12 @@
 
   globalThis.BriskDbAdminLogic = Object.freeze({
     acceptAuthenticationFailure,
+    acceptsTableResponse,
     cellPresentation,
     createAuthEpoch,
+    exactRowCount,
+    pageSummary,
+    rowCountPresentation,
     taggedInteger,
   });
 })();

--- a/src/protocol/http/admin/styles.css
+++ b/src/protocol/http/admin/styles.css
@@ -172,6 +172,8 @@ select { min-height: 2.55rem; padding: 0 2.2rem 0 0.75rem; }
 .content-header { display: flex; align-items: end; justify-content: space-between; gap: 1rem; margin-bottom: 1rem; }
 .content-header h1 { margin: 0.15rem 0 0.4rem; font-size: clamp(1.5rem, 3vw, 2.1rem); letter-spacing: -0.035em; }
 .content-header p { margin-top: 0; }
+.record-count { margin-bottom: 0; color: var(--accent); font-size: 0.84rem; font-weight: 680; }
+.record-count.error { color: var(--error); }
 .page-size-control { display: grid; width: 8.5rem; gap: 0.35rem; }
 .status { min-height: 1.5rem; margin-bottom: 0.7rem; color: var(--muted); font-size: 0.82rem; }
 .status.error { color: var(--error); }

--- a/tests/admin_browser_logic.test.js
+++ b/tests/admin_browser_logic.test.js
@@ -49,6 +49,45 @@ test("ordinary cells keep their existing browser presentation", () => {
   assert.equal(logic.cellPresentation([0, 15, 255]).text, "0x000fff");
 });
 
+test("all-shard row counts are formatted without losing integer precision", () => {
+  assert.equal(logic.exactRowCount(1536282), "1536282");
+  let presentation = logic.rowCountPresentation(1536282, 2);
+  assert.equal(presentation.text, "1,536,282 total records across 2 physical shards");
+  assert.match(presentation.title, /Replicated records/);
+
+  const maximum = { $briskdb_type: "uint64", value: "18446744073709551615" };
+  assert.equal(logic.exactRowCount(maximum), "18446744073709551615");
+  presentation = logic.rowCountPresentation(maximum, 64);
+  assert.equal(
+    presentation.text,
+    "18,446,744,073,709,551,615 total records across 64 physical shards",
+  );
+
+  assert.equal(logic.rowCountPresentation(1, 1).text, "1 total record across 1 physical shard");
+  for (const invalid of [-1, Number.MAX_SAFE_INTEGER + 1, { $briskdb_type: "int64", value: "-1" }]) {
+    assert.equal(logic.exactRowCount(invalid), null);
+  }
+  assert.throws(() => logic.rowCountPresentation(-1, 2), /Invalid all-shard/);
+  assert.throws(() => logic.rowCountPresentation(0, 0), /Invalid all-shard/);
+});
+
+test("page summaries retain their selected physical-shard scope", () => {
+  assert.equal(
+    logic.pageSummary({ shard: 1, offset: 50, rows: [[1], [2]] }),
+    "Showing rows 51–52 on physical shard 1",
+  );
+  assert.equal(
+    logic.pageSummary({ shard: 0, offset: 0, rows: [] }),
+    "No rows on physical shard 0",
+  );
+});
+
+test("table response guards reject stale counts after table or shard changes", () => {
+  assert.equal(logic.acceptsTableResponse(4, 4, "orders", "orders"), true);
+  assert.equal(logic.acceptsTableResponse(3, 4, "orders", "orders"), false);
+  assert.equal(logic.acceptsTableResponse(4, 4, "orders", "payments"), false);
+});
+
 test("authentication epochs reject stale responses after login or logout starts", () => {
   const epochs = logic.createAuthEpoch();
   const initialSession = epochs.current();


### PR DESCRIPTION
## Summary

- add an authenticated exact row-count endpoint that verifies and counts the selected ordinary table across every physical shard
- show the independently loaded physical total while keeping row pages explicitly scoped to the selected shard
- preserve exact unsigned values, bounded concurrency, one deadline, schema-generation safety, and fail-closed no-partial behavior
- document the physical-count semantics for sharded and replicated tables

## Verification

- cargo fmt --all --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-targets --all-features
- cargo test --locked --doc --all-features
- cargo +1.85.0 test --locked --all-targets --all-features
- node --check for both embedded scripts
- node --test tests/admin_browser_logic.test.js
- live two-shard checks against the imported LARGE_Data dataset

Closes #112