### PR TITLE
Make table placement metadata authoritative

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ hyper-util = { version = "0.1.20", features = ["service", "tokio"] }
 # baseline. Keep the pre-1.0 dependency exact and enable only the plaintext
 # server surface; later roadmap work owns TLS and extended type adapters.
 pgwire = { version = "=0.36.3", default-features = false, features = ["server-api"] }
-rusqlite = { version = "0.39.0", features = ["bundled", "hooks"] }
+rusqlite = { version = "0.39.0", features = ["bundled", "column_metadata", "hooks"] }
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0"
 # The exact upstream revision contains the post-0.62.0 `parse_interval`

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ The [architecture map](docs/ARCHITECTURE.md) defines the crate's module
 boundaries and dependency direction.
 
 The [SQL compatibility contract](docs/SQL_COMPATIBILITY.md) distinguishes the
-current SQLite pass-through API from PostgreSQL startup support and planned
-PostgreSQL/MySQL query compatibility.
+unregistered legacy SQLite pass-through from the authoritative-catalog HTTP
+path, PostgreSQL startup support, and planned PostgreSQL/MySQL query
+compatibility.
 The [PostgreSQL listener contract](docs/POSTGRES_LISTENER.md) defines its
 address configuration, startup/session behavior, parameter status, deferred
 query boundary, and shared shutdown lifecycle.
@@ -87,10 +88,14 @@ minimum supported Rust version (MSRV) and the latest stable toolchain.
   SQLite, PostgreSQL, and MySQL dialects, followed by opt-in source-preserving
   statement/batch classification, placeholder normalization, per-statement
   binding metadata, and catalog-aware typed shard-key inference plus
-  synchronous bound-value-aware routing plans with single-shard write policy,
-  all isolated from the current raw SQLite HTTP execution path
+  synchronous bound-value-aware routing plans with single-shard write policy;
+  a populated authoritative catalog composes that SQLite frontend and policy
+  into the raw HTTP execute/query path, while an empty catalog alone retains
+  the legacy pass-through behavior
 - A transactionally versioned `manifest.sqlite` with durable 4,096-bucket
-  routing plus logical-database and table metadata
+  routing plus logical-database and authoritative table-placement metadata
+- Initialization-only registration of a complete, empty physical schema, with
+  later schema migrations checked against its table and shard-key declarations
 - Identity-bound, WAL-enabled SQLite shard files that are never silently
   recreated after initialization
 - Routed execute and query endpoints
@@ -211,6 +216,20 @@ bytes and no NUL. The endpoint retains its experimental `broadcast` name and
 returns `{"completed_shards":[...]}`, but it is the only client surface allowed
 to change persistent application schema.
 
+Before loading rows, a Rust embedder may register the complete table layout once
+with `Database::register_tables`. Every ordinary physical table must exist with
+the same name on every shard, be empty, and be declared `Sharded` or `Global`;
+a `Catalog` declaration must have no physical table or view. A sharded
+declaration also names a visible, physically non-null column with compatible
+`Int64`, text, or binary affinity. SQLite's non-null `INTEGER PRIMARY KEY`
+rowid alias is accepted; nullable legacy primary-key forms are not. Text keys
+use SQLite `BINARY` collation, and every primary/unique key on a sharded table
+must include its shard key with `BINARY` collation. Application foreign keys,
+triggers, and virtual tables are temporarily unsupported. An exact repeat is
+idempotent, but a different or partial replacement is rejected. Registration
+is an initialization boundary, not an online catalog-editing API; close and
+reopen the registering handle after an ambiguous manifest-commit error.
+
 Insert a keyed row:
 
 ```bash
@@ -314,9 +333,13 @@ plan, `rusqlite` statement, or connection, and closing a statement closes all
 of its portals.
 
 Translation and planning remain independently callable branches over the same
-normalized request. The HTTP execute, query, and migration endpoints invoke
-none of these opt-in/prepared layers and retain their existing raw SQLite
-behavior. The exact translation matrix and strict-mode boundary are in
+normalized request. With an empty table catalog, HTTP execute/query retains the
+legacy caller-routed raw SQLite path. Once tables are registered, those same
+endpoints require exactly one SQLite common-subset statement, normalize its
+placeholders, apply strict SQLite translation, infer its authoritative
+placement, and enforce a finite single-shard target. The migration endpoint
+keeps its separate exact-text journal identity and parameterless batch
+contract. The exact translation matrix and strict-mode boundary are in
 [`docs/SQL_TRANSLATION.md`](docs/SQL_TRANSLATION.md), and the complete lifecycle
 is in
 [`docs/SQL_PREPARED_STATEMENTS.md`](docs/SQL_PREPARED_STATEMENTS.md).
@@ -324,8 +347,9 @@ is in
 `EngineOptions` permits 1–16 active connections and 1–1,024 queued operations
 per shard, with at most 512 active connections across all shards.
 SQLite statements that can leave connection-local state remain uncontracted
-pass-through behavior. Such connections, and connections left in a transaction,
-are retired rather than reused by another session. Clean read handles can be
+empty-catalog pass-through behavior; the populated-catalog common subset rejects
+those forms. Such connections, and connections left in a transaction, are
+retired rather than reused by another session. Clean read handles can be
 shared for ordinary SQL, but a deny-only authorizer probe moves connection-local
 SQL such as `PRAGMA data_version`, plus any cross-owner write, to a fresh
 disposable handle before execution.
@@ -359,11 +383,14 @@ new ordinary operations and a second coordinator receive retryable `Busy`.
 After durable partial progress, ordinary work receives non-retryable
 `FailedPrecondition` until the same migration resumes. The exact SQL text is
 retained permanently for recovery and idempotency, so migration batches must
-not contain passwords, tokens, or other sensitive literals.
+not contain passwords, tokens, or other sensitive literals. Once the catalog is
+registered, migration rejects row-moving DML, table drops, trigger creation,
+foreign keys, virtual tables, and any change that breaks declared placement,
+Text collation, or one-owner uniqueness.
 
 The initial shard count is immutable, so resharding will require an explicit
-migration workflow. Opening upgrades exact version-1 through version-6
-manifests to version 7 through ordered, resumable steps.
+migration workflow. Opening upgrades exact version-1 through version-7
+manifests to version 8 through ordered, resumable steps.
 Version 3 introduced the versioned, generation-stamped 4,096-bucket routing
 map. Version 4 adds schema generation 0 and immutable logical metadata with
 default database ID 1 named `default`; identifier encoding version 1 accepts
@@ -403,15 +430,38 @@ than rewriting checksum values. These unkeyed
 checksums are corruption detectors, not authentication, and they do not cover
 application row values or provide a continuous whole-data scan.
 
-The v3-to-v4 step deliberately leaves the table catalog empty: it neither
-infers nor adopts tables already present in physical shard files. The v4-to-v5
-upgrade retains every validated v4 catalog row, while shard adoption preserves
-physical application tables and their data. The public catalog returned by
-`Database::catalog()` and `Engine::catalog()` remains read-only and advisory.
-Its database and table entries stay immutable, while its schema generation
-advances after migration finalization; migrations neither infer nor mutate
-`briskdb_tables`. Current query results, routing, SQLite value behavior, HTTP
-shapes, and wire contracts are otherwise unchanged.
+Version 8 makes newly registered table placement authoritative and raises the
+downgrade fence. Because version-7 table rows were only advisory, the v7-to-v8
+upgrade clears them instead of silently treating them as proven declarations;
+it preserves logical databases, routing, schema history, shard files, and rows.
+`Database::register_tables` can then install one complete declaration set only
+after its matching physical tables are empty. Once installed, migrations must
+preserve that exact physical table set and every sharded key's required column
+and affinity. Text shard keys use SQLite `BINARY` collation. Application
+foreign keys, triggers, and virtual tables are temporarily unsupported; every
+`PRIMARY KEY` or `UNIQUE` key on a sharded table must include its shard key with
+`BINARY` collation so uniqueness has one physical owner. The public catalog
+returned by `Database::catalog()` and `Engine::catalog()` remains read-only to
+observers.
+
+Registration marks schema admission `Pending` before its manifest commit. If
+that commit reports an ambiguous cleanup or I/O failure, close the registering
+handle and reopen the data root; a durably committed replacement cannot be
+loaded while the stale pre-registration handle remains live. Do not retry a
+new registration through that pending handle.
+
+For a `Sharded` table, each logical row has exactly one owner selected from its
+canonical shard-key bytes; storing the same ordinary row on several shards is
+not sharding. `Global` is the explicit replicated placement, while `Catalog`
+is manifest-only. Registration establishes the authority used by later import
+and execution work; it does not repartition existing data.
+
+Logical reads that are not pinned to one key still require the scatter/gather
+follow-ups (#57 and #58). Their contract is one logical result over all owning
+shards—equivalent to a shard `UNION ALL` before global filtering, ordering,
+pagination, or aggregation—not duplicated copies in every file. The current
+admin browser remains a physical-shard diagnostic until its logical catalog
+view lands separately.
 Startup loads routing and logical metadata in one validated shared snapshot;
 runtime routing continues to hash the exact key bytes, derive a virtual bucket,
 and read its persisted physical-shard assignment. The generation-1 ranges

--- a/docs/ADMIN_BROWSER.md
+++ b/docs/ADMIN_BROWSER.md
@@ -72,7 +72,8 @@ tests; serving the embedded browser has no frontend build step.
 ## Physical-shard view
 
 The explorer intentionally selects a physical shard number. This differs from
-normal `/v1/query` routing, which hashes a caller-provided logical `shard_key`.
+normal `/v1/query`, which requires a caller routing key and, once the table
+catalog is populated, validates it against inferred authoritative placement.
 The overview accepts only `0 <= shard < shard_count`. It discovers ordinary
 tables in SQLite's `main` schema and excludes SQLite-owned names beginning with
 `sqlite_` plus the exact BriskDB-owned name `briskdb` and names beginning with
@@ -80,9 +81,9 @@ tables in SQLite's `main` schema and excludes SQLite-owned names beginning with
 are not presented. Names have a stable binary ordering in the response.
 
 Discovery describes the tables physically present on the selected shard. It is
-not the advisory logical `briskdb_tables` catalog, and it makes no claim that a
-table exists on another shard. Guessing an excluded or absent name does not make
-it browseable.
+not the authoritative logical `briskdb_tables` view, does not consult placement
+metadata, and makes no claim that another shard contributes the same rows.
+Guessing an excluded or absent name does not make it browseable.
 
 The browser offers page sizes 25, 50, 100, and 200 rows and initially selects
 50. The JSON endpoint accepts only limits from 1 through 200 and offsets from 0
@@ -112,8 +113,10 @@ every pagination request.
 `scope: "all_physical_shards"` is literal. A properly partitioned table's sum
 is its logical row count. A replicated or global table counts every physical
 copy, so identical rows stored on two shards contribute twice. The physical
-browser cannot safely infer deduplication from the advisory catalog, especially
-for imported uncataloged tables. Each shard count is also a separate live read,
+browser deliberately does not infer deduplication or change multiplicity from
+catalog placement. For a registered sharded table, the one-row-one-owner
+invariant makes the physical sum logical; for `Global`, physical copies remain
+separate count contributions. Each shard count is also a separate live read,
 not one atomic cross-shard snapshot, so concurrent writes can affect which
 instant each shard represents.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -29,8 +29,8 @@ server ---------> protocol::http
 
 | Module | Responsibility | Must not own |
 | --- | --- | --- |
-| `core` | Protocol-neutral `Engine`, `Session`, statements, immutable bound portals, values, results, errors, read-only logical catalog, synchronous bound-value-aware plans, prepared lifecycle, explicit-shard read-only inspection, and sharded routing policy; stable key routing; bounded per-session and per-shard admission; routed execution and journaled schema migration | JSON/HTTP types, listeners, or Axum handlers |
-| `storage` | Versioned routing/logical manifest, shard layout, migration journal and recovery, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
+| `core` | Protocol-neutral `Engine`, `Session`, statements, immutable bound portals, values, results, errors, read-only catalog views and initialization declarations, synchronous bound-value-aware plans, prepared lifecycle, explicit-shard read-only inspection, and sharded routing policy; stable key routing; bounded per-session and per-shard admission; routed execution and journaled schema migration | JSON/HTTP types, listeners, or Axum handlers |
+| `storage` | Versioned routing and authoritative logical manifest, one-time table registration, shard layout, migration journal and recovery, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
 | `sql` | Dialect-explicit SQL syntax parsing, recursive common-subset validation, protocol-neutral statement/batch classification, source-preserving placeholder normalization, explicit strict/compatibility translation, catalog-aware typed shard-key inference, and narrow crate-private DML-shape inspection behind BriskDB-owned boundaries; exact source retention; SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, key hashing or shard selection, mutable session state, physical write-routing policy, filesystem layout, protocol responses, protocol-buffer ownership, or protocol-specific support policy |
 | `protocol::http` | Existing HTTP request extraction, shared JSON/BriskDB value and RFC 9457 problem-detail encoding, and the embedded admin shell/assets, temporary browser sessions, discovery, all-shard physical counts, and page handlers | BLAKE3 routing, shard files, direct SQLite access, or rusqlite calls |
 | `protocol::postgres` | BriskDB-owned bounded protocol-3.0 framing, finite parameter validation, selected identity/status, per-connection core-session ownership, query-deferral responses, and private compile/query-parser seam around the exactly pinned `pgwire` library | Listener binding, direct SQLite access, routing, unbounded authoritative prepared state, or public dependency-owned types |
@@ -53,7 +53,9 @@ The module split deliberately preserved:
 - every HTTP route and request field, the health, execute, and broadcast response
   shapes, and current error statuses;
 - BLAKE3 routing, shard filenames, manifest schema, WAL and synchronous modes;
-- SQLite pass-through semantics and cell-level HTTP JSON encoding behavior; and
+- legacy SQLite pass-through semantics while the table catalog is empty,
+  authoritative catalog gating after registration, and cell-level HTTP JSON
+  encoding behavior; and
 - the existing `briskdb::api::router` and `briskdb::storage::Database` Rust
   paths through compatibility re-exports.
 
@@ -191,13 +193,14 @@ an independent depth limit of 128 so iteratively parsed flat operator chains rem
 The normative accepted forms and exclusions are in the [common SQL subset
 contract](SQL_SUBSET.md).
 
-The current HTTP execute/query and migration paths deliberately remain raw
-SQLite pass-through and call none of the parser, subset validator, statement
-classifier, placeholder normalizer, translator, shard-key inference, bound
-statement-planning, or prepared-lifecycle layers. Issues #19 through #27
-therefore change no HTTP shape, SQL acceptance, execution routing, or storage
-behavior. Rust callers can now invoke those layers together through the
-separate prepared API.
+HTTP execute/query has two explicit modes. An empty authoritative table catalog
+retains the legacy caller-routed raw SQLite path. Once any table is registered,
+the engine parses exactly one SQLite statement, validates the common subset,
+classifies behavior, normalizes placeholders, applies strict SQLite
+translation, infers catalog placement, and enforces a finite single-shard
+target. The journaled migration endpoint remains a separate parameterless
+exact-text SQLite batch whose SQL bytes define durable identity. Rust callers
+can also invoke the SQL layers directly or through the prepared API.
 
 ### Statement-classification boundary
 
@@ -281,12 +284,13 @@ normalized batch, and the selected statement's complete protocol-neutral
 `Value` slice. It resolves the accepted base table and cataloged shard-key type,
 then produces an owned `ShardKeyInference` classification and typed values.
 
-For `SELECT`, `UPDATE`, and `DELETE`, the layer proves finite key sets only from
-direct `Int64` or `Binary` shard-column equality and combines those sets through
-Boolean `AND` and `OR`. Non-null `Text` equality remains unconstrained until the
-catalog declares and physical schemas enforce comparison collation. For
-`INSERT`, inference examines the explicit shard-key column in every `VALUES`
-row and retains one value per row, including text values. The result
+For `SELECT`, `UPDATE`, and `DELETE`, the layer proves finite key sets from
+direct `Int64`, `Text`, or `Binary` shard-column equality and combines those
+sets through Boolean `AND` and `OR`. Authoritative registration requires a Text
+shard-key column to retain SQLite `BINARY` collation, so exact UTF-8 equality is
+safe to route without Unicode normalization or case folding. For `INSERT`,
+inference examines the explicit shard-key column in every `VALUES` row and
+retains one value per row, including text values. The result
 distinguishes statements that are not applicable, known non-sharded tables,
 unconstrained predicates, contradictions, one exact key, and multiple keys.
 
@@ -440,6 +444,12 @@ exact journal prefix during recovery. The full input encodings and state
 invariants are frozen in the
 [manifest storage format](STORAGE_FORMAT.md).
 
+Version 8 makes newly registered `briskdb_tables` rows authoritative. Its new
+downgrade fence prevents a v7 binary from treating those rows as advisory. The
+v7-to-v8 transaction clears all legacy advisory table rows, reseals the
+manifest, and preserves routing, logical databases, migration history, shard
+schema, and application data.
+
 Each manifest version retains an intentionally incompatible
 `briskdb_metadata` definition and row as a downgrade fence. The v3-to-v4
 migration remains manifest-atomic. The v4-to-v5 step first validates the v4
@@ -455,8 +465,10 @@ The v5-to-v6 step is manifest-only: it preserves layout state, routing, logical
 metadata, and data while rebuilding the schema-generation constraint, creating
 an empty journal, and fencing v5 readers. The v6-to-v7 step is also
 manifest-only and begins in `Verifying`; it cannot manufacture a historical
-checksum that v6 never stored. There is no automatic downgrade; an older binary
-requires a backup from before the newer format.
+checksum that v6 never stored. The v7-to-v8 step is likewise manifest-only and
+clears advisory table rows before installing the authoritative-catalog fence.
+There is no automatic downgrade; an older binary requires a backup from before
+the newer format.
 
 Startup first canonicalizes the data-directory path and joins the process-wide
 root coordination keyed by that path. It acquires the shared schema gate before
@@ -470,9 +482,9 @@ Manifest loading then acquires `BEGIN IMMEDIATE` before making a format
 migration or layout-state decision. Numbered manifest-only steps rewrite
 schema/data, stamp and read back their target identity/version, validate the
 destination, and commit in their own transaction. An `Applying` v6 migration is
-finished under v6 rules before v7 establishes checksum authority. An active v7
-migration is resumed only after every shard matches the preserved source or
-target fingerprint for its exact journal-prefix position.
+finished under v6 rules before v7 establishes checksum authority. An active
+checksum-authoritative migration is resumed only after every shard matches the
+preserved source or target fingerprint for its exact journal-prefix position.
 
 Layout reconciliation then acquires a new immediate manifest transaction,
 re-reads and validates the layout state under that write lock, and holds the
@@ -507,33 +519,67 @@ coordinator publishes a newly committed generation into that snapshot only
 after every shard verifies. `Database::catalog()` and `Engine::catalog()` expose
 the logical portion as a read-only `Catalog` with lookup accessors.
 
-The logical catalog remains advisory: there is no catalog mutation API,
-planner integration, or schema enforcement yet. Fresh manifests and upgrades
-originating before v4 contain no table rows; a v4-to-v5 upgrade retains every
-validated v4 logical-catalog row. Schema migration does not inspect, infer, or
-mutate `briskdb_tables`; instead, v7 independently requires the exact
-`sqlite_schema` fingerprint to agree across shards without claiming the
-advisory catalog describes it. Existing tables remain reachable through the
-explicit-key execute/query surfaces. Core
-routing still hashes the exact caller-provided key bytes, derives a versioned
-virtual bucket, and reads the final physical shard from the snapshot without
-querying SQLite. The generation-1 ranges reproduce prior modulo placement for
-every supported initial shard count, including counts that do not divide 4,096.
-Version-5 adoption adds only BriskDB identity metadata to legacy shards and
-preserves their application schema and data. It changes no SQL planning, HTTP
-shape, or routing result.
+`Database::register_tables` is the sole logical-catalog mutation boundary. It
+is an initialization-only operation over an empty catalog and requires one
+exclusive live owner for the canonical root. The complete declaration set must
+exactly match the empty application tables on every shard: each physical table
+is `Sharded` or `Global`, each `Catalog` declaration remains manifest-only, and
+every sharded key is a visible, physically non-null column with compatible
+SQLite affinity. The non-null `INTEGER PRIMARY KEY` rowid alias is accepted,
+but SQLite's nullable legacy primary-key forms are not. Text keys must use
+SQLite `BINARY` collation. Application foreign keys, triggers, and virtual
+tables are temporarily rejected. Every primary or unique key on a sharded
+table must contain the shard-key column with `BINARY` collation, which keeps
+that constraint's complete equality domain on one owner. The coordinator
+validates physical state before opening an immediate manifest transaction,
+assigns deterministic table IDs, reseals the semantic root, revalidates, and
+atomically publishes the replacement snapshot. An exact repeat is idempotent;
+any other replacement is rejected.
+
+The registration guard changes admission to `Pending` before manifest commit.
+If SQLite reports an ambiguous commit cleanup or I/O failure, the registering
+handle deliberately keeps its old catalog and cannot serve ordinary work. The
+operator must close that stale handle and reopen the canonical root so startup
+can determine whether the old or complete new catalog committed; a live stale
+handle prevents a conflicting durable catalog from being published in-process.
+
+Once registered, table placement is authoritative. A `Sharded` row has exactly
+one owner selected by its canonical key; only `Global` data is intentionally
+replicated, and `Catalog` data is not an application-shard table. Registration
+accepts only empty physical tables, so it cannot bless or repartition existing
+duplicates. Every later schema-migration preflight must preserve the exact
+registered table set on all shards and each sharded key's required column and
+affinity and `BINARY` Text collation. It also preserves one-owner unique keys
+and the temporary foreign-key, trigger, and virtual-table restrictions before a
+journal can be published.
+
+Core routing still hashes the exact key bytes, derives a versioned virtual
+bucket, and reads the final physical shard from the snapshot without querying
+SQLite. The generation-1 ranges reproduce prior modulo placement for every
+supported initial shard count, including counts that do not divide 4,096.
+Point reads and writes can therefore target one owner. Unpinned logical reads
+still require the bounded shard `UNION ALL`/scatter and merge work in issues
+#57 and #58; catalog registration does not make that execution path complete.
+The existing admin browser remains an explicit physical-shard diagnostic.
+Version-5 adoption preserves legacy application schema and data and does not
+implicitly register it.
 
 The storage-owned `briskdb_shard_metadata` table is inaccessible through client
 SQL, and creation of new objects in the reserved `briskdb` or `briskdb_*`
 namespaces is
 denied by the SQLite authorizer. Client attempts to mutate `application_id`,
 `user_version`, persistent `journal_mode`, `schema_version`, or
-`writable_schema` are also denied. This prevents a pass-through statement from
+`writable_schema` are also denied. This prevents client SQL from
 invalidating the validated layout. Ordinary routed SQL also denies every
 persistent DDL action. The journaled migration connection is the sole exception:
-it allows main-schema DDL and DML, including `ALTER TABLE`, inside BriskDB's
-transaction while denying transaction escape, attachments, temporary/virtual
-objects, and reserved-state access. Because SQLite does not reveal an
+it allows main-schema DDL, including `ALTER TABLE`, inside BriskDB's transaction
+while denying transaction escape, attachments, temporary/virtual objects, and
+reserved-state access. Before registration, its legacy batch may also contain
+DML. With a populated authoritative catalog, an additional parser gate rejects
+row-moving DML, `CREATE TABLE AS SELECT`, `DROP TABLE`, and `CREATE TRIGGER`;
+postflight validation also rejects any resulting trigger, virtual table,
+foreign key, invalid unique key, or placement/key change. Because SQLite does
+not reveal an
 `ALTER TABLE ... RENAME TO` destination to the authorizer, the coordinator also
 compares the reserved schema before and after the batch. The exact format,
 numeric codes, downgrade policy, recovery cases, and tests are documented in
@@ -622,9 +668,15 @@ for the same canonical root share the gate and live catalog publication.
 Separate server processes for one data directory are unsupported; the gate is
 not a distributed coordination mechanism.
 
-After every-shard preflight succeeds, the coordinator records the exact SQL and
-its BLAKE3 identity, then visits shards in ascending order. One shard's complete
-batch and target `user_version` commit atomically, followed by a separate
+Every-shard preflight executes the complete batch inside a rollback-only
+transaction. When the authoritative table catalog is populated, that tentative
+schema must still contain exactly its declared physical tables, compatible
+sharded keys, `BINARY` Text collation, and one-owner unique constraints, with no
+application foreign key, trigger, or virtual table. The catalog-aware migration
+gate also rejects row-moving DML, table drops, and trigger creation before
+preflight. Only after all preflights succeed does the coordinator record the
+exact SQL and its BLAKE3 identity, then visit shards in ascending order. One
+shard's complete batch and target `user_version` commit atomically, followed by a separate
 manifest prefix update. There is no cross-shard transaction. Recovery accepts
 the committed prefix plus the single possible shard commit whose acknowledgement
 was interrupted, and never skips ahead. Finalization marks the retained row
@@ -637,8 +689,9 @@ events identify operations that can persist connection-local state, including
 transaction and savepoint control, `PRAGMA`, `ATTACH`/`DETACH`, and temporary
 objects. BriskDB-owned metadata access and storage-control PRAGMA mutations are
 always denied. Other connection-local operations remain allowed under the
-current one-call SQLite pass-through behavior, but that behavior is
-uncontracted. Clean read handles may cross sessions for ordinary statements.
+empty-catalog one-call SQLite pass-through behavior, but that behavior is
+uncontracted and is outside the populated-catalog common subset. Clean read
+handles may cross sessions for ordinary statements.
 The pool retains the first session associated with each physical handle; an
 ordinary foreign read does not relabel that history. Before a routed statement
 uses such a foreign handle, the engine prepares it under a deny-only authorizer

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -248,6 +248,14 @@ no new error kind, retains no failed parameters, and does not change protocol
 mappings. See the [bound statement-planning and routing-policy
 contract](SQL_PLANNING.md).
 
+Populated-catalog raw execute/query preserves those frontend and planner kinds.
+It adds `InvalidArgument` when the request is not exactly one top-level
+statement, `InvalidQuery` when logical read/write behavior does not match the
+chosen endpoint, `PermissionDenied` for Catalog placement, and `Unsupported`
+for schema/session behavior, Global writes, or a sharded read/write without one
+finite executable owner. An undeclared table remains `InvalidQuery`. Empty
+catalogs retain the legacy SQLite error boundary instead of this catalog gate.
+
 The prepared lifecycle preserves each earlier frontend/planner kind. Prepare
 adds `InvalidArgument` for an unknown logical database and for anything other
 than exactly one top-level statement, `LimitExceeded` for a full session
@@ -329,6 +337,33 @@ retain the normal SQL classification, and attempts to reach the reserved
 BriskDB schema or storage controls are `PermissionDenied`. The public problem
 detail never includes the retained SQL.
 
+With a populated authoritative catalog, row-moving DML,
+`CREATE TABLE ... AS SELECT`, `DROP TABLE`, `CREATE TRIGGER`, or a final schema
+containing an application foreign key, trigger, virtual table, invalid
+primary/unique key, or changed placement/key invariant is
+`FailedPrecondition` before journal publication.
+
+Manifest v8 table registration reports malformed, empty, duplicate, or
+unknown-database declarations as `InvalidArgument` and an oversized catalog as
+`LimitExceeded`. A nonempty physical table, an incomplete or differing physical
+table set, a catalog-table shadow, an invalid sharded key or Text collation, a
+sharded primary/unique key without its `BINARY` shard-key term, any application
+foreign key, trigger, or virtual table, another live owner, or an attempted
+replacement of an already populated catalog is `FailedPrecondition`. The same
+complete declaration set is idempotent. Schema SQL that would violate a
+populated authoritative catalog is also `FailedPrecondition` before a journal
+or shard mutation is published.
+
+Registration changes schema admission to `Pending` immediately before the
+manifest commit attempt. A commit cleanup/I/O error retains its precise storage
+kind; a later in-process publication failure is `Internal`. Either can be
+durability-ambiguous, so ordinary operations on the registering handle return
+`FailedPrecondition`. If the complete catalog committed, another open while the
+stale handle remains live also returns `FailedPrecondition` rather than exposing
+two catalog snapshots. Close the stale handle and reopen the data root to
+reconcile old versus new durable state; do not retry registration through that
+pending handle.
+
 Shard-layout validation follows the same distinction. A foreign shard
 application ID, unexpected canonical four-digit `.sqlite` shard file or
 symbolic link, persistent journal mode other than WAL, or shard generation
@@ -347,7 +382,9 @@ serialized directly by an adapter.
 The earlier taxonomy change affected reporting only. Manifest v5 later added
 identity metadata to shard files, manifest v6 added retained crash-resumable
 application-schema history, and manifest v7 added semantic and schema
-fingerprints plus explicit integrity state. Their format upgrades preserve
+fingerprints plus explicit integrity state. Manifest v8 clears unproved v7
+advisory table rows and adds authoritative initialization registration. These
+format upgrades preserve
 legacy application tables, rows, routing, SQL results, and wire configuration.
 
 This is a pre-1.0 Rust API migration: public `Database` operations now return

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -24,10 +24,11 @@ available behind BriskDB-owned types.
 Validation is explicit and returns `Unsupported` for a parsed form outside the
 subset; parser acceptance alone is not product support. Translation,
 classification, normalization, inference, bound planning, and routing policy
-are also explicit.
-The current experimental HTTP interface is still a raw SQLite pass-through and
-can execute uncontracted SQLite syntax because it calls none of these layers.
-That behavior is not a compatibility promise.
+are also explicit APIs. HTTP execute/query retains raw SQLite pass-through only
+while the authoritative table catalog is empty. Once any table is registered,
+the same endpoints compose those SQLite-mode layers and enforce the committed
+placement catalog. The empty-catalog behavior is a legacy compatibility
+boundary, not a promise for registered databases.
 
 ## Compatibility layers
 
@@ -78,14 +79,17 @@ protocol-neutral prepared lifecycle composes these SQL stages for exactly one
 statement, exposes retained behavior in description metadata, binds typed
 values into a session-scoped portal, refreshes stale description metadata,
 plans freshly at every execution, and executes supported physical targets.
-HTTP requests still send caller-provided SQLite SQL directly to the raw engine
-path; they do not pass through these opt-in SQL layers.
+HTTP requests still send caller-provided SQLite SQL to the engine. With an empty
+catalog it follows the legacy raw path. With a populated catalog, the engine
+requires exactly one common-subset SQLite statement and runs normalization,
+strict translation, classification, inference, and routing policy before
+SQLite execution.
 
 | Interface | Status | SQL accepted | Routing |
 | --- | --- | --- | --- |
-| HTTP `/v1/execute` | Experimental | One SQLite statement with positional parameters | Required caller-provided `shard_key` |
-| HTTP `/v1/query` | Experimental | One raw SQLite statement prepared transiently by the row-returning path; no session cache | Required caller-provided `shard_key` |
-| HTTP `/v1/admin/broadcast` | Experimental | A journaled parameterless SQLite schema batch | Preflight on every shard, then ascending resumable apply |
+| HTTP `/v1/execute` | Experimental | Empty catalog: legacy SQLite statement. Populated catalog: exactly one SQLite common-subset write with normalized positional parameters and strict SQLite translation | Required caller `shard_key`; a populated catalog also requires authoritative finite single-shard inference and rejects Global/Catalog writes |
+| HTTP `/v1/query` | Experimental | Empty catalog: legacy raw SQLite query. Populated catalog: exactly one SQLite common-subset read; no session cache | Required caller `shard_key`; a populated catalog reads Global data on shard 0, denies Catalog/undeclared tables, and requires one sharded owner |
+| HTTP `/v1/admin/broadcast` | Experimental | A journaled parameterless SQLite schema batch; populated catalogs reject row-moving DML, table drops, and trigger creation | Preflight on every shard, then ascending resumable apply |
 | HTTP `/admin` browser | Experimental, read-only | No caller SQL; server-generated physical table discovery, exact all-shard physical `COUNT(*)`, and bounded `SELECT *` pages | Pages require a validated physical shard; the specialized count fans out with bounded concurrency but is not a general scatter-query surface |
 | PostgreSQL wire protocol | Protocol-3.0 startup/session only on loopback; SQL flow deferred | No SQL accepted over the wire; simple `Query` and extended `Parse` return fixed `0A000` responses | Startup selects an exact logical database; no wire SQL request reaches planning or routing |
 | MySQL wire protocol | Planned | Rust parsing, validation, classification, placeholder normalization, finite compatibility translation, and prepared lifecycle implemented; listener adoption planned | Core batch/write policy, bind validation, routing snapshots, current execute-time planning, and supported target execution implemented; wire mapping planned |
@@ -95,8 +99,9 @@ translator, shard-key inference function, engine planner, and prepared
 lifecycle are implemented Rust APIs, not PostgreSQL or MySQL query interfaces.
 PostgreSQL production startup connects only identity, catalog selection,
 status, and session cleanup; the historical private issue-29 parser probe does
-not make that prepared pipeline public wire behavior. These changes do not
-alter any HTTP row in this table.
+not make that prepared pipeline public wire behavior. Authoritative table
+registration composes the SQLite frontend and planner into the existing HTTP
+execute/query rows as described above; it adds no HTTP field or route.
 
 Every HTTP database operation now calls the same protocol-neutral async engine
 used by PostgreSQL startup status and intended for issue-31 PostgreSQL SQL flow
@@ -115,8 +120,8 @@ compatibility mode. The browser never submits SQL. Its overview selects one
 physical shard from the configured range and discovers ordinary `main`-schema
 tables through SQLite's typed `table_list` metadata. ASCII-case-insensitive `sqlite_`,
 the exact name `briskdb`, and `briskdb_` prefixes are excluded, as are non-table
-objects. This is a physical schema view, not a promise that advisory logical
-catalog metadata describes the table or that another shard has an equal table.
+objects. This is a physical schema view, not the authoritative logical-catalog
+view and not a promise that another shard contributes the same rows.
 
 Row browsing generates one safely quoted `SELECT *` for a table returned by
 discovery. Page limits are 1 through 200 and offsets are 0 through 1,000,000;
@@ -152,7 +157,8 @@ migration drains admitted ordinary work and uses fresh coordinator-owned
 connections instead of reserving every shard pool.
 
 SQLite forms that can leave connection-local state remain allowed by the
-current one-call pass-through, but they are uncontracted. The pool observes
+empty-catalog one-call pass-through, but they are uncontracted and are outside
+the populated-catalog common subset. The pool observes
 transaction and savepoint control, `PRAGMA`, `ATTACH`/`DETACH`, and temporary
 objects and marks the connection tainted. A clean read handle can be reused by
 another session for ordinary SQL without transferring the handle's recorded
@@ -185,6 +191,11 @@ the journaled migration batch. That coordinator denies transaction/savepoint
 escape, attachments, temporary and virtual objects, and storage-owned state.
 SQLite reports the source table but not a `RENAME TO` destination, so BriskDB
 also compares the reserved schema before and after the migration transaction.
+When the authoritative catalog is populated, migration parsing additionally
+rejects `INSERT`, `UPDATE`, `DELETE`, `MERGE`, `TRUNCATE`,
+`CREATE TABLE ... AS SELECT`, `DROP TABLE`, and `CREATE TRIGGER`. Final
+rollback-only validation rejects application foreign keys, triggers, virtual
+tables, invalid unique keys, and any table-placement or shard-key change.
 
 SQLite also retains `last_insert_rowid()`, `changes()`, and `total_changes()` on
 the physical connection after ordinary writes. A write-bearing handle may be
@@ -224,10 +235,18 @@ comments, and casing are identity-significant. Completed journal rows and their
 exact SQL remain in the manifest, so callers must not include credentials or
 other sensitive literals. A byte-identical retry of completed SQL is
 idempotent and does not advance the schema generation again.
-The migration does not infer or update advisory `briskdb_tables` rows. Richer
-migration/history APIs remain issue #53. Manifest v7 independently requires a
-generation-bound persistent-schema fingerprint to agree across every shard; it
-does not claim the advisory catalog describes that schema.
+The migration does not infer or update `briskdb_tables` rows. When the
+authoritative catalog is populated, however, every tentative shard schema must
+still contain exactly the declared `Sharded` and `Global` tables, no physical
+`Catalog` table, and each sharded key with its required column, affinity, and
+`BINARY` Text collation. Every sharded primary/unique key must still include the
+shard key with `BINARY` collation, and application foreign keys, triggers, and
+virtual tables remain prohibited. Row-moving DML, table drops, and trigger
+creation are rejected before this rollback-only check. A violation fails
+preflight before journal publication. Richer
+migration/history APIs remain issue #53. Manifest v8 retains the v7
+generation-bound persistent-schema fingerprint requirement in addition to this
+catalog enforcement.
 
 The schema gate admits no new routed work after migration begins and waits for
 previously admitted operations to drain. During active preflight or apply,
@@ -244,9 +263,10 @@ is reconciled from the retained journal prefix.
 Use SQLite positional placeholders such as `?1` and `?2`. Values are never
 interpolated into SQL text. The HTTP adapter converts JSON parameters into
 protocol-neutral BriskDB values; the SQL layer binds only those typed values.
-This existing execution-time binding is separate from the opt-in
-`normalize_placeholders(CommonSql)` Rust API: the HTTP adapter neither invokes
-that function nor changes the caller's SQL marker text.
+An empty catalog binds the caller's SQLite markers on the legacy path. A
+populated catalog runs `normalize_placeholders(CommonSql)` and executes its
+strict translated `?N` SQL; named SQLite markers accepted by the legacy path
+are therefore not part of the registered-catalog contract.
 
 | JSON input | SQLite binding |
 | --- | --- |
@@ -398,28 +418,29 @@ contract](SQL_PREPARED_STATEMENTS.md) defines the composed exact-one-statement
 lifecycle, session limits, metadata, routing snapshots, current execution
 planning, and supported physical targets.
 
-### Implemented pass-through surface
+### Implemented HTTP SQLite surface
 
-The following operations work when expressed in syntax accepted by the bundled
-SQLite library and used through the matching HTTP endpoint:
+The following operations work through the matching HTTP endpoint. “Legacy”
+below means the authoritative table catalog is empty; registered databases use
+the bounded catalog-aware path.
 
 | Operation | Current contract | Important boundary |
 | --- | --- | --- |
-| Persistent DDL, including `CREATE`, `DROP`, and `ALTER` | Execute only through the migration/broadcast endpoint | Per-shard atomic and crash-resumable; not atomic across shards |
-| `INSERT`, `UPDATE`, `DELETE` | Execute on the shard selected by `shard_key` | BriskDB does not yet prove that SQL values match the supplied key |
-| `SELECT` | Query the shard selected by `shard_key` | No scatter/gather path |
-| SQLite expressions and functions | Passed through without translation | Semantics are SQLite semantics |
-| SQLite constraints | Enforced inside one shard | No global unique-constraint coordinator |
+| Persistent DDL, including `CREATE`, `DROP`, and `ALTER` | Execute only through the migration/broadcast endpoint | Per-shard atomic and crash-resumable; with a populated catalog, row-moving DML, table drops, trigger creation, and any final catalog violation are rejected |
+| `INSERT`, `UPDATE`, `DELETE` | Legacy: caller-selected shard. Registered: exactly one inferred owner, compatible with the caller route | Inserts prove every row key; shard-key updates and multi-owner writes are rejected |
+| `SELECT` | Legacy: caller-selected shard. Registered: one inferred sharded owner, Global shard 0, or table-free shard 0 | No scatter/gather path; unconstrained and multi-owner reads are rejected |
+| SQLite expressions and functions | Legacy syntax may pass through; registered execution accepts only the common subset and strict SQLite translation | Executed semantics remain SQLite semantics |
+| SQLite constraints | SQLite enforces each accepted constraint in one shard | Every sharded `PRIMARY KEY`/`UNIQUE` key includes the `BINARY` shard key, so all possible collisions have one owner; no independent global reservation service exists |
 
-Other SQLite syntax may happen to pass through, but it is not a stable BriskDB
-contract until it appears in this table and has conformance tests. In
+Other SQLite syntax may happen to pass through only on the empty-catalog legacy
+path and is not a stable BriskDB contract. In
 particular, multi-request transactions, multi-shard writes, multiple statements
 outside the migration endpoint, and attached-database operations are
 uncontracted public API behavior today. Persistent DDL outside the migration
 endpoint is explicitly denied. DML `RETURNING` is explicitly rejected from the
 query surface, and the execute surface exposes only a rows-affected count,
-never a returned rowset. The experimental raw HTTP path uses those same engine
-boundaries.
+never a returned rowset. Both empty- and populated-catalog HTTP modes use those
+same engine boundaries.
 
 The current `Session` `Ready`/`Closed` lifecycle is not a transaction state
 machine. Real `BEGIN`/`COMMIT`/`ROLLBACK`, failed-transaction behavior, and
@@ -456,9 +477,11 @@ forms are outside this first subset. The exact clause, expression, constraint,
 name, and diagnostic rules are normative in
 [the common SQL subset contract](SQL_SUBSET.md).
 
-This implemented status means structural validation exists and is tested. It
-does not mean the subset is connected to execution. Column type names need only
-be explicit at validation; the separate compatibility translator applies its
+This implemented status means structural validation exists and is tested. The
+subset is connected to prepared execution and populated-catalog HTTP
+execute/query, but remains directly callable analysis and is not the
+empty-catalog or migration contract. Column type names need only be explicit at
+validation; the separate compatibility translator applies its
 finite dialect-specific declaration whitelist. Insert/update duplicate checks
 fold ASCII letter case regardless of quoting. Compatibility translation
 canonicalizes accepted backtick-quoted identifiers, but does not define general
@@ -533,8 +556,9 @@ This implemented normalization does not bind or count supplied values, infer a
 shard, translate other dialect syntax, create a prepared statement, classify
 statement behavior, authorize a request, or execute SQL by itself. Translation
 is the separate opt-in layer described next. The prepared lifecycle composes
-both layers, while the raw HTTP paths continue to bind caller-supplied SQLite
-SQL directly.
+both layers. Populated-catalog HTTP execute/query also runs normalization before
+strict SQLite translation; empty-catalog HTTP and the migration identity path
+retain their separate legacy/exact-text behavior.
 
 ### Implemented SQL translation
 
@@ -570,21 +594,22 @@ placement and a sharded table's key column/type. Its owned result distinguishes
 not-applicable, non-sharded, unconstrained, contradictory, exact, and multiple
 key outcomes and exposes typed integer, text, or binary values.
 
-For `SELECT`, `UPDATE`, and `DELETE`, direct equality against an `Int64` or
-`Binary` shard-key column produces a finite key set; Boolean `AND` intersects
-and `OR` unions those proofs. Non-null `Text` equality remains unconstrained
-because the current catalog does not declare or enforce comparison collation.
+For `SELECT`, `UPDATE`, and `DELETE`, direct equality against an `Int64`, `Text`,
+or `Binary` shard-key column produces a finite key set; Boolean `AND` intersects
+and `OR` unions those proofs. Authoritative registration requires Text keys to
+use SQLite `BINARY` collation, so inference compares their exact UTF-8 bytes
+without case folding or Unicode normalization.
 Other predicates do not establish a key. For `INSERT`, every `VALUES` row's
 explicit shard-key cell must be a compatible direct literal or placeholder to
 produce a complete result, and one value per row is retained, including text
 values. The exact identifier, value, result, and error rules are in [shard-key
 inference](SQL_SHARD_KEYS.md).
 
-Inference does not encode, hash, route, plan, authorize, enforce, or execute.
-The implemented planner described below uses the result at bind/execute time to
-construct routes, validate physical-target compatibility, and reject
-unroutable sharded DML. The raw HTTP execution paths do not invoke inference or
-that policy.
+Inference by itself does not encode, hash, route, plan, authorize, enforce, or
+execute. The implemented planner described below uses the result at
+bind/execute time to construct routes, validate physical-target compatibility,
+and reject unroutable sharded DML. Prepared execution and populated-catalog HTTP
+execute/query invoke that policy; the empty-catalog legacy path does not.
 
 ### Implemented bound statement planning
 
@@ -740,28 +765,44 @@ underlying execution semantics.
 
 ### Current
 
-- The caller supplies an opaque `shard_key` independently from the SQL text.
+- HTTP continues to require an opaque caller `shard_key`. With an empty catalog
+  it alone selects the shard; with a populated catalog it is retained as an
+  explicit route and must agree by physical shard with finite SQL inference.
 - Exact key bytes are hashed with version-1 BLAKE3; the little-endian 64-bit
   prefix selects one of 4,096 virtual buckets through the versioned
   compatibility algorithm.
 - The final physical shard is read from the validated, generation-stamped
-  bucket map retained in manifest version 7. Routing generation 1 preserves
+  bucket map retained in manifest version 8. Routing generation 1 preserves
   the earlier modulo placement for every supported shard count.
-- Manifest version 7 retains the read-only logical catalog introduced in v4,
-  with a journaled schema generation from 0 through 2,147,483,647 and default
-  database ID 1 named `default`. Its optional table rows can describe sharded,
-  global, or catalog placement and a sharded table's `Int64`, text, or binary
-  key column.
+- Manifest version 8 retains the read-only catalog view introduced in v4, with
+  a journaled schema generation from 0 through 2,147,483,647 and default
+  database ID 1 named `default`. `Database::register_tables` may populate its
+  table rows exactly once during initialization after proving that every shard
+  has the same complete, empty physical table set. A sharded declaration names
+  one visible, physically non-null `Int64`, text, or binary key column; the
+  `INTEGER PRIMARY KEY` rowid alias qualifies, but nullable legacy primary-key
+  forms do not. Text keys must use SQLite `BINARY` collation. Application
+  foreign keys, triggers, and virtual tables are temporarily unsupported, and
+  every sharded primary/unique key must contain the shard key with `BINARY`
+  collation.
+- Registration changes schema admission to `Pending` before manifest commit.
+  If commit reports an ambiguous cleanup or I/O error, close the stale
+  registering handle and reopen the data root so startup can determine whether
+  the old or complete new catalog committed. A live stale handle deliberately
+  prevents publication of a conflicting durable catalog.
 - The ready layout retained from v5 binds every shard to one random 16-byte
   layout ID and its
   physical shard ID. Each connection is opened without create or symlink
   following and must match the `BRSH` application ID, expected schema
   generation, exact metadata, and existing WAL mode.
-- Logical metadata is currently read-only and advisory. Fresh manifests and
-  upgrades originating before v4 contain no table rows; v4-to-v5 retains every
-  validated v4 logical-catalog row. Existing physical tables are not inferred
-  or adopted. The opt-in Rust inference and planning/policy APIs can consult
-  catalog contents, but they do not alter current HTTP routing or execution.
+- Present version-8 table metadata is authoritative. `Sharded` means each
+  ordinary row has exactly one key-selected physical owner; `Global` is the
+  explicit replicated placement; `Catalog` is manifest-only. The v7-to-v8
+  upgrade clears legacy advisory rows rather than promoting them, and existing
+  physical tables are never inferred or adopted. Registration requires empty
+  tables and does not repartition existing data. The opt-in Rust APIs,
+  prepared execution, and populated-catalog HTTP execute/query all consult the
+  same catalog; only an empty catalog retains caller-key-only routing.
 - Opt-in inference can extract typed cataloged keys from supported equality
   predicates and every row of a supported `INSERT`.
 - Opt-in bound planning converts every inferred occurrence to an owned route,
@@ -771,20 +812,26 @@ underlying execution semantics.
 - The Rust prepared lifecycle snapshots bound values and session routing in an
   immutable portal, transiently validates at bind, plans on every execution,
   executes accepted sharded targets, and uses shard 0 for supported
-  replicated-schema reads. It does not change current HTTP behavior or
-  implement scatter reads.
-- Point queries and writes visit only that shard.
-- No scatter/gather query path exists.
-- Unique constraints and transactions are local to one SQLite shard.
+  replicated-schema reads. Populated-catalog HTTP uses the same routing policy
+  without a prepared cache. Neither path implements scatter reads.
+- Point queries and writes visit only that key's owning shard.
+- No general scatter/gather query path exists. Logical unpinned reads still
+  require the shard `UNION ALL`/scatter and merge work in issues #57 and #58.
+- SQLite transactions remain local to one shard. Registration accepts a
+  sharded primary/unique key only when it contains the `BINARY` shard-key term,
+  ensuring every possible collision is checked by one owning SQLite file.
 - Schema migration preflights every shard, then commits an ascending prefix
   under a retained journal. Each shard is atomic; the shard set is not one
   transaction. The manifest preserves committed-source and target schema
   fingerprints, and startup resumes only an exact checksummed prefix before
-  serving work.
+  serving work. Once tables are registered, preflight also rejects a migration
+  that changes the complete physical table set or a sharded key's required
+  column, affinity, or Text collation; creates row-moving DML, drops a table, or
+  creates a trigger; introduces a foreign key, trigger, or virtual table; or
+  breaks one-owner unique-key locality.
 
 ### Planned stable contract
 
-- Every sharded table declares one non-null shard-key column in the catalog.
 - Canonical key encoding, hash version, virtual bucket count, and bucket map are
   persisted in the manifest.
 - A transaction is pinned to its first shard. Targeting another shard returns a
@@ -792,9 +839,9 @@ underlying execution semantics.
 - Read-only plans may scatter with bounded concurrency and deterministic merge.
 - Cross-shard writes remain unsupported unless a future coordinator can prove
   its crash semantics.
-- Global uniqueness is unsupported unless backed by an explicit reservation
-  design; shard-local uniqueness must include the shard key when applications
-  require system-wide uniqueness by construction.
+- A future reservation design is required for a unique key that intentionally
+  omits the shard key. The current registration contract rejects that shape
+  instead of exposing shard-local duplicates as logical uniqueness.
 
 ## Transactions and concurrency
 
@@ -806,10 +853,11 @@ reject cross-shard access.
 Manifest-format migrations are separate from application SQL migrations. They
 run internally during storage open, are transactional only within
 `manifest.sqlite`, and cannot be requested through any protocol or SQL
-statement. The atomic version-3-to-version-4 manifest upgrade adds only
-read-only advisory logical metadata and its downgrade fence. It does not infer
-or adopt existing physical tables and does not change shard schemas, supported
-SQLite syntax, result conversion, or routing. Version 5 then adds a resumable
+statement. The atomic version-3-to-version-4 manifest upgrade added advisory
+logical metadata and its downgrade fence. Version 8 clears any surviving v7
+advisory table rows, installs a stronger downgrade fence, and allows a later
+initialization-only registration to establish authoritative placement. Neither
+upgrade infers, adopts, or repartitions physical rows. Version 5 added a resumable
 physical-layout state machine. Its `Adopting` path accepts only exact legacy
 zero-header WAL shards, preserves their tables and rows, and adds BriskDB
 identity metadata. Version 6 adds the application-schema journal. A migration
@@ -819,6 +867,8 @@ those files. Ascending-prefix validation and replay provide recovery rather
 than cross-file atomicity. Version 7 adds the semantic manifest root, explicit
 integrity states, and generation-bound shard-schema fingerprints; journal,
 state, checksum, and catalog changes reseal atomically within the manifest.
+Version 8 retains those integrity rules and includes authoritative table
+registration in the same semantic root.
 See the [manifest storage-format contract](STORAGE_FORMAT.md).
 
 Scatter reads will combine committed results from multiple SQLite files. They

--- a/docs/SQL_PARAMETERS.md
+++ b/docs/SQL_PARAMETERS.md
@@ -18,11 +18,12 @@ public SQLite parameter-index ceiling is `MAX_SQL_PARAMETERS`, currently
 
 This layer changes placeholder tokens only. No parameter values enter the
 normalizer, and values are never rendered or interpolated into SQL text. The
-current HTTP execute, query, and migration endpoints do not invoke this opt-in
-layer; they retain their existing raw SQLite behavior. The asynchronous
-prepared lifecycle does invoke it and requires exactly one statement before it
-creates a prepared handle. Before consuming `CommonSql`, callers can borrow it
-with the implemented [statement/batch
+asynchronous prepared lifecycle invokes it and requires exactly one statement
+before it creates a prepared handle. Populated-catalog HTTP execute/query also
+invokes it after requiring exactly one SQLite common-subset statement; an empty
+catalog alone retains legacy raw marker binding. The journaled migration path
+keeps its parameterless exact-text identity and does not normalize its batch.
+Before consuming `CommonSql`, callers can borrow it with the implemented [statement/batch
 classifier](SQL_STATEMENT_CLASSIFICATION.md). That separate layer owns general
 empty and multi-statement request policy.
 
@@ -193,6 +194,7 @@ anonymous SQLite markers, per-statement reset, empty and marker-free input,
 exact preservation of comments/literals/whitespace/UTF-8, zero,
 exact-maximum, and over-maximum index cases, named SQLite rejection, diagnostic
 and `Debug` redaction, cloning, concurrent normalization, and recovery after an
-independent error. A raw HTTP regression must continue to bind SQLite named
-parameters without calling this layer, proving that issue #21 did not change
-current execution behavior.
+independent error. HTTP regressions prove that an empty catalog continues to
+bind legacy SQLite named parameters without this layer, while a populated
+catalog invokes normalization and rejects named SQLite markers outside its
+positional registered-data contract.

--- a/docs/SQL_PARSER.md
+++ b/docs/SQL_PARSER.md
@@ -9,8 +9,9 @@ defines that boundary. The separate [common SQL subset contract](SQL_SUBSET.md)
 defines the opt-in structural validator, and the [SQL parameter-normalization
 contract](SQL_PARAMETERS.md) defines the opt-in dialect-specific placeholder
 rewrite. The [SQL translation contract](SQL_TRANSLATION.md) defines the
-implemented opt-in strict and finite compatibility modes. None of these layers
-is in the current HTTP execution path.
+implemented opt-in strict and finite compatibility modes. Prepared execution
+and populated-catalog HTTP execute/query compose these layers; empty-catalog
+HTTP retains the legacy raw SQLite path.
 
 ## Decision
 
@@ -87,14 +88,15 @@ particular surface accepts one statement or a combination is decided by the
 statement is a read. The subset validator first checks each ordered statement
 independently and returns `Unsupported` for a parsed form outside its contract.
 
-The existing HTTP execute, query, and migration paths remain raw SQLite
-pass-through surfaces with their existing authorizer and endpoint-specific
-rules. They call neither this parser, the opt-in common-subset validator,
-statement classifier, placeholder normalizer, translator, shard-key inference,
-nor bound statement planner. The separate Rust
-[prepared lifecycle](SQL_PREPARED_STATEMENTS.md) now connects those layers for
-an exact-one-statement handle without changing the experimental HTTP SQL
-surface.
+HTTP execute/query retains raw SQLite pass-through only while the authoritative
+table catalog is empty. With a populated catalog, each request is parsed as
+SQLite, must contain exactly one statement, and continues through the common
+subset, classifier, normalizer, strict translator, inference, and planner. The
+separate Rust [prepared lifecycle](SQL_PREPARED_STATEMENTS.md) composes the same
+frontend for an exact-one-statement handle. The journaled migration endpoint
+keeps its own exact-text batch identity, but a populated catalog adds a parser
+gate that rejects row-moving DML, `CREATE TABLE ... AS SELECT`, `DROP TABLE`,
+and `CREATE TRIGGER` before rollback-only physical preflight.
 
 ## Resource and error boundaries
 
@@ -109,9 +111,10 @@ work:
 
 Empty, whitespace-only, and comment-only input successfully produces an empty
 AST. The general classifier later returns `InvalidArgument` for that empty AST;
-prepared statements apply their own exact-one check, while raw HTTP surfaces
-retain endpoint-specific rules. NUL input, malformed tokens, incomplete syntax,
-and other parse failures are `InvalidQuery`. A syntactically valid statement
+prepared statements and populated-catalog HTTP apply an exact-one check, while
+empty-catalog HTTP and migration retain their endpoint-specific rules. NUL
+input, malformed tokens, incomplete syntax, and other parse failures are
+`InvalidQuery`. A syntactically valid statement
 that is outside BriskDB's common subset is not a parse failure;
 `validate_common_subset` classifies it as `Unsupported`. Public protocol errors
 continue to use the fixed safe text for the error kind and must not serialize
@@ -172,6 +175,10 @@ in a subprocess so a future stack overflow or abort is observed as a failed
 test instead of terminating the test harness. The child must exit normally
 with the configured recursion-limit error.
 
+Authoritative-migration tests cover every row-moving top-level family,
+`CREATE TABLE ... AS SELECT`, table drop, and trigger creation, and prove that a
+schema-only batch remains admissible for later physical preflight.
+
 Structural tests must assert AST meaning for tricky statements rather than
 matching SQL substrings. Source review and dependency review must also confirm
 that BriskDB has no regular-expression parser or routing helper. A transitive
@@ -179,6 +186,8 @@ regular-expression crate elsewhere in `Cargo.lock` is not evidence of SQL
 routing; the architectural proof is that this layer returns structured syntax
 and makes no routing decision.
 
-This decision and the later opt-in subset validator change no HTTP request or
-response shape, routing result, configuration, manifest schema, shard file, or
-stored data.
+This parser decision by itself changes no HTTP request or response shape,
+configuration, manifest schema, shard file, or stored data. The later
+authoritative-catalog integration consumes its SQLite result for HTTP
+execute/query and can change routing or rejection according to committed table
+placement without changing the HTTP JSON shape.

--- a/docs/SQL_PLANNING.md
+++ b/docs/SQL_PLANNING.md
@@ -67,6 +67,14 @@ for a classified safe `NotApplicable` or `Global` read. It still rejects
 catalog placement and sharded reads that need scatter. That target-selection
 integration does not change this planner's meaning of `assigned_shard()`.
 
+Populated-catalog raw execute/query uses the same internal planning result after
+SQLite parsing, common-subset validation, placeholder normalization, and strict
+translation. It requires finite `Exact`/`Multiple` inference with one assigned
+owner for `Sharded` tables, uses shard 0 for supported Global or table-free
+reads, and rejects Catalog, undeclared, unconstrained, contradictory, and
+multi-owner targets. An empty catalog alone bypasses this composition and keeps
+the legacy caller-key route.
+
 `Debug` output reports identifiers, versions, shard IDs, and counts where
 useful. It does not render SQL, AST contents, inferred key values, explicit key
 bytes, or parameter values.
@@ -197,11 +205,22 @@ and routing snapshot remain authoritative by producing a new plan from the
 portal's owned values and route snapshot under every execution's fresh
 schema-operation guard. Bind uses its plan only for transient validation.
 
-The logical table catalog remains read-only and advisory. Planning does not
-assert that its table metadata describes an existing physical SQLite table or
-column. Prepared setup transiently compiles translated SQL against shard 0, but
-it does not reconcile advisory table rows with the physical schema or mutate
-the catalog.
+The logical table catalog is read-only to planning callers. In manifest version
+8, any populated table set was installed through initialization-only
+`Database::register_tables` after exact empty-schema validation, and later
+schema migrations must preserve those registered tables and sharded keys. Text
+keys are physically pinned to SQLite `BINARY` collation, so exact UTF-8 equality
+is a finite proof. Each accepted sharded primary/unique key contains that shard
+key, keeping every possible collision on one owner. An empty catalog means
+table placement has not been registered; physical tables are never inferred.
+Planning consumes the published snapshot and does not reopen or revalidate
+every shard on each call.
+
+For a registered `Sharded` table, every ordinary row belongs on exactly the one
+owner produced from its canonical key. Finite point plans can assign that
+owner. An unpinned or multi-owner read still remains unassigned here; executing
+it as a logical shard `UNION ALL` with bounded scatter and deterministic merge
+is follow-up work in issues #57 and #58, not part of catalog registration.
 
 ## Errors and recovery
 
@@ -248,8 +267,9 @@ path. In particular:
 
 - `Engine::plan_bound_statement` is synchronous and stateless; it neither
   accepts nor mutates a `Session`;
-- `assigned_shard()` is not consumed by the current raw HTTP execute/query
-  paths, but it is consumed by issue #26 portal execution;
+- `assigned_shard()` is consumed by prepared execution and by raw HTTP
+  execute/query when the authoritative catalog is populated; an empty catalog
+  retains legacy routing without a plan;
 - no read scatter, merge, contradiction short circuit, or write executes here;
 - no transaction pinning or cross-call routing context is applied;
 - this synchronous method creates no per-session or global cache; issue #26
@@ -260,8 +280,9 @@ path. In particular:
   session cache or `PreparedStatementLimits` to consult;
 - planning does not invoke the separate PostgreSQL/MySQL-to-SQLite translation
   layer;
-- the current HTTP execute, query, and migration paths do not invoke parsing,
-  validation, classification, normalization, inference, or planning.
+- the migration path does not substitute normalized or translated SQL for its
+  exact durable identity; populated-catalog execute/query does compose the
+  SQLite frontend and this policy, while empty-catalog execute/query does not.
 
 The implemented issue #25 translation API can independently consume the same
 normalized statement, but it neither changes nor executes a bound plan. The
@@ -284,5 +305,6 @@ redaction; policy-error retries; deterministic valid and rejected concurrent
 calls; schema-gate precedence and recovery; owned
 public results; selected behavior; empty, all-read, and rejected mutating batch
 policy; provenance; and equivalent SQLite, PostgreSQL, and MySQL typed requests.
-Raw HTTP regressions prove that opt-in planning still does not change existing
-execution behavior.
+HTTP regressions prove both boundaries: an empty catalog preserves legacy raw
+execution, while a populated catalog consumes the plan, enforces declared
+placement, and fails closed for unsafe or undeclared targets.

--- a/docs/SQL_PREPARED_STATEMENTS.md
+++ b/docs/SQL_PREPARED_STATEMENTS.md
@@ -418,7 +418,7 @@ interpolate values into SQL, or choose a physical shard itself.
 ## Storage-format boundary
 
 Issue #26 adds only process-memory session state and execution orchestration.
-It does not change manifest version 7, a manifest table, routing encoding,
+It does not change manifest version 8, a manifest table, routing encoding,
 shard identity, schema fingerprint, migration journal, SQLite header field,
 WAL/synchronous mode, or filename. Prepared statements and portals disappear
 when their owning process/session ends. Preparing or describing changes no

--- a/docs/SQL_SHARD_KEYS.md
+++ b/docs/SQL_SHARD_KEYS.md
@@ -76,7 +76,7 @@ assignments do not establish a routing key at this layer.
 
 The finite proof grammar is deliberately small:
 
-- direct equality between an `Int64` or `Binary` shard-key column and a
+- direct equality between an `Int64`, `Text`, or `Binary` shard-key column and a
   compatible literal or placeholder, in either operand order, produces one
   value;
 - transparent parentheses do not change that result;
@@ -92,13 +92,12 @@ such as inequalities, `IN`, `BETWEEN`, `LIKE`, `NOT`, arithmetic, and `CASE`
 remain `Unconstrained` unless another `AND` branch independently proves a
 finite set.
 
-The current catalog declares UTF-8 `Text` key values but does not declare or
-enforce their comparison collation. A non-null `Text` equality predicate is
-therefore `Unconstrained`, even when its literal or bound value has the correct
-type: case- or accent-folding equality could match a different key identity.
-`Text = NULL` remains `Contradiction` because shard-key non-nullness is part of
-the declaration. Text extraction from `INSERT` is unaffected because it
-reports the value being supplied rather than proving comparison semantics.
+Authoritative table registration requires every UTF-8 `Text` shard-key column
+to use SQLite `BINARY` collation and later schema migration must preserve it.
+Inference can therefore treat a compatible non-null Text equality as an exact
+byte-for-byte proof. It performs no case folding, accent folding, or Unicode
+normalization. `Text = NULL` remains `Contradiction` because shard-key
+non-nullness is part of the declaration.
 
 ## INSERT inference
 
@@ -125,7 +124,7 @@ Inference uses the shard-key type declared by the catalog:
 | Catalog key type | Accepted SQL literal | Accepted bound `Value` |
 | --- | --- | --- |
 | `Int64` | An integral decimal magnitude with nested unary `+`/`-`, within the signed 64-bit range | `Int64`, or `UInt64` when it converts losslessly to `i64` |
-| `Text` | A single-quoted string for `INSERT` extraction; predicate equality remains unconstrained without collation metadata | Valid UTF-8 `Text`, with the same predicate limitation |
+| `Text` | A single-quoted UTF-8 string for predicate equality or `INSERT` extraction | Valid UTF-8 `Text`; equality is exact under the registered `BINARY` collation contract |
 | `Binary` | None in the first common literal subset | `Binary` |
 
 Compatible literal and bound values become the same `ShardKeyValue` form.
@@ -160,9 +159,12 @@ snapshot, and a borrowed parameter slice. It does not mutate the catalog,
 manifest, shard files, configuration, session, or caller values. It introduces
 no storage-format or network-contract change.
 
-The current HTTP execute, query, and migration paths do not invoke parsing,
-common-subset validation, normalization, or inference. They retain their
-existing raw SQLite SQL and caller-provided `shard_key` behavior.
+Populated-catalog HTTP execute/query invokes SQLite parsing, common-subset
+validation, normalization, inference, and planning. The caller-provided
+`shard_key` remains an explicit route that must agree by physical shard with
+finite inference. An empty catalog retains the legacy raw route. The migration
+path does not infer row routes; it preserves exact SQL identity and applies its
+separate authoritative-schema restrictions.
 
 The implemented synchronous
 [`Engine::plan_bound_statement`](SQL_PLANNING.md) API invokes inference at
@@ -184,9 +186,9 @@ Tests cover all result categories; literal and bound keys in SQLite,
 PostgreSQL, and MySQL syntax; numbered gaps and repeated parameters; identifier
 quoting, aliases, and qualifiers; Boolean intersection, union, and
 contradiction; `SELECT`, `UPDATE`, and `DELETE`; multi-row inserts and retained
-duplicates; all three catalog key types and the conservative text-collation
-boundary; range, type, text, null, database,
+duplicates; all three catalog key types and authoritative `BINARY` Text
+equality; range, type, text, null, database,
 table, statement-index, and arity errors; empty and multi-statement batches;
 redacted diagnostics and `Debug`; concurrent deterministic inference; and
-successful inference after an independent error. Raw HTTP regressions continue
-to prove that this opt-in API does not change current execution behavior.
+successful inference after an independent error. HTTP regressions prove the
+empty-catalog legacy boundary and populated-catalog inference enforcement.

--- a/docs/SQL_STATEMENT_CLASSIFICATION.md
+++ b/docs/SQL_STATEMENT_CLASSIFICATION.md
@@ -4,10 +4,10 @@ Status: implemented for roadmap issue #27
 
 BriskDB classifies the already validated common SQL AST into a small,
 protocol-neutral behavior taxonomy. The classifier is the shared request gate
-for the PostgreSQL adapter's deferred SQL flow, the planned MySQL adapter, and
-other future adapters; a frontend must not infer behavior from SQL text, a wire
-command, SQLite result columns, or whether SQLite reports a statement as
-read-only.
+for populated-catalog HTTP execute/query, the PostgreSQL adapter's deferred SQL
+flow, the planned MySQL adapter, and other future adapters; a frontend must not
+infer behavior from SQL text, a wire command, SQLite result columns, or whether
+SQLite reports a statement as read-only.
 
 ```rust
 classify_statements(
@@ -214,12 +214,14 @@ tags or status handling, but must not implement a second keyword classifier or
 loosen batch policy on their own. The same typed common SQL produces the same
 classification regardless of its wire protocol.
 
-Issue #27 adds no PostgreSQL or MySQL listener and no new HTTP route, request
-field, response body, or configuration option. The experimental HTTP execute,
-query, and migration endpoints remain raw SQLite surfaces and do not invoke the
-opt-in common frontend. In particular, the journaled migration endpoint keeps
-its own bounded, parameterless SQLite batch contract and can accept a schema
-batch that the general common-SQL classifier deliberately rejects.
+Issue #27 added no PostgreSQL or MySQL listener and no new HTTP route, request
+field, response body, or configuration option. The later authoritative-catalog
+integration now invokes the common frontend and classifier for
+populated-catalog HTTP execute/query; an empty catalog retains the legacy raw
+path. The journaled migration endpoint keeps its own bounded, parameterless
+SQLite batch contract and can accept a schema batch that the general common-SQL
+classifier rejects, subject to the populated-catalog ban on row-moving DML,
+table drops, and trigger creation.
 At the issue-28 milestone, the PostgreSQL endpoint was only an accept/close
 scaffold. Issue #30 connected startup, catalog selection, status, and session
 cleanup, but SQL messages still stop before classification or any other shared
@@ -228,7 +230,7 @@ SQL layer until issue #31.
 ## Storage-format and configuration boundary
 
 Classification is process-memory analysis over an already owned AST. It does
-not change manifest format version 7, manifest tables, logical catalog rows,
+not change manifest format version 8, manifest tables, logical catalog rows,
 routing-key encoding, virtual buckets, shard identity, SQLite headers,
 application-schema fingerprints, migration-journal records, WAL/synchronous
 mode, or filenames. It opens no database connection and performs no recovery
@@ -260,6 +262,7 @@ planning, inference's separate statement-local boundary, and behavior retained
 across equivalent dialect inputs. Prepared tests cover exact-one precedence,
 description behavior, schema refresh, behavior-based physical target policy,
 denied schema prepare and rejected session execution without side effects, and
-later valid work in the same session. Raw HTTP and storage regressions prove
-that classification does not alter the existing migration or pass-through
-contracts.
+later valid work in the same session. HTTP and storage regressions prove that
+populated-catalog execute/query consumes classification, empty-catalog
+execution preserves the legacy path, and migration retains its separate
+exact-text contract.

--- a/docs/SQL_SUBSET.md
+++ b/docs/SQL_SUBSET.md
@@ -16,11 +16,12 @@ byte-exact source, and the ordered statement count. It does not expose the
 dependency-owned AST. Its `Debug` representation reports only the dialect,
 source byte count, and statement count; it does not render SQL or AST contents.
 
-Validation is deliberately opt-in. The current HTTP execute, query, and schema
-migration paths remain raw SQLite pass-through surfaces and do not call either
-the parser or this validator. Issue #20 therefore changes no HTTP request or
-response shape, SQL accepted by HTTP, routing result, transaction behavior,
-configuration, manifest, shard file, or stored data.
+Validation remains a directly callable API. HTTP execute/query also invokes it
+once the authoritative table catalog is populated; an empty catalog retains the
+legacy raw SQLite path. The schema-migration endpoint keeps a separate exact-text
+batch contract and does not require this common subset, although a populated
+catalog applies its narrower no-row-movement parser gate and physical
+postflight. No HTTP request or response field changes with either mode.
 
 ## Boundary
 
@@ -220,6 +221,7 @@ dialects, every recursive clause boundary, exact source ownership, redacted
 debug and unsupported diagnostics, empty and mixed batches, dialect-native
 placeholders, multi-row insert width, duplicate insert/update targets,
 concurrent validation, ordinary nested expressions, and the exact independent
-validator-depth boundary for flat operator chains. A raw HTTP regression must
-also continue to execute SQLite syntax outside this subset, proving that this
-opt-in marker has not become an implicit HTTP execution gate.
+validator-depth boundary for flat operator chains. HTTP regressions must prove
+both modes: an empty catalog can retain legacy SQLite syntax outside this
+subset, while a populated catalog makes this marker an intentional execution
+gate before placement-aware routing.

--- a/docs/SQL_TRANSLATION.md
+++ b/docs/SQL_TRANSLATION.md
@@ -44,8 +44,9 @@ placeholder normalization may differ from `source()`.
 Strict translation does not bypass parsing, common-subset validation, or
 placeholder normalization. It is also unrelated to SQLite's
 `CREATE TABLE ... STRICT` option, which remains outside the structural common
-subset. Existing raw HTTP SQLite pass-through remains a separate interface and
-is not routed through this API.
+subset. Populated-catalog HTTP execute/query uses this exact strict mode after
+normalization; empty-catalog HTTP alone retains a separate raw SQLite
+pass-through.
 
 ### `Compatibility`
 
@@ -177,11 +178,12 @@ can succeed.
 
 ## Deliberate boundaries
 
-Issue #25 adds no CLI flag, environment variable, listener default, HTTP field,
+Issue #25 added no CLI flag, environment variable, listener default, HTTP field,
 wire message, catalog rule, session state, prepared-statement cache, routing
-decision, SQLite execution call, manifest migration, shard-file change, or
-storage-format version. The current HTTP execute/query/migration paths continue
-to send caller-provided SQLite SQL directly to their existing engine paths.
+decision, manifest migration, shard-file change, or storage-format version. The
+later authoritative-catalog integration composes strict translation into
+populated-catalog HTTP execute/query. Empty-catalog HTTP and the migration
+endpoint retain their legacy/exact-text engine paths.
 
 The implemented protocol-neutral [prepared lifecycle](SQL_PREPARED_STATEMENTS.md)
 owns prepare/bind/describe/execute state and adopts `sqlite_sql()` only after
@@ -200,5 +202,5 @@ transaction, and limit syntax; repeated, gapped, reordered, and per-statement
 placeholder identities; empty and 256-statement batches; NUL and synthetic
 metadata failures; diagnostic and `Debug` redaction; deterministic concurrent
 translation; recovery after independent errors; equivalent SQLite,
-PostgreSQL, and MySQL declarations, plans, and executed SQLite results; and the
-absence of changes to raw SQLite execution.
+PostgreSQL, and MySQL declarations, plans, and executed SQLite results; plus
+empty-catalog legacy execution and populated-catalog strict-mode integration.

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -11,23 +11,24 @@ permitted; later migration opens never create a missing replacement, use
 SQLite's no-follow mode, and revalidate the freshly opened layout identity
 inside the same manifest transaction before changing journal state.
 
-## Current format: version 7
+## Current format: version 8
 
 SQLite header fields identify the file and its format:
 
 | Header field | Value | Meaning |
 | --- | --- | --- |
 | `PRAGMA application_id` | `0x42524442` (`BRDB`) | Permanent BriskDB manifest-family marker |
-| `PRAGMA user_version` | `7` | Authoritative manifest schema version |
+| `PRAGMA user_version` | `8` | Authoritative manifest schema version |
 
 The application ID prevents an accidental foreign SQLite file from being
 adopted as a manifest. It is not authentication or tamper protection: a process
 that can write the data directory can forge it and the unkeyed checksums
 described below.
 
-Version 7 has eleven strict manifest tables. It retains the v6 routing, logical
-catalog, physical-layout, and application-schema migration tables; replaces the
-downgrade fence; and adds one integrity singleton.
+Version 8 has eleven strict manifest tables. It retains the v7 routing,
+logical-catalog, physical-layout, application-schema migration, and integrity
+tables; replaces the downgrade fence; and makes newly registered table rows
+authoritative.
 
 ```sql
 CREATE TABLE briskdb_manifest (
@@ -37,7 +38,7 @@ CREATE TABLE briskdb_manifest (
 
 CREATE TABLE briskdb_metadata (
     requires_manifest_version INTEGER NOT NULL
-        CHECK (requires_manifest_version >= 7)
+        CHECK (requires_manifest_version >= 8)
 ) STRICT;
 
 CREATE TABLE briskdb_routing (
@@ -201,27 +202,27 @@ CREATE TABLE briskdb_integrity (
 ```
 
 The manifest, metadata, routing, schema-catalog, shard-layout, and integrity
-tables each contain exactly one row. The v7 downgrade-fence row is exactly `7`.
+tables each contain exactly one row. The v8 downgrade-fence row is exactly `8`.
 The two integrity-version columns deliberately accept any positive integer so
 a future digest encoding can remain structurally readable long enough for an
-older binary to reject it as `FailedPrecondition`; v7 writers emit only `1`.
+older binary to reject it as `FailedPrecondition`; v8 writers emit only `1`.
 Zero or negative versions are malformed and are `DataCorruption`.
 `briskdb_manifest.shard_count` is immutable and is the initial routing modulus;
 it is also the live physical-shard count. Physical IDs are exactly
 `0..shard_count - 1`. Filenames remain derived by trusted code as
 `shards/{shard_id:04}.sqlite` and are never read from catalog-controlled paths.
-Version 7 supports only the `active` physical-shard lifecycle state. Adding
+Version 8 supports only the `active` physical-shard lifecycle state. Adding
 provisioning, draining, or retirement states to the routing catalog requires a
 later format and state-machine change. The separate shard-layout state governs
 only startup identity reconciliation.
 
 ### Logical catalog
 
-Every fresh or upgraded v7 manifest contains logical database ID `1` named
+Every fresh or upgraded v8 manifest contains logical database ID `1` named
 `default`. A fresh or pre-v6 upgrade begins at application-schema
 generation `0`; each completed journal row advances it by exactly one, through
 a maximum of `2,147,483,647`. The schema-catalog singleton also contains
-identifier encoding version `1` and default database ID `1`. Version 7 permits
+identifier encoding version `1` and default database ID `1`. Version 8 permits
 at most 64 logical databases and 4,096 table rows. Database and table IDs are
 positive; table names are unique within their owning database, and every table
 references an existing database.
@@ -245,31 +246,74 @@ Table placement and shard-key type use stable numeric codes:
 | `placement` | `2` | `Global` | Shard-key column and type must both be null |
 | `placement` | `3` | `Catalog` | Shard-key column and type must both be null |
 | `shard_key_type` | `1` | `Int64` | Signed 64-bit integer |
-| `shard_key_type` | `2` | `Text` | UTF-8 text without Unicode normalization; no comparison collation is declared |
+| `shard_key_type` | `2` | `Text` | Exact UTF-8 without Unicode normalization; authoritative physical columns must use SQLite `BINARY` collation |
 | `shard_key_type` | `3` | `Binary` | Arbitrary bytes |
 
-`Sharded` means the same logical schema is expected on every shard and rows
-are key-routed. `Global` describes small replicated lookup data. `Catalog`
-describes manifest-owned metadata rather than a user shard table.
+`Sharded` means the same logical schema exists on every shard but each ordinary
+row has exactly one physical owner selected from its canonical shard-key bytes.
+A duplicate ordinary row on several shards violates that placement; it is not a
+sharded copy. `Global` explicitly describes replicated lookup rows. `Catalog`
+describes manifest-owned logical metadata and has no physical application-table
+shadow.
 
-The loaded `Catalog` is read-only to callers and remains advisory in version 7:
-the opt-in SQL inference API may consult its database, table placement, and key
-metadata, but there is no table-catalog mutation API or automatic proof that a
-catalog row matches a physical application table. The prepared lifecycle now
-uses catalog placement and keys for its bind-time plan and supported execution
-target; the raw explicit-key execute/query API remains independent of that
-opt-in integration. The engine publishes a newly committed schema generation
-into its shared catalog snapshot only after every shard has reached that
-generation.
-Fresh initialization and every v1/v2/v3 upgrade leave `briskdb_tables` empty;
-a v4-to-v5 upgrade retains every validated v4 catalog row. Schema migration
-does not inspect, infer, or mutate `briskdb_tables` from the journaled SQL; the
-physical-schema fingerprint independently establishes exact consensus across
-shards. Tables that are absent from the advisory catalog remain usable through
-the existing explicit-key execute/query API. Version-5 adoption preserves
-existing tables and rows while adding only BriskDB-owned shard identity
-metadata. Shard-key inference changes no manifest table, encoding, version, or
-upgrade rule.
+The loaded `Catalog` remains read-only to observers. Version 8 adds the one-time
+`Database::register_tables` mutation boundary for an empty table catalog. The
+caller supplies the complete declaration set for the storage-default logical
+database. On every shard, the ordinary application-table names must exactly
+equal the `Sharded` and `Global` names, every declared physical table must be
+empty, and each `Catalog` name must have no physical table or view shadow. A
+sharded key must be a visible, physically non-null column whose SQLite affinity
+is compatible with its declared `Int64`, `Text`, or `Binary` type. The
+non-null `INTEGER PRIMARY KEY` rowid alias qualifies; nullable legacy
+primary-key forms do not. A Text shard key must use SQLite `BINARY` collation.
+Every primary or unique key on a sharded table must include its shard-key column
+with `BINARY` collation, so every possible collision has one physical owner.
+Application foreign keys, triggers, and virtual tables are temporarily
+unsupported for every registered physical table. Registration assigns table IDs
+after sorting by logical database and canonical table name, commits the rows
+and refreshed manifest root atomically, and publishes the replacement catalog
+only after revalidation.
+
+Registration is initialization-only and requires exclusive live ownership of
+the data root. An exact complete repeat is a read-only idempotent success;
+empty, partial, different, duplicate, nonempty, or physically mismatched
+declarations fail without replacing the catalog. Once populated, the catalog
+cannot be edited in place. A later journaled schema migration must preserve the
+exact registered physical table set on every shard and retain every sharded
+key's visible, physically non-null column, compatible affinity, Text collation,
+and one-owner unique keys. It must not introduce an application foreign key,
+trigger, or virtual table. A populated-catalog migration also rejects row-moving
+DML, `CREATE TABLE ... AS SELECT`, `DROP TABLE`, and `CREATE TRIGGER`. A
+violation is rejected before journal or shard publication.
+
+The registration guard changes in-process schema admission to `Pending` before
+attempting manifest commit. If SQLite reports an ambiguous commit cleanup or
+I/O failure, the registering handle deliberately retains its old catalog and
+ordinary work remains closed. Close that stale handle and reopen the canonical
+data root; startup then validates whether the old catalog or complete new
+catalog became durable. While the stale handle is live, a reopen that observes
+the committed replacement fails `FailedPrecondition` rather than publishing
+conflicting catalog snapshots. A new registration must not be attempted through
+the pending handle.
+
+Fresh v8 initialization leaves `briskdb_tables` empty. The v7-to-v8 migration
+also clears all v7 table rows because those rows were advisory and were never
+proved against the physical schema; silently promoting them would create false
+routing authority. The upgrade preserves logical databases, routing, schema
+generation and history, layout and integrity state, shard files, application
+schema, and rows. Registration does not inspect or repartition existing row
+data, which is why it accepts only empty declared physical tables. Raw HTTP
+execute/query remains caller-key-only while this catalog is empty. Once
+populated, it parses and strictly translates one SQLite common-subset statement,
+consults placement, and permits only one safe physical target; undeclared and
+Catalog targets fail closed, Global reads use shard 0, and Global writes require
+a future replication operation.
+
+The authoritative catalog supplies placement to inference, planning, prepared
+execution, and later import/query layers. It does not itself implement logical
+multi-shard execution. Unpinned sharded reads still require the bounded
+scatter/`UNION ALL` and merge work tracked by issues #57 and #58; the current
+physical admin browser is not that logical query surface.
 
 ### Application-schema migration journal
 
@@ -296,7 +340,7 @@ additional `Applying` row may exist, and it must target
 `schema_generation + 1`. Its stored source generation, shard count, SQL text,
 digest, state, and progress are validated on every manifest open. Any journal
 history requires the physical layout to be `Ready`; `Creating` and `Adopting`
-manifests have an empty journal. Fresh v7 initialization and pre-v6 upgrades
+manifests have an empty journal. Fresh v8 initialization and pre-v6 upgrades
 begin with an empty journal at generation 0.
 
 The retained journal proves which exact batches BriskDB coordinated; it does
@@ -321,10 +365,12 @@ are distinct from the v5 physical-layout states:
 | `3` | `Migrating` | Committed source and target fingerprints plus exactly one `Applying` journal row, physical layout `Ready` | Only the migration coordinator may advance the validated prefix |
 | `4` | `Degraded` | Preserves whatever trusted committed/target fingerprints and active journal existed when validation failed | Terminal fail-closed state; startup and all new work return non-retryable `DataCorruption` until the complete database is restored from a known-good copy |
 
-`Pending` is an in-process admission state used after durable partial progress;
-it is not a fifth manifest state. A state transition, its checksum fields, the
-corresponding journal/catalog mutation, and the refreshed semantic root commit
-in one `manifest.sqlite` transaction. A failed validation marks the canonical
+`Pending` is an in-process admission state used after durable migration progress
+or a durability-ambiguous manifest commit, including first catalog
+registration; it is not a fifth manifest state. A state transition, its
+checksum fields, the corresponding journal/catalog mutation, and the refreshed
+semantic root commit in one `manifest.sqlite` transaction. A failed validation
+marks the canonical
 root's shared in-process gate `Degraded` immediately. BriskDB also persists
 `Degraded` on a best-effort basis when the existing manifest root can first be
 validated; it never reseals altered manifest payload as part of handling a root
@@ -369,7 +415,7 @@ self-reference; its version, database state, and schema digest fields are
 covered. Frozen SQL definitions, STRICT flags, indexes, and foreign keys are
 validated separately rather than encoded as semantic rows.
 
-Every BriskDB-owned v7 manifest mutation recalculates the root after its row
+Every BriskDB-owned v8 manifest mutation recalculates the root after its row
 changes and before the same transaction commits. Progress acknowledgement,
 migration publication/finalization, layout publication, state changes, and
 catalog changes therefore cannot commit with a stale root through supported
@@ -377,11 +423,11 @@ code. Hashing semantic values instead of the raw SQLite file makes the root
 stable across WAL checkpoints, page relocation, and `VACUUM`; it deliberately
 does not cover SQLite page bytes, rollback journals, WAL, or shared memory.
 
-The frozen four-shard v7 fixture with layout ID
+The frozen four-shard v8 fixture with layout ID
 `000102030405060708090a0b0c0d0e0f`, committed schema fingerprint `5a` repeated
 32 times, and the catalog rows in
 `manifest_semantic_digest_v1_has_a_frozen_golden_vector` hashes to
-`579d8a7854a9a7aa3add69dbb8c413b2851db74edce19ad6def22ab94f029ed1`.
+`7be14b4f0af4d041799be8d219e55add133829623c2befcefb5c4dc9e9ff5ce0`.
 The adjacent reverse-insertion fixture must produce the same root.
 
 Schema digest version 1 is also a full 32-byte, unkeyed BLAKE3 digest. It begins
@@ -490,6 +536,15 @@ escape, attachments, temporary and virtual objects, and storage-owned controls,
 then compares the reserved schema before and after the batch. BriskDB, not the
 submitted SQL, stamps `user_version` inside the shard transaction.
 
+Before registration, the legacy migration batch may include main-schema DML.
+After registration, BriskDB parses the exact submitted SQLite batch before
+preflight and rejects row-moving `INSERT`, `UPDATE`, `DELETE`, `MERGE`, or
+`TRUNCATE`, `CREATE TABLE ... AS SELECT`, `DROP TABLE`, and `CREATE TRIGGER`.
+Rollback-only postflight then rechecks the complete authoritative table set,
+key affinity/nullability/collation, unique-key locality, and the ban on
+application foreign keys, triggers, and virtual tables. Parsing never replaces
+the exact submitted bytes used for migration identity.
+
 ### Routing catalog
 
 The routing singleton contains exactly these generation-1 values:
@@ -500,7 +555,7 @@ The routing singleton contains exactly these generation-1 values:
 | `key_encoding_version` | `1` | Canonical bytes defined below for raw, explicit, and typed inferred routing keys |
 | `bucket_algorithm_version` | `1` | Compatibility-preserving range algorithm below |
 | `virtual_bucket_count` | `4096` | Fixed virtual bucket space `0..4095` |
-| `map_generation` | `1` | Initial committed bucket map and the only generation version 7 can interpret |
+| `map_generation` | `1` | Initial committed bucket map and the only generation version 8 can interpret |
 
 Every bucket ID exists exactly once and references an active physical shard.
 Every physical shard owns at least one bucket. The generation-1 map partitions
@@ -542,7 +597,7 @@ vectors freeze the exact key bytes, BLAKE3 prefix, little-endian hash integer,
 bucket ID, and persisted physical shard.
 
 `map_generation` is separate from manifest `user_version` and from
-`schema_generation`. Version 7 accepts only routing generation 1 and validates
+`schema_generation`. Version 8 accepts only routing generation 1 and validates
 its exact deterministic assignment; no public map-mutation operation exists
 yet. A future format that can commit a changed map must bump `user_version` and
 its downgrade fence as well as `map_generation`. That requirement makes this
@@ -553,12 +608,29 @@ At each open, BriskDB validates the exact objects, columns, strict flags, frozen
 schema SQL, singleton rows, logical identifiers and limits, metadata codes,
 supported algorithm values, contiguous physical and bucket IDs, active
 lifecycle states, assignments, coverage, and foreign keys. A recognized
-version-7 manifest that violates any invariant is `DataCorruption` and is
+version-8 manifest that violates any invariant is `DataCorruption` and is
 rejected before shard connections are opened. The same locked transaction
 returns routing and logical rows as one coherent shared snapshot. Request
 routing performs no manifest query and cannot fall back to modulo after a failed
 validation; only successful migration finalization publishes a newer logical
 schema generation into the snapshot.
+
+## Previous version 7
+
+Version 7 has the same eleven table roles as version 8 and introduced the
+integrity singleton, semantic manifest root, durable database states, and
+generation-bound shard-schema fingerprints. Its exact downgrade fence requires
+manifest version 7, contains exactly `7`, and `PRAGMA user_version` is `7`.
+
+Its `briskdb_tables` rows were explicitly advisory: version 7 exposed no safe
+registration operation and did not prove those rows against the physical
+application schema. The atomic v7-to-v8 manifest migration therefore deletes
+all such rows, replaces the fence with the exact version-8 definition and row,
+stamps version 8, reseals the semantic root, validates the complete destination,
+and commits those changes together. It does not change any logical-database, routing, schema
+generation/history, layout, integrity, shard-schema, or application-row data.
+A version-7 reader rejects the version-8 header before it can interpret an
+authoritative table row as advisory.
 
 ## Previous version 6
 
@@ -568,7 +640,7 @@ and `PRAGMA user_version` is `6`. It introduced the retained application-schema
 migration journal but had no trusted manifest or shard-schema checksum and no
 durable database integrity state.
 
-A v7 opener first performs full v6 structural validation. If v6 has an
+A current opener first performs full v6 structural validation. If v6 has an
 `Applying` journal row, startup completes that exact ascending source/target
 prefix under the frozen v6 recovery rules while the manifest is still version
 6. Only after the row is `Complete` and its target generation is committed may
@@ -672,7 +744,7 @@ CREATE TABLE briskdb_metadata (
 
 The fence contains exactly `2`. A current opener validates this complete format
 before applying the numbered v2-to-v3, v3-to-v4, v4-to-v5, v5-to-v6, and
-v6-to-v7 transactions.
+v6-to-v7 and v7-to-v8 transactions.
 
 ## Legacy version 1
 
@@ -723,17 +795,20 @@ returning:
 5. Apply each compile-time registered manifest migration with static SQL and
    bound data. The destination application ID and `user_version` are the final
    mutations; validate the complete destination and commit one numbered step at
-   a time. The v6-to-v7 transaction adds an integrity row in `Verifying`; older
-   formats therefore cannot be mistaken for checksummed data.
+   a time. The v6-to-v7 transaction adds an integrity row in `Verifying`; the
+   v7-to-v8 transaction clears advisory table rows and installs the
+   authoritative-catalog downgrade fence. Older formats therefore cannot be
+   mistaken for checksummed or authoritative-catalog data.
 6. Fresh initialization is allowed only beside an otherwise empty physical
-   layout and commits v7 physical state `Creating`, integrity state
+   layout and commits v8 physical state `Creating`, integrity state
    `Verifying`, generation 0, and an empty migration journal. An existing
    v1/v2/v3 manifest first advances through v4; the v4-to-v5 transaction commits
    a random 16-byte layout ID and physical state `Adopting` before any shard
-   file changes. The v5-to-v6 step creates the journal, and v6-to-v7 establishes
-   the unsealed integrity row.
+   file changes. The v5-to-v6 step creates the journal, v6-to-v7 establishes
+   the unsealed integrity row, and v7-to-v8 establishes an empty authoritative
+   table catalog.
 7. If the validated integrity state is `Degraded`, fail startup without
-   changing it. Otherwise, if a validated v7 manifest contains one `Applying`
+   changing it. Otherwise, if a validated v8 manifest contains one `Applying`
    migration, require state `Migrating`, validate every shard against the
    trusted source/target fingerprint for its exact journal-prefix position,
    and resume it in ascending order. The final transaction publishes the
@@ -759,8 +834,8 @@ returning:
     `Database`, or `Engine`.
 
 SQLite transactional DDL keeps each numbered manifest step atomic within
-`manifest.sqlite`. A version-1 upgrade commits versions 2, 3, 4, 5, 6, and then
-7; a version-2 upgrade begins at 3, and so on. The v3-to-v4 step still creates the
+`manifest.sqlite`. A version-1 upgrade commits versions 2, 3, 4, 5, 6, 7, and
+then 8; a version-2 upgrade begins at 3, and so on. The v3-to-v4 step still creates the
 logical catalog, inserts database ID 1 named `default` plus the
 schema-generation-0 singleton, and leaves the table catalog empty.
 
@@ -779,8 +854,9 @@ non-WAL mode, or a missing file is rejected without being repaired or replaced.
 The v5-to-v6 step does not change any shard because a valid v5 database is at
 schema generation 0 and has no journal history. The v6-to-v7 step also changes
 no shard; it establishes a first fingerprint only after later cross-file
-consensus verification. `briskdb_tables` remains advisory and is not inferred
-from physical DDL.
+consensus verification. The v7-to-v8 step changes no shard and clears advisory
+`briskdb_tables` rows rather than inferring or blessing declarations from
+physical DDL.
 
 A new application-schema migration follows a separate durable protocol:
 
@@ -832,8 +908,9 @@ If checksum or structural validation fails, the canonical-root gate becomes
 sticky `Degraded`, so a migration guard's later drop cannot reopen admission.
 When the semantic manifest root was still trustworthy, BriskDB records durable
 state `Degraded` without discarding its committed/target fingerprints or active
-journal. That state is terminal for v7: startup never clears it or chooses a
-new baseline. This is deliberately conservative because a runtime SQLite
+journal. That state is terminal for integrity-checksummed formats (v7 and
+later): startup never clears it or chooses a new baseline. This is deliberately
+conservative because a runtime SQLite
 corruption result can originate in application-row pages that the schema
 fingerprint does not cover, while whole-shard scans are deferred.
 
@@ -849,12 +926,14 @@ later storage-hardening certification.
 
 ## Compatibility and operations
 
-- Version 1 upgrades through versions 2, 3, 4, 5, 6, and 7; later versions
+- Version 1 upgrades through versions 2, 3, 4, 5, 6, 7, and 8; later versions
   begin at the next numbered transaction. Opening is therefore potentially
   mutating. An active v6 journal is completed before its v7 transaction.
 - There is no automatic downgrade. Older readers are fenced by the incompatible
-  metadata schema and authoritative header; in particular, a version-6 reader
-  rejects `user_version = 7` before it can ignore integrity state.
+  metadata schema and authoritative header. In particular, a version-7 reader
+  rejects `user_version = 8` before it can treat authoritative table rows as
+  advisory, and a version-6 reader rejects version 7 before it can ignore
+  integrity state.
 - A manifest with the BriskDB application ID and a `user_version` newer than the
   binary supports fails with non-retryable `FailedPrecondition`; it is not
   downgraded or switched to WAL, and shard files are not opened.
@@ -904,7 +983,7 @@ header value, format version, digest input, routing metadata, schema
 fingerprint, journal record, or recovery step. Listener settings are not
 persisted. Because engine open and its existing recovery precede listener
 binding, a later bind failure does not undo a migration or recovery transaction
-that already committed; a subsequent startup revalidates the same version-7
+that already committed; a subsequent startup revalidates the same version-8
 layout normally.
 
 Issue #29's pinned `pgwire` dependency and issue #30's production startup,
@@ -942,13 +1021,14 @@ The current deployment boundary remains local storage and one BriskDB process
 per data directory. Independent handles inside that process share a gate,
 schema fingerprints, and live catalog coordination keyed by the canonical
 root. A formal backup/restore workflow is not implemented. Recovery to an older
-binary requires a pre-v7 backup. Separate server processes against one data
+binary requires a backup from before the unsupported format. Separate server
+processes against one data
 directory are unsupported even though SQLite and the manifest use file locks;
 the in-process coordination is intentionally not a distributed lock.
 
 ## Verification contract
 
-Tests cover fresh creation and every v1/v2/v3/v4/v5/v6-to-v7 upgrade, every
+Tests cover fresh creation and every v1/v2/v3/v4/v5/v6/v7-to-v8 upgrade, every
 manifest layout and integrity state, the exact shard header and metadata row,
 dynamic schema generations, retained migration history, checksum golden
 vectors, and no-op ready reopen. Failure
@@ -963,8 +1043,11 @@ being published before full strict revalidation. Concurrent openers exercise
 matching and conflicting shard counts and layout transitions.
 
 Catalog tests continue to cover default logical metadata, every placement and
-shard-key type code, identifier and relational corruption, row limits, and
-immutable public lookups. Routing tests freeze golden hash/bucket/shard vectors,
+shard-key type code, identifier and relational corruption, row limits,
+v7 advisory-row clearing, atomic registration and commit ambiguity, exact
+idempotency, empty-schema and key/constraint validation, immutable public
+lookups, stale-handle exclusion, and migration enforcement. Routing tests
+freeze golden hash/bucket/shard vectors,
 cover every algorithm state for every supported shard count, prove the final
 map lookup with a synthetic reassignment, and exercise parallel and reopen
 stability. Schema-migration tests cover exact identity and input limits,

--- a/docs/SUPPORTED_PLATFORMS.md
+++ b/docs/SUPPORTED_PLATFORMS.md
@@ -119,15 +119,16 @@ Startup and runtime migration opens disable symbolic-link following; a runtime
 open will not create a missing manifest and rechecks the opened layout identity
 before journal mutation.
 
-Manifest v7 retains the v6 journal's exact migration SQL for idempotency and
+Manifest v8 retains the v6 journal's exact migration SQL for idempotency and
 startup recovery. Treat the data directory accordingly and do not include
 credentials, tokens, or other sensitive literals in migration SQL.
 
 Manifest and shard application IDs plus the random 16-byte layout ID guard
 against accidental wrong-file placement. They are not authentication or
-protection from a process that can write the data directory. The v7 semantic
-and schema checksums are likewise unkeyed corruption detectors, not
-authentication, and do not checksum application row values. Targeted
+protection from a process that can write the data directory. The semantic and
+schema checksums introduced in v7 and retained by v8 are likewise unkeyed
+corruption detectors, not authentication, and do not checksum application row
+values. Targeted
 subprocess-abort tests cover schema-journal persistence boundaries, but
 arbitrary process-kill timing, power-loss, and filesystem-fault certification
 remain later hardening work.

--- a/src/core/catalog.rs
+++ b/src/core/catalog.rs
@@ -109,16 +109,13 @@ impl LogicalDatabaseMetadata {
 }
 
 /// Versioned declared type of a non-null shard-key column.
-///
-/// Manifest v4 exposes this as read-only metadata. Routed execution continues
-/// to accept the caller's opaque routing-key bytes and does not yet encode keys
-/// from table values.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum ShardKeyType {
     /// Signed 64-bit integer.
     Int64,
-    /// UTF-8 text, declared without Unicode normalization or collation.
+    /// UTF-8 text routed as exact bytes and compared with SQLite `BINARY`
+    /// collation, without Unicode normalization.
     Text,
     /// Arbitrary bytes.
     Binary,
@@ -132,6 +129,13 @@ pub struct ShardKeyMetadata {
 }
 
 impl ShardKeyMetadata {
+    /// Construct a validated single-column shard key.
+    pub fn new(column: impl Into<String>, key_type: ShardKeyType) -> EngineResult<Self> {
+        let column = column.into();
+        ensure_catalog_identifier(&column)?;
+        Ok(Self { column, key_type })
+    }
+
     pub(crate) fn from_validated(column: String, key_type: ShardKeyType) -> Self {
         debug_assert!(validate_catalog_identifier(&column));
         Self { column, key_type }
@@ -148,20 +152,82 @@ impl ShardKeyMetadata {
     }
 }
 
-/// Declared physical placement of a logical table.
-///
-/// These declarations remain advisory in the current manifest. Future
-/// catalog-driven DDL and physical-schema validation must make them
-/// authoritative before execution planning relies on them.
+/// Authoritative physical placement of a registered logical table.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum TablePlacement {
-    /// Intended for the same logical schema on every shard and key-routed rows.
+    /// The schema exists on every shard and each row belongs to one key-selected
+    /// owner. Every local unique key must include the shard key.
     Sharded(ShardKeyMetadata),
     /// Intended for a small lookup table replicated to every shard.
     Global,
     /// Intended for manifest-owned metadata rather than a user shard table.
     Catalog,
+}
+
+/// One validated table declaration to register in an empty logical catalog.
+///
+/// Registration assigns a stable table ID after sorting declarations by
+/// logical database and canonical table name. The declaration itself contains
+/// no physical rows and can be safely prepared before storage is opened.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TableDeclaration {
+    database_id: LogicalDatabaseId,
+    name: String,
+    placement: TablePlacement,
+}
+
+impl TableDeclaration {
+    /// Declare a key-routed table whose schema exists on every shard.
+    pub fn sharded(
+        database_id: LogicalDatabaseId,
+        name: impl Into<String>,
+        shard_key: ShardKeyMetadata,
+    ) -> EngineResult<Self> {
+        Self::new(database_id, name.into(), TablePlacement::Sharded(shard_key))
+    }
+
+    /// Declare a table whose explicitly replicated rows exist on every shard.
+    pub fn global(database_id: LogicalDatabaseId, name: impl Into<String>) -> EngineResult<Self> {
+        Self::new(database_id, name.into(), TablePlacement::Global)
+    }
+
+    /// Declare a manifest-owned table that is never an application SQL target.
+    pub fn catalog(database_id: LogicalDatabaseId, name: impl Into<String>) -> EngineResult<Self> {
+        Self::new(database_id, name.into(), TablePlacement::Catalog)
+    }
+
+    fn new(
+        database_id: LogicalDatabaseId,
+        name: String,
+        placement: TablePlacement,
+    ) -> EngineResult<Self> {
+        ensure_catalog_identifier(&name)?;
+        Ok(Self {
+            database_id,
+            name,
+            placement,
+        })
+    }
+
+    /// Return the owning logical database.
+    pub const fn database_id(&self) -> LogicalDatabaseId {
+        self.database_id
+    }
+
+    /// Return the canonical lowercase table name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Return the declared physical placement.
+    pub const fn placement(&self) -> &TablePlacement {
+        &self.placement
+    }
+
+    pub(crate) fn into_parts(self) -> (LogicalDatabaseId, String, TablePlacement) {
+        (self.database_id, self.name, self.placement)
+    }
 }
 
 /// Logical table metadata loaded from the manifest.
@@ -526,6 +592,45 @@ mod tests {
     }
 
     #[test]
+    fn table_declarations_are_validated_owned_and_database_scoped() {
+        let database = LogicalDatabaseId::new(9).unwrap();
+        let shard_key = ShardKeyMetadata::new("tenant_id", ShardKeyType::Text).unwrap();
+        let declaration =
+            TableDeclaration::sharded(database, "accounts", shard_key.clone()).unwrap();
+        assert_eq!(declaration.database_id(), database);
+        assert_eq!(declaration.name(), "accounts");
+        assert_eq!(declaration.placement(), &TablePlacement::Sharded(shard_key));
+
+        assert_eq!(
+            TableDeclaration::global(database, "countries")
+                .unwrap()
+                .placement(),
+            &TablePlacement::Global
+        );
+        assert_eq!(
+            TableDeclaration::catalog(database, "audit_catalog")
+                .unwrap()
+                .placement(),
+            &TablePlacement::Catalog
+        );
+
+        for invalid in ["", "Accounts", "two-words", "briskdb_tables"] {
+            assert_eq!(
+                TableDeclaration::global(database, invalid)
+                    .unwrap_err()
+                    .kind(),
+                EngineErrorKind::InvalidArgument
+            );
+            assert_eq!(
+                ShardKeyMetadata::new(invalid, ShardKeyType::Int64)
+                    .unwrap_err()
+                    .kind(),
+                EngineErrorKind::InvalidArgument
+            );
+        }
+    }
+
+    #[test]
     fn metadata_accessors_and_lookups_are_stable_and_database_scoped() {
         let catalog = sample_catalog();
         assert_eq!(LogicalDatabaseId::new(9).unwrap().get(), 9);
@@ -608,6 +713,7 @@ mod tests {
         assert_send_sync_static::<LogicalDatabaseMetadata>();
         assert_send_sync_static::<TableMetadata>();
         assert_send_sync_static::<TablePlacement>();
+        assert_send_sync_static::<TableDeclaration>();
         assert_send_sync_static::<ShardKeyMetadata>();
         assert_send_sync_static::<ShardKeyType>();
     }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -16,8 +16,9 @@ use super::{
     Database, DescribeTarget, EngineError, EngineErrorKind, EngineOptions, EngineResult,
     EngineState, Lifecycle, LogicalDatabaseId, OperationControl, OperationLease, PortalId,
     PrepareRequest, PreparedExecution, PreparedStatementDescription, PreparedStatementId,
-    PreparedStatementLimits, RequestContext, ResultLimits, ResultSet, Routed, Session,
-    SessionInner, ShutdownReport, TablePlacement, Value, wait_for_cancellation, wait_pending,
+    PreparedStatementLimits, RawDataOperation, RequestContext, ResultLimits, ResultSet, Routed,
+    Session, SessionInner, ShutdownReport, TablePlacement, Value, wait_for_cancellation,
+    wait_pending,
 };
 use crate::{
     sql,
@@ -554,6 +555,14 @@ impl Engine {
             Ok(prepared) => prepared,
             Err(error) => return operation.finish(Err(error)),
         };
+        if let Err(error) = reject_catalog_prepared_target(
+            self.catalog(),
+            database,
+            translated.normalized_sql(),
+            translated.statement_parameters()[0].parameter_count(),
+        ) {
+            return operation.finish(Err(error));
+        }
         if let Err(error) = guard.prepared().ensure_statement_capacity() {
             return operation.finish(Err(error));
         }
@@ -866,8 +875,23 @@ impl Engine {
             Ok(key) => key.to_owned(),
             Err(error) => return operation.finish(Err(error)),
         };
-        let shard = self.inner.database.shard_for_key(routing_key.as_bytes());
         let (sql, params) = statement.into_parts();
+        let plan = match self.inner.database.raw_data_plan(
+            &routing_key,
+            &sql,
+            &params,
+            RawDataOperation::Execute,
+        ) {
+            Ok(plan) => plan,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let (shard, sql) = match plan {
+            Some(plan) => (plan.shard, plan.sqlite_sql),
+            None => (
+                self.inner.database.shard_for_key(routing_key.as_bytes()),
+                sql,
+            ),
+        };
 
         let value = self
             .run_on_shard(
@@ -920,8 +944,23 @@ impl Engine {
             Ok(key) => key.to_owned(),
             Err(error) => return operation.finish(Err(error)),
         };
-        let shard = self.inner.database.shard_for_key(routing_key.as_bytes());
         let (sql, params) = statement.into_parts();
+        let plan = match self.inner.database.raw_data_plan(
+            &routing_key,
+            &sql,
+            &params,
+            RawDataOperation::Query,
+        ) {
+            Ok(plan) => plan,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let (shard, sql) = match plan {
+            Some(plan) => (plan.shard, plan.sqlite_sql),
+            None => (
+                self.inner.database.shard_for_key(routing_key.as_bytes()),
+                sql,
+            ),
+        };
         let limits = operation.result_limits;
 
         let value = self
@@ -1347,6 +1386,41 @@ fn ensure_parameter_metadata(expected: usize, actual: usize) -> EngineResult<()>
     }
 }
 
+fn reject_catalog_prepared_target(
+    catalog: &super::Catalog,
+    database: LogicalDatabaseId,
+    normalized: &sql::NormalizedSql,
+    parameter_count: usize,
+) -> EngineResult<()> {
+    // Resolving a Global or Catalog target does not inspect predicate values.
+    // Supplying NULL placeholders therefore lets prepare enforce the Catalog
+    // boundary before SQLite tries to compile a manifest-only table name. Any
+    // value-dependent inference error belongs to bind-time planning and leaves
+    // the existing prepared-statement behavior unchanged.
+    let placeholders = vec![Value::Null; parameter_count];
+    let Ok(inference) = sql::infer_shard_keys(catalog, database, normalized, 0, &placeholders)
+    else {
+        return Ok(());
+    };
+    let Some(table) = inference
+        .table_id()
+        .and_then(|table| catalog.table_by_id(table))
+    else {
+        return Ok(());
+    };
+    if matches!(table.placement(), TablePlacement::Catalog) {
+        return Err(catalog_target_denied());
+    }
+    Ok(())
+}
+
+fn catalog_target_denied() -> EngineError {
+    EngineError::new(
+        EngineErrorKind::PermissionDenied,
+        "catalog-placed tables cannot execute as client SQL",
+    )
+}
+
 fn prepared_execution_shard(
     plan: &BoundStatementPlan,
     catalog: &super::Catalog,
@@ -1371,10 +1445,7 @@ fn prepared_execution_shard(
             })?;
         match table.placement() {
             TablePlacement::Catalog => {
-                return Err(EngineError::new(
-                    EngineErrorKind::PermissionDenied,
-                    "catalog-placed tables cannot execute as client SQL",
-                ));
+                return Err(catalog_target_denied());
             }
             TablePlacement::Global => true,
             TablePlacement::Sharded(_) => {
@@ -1484,7 +1555,9 @@ mod tests {
     use tokio::{sync::oneshot, time::timeout};
 
     use super::*;
-    use crate::core::{Column, DataType, Row, SessionState};
+    use crate::core::{
+        Column, DataType, Row, SessionState, ShardKeyMetadata, ShardKeyType, TableDeclaration,
+    };
 
     fn engine() -> (tempfile::TempDir, Engine) {
         let temp = tempfile::tempdir().unwrap();
@@ -1515,38 +1588,7 @@ mod tests {
         options: EngineOptions,
     ) -> (tempfile::TempDir, Engine, LogicalDatabaseId) {
         let temp = tempfile::tempdir().unwrap();
-        drop(Database::open(temp.path(), 4).unwrap());
-        let manifest = rusqlite::Connection::open(temp.path().join("manifest.sqlite")).unwrap();
-        manifest
-            .execute_batch(
-                "PRAGMA foreign_keys = ON;
-                 BEGIN IMMEDIATE;
-                 DROP TABLE briskdb_integrity;
-                 DROP TABLE briskdb_metadata;
-                 CREATE TABLE briskdb_metadata (
-                     requires_manifest_version INTEGER NOT NULL
-                         CHECK (requires_manifest_version >= 6)
-                 ) STRICT;
-                 INSERT INTO briskdb_metadata VALUES (6);
-                 INSERT INTO briskdb_tables (
-                    table_id,
-                    database_id,
-                    table_name,
-                    placement,
-                    shard_key_column,
-                    shard_key_type
-                 ) VALUES
-                    (4, 1, 'events', 1, 'tenant_id', 1),
-                    (5, 1, 'global_events', 2, NULL, NULL),
-                    (6, 1, 'catalog_records', 3, NULL, NULL),
-                    (7, 1, 'text_events', 1, 'tenant_key', 2);
-                 PRAGMA user_version = 6;
-                 COMMIT;",
-            )
-            .unwrap();
-        drop(manifest);
-
-        let database = Arc::new(Database::open(temp.path(), 4).unwrap());
+        let mut database = Database::open(temp.path(), 4).unwrap();
         database
             .broadcast(
                 "CREATE TABLE events (
@@ -1554,14 +1596,32 @@ mod tests {
                     payload TEXT NOT NULL
                  );
                  CREATE TABLE global_events (code INTEGER NOT NULL);
-                 CREATE TABLE catalog_records (code INTEGER NOT NULL);
                  CREATE TABLE text_events (
-                    tenant_key TEXT PRIMARY KEY,
+                    tenant_key TEXT PRIMARY KEY NOT NULL,
                     payload TEXT NOT NULL
                  );",
             )
             .unwrap();
         let logical_database = database.catalog().default_database().id();
+        database
+            .register_tables(vec![
+                TableDeclaration::sharded(
+                    logical_database,
+                    "events",
+                    ShardKeyMetadata::new("tenant_id", ShardKeyType::Int64).unwrap(),
+                )
+                .unwrap(),
+                TableDeclaration::global(logical_database, "global_events").unwrap(),
+                TableDeclaration::catalog(logical_database, "catalog_records").unwrap(),
+                TableDeclaration::sharded(
+                    logical_database,
+                    "text_events",
+                    ShardKeyMetadata::new("tenant_key", ShardKeyType::Text).unwrap(),
+                )
+                .unwrap(),
+            ])
+            .unwrap();
+        let database = Arc::new(database);
         let engine = Engine::from_database_with_options(database, options).unwrap();
         (temp, engine, logical_database)
     }
@@ -1571,6 +1631,19 @@ mod tests {
             .map(|value| format!("shard-{value}"))
             .find(|key| engine.inner.database.shard_for_key(key.as_bytes()) == expected)
             .expect("the finite shard layout has a routing key")
+    }
+
+    fn integer_key_for_shard(engine: &Engine, expected: u16, excluded: Option<i64>) -> i64 {
+        (1_i64..)
+            .find(|value| {
+                Some(*value) != excluded
+                    && engine
+                        .inner
+                        .database
+                        .shard_for_key(value.to_string().as_bytes())
+                        == expected
+            })
+            .expect("the finite shard layout has an integer routing key")
     }
 
     #[test]
@@ -2436,49 +2509,33 @@ mod tests {
             );
         }
 
-        let catalog_statement = engine
-            .prepare_statement(
-                &session,
-                PrepareRequest::new(
-                    database,
-                    sql::SqlDialect::Sqlite,
-                    sql::SqlTranslationMode::StrictSqlite,
-                    "SELECT code FROM catalog_records",
-                ),
-            )
-            .await
-            .unwrap();
-        let catalog_portal = engine
-            .bind_statement(&session, catalog_statement, vec![])
-            .await
-            .unwrap();
         assert_eq!(
             engine
-                .execute_portal(&session, catalog_portal)
+                .prepare_statement(
+                    &session,
+                    PrepareRequest::new(
+                        database,
+                        sql::SqlDialect::Sqlite,
+                        sql::SqlTranslationMode::StrictSqlite,
+                        "SELECT code FROM catalog_records",
+                    ),
+                )
                 .await
                 .unwrap_err()
                 .kind(),
             EngineErrorKind::PermissionDenied
         );
-        let catalog_update = engine
-            .prepare_statement(
-                &session,
-                PrepareRequest::new(
-                    database,
-                    sql::SqlDialect::Sqlite,
-                    sql::SqlTranslationMode::StrictSqlite,
-                    "UPDATE catalog_records SET code = 1",
-                ),
-            )
-            .await
-            .unwrap();
-        let catalog_update_portal = engine
-            .bind_statement(&session, catalog_update, vec![])
-            .await
-            .unwrap();
         assert_eq!(
             engine
-                .execute_portal(&session, catalog_update_portal)
+                .prepare_statement(
+                    &session,
+                    PrepareRequest::new(
+                        database,
+                        sql::SqlDialect::Sqlite,
+                        sql::SqlTranslationMode::StrictSqlite,
+                        "UPDATE catalog_records SET code = 1",
+                    ),
+                )
                 .await
                 .unwrap_err()
                 .kind(),
@@ -2598,6 +2655,15 @@ mod tests {
     async fn failed_description_refresh_preserves_cached_metadata_and_can_retry() {
         let (_temp, engine, database) = engine_with_prepared_catalog(EngineOptions::default());
         let session = engine.session();
+        engine
+            .broadcast(
+                &session,
+                "CREATE VIEW refreshable_events AS
+                 SELECT tenant_id, payload FROM events"
+                    .to_owned(),
+            )
+            .await
+            .unwrap();
         let statement = engine
             .prepare_statement(
                 &session,
@@ -2605,7 +2671,7 @@ mod tests {
                     database,
                     sql::SqlDialect::Sqlite,
                     sql::SqlTranslationMode::StrictSqlite,
-                    "SELECT * FROM events",
+                    "SELECT * FROM refreshable_events",
                 ),
             )
             .await
@@ -2618,7 +2684,7 @@ mod tests {
         assert_eq!(before.columns().len(), 2);
 
         engine
-            .broadcast(&session, "DROP TABLE events".to_owned())
+            .broadcast(&session, "DROP VIEW refreshable_events".to_owned())
             .await
             .unwrap();
         let error = engine
@@ -2640,12 +2706,9 @@ mod tests {
         engine
             .broadcast(
                 &session,
-                "CREATE TABLE events (
-                    tenant_id INTEGER PRIMARY KEY,
-                    payload TEXT NOT NULL,
-                    restored TEXT
-                 )"
-                .to_owned(),
+                "CREATE VIEW refreshable_events AS
+                 SELECT tenant_id, payload, NULL AS restored FROM events"
+                    .to_owned(),
             )
             .await
             .unwrap();
@@ -2660,15 +2723,16 @@ mod tests {
 
     #[tokio::test]
     async fn portal_execution_result_limit_failure_is_retryable_with_the_same_handle() {
-        let (_temp, engine, database) = engine_with_prepared_catalog(EngineOptions::default());
+        let (temp, engine, database) = engine_with_prepared_catalog(EngineOptions::default());
         let session = engine.session();
-        engine
-            .broadcast(
-                &session,
-                "INSERT INTO global_events (code) VALUES (1), (2)".to_owned(),
-            )
-            .await
-            .unwrap();
+        for shard in 0..engine.shard_count() {
+            let connection =
+                rusqlite::Connection::open(temp.path().join(format!("shards/{shard:04}.sqlite")))
+                    .unwrap();
+            connection
+                .execute_batch("INSERT INTO global_events (code) VALUES (1), (2)")
+                .unwrap();
+        }
         let statement = engine
             .prepare_statement(
                 &session,
@@ -3200,6 +3264,133 @@ mod tests {
             }
             assert_eq!(shard.retired, 0);
         }
+    }
+
+    #[tokio::test]
+    async fn populated_catalog_gates_async_raw_data_plane_routing() {
+        let (_temp, engine, _database) = engine_with_prepared_catalog(EngineOptions::default());
+        let session = engine.session();
+        let shard_zero_value = integer_key_for_shard(&engine, 0, None);
+        let shard_one_value = integer_key_for_shard(&engine, 1, None);
+        let shard_zero_key = shard_zero_value.to_string();
+        let shard_one_key = shard_one_value.to_string();
+
+        session.set_routing_key(&shard_zero_key).await.unwrap();
+        let write = engine
+            .execute(
+                &session,
+                Statement::new(
+                    "INSERT INTO events (tenant_id, payload) VALUES (?1, ?2)",
+                    vec![Value::from(shard_zero_value), Value::from("owned")],
+                ),
+            )
+            .await
+            .unwrap();
+        assert_eq!(write.shard, 0);
+        assert_eq!(write.value, 1);
+
+        let read = engine
+            .query(
+                &session,
+                Statement::new(
+                    "SELECT payload FROM events WHERE tenant_id = ?1",
+                    vec![Value::from(shard_zero_value)],
+                ),
+            )
+            .await
+            .unwrap();
+        assert_eq!(read.shard, 0);
+        assert_eq!(read.value.rows()[0].get(0), Some(&Value::from("owned")));
+
+        session.set_routing_key(&shard_one_key).await.unwrap();
+        let global = engine
+            .query(
+                &session,
+                Statement::new(
+                    "SELECT code FROM global_events WHERE code = ?1",
+                    vec![Value::from(7_i64)],
+                ),
+            )
+            .await
+            .unwrap();
+        assert_eq!(global.shard, 0);
+
+        for (error, expected) in [
+            (
+                engine
+                    .query(
+                        &session,
+                        Statement::new(
+                            "SELECT payload FROM events WHERE tenant_id = ?1",
+                            vec![Value::from(shard_zero_value)],
+                        ),
+                    )
+                    .await
+                    .unwrap_err(),
+                EngineErrorKind::InvalidArgument,
+            ),
+            (
+                engine
+                    .query(
+                        &session,
+                        Statement::new("SELECT payload FROM events", vec![]),
+                    )
+                    .await
+                    .unwrap_err(),
+                EngineErrorKind::Unsupported,
+            ),
+            (
+                engine
+                    .query(
+                        &session,
+                        Statement::new(
+                            "SELECT payload FROM events
+                             WHERE tenant_id = ?1 OR tenant_id = ?2",
+                            vec![Value::from(shard_zero_value), Value::from(shard_one_value)],
+                        ),
+                    )
+                    .await
+                    .unwrap_err(),
+                EngineErrorKind::InvalidArgument,
+            ),
+            (
+                engine
+                    .execute(
+                        &session,
+                        Statement::new(
+                            "INSERT INTO global_events (code) VALUES (?1)",
+                            vec![Value::from(1_i64)],
+                        ),
+                    )
+                    .await
+                    .unwrap_err(),
+                EngineErrorKind::Unsupported,
+            ),
+            (
+                engine
+                    .query(
+                        &session,
+                        Statement::new("SELECT code FROM catalog_records", vec![]),
+                    )
+                    .await
+                    .unwrap_err(),
+                EngineErrorKind::PermissionDenied,
+            ),
+            (
+                engine
+                    .query(
+                        &session,
+                        Statement::new("SELECT * FROM undeclared_events", vec![]),
+                    )
+                    .await
+                    .unwrap_err(),
+                EngineErrorKind::InvalidQuery,
+            ),
+        ] {
+            assert_eq!(error.kind(), expected, "{}", error.diagnostic());
+        }
+        assert_eq!(session.state().await, SessionState::Ready);
+        assert_eq!(engine.active_operations_for_test(), 0);
     }
 
     #[tokio::test]

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -17,8 +17,8 @@ mod types;
 pub(crate) mod worker;
 
 pub use catalog::{
-    Catalog, LogicalDatabaseId, LogicalDatabaseMetadata, ShardKeyMetadata, ShardKeyType, TableId,
-    TableMetadata, TablePlacement,
+    Catalog, LogicalDatabaseId, LogicalDatabaseMetadata, ShardKeyMetadata, ShardKeyType,
+    TableDeclaration, TableId, TableMetadata, TablePlacement,
 };
 pub(crate) use catalog::{
     CatalogSnapshot, DEFAULT_LOGICAL_DATABASE_ID, DEFAULT_LOGICAL_DATABASE_NAME,
@@ -63,6 +63,18 @@ use std::path::Path;
 
 use crate::{sql, storage::Storage};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RawDataOperation {
+    Execute,
+    Query,
+}
+
+#[derive(Debug)]
+pub(crate) struct RawDataPlan {
+    pub(crate) shard: u16,
+    pub(crate) sqlite_sql: String,
+}
+
 #[derive(Debug)]
 pub struct Database {
     storage: Storage,
@@ -85,6 +97,20 @@ impl Database {
         self.storage.shard_count()
     }
 
+    /// Atomically register the complete logical table catalog for an empty
+    /// application schema.
+    ///
+    /// This initialization-only operation requires exclusive ownership of the
+    /// database before it is wrapped in an [`Engine`]. Every declared physical
+    /// table must already exist with the same empty schema on all shards.
+    /// Sharded text keys use `BINARY` collation, every unique key must include
+    /// the shard key, and foreign keys, triggers, and virtual tables are not yet
+    /// supported. The catalog can be registered exactly once; later table
+    /// changes belong to a journaled schema-and-catalog migration.
+    pub fn register_tables(&mut self, declarations: Vec<TableDeclaration>) -> EngineResult<()> {
+        self.storage.register_tables(declarations)
+    }
+
     /// Return the immutable logical database and table catalog.
     pub fn catalog(&self) -> &Catalog {
         self.storage.logical_catalog()
@@ -98,6 +124,61 @@ impl Database {
         self.storage.routing_provenance()
     }
 
+    /// Plan a legacy raw statement against the authoritative catalog.
+    ///
+    /// An empty catalog deliberately returns `None` so pre-catalog callers
+    /// retain their existing explicit-route behavior. Once any table has been
+    /// registered, every raw data-plane statement must pass the same bounded
+    /// SQL frontend, inference, and routing policy as prepared statements.
+    pub(crate) fn raw_data_plan(
+        &self,
+        shard_key: &str,
+        statement: &str,
+        params: &[Value],
+        operation: RawDataOperation,
+    ) -> EngineResult<Option<RawDataPlan>> {
+        let catalog = self.catalog();
+        if catalog.tables().is_empty() {
+            return Ok(None);
+        }
+
+        let parsed = sql::parse(sql::SqlDialect::Sqlite, statement)?;
+        if parsed.statement_count() != 1 {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "catalog-routed raw SQL must contain exactly one top-level statement",
+            ));
+        }
+        let common = sql::validate_common_subset(parsed)?;
+        let normalized = sql::normalize_placeholders(common)?;
+        let translated = sql::translate_sql(normalized, sql::SqlTranslationMode::StrictSqlite)?;
+        let (hash_version, key_encoding_version, bucket_algorithm_version, map_generation) =
+            self.routing_provenance();
+        let plan = planner::plan_bound_statement(
+            planner::BoundStatementPlanInput::new(
+                catalog,
+                catalog.default_database().id(),
+                translated.normalized_sql(),
+                0,
+                params,
+                Some(shard_key.as_bytes()),
+            ),
+            planner::RoutingProvenance::new(
+                hash_version,
+                key_encoding_version,
+                bucket_algorithm_version,
+                map_generation,
+            ),
+            |key| self.shard_for_key(key),
+        )?;
+        let shard = raw_data_execution_shard(&plan, catalog, operation)?;
+
+        Ok(Some(RawDataPlan {
+            shard,
+            sqlite_sql: translated.sqlite_sql().to_owned(),
+        }))
+    }
+
     pub fn execute_routed(
         &self,
         shard_key: &str,
@@ -105,7 +186,14 @@ impl Database {
         params: &[Value],
     ) -> EngineResult<Routed<usize>> {
         let _schema_operation = self.storage.enter_schema_operation()?;
-        let shard = self.shard_for_key(shard_key.as_bytes());
+        let plan = self.raw_data_plan(shard_key, statement, params, RawDataOperation::Execute)?;
+        let shard = plan.as_ref().map_or_else(
+            || self.shard_for_key(shard_key.as_bytes()),
+            |plan| plan.shard,
+        );
+        let statement = plan
+            .as_ref()
+            .map_or(statement, |plan| plan.sqlite_sql.as_str());
         let connection = self.storage.open_shard(shard)?;
         let value =
             self.storage
@@ -120,7 +208,14 @@ impl Database {
         params: &[Value],
     ) -> EngineResult<Routed<ResultSet>> {
         let _schema_operation = self.storage.enter_schema_operation()?;
-        let shard = self.shard_for_key(shard_key.as_bytes());
+        let plan = self.raw_data_plan(shard_key, statement, params, RawDataOperation::Query)?;
+        let shard = plan.as_ref().map_or_else(
+            || self.shard_for_key(shard_key.as_bytes()),
+            |plan| plan.shard,
+        );
+        let statement = plan
+            .as_ref()
+            .map_or(statement, |plan| plan.sqlite_sql.as_str());
         let connection = self.storage.open_shard(shard)?;
         let value =
             self.storage
@@ -157,6 +252,95 @@ impl Database {
     }
 }
 
+fn raw_data_execution_shard(
+    plan: &BoundStatementPlan,
+    catalog: &Catalog,
+    operation: RawDataOperation,
+) -> EngineResult<u16> {
+    let behavior_matches_operation = matches!(
+        (operation, plan.behavior()),
+        (RawDataOperation::Execute, sql::StatementBehavior::Write(_))
+            | (RawDataOperation::Query, sql::StatementBehavior::Read)
+    );
+    if !behavior_matches_operation {
+        return match plan.behavior() {
+            sql::StatementBehavior::Schema(_) | sql::StatementBehavior::Session(_) => {
+                Err(EngineError::new(
+                    EngineErrorKind::Unsupported,
+                    "schema and session statements require a dedicated engine operation",
+                ))
+            }
+            sql::StatementBehavior::Read | sql::StatementBehavior::Write(_) => {
+                Err(EngineError::new(
+                    EngineErrorKind::InvalidQuery,
+                    "raw statement behavior does not match the requested operation",
+                ))
+            }
+        };
+    }
+
+    let inference = plan.inference();
+    let Some(table_id) = inference.table_id() else {
+        return if inference.kind() == sql::ShardKeyInferenceKind::NotApplicable
+            && plan.behavior() == sql::StatementBehavior::Read
+        {
+            Ok(0)
+        } else {
+            Err(EngineError::new(
+                EngineErrorKind::Internal,
+                "catalog-routed raw planning lost its target table",
+            ))
+        };
+    };
+    let table = catalog.table_by_id(table_id).ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::Internal,
+            "catalog-routed raw planning resolved an unknown table identity",
+        )
+    })?;
+
+    match table.placement() {
+        TablePlacement::Catalog => Err(EngineError::new(
+            EngineErrorKind::PermissionDenied,
+            "catalog-placed tables cannot execute as client SQL",
+        )),
+        TablePlacement::Global => match plan.behavior() {
+            sql::StatementBehavior::Read => Ok(0),
+            sql::StatementBehavior::Write(_) => Err(EngineError::new(
+                EngineErrorKind::Unsupported,
+                "raw writes to global tables require an explicit replication operation",
+            )),
+            sql::StatementBehavior::Schema(_) | sql::StatementBehavior::Session(_) => {
+                Err(EngineError::new(
+                    EngineErrorKind::Internal,
+                    "catalog-routed raw planning assigned non-data behavior to a global table",
+                ))
+            }
+        },
+        TablePlacement::Sharded(_) => match inference.kind() {
+            sql::ShardKeyInferenceKind::Exact | sql::ShardKeyInferenceKind::Multiple => {
+                plan.assigned_shard().ok_or_else(|| {
+                    EngineError::new(
+                        EngineErrorKind::Unsupported,
+                        "raw sharded statement does not have one executable physical shard",
+                    )
+                })
+            }
+            sql::ShardKeyInferenceKind::Unconstrained
+            | sql::ShardKeyInferenceKind::Contradiction => Err(EngineError::new(
+                EngineErrorKind::Unsupported,
+                "raw sharded statement requires a finite single-shard key constraint",
+            )),
+            sql::ShardKeyInferenceKind::NotApplicable | sql::ShardKeyInferenceKind::NotSharded => {
+                Err(EngineError::new(
+                    EngineErrorKind::Internal,
+                    "catalog-routed raw inference disagrees with sharded table placement",
+                ))
+            }
+        },
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{
@@ -174,6 +358,47 @@ mod tests {
             .map(|value| format!("sync-corruption-{value}"))
             .find(|key| database.shard_for_key(key.as_bytes()) == expected)
             .expect("the finite shard layout has a routing key")
+    }
+
+    fn integer_key_for_shard(database: &Database, expected: u16, excluded: Option<i64>) -> i64 {
+        (1_i64..)
+            .find(|value| {
+                Some(*value) != excluded
+                    && database.shard_for_key(value.to_string().as_bytes()) == expected
+            })
+            .expect("the finite shard layout has an integer routing key")
+    }
+
+    fn database_with_raw_catalog() -> (tempfile::TempDir, Database) {
+        let temp = tempfile::tempdir().unwrap();
+        let mut database = Database::open(temp.path(), 4).unwrap();
+        database
+            .broadcast(
+                "CREATE TABLE events (
+                    tenant_id INTEGER NOT NULL,
+                    sequence INTEGER NOT NULL,
+                    payload TEXT NOT NULL,
+                    PRIMARY KEY (tenant_id, sequence)
+                 );
+                 CREATE TABLE global_events (code TEXT PRIMARY KEY, label TEXT NOT NULL);
+                 CREATE VIEW undeclared_events AS
+                 SELECT tenant_id, sequence, payload FROM events;",
+            )
+            .unwrap();
+        let logical_database = database.catalog().default_database().id();
+        database
+            .register_tables(vec![
+                TableDeclaration::sharded(
+                    logical_database,
+                    "events",
+                    ShardKeyMetadata::new("tenant_id", ShardKeyType::Int64).unwrap(),
+                )
+                .unwrap(),
+                TableDeclaration::global(logical_database, "global_events").unwrap(),
+                TableDeclaration::catalog(logical_database, "catalog_records").unwrap(),
+            ])
+            .unwrap();
+        (temp, database)
     }
 
     fn corrupt_application_table_root(root: &Path, shard: u16, table: &str) {
@@ -376,6 +601,152 @@ mod tests {
             )
             .unwrap()
         );
+    }
+
+    #[test]
+    fn populated_catalog_routes_raw_point_operations_without_replicating_rows() {
+        let (_temp, database) = database_with_raw_catalog();
+        let first_key = integer_key_for_shard(&database, 0, None);
+        let second_key = integer_key_for_shard(&database, 0, Some(first_key));
+        let first_route = first_key.to_string();
+        let second_route = second_key.to_string();
+
+        let write = database
+            .execute_routed(
+                &first_route,
+                "INSERT INTO events (tenant_id, sequence, payload)
+                 VALUES (?1, ?2, ?3), (?4, ?5, ?6)",
+                &[
+                    Value::from(first_key),
+                    Value::from(1_i64),
+                    Value::from("first"),
+                    Value::from(second_key),
+                    Value::from(2_i64),
+                    Value::from("second"),
+                ],
+            )
+            .unwrap();
+        assert_eq!(write.shard, 0);
+        assert_eq!(write.value, 2);
+
+        let read = database
+            .query_routed(
+                &second_route,
+                "SELECT payload FROM events WHERE tenant_id = ?1",
+                &[Value::from(second_key)],
+            )
+            .unwrap();
+        assert_eq!(read.shard, 0);
+        assert_eq!(read.value.rows().len(), 1);
+        assert_eq!(read.value.rows()[0].get(0), Some(&Value::from("second")));
+
+        let same_shard_read = database
+            .query_routed(
+                &first_route,
+                "SELECT payload FROM events
+                 WHERE tenant_id = ?1 OR tenant_id = ?2",
+                &[Value::from(first_key), Value::from(second_key)],
+            )
+            .unwrap();
+        assert_eq!(same_shard_read.shard, 0);
+        assert_eq!(same_shard_read.value.rows().len(), 2);
+
+        for shard in 0..database.shard_count() {
+            let connection = database.storage.open_shard(shard).unwrap();
+            let row_count: i64 = connection
+                .query_row("SELECT COUNT(*) FROM events", [], |row| row.get(0))
+                .unwrap();
+            assert_eq!(row_count, if shard == 0 { 2 } else { 0 }, "shard {shard}");
+        }
+    }
+
+    #[test]
+    fn populated_catalog_raw_gate_rejects_unsafe_routes_and_targets() {
+        let (_temp, database) = database_with_raw_catalog();
+        let shard_zero_value = integer_key_for_shard(&database, 0, None);
+        let shard_one_value = integer_key_for_shard(&database, 1, None);
+        let shard_zero_key = shard_zero_value.to_string();
+        let shard_one_key = shard_one_value.to_string();
+
+        let global = database
+            .query_routed(
+                &shard_one_key,
+                "SELECT code FROM global_events WHERE code = ?1",
+                &[Value::from("US")],
+            )
+            .unwrap();
+        assert_eq!(global.shard, 0);
+        assert!(global.value.rows().is_empty());
+
+        for (error, expected) in [
+            (
+                database
+                    .execute(
+                        &shard_zero_key,
+                        "INSERT INTO global_events (code, label) VALUES (?1, ?2)",
+                        &[Value::from("US"), Value::from("United States")],
+                    )
+                    .unwrap_err(),
+                EngineErrorKind::Unsupported,
+            ),
+            (
+                database
+                    .query(&shard_zero_key, "SELECT * FROM catalog_records", &[])
+                    .unwrap_err(),
+                EngineErrorKind::PermissionDenied,
+            ),
+            (
+                database
+                    .query(&shard_zero_key, "SELECT * FROM undeclared_events", &[])
+                    .unwrap_err(),
+                EngineErrorKind::InvalidQuery,
+            ),
+            (
+                database
+                    .query(&shard_zero_key, "SELECT payload FROM events", &[])
+                    .unwrap_err(),
+                EngineErrorKind::Unsupported,
+            ),
+            (
+                database
+                    .execute(
+                        &shard_zero_key,
+                        "UPDATE events SET payload = ?1",
+                        &[Value::from("unsafe")],
+                    )
+                    .unwrap_err(),
+                EngineErrorKind::Unsupported,
+            ),
+            (
+                database
+                    .query(
+                        &shard_one_key,
+                        "SELECT payload FROM events WHERE tenant_id = ?1",
+                        &[Value::from(shard_zero_value)],
+                    )
+                    .unwrap_err(),
+                EngineErrorKind::InvalidArgument,
+            ),
+            (
+                database
+                    .query(
+                        &shard_zero_key,
+                        "SELECT payload FROM events
+                         WHERE tenant_id = ?1 OR tenant_id = ?2",
+                        &[Value::from(shard_zero_value), Value::from(shard_one_value)],
+                    )
+                    .unwrap_err(),
+                EngineErrorKind::InvalidArgument,
+            ),
+            (
+                database
+                    .execute(&shard_zero_key, "CREATE TABLE bypass (id INTEGER)", &[])
+                    .unwrap_err(),
+                EngineErrorKind::Unsupported,
+            ),
+        ] {
+            assert_eq!(error.kind(), expected, "{}", error.diagnostic());
+        }
     }
 
     #[test]

--- a/src/core/planner.rs
+++ b/src/core/planner.rs
@@ -440,7 +440,6 @@ fn canonical_key_bytes(value: &ShardKeyValue) -> Arc<[u8]> {
 #[cfg(test)]
 mod tests {
     use std::{
-        path::Path,
         sync::{Arc, Barrier},
         thread,
     };
@@ -450,7 +449,7 @@ mod tests {
         core::{
             BUCKET_ALGORITHM_VERSION, Database, Engine, HASH_VERSION, INITIAL_MAP_GENERATION,
             KEY_ENCODING_VERSION, LogicalDatabaseMetadata, RoutingCatalog, ShardKeyMetadata,
-            ShardKeyType, TableMetadata, TablePlacement, VIRTUAL_BUCKET_COUNT,
+            ShardKeyType, TableDeclaration, TableMetadata, TablePlacement, VIRTUAL_BUCKET_COUNT,
             initial_physical_shard,
         },
         sql::{SqlDialect, normalize_placeholders, parse, validate_common_subset},
@@ -519,30 +518,25 @@ mod tests {
         )
     }
 
-    fn insert_engine_catalog_fixture(root: &Path) {
-        let manifest = rusqlite::Connection::open(root.join("manifest.sqlite")).unwrap();
-        manifest
-            .execute_batch(
-                "PRAGMA foreign_keys = ON;
-                 BEGIN IMMEDIATE;
-                 DROP TABLE briskdb_integrity;
-                 DROP TABLE briskdb_metadata;
-                 CREATE TABLE briskdb_metadata (
-                     requires_manifest_version INTEGER NOT NULL
-                         CHECK (requires_manifest_version >= 6)
-                 ) STRICT;
-                 INSERT INTO briskdb_metadata VALUES (6);
-                 INSERT INTO briskdb_tables (
-                    table_id,
-                    database_id,
-                    table_name,
-                    placement,
-                    shard_key_column,
-                    shard_key_type
-                 ) VALUES (4, 1, 'events', 1, 'tenant_id', 1);
-                 PRAGMA user_version = 6;
-                 COMMIT;",
+    fn register_engine_catalog_fixture(database: &mut Database) {
+        database
+            .broadcast(
+                "CREATE TABLE events (
+                    tenant_id INTEGER PRIMARY KEY,
+                    payload TEXT NOT NULL
+                 );",
             )
+            .unwrap();
+        let logical_database = database.catalog().default_database().id();
+        database
+            .register_tables(vec![
+                TableDeclaration::sharded(
+                    logical_database,
+                    "events",
+                    ShardKeyMetadata::new("tenant_id", ShardKeyType::Int64).unwrap(),
+                )
+                .unwrap(),
+            ])
             .unwrap();
     }
 
@@ -1514,7 +1508,7 @@ mod tests {
     }
 
     #[test]
-    fn text_predicates_remain_conservative_while_text_inserts_are_routed() {
+    fn authoritative_binary_text_predicates_and_inserts_are_routed() {
         let catalog = sample_catalog();
         let predicate = plan(
             &catalog,
@@ -1525,18 +1519,12 @@ mod tests {
             ),
             0,
             &[Value::Text("tenant-a".to_owned())],
-            Some(b"caller-route"),
+            Some(b"tenant-a"),
         )
         .unwrap();
-        assert_eq!(
-            predicate.inference().kind(),
-            ShardKeyInferenceKind::Unconstrained
-        );
-        assert!(predicate.inferred_routes().is_empty());
-        assert_eq!(
-            predicate.explicit_route().unwrap().key_bytes(),
-            b"caller-route"
-        );
+        assert_eq!(predicate.inference().kind(), ShardKeyInferenceKind::Exact);
+        assert_eq!(predicate.inferred_routes()[0].key_bytes(), b"tenant-a");
+        assert_eq!(predicate.explicit_route().unwrap().key_bytes(), b"tenant-a");
 
         let insert = plan(
             &catalog,
@@ -1935,9 +1923,9 @@ mod tests {
     #[test]
     fn schema_gate_precedes_write_policy_and_a_later_valid_plan_recovers() {
         let temp = tempfile::tempdir().unwrap();
-        drop(Database::open(temp.path(), 2).unwrap());
-        insert_engine_catalog_fixture(temp.path());
-        let database = Arc::new(Database::open(temp.path(), 2).unwrap());
+        let mut database = Database::open(temp.path(), 2).unwrap();
+        register_engine_catalog_fixture(&mut database);
+        let database = Arc::new(database);
         let engine = Engine::from_database(Arc::clone(&database));
         let logical_database = engine.catalog().default_database().id();
         let broad_write = normalize(SqlDialect::Sqlite, "DELETE FROM events");

--- a/src/protocol/http.rs
+++ b/src/protocol/http.rs
@@ -487,7 +487,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn current_http_sql_remains_raw_sqlite_pass_through_until_planner_integration() {
+    async fn empty_catalog_http_sql_retains_raw_sqlite_compatibility() {
         let temp = tempfile::tempdir().unwrap();
         let database = Arc::new(Database::open(temp.path(), 2).unwrap());
         let expected_shard = database.shard_for_key(b"raw-http-parser-boundary");

--- a/src/sql/inference.rs
+++ b/src/sql/inference.rs
@@ -491,38 +491,11 @@ fn atom_domain(
     key_type: ShardKeyType,
     context: &InferenceContext<'_>,
 ) -> EngineResult<KeyDomain> {
-    if matches!(key_type, ShardKeyType::Text) {
-        return text_atom_domain(expression, context);
-    }
     Ok(match infer_atom(expression, key_type, context)? {
         InferredAtom::Value(value) => KeyDomain::Finite(vec![value]),
         InferredAtom::Null => KeyDomain::Finite(Vec::new()),
         InferredAtom::Unresolved => KeyDomain::Any,
     })
-}
-
-fn text_atom_domain(expression: &Expr, context: &InferenceContext<'_>) -> EngineResult<KeyDomain> {
-    let Expr::Value(value) = peel_nested(expression) else {
-        return Ok(KeyDomain::Any);
-    };
-    match &value.value {
-        AstValue::Placeholder(_) => match bound_parameter(value.span, context)? {
-            Value::Null => Ok(KeyDomain::Finite(Vec::new())),
-            Value::Text(_) => Ok(KeyDomain::Any),
-            Value::InvalidText(_) => Err(EngineError::new(
-                EngineErrorKind::InvalidTextEncoding,
-                format!(
-                    "statement {} binds non-UTF-8 text to its shard key",
-                    context.statement_index + 1
-                ),
-            )),
-            _ => Err(type_mismatch(context)),
-        },
-        AstValue::Null => Ok(KeyDomain::Finite(Vec::new())),
-        AstValue::SingleQuotedString(_) => Ok(KeyDomain::Any),
-        AstValue::Number(_, false) | AstValue::Boolean(_) => Err(type_mismatch(context)),
-        _ => Err(inference_invariant()),
-    }
 }
 
 fn is_shard_column(expression: &Expr, target: &PredicateTarget<'_>) -> bool {
@@ -1436,7 +1409,7 @@ mod tests {
     }
 
     #[test]
-    fn text_predicates_need_collation_metadata_and_binary_keys_are_exact() {
+    fn authoritative_binary_text_and_binary_predicates_are_exact() {
         let catalog = sample_catalog();
         let text = infer(
             &catalog,
@@ -1446,8 +1419,8 @@ mod tests {
             &[Value::Text("snowman-☃".to_owned())],
         )
         .unwrap();
-        assert_eq!(text.kind(), ShardKeyInferenceKind::Unconstrained);
-        assert!(text.values().is_empty());
+        assert_eq!(text.kind(), ShardKeyInferenceKind::Exact);
+        assert_eq!(text.values()[0].as_str(), Some("snowman-☃"));
 
         let text_literal = infer(
             &catalog,
@@ -1457,8 +1430,8 @@ mod tests {
             &[],
         )
         .unwrap();
-        assert_eq!(text_literal.kind(), ShardKeyInferenceKind::Unconstrained);
-        assert!(text_literal.values().is_empty());
+        assert_eq!(text_literal.kind(), ShardKeyInferenceKind::Exact);
+        assert_eq!(text_literal.values()[0].as_str(), Some("snowman-☃"));
 
         let folded_candidates = infer(
             &catalog,
@@ -1468,11 +1441,8 @@ mod tests {
             &[],
         )
         .unwrap();
-        assert_eq!(
-            folded_candidates.kind(),
-            ShardKeyInferenceKind::Unconstrained
-        );
-        assert!(folded_candidates.values().is_empty());
+        assert_eq!(folded_candidates.kind(), ShardKeyInferenceKind::Multiple);
+        assert_eq!(folded_candidates.values().len(), 2);
 
         let bound_null = infer(
             &catalog,

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -4,9 +4,10 @@
 //! common-subset validator recursively admits only protocol-neutral SQL shapes,
 //! the statement classifier identifies protocol-neutral behavior and enforces
 //! read-only multi-statement batches, and the placeholder normalizer produces a
-//! separate source-preserving SQLite parameter representation for later
-//! planning work. Current HTTP execution remains deliberate SQLite pass-through;
-//! these opt-in layers do not route or execute statements.
+//! separate source-preserving SQLite parameter representation for planning.
+//! HTTP execution uses these layers whenever an authoritative table catalog is
+//! populated; only an empty-catalog compatibility path remains raw SQLite
+//! pass-through. The SQL layer itself does not open storage or execute a plan.
 
 mod classifier;
 mod dml;
@@ -27,6 +28,7 @@ pub use inference::{ShardKeyInference, ShardKeyInferenceKind, ShardKeyValue, inf
 pub use normalizer::{
     MAX_SQL_PARAMETERS, NormalizedSql, StatementParameters, normalize_placeholders,
 };
+pub(crate) use parser::validate_authoritative_schema_migration;
 pub use parser::{
     MAX_PARSED_SQL_BYTES, MAX_PARSED_SQL_STATEMENTS, ParsedSql, SQL_PARSE_RECURSION_LIMIT,
     SqlDialect, parse,

--- a/src/sql/parser.rs
+++ b/src/sql/parser.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, fmt};
 
 use sqlparser::{
-    ast::Statement as AstStatement,
+    ast::{ObjectType, Statement as AstStatement},
     dialect::{Dialect, MySqlDialect, PostgreSqlDialect, SQLiteDialect},
     parser::{Parser, ParserError},
 };
@@ -139,6 +139,33 @@ pub fn parse<'a>(dialect: SqlDialect, source: impl Into<Cow<'a, str>>) -> Engine
         source: source.into_owned(),
         statements,
     })
+}
+
+/// Reject data-moving SQL from the application-schema migration path once an
+/// authoritative placement catalog exists. Those migrations may alter schema
+/// while preserving registered tables and shard keys, but row movement needs
+/// a separate placement-aware coordinator.
+pub(crate) fn validate_authoritative_schema_migration(source: &str) -> EngineResult<()> {
+    let parsed = parse(SqlDialect::Sqlite, source)?;
+    let unsafe_statement = parsed.statements.iter().any(|statement| match statement {
+        AstStatement::Insert(_)
+        | AstStatement::Update(_)
+        | AstStatement::Delete(_)
+        | AstStatement::Merge(_)
+        | AstStatement::Truncate(_)
+        | AstStatement::CreateTrigger(_) => true,
+        AstStatement::CreateTable(table) => table.query.is_some(),
+        AstStatement::Drop { object_type, .. } => *object_type == ObjectType::Table,
+        _ => false,
+    });
+    if unsafe_statement {
+        Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "authoritative-catalog schema migrations cannot move rows, drop tables, or create triggers",
+        ))
+    } else {
+        Ok(())
+    }
 }
 
 fn parse_with(dialect: &dyn Dialect, source: &str) -> Result<Vec<AstStatement>, ParserError> {
@@ -309,6 +336,34 @@ mod tests {
                     .unwrap_or_else(|error| panic!("{dialect} rejected {source}: {error}"));
                 assert_eq!(parsed.statement_count(), 1, "{dialect}: {source}");
             }
+        }
+    }
+
+    #[test]
+    fn authoritative_schema_migrations_reject_every_row_moving_shape() {
+        for source in [
+            "INSERT INTO widgets (id) VALUES (1)",
+            "UPDATE widgets SET id = 2 WHERE id = 1",
+            "DELETE FROM widgets WHERE id = 1",
+            "DROP TABLE widgets",
+            "CREATE TABLE copied AS SELECT * FROM widgets",
+            "CREATE TRIGGER move_row AFTER INSERT ON widgets BEGIN DELETE FROM widgets WHERE id = NEW.id; END",
+        ] {
+            assert_eq!(
+                validate_authoritative_schema_migration(source)
+                    .unwrap_err()
+                    .kind(),
+                EngineErrorKind::FailedPrecondition,
+                "{source}"
+            );
+        }
+        for source in [
+            "CREATE INDEX widgets_id ON widgets (id)",
+            "ALTER TABLE widgets ADD COLUMN payload TEXT",
+            "CREATE VIEW widget_ids AS SELECT id FROM widgets",
+        ] {
+            validate_authoritative_schema_migration(source)
+                .unwrap_or_else(|error| panic!("{source}: {error}"));
         }
     }
 

--- a/src/storage/manifest.rs
+++ b/src/storage/manifest.rs
@@ -2,14 +2,17 @@
 
 use rusqlite::{Connection, Transaction, TransactionBehavior, types::ValueRef};
 
+#[cfg(test)]
+use std::cell::Cell;
+
 use crate::{
     core::{
         BUCKET_ALGORITHM_VERSION, Catalog, CatalogSnapshot, DEFAULT_LOGICAL_DATABASE_ID,
         DEFAULT_LOGICAL_DATABASE_NAME, EngineError, EngineErrorKind, EngineResult, HASH_VERSION,
         IDENTIFIER_ENCODING_VERSION, INITIAL_MAP_GENERATION, KEY_ENCODING_VERSION,
         LogicalDatabaseMetadata, MAX_LOGICAL_DATABASES, MAX_TABLES, RoutingCatalog,
-        ShardKeyMetadata, ShardKeyType, TableMetadata, TablePlacement, VIRTUAL_BUCKET_COUNT,
-        initial_physical_shard, validate_catalog_identifier,
+        ShardKeyMetadata, ShardKeyType, TableDeclaration, TableMetadata, TablePlacement,
+        VIRTUAL_BUCKET_COUNT, initial_physical_shard, validate_catalog_identifier,
     },
     sqlite_error,
 };
@@ -25,7 +28,8 @@ const V4_SCHEMA_VERSION: u32 = 4;
 const V5_SCHEMA_VERSION: u32 = 5;
 const V6_SCHEMA_VERSION: u32 = 6;
 const V7_SCHEMA_VERSION: u32 = 7;
-pub(super) const CURRENT_SCHEMA_VERSION: u32 = V7_SCHEMA_VERSION;
+const V8_SCHEMA_VERSION: u32 = 8;
+pub(super) const CURRENT_SCHEMA_VERSION: u32 = V8_SCHEMA_VERSION;
 const MAX_TABLE_SQL_BYTES: i64 = 4_096;
 
 pub(super) const MAX_SCHEMA_MIGRATION_SQL_BYTES: usize = 65_536;
@@ -51,6 +55,23 @@ const TEXT_SHARD_KEY_TYPE: i64 = 2;
 const BINARY_SHARD_KEY_TYPE: i64 = 3;
 
 const ACTIVE_LIFECYCLE_STATE: &str = "active";
+
+#[cfg(test)]
+thread_local! {
+    static FAIL_NEXT_TABLE_REGISTRATION_POST_COMMIT: Cell<bool> = const { Cell::new(false) };
+}
+
+#[cfg(test)]
+pub(super) fn fail_next_table_registration_post_commit_for_test() {
+    FAIL_NEXT_TABLE_REGISTRATION_POST_COMMIT.with(|fail| fail.set(true));
+}
+
+#[cfg(test)]
+fn abort_table_registration_at_test_boundary(boundary: &str) {
+    if std::env::var("BRISKDB_TABLE_REGISTRATION_ABORT_POINT").as_deref() == Ok(boundary) {
+        std::process::abort();
+    }
+}
 
 const LEGACY_METADATA_TABLE_SQL: &str = "CREATE TABLE briskdb_metadata (
     key TEXT PRIMARY KEY,
@@ -83,6 +104,10 @@ const V6_DOWNGRADE_FENCE_SQL: &str = "CREATE TABLE briskdb_metadata (
 const V7_DOWNGRADE_FENCE_SQL: &str = "CREATE TABLE briskdb_metadata (
     requires_manifest_version INTEGER NOT NULL
         CHECK (requires_manifest_version >= 7)
+) STRICT";
+const V8_DOWNGRADE_FENCE_SQL: &str = "CREATE TABLE briskdb_metadata (
+    requires_manifest_version INTEGER NOT NULL
+        CHECK (requires_manifest_version >= 8)
 ) STRICT";
 const V3_ROUTING_TABLE_SQL: &str = "CREATE TABLE briskdb_routing (
     singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
@@ -497,6 +522,13 @@ const MIGRATIONS: &[Migration] = &[
         apply: migrate_v6_to_v7,
         validate: validate_v7,
     },
+    Migration {
+        from: V7_SCHEMA_VERSION,
+        to: V8_SCHEMA_VERSION,
+        name: "authoritative_table_catalog",
+        apply: migrate_v7_to_v8,
+        validate: validate_v8,
+    },
 ];
 
 #[derive(Clone, Copy)]
@@ -510,8 +542,8 @@ struct MigrationPlan<'a> {
 const CURRENT_PLAN: MigrationPlan<'static> = MigrationPlan {
     current_version: CURRENT_SCHEMA_VERSION,
     migrations: MIGRATIONS,
-    initialize_current: create_v7_schema,
-    initialize_interrupted_legacy: migrate_interrupted_legacy_to_v7,
+    initialize_current: create_v8_schema,
+    initialize_interrupted_legacy: migrate_interrupted_legacy_to_v8,
 };
 
 // Startup uses this frozen plan only to finish an already-active v6 journal
@@ -1347,6 +1379,222 @@ fn current_manifest_snapshot(
     }
 }
 
+/// Atomically install the complete authoritative table catalog.
+///
+/// Physical-table and emptiness validation belongs to the storage coordinator,
+/// which holds the root schema gate before entering this manifest transaction.
+/// This layer revalidates the checksummed v8 manifest under its write lock,
+/// assigns deterministic IDs, refreshes the semantic root in the same
+/// transaction, and returns only the fully revalidated replacement snapshot.
+/// An exact repeat is a read-only idempotent success. Every other attempt to
+/// replace an already-populated authoritative catalog fails closed.
+pub(super) fn register_table_catalog<F>(
+    connection: &mut Connection,
+    requested_shards: u16,
+    declarations: Vec<TableDeclaration>,
+    on_commit_attempted: F,
+) -> EngineResult<CatalogSnapshot>
+where
+    F: FnOnce(),
+{
+    if declarations.is_empty() {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            "table registration requires at least one declaration",
+        ));
+    }
+    if declarations.len() > MAX_TABLES {
+        return Err(EngineError::new(
+            EngineErrorKind::LimitExceeded,
+            format!("table registration exceeds its {MAX_TABLES}-table limit"),
+        ));
+    }
+
+    let mut declarations = declarations
+        .into_iter()
+        .map(TableDeclaration::into_parts)
+        .collect::<Vec<_>>();
+    declarations.sort_by(|left, right| (left.0, left.1.as_str()).cmp(&(right.0, right.1.as_str())));
+    if declarations
+        .windows(2)
+        .any(|rows| (rows[0].0, rows[0].1.as_str()) == (rows[1].0, rows[1].1.as_str()))
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            "table registration contains a duplicate logical table",
+        ));
+    }
+
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    let current = current_manifest_snapshot(&transaction, requested_shards)?;
+    ensure_table_registration_ready(&current)?;
+    let current_catalog = current.logical_catalog.as_ref().ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::Internal,
+            "current manifest validation omitted its logical catalog",
+        )
+    })?;
+    for (database_id, table_name, _) in &declarations {
+        if current_catalog.database_by_id(*database_id).is_none() {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                format!("table {table_name} references an unknown logical database"),
+            ));
+        }
+    }
+
+    if !current_catalog.tables().is_empty() {
+        if declarations_match_catalog(&declarations, current_catalog) {
+            let current = catalog_snapshot_from_manifest(current)?;
+            transaction.commit().map_err(sqlite_error::storage)?;
+            return Ok(current);
+        }
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "the authoritative table catalog is already registered with different declarations",
+        ));
+    }
+
+    {
+        let mut insert = transaction
+            .prepare(
+                "INSERT INTO briskdb_tables (
+                    table_id,
+                    database_id,
+                    table_name,
+                    placement,
+                    shard_key_column,
+                    shard_key_type
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            )
+            .map_err(sqlite_error::storage)?;
+        for (index, (database_id, table_name, placement)) in declarations.iter().enumerate() {
+            let table_id = i64::try_from(index + 1).expect("bounded table ID fits in SQLite");
+            let database_id = i64::try_from(database_id.get()).map_err(|error| {
+                EngineError::from_source(
+                    EngineErrorKind::NumericOutOfRange,
+                    format!("logical database ID for table {table_name} does not fit in SQLite"),
+                    error,
+                )
+            })?;
+            let (placement, shard_key_column, shard_key_type) = encoded_table_placement(placement);
+            insert
+                .execute(rusqlite::params![
+                    table_id,
+                    database_id,
+                    table_name,
+                    placement,
+                    shard_key_column,
+                    shard_key_type,
+                ])
+                .map_err(sqlite_error::storage)?;
+        }
+    }
+
+    refresh_manifest_digest(&transaction)?;
+    let replacement = current_manifest_snapshot(&transaction, requested_shards)?;
+    ensure_table_registration_ready(&replacement)?;
+    let replacement = catalog_snapshot_from_manifest(replacement)?;
+    if !declarations_match_catalog(&declarations, replacement.logical()) {
+        return Err(EngineError::new(
+            EngineErrorKind::Internal,
+            "table registration did not preserve its complete declaration set",
+        ));
+    }
+
+    // From this point, a failed COMMIT can be durability-ambiguous. The root
+    // coordinator uses this boundary to stop ordinary admission until it has
+    // reconciled the checksummed manifest to either the old or new snapshot.
+    on_commit_attempted();
+    #[cfg(test)]
+    abort_table_registration_at_test_boundary("before-commit");
+    transaction.commit().map_err(sqlite_error::storage)?;
+    #[cfg(test)]
+    abort_table_registration_at_test_boundary("after-commit");
+    #[cfg(test)]
+    if FAIL_NEXT_TABLE_REGISTRATION_POST_COMMIT.with(|fail| fail.replace(false)) {
+        return Err(EngineError::new(
+            EngineErrorKind::Internal,
+            "injected table-registration post-commit publication failure",
+        ));
+    }
+    Ok(replacement)
+}
+
+fn ensure_table_registration_ready(snapshot: &ManifestSnapshot) -> EngineResult<()> {
+    if snapshot.active_migration.is_some() {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "table registration cannot run during an application-schema migration",
+        ));
+    }
+    if snapshot.integrity.map(ManifestIntegrity::state) != Some(DatabaseIntegrityState::Ready) {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "table registration requires a ready checksummed manifest",
+        ));
+    }
+    if snapshot
+        .shard_layout
+        .as_ref()
+        .is_none_or(|layout| layout.state() != ShardLayoutState::Ready)
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "table registration requires a ready physical shard layout",
+        ));
+    }
+    Ok(())
+}
+
+fn catalog_snapshot_from_manifest(snapshot: ManifestSnapshot) -> EngineResult<CatalogSnapshot> {
+    let routing = snapshot.routing_catalog.ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::Internal,
+            "current manifest validation omitted its routing catalog",
+        )
+    })?;
+    let logical = snapshot.logical_catalog.ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::Internal,
+            "current manifest validation omitted its logical catalog",
+        )
+    })?;
+    Ok(CatalogSnapshot::from_validated_parts(routing, logical))
+}
+
+fn declarations_match_catalog(
+    declarations: &[(crate::core::LogicalDatabaseId, String, TablePlacement)],
+    catalog: &Catalog,
+) -> bool {
+    declarations.len() == catalog.tables().len()
+        && declarations.iter().zip(catalog.tables()).all(
+            |((database_id, name, placement), table)| {
+                *database_id == table.database_id()
+                    && name == table.name()
+                    && placement == table.placement()
+            },
+        )
+}
+
+fn encoded_table_placement(placement: &TablePlacement) -> (i64, Option<&str>, Option<i64>) {
+    match placement {
+        TablePlacement::Sharded(shard_key) => (
+            SHARDED_PLACEMENT,
+            Some(shard_key.column()),
+            Some(match shard_key.key_type() {
+                ShardKeyType::Int64 => INT64_SHARD_KEY_TYPE,
+                ShardKeyType::Text => TEXT_SHARD_KEY_TYPE,
+                ShardKeyType::Binary => BINARY_SHARD_KEY_TYPE,
+            }),
+        ),
+        TablePlacement::Global => (GLOBAL_PLACEMENT, None, None),
+        TablePlacement::Catalog => (CATALOG_PLACEMENT, None, None),
+    }
+}
+
 fn find_schema_migration(
     connection: &Connection,
     expected_shard_count: u16,
@@ -1670,7 +1918,7 @@ where
     })?;
 
     set_identity(&transaction, change.to)?;
-    if change.to == V7_SCHEMA_VERSION {
+    if change.to >= V7_SCHEMA_VERSION {
         refresh_manifest_digest(&transaction)?;
     }
     hook(MigrationPoint {
@@ -1752,6 +2000,11 @@ fn create_v7_schema(transaction: &Transaction<'_>, shard_count: u16) -> EngineRe
     migrate_v6_to_v7(transaction, shard_count)
 }
 
+fn create_v8_schema(transaction: &Transaction<'_>, shard_count: u16) -> EngineResult<()> {
+    create_v7_schema(transaction, shard_count)?;
+    migrate_v7_to_v8(transaction, shard_count)
+}
+
 fn migrate_interrupted_legacy_to_v6(
     transaction: &Transaction<'_>,
     shard_count: u16,
@@ -1762,6 +2015,7 @@ fn migrate_interrupted_legacy_to_v6(
     create_v6_schema(transaction, shard_count)
 }
 
+#[cfg(test)]
 fn migrate_interrupted_legacy_to_v7(
     transaction: &Transaction<'_>,
     shard_count: u16,
@@ -1770,6 +2024,16 @@ fn migrate_interrupted_legacy_to_v7(
         .execute_batch("DROP TABLE briskdb_metadata;")
         .map_err(sqlite_error::storage)?;
     create_v7_schema(transaction, shard_count)
+}
+
+fn migrate_interrupted_legacy_to_v8(
+    transaction: &Transaction<'_>,
+    shard_count: u16,
+) -> EngineResult<()> {
+    transaction
+        .execute_batch("DROP TABLE briskdb_metadata;")
+        .map_err(sqlite_error::storage)?;
+    create_v8_schema(transaction, shard_count)
 }
 
 #[cfg(test)]
@@ -2027,6 +2291,28 @@ fn migrate_v6_to_v7(transaction: &Transaction<'_>, _shard_count: u16) -> EngineR
                 SCHEMA_DIGEST_VERSION,
                 DATABASE_STATE_VERIFYING,
             ],
+        )
+        .map_err(sqlite_error::storage)?;
+    Ok(())
+}
+
+fn migrate_v7_to_v8(transaction: &Transaction<'_>, _shard_count: u16) -> EngineResult<()> {
+    // Version 7 table rows were explicitly advisory and could be installed
+    // without proving any relationship to the physical shard schema. They
+    // cannot be silently promoted into authoritative routing declarations.
+    transaction
+        .execute("DELETE FROM briskdb_tables", [])
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch("DROP TABLE briskdb_metadata;")
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch(V8_DOWNGRADE_FENCE_SQL)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "INSERT INTO briskdb_metadata (requires_manifest_version) VALUES (?1)",
+            [V8_SCHEMA_VERSION],
         )
         .map_err(sqlite_error::storage)?;
     Ok(())
@@ -2892,13 +3178,43 @@ fn validate_v7(
     requested_shards: u16,
     objects: &[SchemaObject],
 ) -> EngineResult<ManifestSnapshot> {
+    validate_integrity_manifest(
+        connection,
+        requested_shards,
+        objects,
+        V7_SCHEMA_VERSION,
+        V7_DOWNGRADE_FENCE_SQL,
+    )
+}
+
+fn validate_v8(
+    connection: &Connection,
+    requested_shards: u16,
+    objects: &[SchemaObject],
+) -> EngineResult<ManifestSnapshot> {
+    validate_integrity_manifest(
+        connection,
+        requested_shards,
+        objects,
+        V8_SCHEMA_VERSION,
+        V8_DOWNGRADE_FENCE_SQL,
+    )
+}
+
+fn validate_integrity_manifest(
+    connection: &Connection,
+    requested_shards: u16,
+    objects: &[SchemaObject],
+    version: u32,
+    downgrade_fence_sql: &str,
+) -> EngineResult<ManifestSnapshot> {
     let mut snapshot = validate_catalog_manifest(
         connection,
         requested_shards,
         objects,
         CatalogManifestDefinition {
-            version: V7_SCHEMA_VERSION,
-            downgrade_fence_sql: V7_DOWNGRADE_FENCE_SQL,
+            version,
+            downgrade_fence_sql,
             expected_objects: &v7_objects(),
             schema_catalog_sql: V6_SCHEMA_CATALOG_TABLE_SQL,
             generation_policy: SchemaGenerationPolicy::Journaled,
@@ -3182,7 +3498,12 @@ fn refresh_manifest_digest(connection: &Connection) -> EngineResult<[u8; 32]> {
 
 fn refresh_manifest_digest_if_v7(connection: &Connection) -> EngineResult<()> {
     let (application_id, version) = read_identity(connection)?;
-    if application_id == MANIFEST_APPLICATION_ID && version == i64::from(V7_SCHEMA_VERSION) {
+    if application_id == MANIFEST_APPLICATION_ID
+        && matches!(
+            u32::try_from(version),
+            Ok(V7_SCHEMA_VERSION | V8_SCHEMA_VERSION)
+        )
+    {
         let _ = refresh_manifest_digest(connection)?;
     }
     Ok(())
@@ -4458,6 +4779,33 @@ mod tests {
         seal_verified_schema(connection, shards, [0x5a; 32]).unwrap();
     }
 
+    fn create_ready_v7_manifest(connection: &mut Connection, shards: u16) {
+        let transaction = connection.transaction().unwrap();
+        create_v7_schema(&transaction, shards).unwrap();
+        transaction
+            .execute(
+                "UPDATE briskdb_shard_layout
+                 SET layout_state = ?1
+                 WHERE singleton = 1",
+                [ShardLayoutState::Ready.code()],
+            )
+            .unwrap();
+        transaction
+            .execute(
+                "UPDATE briskdb_integrity
+                 SET database_state = ?1,
+                     committed_schema_digest = ?2,
+                     target_schema_digest = NULL
+                 WHERE singleton = 1",
+                rusqlite::params![DATABASE_STATE_READY, [0x5a_u8; 32].as_slice()],
+            )
+            .unwrap();
+        set_identity(&transaction, V7_SCHEMA_VERSION).unwrap();
+        refresh_manifest_digest(&transaction).unwrap();
+        validate_v7(&transaction, shards, &schema_objects(&transaction).unwrap()).unwrap();
+        transaction.commit().unwrap();
+    }
+
     fn complete_manifest_migration(
         connection: &mut Connection,
         shards: u16,
@@ -4640,7 +4988,7 @@ mod tests {
                     |row| row.get::<_, i64>(0),
                 )
                 .unwrap(),
-            i64::from(V7_SCHEMA_VERSION)
+            i64::from(CURRENT_SCHEMA_VERSION)
         );
         assert_eq!(
             routing_configuration(connection),
@@ -4785,7 +5133,10 @@ mod tests {
             .unwrap(),
             4
         );
-        assert_eq!(resumed_steps, [(2, 3), (3, 4), (4, 5), (5, 6), (6, 7)]);
+        assert_eq!(
+            resumed_steps,
+            [(2, 3), (3, 4), (4, 5), (5, 6), (6, 7), (7, 8)]
+        );
         assert_generation_one_catalog(&connection, 4);
         assert_eq!(quick_check(&connection), "ok");
     }
@@ -4810,6 +5161,235 @@ mod tests {
             .pragma_query_value(None, "data_version", |row| row.get(0))
             .unwrap();
         assert_eq!(before, after, "a current-version reopen must not write");
+    }
+
+    #[test]
+    fn v8_upgrade_clears_advisory_rows_and_fences_out_v7_readers() {
+        const V7_PLAN: MigrationPlan<'static> = MigrationPlan {
+            current_version: V7_SCHEMA_VERSION,
+            migrations: MIGRATIONS,
+            initialize_current: create_v7_schema,
+            initialize_interrupted_legacy: migrate_interrupted_legacy_to_v7,
+        };
+
+        let mut connection = Connection::open_in_memory().unwrap();
+        create_ready_v7_manifest(&mut connection, 4);
+        insert_valid_table_catalog(&connection);
+        assert_eq!(table_metadata_rows(&connection).len(), 5);
+        assert_eq!(logical_databases(&connection).len(), 2);
+
+        let loaded = load_or_create_catalog(&mut connection, 4).unwrap();
+        assert!(loaded.logical().tables().is_empty());
+        assert_eq!(loaded.logical().logical_databases().len(), 2);
+        assert_eq!(
+            identity(&connection),
+            (MANIFEST_APPLICATION_ID, i64::from(V8_SCHEMA_VERSION))
+        );
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT requires_manifest_version FROM briskdb_metadata",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            i64::from(V8_SCHEMA_VERSION)
+        );
+        let root = stored_manifest_digest(&connection);
+        assert_eq!(manifest_semantic_digest(&connection).unwrap(), root);
+
+        let identity_before = identity(&connection);
+        let error = inspect_with_plan(&connection, 4, V7_PLAN).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert_eq!(identity(&connection), identity_before);
+        assert_eq!(stored_manifest_digest(&connection), root);
+    }
+
+    #[test]
+    fn v7_to_v8_upgrade_errors_and_panics_restore_the_exact_v7_catalog() {
+        for failing_phase in [
+            MigrationPhase::AfterSchemaChange,
+            MigrationPhase::AfterVersionStamp,
+        ] {
+            for inject_panic in [false, true] {
+                let mut connection = Connection::open_in_memory().unwrap();
+                create_ready_v7_manifest(&mut connection, 4);
+                insert_valid_table_catalog(&connection);
+                let original_root = stored_manifest_digest(&connection);
+                let original_tables = table_metadata_rows(&connection);
+                let original_databases = logical_databases(&connection);
+                let original_objects = schema_objects(&connection).unwrap();
+
+                let attempt = catch_unwind(AssertUnwindSafe(|| {
+                    load_or_create_with_hook(&mut connection, 4, |point| {
+                        if point.from == V7_SCHEMA_VERSION && point.phase == failing_phase {
+                            if inject_panic {
+                                panic!("injected v7 to v8 migration panic");
+                            }
+                            return Err(EngineError::new(
+                                EngineErrorKind::Internal,
+                                "injected v7 to v8 migration failure",
+                            ));
+                        }
+                        Ok(())
+                    })
+                }));
+                if inject_panic {
+                    assert!(attempt.is_err());
+                } else {
+                    assert_eq!(
+                        attempt.unwrap().unwrap_err().kind(),
+                        EngineErrorKind::Internal
+                    );
+                }
+
+                assert_eq!(
+                    identity(&connection),
+                    (MANIFEST_APPLICATION_ID, i64::from(V7_SCHEMA_VERSION))
+                );
+                assert_eq!(schema_objects(&connection).unwrap(), original_objects);
+                assert_eq!(table_metadata_rows(&connection), original_tables);
+                assert_eq!(logical_databases(&connection), original_databases);
+                assert_eq!(stored_manifest_digest(&connection), original_root);
+                assert_eq!(
+                    manifest_semantic_digest(&connection).unwrap(),
+                    original_root
+                );
+                assert_eq!(
+                    connection
+                        .query_row(
+                            "SELECT requires_manifest_version FROM briskdb_metadata",
+                            [],
+                            |row| row.get::<_, i64>(0),
+                        )
+                        .unwrap(),
+                    i64::from(V7_SCHEMA_VERSION)
+                );
+
+                let loaded = load_or_create_catalog(&mut connection, 4).unwrap();
+                assert!(loaded.logical().tables().is_empty());
+                assert_eq!(
+                    identity(&connection),
+                    (MANIFEST_APPLICATION_ID, i64::from(V8_SCHEMA_VERSION))
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn authoritative_catalog_registration_is_atomic_exact_and_idempotent() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        create_ready_current_manifest(&mut connection, 4);
+        let database = crate::core::LogicalDatabaseId::new(1).unwrap();
+        let declarations = vec![
+            TableDeclaration::catalog(database, "internal_catalog").unwrap(),
+            TableDeclaration::global(database, "countries").unwrap(),
+            TableDeclaration::sharded(
+                database,
+                "accounts",
+                ShardKeyMetadata::new("tenant_id", ShardKeyType::Text).unwrap(),
+            )
+            .unwrap(),
+        ];
+
+        let mut commit_attempted = false;
+        let registered = register_table_catalog(&mut connection, 4, declarations.clone(), || {
+            commit_attempted = true
+        })
+        .unwrap();
+        assert!(commit_attempted);
+        assert_eq!(
+            registered
+                .logical()
+                .tables()
+                .iter()
+                .map(|table| (table.id().get(), table.name()))
+                .collect::<Vec<_>>(),
+            [(1, "accounts"), (2, "countries"), (3, "internal_catalog")]
+        );
+        assert_eq!(
+            table_metadata_rows(&connection),
+            [
+                (
+                    1,
+                    1,
+                    "accounts".to_owned(),
+                    SHARDED_PLACEMENT,
+                    Some("tenant_id".to_owned()),
+                    Some(TEXT_SHARD_KEY_TYPE),
+                ),
+                (2, 1, "countries".to_owned(), GLOBAL_PLACEMENT, None, None,),
+                (
+                    3,
+                    1,
+                    "internal_catalog".to_owned(),
+                    CATALOG_PLACEMENT,
+                    None,
+                    None,
+                ),
+            ]
+        );
+        let registered_root = stored_manifest_digest(&connection);
+        assert_eq!(
+            manifest_semantic_digest(&connection).unwrap(),
+            registered_root
+        );
+
+        let mut repeated_commit = false;
+        let repeated = register_table_catalog(&mut connection, 4, declarations.clone(), || {
+            repeated_commit = true
+        })
+        .unwrap();
+        assert!(!repeated_commit);
+        assert_eq!(repeated, registered);
+        assert_eq!(stored_manifest_digest(&connection), registered_root);
+
+        let conflict = vec![
+            TableDeclaration::global(database, "accounts").unwrap(),
+            TableDeclaration::global(database, "countries").unwrap(),
+            TableDeclaration::catalog(database, "internal_catalog").unwrap(),
+        ];
+        let mut conflicting_commit = false;
+        let error = register_table_catalog(&mut connection, 4, conflict, || {
+            conflicting_commit = true;
+        })
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert!(!conflicting_commit);
+        assert_eq!(stored_manifest_digest(&connection), registered_root);
+        assert_eq!(
+            manifest_semantic_digest(&connection).unwrap(),
+            registered_root
+        );
+    }
+
+    #[test]
+    fn registration_commit_boundary_rolls_back_before_sqlite_commit() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        create_ready_current_manifest(&mut connection, 4);
+        let original_root = stored_manifest_digest(&connection);
+        let database = crate::core::LogicalDatabaseId::new(1).unwrap();
+        let declaration = TableDeclaration::global(database, "countries").unwrap();
+
+        let panic = catch_unwind(AssertUnwindSafe(|| {
+            let _ = register_table_catalog(&mut connection, 4, vec![declaration], || {
+                panic!("injected interruption immediately before COMMIT");
+            });
+        }));
+        assert!(panic.is_err());
+        assert!(table_metadata_rows(&connection).is_empty());
+        assert_eq!(stored_manifest_digest(&connection), original_root);
+        assert_eq!(
+            manifest_semantic_digest(&connection).unwrap(),
+            original_root
+        );
+        assert!(
+            load_or_create_catalog(&mut connection, 4)
+                .unwrap()
+                .logical()
+                .tables()
+                .is_empty()
+        );
     }
 
     #[test]
@@ -4854,9 +5434,9 @@ mod tests {
         assert_eq!(
             digest,
             [
-                0x57, 0x9d, 0x8a, 0x78, 0x54, 0xa9, 0xa7, 0xaa, 0x3a, 0xdd, 0x69, 0xdb, 0xb8, 0xc4,
-                0x13, 0xb2, 0x85, 0x1d, 0xb7, 0x4e, 0xdc, 0xe1, 0x9a, 0xd6, 0xde, 0xf2, 0x2a, 0xb9,
-                0x4f, 0x02, 0x9e, 0xd1,
+                0x7b, 0xe1, 0x4b, 0x4f, 0x0a, 0xf4, 0xd0, 0x41, 0x79, 0x9b, 0xe8, 0xd2, 0x19, 0xe5,
+                0x5a, 0xdd, 0x13, 0x38, 0x29, 0x62, 0x3c, 0x2b, 0xef, 0xce, 0xfb, 0x5c, 0x4d, 0xc9,
+                0xe9, 0xff, 0x5c, 0xe0,
             ]
         );
         assert_eq!(manifest_semantic_digest(&connection).unwrap(), digest);
@@ -4899,7 +5479,7 @@ mod tests {
     fn semantic_root_covers_every_authoritative_manifest_table_and_integrity_state() {
         let mutations = [
             "UPDATE briskdb_manifest SET singleton = 2 WHERE singleton = 1",
-            "UPDATE briskdb_metadata SET requires_manifest_version = 8",
+            "UPDATE briskdb_metadata SET requires_manifest_version = 9",
             "UPDATE briskdb_routing SET hash_version = 2 WHERE singleton = 1",
             "UPDATE briskdb_physical_shards SET lifecycle_state = 'retired' WHERE shard_id = 0",
             "UPDATE briskdb_virtual_buckets SET physical_shard_id = 1 WHERE bucket_id = 0",
@@ -5154,7 +5734,7 @@ mod tests {
     }
 
     #[test]
-    fn version_four_upgrade_enters_adopting_and_preserves_catalog_rows() {
+    fn version_four_upgrade_enters_adopting_and_clears_advisory_catalog_rows() {
         let mut connection = Connection::open_in_memory().unwrap();
         create_v4_manifest(&mut connection, 4);
         insert_valid_table_catalog(&connection);
@@ -5165,7 +5745,7 @@ mod tests {
 
         assert_eq!(layout.state(), ShardLayoutState::Adopting);
         assert_eq!(catalog.logical().logical_databases().len(), 2);
-        assert_eq!(catalog.logical().tables().len(), 5);
+        assert!(catalog.logical().tables().is_empty());
         assert_eq!(
             identity(&connection),
             (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
@@ -5179,13 +5759,12 @@ mod tests {
     }
 
     #[test]
-    fn version_five_upgrade_preserves_ready_layout_catalog_and_empty_history() {
+    fn version_five_upgrade_preserves_layout_and_clears_advisory_catalog_rows() {
         let mut connection = Connection::open_in_memory().unwrap();
         create_v5_manifest(&mut connection, 4);
         insert_valid_table_catalog(&connection);
         let layout_before = shard_layout_row(&connection);
         let databases_before = logical_databases(&connection);
-        let tables_before = table_metadata_rows(&connection);
 
         let loaded = load_or_create_manifest(&mut connection, 4).unwrap();
         assert!(loaded.active_migration().is_none());
@@ -5200,7 +5779,7 @@ mod tests {
         assert_eq!(shard_layout_row(&connection), layout_before);
         assert_eq!(catalog.logical().schema_generation(), 0);
         assert_eq!(logical_databases(&connection), databases_before);
-        assert_eq!(table_metadata_rows(&connection), tables_before);
+        assert!(table_metadata_rows(&connection).is_empty());
         assert!(active.is_none());
         assert_eq!(integrity.state(), DatabaseIntegrityState::Verifying);
         assert_eq!(integrity.committed_schema_digest(), None);
@@ -5223,7 +5802,7 @@ mod tests {
     }
 
     #[test]
-    fn version_six_upgrade_enters_verifying_without_changing_catalog_or_history() {
+    fn version_six_upgrade_enters_verifying_and_clears_advisory_catalog_rows() {
         let mut connection = Connection::open_in_memory().unwrap();
         create_v5_manifest(&mut connection, 4);
         insert_valid_table_catalog(&connection);
@@ -5232,14 +5811,13 @@ mod tests {
             .unwrap();
         assert_eq!(identity(&connection), (MANIFEST_APPLICATION_ID, 6));
         let databases_before = logical_databases(&connection);
-        let tables_before = table_metadata_rows(&connection);
         assert!(v6.active_migration.is_none());
 
         let loaded = load_or_create_manifest(&mut connection, 4).unwrap();
         assert_eq!(loaded.integrity.state(), DatabaseIntegrityState::Verifying);
         assert_eq!(loaded.integrity.committed_schema_digest(), None);
         assert_eq!(logical_databases(&connection), databases_before);
-        assert_eq!(table_metadata_rows(&connection), tables_before);
+        assert!(table_metadata_rows(&connection).is_empty());
         assert_eq!(
             connection
                 .query_row(
@@ -6907,7 +7485,7 @@ mod tests {
         for mutation in [
             "DELETE FROM briskdb_metadata",
             "DELETE FROM briskdb_manifest",
-            "INSERT INTO briskdb_metadata VALUES (7)",
+            "INSERT INTO briskdb_metadata VALUES (8)",
             "DELETE FROM briskdb_routing",
             "DELETE FROM briskdb_virtual_buckets WHERE bucket_id = 4095",
             "DELETE FROM briskdb_physical_shards WHERE shard_id = 3",

--- a/src/storage/migration.rs
+++ b/src/storage/migration.rs
@@ -354,6 +354,7 @@ where
                 control: control.as_ref(),
             },
             &source_digest,
+            &storage.catalog,
         )
         .map_err(|error| sanitized_shard_error(error, "preflight", shard_id))?;
         if state != shard::SchemaMigrationShardState::Source {
@@ -991,6 +992,7 @@ struct ShardMigrationRequest<'a> {
 fn preflight_one_shard(
     request: ShardMigrationRequest<'_>,
     expected_source_digest: &[u8; 32],
+    catalog: &CatalogSnapshot,
 ) -> EngineResult<(shard::SchemaMigrationShardState, [u8; 32])> {
     let ShardMigrationRequest {
         path,
@@ -1016,7 +1018,7 @@ fn preflight_one_shard(
                 layout,
             )?;
             shard::verify_schema_digest(&connection, source_generation, expected_source_digest)?;
-            shard::preflight_schema_migration_on_connection_with_digest(
+            shard::preflight_schema_migration_on_connection_with_digest_and_catalog(
                 &mut connection,
                 path,
                 shard_id,
@@ -1024,6 +1026,7 @@ fn preflight_one_shard(
                 target_generation,
                 layout,
                 sql,
+                catalog.logical(),
             )
         }
         Some(control) => {
@@ -1038,7 +1041,7 @@ fn preflight_one_shard(
                     layout,
                 )?;
                 shard::verify_schema_digest(connection, source_generation, expected_source_digest)?;
-                shard::preflight_schema_migration_on_connection_with_digest(
+                shard::preflight_schema_migration_on_connection_with_digest_and_catalog(
                     connection,
                     path,
                     shard_id,
@@ -1046,6 +1049,7 @@ fn preflight_one_shard(
                     target_generation,
                     layout,
                     sql,
+                    catalog.logical(),
                 )
             })
         }
@@ -1255,7 +1259,10 @@ mod tests {
     use rusqlite::OptionalExtension;
 
     use super::*;
-    use crate::storage::SchemaGateState;
+    use crate::{
+        core::{LogicalDatabaseId, ShardKeyMetadata, ShardKeyType, TableDeclaration},
+        storage::SchemaGateState,
+    };
 
     const MIGRATION_SQL: &str =
         "CREATE TABLE migration_marker (id INTEGER PRIMARY KEY, value TEXT NOT NULL)";
@@ -1813,6 +1820,136 @@ mod tests {
             0,
             "preflight corruption must not publish a migration journal"
         );
+    }
+
+    #[test]
+    fn authoritative_catalog_rejects_breaking_migrations_before_journal_or_shard_mutation() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut storage = Storage::open(temp.path(), 2).unwrap();
+        run_sql_with_hook(
+            &storage,
+            "CREATE TABLE accounts (
+                 id INTEGER PRIMARY KEY,
+                 display_name TEXT NOT NULL
+             ) STRICT;
+             CREATE TABLE countries (
+                 code TEXT PRIMARY KEY,
+                 display_name TEXT NOT NULL
+             ) STRICT",
+            |_| Ok(()),
+        )
+        .unwrap();
+        let database = LogicalDatabaseId::new(1).unwrap();
+        storage
+            .register_tables(vec![
+                TableDeclaration::sharded(
+                    database,
+                    "accounts",
+                    ShardKeyMetadata::new("id", ShardKeyType::Int64).unwrap(),
+                )
+                .unwrap(),
+                TableDeclaration::catalog(database, "audit_catalog").unwrap(),
+                TableDeclaration::global(database, "countries").unwrap(),
+            ])
+            .unwrap();
+
+        let manifest_before = Connection::open(temp.path().join("manifest.sqlite"))
+            .unwrap()
+            .query_row(
+                "SELECT c.schema_generation,
+                        (SELECT COUNT(*) FROM briskdb_schema_migrations)
+                 FROM briskdb_schema_catalog AS c
+                 WHERE c.singleton = 1",
+                [],
+                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+            )
+            .unwrap();
+        let generations_before = shard_generations(temp.path());
+
+        for sql in [
+            "DROP TABLE accounts",
+            "DROP TABLE accounts;
+             CREATE TABLE accounts (
+                 id TEXT PRIMARY KEY,
+                 display_name TEXT NOT NULL
+             ) STRICT",
+            "CREATE TABLE undeclared (id INTEGER PRIMARY KEY) STRICT",
+            "CREATE TABLE audit_catalog (id INTEGER PRIMARY KEY) STRICT",
+            "CREATE VIEW audit_catalog AS SELECT id FROM accounts",
+        ] {
+            let error = run_sql_with_hook(&storage, sql, |_| Ok(())).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition, "{sql}");
+            assert_eq!(storage.schema_gate_snapshot().state, SchemaGateState::Ready);
+            assert_eq!(active_journal_snapshot(temp.path()), None, "{sql}");
+            assert_eq!(shard_generations(temp.path()), generations_before, "{sql}");
+            assert_eq!(
+                Connection::open(temp.path().join("manifest.sqlite"))
+                    .unwrap()
+                    .query_row(
+                        "SELECT c.schema_generation,
+                                (SELECT COUNT(*) FROM briskdb_schema_migrations)
+                         FROM briskdb_schema_catalog AS c
+                         WHERE c.singleton = 1",
+                        [],
+                        |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+                    )
+                    .unwrap(),
+                manifest_before,
+                "{sql}"
+            );
+            for shard_id in 0..2 {
+                let connection = storage.open_shard(shard_id).unwrap();
+                assert_eq!(
+                    connection
+                        .query_row(
+                            "SELECT COUNT(*) FROM pragma_table_list
+                             WHERE schema = 'main' AND type = 'table'
+                               AND name IN ('accounts', 'countries')",
+                            [],
+                            |row| row.get::<_, i64>(0),
+                        )
+                        .unwrap(),
+                    2,
+                    "{sql}"
+                );
+                assert_eq!(
+                    connection
+                        .query_row(
+                            "SELECT COUNT(*) FROM pragma_table_list
+                             WHERE schema = 'main'
+                               AND name IN ('undeclared', 'audit_catalog')",
+                            [],
+                            |row| row.get::<_, i64>(0),
+                        )
+                        .unwrap(),
+                    0,
+                    "{sql}"
+                );
+            }
+        }
+
+        run_sql_with_hook(
+            &storage,
+            "CREATE INDEX accounts_display_name_idx ON accounts (display_name)",
+            |_| Ok(()),
+        )
+        .unwrap();
+        for shard_id in 0..2 {
+            assert!(
+                storage
+                    .open_shard(shard_id)
+                    .unwrap()
+                    .query_row(
+                        "SELECT EXISTS(
+                             SELECT 1 FROM sqlite_schema
+                             WHERE type = 'index' AND name = 'accounts_display_name_idx'
+                         )",
+                        [],
+                        |row| row.get::<_, bool>(0),
+                    )
+                    .unwrap()
+            );
+        }
     }
 
     #[test]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -9,11 +9,11 @@ pub(crate) mod pool;
 pub(crate) use pool::{ConnectionOwner, ConnectionPools, PooledConnection};
 
 use std::{
-    collections::HashMap,
+    collections::{BTreeSet, HashMap},
     fs,
     path::{Path, PathBuf},
     sync::{
-        Arc, Mutex, OnceLock, Weak,
+        Arc, Mutex, MutexGuard, OnceLock, Weak,
         atomic::{AtomicBool, Ordering},
     },
     time::Instant,
@@ -32,7 +32,10 @@ pub(crate) use schema_gate::{SchemaMigrationGuard, SchemaOperationGuard};
 
 pub use crate::core::Database;
 use crate::{
-    core::{Catalog, CatalogSnapshot, EngineError, EngineErrorKind, EngineResult},
+    core::{
+        Catalog, CatalogSnapshot, EngineError, EngineErrorKind, EngineResult, MAX_TABLES,
+        ShardKeyType, TableDeclaration, TablePlacement,
+    },
     sqlite_error,
 };
 
@@ -43,6 +46,31 @@ struct RootSchemaCoordination {
     gate: schema_gate::SchemaGate,
     catalogs: Mutex<Vec<Weak<CatalogSnapshot>>>,
     schema_digests: Mutex<RuntimeSchemaDigests>,
+}
+
+struct CatalogReplacementGuard<'a> {
+    catalogs: MutexGuard<'a, Vec<Weak<CatalogSnapshot>>>,
+}
+
+impl CatalogReplacementGuard<'_> {
+    fn publish(
+        mut self,
+        current: &Arc<CatalogSnapshot>,
+        replacement: CatalogSnapshot,
+    ) -> EngineResult<Arc<CatalogSnapshot>> {
+        if current.routing() != replacement.routing()
+            || current.logical().schema_generation() != replacement.logical().schema_generation()
+        {
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                "table registration changed routing or schema-generation metadata",
+            ));
+        }
+        let replacement = Arc::new(replacement);
+        self.catalogs.clear();
+        self.catalogs.push(Arc::downgrade(&replacement));
+        Ok(replacement)
+    }
 }
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -111,7 +139,6 @@ impl RootSchemaCoordination {
     }
 
     fn register_catalog(&self, loaded: CatalogSnapshot) -> EngineResult<Arc<CatalogSnapshot>> {
-        let loaded = Arc::new(loaded);
         let mut catalogs = self.catalogs.lock().map_err(|error| {
             EngineError::new(
                 EngineErrorKind::Internal,
@@ -119,8 +146,49 @@ impl RootSchemaCoordination {
             )
         })?;
         catalogs.retain(|catalog| catalog.strong_count() != 0);
+        if catalogs
+            .iter()
+            .filter_map(Weak::upgrade)
+            .any(|live| !immutable_catalog_metadata_matches(&live, &loaded))
+        {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "the committed table catalog conflicts with a live database handle; close stale handles before reopening",
+            ));
+        }
+        let loaded = Arc::new(loaded);
         catalogs.push(Arc::downgrade(&loaded));
         Ok(loaded)
+    }
+
+    fn reserve_catalog_replacement<'a>(
+        &'a self,
+        current: &Arc<CatalogSnapshot>,
+    ) -> EngineResult<CatalogReplacementGuard<'a>> {
+        if Arc::strong_count(current) != 1 {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "table registration requires one exclusively owned database handle",
+            ));
+        }
+        let mut catalogs = self.catalogs.lock().map_err(|error| {
+            EngineError::new(
+                EngineErrorKind::Internal,
+                format!("root schema catalog coordination is poisoned: {error}"),
+            )
+        })?;
+        catalogs.retain(|catalog| catalog.strong_count() != 0);
+        let current = Arc::downgrade(current);
+        let mut live = catalogs
+            .iter()
+            .filter(|catalog| catalog.strong_count() != 0);
+        if live.next().is_none_or(|catalog| !catalog.ptr_eq(&current)) || live.next().is_some() {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "table registration requires every other database handle to be closed",
+            ));
+        }
+        Ok(CatalogReplacementGuard { catalogs })
     }
 
     fn publish_schema_generation(
@@ -182,6 +250,16 @@ impl RootSchemaCoordination {
 
         if live
             .iter()
+            .any(|catalog| !immutable_catalog_metadata_matches(catalog, validated))
+        {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "the validated table catalog conflicts with a live database handle",
+            ));
+        }
+
+        if live
+            .iter()
             .all(|catalog| catalog.logical().schema_generation() == target_generation)
         {
             return Ok(());
@@ -211,6 +289,19 @@ impl RootSchemaCoordination {
         }
         Ok(())
     }
+}
+
+/// Compare the routing and logical metadata that cannot change while a handle
+/// remains live. Schema generation is deliberately excluded: crash recovery
+/// may publish one validated generation transition into existing snapshots.
+fn immutable_catalog_metadata_matches(left: &CatalogSnapshot, right: &CatalogSnapshot) -> bool {
+    let left_logical = left.logical();
+    let right_logical = right.logical();
+    left.routing() == right.routing()
+        && left_logical.identifier_encoding_version() == right_logical.identifier_encoding_version()
+        && left_logical.default_database().id() == right_logical.default_database().id()
+        && left_logical.logical_databases() == right_logical.logical_databases()
+        && left_logical.tables() == right_logical.tables()
 }
 
 static ROOT_SCHEMA_COORDINATIONS: OnceLock<Mutex<HashMap<PathBuf, Weak<RootSchemaCoordination>>>> =
@@ -529,6 +620,182 @@ impl Storage {
         self.catalog.logical()
     }
 
+    pub(crate) fn register_tables(
+        &mut self,
+        declarations: Vec<TableDeclaration>,
+    ) -> EngineResult<()> {
+        let result = self.register_tables_inner(declarations);
+        self.fail_closed_on_corruption(result)
+    }
+
+    fn register_tables_inner(&mut self, declarations: Vec<TableDeclaration>) -> EngineResult<()> {
+        self.validate_table_declaration_request(&declarations)?;
+        if !self.catalog.logical().tables().is_empty() {
+            let _operation = self.enter_schema_operation()?;
+            return if declarations_match_catalog(self.catalog.logical(), &declarations) {
+                Ok(())
+            } else {
+                Err(EngineError::new(
+                    EngineErrorKind::FailedPrecondition,
+                    "the authoritative table catalog is already registered",
+                ))
+            };
+        }
+        let mut migration = self.schema_coordination.gate.begin_new_migration()?;
+        migration.wait_for_quiescence_blocking();
+        let registration = (|| {
+            self.validate_empty_table_declarations(&declarations)?;
+            let replacement_guard = self
+                .schema_coordination
+                .reserve_catalog_replacement(&self.catalog)?;
+
+            let manifest_path = self.root.join("manifest.sqlite");
+            let mut manifest_connection = open_existing_manifest(&manifest_path)?;
+            configure_manifest_connection(&manifest_connection)?;
+            let replacement = manifest::register_table_catalog(
+                &mut manifest_connection,
+                self.shard_count(),
+                declarations,
+                || migration.mark_pending_on_drop(),
+            )?;
+            let replacement = replacement_guard.publish(&self.catalog, replacement)?;
+            self.catalog = replacement;
+            Ok(())
+        })();
+        if registration
+            .as_ref()
+            .is_err_and(|error: &EngineError| error.kind() == EngineErrorKind::DataCorruption)
+        {
+            // Keep the exclusive migration guard live while degradation is
+            // published so no concurrent operation observes a transient Ready
+            // state between error propagation and fail-closed handling.
+            self.record_schema_degraded();
+        }
+        registration?;
+        migration.publish_ready()
+    }
+
+    fn validate_table_declaration_request(
+        &self,
+        declarations: &[TableDeclaration],
+    ) -> EngineResult<()> {
+        if declarations.is_empty() {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "table registration requires at least one declaration",
+            ));
+        }
+        if declarations.len() > MAX_TABLES {
+            return Err(EngineError::new(
+                EngineErrorKind::LimitExceeded,
+                format!("table registration exceeds its {MAX_TABLES}-table limit"),
+            ));
+        }
+        let default_database_id = self.catalog.logical().default_database().id();
+        let mut names = BTreeSet::new();
+        for declaration in declarations {
+            if declaration.database_id() != default_database_id {
+                return Err(EngineError::new(
+                    EngineErrorKind::InvalidArgument,
+                    format!(
+                        "table {} must use the storage-default logical database",
+                        declaration.name()
+                    ),
+                ));
+            }
+            if !names.insert(declaration.name()) {
+                return Err(EngineError::new(
+                    EngineErrorKind::InvalidArgument,
+                    format!("table {} is declared more than once", declaration.name()),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_empty_table_declarations(
+        &self,
+        declarations: &[TableDeclaration],
+    ) -> EngineResult<()> {
+        let mut physical_declarations = BTreeSet::new();
+        let mut catalog_declarations = BTreeSet::new();
+        for declaration in declarations {
+            if matches!(declaration.placement(), TablePlacement::Catalog) {
+                catalog_declarations.insert(declaration.name().to_owned());
+            } else {
+                physical_declarations.insert(declaration.name().to_owned());
+            }
+        }
+
+        for shard_id in 0..self.shard_count() {
+            let connection = self.open_shard(shard_id)?;
+            let has_application_trigger = connection
+                .query_row(
+                    "SELECT EXISTS(
+                         SELECT 1 FROM main.sqlite_schema
+                         WHERE type = 'trigger' AND name NOT GLOB 'sqlite_*'
+                     )",
+                    [],
+                    |row| row.get::<_, bool>(0),
+                )
+                .map_err(sqlite_error::storage)?;
+            if has_application_trigger {
+                return Err(EngineError::new(
+                    EngineErrorKind::FailedPrecondition,
+                    format!(
+                        "application triggers are not supported with authoritative placement on physical shard {shard_id}"
+                    ),
+                ));
+            }
+            let has_application_virtual_table = connection
+                .query_row(
+                    "SELECT EXISTS(
+                         SELECT 1 FROM pragma_table_list
+                         WHERE schema = 'main' AND type = 'virtual'
+                     )",
+                    [],
+                    |row| row.get::<_, bool>(0),
+                )
+                .map_err(sqlite_error::storage)?;
+            if has_application_virtual_table {
+                return Err(EngineError::new(
+                    EngineErrorKind::FailedPrecondition,
+                    format!(
+                        "virtual tables are not supported with authoritative placement on physical shard {shard_id}"
+                    ),
+                ));
+            }
+            let physical_names = application_table_names(&connection)?;
+            let relation_names = application_relation_names(&connection)?;
+            if let Some(shadow) = catalog_declarations.iter().find(|name| {
+                relation_names
+                    .iter()
+                    .any(|relation| relation.eq_ignore_ascii_case(name))
+            }) {
+                return Err(EngineError::new(
+                    EngineErrorKind::FailedPrecondition,
+                    format!(
+                        "catalog table {shadow} has an application-table shadow on physical shard {shard_id}"
+                    ),
+                ));
+            }
+            if physical_declarations != physical_names {
+                return Err(EngineError::new(
+                    EngineErrorKind::FailedPrecondition,
+                    format!(
+                        "the declared physical tables do not exactly match physical shard {shard_id}"
+                    ),
+                ));
+            }
+            for declaration in declarations {
+                if !matches!(declaration.placement(), TablePlacement::Catalog) {
+                    validate_empty_table_declaration(&connection, shard_id, declaration)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
     pub(crate) fn current_schema_generation(&self) -> u64 {
         self.catalog.logical().schema_generation()
     }
@@ -767,6 +1034,236 @@ impl Storage {
             },
         ))
     }
+}
+
+fn declarations_match_catalog(catalog: &Catalog, declarations: &[TableDeclaration]) -> bool {
+    if catalog.tables().len() != declarations.len() {
+        return false;
+    }
+    let mut declarations = declarations.iter().collect::<Vec<_>>();
+    declarations.sort_by_key(|declaration| (declaration.database_id(), declaration.name()));
+    catalog
+        .tables()
+        .iter()
+        .zip(declarations)
+        .all(|(table, declaration)| {
+            table.database_id() == declaration.database_id()
+                && table.name() == declaration.name()
+                && table.placement() == declaration.placement()
+        })
+}
+
+fn application_table_names(connection: &Connection) -> EngineResult<BTreeSet<String>> {
+    let mut statement = connection
+        .prepare(
+            "SELECT name FROM pragma_table_list
+             WHERE schema = 'main' AND type IN ('table', 'virtual')
+               AND name NOT GLOB 'sqlite_*'
+               AND name <> 'briskdb_shard_metadata'
+             ORDER BY name COLLATE BINARY",
+        )
+        .map_err(sqlite_error::storage)?;
+    statement
+        .query_map([], |row| row.get::<_, String>(0))
+        .map_err(sqlite_error::storage)?
+        .collect::<Result<BTreeSet<_>, _>>()
+        .map_err(sqlite_error::storage)
+}
+
+fn application_relation_names(connection: &Connection) -> EngineResult<BTreeSet<String>> {
+    let mut statement = connection
+        .prepare(
+            "SELECT name FROM main.sqlite_schema
+             WHERE type IN ('table', 'view')
+             ORDER BY name COLLATE BINARY",
+        )
+        .map_err(sqlite_error::storage)?;
+    statement
+        .query_map([], |row| row.get::<_, String>(0))
+        .map_err(sqlite_error::storage)?
+        .collect::<Result<BTreeSet<_>, _>>()
+        .map_err(sqlite_error::storage)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SqliteAffinity {
+    Integer,
+    Text,
+    Blob,
+    Real,
+    Numeric,
+}
+
+fn sqlite_affinity(declared_type: &str) -> SqliteAffinity {
+    let declared_type = declared_type.to_ascii_uppercase();
+    if declared_type.contains("INT") {
+        SqliteAffinity::Integer
+    } else if declared_type.contains("CHAR")
+        || declared_type.contains("CLOB")
+        || declared_type.contains("TEXT")
+    {
+        SqliteAffinity::Text
+    } else if declared_type.contains("BLOB") || declared_type.is_empty() {
+        SqliteAffinity::Blob
+    } else if declared_type.contains("REAL")
+        || declared_type.contains("FLOA")
+        || declared_type.contains("DOUB")
+    {
+        SqliteAffinity::Real
+    } else {
+        SqliteAffinity::Numeric
+    }
+}
+
+fn validate_empty_table_declaration(
+    connection: &Connection,
+    shard_id: u16,
+    declaration: &TableDeclaration,
+) -> EngineResult<()> {
+    let quoted_table = quote_identifier(declaration.name());
+    let has_rows = connection
+        .query_row(
+            &format!("SELECT EXISTS(SELECT 1 FROM {quoted_table} LIMIT 1)"),
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .map_err(sqlite_error::storage)?;
+    if has_rows != 0 {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!(
+                "table {} must be empty on physical shard {shard_id} before registration",
+                declaration.name()
+            ),
+        ));
+    }
+
+    let TablePlacement::Sharded(shard_key) = declaration.placement() else {
+        shard::validate_authoritative_table_constraints(connection, declaration.name(), None)?;
+        return Ok(());
+    };
+    let mut statement = connection
+        .prepare(
+            "SELECT name, type, \"notnull\", pk, hidden
+             FROM pragma_table_xinfo(?1)
+             ORDER BY cid",
+        )
+        .map_err(sqlite_error::storage)?;
+    let columns = statement
+        .query_map([declaration.name()], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, i64>(3)?,
+                row.get::<_, i64>(4)?,
+            ))
+        })
+        .map_err(sqlite_error::storage)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(sqlite_error::storage)?;
+    let Some((_, declared_type, not_null, primary_key, hidden)) = columns
+        .iter()
+        .find(|(name, _, _, _, _)| name == shard_key.column())
+    else {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!(
+                "shard key {} is missing from table {} on physical shard {shard_id}",
+                shard_key.column(),
+                declaration.name()
+            ),
+        ));
+    };
+    if *hidden != 0
+        || !shard_key_is_non_null(
+            connection,
+            declaration.name(),
+            declared_type,
+            *not_null,
+            *primary_key,
+        )?
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!(
+                "shard key {} on table {} must be a visible physically non-null column",
+                shard_key.column(),
+                declaration.name()
+            ),
+        ));
+    }
+    let affinity = sqlite_affinity(declared_type);
+    let compatible = matches!(
+        (shard_key.key_type(), affinity),
+        (ShardKeyType::Int64, SqliteAffinity::Integer)
+            | (ShardKeyType::Text, SqliteAffinity::Text)
+            | (ShardKeyType::Binary, SqliteAffinity::Blob)
+    );
+    if !compatible {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!(
+                "shard key {} on table {} has an incompatible SQLite declared type",
+                shard_key.column(),
+                declaration.name()
+            ),
+        ));
+    }
+    if matches!(shard_key.key_type(), ShardKeyType::Text)
+        && !shard::shard_key_uses_binary_collation(
+            connection,
+            declaration.name(),
+            shard_key.column(),
+        )?
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!(
+                "shard key {} on table {} must use SQLite BINARY collation",
+                shard_key.column(),
+                declaration.name()
+            ),
+        ));
+    }
+    shard::validate_authoritative_table_constraints(
+        connection,
+        declaration.name(),
+        Some(shard_key),
+    )?;
+    Ok(())
+}
+
+fn shard_key_is_non_null(
+    connection: &Connection,
+    table: &str,
+    declared_type: &str,
+    not_null: i64,
+    primary_key: i64,
+) -> EngineResult<bool> {
+    if not_null != 0 {
+        return Ok(true);
+    }
+    if primary_key == 0 || !declared_type.trim().eq_ignore_ascii_case("INTEGER") {
+        return Ok(false);
+    }
+    let has_primary_key_index = connection
+        .query_row(
+            "SELECT EXISTS(
+                 SELECT 1 FROM pragma_index_list(?1) WHERE origin = 'pk'
+             )",
+            [table],
+            |row| row.get::<_, bool>(0),
+        )
+        .map_err(sqlite_error::storage)?;
+    // An exact INTEGER PRIMARY KEY without a separate primary-key index is the
+    // rowid alias. SQLite always materializes a non-null integer for it. Other
+    // rowid-table PRIMARY KEY forms retain SQLite's legacy NULL exception.
+    Ok(!has_primary_key_index)
+}
+
+fn quote_identifier(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
 }
 
 fn physical_layout_is_empty(shards_dir: &Path) -> EngineResult<bool> {
@@ -1070,6 +1567,7 @@ fn configure_journal_mode(connection: &Connection) -> EngineResult<()> {
 mod tests {
     use std::{
         error::Error as _,
+        process::Command,
         sync::{Arc, Barrier},
         thread,
     };
@@ -2520,5 +3018,493 @@ mod tests {
                     .unwrap()
             );
         }
+    }
+
+    fn registered_table_declarations(database: &Database) -> Vec<TableDeclaration> {
+        let logical_database = database.catalog().default_database().id();
+        vec![
+            TableDeclaration::global(logical_database, "countries").unwrap(),
+            TableDeclaration::sharded(
+                logical_database,
+                "events",
+                crate::core::ShardKeyMetadata::new("tenant_id", ShardKeyType::Text).unwrap(),
+            )
+            .unwrap(),
+        ]
+    }
+
+    fn create_registered_table_schema(database: &Database) {
+        database
+            .broadcast(
+                "CREATE TABLE events (
+                    id INTEGER NOT NULL,
+                    tenant_id TEXT NOT NULL,
+                    payload BLOB NOT NULL,
+                    PRIMARY KEY (tenant_id, id)
+                 );
+                 CREATE TABLE countries (
+                    code TEXT PRIMARY KEY,
+                    name TEXT NOT NULL
+                 );",
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn table_registration_is_authoritative_persistent_and_idempotent() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut database = Database::open(temp.path(), 3).unwrap();
+        create_registered_table_schema(&database);
+        let declarations = registered_table_declarations(&database);
+
+        database.register_tables(declarations.clone()).unwrap();
+        let tables = database.catalog().tables().to_vec();
+        assert_eq!(tables.len(), 2);
+        assert_eq!(tables[0].name(), "countries");
+        assert_eq!(tables[0].placement(), &TablePlacement::Global);
+        assert_eq!(tables[1].name(), "events");
+        assert_eq!(tables[1].placement(), declarations[1].placement());
+
+        database
+            .execute(
+                "tenant-one",
+                "INSERT INTO events (id, tenant_id, payload) VALUES (?1, ?2, ?3)",
+                &[
+                    crate::core::Value::from(1_i64),
+                    crate::core::Value::from("tenant-one"),
+                    crate::core::Value::from(vec![1_u8, 2, 3]),
+                ],
+            )
+            .unwrap();
+        database.register_tables(declarations).unwrap();
+        drop(database);
+
+        let reopened = Database::open(temp.path(), 3).unwrap();
+        assert_eq!(reopened.catalog().tables(), tables.as_slice());
+        assert_eq!(
+            reopened
+                .catalog()
+                .table("default", "events")
+                .unwrap()
+                .unwrap()
+                .placement(),
+            &TablePlacement::Sharded(
+                crate::core::ShardKeyMetadata::new("tenant_id", ShardKeyType::Text).unwrap()
+            )
+        );
+    }
+
+    #[test]
+    fn table_registration_rejects_incomplete_or_invalid_physical_metadata_atomically() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut database = Database::open(temp.path(), 2).unwrap();
+        create_registered_table_schema(&database);
+        let logical_database = database.catalog().default_database().id();
+
+        let incomplete = vec![
+            TableDeclaration::sharded(
+                logical_database,
+                "events",
+                crate::core::ShardKeyMetadata::new("tenant_id", ShardKeyType::Text).unwrap(),
+            )
+            .unwrap(),
+        ];
+        assert_eq!(
+            database.register_tables(incomplete).unwrap_err().kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+        assert!(database.catalog().tables().is_empty());
+
+        let wrong_type = vec![
+            TableDeclaration::global(logical_database, "countries").unwrap(),
+            TableDeclaration::sharded(
+                logical_database,
+                "events",
+                crate::core::ShardKeyMetadata::new("tenant_id", ShardKeyType::Int64).unwrap(),
+            )
+            .unwrap(),
+        ];
+        assert_eq!(
+            database.register_tables(wrong_type).unwrap_err().kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+        assert!(database.catalog().tables().is_empty());
+
+        let missing_key = vec![
+            TableDeclaration::global(logical_database, "countries").unwrap(),
+            TableDeclaration::sharded(
+                logical_database,
+                "events",
+                crate::core::ShardKeyMetadata::new("missing_key", ShardKeyType::Text).unwrap(),
+            )
+            .unwrap(),
+        ];
+        assert_eq!(
+            database.register_tables(missing_key).unwrap_err().kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+        assert!(database.catalog().tables().is_empty());
+
+        database
+            .broadcast("CREATE VIEW Audit_Catalog AS SELECT 1 AS id")
+            .unwrap();
+        let mut catalog_shadow = registered_table_declarations(&database);
+        catalog_shadow.push(TableDeclaration::catalog(logical_database, "audit_catalog").unwrap());
+        assert_eq!(
+            database.register_tables(catalog_shadow).unwrap_err().kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+        assert!(database.catalog().tables().is_empty());
+        database.broadcast("DROP VIEW Audit_Catalog").unwrap();
+
+        database
+            .register_tables(registered_table_declarations(&database))
+            .unwrap();
+        drop(database);
+        assert_eq!(
+            Database::open(temp.path(), 2)
+                .unwrap()
+                .catalog()
+                .tables()
+                .len(),
+            2
+        );
+    }
+
+    #[test]
+    fn first_table_registration_requires_exclusive_database_ownership() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut database = Database::open(temp.path(), 2).unwrap();
+        create_registered_table_schema(&database);
+        let observer = Database::open(temp.path(), 2).unwrap();
+        let declarations = registered_table_declarations(&database);
+
+        assert_eq!(
+            database
+                .register_tables(declarations.clone())
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+        assert!(database.catalog().tables().is_empty());
+        assert!(observer.catalog().tables().is_empty());
+
+        drop(observer);
+        database.register_tables(declarations).unwrap();
+        assert_eq!(database.catalog().tables().len(), 2);
+    }
+
+    #[test]
+    fn malformed_or_nonempty_registration_changes_no_catalog_metadata() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut database = Database::open(temp.path(), 2).unwrap();
+        create_registered_table_schema(&database);
+        let manifest_path = temp.path().join("manifest.sqlite");
+        let manifest_root = || {
+            Connection::open(&manifest_path)
+                .unwrap()
+                .query_row(
+                    "SELECT manifest_digest FROM briskdb_integrity WHERE singleton = 1",
+                    [],
+                    |row| row.get::<_, Vec<u8>>(0),
+                )
+                .unwrap()
+        };
+        let original_root = manifest_root();
+        let declarations = registered_table_declarations(&database);
+        assert_eq!(
+            database
+                .register_tables(vec![declarations[0].clone(), declarations[0].clone()])
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::InvalidArgument
+        );
+        let unknown_database = crate::core::LogicalDatabaseId::new(99).unwrap();
+        assert_eq!(
+            database
+                .register_tables(vec![
+                    TableDeclaration::global(unknown_database, "countries").unwrap()
+                ])
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::InvalidArgument
+        );
+        assert_eq!(manifest_root(), original_root);
+
+        database
+            .execute(
+                "tenant-one",
+                "INSERT INTO events (id, tenant_id, payload) VALUES (?1, ?2, ?3)",
+                &[
+                    crate::core::Value::from(1_i64),
+                    crate::core::Value::from("tenant-one"),
+                    crate::core::Value::from(vec![1_u8]),
+                ],
+            )
+            .unwrap();
+        assert_eq!(
+            database.register_tables(declarations).unwrap_err().kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+        assert!(database.catalog().tables().is_empty());
+        assert_eq!(manifest_root(), original_root);
+        assert_eq!(
+            Connection::open(&manifest_path)
+                .unwrap()
+                .query_row("SELECT COUNT(*) FROM briskdb_tables", [], |row| {
+                    row.get::<_, i64>(0)
+                })
+                .unwrap(),
+            0
+        );
+        drop(database);
+        assert!(
+            Database::open(temp.path(), 2)
+                .unwrap()
+                .catalog()
+                .tables()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn table_registration_crash_child() {
+        let Ok(root) = std::env::var("BRISKDB_TABLE_REGISTRATION_ABORT_ROOT") else {
+            return;
+        };
+        let mut database = Database::open(root, 2).unwrap();
+        create_registered_table_schema(&database);
+        let declarations = registered_table_declarations(&database);
+        let result = database.register_tables(declarations);
+        panic!("child did not reach requested table-registration boundary: {result:?}");
+    }
+
+    #[test]
+    fn real_process_abort_leaves_exactly_the_old_or_new_table_catalog() {
+        for (boundary, expected_tables) in [("before-commit", 0), ("after-commit", 2)] {
+            let temp = tempfile::tempdir().unwrap();
+            let status = Command::new(std::env::current_exe().unwrap())
+                .arg("--exact")
+                .arg("storage::tests::table_registration_crash_child")
+                .arg("--nocapture")
+                .env("BRISKDB_TABLE_REGISTRATION_ABORT_ROOT", temp.path())
+                .env("BRISKDB_TABLE_REGISTRATION_ABORT_POINT", boundary)
+                .status()
+                .unwrap();
+            assert!(!status.success(), "child did not abort {boundary}");
+
+            let mut reopened = Database::open(temp.path(), 2).unwrap();
+            assert_eq!(reopened.catalog().tables().len(), expected_tables);
+            let declarations = registered_table_declarations(&reopened);
+            reopened.register_tables(declarations).unwrap();
+            assert_eq!(reopened.catalog().tables().len(), 2);
+        }
+    }
+
+    #[test]
+    fn post_commit_registration_ambiguity_stays_pending_until_stale_handle_closes() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut database = Database::open(temp.path(), 2).unwrap();
+        create_registered_table_schema(&database);
+        let declarations = registered_table_declarations(&database);
+        let canonical_root = fs::canonicalize(temp.path()).unwrap();
+        let coordination = root_schema_coordination(&canonical_root).unwrap();
+
+        manifest::fail_next_table_registration_post_commit_for_test();
+        let error = database.register_tables(declarations).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Internal);
+        assert!(database.catalog().tables().is_empty());
+        assert_eq!(coordination.gate.snapshot().state, SchemaGateState::Pending);
+
+        let conflict = Database::open(temp.path(), 2).unwrap_err();
+        assert_eq!(conflict.kind(), EngineErrorKind::FailedPrecondition);
+        assert_eq!(coordination.gate.snapshot().state, SchemaGateState::Pending);
+        assert_eq!(
+            database
+                .execute("tenant-one", "SELECT 1", &[])
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+
+        drop(database);
+        let reopened = Database::open(temp.path(), 2).unwrap();
+        assert_eq!(reopened.catalog().tables().len(), 2);
+        assert_eq!(coordination.gate.snapshot().state, SchemaGateState::Ready);
+    }
+
+    #[test]
+    fn registration_manifest_corruption_degrades_every_live_alias() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut database = Database::open(temp.path(), 2).unwrap();
+        create_registered_table_schema(&database);
+        let alias = Database::open(temp.path(), 2).unwrap();
+        let canonical_root = fs::canonicalize(temp.path()).unwrap();
+        let coordination = root_schema_coordination(&canonical_root).unwrap();
+        Connection::open(temp.path().join("manifest.sqlite"))
+            .unwrap()
+            .execute(
+                "UPDATE briskdb_virtual_buckets
+                 SET physical_shard_id = 1 - physical_shard_id
+                 WHERE bucket_id = 0",
+                [],
+            )
+            .unwrap();
+
+        // Close the observer so exclusivity does not mask the checksummed
+        // manifest read performed by the registration transaction.
+        drop(alias);
+        let error = database
+            .register_tables(registered_table_declarations(&database))
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+        assert_eq!(
+            coordination.gate.snapshot().state,
+            SchemaGateState::Degraded
+        );
+        assert_eq!(
+            database
+                .execute("tenant-one", "SELECT 1", &[])
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::DataCorruption
+        );
+    }
+
+    #[test]
+    fn table_registration_rejects_sqlite_nullable_primary_key_forms() {
+        for definition in [
+            "key TEXT PRIMARY KEY",
+            "key BIGINT PRIMARY KEY",
+            "key INTEGER PRIMARY KEY DESC",
+        ] {
+            let temp = tempfile::tempdir().unwrap();
+            let mut database = Database::open(temp.path(), 2).unwrap();
+            database
+                .broadcast(&format!("CREATE TABLE nullable_keys ({definition})"))
+                .unwrap();
+            let logical_database = database.catalog().default_database().id();
+            let key_type = if definition.starts_with("key TEXT") {
+                ShardKeyType::Text
+            } else {
+                ShardKeyType::Int64
+            };
+            let declaration = TableDeclaration::sharded(
+                logical_database,
+                "nullable_keys",
+                crate::core::ShardKeyMetadata::new("key", key_type).unwrap(),
+            )
+            .unwrap();
+
+            assert_eq!(
+                database
+                    .register_tables(vec![declaration])
+                    .unwrap_err()
+                    .kind(),
+                EngineErrorKind::FailedPrecondition,
+                "{definition}"
+            );
+            assert!(database.catalog().tables().is_empty());
+        }
+    }
+
+    #[test]
+    fn table_registration_rejects_nonlocal_constraints_collations_and_triggers() {
+        for schema in [
+            "CREATE TABLE records (
+                 id INTEGER PRIMARY KEY,
+                 tenant_id TEXT NOT NULL
+             )",
+            "CREATE TABLE records (
+                 tenant_id TEXT COLLATE NOCASE PRIMARY KEY NOT NULL,
+                 payload TEXT
+             )",
+            "CREATE TABLE records (
+                 tenant_id TEXT PRIMARY KEY NOT NULL,
+                 email TEXT NOT NULL UNIQUE
+             )",
+            "CREATE TABLE records (
+                 tenant_id TEXT PRIMARY KEY NOT NULL,
+                 email TEXT,
+                 UNIQUE (tenant_id COLLATE NOCASE, email)
+             )",
+        ] {
+            let temp = tempfile::tempdir().unwrap();
+            let mut database = Database::open(temp.path(), 2).unwrap();
+            database.broadcast(schema).unwrap();
+            let logical_database = database.catalog().default_database().id();
+            let declaration = TableDeclaration::sharded(
+                logical_database,
+                "records",
+                crate::core::ShardKeyMetadata::new("tenant_id", ShardKeyType::Text).unwrap(),
+            )
+            .unwrap();
+            assert_eq!(
+                database
+                    .register_tables(vec![declaration])
+                    .unwrap_err()
+                    .kind(),
+                EngineErrorKind::FailedPrecondition,
+                "{schema}"
+            );
+            assert!(database.catalog().tables().is_empty());
+        }
+
+        let temp = tempfile::tempdir().unwrap();
+        let mut database = Database::open(temp.path(), 2).unwrap();
+        database
+            .broadcast(
+                "CREATE TABLE parents (tenant_id TEXT PRIMARY KEY NOT NULL);
+                 CREATE TABLE children (
+                     tenant_id TEXT PRIMARY KEY NOT NULL,
+                     FOREIGN KEY (tenant_id) REFERENCES parents (tenant_id)
+                 );",
+            )
+            .unwrap();
+        let logical_database = database.catalog().default_database().id();
+        let declarations = ["parents", "children"]
+            .into_iter()
+            .map(|table| {
+                TableDeclaration::sharded(
+                    logical_database,
+                    table,
+                    crate::core::ShardKeyMetadata::new("tenant_id", ShardKeyType::Text).unwrap(),
+                )
+                .unwrap()
+            })
+            .collect();
+        assert_eq!(
+            database.register_tables(declarations).unwrap_err().kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+
+        let temp = tempfile::tempdir().unwrap();
+        let mut database = Database::open(temp.path(), 2).unwrap();
+        create_registered_table_schema(&database);
+        database
+            .broadcast(
+                "CREATE TRIGGER events_copy AFTER INSERT ON events
+                 BEGIN UPDATE events SET payload = NEW.payload
+                 WHERE tenant_id = NEW.tenant_id AND id = NEW.id; END",
+            )
+            .unwrap();
+        assert_eq!(
+            database
+                .register_tables(registered_table_declarations(&database))
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+    }
+
+    #[test]
+    fn virtual_tables_are_never_classified_as_ordinary_physical_tables() {
+        let connection = Connection::open_in_memory().unwrap();
+        connection
+            .execute_batch("CREATE VIRTUAL TABLE search_records USING fts5(body)")
+            .unwrap();
+        let names = application_table_names(&connection).unwrap();
+        assert!(names.contains("search_records"));
+        assert!(!names.contains("search_records_data"));
     }
 }

--- a/src/storage/schema_gate.rs
+++ b/src/storage/schema_gate.rs
@@ -164,6 +164,32 @@ impl SchemaGate {
             finished: false,
         })
     }
+
+    /// Begin work that is valid only from a fully ready root. Unlike recovery,
+    /// first-time catalog registration must never reinterpret `Pending` as a
+    /// safe source snapshot before the manifest has reconciled that state.
+    pub(crate) fn begin_new_migration(&self) -> EngineResult<SchemaMigrationGuard> {
+        let mut data = self.inner.lock();
+        match data.state {
+            SchemaGateState::Ready => {
+                data.state = SchemaGateState::Migrating;
+                Ok(SchemaMigrationGuard {
+                    inner: Arc::clone(&self.inner),
+                    restore_state: SchemaGateState::Ready,
+                    finished: false,
+                })
+            }
+            SchemaGateState::Migrating => Err(EngineError::new(
+                EngineErrorKind::Busy,
+                "an application-schema migration is already in progress",
+            )),
+            SchemaGateState::Pending => Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "pending schema state must be reconciled before new catalog registration",
+            )),
+            SchemaGateState::Degraded => Err(degraded_error()),
+        }
+    }
 }
 
 impl Default for SchemaGate {

--- a/src/storage/shard.rs
+++ b/src/storage/shard.rs
@@ -1,18 +1,18 @@
 //! Physical-shard identity, provisioning, and strict reopen validation.
 
 use std::{
-    collections::HashSet,
+    collections::{BTreeSet, HashSet},
     fs,
     path::{Path, PathBuf},
 };
 
 use rusqlite::{
-    Connection, MAIN_DB, OpenFlags, TransactionBehavior,
+    Connection, MAIN_DB, OpenFlags, OptionalExtension, TransactionBehavior,
     hooks::{AuthAction, AuthContext, Authorization},
 };
 
 use crate::{
-    core::{EngineError, EngineErrorKind, EngineResult},
+    core::{Catalog, EngineError, EngineErrorKind, EngineResult, ShardKeyType, TablePlacement},
     sqlite_error,
 };
 
@@ -551,6 +551,7 @@ pub(super) fn preflight_schema_migration_with_digest(
 }
 
 /// Connection-level digesting preflight for a cancellation-aware coordinator.
+#[cfg(test)]
 pub(super) fn preflight_schema_migration_on_connection_with_digest(
     connection: &mut Connection,
     path: &Path,
@@ -560,6 +561,58 @@ pub(super) fn preflight_schema_migration_on_connection_with_digest(
     layout: &ShardLayout,
     sql: &str,
 ) -> EngineResult<(SchemaMigrationShardState, SchemaDigest)> {
+    preflight_schema_migration_on_connection_with_digest_inner(
+        connection,
+        path,
+        shard_id,
+        source_generation,
+        target_generation,
+        layout,
+        sql,
+        None,
+    )
+}
+
+/// Connection-level digesting preflight that also preserves the complete
+/// authoritative table catalog. The catalog check runs inside the rollback
+/// transaction after the SQL batch, before its target digest is trusted.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn preflight_schema_migration_on_connection_with_digest_and_catalog(
+    connection: &mut Connection,
+    path: &Path,
+    shard_id: u16,
+    source_generation: u64,
+    target_generation: u64,
+    layout: &ShardLayout,
+    sql: &str,
+    catalog: &Catalog,
+) -> EngineResult<(SchemaMigrationShardState, SchemaDigest)> {
+    preflight_schema_migration_on_connection_with_digest_inner(
+        connection,
+        path,
+        shard_id,
+        source_generation,
+        target_generation,
+        layout,
+        sql,
+        Some(catalog),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn preflight_schema_migration_on_connection_with_digest_inner(
+    connection: &mut Connection,
+    path: &Path,
+    shard_id: u16,
+    source_generation: u64,
+    target_generation: u64,
+    layout: &ShardLayout,
+    sql: &str,
+    catalog: Option<&Catalog>,
+) -> EngineResult<(SchemaMigrationShardState, SchemaDigest)> {
+    if catalog.is_some_and(|catalog| !catalog.tables().is_empty()) {
+        crate::sql::validate_authoritative_schema_migration(sql)?;
+    }
     let initial = validate_schema_migration_connection(
         connection,
         path,
@@ -569,6 +622,9 @@ pub(super) fn preflight_schema_migration_on_connection_with_digest(
         layout,
     )?;
     if initial == SchemaMigrationShardState::Target {
+        if let Some(catalog) = catalog {
+            validate_registered_table_schema(connection, catalog)?;
+        }
         let digest = calculate_schema_digest(connection, target_generation)?;
         return Ok((initial, digest));
     }
@@ -596,6 +652,9 @@ pub(super) fn preflight_schema_migration_on_connection_with_digest(
             target_generation,
             layout,
         )?;
+        if let Some(catalog) = catalog {
+            validate_registered_table_schema(connection, catalog)?;
+        }
         let digest = calculate_schema_digest(connection, target_generation)?;
         return Ok((state, digest));
     }
@@ -604,6 +663,9 @@ pub(super) fn preflight_schema_migration_on_connection_with_digest(
     execute_schema_migration_batch(&transaction, sql)?;
     ensure_reserved_schema_unchanged(&reserved_before, &transaction)?;
     ensure_no_foreign_key_violations(&transaction)?;
+    if let Some(catalog) = catalog {
+        validate_registered_table_schema(&transaction, catalog)?;
+    }
     let target_digest = calculate_schema_digest(&transaction, target_generation)?;
     transaction.rollback().map_err(sqlite_error::storage)?;
 
@@ -622,6 +684,399 @@ pub(super) fn preflight_schema_migration_on_connection_with_digest(
         ));
     }
     Ok((state, target_digest))
+}
+
+/// Verify that one physical shard still implements the complete authoritative
+/// logical table catalog after a tentative schema migration.
+///
+/// An empty table catalog predates authoritative registration and deliberately
+/// retains the unrestricted migration behavior. Once any table is registered,
+/// every physical application table must be declared Sharded or Global, every
+/// such declaration must have a physical table, and Catalog declarations must
+/// remain manifest-only. Sharded keys additionally retain the representation
+/// required by deterministic routing.
+fn validate_registered_table_schema(
+    connection: &Connection,
+    catalog: &Catalog,
+) -> EngineResult<()> {
+    if catalog.tables().is_empty() {
+        return Ok(());
+    }
+
+    let has_application_trigger = connection
+        .query_row(
+            "SELECT EXISTS(
+                 SELECT 1 FROM main.sqlite_schema
+                 WHERE type = 'trigger' AND name NOT GLOB 'sqlite_*'
+             )",
+            [],
+            |row| row.get::<_, bool>(0),
+        )
+        .map_err(sqlite_error::storage)?;
+    if has_application_trigger {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "schema migration violates the authoritative table catalog: application triggers are not supported",
+        ));
+    }
+    let has_application_virtual_table = connection
+        .query_row(
+            "SELECT EXISTS(
+                 SELECT 1 FROM pragma_table_list
+                 WHERE schema = 'main' AND type = 'virtual'
+             )",
+            [],
+            |row| row.get::<_, bool>(0),
+        )
+        .map_err(sqlite_error::storage)?;
+    if has_application_virtual_table {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "schema migration violates the authoritative table catalog: virtual tables are not supported",
+        ));
+    }
+
+    let expected = catalog
+        .tables()
+        .iter()
+        .filter(|table| {
+            matches!(
+                table.placement(),
+                TablePlacement::Sharded(_) | TablePlacement::Global
+            )
+        })
+        .map(|table| table.name().to_owned())
+        .collect::<BTreeSet<_>>();
+    let observed = application_table_names(connection)?;
+    if observed != expected {
+        let missing = expected.difference(&observed).next().map(String::as_str);
+        let unexpected = observed.difference(&expected).next().map(String::as_str);
+        let detail = match (missing, unexpected) {
+            (Some(missing), Some(unexpected)) => {
+                format!("missing table {missing} and found undeclared table {unexpected}")
+            }
+            (Some(missing), None) => format!("missing table {missing}"),
+            (None, Some(unexpected)) => format!("found undeclared table {unexpected}"),
+            (None, None) => "physical table set differs".to_owned(),
+        };
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!("schema migration violates the authoritative table catalog: {detail}"),
+        ));
+    }
+
+    for table in catalog.tables() {
+        if matches!(table.placement(), TablePlacement::Catalog) {
+            let has_physical_shadow = connection
+                .query_row(
+                    "SELECT EXISTS(
+                         SELECT 1 FROM main.sqlite_schema
+                         WHERE name = ?1 COLLATE NOCASE
+                           AND type IN ('table', 'view')
+                     )",
+                    [table.name()],
+                    |row| row.get::<_, bool>(0),
+                )
+                .map_err(sqlite_error::storage)?;
+            if has_physical_shadow {
+                return Err(EngineError::new(
+                    EngineErrorKind::FailedPrecondition,
+                    format!(
+                        "schema migration violates the authoritative table catalog: catalog table {} has a physical shadow",
+                        table.name()
+                    ),
+                ));
+            }
+            continue;
+        }
+        let TablePlacement::Sharded(shard_key) = table.placement() else {
+            validate_authoritative_table_constraints(connection, table.name(), None)?;
+            continue;
+        };
+        let mut statement = connection
+            .prepare(
+                "SELECT name, type, \"notnull\", pk, hidden
+                 FROM pragma_table_xinfo(?1)
+                 ORDER BY cid",
+            )
+            .map_err(sqlite_error::storage)?;
+        let columns = statement
+            .query_map([table.name()], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, i64>(4)?,
+                ))
+            })
+            .map_err(sqlite_error::storage)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(sqlite_error::storage)?;
+        let Some((_, declared_type, not_null, primary_key, hidden)) = columns
+            .iter()
+            .find(|(name, _, _, _, _)| name == shard_key.column())
+        else {
+            return Err(registered_shard_key_error(
+                table.name(),
+                shard_key.column(),
+                "is missing",
+            ));
+        };
+        if *hidden != 0
+            || !registered_shard_key_is_non_null(
+                connection,
+                table.name(),
+                declared_type,
+                *not_null,
+                *primary_key,
+            )?
+        {
+            return Err(registered_shard_key_error(
+                table.name(),
+                shard_key.column(),
+                "must remain a visible physically non-null column",
+            ));
+        }
+        if !shard_key_affinity_is_compatible(shard_key.key_type(), declared_type) {
+            return Err(registered_shard_key_error(
+                table.name(),
+                shard_key.column(),
+                "has an incompatible SQLite declared type",
+            ));
+        }
+        if matches!(shard_key.key_type(), ShardKeyType::Text)
+            && !shard_key_uses_binary_collation(connection, table.name(), shard_key.column())?
+        {
+            return Err(registered_shard_key_error(
+                table.name(),
+                shard_key.column(),
+                "must retain SQLite BINARY collation",
+            ));
+        }
+        validate_authoritative_table_constraints(connection, table.name(), Some(shard_key))?;
+    }
+    Ok(())
+}
+
+/// Enforce constraints that SQLite can only check inside one physical file.
+/// Foreign keys need an explicit co-location policy that is not implemented
+/// yet. Every unique key of a Sharded table must contain its routing key using
+/// BINARY collation so two different owners cannot both accept the same value.
+pub(super) fn validate_authoritative_table_constraints(
+    connection: &Connection,
+    table: &str,
+    shard_key: Option<&crate::core::ShardKeyMetadata>,
+) -> EngineResult<()> {
+    let has_foreign_key = connection
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM pragma_foreign_key_list(?1))",
+            [table],
+            |row| row.get::<_, bool>(0),
+        )
+        .map_err(sqlite_error::storage)?;
+    if has_foreign_key {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!(
+                "table {table} declares a foreign key, but authoritative foreign-key co-location is not supported"
+            ),
+        ));
+    }
+
+    let Some(shard_key) = shard_key else {
+        return Ok(());
+    };
+    let mut statement = connection
+        .prepare(
+            "SELECT name, origin
+             FROM pragma_index_list(?1)
+             WHERE \"unique\" <> 0
+             ORDER BY seq",
+        )
+        .map_err(sqlite_error::storage)?;
+    let unique_indexes = statement
+        .query_map([table], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })
+        .map_err(sqlite_error::storage)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(sqlite_error::storage)?;
+    let has_primary_key_index = unique_indexes.iter().any(|(_, origin)| origin == "pk");
+
+    for (index, _) in &unique_indexes {
+        let mut columns = connection
+            .prepare(
+                "SELECT name, coll
+                 FROM pragma_index_xinfo(?1)
+                 WHERE key = 1
+                 ORDER BY seqno",
+            )
+            .map_err(sqlite_error::storage)?;
+        let indexed_columns = columns
+            .query_map([index], |row| {
+                Ok((
+                    row.get::<_, Option<String>>(0)?,
+                    row.get::<_, Option<String>>(1)?,
+                ))
+            })
+            .map_err(sqlite_error::storage)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(sqlite_error::storage)?;
+        let has_shard_term = indexed_columns
+            .iter()
+            .any(|(column, _)| column.as_deref() == Some(shard_key.column()));
+        if !has_shard_term {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "unique index {index} on sharded table {table} does not include shard key {}",
+                    shard_key.column()
+                ),
+            ));
+        }
+        let has_binary_shard_term = indexed_columns.iter().any(|(column, collation)| {
+            column.as_deref() == Some(shard_key.column())
+                && collation
+                    .as_deref()
+                    .is_some_and(|collation| collation.eq_ignore_ascii_case("BINARY"))
+        });
+        if !has_binary_shard_term {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "unique index {index} on sharded table {table} must use BINARY collation for shard key {}",
+                    shard_key.column()
+                ),
+            ));
+        }
+    }
+
+    if !has_primary_key_index {
+        let rowid_primary_key = connection
+            .query_row(
+                "SELECT name
+                 FROM pragma_table_xinfo(?1)
+                 WHERE pk <> 0
+                 ORDER BY pk
+                 LIMIT 1",
+                [table],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(sqlite_error::storage)?;
+        if rowid_primary_key
+            .as_deref()
+            .is_some_and(|column| column != shard_key.column())
+        {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "primary key on sharded table {table} does not include shard key {}",
+                    shard_key.column()
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn shard_key_uses_binary_collation(
+    connection: &Connection,
+    table: &str,
+    column: &str,
+) -> EngineResult<bool> {
+    let (_, collation, _, _, _) = connection
+        .column_metadata(Some("main"), table, column)
+        .map_err(sqlite_error::storage)?;
+    Ok(collation.is_some_and(|name| name.to_bytes().eq_ignore_ascii_case(b"BINARY")))
+}
+
+fn registered_shard_key_is_non_null(
+    connection: &Connection,
+    table: &str,
+    declared_type: &str,
+    not_null: i64,
+    primary_key: i64,
+) -> EngineResult<bool> {
+    if not_null != 0 {
+        return Ok(true);
+    }
+    if primary_key == 0 || !declared_type.trim().eq_ignore_ascii_case("INTEGER") {
+        return Ok(false);
+    }
+    let has_primary_key_index = connection
+        .query_row(
+            "SELECT EXISTS(
+                 SELECT 1 FROM pragma_index_list(?1) WHERE origin = 'pk'
+             )",
+            [table],
+            |row| row.get::<_, bool>(0),
+        )
+        .map_err(sqlite_error::storage)?;
+    Ok(!has_primary_key_index)
+}
+
+fn application_table_names(connection: &Connection) -> EngineResult<BTreeSet<String>> {
+    let mut statement = connection
+        .prepare(
+            "SELECT name FROM pragma_table_list
+             WHERE schema = 'main' AND type IN ('table', 'virtual')
+               AND name NOT GLOB 'sqlite_*'
+               AND name <> 'briskdb_shard_metadata'
+             ORDER BY name COLLATE BINARY",
+        )
+        .map_err(sqlite_error::storage)?;
+    statement
+        .query_map([], |row| row.get::<_, String>(0))
+        .map_err(sqlite_error::storage)?
+        .collect::<Result<BTreeSet<_>, _>>()
+        .map_err(sqlite_error::storage)
+}
+
+fn registered_shard_key_error(table: &str, column: &str, detail: &str) -> EngineError {
+    EngineError::new(
+        EngineErrorKind::FailedPrecondition,
+        format!(
+            "schema migration violates the authoritative table catalog: shard key {column} on table {table} {detail}"
+        ),
+    )
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SqliteAffinity {
+    Integer,
+    Text,
+    Blob,
+    Real,
+    Numeric,
+}
+
+fn shard_key_affinity_is_compatible(key_type: ShardKeyType, declared_type: &str) -> bool {
+    let declared_type = declared_type.to_ascii_uppercase();
+    let affinity = if declared_type.contains("INT") {
+        SqliteAffinity::Integer
+    } else if declared_type.contains("CHAR")
+        || declared_type.contains("CLOB")
+        || declared_type.contains("TEXT")
+    {
+        SqliteAffinity::Text
+    } else if declared_type.contains("BLOB") || declared_type.is_empty() {
+        SqliteAffinity::Blob
+    } else if declared_type.contains("REAL")
+        || declared_type.contains("FLOA")
+        || declared_type.contains("DOUB")
+    {
+        SqliteAffinity::Real
+    } else {
+        SqliteAffinity::Numeric
+    };
+    matches!(
+        (key_type, affinity),
+        (ShardKeyType::Int64, SqliteAffinity::Integer)
+            | (ShardKeyType::Text, SqliteAffinity::Text)
+            | (ShardKeyType::Binary, SqliteAffinity::Blob)
+    )
 }
 
 /// Atomically apply one journaled batch and its target generation, or strictly
@@ -2086,6 +2541,9 @@ mod tests {
     use rusqlite::hooks::TransactionOperation;
 
     use super::*;
+    use crate::core::{
+        IDENTIFIER_ENCODING_VERSION, LogicalDatabaseMetadata, ShardKeyMetadata, TableMetadata,
+    };
 
     const LAYOUT_ID: [u8; 16] = *b"brisk-layout-001";
     const SHARD_CRASH_SQL: &str = "\
@@ -2124,6 +2582,72 @@ mod tests {
         let shards = temp.path().join("shards");
         prepare_layout(&shards, shard_count, 0, &layout(ShardLayoutState::Creating)).unwrap();
         (temp, shards, layout(ShardLayoutState::Ready))
+    }
+
+    fn catalog_with_registered_tables() -> Catalog {
+        Catalog::from_validated_parts(
+            IDENTIFIER_ENCODING_VERSION,
+            0,
+            1,
+            vec![LogicalDatabaseMetadata::from_validated(
+                1,
+                "default".to_owned(),
+            )]
+            .into_boxed_slice(),
+            vec![
+                TableMetadata::from_validated(
+                    1,
+                    1,
+                    "accounts".to_owned(),
+                    TablePlacement::Sharded(ShardKeyMetadata::from_validated(
+                        "id".to_owned(),
+                        ShardKeyType::Int64,
+                    )),
+                ),
+                TableMetadata::from_validated(
+                    2,
+                    1,
+                    "audit_catalog".to_owned(),
+                    TablePlacement::Catalog,
+                ),
+                TableMetadata::from_validated(3, 1, "countries".to_owned(), TablePlacement::Global),
+            ]
+            .into_boxed_slice(),
+        )
+    }
+
+    fn empty_catalog() -> Catalog {
+        Catalog::from_validated_parts(
+            IDENTIFIER_ENCODING_VERSION,
+            0,
+            1,
+            vec![LogicalDatabaseMetadata::from_validated(
+                1,
+                "default".to_owned(),
+            )]
+            .into_boxed_slice(),
+            Vec::new().into_boxed_slice(),
+        )
+    }
+
+    fn preflight_with_catalog(
+        path: &Path,
+        ready: &ShardLayout,
+        sql: &str,
+        catalog: &Catalog,
+    ) -> EngineResult<(SchemaMigrationShardState, SchemaDigest)> {
+        let mut connection = open_required_file(path)?;
+        configure_busy_timeout(&connection)?;
+        preflight_schema_migration_on_connection_with_digest_and_catalog(
+            &mut connection,
+            path,
+            0,
+            0,
+            1,
+            ready,
+            sql,
+            catalog,
+        )
     }
 
     fn schema_object_exists(path: &Path, name: &str) -> bool {
@@ -2407,6 +2931,150 @@ mod tests {
         );
         assert_eq!(identity(&second), (SHARD_APPLICATION_ID, 0));
         assert!(!schema_object_exists(&second, "migrated_widgets"));
+    }
+
+    #[test]
+    fn migration_preflight_preserves_authoritative_table_catalog_and_shard_keys() {
+        let (_temp, shards, ready) = create_ready_layout(2);
+        let path = shard_path(&shards, 0);
+        let connection = Connection::open(&path).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE accounts (
+                     id INTEGER PRIMARY KEY,
+                     display_name TEXT NOT NULL
+                 ) STRICT;
+                 CREATE TABLE countries (
+                     code TEXT PRIMARY KEY,
+                     display_name TEXT NOT NULL
+                 ) STRICT;",
+            )
+            .unwrap();
+        drop(connection);
+        let catalog = catalog_with_registered_tables();
+
+        let (state, _) = preflight_with_catalog(
+            &path,
+            &ready,
+            "CREATE INDEX accounts_display_name_idx ON accounts (display_name)",
+            &catalog,
+        )
+        .unwrap();
+        assert_eq!(state, SchemaMigrationShardState::Source);
+        assert!(!schema_object_exists(&path, "accounts_display_name_idx"));
+
+        for (sql, transient_object) in [
+            (
+                "INSERT INTO accounts (id, display_name) VALUES (1, 'duplicate')",
+                None,
+            ),
+            (
+                "UPDATE accounts SET display_name = upper(display_name)",
+                None,
+            ),
+            ("DELETE FROM accounts", None),
+            ("DROP TABLE accounts", None),
+            (
+                "DROP TABLE accounts;
+                 CREATE TABLE accounts (
+                     account_id INTEGER PRIMARY KEY,
+                     display_name TEXT NOT NULL
+                 ) STRICT",
+                None,
+            ),
+            (
+                "DROP TABLE accounts;
+                 CREATE TABLE accounts (
+                     id TEXT PRIMARY KEY,
+                     display_name TEXT NOT NULL
+                 ) STRICT",
+                None,
+            ),
+            (
+                "DROP TABLE accounts;
+                 CREATE TABLE accounts (
+                     id INTEGER PRIMARY KEY DESC,
+                     display_name TEXT NOT NULL
+                 )",
+                None,
+            ),
+            (
+                "DROP TABLE accounts;
+                 CREATE TABLE accounts (
+                     row_id INTEGER PRIMARY KEY,
+                     id INTEGER,
+                     display_name TEXT NOT NULL
+                 ) STRICT",
+                None,
+            ),
+            (
+                "CREATE TABLE undeclared (id INTEGER PRIMARY KEY) STRICT",
+                Some("undeclared"),
+            ),
+            (
+                "CREATE TABLE copied_accounts AS SELECT * FROM accounts",
+                Some("copied_accounts"),
+            ),
+            (
+                "CREATE UNIQUE INDEX accounts_display_unique ON accounts (display_name)",
+                Some("accounts_display_unique"),
+            ),
+            (
+                "CREATE TRIGGER accounts_move AFTER INSERT ON accounts
+                 BEGIN DELETE FROM accounts WHERE id = NEW.id; END",
+                Some("accounts_move"),
+            ),
+            (
+                "CREATE VIEW Audit_Catalog AS SELECT 1 AS id",
+                Some("Audit_Catalog"),
+            ),
+            (
+                "CREATE VIEW audit_catalog AS SELECT id FROM accounts",
+                Some("audit_catalog"),
+            ),
+        ] {
+            let error = preflight_with_catalog(&path, &ready, sql, &catalog).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition, "{sql}");
+            assert!(schema_object_exists(&path, "accounts"), "{sql}");
+            assert!(schema_object_exists(&path, "countries"), "{sql}");
+            if let Some(transient_object) = transient_object {
+                assert!(!schema_object_exists(&path, transient_object), "{sql}");
+            }
+            assert_eq!(identity(&path), (SHARD_APPLICATION_ID, 0), "{sql}");
+        }
+
+        let empty = empty_catalog();
+        let (state, _) = preflight_with_catalog(
+            &path,
+            &ready,
+            "CREATE TABLE legacy_unregistered (id INTEGER PRIMARY KEY) STRICT",
+            &empty,
+        )
+        .unwrap();
+        assert_eq!(state, SchemaMigrationShardState::Source);
+        assert!(!schema_object_exists(&path, "legacy_unregistered"));
+    }
+
+    #[test]
+    fn authoritative_unique_index_accepts_a_later_binary_shard_key_term() {
+        let connection = Connection::open_in_memory().unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE records (
+                     tenant_id TEXT NOT NULL COLLATE BINARY,
+                     email TEXT NOT NULL
+                 );
+                 CREATE UNIQUE INDEX records_unique ON records (
+                     tenant_id COLLATE NOCASE,
+                     tenant_id COLLATE BINARY,
+                     email
+                 );",
+            )
+            .unwrap();
+        let shard_key =
+            ShardKeyMetadata::from_validated("tenant_id".to_owned(), ShardKeyType::Text);
+
+        validate_authoritative_table_constraints(&connection, "records", Some(&shard_key)).unwrap();
     }
 
     #[test]

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -1,5 +1,4 @@
 use std::{
-    path::Path,
     sync::Arc,
     thread,
     time::{Duration, Instant},
@@ -12,81 +11,75 @@ use briskdb::{
     server, sql, storage,
 };
 
-fn insert_catalog_fixture(root: &Path) {
-    let manifest = rusqlite::Connection::open(root.join("manifest.sqlite")).unwrap();
-    manifest
-        .execute_batch(
-            "PRAGMA foreign_keys = ON;
-             BEGIN IMMEDIATE;
-             DROP TABLE briskdb_integrity;
-             DROP TABLE briskdb_metadata;
-             CREATE TABLE briskdb_metadata (
-                 requires_manifest_version INTEGER NOT NULL
-                     CHECK (requires_manifest_version >= 6)
-             ) STRICT;
-             INSERT INTO briskdb_metadata VALUES (6);
-             INSERT INTO briskdb_logical_databases (database_id, database_name)
-             VALUES (9, 'tenant');
-             INSERT INTO briskdb_tables (
-                table_id,
-                database_id,
-                table_name,
-                placement,
-                shard_key_column,
-                shard_key_type
-             ) VALUES
-                (20, 1, 'countries', 2, NULL, NULL),
-                (30, 9, 'accounts', 1, 'tenant_id', 2),
-                (40, 9, 'internal_catalog', 3, NULL, NULL);
-             PRAGMA user_version = 6;
-             COMMIT;",
+fn register_catalog_fixture(database: &mut core::Database) {
+    database
+        .broadcast(
+            "CREATE TABLE accounts (
+                id INTEGER NOT NULL,
+                tenant_id TEXT NOT NULL,
+                payload TEXT,
+                PRIMARY KEY (tenant_id, id)
+             );
+             CREATE TABLE countries (
+                code TEXT PRIMARY KEY,
+                name TEXT NOT NULL
+             );",
         )
+        .unwrap();
+    let logical_database = database.catalog().default_database().id();
+    database
+        .register_tables(vec![
+            core::TableDeclaration::global(logical_database, "countries").unwrap(),
+            core::TableDeclaration::catalog(logical_database, "internal_catalog").unwrap(),
+            core::TableDeclaration::sharded(
+                logical_database,
+                "accounts",
+                core::ShardKeyMetadata::new("tenant_id", core::ShardKeyType::Text).unwrap(),
+            )
+            .unwrap(),
+        ])
         .unwrap();
 }
 
-fn insert_prepared_catalog_fixture(root: &Path) {
-    let manifest = rusqlite::Connection::open(root.join("manifest.sqlite")).unwrap();
-    manifest
-        .execute_batch(
-            "PRAGMA foreign_keys = ON;
-             BEGIN IMMEDIATE;
-             DROP TABLE briskdb_integrity;
-             DROP TABLE briskdb_metadata;
-             CREATE TABLE briskdb_metadata (
-                 requires_manifest_version INTEGER NOT NULL
-                     CHECK (requires_manifest_version >= 6)
-             ) STRICT;
-             INSERT INTO briskdb_metadata VALUES (6);
-             INSERT INTO briskdb_tables (
-                table_id,
-                database_id,
-                table_name,
-                placement,
-                shard_key_column,
-                shard_key_type
-             ) VALUES (50, 1, 'prepared_events', 1, 'tenant_id', 1);
-             PRAGMA user_version = 6;
-             COMMIT;",
+fn register_prepared_catalog_fixture(database: &mut core::Database) {
+    database
+        .broadcast(
+            "CREATE TABLE prepared_events (
+                tenant_id INTEGER PRIMARY KEY,
+                payload TEXT NOT NULL
+             )",
         )
+        .unwrap();
+    let logical_database = database.catalog().default_database().id();
+    database
+        .register_tables(vec![
+            core::TableDeclaration::sharded(
+                logical_database,
+                "prepared_events",
+                core::ShardKeyMetadata::new("tenant_id", core::ShardKeyType::Int64).unwrap(),
+            )
+            .unwrap(),
+        ])
         .unwrap();
 }
 
 fn assert_catalog_fixture(catalog: &core::Catalog) {
     assert_eq!(catalog.identifier_encoding_version(), 1);
-    assert_eq!(catalog.schema_generation(), 0);
+    assert_eq!(catalog.schema_generation(), 1);
     assert_eq!(catalog.default_database().id().get(), 1);
     assert_eq!(catalog.default_database().name(), "default");
-    assert_eq!(catalog.logical_databases().len(), 2);
+    assert_eq!(catalog.logical_databases().len(), 1);
     assert_eq!(catalog.tables().len(), 3);
 
-    let tenant = catalog.database("tenant").unwrap().unwrap();
-    assert_eq!(tenant.id().get(), 9);
-    assert_eq!(tenant.id().to_string(), "9");
-    assert_eq!(catalog.database_by_id(tenant.id()), Some(tenant));
+    let logical_database = catalog.default_database();
+    assert_eq!(
+        catalog.database_by_id(logical_database.id()),
+        Some(logical_database)
+    );
 
     let countries = catalog.table("default", "countries").unwrap().unwrap();
-    assert_eq!(countries.id().get(), 20);
-    assert_eq!(countries.id().to_string(), "20");
+    assert_eq!(countries.id().get(), 2);
+    assert_eq!(countries.id().to_string(), "2");
     assert_eq!(countries.database_id().get(), 1);
     assert!(matches!(
         countries.placement(),
@@ -97,9 +90,9 @@ fn assert_catalog_fixture(catalog: &core::Catalog) {
         Some(countries)
     );
 
-    let accounts = catalog.table("tenant", "accounts").unwrap().unwrap();
-    assert_eq!(accounts.id().get(), 30);
-    assert_eq!(accounts.database_id(), tenant.id());
+    let accounts = catalog.table("default", "accounts").unwrap().unwrap();
+    assert_eq!(accounts.id().get(), 1);
+    assert_eq!(accounts.database_id(), logical_database.id());
     match accounts.placement() {
         core::TablePlacement::Sharded(shard_key) => {
             assert_eq!(shard_key.column(), "tenant_id");
@@ -110,7 +103,7 @@ fn assert_catalog_fixture(catalog: &core::Catalog) {
 
     assert!(matches!(
         catalog
-            .table("tenant", "internal_catalog")
+            .table("default", "internal_catalog")
             .unwrap()
             .unwrap()
             .placement(),
@@ -122,7 +115,7 @@ fn assert_catalog_fixture(catalog: &core::Catalog) {
             .iter()
             .map(|table| (table.database_id().get(), table.name()))
             .collect::<Vec<_>>(),
-        [(1, "countries"), (9, "accounts"), (9, "internal_catalog")]
+        [(1, "accounts"), (1, "countries"), (1, "internal_catalog")]
     );
 }
 
@@ -224,8 +217,8 @@ fn protocol_neutral_sql_parser_facade_is_public_bounded_and_opt_in() {
     assert_eq!(sql::MAX_PARSED_SQL_STATEMENTS, 256);
     assert_eq!(sql::SQL_PARSE_RECURSION_LIMIT, 32);
 
-    // Parsing and subset validation are opt-in infrastructure. The existing
-    // raw SQLite path deliberately does not invoke either layer yet.
+    // An empty authoritative catalog deliberately retains the raw SQLite
+    // compatibility path and therefore does not invoke either layer.
     let temp = tempfile::tempdir().unwrap();
     let database = core::Database::open(temp.path(), 2).unwrap();
     let mut raw_sql = "SELECT 1".to_owned();
@@ -543,11 +536,11 @@ fn sql_translation_is_public_owned_dialect_equivalent_and_opt_in() {
     assert!(!format!("{strict:?}").contains("private"));
 
     let temp = tempfile::tempdir().unwrap();
-    drop(core::Database::open(temp.path(), 4).unwrap());
-    insert_catalog_fixture(temp.path());
-    let database = Arc::new(core::Database::open(temp.path(), 4).unwrap());
+    let mut database = core::Database::open(temp.path(), 4).unwrap();
+    register_catalog_fixture(&mut database);
+    let database = Arc::new(database);
     let engine = core::Engine::from_database(Arc::clone(&database));
-    let tenant = database.catalog().database("tenant").unwrap().unwrap();
+    let logical_database = database.catalog().default_database();
     let parameter = [core::Value::Text("tenant-public-translation".to_owned())];
     let requests = [
         (
@@ -578,7 +571,7 @@ fn sql_translation_is_public_owned_dialect_equivalent_and_opt_in() {
         );
         engine
             .plan_bound_statement(
-                tenant.id(),
+                logical_database.id(),
                 translated.normalized_sql(),
                 0,
                 &parameter,
@@ -589,14 +582,22 @@ fn sql_translation_is_public_owned_dialect_equivalent_and_opt_in() {
     assert_eq!(plans[0], plans[1]);
     assert_eq!(plans[1], plans[2]);
 
-    // Translation remains opt-in. Existing raw SQLite execution continues to
-    // accept its current named-parameter behavior directly.
+    // A populated authoritative catalog sends raw calls through the bounded
+    // SQLite frontend, which accepts positional parameters and rejects named
+    // parameters instead of retaining the empty-catalog pass-through.
+    assert_eq!(
+        database
+            .query(
+                "translation-opt-in",
+                "SELECT :value",
+                &[core::Value::Int64(29)],
+            )
+            .unwrap_err()
+            .kind(),
+        core::EngineErrorKind::Unsupported
+    );
     let raw = database
-        .query(
-            "translation-opt-in",
-            "SELECT :value",
-            &[core::Value::Int64(29)],
-        )
+        .query("translation-opt-in", "SELECT ?1", &[core::Value::Int64(29)])
         .unwrap();
     assert_eq!(raw.rows()[0].get(0), Some(&core::Value::Int64(29)));
 }
@@ -609,10 +610,9 @@ fn shard_key_inference_is_public_typed_and_opt_in() {
     assert_owned_public::<sql::ShardKeyValue>();
 
     let temp = tempfile::tempdir().unwrap();
-    drop(core::Database::open(temp.path(), 4).unwrap());
-    insert_catalog_fixture(temp.path());
-    let database = core::Database::open(temp.path(), 4).unwrap();
-    let tenant = database.catalog().database("tenant").unwrap().unwrap();
+    let mut database = core::Database::open(temp.path(), 4).unwrap();
+    register_catalog_fixture(&mut database);
+    let logical_database = database.catalog().default_database();
 
     let source = "INSERT INTO accounts (payload, tenant_id) VALUES ($1, $2), ($3, 'tenant-b')";
     let parsed = sql::parse(sql::SqlDialect::PostgreSql, source).unwrap();
@@ -620,7 +620,7 @@ fn shard_key_inference_is_public_typed_and_opt_in() {
     let normalized = sql::normalize_placeholders(common).unwrap();
     let inference = sql::infer_shard_keys(
         database.catalog(),
-        tenant.id(),
+        logical_database.id(),
         &normalized,
         0,
         &[
@@ -631,7 +631,7 @@ fn shard_key_inference_is_public_typed_and_opt_in() {
     )
     .unwrap();
 
-    assert_eq!(inference.table_id().unwrap().get(), 30);
+    assert_eq!(inference.table_id().unwrap().get(), 1);
     assert_eq!(inference.key_type(), Some(core::ShardKeyType::Text));
     assert_eq!(inference.kind(), sql::ShardKeyInferenceKind::Multiple);
     assert_eq!(inference.values().len(), 2);
@@ -690,11 +690,11 @@ async fn bound_statement_planning_is_public_owned_value_aware_and_opt_in() {
     assert_owned_public::<core::PlannedRoute>();
 
     let temp = tempfile::tempdir().unwrap();
-    drop(core::Database::open(temp.path(), 8).unwrap());
-    insert_catalog_fixture(temp.path());
-    let database = Arc::new(core::Database::open(temp.path(), 8).unwrap());
+    let mut database = core::Database::open(temp.path(), 8).unwrap();
+    register_catalog_fixture(&mut database);
+    let database = Arc::new(database);
     let engine = core::Engine::from_database(Arc::clone(&database));
-    let tenant = database.catalog().database("tenant").unwrap().unwrap();
+    let logical_database = database.catalog().default_database();
 
     let source = "INSERT INTO accounts (tenant_id) VALUES ($1), ($2), ($3)";
     let parsed = sql::parse(sql::SqlDialect::PostgreSql, source).unwrap();
@@ -715,7 +715,7 @@ async fn bound_statement_planning_is_public_owned_value_aware_and_opt_in() {
 
     let plan = engine
         .plan_bound_statement(
-            tenant.id(),
+            logical_database.id(),
             &normalized,
             0,
             &first_parameters,
@@ -723,7 +723,7 @@ async fn bound_statement_planning_is_public_owned_value_aware_and_opt_in() {
         )
         .unwrap();
 
-    assert_eq!(plan.database(), tenant.id());
+    assert_eq!(plan.database(), logical_database.id());
     assert_eq!(
         plan.schema_generation(),
         database.catalog().schema_generation()
@@ -787,7 +787,7 @@ async fn bound_statement_planning_is_public_owned_value_aware_and_opt_in() {
     assert_ne!(database.shard_for_key(&conflicting_key), first_shard);
     let conflict = engine
         .plan_bound_statement(
-            tenant.id(),
+            logical_database.id(),
             &normalized,
             0,
             &first_parameters,
@@ -808,7 +808,7 @@ async fn bound_statement_planning_is_public_owned_value_aware_and_opt_in() {
 
     let recovered = engine
         .plan_bound_statement(
-            tenant.id(),
+            logical_database.id(),
             &normalized,
             0,
             &first_parameters,
@@ -829,7 +829,13 @@ async fn bound_statement_planning_is_public_owned_value_aware_and_opt_in() {
         .map(|key| core::Value::Text((*key).to_owned()))
         .collect::<Vec<_>>();
     let replanned = engine
-        .plan_bound_statement(tenant.id(), &normalized, 0, &second_parameters, None)
+        .plan_bound_statement(
+            logical_database.id(),
+            &normalized,
+            0,
+            &second_parameters,
+            None,
+        )
         .unwrap();
     assert_eq!(replanned.inferred_routes().len(), second_keys.len());
     assert!(replanned.explicit_route().is_none());
@@ -878,6 +884,7 @@ fn logical_catalog_types_and_access_are_public_and_protocol_neutral() {
     assert_public_metadata::<core::LogicalDatabaseId>();
     assert_public_metadata::<core::LogicalDatabaseMetadata>();
     assert_public_metadata::<core::TableId>();
+    assert_public_metadata::<core::TableDeclaration>();
     assert_public_metadata::<core::TableMetadata>();
     assert_public_metadata::<core::TablePlacement>();
     assert_public_metadata::<core::ShardKeyMetadata>();
@@ -1103,17 +1110,9 @@ async fn prepared_lifecycle_is_public_owned_and_protocol_neutral() {
     assert_owned::<core::PreparedExecution>();
 
     let temp = tempfile::tempdir().unwrap();
-    drop(core::Database::open(temp.path(), 4).unwrap());
-    insert_prepared_catalog_fixture(temp.path());
-    let database = Arc::new(core::Database::open(temp.path(), 4).unwrap());
-    database
-        .broadcast(
-            "CREATE TABLE prepared_events (
-                tenant_id INTEGER PRIMARY KEY,
-                payload TEXT NOT NULL
-             )",
-        )
-        .unwrap();
+    let mut database = core::Database::open(temp.path(), 4).unwrap();
+    register_prepared_catalog_fixture(&mut database);
+    let database = Arc::new(database);
     let logical_database = database.catalog().default_database().id();
     let engine = core::Engine::from_database(database);
     let session = engine.session();
@@ -1258,16 +1257,10 @@ fn catalog_snapshot_is_immutable_and_reopen_observes_only_valid_commits() {
         &[0, 1, 2, 0xff],
         "snowman-☃".as_bytes(),
     ];
-    let database = core::Database::open(temp.path(), 10).unwrap();
+    let mut database = core::Database::open(temp.path(), 10).unwrap();
     let expected_routes = keys.map(|key| database.shard_for_key(key));
-    assert_eq!(database.catalog().logical_databases().len(), 1);
-    assert!(database.catalog().tables().is_empty());
-
-    insert_catalog_fixture(temp.path());
-
-    assert_eq!(database.catalog().logical_databases().len(), 1);
-    assert!(database.catalog().tables().is_empty());
-    assert_eq!(database.catalog().database("tenant").unwrap(), None);
+    register_catalog_fixture(&mut database);
+    assert_catalog_fixture(database.catalog());
     assert_eq!(keys.map(|key| database.shard_for_key(key)), expected_routes);
 
     let reopened = core::Database::open(temp.path(), 10).unwrap();
@@ -1278,7 +1271,7 @@ fn catalog_snapshot_is_immutable_and_reopen_observes_only_valid_commits() {
     manifest
         .execute_batch(
             "PRAGMA ignore_check_constraints = ON;
-             UPDATE briskdb_tables SET placement = 99 WHERE table_id = 30;
+             UPDATE briskdb_tables SET placement = 99 WHERE table_id = 1;
              PRAGMA ignore_check_constraints = OFF;",
         )
         .unwrap();
@@ -1289,18 +1282,16 @@ fn catalog_snapshot_is_immutable_and_reopen_observes_only_valid_commits() {
     let error = core::Database::open(temp.path(), 10).unwrap_err();
     assert_eq!(error.kind(), core::EngineErrorKind::DataCorruption);
 
-    assert_eq!(database.catalog().logical_databases().len(), 1);
-    assert!(database.catalog().tables().is_empty());
+    assert_catalog_fixture(database.catalog());
     assert_eq!(keys.map(|key| database.shard_for_key(key)), expected_routes);
 }
 
 #[test]
 fn database_and_engine_catalog_reads_are_deterministic_in_parallel() {
     let temp = tempfile::tempdir().unwrap();
-    drop(core::Database::open(temp.path(), 6).unwrap());
-    insert_catalog_fixture(temp.path());
-
-    let database = Arc::new(core::Database::open(temp.path(), 6).unwrap());
+    let mut database = core::Database::open(temp.path(), 6).unwrap();
+    register_catalog_fixture(&mut database);
+    let database = Arc::new(database);
     let engine = core::Engine::from_database(Arc::clone(&database));
     assert!(std::ptr::eq(database.catalog(), engine.catalog()));
     assert_catalog_fixture(database.catalog());
@@ -1319,12 +1310,12 @@ fn database_and_engine_catalog_reads_are_deterministic_in_parallel() {
                     assert_eq!(
                         database
                             .catalog()
-                            .table("tenant", "accounts")
+                            .table("default", "accounts")
                             .unwrap()
                             .unwrap()
                             .id()
                             .get(),
-                        30
+                        1
                     );
                     assert_eq!(database.shard_for_key(b"parallel-catalog"), expected_shard);
                 }


### PR DESCRIPTION
## Summary

- upgrade the manifest to v8 and atomically register a complete authoritative table catalog
- prove physical table, shard-key, collation, uniqueness, and placement invariants across every shard
- route populated-catalog raw and prepared operations from metadata and reject undeclared or unsafe targets
- preserve catalog invariants through schema migrations and crash/restart boundaries
- document the exact-once sharded-row model and the pending scatter/gather boundary

## Verification

- cargo test --all-targets --no-fail-fast
- cargo clippy --all-targets --all-features -- -D warnings
- cargo +1.85.0 test --locked --all-targets --all-features --no-fail-fast
- cargo test --doc
- cargo fmt --all -- --check
- git diff --check

Closes #114