### PR TITLE
Add metadata-driven scatter-gather reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,14 +74,17 @@ minimum supported Rust version (MSRV) and the latest stable toolchain.
 - Bounded, lazy per-shard SQLite connection pools with explicit backpressure
 - Request cancellation and deadlines that interrupt SQLite and await cleanup
 - Finite per-query row/logical-byte budgets with no partial results
+- Catalog-aware logical reads: exact keys visit one owner, finite key sets visit
+  their distinct owners, and unconstrained Sharded reads gather every shard
+  with bounded concurrency and `UNION ALL` duplicate semantics
 - Explicit graceful drain, forced cancellation, and blocking handle cleanup
 - Independently configured HTTP and PostgreSQL TCP listeners; the loopback
   PostgreSQL endpoint supports protocol 3.0 startup, logical database/user
   selection, BriskDB parameter status, and clean connection termination through
   a BriskDB-owned `pgwire` 0.36.3 boundary
 - An embedded read-only browser at `/admin` for inspecting user tables, showing
-  exact physical-row totals across all shards, and reading bounded row pages on
-  one explicitly selected physical shard
+  exact logical-row totals, and reading bounded logical pages across each
+  table's metadata-selected files without a shard selector
 - Protocol-neutral typed values, ordered columns, positional rows, and results
 - A bounded per-session prepared-statement and immutable bound-portal lifecycle
   with transient shard-0 metadata compilation, bind-time routing snapshots,
@@ -104,7 +107,7 @@ minimum supported Rust version (MSRV) and the latest stable toolchain.
   later schema migrations checked against its table and shard-key declarations
 - Identity-bound, WAL-enabled SQLite shard files that are never silently
   recreated after initialization
-- Routed execute and query endpoints
+- Routed writes and catalog-aware logical query execution
 - A crash-resumable, journaled schema-migration endpoint for every shard
 - A checksummed manifest, generation-bound shard-schema fingerprints, and
   fail-closed `Verifying`/`Ready`/`Migrating`/`Degraded` storage states
@@ -175,14 +178,15 @@ a query-capable PostgreSQL interface. See the
 
 The HTTP listener also serves the embedded data explorer at
 <http://127.0.0.1:7654/admin>. Its temporary credentials are `admin` / `admin`.
-The explorer is read-only: select one physical shard and an ordinary user table,
-see its exact physical-row sum across every shard, then move through live
-offset-based pages of at most 200 rows from the selected shard. Browser sessions
-are held only in process memory, expire after eight hours, and disappear on
-restart. The fixed credentials are a development convenience; keep this
-experimental HTTP service on a trusted network. Existing `/health` and `/v1/*`
-behavior is unchanged. See the [admin browser contract](docs/ADMIN_BROWSER.md)
-for the route, table-filtering, pagination, and session boundaries.
+The explorer is read-only: select a logical table, see its exact logical row
+total, then move through live shard-major pages of at most 200 rows. Sharded
+tables visit every owning file; Global tables visit canonical shard 0 once.
+Browser sessions are held only in process memory, expire after eight hours,
+and disappear on restart. The fixed credentials are a development convenience;
+keep this experimental HTTP service on a trusted network. Existing `/health`
+and `/v1/*` behavior is unchanged. See the
+[admin browser contract](docs/ADMIN_BROWSER.md) for the route, table-filtering,
+pagination, and session boundaries.
 
 Rust embedders can customize pool sizing through the public `EngineOptions`
 type. Existing engine constructors and server startup keep the defaults of four
@@ -265,20 +269,21 @@ curl -X POST http://127.0.0.1:7654/v1/execute \
   }'
 ```
 
-Read it from the same shard:
+Read it through the logical table:
 
 ```bash
 curl -X POST http://127.0.0.1:7654/v1/query \
   -H 'content-type: application/json' \
   -d '{
-    "shard_key":"widget-1",
     "sql":"SELECT id, name FROM widgets WHERE id = ?1",
     "params":["widget-1"]
   }'
 ```
 
 The response keeps column metadata and row values in matching index order. The
-selected shard depends on the routing key; an example response is:
+inferred key selects its one metadata-owned shard, so this point query reports
+one `shard`; a query that visits several reports a sorted `shards` array
+instead. An example point response is:
 
 ```json
 {
@@ -351,18 +356,25 @@ columns, decides whether the target is a read, write, schema change, or session
 control. It runs accepted sharded work on its assigned shard and safe
 `NotApplicable`/`Global` reads on deterministic shard 0, returning routed rows
 or an affected-row count. Schema/session execution and sharded reads requiring
-scatter remain unsupported. There is no implicit cache eviction, no retained
-plan, `rusqlite` statement, or connection, and closing a statement closes all
-of its portals.
+scatter remain unsupported on that compatibility method. The corresponding
+logical portal method uses the same fresh plan but gathers a supported
+multi-owner or unconstrained Sharded read from the relevant physical files.
+It concatenates shard results in physical-shard order, retaining duplicate
+rows exactly as `UNION ALL`; a `Global` read still executes once on shard 0.
+There is no implicit cache eviction, no retained plan, `rusqlite` statement, or
+connection, and closing a statement closes all of its portals.
 
 Translation and planning remain independently callable branches over the same
 normalized request. With an empty table catalog, HTTP execute/query retains the
 legacy caller-routed raw SQLite path. Once tables are registered, those same
 endpoints require exactly one SQLite common-subset statement, normalize its
-placeholders, apply strict SQLite translation, infer its authoritative
-placement, and enforce a finite single-shard target. The migration endpoint
-keeps its separate exact-text journal identity and parameterless batch
-contract. The exact translation matrix and strict-mode boundary are in
+placeholders, apply strict SQLite translation, and infer its authoritative
+placement. Writes still require one owner. Reads select their logical targets
+from metadata: an exact key visits one owner, finite keys visit each distinct
+owner, an unconstrained Sharded read visits every shard, and a `Global` or
+table-free read visits shard 0 once. The migration endpoint keeps its separate
+exact-text journal identity and parameterless batch contract. The exact
+translation matrix and strict-mode boundary are in
 [`docs/SQL_TRANSLATION.md`](docs/SQL_TRANSLATION.md), and the complete lifecycle
 is in
 [`docs/SQL_PREPARED_STATEMENTS.md`](docs/SQL_PREPARED_STATEMENTS.md).
@@ -479,12 +491,19 @@ not sharding. `Global` is the explicit replicated placement, while `Catalog`
 is manifest-only. Registration establishes the authority used by later import
 and execution work; it does not repartition existing data.
 
-Logical reads that are not pinned to one key still require the scatter/gather
-follow-ups (#57 and #58). Their contract is one logical result over all owning
-shards—equivalent to a shard `UNION ALL` before global filtering, ordering,
-pagination, or aggregation—not duplicated copies in every file. The current
-admin browser remains a physical-shard diagnostic until its logical catalog
-view lands separately.
+Supported logical reads that are not pinned to one key now gather the relevant
+physical files with at most eight shard tasks. Sharded rows remain stored once,
+on the metadata-selected owner; the logical result concatenates per-shard rows
+in physical-shard order with `UNION ALL` semantics, including duplicates.
+Exact-key reads visit one owner, finite key sets visit only distinct owners, and
+`Global` data is read once from canonical shard 0. One deadline, cancellation
+signal, and combined result budget cover the complete operation; any shard
+failure returns an error rather than a partial result. This baseline is
+row-local: multi-shard `DISTINCT`, aggregate, grouping, ordering, pagination,
+join, subquery, CTE, set-operation, and window semantics remain rejected until
+their dedicated planner work lands. The admin browser uses a separate,
+server-generated logical count and shard-major paging plan; it does not expose
+arbitrary aggregate, ordering, or pagination SQL.
 Startup loads routing and logical metadata in one validated shared snapshot;
 runtime routing continues to hash the exact key bytes, derive a virtual bucket,
 and read its persisted physical-shard assignment. The generation-1 ranges
@@ -500,8 +519,8 @@ server processes must not use the same data directory.
 
 The `/admin` browser's fixed development login is separate from the planned
 authentication and role model. Near-term work includes that model, richer
-migration administration and status APIs in issue #53, scatter/gather reads,
-observability, and backup tooling.
+migration administration and status APIs in issue #53, richer global logical
+query semantics, observability, and backup tooling.
 
 ## License
 

--- a/docs/ADMIN_BROWSER.md
+++ b/docs/ADMIN_BROWSER.md
@@ -1,6 +1,7 @@
 # Admin data browser
 
-Status: implemented for roadmap issue #106 and hardened by issue #110
+Status: implemented for roadmap issue #106, hardened by issue #110, and made
+placement-aware by issue #57
 
 BriskDB serves a small read-only data explorer from the existing HTTP listener.
 Open `/admin` (or `/admin/`) to use the embedded application. Its HTML, CSS,
@@ -54,9 +55,9 @@ multi-request SQL transaction.
 | `POST /admin/api/login` | Accept JSON `{"username":"admin","password":"admin"}`; return `{"authenticated":true}` and set the session cookie |
 | `GET /admin/api/session` | Return `{"authenticated":true,"username":"admin"}` for a live cookie; otherwise return HTTP 401 |
 | `POST /admin/api/logout` | Revoke a presented live token if any, always clear the cookie, and return `{"authenticated":false}` |
-| `GET /admin/api/overview?shard=N` | Return `shard_count`, `selected_shard`, and the selected shard's binary-ordered `tables`; omitted `shard` selects zero |
-| `GET /admin/api/count?table=T` | Return the exact physical-row sum for `T` as `table`, `scope: "all_physical_shards"`, `shard_count`, and `total_rows` |
-| `GET /admin/api/rows?shard=N&table=T&limit=L&offset=O` | Return one page as `shard`, `table`, `limit`, `offset`, `has_more`, ordered `columns`, and positional `rows`; limit defaults to 50 and offset to zero |
+| `GET /admin/api/overview` | Return the default logical database's browseable `tables`, logical `scope`, configured `shard_count`, and any discovery `visited_shards` |
+| `GET /admin/api/count?table=T` | Return the exact placement-aware total as `table`, logical `scope`, sorted `visited_shards`, and `total_rows` |
+| `GET /admin/api/rows?table=T&limit=L&offset=O` | Return one logical page as `table`, `scope`, sorted `visited_shards`, `ordering`, `limit`, `offset`, `has_more`, ordered `columns`, and positional `rows`; limit defaults to 50 and offset to zero |
 
 The shell and its three assets are public so the application can render its login
 state. Session, overview, count, and row calls require the server-side session check;
@@ -69,69 +70,66 @@ integration test syntax-checks both scripts and runs the logic suite as part of
 the existing all-target CI command. Node.js is needed only for development
 tests; serving the embedded browser has no frontend build step.
 
-## Physical-shard view
+## Logical table view
 
-The explorer intentionally selects a physical shard number. This differs from
-normal `/v1/query`, which requires a caller routing key and, once the table
-catalog is populated, validates it against inferred authoritative placement.
-The overview accepts only `0 <= shard < shard_count`. It discovers ordinary
-tables in SQLite's `main` schema and excludes SQLite-owned names beginning with
-`sqlite_` plus the exact BriskDB-owned name `briskdb` and names beginning with
-`briskdb_`, using ASCII-case-insensitive prefix checks. Views and internal tables
-are not presented. Names have a stable binary ordering in the response.
+The normal explorer has no physical-shard selector. With a populated catalog,
+the overview reads authoritative metadata for the default logical database and
+lists every `Sharded` or `Global` table while excluding `Catalog` placement.
+With an empty catalog, compatibility discovery reads ordinary tables from
+physical shard 0. SQLite-owned names beginning with `sqlite_`, the exact
+BriskDB-owned name `briskdb`, names beginning with `briskdb_`, views, and other
+non-table objects are never presented. Guessing an excluded, Catalog, or absent
+name does not make it browseable.
 
-Discovery describes the tables physically present on the selected shard. It is
-not the authoritative logical `briskdb_tables` view, does not consult placement
-metadata, and makes no claim that another shard contributes the same rows.
-Guessing an excluded or absent name does not make it browseable.
+Placement determines the logical table's files:
+
+- `Sharded` visits every physical shard because each ordinary row has exactly
+  one metadata-selected owner.
+- `Global` visits canonical shard 0 once, even if an operator has copied the
+  same data elsewhere.
+- Empty-catalog compatibility visits every file and requires the table and
+  column shape to match on all of them.
+
+Before counting or paging, BriskDB verifies the exact ordinary table and column
+metadata on every relevant file. At most eight physical inspections run at
+once. A missing table, incompatible shape, shard failure, deadline, schema
+generation change, or arithmetic overflow fails the request; no partial count
+or page is returned.
+
+## Logical pagination and exact total
+
+Selecting a table starts a specialized exact count. BriskDB runs generated
+read-only `COUNT(*)` inspections on the relevant files and checked-adds them as
+an unsigned 64-bit total. A Sharded row is counted once at its owner; a Global
+row is counted once on shard 0. This is an admin-specific aggregation plan, not
+support for arbitrary multi-shard aggregate SQL. `total_rows` uses a direct JSON
+integer through `9007199254740991`; larger values use the admin `uint64` tagged
+representation described below.
 
 The browser offers page sizes 25, 50, 100, and 200 rows and initially selects
 50. The JSON endpoint accepts only limits from 1 through 200 and offsets from 0
-through 1,000,000. BriskDB validates the shard, table identity, limit, offset,
-and checked pagination arithmetic before running the row read. The continuation
-indicator is derived by reading at most one row beyond the requested page; that
-extra row is not included in the returned page. It remains false when the next
-offset would exceed 1,000,000, even if more physical rows exist.
+through 1,000,000. Counts locate the requested shard-major slice; the page then
+reads only those bounded slices, orders each slice by every visible column,
+concatenates shards in ascending physical order, preserves duplicate rows, and
+reads at most one extra logical row to derive `has_more`. The combined page is
+checked against one configured row and logical-byte budget. The extra row is
+not serialized, and `has_more` remains false when the next offset would exceed
+1,000,000.
 
-Each page is a separate read of the selected shard. Offset pagination is
-therefore a live view, not a retained snapshot: inserts or deletes between page
-requests can move or repeat rows, and SQLite's table scan supplies no general
-ordering guarantee. The explorer does not merge row pages or implement the
-later general scatter/gather roadmap.
-
-## All-shard physical row total
-
-Selecting a table also starts a separate exact count request. BriskDB verifies
-that the same exact ordinary table is browseable on every configured shard,
-runs a generated read-only `COUNT(*)` through the engine on each shard with at
-most eight shard operations in flight, and checked-adds the results as an
-unsigned 64-bit total. One missing table, shard failure, deadline, completed
-schema migration, or arithmetic overflow fails the whole request; no partial
-total is returned. The count is loaded once per table selection rather than on
-every pagination request.
-
-`scope: "all_physical_shards"` is literal. A properly partitioned table's sum
-is its logical row count. A replicated or global table counts every physical
-copy, so identical rows stored on two shards contribute twice. The physical
-browser deliberately does not infer deduplication or change multiplicity from
-catalog placement. For a registered sharded table, the one-row-one-owner
-invariant makes the physical sum logical; for `Global`, physical copies remain
-separate count contributions. Each shard count is also a separate live read,
-not one atomic cross-shard snapshot, so concurrent writes can affect which
-instant each shard represents.
-
-`total_rows` uses a direct JSON integer through `9007199254740991`; larger
-values use the admin `uint64` tagged representation described below. The page
-summary continues to state the selected physical shard so the global count is
-not mistaken for globally merged displayed rows.
+Each count and page is a set of separate committed file reads, not an atomic
+cross-file or retained multi-page snapshot. Concurrent inserts or deletes can
+therefore move or repeat rows between requests. The browser accepts no caller
+SQL or arbitrary filter, aggregation, ordering, or pagination expression.
 
 ## Engine and JSON boundaries
 
 The HTTP adapter does not open shard files or call `rusqlite`. Discovery, count,
-and row reads use BriskDB's bounded explicit-shard inspection operation. That operation
-uses the ordinary engine lifecycle, schema gate, per-shard pool and worker
-admission, cancellation, deadline, and effective result limits. SQLite must
-classify its generated statement as read-only before it is stepped.
+and row reads coordinate BriskDB's bounded explicit-shard inspection operation
+according to catalog placement. Each inspection uses the ordinary engine
+lifecycle, schema gate, per-shard pool and worker admission, cancellation,
+deadline, and effective result limits. The merged page receives one additional
+combined budget check. SQLite must classify every generated statement as
+read-only before it is stepped.
 
 Results retain ordered column metadata and positional row arrays. Duplicate or
 empty column names remain representable. Nulls, finite floats, valid text, and
@@ -153,9 +151,9 @@ continue.
 
 ## Deliberate non-goals
 
-Issue #106 does not add editing, arbitrary SQL, schema migration, backup,
-maintenance, query cancellation, a separate admin listener, stable pagination
-across concurrent writes, general scatter/gather browsing, durable users or roles,
-credential configuration, or TLS. Those remain separate roadmap work. The
-browser adds no manifest table, file, version, checksum input, migration, or
-recovery step.
+The browser does not add editing, arbitrary SQL, schema migration, backup,
+maintenance, a separate admin listener, an atomic cross-file snapshot, stable
+pagination across concurrent writes, general distributed SQL aggregation or
+ordering, durable users or roles, credential configuration, or TLS. Those
+remain separate roadmap work. The browser adds no manifest table, file,
+version, checksum input, migration, or recovery step.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -29,20 +29,21 @@ server ---------> protocol::http
 
 | Module | Responsibility | Must not own |
 | --- | --- | --- |
-| `core` | Protocol-neutral `Engine`, `Session`, statements, immutable bound portals, values, results, errors, read-only catalog views and initialization declarations, synchronous bound-value-aware plans, prepared lifecycle, explicit-shard read-only inspection, and sharded routing policy; stable key routing; bounded per-session and per-shard admission; routed execution and journaled schema migration | JSON/HTTP types, listeners, or Axum handlers |
+| `core` | Protocol-neutral `Engine`, `Session`, statements, immutable bound portals, values, results, errors, read-only catalog views and initialization declarations, synchronous bound-value-aware plans, prepared lifecycle, explicit-shard read-only inspection, logical Sharded read target selection and scatter/gather, and sharded routing policy; stable key routing; bounded per-session and per-shard admission; routed execution and journaled schema migration | JSON/HTTP types, listeners, or Axum handlers |
 | `storage` | Versioned routing and authoritative logical manifest, one-time table registration, shard layout, migration journal and recovery, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
 | `import` | Offline source-schema preflight, explicit placement-plan validation, exact-value row routing into private staging, independent verification, durable receipt creation, and atomic publication | Network handlers, live/incremental migration, implicit Global placement, or protocol-specific behavior |
 | `sql` | Dialect-explicit SQL syntax parsing, recursive common-subset validation, protocol-neutral statement/batch classification, source-preserving placeholder normalization, explicit strict/compatibility translation, catalog-aware typed shard-key inference, and narrow crate-private DML-shape inspection behind BriskDB-owned boundaries; exact source retention; SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, key hashing or shard selection, mutable session state, physical write-routing policy, filesystem layout, protocol responses, protocol-buffer ownership, or protocol-specific support policy |
-| `protocol::http` | Existing HTTP request extraction, shared JSON/BriskDB value and RFC 9457 problem-detail encoding, and the embedded admin shell/assets, temporary browser sessions, discovery, all-shard physical counts, and page handlers | BLAKE3 routing, shard files, direct SQLite access, or rusqlite calls |
+| `protocol::http` | Existing HTTP request extraction, shared JSON/BriskDB value and RFC 9457 problem-detail encoding, and the embedded admin shell/assets, temporary browser sessions, metadata-driven logical discovery, exact logical counts, and bounded shard-major page handlers | BLAKE3 routing, shard files, direct SQLite access, or rusqlite calls |
 | `protocol::postgres` | BriskDB-owned bounded protocol-3.0 framing, finite parameter validation, selected identity/status, per-connection core-session ownership, query-deferral responses, and private compile/query-parser seam around the exactly pinned `pgwire` library | Listener binding, direct SQLite access, routing, unbounded authoritative prepared state, or public dependency-owned types |
 | `protocol::error` | Exhaustive HTTP, PostgreSQL, and MySQL mappings from stable engine error kinds | SQLite errors, routing decisions, or wire-protocol session state |
 | `server` | Process configuration, database assembly, loopback validation, separate HTTP/PostgreSQL listener binding, finite connection-task supervision, and shared graceful/forced draining | SQL parsing, PostgreSQL wire framing, or storage implementation details |
 
 Implementation dependencies flow one way: adapters call the async `Engine` in
 `core`; the engine coordinates routing, `storage`, and `sql`. An adapter supplies
-protocol-neutral session routing context and an owned statement, then receives
-the selected shard together with the operation result. It neither computes a
-shard nor opens a SQLite connection. The only reverse-facing name is
+protocol-neutral session context and an owned statement, then receives the
+engine-selected physical target or target set together with the operation
+result. It neither computes a shard nor opens a SQLite connection. The only
+reverse-facing name is
 `storage::Database`, a compatibility re-export of `core::Database`; the storage
 implementation does not call core.
 
@@ -367,13 +368,15 @@ only that snapshot and the values in an immutable logical portal. Later
 session-route changes do not affect it. Describing after a schema-generation
 change recompiles owned metadata on shard 0. Every execution plans again from
 the portal snapshot under the current schema/routing guard before choosing the
-supported physical target. Logical behavior, not SQLite result-column metadata,
+supported physical target or target set. Logical behavior, not SQLite
+result-column metadata,
 distinguishes reads from writes, schema changes, and session control. Safe
-`NotApplicable` and `Global` reads may use deterministic shard 0; a sharded
-read that still needs scatter remains unsupported. Schema/session execution is
-not implemented, and Catalog placement is never exposed as an application
-target. `PreparedStatementDescription::behavior()` gives adapters the same
-retained behavior.
+`NotApplicable` and `Global` reads use deterministic shard 0. The compatibility
+portal executor remains single-target; its logical counterpart gathers
+supported finite multi-owner and unconstrained Sharded reads. Schema/session
+execution is not implemented, and Catalog placement is never exposed as an
+application target. `PreparedStatementDescription::behavior()` gives adapters
+the same retained behavior.
 
 Per-session limits independently bound statement count, portal count, and the
 logical accounted value bytes plus routing bytes retained by all portals. Full
@@ -388,10 +391,11 @@ expansion by charging its captured route once and each normalized marker
 occurrence twice; repeated markers cannot cause unbounded inference/route
 allocation before the check.
 
-The prepared lifecycle integrates the classifier, translation, and planning
-layers but deliberately does not execute a multi-statement batch, scatter
-reads, execute schema/session statements, or implement transactions. Those
-remain later planner/transaction milestones. The complete API, accounting,
+The prepared lifecycle integrates the classifier, translation, planning, and
+logical scatter layers but deliberately does not execute a multi-statement
+batch, global non-row-local query semantics, schema/session statements, or
+transactions. Those remain later planner/transaction milestones. The complete
+API, accounting,
 execution, error, adapter, and persistence contract is in [prepared statements
 and bound portals](SQL_PREPARED_STATEMENTS.md).
 
@@ -558,10 +562,25 @@ Core routing still hashes the exact key bytes, derives a versioned virtual
 bucket, and reads the final physical shard from the snapshot without querying
 SQLite. The generation-1 ranges reproduce prior modulo placement for every
 supported initial shard count, including counts that do not divide 4,096.
-Point reads and writes can therefore target one owner. Unpinned logical reads
-still require the bounded shard `UNION ALL`/scatter and merge work in issues
-#57 and #58; catalog registration does not make that execution path complete.
-The existing admin browser remains an explicit physical-shard diagnostic.
+Point reads and writes can therefore target one owner. The logical read path
+uses this same metadata to select targets: exact inference visits one owner,
+finite inference visits each distinct owner, unconstrained Sharded inference
+visits every shard, and `Global` or table-free reads visit canonical shard 0
+once. Supported multi-shard reads run with at most eight shard tasks and merge
+in ascending physical-shard order as `UNION ALL`, without deduplicating rows.
+Catalog registration establishes ownership; it never copies every Sharded row
+into every file. The admin browser consumes the same placement metadata: it
+targets every file for Sharded tables and canonical shard 0 once for Global
+tables, then exposes one bounded shard-major logical page rather than a shard
+selector.
+
+The initial scatter executor accepts only a row-local single-table `SELECT`
+whose translated SQL can run unchanged on every target. It rejects
+multi-shard `DISTINCT`, aggregate or other function calls, grouping, ordering,
+limit/offset, joins, subqueries, CTEs, set operations, and windows because
+concatenating independently evaluated shard results would not implement their
+global SQL semantics. A statement routed to one shard, including a `Global`
+read on shard 0, is not subject to that multi-shard restriction.
 Version-5 adoption preserves legacy application schema and data and does not
 implicitly register it.
 
@@ -603,19 +622,24 @@ clonable. Frontends may issue concurrent calls against one borrowed session,
 but the engine serializes them; the HTTP adapter instead creates an independent
 session for every request.
 
-The current routing context is an optional caller-supplied shard key. Routed
-execute and query operations require that context, and the engine alone hashes
-it and reports the selected shard in `Routed<T>`. `Statement` owns its SQL text
-and typed parameters so an adapter can hand work across the asynchronous
-boundary without borrowing protocol buffers. Prepared statements and portals
+The current routing context is an optional caller-supplied shard key. Legacy
+routed execute and query operations require that context, and the engine alone
+hashes it and reports the selected shard in `Routed<T>`. Catalog-aware logical
+reads instead derive their physical targets from the statement's inferred keys
+and registered placement metadata and report those targets with the combined
+result. `Statement` owns its SQL text and typed parameters so an adapter can
+hand work across the asynchronous boundary without borrowing protocol buffers.
+Prepared statements and portals
 are session-scoped logical objects; binding captures the routing context so a
 later session change cannot retarget an existing portal. `EngineStatus` exposes
 the shard count and prepared-state limits needed by health/configuration
 reporting without exposing the storage implementation.
 
 HTTP SQL state remains request-local: each execute or query request creates a
-fresh session and initializes its routing context from the request's
-`shard_key`. Each admin inspection likewise creates a fresh core session but
+fresh session. Execute and empty-catalog legacy query initialize routing from
+the request's `shard_key`; a populated-catalog query selects logical targets
+from catalog metadata and does not use a caller key to narrow its shard set.
+Each admin inspection likewise creates a fresh core session but
 selects a validated physical shard through the dedicated read-only boundary;
 the count handler coordinates multiple such explicitly bounded inspections.
 Consequently, session settings and transactions cannot span HTTP requests. The
@@ -654,6 +678,15 @@ When a shard has no active slot and its admission queue is full, a new operation
 fails immediately with retryable `Busy`, which the HTTP adapter maps to 503.
 Capacity for routed work belongs to its selected shard: saturation on shard A
 neither consumes shard B's slots nor delays work already admitted there.
+
+A logical multi-shard read admits one outer operation and schedules no more
+than eight shard tasks at once. Each child uses the independent pool for its
+physical file, so SQLite writes to other shard files retain their own
+connections and transaction locks while the read is gathering. Target order is
+stable even though the child reads may complete in another order. The first
+child failure cancels outstanding children, waits for their SQLite cleanup, and
+returns only the error; BriskDB never exposes the successfully completed prefix
+as a partial logical result.
 
 Schema migration uses a separate, shared admission gate. Transitioning from
 `Ready` to `Migrating` immediately rejects new ordinary operations and a second
@@ -743,7 +776,10 @@ SQLite control policy. Prepare, bind, describe, and portal execution expose the
 same `*_with_context` boundary as raw operations; explicit-shard inspection has
 the same controlled form. Queries, inspection pages, and prepared row results
 account a stable logical representation while stepping SQLite and before
-cloning payloads. A row or byte overflow returns no partial `ResultSet`;
+cloning payloads. A logical scatter shares one budget, absolute deadline, and
+cancellation source across all targets rather than resetting any of them per
+shard. A row or byte overflow or any child failure returns no partial
+`ResultSet`;
 row-producing writes are rejected so early termination cannot hide DML effects.
 The exact accounting contract is documented in [request
 controls](REQUEST_CONTROLS.md).

--- a/docs/REQUEST_CONTROLS.md
+++ b/docs/REQUEST_CONTROLS.md
@@ -10,10 +10,10 @@ deferred to issue #31.
 
 The existing `Engine::execute`, `query`, `broadcast`, and `status` methods, the
 crate-private explicit-shard inspection operation, plus `prepare_statement`,
-`bind_statement`, `describe_prepared`, and `execute_portal`, use a default
-`RequestContext`. `broadcast` now means a journaled application-schema
-migration. Frontends that have their own cancellation or deadline source can
-call the corresponding `*_with_context` method:
+`bind_statement`, `describe_prepared`, `execute_portal`, and their logical read
+counterparts use a default `RequestContext`. `broadcast` now means a journaled
+application-schema migration. Frontends that have their own cancellation or
+deadline source can call the corresponding `*_with_context` method:
 
 ```rust
 use std::time::Duration;
@@ -52,10 +52,10 @@ SQLite configuration or statement work proceeds.
 Prepared operations use the same boundary. Prepare and a schema-refreshing
 describe can wait for shard 0 and transient SQLite metadata compilation. Bind
 can wait for the serialized session before it validates and snapshots values.
-Portal execution can wait for its selected shard and runs with the same
-exact-handle interruption and cleanup as raw execution. Cancellation before a
-prepared object is published leaves the session cache unchanged; a cancelled
-or failed execution retains the existing portal.
+Portal execution can wait for its selected shard or logical target set and runs
+with the same exact-handle interruption and cleanup as raw execution.
+Cancellation before a prepared object is published leaves the session cache
+unchanged; a cancelled or failed execution retains the existing portal.
 
 Completion wins a very close race with cancellation. A statement that is known
 to have completed successfully returns success rather than a misleading
@@ -100,18 +100,29 @@ reported as read-only. The prepared executor likewise rejects row-producing
 writes. These rules prevent an early result-budget failure from accompanying a
 partially consumed DML `RETURNING` statement. Raw execute, prepared affected-row
 results, and schema migration do not materialize a `ResultSet` and are
-unaffected by query result budgets. A future scatter/gather implementation must
-apply one budget to the combined result, not a fresh budget for every shard.
+unaffected by query result budgets. A logical scatter applies one budget to the
+combined result, including one result envelope and one set of column metadata;
+it does not grant every shard a fresh row or byte allowance.
+
+Logical scatter/gather schedules at most eight shard tasks concurrently. All
+children inherit the operation's one absolute deadline and sticky cancellation
+source. Cancellation, deadline expiry, a result-budget overflow, inconsistent
+column metadata, or any shard error cancels outstanding children and waits for
+their cleanup. The caller receives only the error, never rows from the shards
+that happened to finish first. Successful results are concatenated in ascending
+physical-shard order and keep duplicate rows.
 
 The `/admin` browser independently caps a requested page at 200 returned rows
 and validates offsets no greater than 1,000,000. It may inspect one additional
 row to decide whether another page exists; that row is not serialized. The
-inspection still uses the engine's effective logical-byte and row budgets, so a
-lower configured engine limit or a byte-heavy page can return `LimitExceeded`
-with no partial page. Every offset page is a separate request and consumes
-capacity only from its selected physical shard. It is not a global budget,
-cross-shard read, or multi-page snapshot. The continuation flag is false if the
-next calculated offset would exceed the browser's 1,000,000 cap.
+physical inspections and their merged logical page use the engine's configured
+row and logical-byte limits, so a lower limit or byte-heavy page can return
+`LimitExceeded` with no partial page. Placement selects the targets: every file
+for Sharded tables and shard 0 once for Global tables. At most eight inspections
+run concurrently, and only the shard-major slices needed for the page are
+materialized. Every offset page is a separate request, not a retained
+multi-file snapshot. The continuation flag is false if the next calculated
+offset would exceed the browser's 1,000,000 cap.
 
 ## Prepared-session limits
 

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -83,14 +83,17 @@ HTTP requests still send caller-provided SQLite SQL to the engine. With an empty
 catalog it follows the legacy raw path. With a populated catalog, the engine
 requires exactly one common-subset SQLite statement and runs normalization,
 strict translation, classification, inference, and routing policy before
-SQLite execution.
+SQLite execution. Registered writes remain single-owner. Registered reads use
+catalog metadata to visit an exact owner, the distinct owners of a finite key
+set, every shard for an unconstrained Sharded read, or shard 0 once for a
+`Global` or table-free read.
 
 | Interface | Status | SQL accepted | Routing |
 | --- | --- | --- | --- |
 | HTTP `/v1/execute` | Experimental | Empty catalog: legacy SQLite statement. Populated catalog: exactly one SQLite common-subset write with normalized positional parameters and strict SQLite translation | Required caller `shard_key`; a populated catalog also requires authoritative finite single-shard inference and rejects Global/Catalog writes |
-| HTTP `/v1/query` | Experimental | Empty catalog: legacy raw SQLite query. Populated catalog: exactly one SQLite common-subset read; no session cache | Required caller `shard_key`; a populated catalog reads Global data on shard 0, denies Catalog/undeclared tables, and requires one sharded owner |
+| HTTP `/v1/query` | Experimental | Empty catalog: legacy raw SQLite query. Populated catalog: exactly one SQLite common-subset read; no session cache; multi-shard execution is limited to the row-local scatter-safe subset | Empty catalog requires caller `shard_key`; populated catalog derives targets from registered metadata, reads Global data once on shard 0, and denies Catalog/undeclared tables |
 | HTTP `/v1/admin/broadcast` | Experimental | A journaled parameterless SQLite schema batch; populated catalogs reject row-moving DML, table drops, and trigger creation | Preflight on every shard, then ascending resumable apply |
-| HTTP `/admin` browser | Experimental, read-only | No caller SQL; server-generated physical table discovery, exact all-shard physical `COUNT(*)`, and bounded `SELECT *` pages | Pages require a validated physical shard; the specialized count fans out with bounded concurrency but is not a general scatter-query surface |
+| HTTP `/admin` browser | Experimental, read-only | No caller SQL; metadata-driven logical table discovery, specialized exact logical `COUNT(*)`, and bounded deterministic `SELECT *` page slices | Sharded tables visit all files; Global tables visit shard 0 once; no browser shard selector or arbitrary SQL |
 | PostgreSQL wire protocol | Protocol-3.0 startup/session only on loopback; SQL flow deferred | No SQL accepted over the wire; simple `Query` and extended `Parse` return fixed `0A000` responses | Startup selects an exact logical database; no wire SQL request reaches planning or routing |
 | MySQL wire protocol | Planned | Rust parsing, validation, classification, placeholder normalization, finite compatibility translation, and prepared lifecycle implemented; listener adoption planned | Core batch/write policy, bind validation, routing snapshots, current execute-time planning, and supported target execution implemented; wire mapping planned |
 
@@ -106,42 +109,46 @@ execute/query rows as described above; it adds no HTTP field or route.
 Every HTTP database operation now calls the same protocol-neutral async engine
 used by PostgreSQL startup status and intended for issue-31 PostgreSQL SQL flow
 and the future MySQL adapter. Execute and query requests create a fresh `Ready`
-session, put the request's `shard_key` in its routing context, and submit an
-owned statement. The engine, rather than the HTTP adapter, selects the shard
-and acquires a pooled SQLite connection. Admin inspection requests also create
-a fresh `Ready` session, but use a bounded read-only engine operation with an
-already validated physical shard. The session is discarded when that HTTP
-request finishes, so a transaction cannot span requests.
+session and submit an owned statement. Execute and empty-catalog legacy query
+put the request's `shard_key` in its routing context. Populated-catalog query
+instead derives its target set from the statement and authoritative metadata;
+a caller key does not narrow that logical set. The engine, rather than the HTTP
+adapter, selects targets and acquires pooled SQLite connections. Admin
+inspection requests also create fresh `Ready` sessions, but their generated
+logical plan uses placement metadata to choose explicit read-only physical
+inspections. The sessions are discarded when that HTTP request finishes, so a
+transaction cannot span requests.
 
 ### Admin browser inspection
 
 The `/admin` application is an early operational view rather than another SQL
-compatibility mode. The browser never submits SQL. Its overview selects one
-physical shard from the configured range and discovers ordinary `main`-schema
-tables through SQLite's typed `table_list` metadata. ASCII-case-insensitive `sqlite_`,
-the exact name `briskdb`, and `briskdb_` prefixes are excluded, as are non-table
-objects. This is a physical schema view, not the authoritative logical-catalog
-view and not a promise that another shard contributes the same rows.
+compatibility mode. The browser never submits SQL. With a populated catalog,
+its overview lists non-Catalog tables in the default logical database. An empty
+catalog retains a shard-0 physical-discovery fallback through SQLite's typed
+`table_list` metadata. ASCII-case-insensitive `sqlite_`, the exact name
+`briskdb`, and `briskdb_` prefixes are excluded, as are non-table objects.
 
-Row browsing generates one safely quoted `SELECT *` for a table returned by
-discovery. Page limits are 1 through 200 and offsets are 0 through 1,000,000;
-the interface reads at most one extra row to decide whether another page is
-available. The user interface offers 25, 50, 100, and 200 and starts at 50.
-Shard, table, limit, offset, and checked arithmetic are validated before
-execution. The engine still requires SQLite to classify the statement as
-read-only and applies its schema gate, pool/worker admission, cancellation,
-deadline, and effective result-byte and row budgets.
+Table placement selects the physical targets: Sharded uses every file, Global
+uses canonical shard 0 once, and the empty-catalog fallback uses every file.
+The browser verifies table presence and identical column metadata, counts each
+target, calculates only the shard-major slices needed for the requested offset,
+and generates safely quoted, all-column-ordered `SELECT *` reads for those
+slices. Duplicate rows are retained. Page limits are 1 through 200 and offsets
+are 0 through 1,000,000; at most one extra logical row decides whether another
+page is available. The user interface offers 25, 50, 100, and 200 and starts at
+50. Table, limit, offset, target shape, and checked arithmetic are validated.
+The combined page is checked against one configured row/logical-byte budget.
 
 Table selection separately verifies the exact ordinary table on every shard
-and runs bounded read-only `COUNT(*)` inspections. It returns the checked sum of
-physical rows, so replicated rows count once per shard. The sum is not a
-cross-shard snapshot and does not make arbitrary SQL scatterable.
+selected by placement and runs bounded read-only `COUNT(*)` inspections. It
+returns their checked sum, so a Sharded row contributes from its sole owner and
+a Global row contributes from shard 0 once. The sum remains a specialized admin
+operation rather than the general logical query planner's aggregate contract.
 
-Each offset page is a new committed read. No order is promised for a general
-SQLite table scan, and concurrent changes may move rows between pages. The
-browser does not merge physical row pages, preserve a multi-page snapshot,
-accept arbitrary filters or SQL, or implement the planned general
-scatter/gather query path.
+Each offset page is a new set of committed reads, not a retained cross-file
+snapshot. Concurrent changes may move or repeat rows between pages. The browser
+does not accept arbitrary filters or SQL, and its dedicated count/paging plan
+does not add general multi-shard aggregate, ordering, or pagination SQL.
 The full route, login, and live-view contract is in the [admin data
 browser](ADMIN_BROWSER.md).
 
@@ -219,6 +226,15 @@ result when a budget is exceeded. This deliberately rejects write-capable query
 forms such as DML `RETURNING`; callers must use the execute surface, whose
 result is rows affected rather than returned rows. Exact accounting and
 configuration semantics are in [request controls](REQUEST_CONTROLS.md).
+
+A supported logical multi-shard query schedules at most eight shard tasks. All
+targets share one absolute request deadline, cancellation source, and combined
+row/logical-byte budget. Rows are concatenated in ascending shard order and
+duplicates are retained, matching `UNION ALL`. A failure on any target cancels
+the remaining work, waits for cleanup, and returns no partial result. Because
+each physical shard has its own SQLite file and connection pool, this read
+coordination does not collapse the independent per-file write paths into one
+database lock.
 
 The `broadcast` surface now implements one application-schema migration. Before
 it creates a journal, BriskDB runs the complete batch on every shard in an
@@ -310,6 +326,11 @@ shape is:
   "rows": [[1, 2]]
 }
 ```
+
+A successful one-target query contains `"shard": N`. A logical query that
+visits multiple targets replaces that member with `"shards": [N, ...]`; the
+array is unique and sorted in physical-shard order, matching the order used to
+concatenate its per-shard rows.
 
 For every row, `rows[row_index][column_index]` is described by
 `columns[column_index]`. Column names may be duplicated or empty and are never
@@ -428,7 +449,7 @@ the bounded catalog-aware path.
 | --- | --- | --- |
 | Persistent DDL, including `CREATE`, `DROP`, and `ALTER` | Execute only through the migration/broadcast endpoint | Per-shard atomic and crash-resumable; with a populated catalog, row-moving DML, table drops, trigger creation, and any final catalog violation are rejected |
 | `INSERT`, `UPDATE`, `DELETE` | Legacy: caller-selected shard. Registered: exactly one inferred owner, compatible with the caller route | Inserts prove every row key; shard-key updates and multi-owner writes are rejected |
-| `SELECT` | Legacy: caller-selected shard. Registered: one inferred sharded owner, Global shard 0, or table-free shard 0 | No scatter/gather path; unconstrained and multi-owner reads are rejected |
+| `SELECT` | Legacy: caller-selected shard. Registered: exact owner, distinct owners for finite keys, every owner for unconstrained Sharded reads, or shard 0 once for Global/table-free reads | Multi-shard execution accepts only unchanged row-local single-table reads and concatenates with `UNION ALL`; unsupported global semantics are rejected |
 | SQLite expressions and functions | Legacy syntax may pass through; registered execution accepts only the common subset and strict SQLite translation | Executed semantics remain SQLite semantics |
 | SQLite constraints | SQLite enforces each accepted constraint in one shard | Every sharded `PRIMARY KEY`/`UNIQUE` key includes the `BINARY` shard key, so all possible collisions have one owner; no independent global reservation service exists |
 
@@ -482,6 +503,14 @@ foreign keys, generated columns, expression/partial indexes, and all other
 forms are outside this first subset. The exact clause, expression, constraint,
 name, and diagnostic rules are normative in
 [the common SQL subset contract](SQL_SUBSET.md).
+
+Structural acceptance is not permission to scatter a statement. When a
+registered Sharded read selects more than one physical target, the issue-57
+baseline requires one plain table and row-local projection/filter expressions
+whose translated SQL can execute unchanged per shard. It rejects `DISTINCT`,
+all functions and aggregates, grouping, ordering, limit/offset, joins,
+subqueries, CTEs, set operations, and windows. A one-target read may still use
+the broader implemented subset because SQLite evaluates it only once.
 
 This implemented status means structural validation exists and is tested. The
 subset is connected to prepared execution and populated-catalog HTTP
@@ -668,11 +697,13 @@ parameter/result column, exposes the classified behavior, and refreshes column
 metadata after schema migration without changing that behavior. Every execution
 creates a fresh plan under its current schema guard. It runs accepted sharded
 work on its assigned shard and classified safe `NotApplicable`/`Global` reads
-on deterministic shard 0; catalog access and sharded reads requiring scatter
-remain unavailable. Persistent schema prepare is denied before a handle is
-published, and session behavior cannot execute through a portal. Results are
-the same protocol-neutral routed rowset or affected-row count for SQLite,
-PostgreSQL, and MySQL source.
+on deterministic shard 0 through the compatibility execution method. Logical
+portal execution additionally visits the distinct metadata-selected targets of
+a finite Sharded read or every shard for an unconstrained Sharded read. Catalog
+access remains denied. Persistent schema prepare is denied before a handle is
+published, and session behavior cannot execute through a portal. Results use
+the same protocol-neutral values for SQLite, PostgreSQL, and MySQL source;
+logical results also report the sorted, unique physical shards visited.
 
 Per-session statement, portal, retained-bound-value, and per-bind planning
 limits are finite and have no implicit eviction. Planning preflight charges the
@@ -771,9 +802,10 @@ underlying execution semantics.
 
 ### Current
 
-- HTTP continues to require an opaque caller `shard_key`. With an empty catalog
-  it alone selects the shard; with a populated catalog it is retained as an
-  explicit route and must agree by physical shard with finite SQL inference.
+- HTTP execute continues to require an opaque caller `shard_key`. Empty-catalog
+  legacy query also requires it. A populated-catalog logical query derives its
+  targets from registered placement and SQL inference instead of using that
+  caller context to narrow the shard set.
 - Exact key bytes are hashed with version-1 BLAKE3; the little-endian 64-bit
   prefix selects one of 4,096 virtual buckets through the versioned
   compatibility algorithm.
@@ -816,13 +848,19 @@ underlying execution semantics.
   provenance. It compares finite routes by physical shard, rejects unroutable
   cataloged sharded writes, and records an accepted single-shard assignment.
 - The Rust prepared lifecycle snapshots bound values and session routing in an
-  immutable portal, transiently validates at bind, plans on every execution,
-  executes accepted sharded targets, and uses shard 0 for supported
-  replicated-schema reads. Populated-catalog HTTP uses the same routing policy
-  without a prepared cache. Neither path implements scatter reads.
+  immutable portal, transiently validates at bind, and plans on every
+  execution. Its logical read method and populated-catalog HTTP query execute
+  supported Sharded target sets without a second prepared cache; `Global` and
+  table-free reads use shard 0 once.
 - Point queries and writes visit only that key's owning shard.
-- No general scatter/gather query path exists. Logical unpinned reads still
-  require the shard `UNION ALL`/scatter and merge work in issues #57 and #58.
+- Finite multi-owner reads visit each distinct owner; unconstrained Sharded
+  reads visit every shard. At most eight tasks run concurrently, and successful
+  rows merge in ascending shard order with duplicates preserved as `UNION ALL`.
+  Every target shares one request deadline, cancellation source, and result
+  budget; any target failure yields no partial result.
+- The issue-57 baseline does not implement global `DISTINCT`, aggregate,
+  grouping, ordering, pagination, join, subquery, CTE, set-operation, or window
+  semantics. Those forms are rejected when more than one shard is selected.
 - SQLite transactions remain local to one shard. Registration accepts a
   sharded primary/unique key only when it contains the `BINARY` shard-key term,
   ensuring every possible collision is checked by one owning SQLite file.
@@ -842,7 +880,8 @@ underlying execution semantics.
   persisted in the manifest.
 - A transaction is pinned to its first shard. Targeting another shard returns a
   stable cross-shard-transaction error.
-- Read-only plans may scatter with bounded concurrency and deterministic merge.
+- Later planner work may extend bounded logical reads with global filtering,
+  ordering, pagination, aggregation, and other non-row-local semantics.
 - Cross-shard writes remain unsupported unless a future coordinator can prove
   its crash semantics.
 - A future reservation design is required for a unique key that intentionally
@@ -877,9 +916,9 @@ Version 8 retains those integrity rules and includes authoritative table
 registration in the same semantic root.
 See the [manifest storage-format contract](STORAGE_FORMAT.md).
 
-Scatter reads will combine committed results from multiple SQLite files. They
-will not claim an atomic cross-file snapshot until BriskDB has an implementation
-and failure tests that establish such a guarantee.
+Scatter reads combine committed results from multiple SQLite files. They do not
+claim an atomic cross-file snapshot; the files can observe different committed
+instants while the bounded tasks run.
 
 ## Compatibility verification
 

--- a/docs/SQL_PLANNING.md
+++ b/docs/SQL_PLANNING.md
@@ -1,6 +1,7 @@
 # Bound statement planning and routing policy
 
-Status: implemented for roadmap issues #23, #24, and #27 integration
+Status: implemented for roadmap issues #23 and #24, with execution integration
+through issues #27 and #57
 
 BriskDB exposes one synchronous, protocol-neutral engine call that plans a
 normalized statement from the values actually bound for that execution:
@@ -61,19 +62,21 @@ to a cataloged sharded table has `Some(shard)`.
 
 The [prepared execution lifecycle](SQL_PREPARED_STATEMENTS.md) consumes this
 result only after values are bound. Bind validates then discards one plan;
-execution creates another under its current schema guard. Execution uses an
-assigned shard for cataloged sharded work and may select deterministic shard 0
-for a classified safe `NotApplicable` or `Global` read. It still rejects
-catalog placement and sharded reads that need scatter. That target-selection
+execution creates another under its current schema guard. Compatibility
+execution uses an assigned shard for cataloged sharded work and may select
+deterministic shard 0 for a classified safe `NotApplicable` or `Global` read.
+Logical execution additionally converts unassigned Sharded reads into target
+sets: every shard for `Unconstrained`, or each distinct inferred owner for a
+finite multi-owner result. Catalog placement remains denied. This execution
 integration does not change this planner's meaning of `assigned_shard()`.
 
 Populated-catalog raw execute/query uses the same internal planning result after
 SQLite parsing, common-subset validation, placeholder normalization, and strict
-translation. It requires finite `Exact`/`Multiple` inference with one assigned
-owner for `Sharded` tables, uses shard 0 for supported Global or table-free
-reads, and rejects Catalog, undeclared, unconstrained, contradictory, and
-multi-owner targets. An empty catalog alone bypasses this composition and keeps
-the legacy caller-key route.
+translation. Execute still requires one assigned Sharded owner. Query uses one
+owner for `Exact`, each distinct inferred owner for finite `Multiple`, every
+shard for `Unconstrained`, and shard 0 once for supported Global or table-free
+reads. Catalog and undeclared placement remain denied. An empty catalog alone
+bypasses this composition and keeps the legacy caller-key route.
 
 `Debug` output reports identifiers, versions, shard IDs, and counts where
 useful. It does not render SQL, AST contents, inferred key values, explicit key
@@ -114,10 +117,17 @@ Only statements classified as `Read` follow these deferred-assignment rules:
 | `Contradiction` | Leave unassigned for later empty-result/validation policy | Assign the explicit shard |
 | `NotApplicable` or `NotSharded` | Leave unassigned | Leave unassigned; retain explicit context only as advisory metadata |
 
-No scatter execution or no-row short circuit is implemented here. In
-particular, a contradictory predicate is still allowed to reach later SQLite
-prepare and validation work rather than having this advisory layer invent a
-result.
+This synchronous planner does not execute a scatter or invent a no-row result.
+The logical executor consumes its inference after planning and retains SQLite
+validation for contradictory predicates rather than letting this advisory
+layer synthesize a result.
+
+When that target set contains more than one shard, issue #57 accepts only a
+single-table, row-local `SELECT` that can be executed unchanged on each target.
+It rejects `DISTINCT`, functions and aggregates, grouping, ordering,
+limit/offset, joins, subqueries, CTEs, set operations, and windows. Those forms
+need later global-semantic planning rather than a concatenation of independently
+evaluated shard results.
 
 ## Sharded write policy
 
@@ -218,9 +228,13 @@ every shard on each call.
 
 For a registered `Sharded` table, every ordinary row belongs on exactly the one
 owner produced from its canonical key. Finite point plans can assign that
-owner. An unpinned or multi-owner read still remains unassigned here; executing
-it as a logical shard `UNION ALL` with bounded scatter and deterministic merge
-is follow-up work in issues #57 and #58, not part of catalog registration.
+owner. An unpinned or multi-owner read remains unassigned by this synchronous
+API, but issue #57's logical executor consumes the inference as a physical
+target set. It runs supported row-local reads with at most eight shard tasks
+and concatenates results in ascending shard order as `UNION ALL`, retaining
+duplicates. Exact inference visits one owner; finite inference deduplicates
+only repeated physical targets; `Unconstrained` visits all shards; `Global`
+visits shard 0 once. One failed target fails the complete operation.
 
 ## Errors and recovery
 
@@ -270,7 +284,8 @@ path. In particular:
 - `assigned_shard()` is consumed by prepared execution and by raw HTTP
   execute/query when the authoritative catalog is populated; an empty catalog
   retains legacy routing without a plan;
-- no read scatter, merge, contradiction short circuit, or write executes here;
+- no read scatter, merge, contradiction short circuit, or write executes in
+  this synchronous planner method;
 - no transaction pinning or cross-call routing context is applied;
 - this synchronous method creates no per-session or global cache; issue #26
   retains only typed values and a routing snapshot in each portal, not this
@@ -291,7 +306,7 @@ integrates translation and planning, validates transiently at bind, and plans
 again from the bounded session portal's snapshot at every execution. The
 implemented classifier supplies authoritative statement behavior and the
 empty/single/multi-statement gate. Direct inference remains statement-local;
-later query-planner work owns scatter/gather execution.
+the logical engine execution path owns scatter/gather rather than this planner.
 
 ## Verification obligations
 
@@ -307,4 +322,5 @@ public results; selected behavior; empty, all-read, and rejected mutating batch
 policy; provenance; and equivalent SQLite, PostgreSQL, and MySQL typed requests.
 HTTP regressions prove both boundaries: an empty catalog preserves legacy raw
 execution, while a populated catalog consumes the plan, enforces declared
-placement, and fails closed for unsafe or undeclared targets.
+placement, gathers supported logical reads without partial results, and fails
+closed for unsafe or undeclared targets.

--- a/docs/SQL_PREPARED_STATEMENTS.md
+++ b/docs/SQL_PREPARED_STATEMENTS.md
@@ -1,6 +1,7 @@
 # Prepared statements and bound portals
 
-Status: implemented for roadmap issue #26
+Status: implemented for roadmap issue #26, with logical read execution from
+issue #57
 
 BriskDB exposes one protocol-neutral lifecycle for SQL submitted by SQLite,
 PostgreSQL, MySQL, and future adapters. A frontend owns a `Session`, explicitly
@@ -69,15 +70,17 @@ describe_prepared(&Session, DescribeTarget)
     -> EngineResult<PreparedStatementDescription>
 execute_portal(&Session, PortalId)
     -> EngineResult<Routed<PreparedExecution>>
+execute_portal_logical(&Session, PortalId)
+    -> EngineResult<Executed<PreparedExecution>>
 close_prepared_statement(&Session, PreparedStatementId)
     -> EngineResult<bool>
 close_portal(&Session, PortalId)
     -> EngineResult<bool>
 ```
 
-Prepare, bind, describe, and execute also have `*_with_context` variants that
-accept `RequestContext`. Close is in-memory session cleanup and has no request
-context.
+Prepare, bind, describe, routed execute, and logical execute also have
+`*_with_context` variants that accept `RequestContext`. Close is in-memory
+session cleanup and has no request context.
 
 `PrepareRequest` owns four explicit inputs:
 
@@ -281,8 +284,9 @@ contains the current schema generation, routing-map generation, hash version,
 key-encoding version, and bucket-algorithm version. The engine keeps that same
 guard through target selection and SQLite completion, then discards the plan.
 
-Target selection is intentionally narrow and starts from the retained logical
-behavior rather than SQLite result-column metadata:
+Target selection starts from the retained logical behavior rather than SQLite
+result-column metadata. The compatibility `execute_portal` method retains its
+single-target contract:
 
 - accepted cataloged sharded reads and writes use the current plan's one
   `assigned_shard()`;
@@ -293,14 +297,33 @@ behavior rather than SQLite result-column metadata:
 - an unassigned sharded read, a `Global` write, or `Session` behavior is
   `Unsupported`.
 
+`execute_portal_logical` retains the same rules for writes and single-target
+reads, but also converts a supported Sharded read into a metadata-selected
+target set:
+
+- `Exact` visits its one owner;
+- finite `Multiple` visits each distinct owner once;
+- `Unconstrained` visits every configured shard; and
+- `Global` and table-free reads visit canonical shard 0 once.
+
+For more than one target, it runs at most eight shard tasks and concatenates
+their rows in ascending physical-shard order. It does not deduplicate equal
+rows, so the result has shard `UNION ALL` semantics. Every Sharded row remains
+stored exactly once on its key-selected owner; logical execution is a read
+across files, not replication.
+
 Shard 0 is valid for the two replicated-schema read cases because every ready
 shard has the same generation-bound application schema and `Global` declares
 replicated lookup placement. This initial path reads one deterministic replica;
 it does not compare replicas.
 
+The baseline multi-shard validator admits only a single-table, row-local
+`SELECT` that can run unchanged on every target. It rejects `DISTINCT`,
+functions and aggregates, grouping, ordering, limit/offset, joins, subqueries,
+CTEs, set operations, and windows until their global semantics are planned.
+
 These paths remain outside the current lifecycle:
 
-- scatter/gather or otherwise multi-shard reads;
 - contradictory reads that might later become an empty result without SQLite;
 - global writes, schema and session-statement execution paths;
 - persistent DDL outside the journaled schema-migration API;
@@ -319,15 +342,18 @@ session-control singleton can be prepared and described, but portal execution
 returns `Unsupported` before SQLite is stepped and leaves the session usable.
 
 SQLite transiently prepares and executes the retained canonical SQLite SQL on
-the selected target. Classified reads must produce
-`Routed<PreparedExecution::Rows(ResultSet)>`; commands produce
-`Routed<PreparedExecution::AffectedRows(usize)>` only for classified writes. A
+the selected target or targets. Classified reads produce either the
+compatibility `Routed<PreparedExecution::Rows(ResultSet)>` or logical
+`Executed<PreparedExecution::Rows(ResultSet)>`; commands remain routed
+`PreparedExecution::AffectedRows(usize)` results. A
 disagreement between classified behavior and SQLite execution metadata is an
 `Internal` invariant failure. Row results preserve ordered
 metadata, duplicate names, positional values, and the normal exact result row
-and logical-byte limits. Row-producing writes are rejected rather than partly
-materialized. The returned `Routed` value always names the physical shard that
-performed the operation.
+and logical-byte limits. One combined budget covers a logical result. Any shard
+failure or budget overflow cancels outstanding work and returns no partial
+rows. Row-producing writes are rejected rather than partly materialized. A
+returned `Routed` value names its one physical shard; `Executed::shards()` is
+the sorted, unique set visited by a logical operation.
 
 ## Controls, concurrency, close, and shutdown
 
@@ -336,7 +362,9 @@ Prepare, bind, describe, and execute are ordinary engine operations. Their
 deadline; the engine default deadline is still an upper bound. Prepare and a
 schema-refreshing describe apply those controls while waiting for shard 0 and
 while SQLite compiles metadata. Execute also applies per-request result limits,
-SQLite interruption, rollback, pool cleanup, and exact-handle retirement.
+SQLite interruption, rollback, pool cleanup, and exact-handle retirement. A
+logical scatter shares one absolute deadline, cancellation source, and result
+budget across all targets, and drains child cleanup before returning an error.
 
 The engine serializes all concurrent operations borrowing one `Session`. The
 session lock remains owned across pending admission and blocking SQLite work,
@@ -404,9 +432,9 @@ the same planning and result path:
 
 | Input | Required mode and parameter form | Prepared execution result |
 | --- | --- | --- |
-| SQLite | `StrictSqlite` for exact normalized SQLite, or explicit finite `Compatibility`; `?` / `?N` | Protocol-neutral routed rows or affected-row count |
-| PostgreSQL | `Compatibility`; `$N` identities, including repeats and gaps | Same protocol-neutral routed rows or affected-row count |
-| MySQL | `Compatibility`; each `?` numbered left-to-right | Same protocol-neutral routed rows or affected-row count |
+| SQLite | `StrictSqlite` for exact normalized SQLite, or explicit finite `Compatibility`; `?` / `?N` | Protocol-neutral routed or logical rows, or routed affected-row count |
+| PostgreSQL | `Compatibility`; `$N` identities, including repeats and gaps | Same protocol-neutral routed/logical rows or routed affected-row count |
+| MySQL | `Compatibility`; each `?` numbered left-to-right | Same protocol-neutral routed/logical rows or routed affected-row count |
 
 Each protocol adapter owns its message framing, authentication,
 statement/portal naming, wire parameter decoding, result type encoding, close
@@ -421,9 +449,9 @@ Issue #26 adds only process-memory session state and execution orchestration.
 It does not change manifest version 8, a manifest table, routing encoding,
 shard identity, schema fingerprint, migration journal, SQLite header field,
 WAL/synchronous mode, or filename. Prepared statements and portals disappear
-when their owning process/session ends. Preparing or describing changes no
-application data; executing a supported command has only its ordinary
-single-shard SQLite row effects.
+when their owning process/session ends. Preparing, describing, or gathering a
+logical read changes no application data; executing a supported command has
+only its ordinary single-shard SQLite row effects.
 
 Canonical translated SQL is never a schema-migration identity. Persistent
 application schema changes continue to require the journaled migration path,
@@ -437,7 +465,10 @@ single-statement enforcement; unknown databases; transient shard-0 metadata;
 classified behavior and parameter/column descriptions; schema-generation
 behavior preservation; fresh planning
 after schema/routing changes; routing snapshots; affected-row and row results;
-result limits; session ownership; statement, portal, and retained-byte limits without
+exact, finite-owner, unconstrained, and Global logical read targets;
+deterministic `UNION ALL` duplicate preservation; bounded fanout; all-or-error
+cancellation, deadline, and combined-result-limit behavior; session ownership;
+statement, portal, and retained-byte limits without
 eviction; repeated-marker planning expansion before allocation; exact close and
 cascading invalidation; invalid arity/value recovery; behavior-based unassigned
 execution; schema-prepare denial and session-execution rejection without state

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -313,15 +313,16 @@ schema, and rows. Registration does not inspect or repartition existing row
 data, which is why it accepts only empty declared physical tables. Raw HTTP
 execute/query remains caller-key-only while this catalog is empty. Once
 populated, it parses and strictly translates one SQLite common-subset statement,
-consults placement, and permits only one safe physical target; undeclared and
-Catalog targets fail closed, Global reads use shard 0, and Global writes require
-a future replication operation.
+consults placement, keeps writes on one proven owner, and selects the relevant
+owner set for supported logical reads; undeclared and Catalog targets fail
+closed, Global reads use shard 0, and Global writes require a future replication
+operation.
 
 The authoritative catalog supplies placement to inference, planning, prepared
-execution, and later import/query layers. It does not itself implement logical
-multi-shard execution. Unpinned sharded reads still require the bounded
-scatter/`UNION ALL` and merge work tracked by issues #57 and #58; the current
-physical admin browser is not that logical query surface.
+execution, import, logical scatter/gather, and the admin browser. Runtime
+coordination now provides bounded `UNION ALL` semantics without changing the
+manifest or shard-file format. Later planner issues extend global ordering,
+aggregation, and pagination semantics for arbitrary client SQL.
 
 ### Application-schema migration journal
 

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -9,16 +9,19 @@ use std::{
     time::{Duration, Instant},
 };
 
-use tokio::{sync::OwnedMutexGuard, task::JoinHandle};
+use tokio::{
+    sync::OwnedMutexGuard,
+    task::{JoinHandle, JoinSet},
+};
 
 use super::{
     BlockingPool, BoundStatementPlan, CancelOnDrop, CancellationReason, CancellationToken,
     Database, DescribeTarget, EngineError, EngineErrorKind, EngineOptions, EngineResult,
-    EngineState, Lifecycle, LogicalDatabaseId, OperationControl, OperationLease, PortalId,
-    PrepareRequest, PreparedExecution, PreparedStatementDescription, PreparedStatementId,
+    EngineState, Executed, Lifecycle, LogicalDatabaseId, OperationControl, OperationLease,
+    PortalId, PrepareRequest, PreparedExecution, PreparedStatementDescription, PreparedStatementId,
     PreparedStatementLimits, RawDataOperation, RequestContext, ResultLimits, ResultSet, Routed,
-    Session, SessionInner, ShutdownReport, TablePlacement, Value, wait_for_cancellation,
-    wait_pending,
+    Session, SessionInner, ShutdownReport, TablePlacement, Value, merge_scatter_results,
+    wait_for_cancellation, wait_pending,
 };
 use crate::{
     sql,
@@ -26,6 +29,7 @@ use crate::{
 };
 
 static NEXT_ENGINE_ID: AtomicU64 = AtomicU64::new(1);
+const MAX_SCATTER_CONCURRENCY: usize = 8;
 
 /// An owned SQL statement and its protocol-neutral parameters.
 #[derive(Debug, Clone, PartialEq)]
@@ -353,6 +357,41 @@ impl Engine {
             ),
             |key| self.inner.database.shard_for_key(key),
         )
+    }
+
+    fn logical_raw_query_plan(
+        &self,
+        statement: &str,
+        parameters: &[Value],
+    ) -> EngineResult<(Vec<u16>, String)> {
+        let parsed = sql::parse(sql::SqlDialect::Sqlite, statement)?;
+        if parsed.statement_count() != 1 {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "logical raw SQL must contain exactly one top-level statement",
+            ));
+        }
+        let common = sql::validate_common_subset(parsed)?;
+        let normalized = sql::normalize_placeholders(common)?;
+        let translated = sql::translate_sql(normalized, sql::SqlTranslationMode::StrictSqlite)?;
+        let plan = self.plan_bound_statement_admitted(
+            self.catalog().default_database().id(),
+            translated.normalized_sql(),
+            0,
+            parameters,
+            None,
+        )?;
+        if !matches!(plan.behavior(), sql::StatementBehavior::Read) {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidQuery,
+                "logical query statements must be read-only",
+            ));
+        }
+        let shards = prepared_execution_shards(&plan, self.catalog(), self.shard_count())?;
+        if shards.len() > 1 {
+            sql::validate_scatter_safe(&translated)?;
+        }
+        Ok((shards, translated.sqlite_sql().to_owned()))
     }
 
     /// Return the engine's immutable pool and admission options.
@@ -824,6 +863,124 @@ impl Engine {
         Ok(Routed { shard, value })
     }
 
+    /// Execute one immutable bound portal as a logical read across every
+    /// metadata-selected physical shard.
+    pub async fn execute_portal_logical(
+        &self,
+        session: &Session,
+        portal: PortalId,
+    ) -> EngineResult<Executed<PreparedExecution>> {
+        self.execute_portal_logical_with_context(session, portal, RequestContext::new())
+            .await
+    }
+
+    /// Execute a logical bound portal with explicit request and result-budget
+    /// controls.
+    pub async fn execute_portal_logical_with_context(
+        &self,
+        session: &Session,
+        portal: PortalId,
+        context: RequestContext,
+    ) -> EngineResult<Executed<PreparedExecution>> {
+        let mut operation = self.operation(context)?;
+        let schema_operation = match self.inner.database.storage.enter_schema_operation() {
+            Ok(guard) => guard,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let guard = match operation.wait_pending(self.ready_session(session)).await {
+            Ok(guard) => guard,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let portal_snapshot = match guard.prepared().portal(portal) {
+            Ok(portal) => portal.clone(),
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let template = match guard.prepared().statement(portal_snapshot.statement()) {
+            Ok(template) => template,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let explicit_routing_key = if matches!(
+            template.description().behavior(),
+            sql::StatementBehavior::Read
+        ) {
+            None
+        } else {
+            portal_snapshot.routing_key()
+        };
+        let plan = match self.plan_bound_statement_admitted(
+            template.database(),
+            template.translated().normalized_sql(),
+            0,
+            portal_snapshot.parameters(),
+            explicit_routing_key,
+        ) {
+            Ok(plan) => plan,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let shards = match prepared_execution_shards(&plan, self.catalog(), self.shard_count()) {
+            Ok(shards) => shards,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        if shards.len() > 1 {
+            if let Err(error) = sql::validate_scatter_safe(template.translated()) {
+                return operation.finish(Err(error));
+            }
+        }
+
+        let sqlite_sql = template.translated().sqlite_sql().to_owned();
+        let behavior = plan.behavior();
+        let result_limits = operation.result_limits;
+        let owner = ConnectionOwner::new(session.id().get());
+        if shards.len() > 1 {
+            if !matches!(behavior, sql::StatementBehavior::Read) {
+                return operation.finish(Err(EngineError::new(
+                    EngineErrorKind::Internal,
+                    "write planning produced more than one execution shard",
+                )));
+            }
+            let parameters = portal_snapshot.parameters().to_vec();
+            let result = self
+                .run_scatter_query(
+                    &mut operation,
+                    owner,
+                    schema_operation,
+                    guard,
+                    shards.clone(),
+                    sqlite_sql,
+                    parameters,
+                )
+                .await
+                .map(PreparedExecution::Rows);
+            let value = operation.finish_started(result)?;
+            return Ok(Executed { shards, value });
+        }
+
+        let shard = shards[0];
+        let result = self
+            .run_on_shard(
+                &mut operation,
+                shard,
+                owner,
+                schema_operation,
+                guard,
+                move |connection, _session, control| {
+                    connection.isolate_foreign_sql_controlled(Arc::clone(&control), &sqlite_sql)?;
+                    connection.run_controlled(control, |connection| {
+                        sql::execute_statement_with_limits(
+                            connection,
+                            &sqlite_sql,
+                            portal_snapshot.parameters(),
+                            result_limits,
+                        )
+                        .and_then(|execution| prepared_execution(behavior, execution))
+                    })
+                },
+            )
+            .await;
+        let value = operation.finish_started(result)?;
+        Ok(Executed { shards, value })
+    }
+
     /// Close a prepared statement and every portal bound from it.
     ///
     /// This in-memory cleanup remains available while the engine is draining.
@@ -962,7 +1119,6 @@ impl Engine {
             ),
         };
         let limits = operation.result_limits;
-
         let value = self
             .run_on_shard(
                 &mut operation,
@@ -980,6 +1136,89 @@ impl Engine {
             .await;
         let value = operation.finish_started(value)?;
         Ok(Routed { shard, value })
+    }
+
+    /// Query one logical table view, visiting every physical shard selected by
+    /// catalog metadata and preserving `UNION ALL` row semantics.
+    pub async fn query_logical(
+        &self,
+        session: &Session,
+        statement: Statement,
+    ) -> EngineResult<Executed<ResultSet>> {
+        self.query_logical_with_context(session, statement, RequestContext::new())
+            .await
+    }
+
+    /// Query one logical table view with explicit cancellation, deadline, and
+    /// result-budget controls.
+    pub async fn query_logical_with_context(
+        &self,
+        session: &Session,
+        statement: Statement,
+        context: RequestContext,
+    ) -> EngineResult<Executed<ResultSet>> {
+        // An empty catalog has no placement metadata, so retain the legacy
+        // explicitly routed compatibility behavior.
+        if self.catalog().tables().is_empty() {
+            return self
+                .query_with_context(session, statement, context)
+                .await
+                .map(|routed| Executed {
+                    shards: vec![routed.shard],
+                    value: routed.value,
+                });
+        }
+
+        let mut operation = self.operation(context)?;
+        let schema_operation = match self.inner.database.storage.enter_schema_operation() {
+            Ok(guard) => guard,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let guard = match operation.wait_pending(self.ready_session(session)).await {
+            Ok(guard) => guard,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let (sql, params) = statement.into_parts();
+        let (shards, sql) = match self.logical_raw_query_plan(&sql, &params) {
+            Ok(plan) => plan,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let owner = ConnectionOwner::new(session.id().get());
+        if shards.len() > 1 {
+            let result = self
+                .run_scatter_query(
+                    &mut operation,
+                    owner,
+                    schema_operation,
+                    guard,
+                    shards.clone(),
+                    sql,
+                    params,
+                )
+                .await;
+            let value = operation.finish_started(result)?;
+            return Ok(Executed { shards, value });
+        }
+
+        let shard = shards[0];
+        let limits = operation.result_limits;
+        let value = self
+            .run_on_shard(
+                &mut operation,
+                shard,
+                owner,
+                schema_operation,
+                guard,
+                move |connection, _session, control| {
+                    connection.isolate_foreign_sql_controlled(Arc::clone(&control), &sql)?;
+                    connection.run_controlled(control, |connection| {
+                        sql::query_with_limits(connection, &sql, &params, limits)
+                    })
+                },
+            )
+            .await;
+        let value = operation.finish_started(value)?;
+        Ok(Executed { shards, value })
     }
 
     /// Run one read-only inspection statement on an explicit physical shard.
@@ -1119,6 +1358,261 @@ impl Engine {
         });
         let result = operation.wait_started(join).await;
         operation.finish_started(result)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn run_scatter_query(
+        &self,
+        operation: &mut Operation,
+        owner: ConnectionOwner,
+        schema_operation: SchemaOperationGuard,
+        session: OwnedMutexGuard<SessionInner>,
+        shards: Vec<u16>,
+        sql: String,
+        params: Vec<Value>,
+    ) -> EngineResult<ResultSet> {
+        if shards.len() < 2 {
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                "scatter execution requires at least two physical shards",
+            ));
+        }
+        if let Err(error) = operation.check_before_start() {
+            return operation.control.complete(Err(error));
+        }
+
+        let cancellation = CancellationToken::new();
+        let cancel_scatter = cancellation.clone();
+        if let Err(reason) = operation.control.arm(Arc::new(move || {
+            cancel_scatter.cancel();
+        })) {
+            return operation.control.complete(Err(reason.error()));
+        }
+
+        let lease = operation.take_lease();
+        let worker_control = Arc::clone(&operation.control);
+        let engine = self.clone();
+        let deadline = operation.deadline;
+        let result_limits = operation.result_limits;
+        let sql: Arc<str> = Arc::from(sql);
+        let params: Arc<[Value]> = Arc::from(params);
+        let join = tokio::spawn(async move {
+            // These guards cover the complete logical operation. Cancellation
+            // cannot release schema, lifecycle, or session ownership until
+            // every started physical read has drained and cleaned up.
+            let _lease = lease;
+            let _schema_operation = schema_operation;
+            let _session = session;
+            let result = engine
+                .coordinate_scatter_query(
+                    owner,
+                    shards,
+                    sql,
+                    params,
+                    cancellation,
+                    deadline,
+                    result_limits,
+                )
+                .await;
+            worker_control.complete(result)
+        });
+        operation.wait_started(join).await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn coordinate_scatter_query(
+        &self,
+        owner: ConnectionOwner,
+        shards: Vec<u16>,
+        sql: Arc<str>,
+        params: Arc<[Value]>,
+        cancellation: CancellationToken,
+        deadline: Option<Instant>,
+        result_limits: ResultLimits,
+    ) -> EngineResult<ResultSet> {
+        let budget = sql::ScatterResultBudget::new(result_limits);
+        let mut remaining = shards.iter().copied();
+        let mut running = JoinSet::new();
+        for shard in remaining.by_ref().take(MAX_SCATTER_CONCURRENCY) {
+            self.spawn_scatter_shard(
+                &mut running,
+                shard,
+                owner,
+                Arc::clone(&sql),
+                Arc::clone(&params),
+                cancellation.clone(),
+                deadline,
+                budget.clone(),
+            );
+        }
+
+        let mut results = Vec::with_capacity(shards.len());
+        let mut first_error = None;
+        while let Some(joined) = running.join_next().await {
+            match joined {
+                Ok((shard, Ok(result))) if first_error.is_none() => {
+                    results.push(Routed {
+                        shard,
+                        value: result,
+                    });
+                }
+                Ok((_, Ok(_))) => {}
+                Ok((_, Err(error))) if first_error.is_none() => {
+                    first_error = Some(error);
+                    cancellation.cancel();
+                }
+                Ok((_, Err(_))) => {}
+                Err(error) if first_error.is_none() => {
+                    first_error = Some(EngineError::from_source(
+                        EngineErrorKind::Internal,
+                        "scatter query task failed",
+                        error,
+                    ));
+                    cancellation.cancel();
+                }
+                Err(_) => {}
+            }
+
+            if first_error.is_none() {
+                if let Some(shard) = remaining.next() {
+                    self.spawn_scatter_shard(
+                        &mut running,
+                        shard,
+                        owner,
+                        Arc::clone(&sql),
+                        Arc::clone(&params),
+                        cancellation.clone(),
+                        deadline,
+                        budget.clone(),
+                    );
+                }
+            }
+        }
+
+        if let Some(error) = first_error {
+            return Err(error);
+        }
+        merge_scatter_results(results, result_limits)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn spawn_scatter_shard(
+        &self,
+        running: &mut JoinSet<(u16, EngineResult<ResultSet>)>,
+        shard: u16,
+        owner: ConnectionOwner,
+        sql: Arc<str>,
+        params: Arc<[Value]>,
+        cancellation: CancellationToken,
+        deadline: Option<Instant>,
+        budget: sql::ScatterResultBudget,
+    ) {
+        let engine = self.clone();
+        running.spawn(async move {
+            let result = engine
+                .run_scatter_shard(shard, owner, sql, params, cancellation, deadline, budget)
+                .await;
+            (shard, result)
+        });
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn run_scatter_shard(
+        &self,
+        shard: u16,
+        owner: ConnectionOwner,
+        sql: Arc<str>,
+        params: Arc<[Value]>,
+        cancellation: CancellationToken,
+        deadline: Option<Instant>,
+        budget: sql::ScatterResultBudget,
+    ) -> EngineResult<ResultSet> {
+        let control = OperationControl::new(deadline);
+        let mut cancel_on_drop = CancelOnDrop::new(Arc::clone(&control));
+        let shutdown_cancel = self.inner.shutdown_cancel.clone();
+
+        let permit = match wait_pending(
+            self.inner.connections.acquire_for_owner(shard, owner),
+            &cancellation,
+            &shutdown_cancel,
+            deadline,
+            &control,
+        )
+        .await
+        {
+            Ok(permit) => permit,
+            Err(error) => {
+                let result = control.complete(Err(error));
+                cancel_on_drop.disarm();
+                return result;
+            }
+        };
+        let worker = match wait_pending(
+            self.inner.workers.acquire(),
+            &cancellation,
+            &shutdown_cancel,
+            deadline,
+            &control,
+        )
+        .await
+        {
+            Ok(worker) => worker,
+            Err(error) => {
+                let result = control.complete(Err(error));
+                cancel_on_drop.disarm();
+                return result;
+            }
+        };
+
+        if let Some(reason) = pending_cancellation_reason(&cancellation, &shutdown_cancel, deadline)
+        {
+            control.request_cancel(reason);
+            let result = control.complete(Err(reason.error()));
+            cancel_on_drop.disarm();
+            return result;
+        }
+
+        let worker_control = Arc::clone(&control);
+        let storage = self.inner.database.storage.clone();
+        let mut join = worker.spawn(move || {
+            let result = permit
+                .checkout_controlled(Arc::clone(&worker_control))
+                .and_then(|mut connection| {
+                    let result = connection
+                        .isolate_foreign_sql_controlled(Arc::clone(&worker_control), &sql)
+                        .and_then(|()| {
+                            connection.run_controlled(Arc::clone(&worker_control), |connection| {
+                                sql::query_with_scatter_budget(
+                                    connection,
+                                    &sql,
+                                    params.as_ref(),
+                                    &budget,
+                                )
+                            })
+                        });
+                    retire_if_broken(&mut connection, &result);
+                    result
+                });
+            if result
+                .as_ref()
+                .is_err_and(|error| error.kind() == EngineErrorKind::DataCorruption)
+            {
+                storage.record_schema_degraded();
+            }
+            worker_control.complete(result)
+        });
+
+        let result = tokio::select! {
+            biased;
+            result = &mut join => flatten_join(result),
+            reason = wait_for_cancellation(&cancellation, &shutdown_cancel, deadline) => {
+                control.request_cancel(reason);
+                flatten_join(join.await)
+            }
+        };
+        let result = control.complete(result);
+        cancel_on_drop.disarm();
+        result
     }
 
     async fn run_on_shard<T, F>(
@@ -1483,6 +1977,88 @@ fn prepared_execution_shard(
     }
 }
 
+fn prepared_execution_shards(
+    plan: &BoundStatementPlan,
+    catalog: &super::Catalog,
+    shard_count: u16,
+) -> EngineResult<Vec<u16>> {
+    if matches!(
+        plan.behavior(),
+        sql::StatementBehavior::Schema(_) | sql::StatementBehavior::Session(_)
+    ) {
+        return Err(unsupported_prepared_behavior());
+    }
+
+    let placement = if plan.inference().kind() == sql::ShardKeyInferenceKind::NotSharded {
+        let table = plan
+            .inference()
+            .table_id()
+            .and_then(|table| catalog.table_by_id(table))
+            .ok_or_else(|| {
+                EngineError::new(
+                    EngineErrorKind::Internal,
+                    "non-sharded prepared planning lost its catalog table",
+                )
+            })?;
+        match table.placement() {
+            TablePlacement::Catalog => {
+                return Err(catalog_target_denied());
+            }
+            TablePlacement::Global => Some(TablePlacement::Global),
+            TablePlacement::Sharded(_) => {
+                return Err(EngineError::new(
+                    EngineErrorKind::Internal,
+                    "non-sharded prepared planning resolved a sharded table",
+                ));
+            }
+        }
+    } else {
+        None
+    };
+
+    match plan.behavior() {
+        sql::StatementBehavior::Read => {
+            let mut shards = match plan.inference().kind() {
+                sql::ShardKeyInferenceKind::NotApplicable => vec![0],
+                sql::ShardKeyInferenceKind::NotSharded
+                    if matches!(placement, Some(TablePlacement::Global)) =>
+                {
+                    vec![0]
+                }
+                sql::ShardKeyInferenceKind::Unconstrained => (0..shard_count).collect(),
+                sql::ShardKeyInferenceKind::Contradiction => vec![0],
+                sql::ShardKeyInferenceKind::Exact | sql::ShardKeyInferenceKind::Multiple => plan
+                    .inferred_routes()
+                    .iter()
+                    .map(super::PlannedRoute::shard)
+                    .collect(),
+                sql::ShardKeyInferenceKind::NotSharded => {
+                    return Err(EngineError::new(
+                        EngineErrorKind::Internal,
+                        "non-sharded prepared planning lost Global placement",
+                    ));
+                }
+            };
+            shards.sort_unstable();
+            shards.dedup();
+            if shards.is_empty() || shards.iter().any(|&shard| shard >= shard_count) {
+                return Err(EngineError::new(
+                    EngineErrorKind::Internal,
+                    "prepared read planning produced invalid physical targets",
+                ));
+            }
+            Ok(shards)
+        }
+        sql::StatementBehavior::Write(_) => plan
+            .assigned_shard()
+            .map(|shard| vec![shard])
+            .ok_or_else(unassigned_prepared_statement),
+        sql::StatementBehavior::Schema(_) | sql::StatementBehavior::Session(_) => {
+            Err(unsupported_prepared_behavior())
+        }
+    }
+}
+
 fn prepared_execution(
     behavior: sql::StatementBehavior,
     execution: sql::StatementExecution,
@@ -1523,6 +2099,20 @@ fn flatten_join<T>(result: Result<EngineResult<T>, tokio::task::JoinError>) -> E
             error,
         )
     })?
+}
+
+fn pending_cancellation_reason(
+    request: &CancellationToken,
+    shutdown: &CancellationToken,
+    deadline: Option<Instant>,
+) -> Option<CancellationReason> {
+    if request.is_cancelled() || shutdown.is_cancelled() {
+        Some(CancellationReason::Cancelled)
+    } else if deadline.is_some_and(|deadline| Instant::now() >= deadline) {
+        Some(CancellationReason::DeadlineExceeded)
+    } else {
+        None
+    }
 }
 
 fn required_routing_key(session: &SessionInner) -> EngineResult<&str> {
@@ -1581,6 +2171,35 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let database = Arc::new(Database::open(temp.path(), shards).unwrap());
         let engine = Engine::from_database_with_options(database, options).unwrap();
+        (temp, engine)
+    }
+
+    fn engine_with_sharded_events(
+        shards: u16,
+        options: EngineOptions,
+    ) -> (tempfile::TempDir, Engine) {
+        let temp = tempfile::tempdir().unwrap();
+        let mut database = Database::open(temp.path(), shards).unwrap();
+        database
+            .broadcast(
+                "CREATE TABLE events (
+                    tenant_id INTEGER PRIMARY KEY,
+                    payload TEXT NOT NULL
+                 )",
+            )
+            .unwrap();
+        let logical_database = database.catalog().default_database().id();
+        database
+            .register_tables(vec![
+                TableDeclaration::sharded(
+                    logical_database,
+                    "events",
+                    ShardKeyMetadata::new("tenant_id", ShardKeyType::Int64).unwrap(),
+                )
+                .unwrap(),
+            ])
+            .unwrap();
+        let engine = Engine::from_database_with_options(Arc::new(database), options).unwrap();
         (temp, engine)
     }
 
@@ -2872,7 +3491,10 @@ mod tests {
             .map(|value| value.to_string())
             .find(|key| engine.inner.database.shard_for_key(key.as_bytes()) != expected_shard)
             .unwrap();
-        session.set_routing_key(different_route).await.unwrap();
+        session
+            .set_routing_key(different_route.clone())
+            .await
+            .unwrap();
 
         let deleted = engine.execute_portal(&session, portal).await.unwrap();
         assert_eq!(deleted.shard, expected_shard);
@@ -2889,6 +3511,24 @@ mod tests {
             .await
             .unwrap();
         assert!(remaining.value.is_empty());
+
+        engine
+            .execute(
+                &session,
+                Statement::new(
+                    "INSERT INTO events (tenant_id, payload) VALUES (?1, ?2)",
+                    vec![Value::from(7_i64), Value::from("delete-me")],
+                ),
+            )
+            .await
+            .unwrap();
+        session.set_routing_key(different_route).await.unwrap();
+        let deleted = engine
+            .execute_portal_logical(&session, portal)
+            .await
+            .unwrap();
+        assert_eq!(deleted.shards, vec![expected_shard]);
+        assert_eq!(deleted.value, PreparedExecution::AffectedRows(1));
     }
 
     #[tokio::test]
@@ -5760,5 +6400,352 @@ mod tests {
         assert_eq!(engine.state(), EngineState::Stopped);
         let snapshot = engine.inner.connections.snapshot().unwrap();
         assert!(snapshot.shards.iter().all(|shard| shard.idle == 0));
+    }
+
+    #[tokio::test]
+    async fn logical_scatter_starts_no_more_than_eight_physical_reads_at_once() {
+        let options = EngineOptions::new(1, 1)
+            .unwrap()
+            .with_request_timeout(None)
+            .unwrap();
+        let (_temp, engine) = engine_with_sharded_events(9, options);
+        let mut started = Vec::new();
+        let mut release = Vec::new();
+        for shard in 0..9 {
+            let (started_tx, started_rx) = mpsc::channel();
+            let (release_tx, release_rx) = mpsc::channel();
+            engine
+                .inner
+                .connections
+                .block_next_connection_setup(shard, started_tx, release_rx)
+                .unwrap();
+            started.push(Some(started_rx));
+            release.push(release_tx);
+        }
+
+        let query_engine = engine.clone();
+        let query = tokio::spawn(async move {
+            let session = query_engine.session();
+            query_engine
+                .query_logical(
+                    &session,
+                    Statement::new("SELECT tenant_id FROM events", vec![]),
+                )
+                .await
+        });
+
+        for (shard, receiver) in started.iter_mut().enumerate().take(8) {
+            wait_for_blocking_signal(
+                receiver.take().unwrap(),
+                "one of the first eight scatter reads should start",
+            )
+            .await;
+            assert_eq!(
+                engine.inner.connections.snapshot().unwrap().shards[shard].active,
+                1
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(matches!(
+            started[8].as_ref().unwrap().try_recv(),
+            Err(mpsc::TryRecvError::Empty)
+        ));
+
+        release[0].send(()).unwrap();
+        wait_for_blocking_signal(
+            started[8].take().unwrap(),
+            "the ninth scatter read should start after one bounded slot is released",
+        )
+        .await;
+        for sender in release.iter().skip(1) {
+            sender.send(()).unwrap();
+        }
+
+        let result = timeout(Duration::from_secs(2), query)
+            .await
+            .expect("the bounded scatter query should complete")
+            .unwrap()
+            .unwrap();
+        assert_eq!(result.shards, (0_u16..9).collect::<Vec<_>>());
+        assert!(result.value.is_empty());
+        wait_for_worker_capacity(&engine, 9).await;
+        assert!(
+            engine
+                .inner
+                .connections
+                .snapshot()
+                .unwrap()
+                .shards
+                .iter()
+                .all(|shard| shard.active == 0 && shard.queued == 0)
+        );
+    }
+
+    #[tokio::test]
+    async fn logical_scatter_deadline_cancels_and_drains_every_started_shard() {
+        let options = EngineOptions::new(1, 1)
+            .unwrap()
+            .with_request_timeout(None)
+            .unwrap();
+        let (_temp, engine) = engine_with_sharded_events(4, options);
+        let (started_tx, started_rx) = mpsc::channel();
+        let (_release_tx, release_rx) = mpsc::channel();
+        engine
+            .inner
+            .connections
+            .block_next_connection_setup(0, started_tx, release_rx)
+            .unwrap();
+
+        let context = RequestContext::new()
+            .with_timeout(Duration::from_secs(1))
+            .unwrap();
+        let session = Arc::new(engine.session());
+        let query_engine = engine.clone();
+        let query_session = Arc::clone(&session);
+        let query = tokio::spawn(async move {
+            query_engine
+                .query_logical_with_context(
+                    &query_session,
+                    Statement::new("SELECT tenant_id FROM events", vec![]),
+                    context,
+                )
+                .await
+        });
+        wait_for_blocking_signal(started_rx, "one scatter shard should enter SQLite setup").await;
+
+        let error = timeout(Duration::from_secs(2), query)
+            .await
+            .expect("the shared deadline should interrupt the blocked shard")
+            .unwrap()
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DeadlineExceeded);
+        assert_eq!(engine.active_operations_for_test(), 0);
+        wait_for_worker_capacity(&engine, 4).await;
+        assert!(
+            engine
+                .inner
+                .connections
+                .snapshot()
+                .unwrap()
+                .shards
+                .iter()
+                .all(|shard| shard.active == 0 && shard.queued == 0)
+        );
+
+        let recovered = engine
+            .query_logical(
+                &session,
+                Statement::new("SELECT tenant_id FROM events", vec![]),
+            )
+            .await
+            .unwrap();
+        assert_eq!(recovered.shards, vec![0, 1, 2, 3]);
+        assert!(recovered.value.is_empty());
+    }
+
+    #[tokio::test]
+    async fn writer_on_another_sqlite_file_progresses_while_scatter_is_in_flight() {
+        let options = EngineOptions::new(1, 1)
+            .unwrap()
+            .with_request_timeout(None)
+            .unwrap();
+        let (_temp, engine) = engine_with_sharded_events(4, options);
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        engine
+            .inner
+            .connections
+            .block_next_connection_setup(0, started_tx, release_rx)
+            .unwrap();
+
+        let query_engine = engine.clone();
+        let scatter = tokio::spawn(async move {
+            let session = query_engine.session();
+            query_engine
+                .query_logical(
+                    &session,
+                    Statement::new("SELECT tenant_id, payload FROM events", vec![]),
+                )
+                .await
+        });
+        wait_for_blocking_signal(started_rx, "scatter should remain active on shard zero").await;
+
+        let key = integer_key_for_shard(&engine, 1, None);
+        let writer = engine.session();
+        writer.set_routing_key(key.to_string()).await.unwrap();
+        let inserted = timeout(
+            Duration::from_secs(2),
+            engine.execute(
+                &writer,
+                Statement::new(
+                    "INSERT INTO events (tenant_id, payload) VALUES (?1, ?2)",
+                    vec![Value::Int64(key), Value::from("written independently")],
+                ),
+            ),
+        )
+        .await
+        .expect("a writer on shard one must not wait for shard zero")
+        .unwrap();
+        assert_eq!(inserted.shard, 1);
+        assert_eq!(inserted.value, 1);
+
+        release_tx.send(()).unwrap();
+        timeout(Duration::from_secs(2), scatter)
+            .await
+            .expect("scatter should finish after the held shard is released")
+            .unwrap()
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn aborting_logical_scatter_retains_guards_until_detached_cleanup_finishes() {
+        let options = EngineOptions::new(1, 1)
+            .unwrap()
+            .with_request_timeout(None)
+            .unwrap();
+        let (_temp, engine) = engine_with_sharded_events(4, options);
+        let (started_tx, started_rx) = mpsc::channel();
+        let (_release_tx, release_rx) = mpsc::channel();
+        engine
+            .inner
+            .connections
+            .block_next_connection_setup(0, started_tx, release_rx)
+            .unwrap();
+
+        let session = Arc::new(engine.session());
+        let query_engine = engine.clone();
+        let query_session = Arc::clone(&session);
+        let query = tokio::spawn(async move {
+            query_engine
+                .query_logical(
+                    &query_session,
+                    Statement::new("SELECT tenant_id FROM events", vec![]),
+                )
+                .await
+        });
+        wait_for_blocking_signal(started_rx, "one scatter child should enter SQLite setup").await;
+        assert_eq!(engine.active_operations_for_test(), 1);
+
+        query.abort();
+        assert!(query.await.unwrap_err().is_cancelled());
+        timeout(Duration::from_secs(2), async {
+            while engine.active_operations_for_test() != 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the detached scatter coordinator should finish child cleanup");
+        wait_for_worker_capacity(&engine, 4).await;
+        assert!(
+            engine
+                .inner
+                .connections
+                .snapshot()
+                .unwrap()
+                .shards
+                .iter()
+                .all(|shard| shard.active == 0 && shard.queued == 0)
+        );
+
+        let recovered = engine
+            .query_logical(
+                &session,
+                Statement::new("SELECT tenant_id FROM events", vec![]),
+            )
+            .await
+            .unwrap();
+        assert_eq!(recovered.shards, vec![0, 1, 2, 3]);
+    }
+
+    #[tokio::test]
+    async fn one_scatter_failure_cancels_and_drains_a_blocked_sibling_without_partial_rows() {
+        let options = EngineOptions::new(1, 1)
+            .unwrap()
+            .with_request_timeout(None)
+            .unwrap();
+        let (_temp, engine) = engine_with_sharded_events(4, options);
+        let session = Arc::new(engine.session());
+        let first = integer_key_for_shard(&engine, 0, None);
+        let second = integer_key_for_shard(&engine, 0, Some(first));
+        session.set_routing_key(first.to_string()).await.unwrap();
+        engine
+            .execute(
+                &session,
+                Statement::new(
+                    "INSERT INTO events (tenant_id, payload) VALUES (?1, 'one'), (?2, 'two')",
+                    vec![Value::Int64(first), Value::Int64(second)],
+                ),
+            )
+            .await
+            .unwrap();
+
+        let (failure_started_tx, failure_started_rx) = mpsc::channel();
+        let (failure_release_tx, failure_release_rx) = mpsc::channel();
+        engine
+            .inner
+            .connections
+            .block_next_control_teardown(0, failure_started_tx, failure_release_rx)
+            .unwrap();
+        let (sibling_started_tx, sibling_started_rx) = mpsc::channel();
+        let (_sibling_release_tx, sibling_release_rx) = mpsc::channel();
+        engine
+            .inner
+            .connections
+            .block_next_connection_setup(3, sibling_started_tx, sibling_release_rx)
+            .unwrap();
+
+        let context = RequestContext::new()
+            .with_result_limits(ResultLimits::new(1, ResultLimits::default().max_bytes()).unwrap());
+        let query_engine = engine.clone();
+        let query_session = Arc::clone(&session);
+        let query = tokio::spawn(async move {
+            query_engine
+                .query_logical_with_context(
+                    &query_session,
+                    Statement::new("SELECT tenant_id FROM events", vec![]),
+                    context,
+                )
+                .await
+        });
+        wait_for_blocking_signal(
+            sibling_started_rx,
+            "a sibling shard should be blocked before the first error is published",
+        )
+        .await;
+        wait_for_blocking_signal(
+            failure_started_rx,
+            "the row-limit failure should reach controlled SQLite cleanup",
+        )
+        .await;
+        failure_release_tx.send(()).unwrap();
+
+        let error = timeout(Duration::from_secs(2), query)
+            .await
+            .expect("the first shard failure should cancel and drain its sibling")
+            .unwrap()
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+        assert!(error.diagnostic().contains("row limit"));
+        assert_eq!(engine.active_operations_for_test(), 0);
+        wait_for_worker_capacity(&engine, 4).await;
+        assert!(
+            engine
+                .inner
+                .connections
+                .snapshot()
+                .unwrap()
+                .shards
+                .iter()
+                .all(|shard| shard.active == 0 && shard.queued == 0)
+        );
+
+        let recovered = engine
+            .query_logical(
+                &session,
+                Statement::new("SELECT tenant_id FROM events", vec![]),
+            )
+            .await
+            .unwrap();
+        assert_eq!(recovered.value.len(), 2);
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -12,6 +12,7 @@ mod options;
 mod planner;
 mod prepared;
 mod routing;
+mod scatter;
 mod session;
 mod types;
 pub(crate) mod worker;
@@ -52,6 +53,7 @@ pub(crate) use routing::{
     BUCKET_ALGORITHM_VERSION, HASH_VERSION, INITIAL_MAP_GENERATION, KEY_ENCODING_VERSION,
     RoutingCatalog, VIRTUAL_BUCKET_COUNT, initial_physical_shard,
 };
+pub(crate) use scatter::merge_scatter_results;
 pub use session::{Session, SessionId, SessionState};
 pub use types::{
     Column, DataType, Decimal, ParseDecimalError, ResultSet, ResultSetShapeError, Row, Value,
@@ -85,6 +87,23 @@ pub struct Database {
 pub struct Routed<T> {
     pub shard: u16,
     pub value: T,
+}
+
+/// Result of one logical engine operation and the physical shards it visited.
+///
+/// Shards are unique and sorted in ascending order. Single-owner reads and
+/// writes contain one entry; logical Sharded reads may contain several.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Executed<T> {
+    pub shards: Vec<u16>,
+    pub value: T,
+}
+
+impl<T> Executed<T> {
+    /// Return the physical shards visited by this logical operation.
+    pub fn shards(&self) -> &[u16] {
+        &self.shards
+    }
 }
 
 impl Database {

--- a/src/core/scatter.rs
+++ b/src/core/scatter.rs
@@ -1,0 +1,352 @@
+//! Deterministic protocol-neutral merging for scatter query results.
+
+use super::{EngineError, EngineErrorKind, EngineResult, ResultLimits, ResultSet, Routed, Value};
+
+const RESULT_ENVELOPE_BYTES: u64 = 16;
+const TYPE_TAG_BYTES: u64 = 1;
+const LENGTH_BYTES: u64 = 8;
+const ROW_FRAME_BYTES: u64 = 8;
+const FIXED_VALUE_PAYLOAD_BYTES: u64 = 8;
+
+/// Merge independently materialized shard results with `UNION ALL` semantics.
+///
+/// Rows are concatenated in ascending physical-shard order, regardless of the
+/// order in which shard work completed. Duplicate rows are deliberately
+/// retained. Every shard must return identical column names and types, and the
+/// final result is charged against one shared row and logical-byte budget.
+/// Validation and accounting finish before any row is moved into the result,
+/// so an error never exposes a partial merge.
+pub(crate) fn merge_scatter_results(
+    mut shard_results: Vec<Routed<ResultSet>>,
+    limits: ResultLimits,
+) -> EngineResult<ResultSet> {
+    shard_results.sort_by_key(|result| result.shard);
+
+    reject_duplicate_shards(&shard_results)?;
+    validate_column_metadata(&shard_results)?;
+    let row_count = account_merged_result(&shard_results, limits)?;
+
+    let capacity = usize::try_from(row_count).map_err(|_| row_limit_exceeded())?;
+    let mut columns = None;
+    let mut rows = Vec::with_capacity(capacity);
+    for routed in shard_results {
+        let (shard_columns, mut shard_rows) = routed.value.into_parts();
+        if columns.is_none() {
+            columns = Some(shard_columns);
+        }
+        rows.append(&mut shard_rows);
+    }
+
+    ResultSet::new(columns.unwrap_or_default(), rows).map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::Internal,
+            "scatter merge produced rows that do not match their column metadata",
+            error,
+        )
+    })
+}
+
+fn reject_duplicate_shards(shard_results: &[Routed<ResultSet>]) -> EngineResult<()> {
+    if let Some(duplicate) = shard_results
+        .windows(2)
+        .find(|pair| pair[0].shard == pair[1].shard)
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::Internal,
+            format!(
+                "scatter query returned more than one result for shard {}",
+                duplicate[0].shard
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_column_metadata(shard_results: &[Routed<ResultSet>]) -> EngineResult<()> {
+    let Some(reference) = shard_results.first() else {
+        return Ok(());
+    };
+
+    if let Some(mismatch) = shard_results
+        .iter()
+        .skip(1)
+        .find(|result| result.value.columns() != reference.value.columns())
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::Internal,
+            format!(
+                "scatter query returned column metadata on shard {} that differs from shard {}",
+                mismatch.shard, reference.shard
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn account_merged_result(
+    shard_results: &[Routed<ResultSet>],
+    limits: ResultLimits,
+) -> EngineResult<u64> {
+    let mut logical_bytes = account_bytes(0, RESULT_ENVELOPE_BYTES, limits.max_bytes())?;
+    if let Some(reference) = shard_results.first() {
+        for column in reference.value.columns() {
+            logical_bytes = account_bytes(logical_bytes, TYPE_TAG_BYTES, limits.max_bytes())?;
+            logical_bytes = account_bytes(logical_bytes, LENGTH_BYTES, limits.max_bytes())?;
+            logical_bytes = account_bytes(
+                logical_bytes,
+                usize_to_u64(column.name.len())?,
+                limits.max_bytes(),
+            )?;
+        }
+    }
+
+    let mut row_count = 0;
+    for routed in shard_results {
+        for row in routed.value.rows() {
+            row_count = account_row(row_count, limits.max_rows())?;
+            logical_bytes = account_bytes(logical_bytes, ROW_FRAME_BYTES, limits.max_bytes())?;
+            for value in row.values() {
+                logical_bytes = account_bytes(
+                    logical_bytes,
+                    logical_value_bytes(value)?,
+                    limits.max_bytes(),
+                )?;
+            }
+        }
+    }
+    Ok(row_count)
+}
+
+fn logical_value_bytes(value: &Value) -> EngineResult<u64> {
+    let payload = match value {
+        Value::Null => 0,
+        Value::Boolean(_) | Value::Int64(_) | Value::UInt64(_) | Value::Float64(_) => {
+            FIXED_VALUE_PAYLOAD_BYTES
+        }
+        Value::Decimal(value) => usize_to_u64(value.as_str().len())?,
+        Value::Text(value) => usize_to_u64(value.len())?,
+        Value::InvalidText(value) | Value::Binary(value) => usize_to_u64(value.len())?,
+    };
+    TYPE_TAG_BYTES
+        .checked_add(LENGTH_BYTES)
+        .and_then(|framing| framing.checked_add(payload))
+        .ok_or_else(byte_limit_exceeded)
+}
+
+fn account_row(current: u64, maximum: u64) -> EngineResult<u64> {
+    let next = current.checked_add(1).ok_or_else(row_limit_exceeded)?;
+    if next > maximum {
+        return Err(row_limit_exceeded());
+    }
+    Ok(next)
+}
+
+fn account_bytes(current: u64, additional: u64, maximum: u64) -> EngineResult<u64> {
+    let next = current
+        .checked_add(additional)
+        .ok_or_else(byte_limit_exceeded)?;
+    if next > maximum {
+        return Err(byte_limit_exceeded());
+    }
+    Ok(next)
+}
+
+fn usize_to_u64(value: usize) -> EngineResult<u64> {
+    u64::try_from(value).map_err(|_| byte_limit_exceeded())
+}
+
+fn row_limit_exceeded() -> EngineError {
+    EngineError::new(
+        EngineErrorKind::LimitExceeded,
+        "query result exceeds the configured row limit",
+    )
+}
+
+fn byte_limit_exceeded() -> EngineError {
+    EngineError::new(
+        EngineErrorKind::LimitExceeded,
+        "query result exceeds the configured logical byte limit",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::{Column, DataType, Row};
+
+    fn columns() -> Vec<Column> {
+        vec![Column::new("v", DataType::Int64)]
+    }
+
+    fn result(shard: u16, values: &[i64]) -> Routed<ResultSet> {
+        Routed {
+            shard,
+            value: ResultSet::new(
+                columns(),
+                values
+                    .iter()
+                    .copied()
+                    .map(|value| Row::new(vec![Value::from(value)]))
+                    .collect(),
+            )
+            .unwrap(),
+        }
+    }
+
+    fn merged_ints(result: &ResultSet) -> Vec<i64> {
+        result
+            .rows()
+            .iter()
+            .map(|row| row.get(0).and_then(Value::as_i64).unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn concatenates_in_ascending_shard_order_and_preserves_duplicates() {
+        let merged = merge_scatter_results(
+            vec![result(2, &[20, 21]), result(0, &[7]), result(1, &[7, 10])],
+            ResultLimits::default(),
+        )
+        .unwrap();
+
+        assert_eq!(merged.columns(), columns());
+        assert_eq!(merged_ints(&merged), [7, 7, 10, 20, 21]);
+    }
+
+    #[test]
+    fn accepts_exact_shared_row_and_byte_boundaries() {
+        // Envelope and one-column metadata use 26 bytes. Each integer row uses
+        // an eight-byte row frame plus 17 bytes for its framed value.
+        let merged = merge_scatter_results(
+            vec![result(1, &[2]), result(0, &[1])],
+            ResultLimits::new(2, 76).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(merged_ints(&merged), [1, 2]);
+    }
+
+    #[test]
+    fn one_over_either_shared_limit_returns_no_partial_result() {
+        let row_error = merge_scatter_results(
+            vec![result(0, &[1]), result(1, &[2])],
+            ResultLimits::new(1, 76).unwrap(),
+        )
+        .unwrap_err();
+        assert_eq!(row_error.kind(), EngineErrorKind::LimitExceeded);
+        assert_eq!(
+            row_error.diagnostic(),
+            "query result exceeds the configured row limit"
+        );
+
+        // Each one-row shard result is 51 logical bytes in isolation. Their
+        // 76-byte union must still share a single 75-byte ceiling.
+        let byte_error = merge_scatter_results(
+            vec![result(0, &[1]), result(1, &[2])],
+            ResultLimits::new(2, 75).unwrap(),
+        )
+        .unwrap_err();
+        assert_eq!(byte_error.kind(), EngineErrorKind::LimitExceeded);
+        assert_eq!(
+            byte_error.diagnostic(),
+            "query result exceeds the configured logical byte limit"
+        );
+    }
+
+    #[test]
+    fn rejects_column_name_or_type_mismatches_before_merging_rows() {
+        let mismatched = Routed {
+            shard: 1,
+            value: ResultSet::new(
+                vec![Column::new("other", DataType::Text)],
+                vec![Row::new(vec![Value::from("not merged")])],
+            )
+            .unwrap(),
+        };
+        let error =
+            merge_scatter_results(vec![mismatched, result(0, &[1])], ResultLimits::default())
+                .unwrap_err();
+
+        assert_eq!(error.kind(), EngineErrorKind::Internal);
+        assert_eq!(
+            error.diagnostic(),
+            "scatter query returned column metadata on shard 1 that differs from shard 0"
+        );
+    }
+
+    #[test]
+    fn empty_shard_results_preserve_metadata_and_consume_one_metadata_budget() {
+        let merged = merge_scatter_results(
+            vec![result(2, &[]), result(0, &[]), result(1, &[])],
+            ResultLimits::new(1, 26).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(merged.columns(), columns());
+        assert!(merged.is_empty());
+
+        let error = merge_scatter_results(
+            vec![result(0, &[]), result(1, &[])],
+            ResultLimits::new(1, 25).unwrap(),
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+    }
+
+    #[test]
+    fn no_shards_produces_an_empty_zero_column_result_with_one_envelope() {
+        let merged = merge_scatter_results(Vec::new(), ResultLimits::new(1, 16).unwrap()).unwrap();
+        assert!(merged.columns().is_empty());
+        assert!(merged.is_empty());
+
+        let error =
+            merge_scatter_results(Vec::new(), ResultLimits::new(1, 15).unwrap()).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+    }
+
+    #[test]
+    fn duplicate_shard_results_are_rejected_as_an_internal_failure() {
+        let error = merge_scatter_results(
+            vec![result(0, &[1]), result(0, &[2])],
+            ResultLimits::default(),
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind(), EngineErrorKind::Internal);
+        assert_eq!(
+            error.diagnostic(),
+            "scatter query returned more than one result for shard 0"
+        );
+    }
+
+    #[test]
+    fn checked_accounting_classifies_integer_overflow_as_a_limit_failure() {
+        assert_eq!(
+            account_row(u64::MAX, u64::MAX).unwrap_err().kind(),
+            EngineErrorKind::LimitExceeded
+        );
+        assert_eq!(
+            account_bytes(u64::MAX, 1, u64::MAX).unwrap_err().kind(),
+            EngineErrorKind::LimitExceeded
+        );
+    }
+
+    #[test]
+    fn accounts_every_protocol_neutral_value_variant() {
+        assert_eq!(logical_value_bytes(&Value::Null).unwrap(), 9);
+        assert_eq!(logical_value_bytes(&Value::from(true)).unwrap(), 17);
+        assert_eq!(logical_value_bytes(&Value::from(1_i64)).unwrap(), 17);
+        assert_eq!(logical_value_bytes(&Value::from(1_u64)).unwrap(), 17);
+        assert_eq!(logical_value_bytes(&Value::from(1.0_f64)).unwrap(), 17);
+        assert_eq!(
+            logical_value_bytes(&Value::decimal("1.25").unwrap()).unwrap(),
+            13
+        );
+        assert_eq!(logical_value_bytes(&Value::from("é")).unwrap(), 11);
+        assert_eq!(
+            logical_value_bytes(&Value::InvalidText(vec![0x80])).unwrap(),
+            10
+        );
+        assert_eq!(logical_value_bytes(&Value::from(vec![0, 255])).unwrap(), 11);
+    }
+}

--- a/src/protocol/http.rs
+++ b/src/protocol/http.rs
@@ -15,7 +15,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value as JsonValue, json};
 
 use crate::{
-    core::{DataType, Database, Engine, EngineError, ResultSet, Routed, Statement, Value},
+    core::{
+        DataType, Database, Engine, EngineError, Executed, ResultSet, Routed, Statement, Value,
+    },
     protocol::error::http_error,
 };
 
@@ -69,6 +71,17 @@ struct RoutedSqlRequest {
 }
 
 #[derive(Debug, Deserialize)]
+struct QueryRequest {
+    /// Retained for empty-catalog compatibility. Registered-table reads are
+    /// routed from catalog metadata and SQL predicates instead.
+    #[serde(default)]
+    shard_key: Option<String>,
+    sql: String,
+    #[serde(default)]
+    params: Vec<JsonValue>,
+}
+
+#[derive(Debug, Deserialize)]
 struct BroadcastRequest {
     sql: String,
 }
@@ -81,7 +94,10 @@ struct ExecuteResponse {
 
 #[derive(Debug, Serialize)]
 struct QueryResponse {
-    shard: u16,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    shard: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    shards: Option<Vec<u16>>,
     columns: Vec<QueryColumn>,
     rows: Vec<Vec<JsonValue>>,
 }
@@ -119,7 +135,7 @@ async fn execute(
 
 async fn query(
     State(state): State<HttpState>,
-    Json(request): Json<RoutedSqlRequest>,
+    Json(request): Json<QueryRequest>,
 ) -> Result<Json<QueryResponse>, ApiError> {
     let engine = state.engine;
     let params = request
@@ -128,14 +144,18 @@ async fn query(
         .map(json_to_value)
         .collect::<Vec<_>>();
     let session = engine.session();
-    session.set_routing_key(request.shard_key).await?;
-    let Routed {
-        shard,
+    if engine.catalog().tables().is_empty() {
+        if let Some(shard_key) = request.shard_key {
+            session.set_routing_key(shard_key).await?;
+        }
+    }
+    let Executed {
+        shards,
         value: result,
     } = engine
-        .query(&session, Statement::new(request.sql, params))
+        .query_logical(&session, Statement::new(request.sql, params))
         .await?;
-    let response = result_set_to_query_response(shard, result);
+    let response = result_set_to_query_response(shards, result);
 
     Ok(Json(response))
 }
@@ -189,7 +209,11 @@ fn value_to_json(value: Value) -> JsonValue {
     }
 }
 
-fn result_set_to_query_response(shard: u16, result: ResultSet) -> QueryResponse {
+fn result_set_to_query_response(shards: Vec<u16>, result: ResultSet) -> QueryResponse {
+    let (shard, shards) = match shards.as_slice() {
+        [shard] => (Some(*shard), None),
+        _ => (None, Some(shards)),
+    };
     let (columns, rows) = result.into_parts();
     let columns = columns
         .into_iter()
@@ -205,6 +229,7 @@ fn result_set_to_query_response(shard: u16, result: ResultSet) -> QueryResponse 
 
     QueryResponse {
         shard,
+        shards,
         columns,
         rows,
     }
@@ -284,7 +309,10 @@ mod tests {
 
     use super::*;
     use crate::{
-        core::{Column, DataType, EngineErrorKind, EngineOptions, ResultLimits, Row},
+        core::{
+            Column, DataType, EngineErrorKind, EngineOptions, ResultLimits, Row, ShardKeyMetadata,
+            ShardKeyType, TableDeclaration,
+        },
         sql::{
             MAX_PARSED_SQL_BYTES, SqlDialect, normalize_placeholders, parse, validate_common_subset,
         },
@@ -415,6 +443,107 @@ mod tests {
                     "rows": [["widget-1", "First widget"]]
                 }),
             )
+        );
+    }
+
+    #[tokio::test]
+    async fn registered_sharded_query_needs_no_shard_key_and_returns_all_shards() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut database = Database::open(temp.path(), 2).unwrap();
+        database
+            .broadcast(
+                "CREATE TABLE events (
+                    tenant_key TEXT NOT NULL PRIMARY KEY,
+                    payload TEXT NOT NULL
+                 )",
+            )
+            .unwrap();
+        let logical_database = database.catalog().default_database().id();
+        database
+            .register_tables(vec![
+                TableDeclaration::sharded(
+                    logical_database,
+                    "events",
+                    ShardKeyMetadata::new("tenant_key", ShardKeyType::Text).unwrap(),
+                )
+                .unwrap(),
+            ])
+            .unwrap();
+
+        let tenant_keys = [0_u16, 1_u16].map(|expected_shard| {
+            (0_u64..)
+                .map(|candidate| format!("tenant-{expected_shard}-{candidate}"))
+                .find(|candidate| database.shard_for_key(candidate.as_bytes()) == expected_shard)
+                .unwrap()
+        });
+
+        for (shard, tenant_key, payload) in [
+            (0_u16, tenant_keys[0].as_str(), "zero payload"),
+            (1_u16, tenant_keys[1].as_str(), "one payload"),
+        ] {
+            let inserted = database
+                .execute_routed(
+                    tenant_key,
+                    "INSERT INTO events (tenant_key, payload) VALUES (?1, ?2)",
+                    &[Value::from(tenant_key), Value::from(payload)],
+                )
+                .unwrap();
+            assert_eq!(inserted.shard, shard);
+            assert_eq!(inserted.value, 1);
+        }
+
+        let application = engine_router(Arc::new(database));
+        assert_eq!(
+            request_json(
+                &application,
+                Method::POST,
+                "/v1/query",
+                Some(json!({
+                    "sql": "SELECT tenant_key, payload FROM events"
+                })),
+            )
+            .await,
+            (
+                StatusCode::OK,
+                json!({
+                    "shards": [0, 1],
+                    "columns": [
+                        {"name": "tenant_key", "data_type": "unknown"},
+                        {"name": "payload", "data_type": "unknown"}
+                    ],
+                    "rows": [
+                        [tenant_keys[0], "zero payload"],
+                        [tenant_keys[1], "one payload"]
+                    ]
+                })
+            )
+        );
+        assert_eq!(
+            request_json(
+                &application,
+                Method::POST,
+                "/v1/query",
+                Some(json!({
+                    "shard_key": tenant_keys[0],
+                    "sql": "SELECT tenant_key, payload FROM events"
+                })),
+            )
+            .await,
+            (
+                StatusCode::OK,
+                json!({
+                    "shards": [0, 1],
+                    "columns": [
+                        {"name": "tenant_key", "data_type": "unknown"},
+                        {"name": "payload", "data_type": "unknown"}
+                    ],
+                    "rows": [
+                        [tenant_keys[0], "zero payload"],
+                        [tenant_keys[1], "one payload"]
+                    ]
+                })
+            ),
+            "registered logical reads must not be narrowed by a legacy shard key"
         );
     }
 
@@ -1110,6 +1239,20 @@ mod tests {
     }
 
     #[test]
+    fn only_reads_may_omit_an_explicit_shard_key() {
+        assert!(
+            serde_json::from_value::<QueryRequest>(json!({"sql": "SELECT payload FROM events"}))
+                .is_ok()
+        );
+        assert!(
+            serde_json::from_value::<RoutedSqlRequest>(json!({
+                "sql": "INSERT INTO events (tenant_key, payload) VALUES (?1, ?2)"
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
     fn typed_values_encode_to_explicit_legacy_json_shapes() {
         assert_eq!(
             value_to_json(Value::from(u64::MAX)),
@@ -1179,7 +1322,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            serde_json::to_value(result_set_to_query_response(3, result)).unwrap(),
+            serde_json::to_value(result_set_to_query_response(vec![3], result)).unwrap(),
             json!({
                 "shard": 3,
                 "columns": [
@@ -1201,14 +1344,35 @@ mod tests {
     fn result_encoding_keeps_valid_zero_column_shapes() {
         let empty = ResultSet::new(Vec::new(), Vec::new()).unwrap();
         assert_eq!(
-            serde_json::to_value(result_set_to_query_response(1, empty)).unwrap(),
+            serde_json::to_value(result_set_to_query_response(vec![1], empty)).unwrap(),
             json!({"shard": 1, "columns": [], "rows": []})
         );
 
         let empty_row = ResultSet::new(Vec::new(), vec![Row::new(Vec::new())]).unwrap();
         assert_eq!(
-            serde_json::to_value(result_set_to_query_response(2, empty_row)).unwrap(),
+            serde_json::to_value(result_set_to_query_response(vec![2], empty_row)).unwrap(),
             json!({"shard": 2, "columns": [], "rows": [[]]})
+        );
+    }
+
+    #[test]
+    fn scatter_result_encoding_reports_every_visited_shard() {
+        let result = ResultSet::new(
+            vec![Column::new("payload", DataType::Text)],
+            vec![
+                Row::new(vec![Value::from("from shard zero")]),
+                Row::new(vec![Value::from("from shard one")]),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(
+            serde_json::to_value(result_set_to_query_response(vec![0, 1], result)).unwrap(),
+            json!({
+                "shards": [0, 1],
+                "columns": [{"name": "payload", "data_type": "text"}],
+                "rows": [["from shard zero"], ["from shard one"]]
+            })
         );
     }
 }

--- a/src/protocol/http/admin.rs
+++ b/src/protocol/http/admin.rs
@@ -20,7 +20,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value as JsonValue, json};
 
 use super::HttpState;
-use crate::core::{EngineError, EngineErrorKind, RequestContext, ResultSet, Statement, Value};
+use crate::core::{
+    Column, EngineError, EngineErrorKind, RequestContext, ResultLimits, ResultSet, Routed, Row,
+    Statement, TablePlacement, Value, merge_scatter_results,
+};
 
 const INDEX_HTML: &str = include_str!("admin/index.html");
 const STYLES_CSS: &str = include_str!("admin/styles.css");
@@ -35,7 +38,7 @@ const MAX_SESSIONS: usize = 128;
 const DEFAULT_PAGE_LIMIT: u16 = 50;
 const MAX_PAGE_LIMIT: u16 = 200;
 const MAX_PAGE_OFFSET: u64 = 1_000_000;
-const MAX_COUNT_CONCURRENCY: usize = 8;
+const MAX_INSPECTION_CONCURRENCY: usize = 8;
 const MAX_JAVASCRIPT_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
 const TABLE_DISCOVERY_SQL: &str = "SELECT name FROM pragma_table_list \
      WHERE schema = 'main' AND type = 'table' \
@@ -248,33 +251,51 @@ async fn session() -> Response {
     )
 }
 
-#[derive(Deserialize)]
-struct OverviewQuery {
-    #[serde(default)]
-    shard: Option<u16>,
-}
-
 #[derive(Serialize)]
 struct OverviewResponse {
+    scope: &'static str,
     shard_count: u16,
-    selected_shard: u16,
+    visited_shards: Vec<u16>,
     tables: Vec<String>,
 }
 
-async fn overview(State(state): State<HttpState>, Query(query): Query<OverviewQuery>) -> Response {
-    let shard = query.shard.unwrap_or(0);
-    let session = state.engine.session();
-    let result = state
-        .engine
-        .inspect_shard(&session, shard, Statement::new(TABLE_DISCOVERY_SQL, vec![]))
-        .await;
+async fn overview(State(state): State<HttpState>) -> Response {
+    let catalog = state.engine.catalog();
+    if !catalog.tables().is_empty() {
+        let default_database = catalog.default_database().id();
+        let tables = catalog
+            .tables()
+            .iter()
+            .filter(|table| {
+                table.database_id() == default_database
+                    && !matches!(table.placement(), TablePlacement::Catalog)
+            })
+            .map(|table| table.name().to_owned())
+            .collect();
+        return admin_json(
+            StatusCode::OK,
+            &OverviewResponse {
+                scope: "logical_default_database",
+                shard_count: state.engine.shard_count(),
+                visited_shards: vec![],
+                tables,
+            },
+        );
+    }
 
-    match result.and_then(table_names) {
+    let session = state.engine.session();
+    match state
+        .engine
+        .inspect_shard(&session, 0, Statement::new(TABLE_DISCOVERY_SQL, vec![]))
+        .await
+        .and_then(table_names)
+    {
         Ok(tables) => admin_json(
             StatusCode::OK,
             &OverviewResponse {
+                scope: "empty_catalog_shard_zero_fallback",
                 shard_count: state.engine.shard_count(),
-                selected_shard: shard,
+                visited_shards: vec![0],
                 tables,
             },
         ),
@@ -291,7 +312,7 @@ struct CountQuery {
 struct CountResponse {
     table: String,
     scope: &'static str,
-    shard_count: u16,
+    visited_shards: Vec<u16>,
     total_rows: JsonValue,
 }
 
@@ -300,53 +321,144 @@ async fn count(State(state): State<HttpState>, Query(query): Query<CountQuery>) 
         return invalid_argument("admin table name is not browseable");
     }
 
-    let shard_count = state.engine.shard_count();
-    match count_table_rows(&state.engine, &query.table).await {
-        Ok(total_rows) => admin_json(
+    match inspect_logical_table(&state.engine, &query.table).await {
+        Ok(inspection) => admin_json(
             StatusCode::OK,
             &CountResponse {
                 table: query.table,
-                scope: "all_physical_shards",
-                shard_count,
-                total_rows: admin_value_to_json(Value::UInt64(total_rows)),
+                scope: inspection.scope,
+                visited_shards: inspection.visited_shards(),
+                total_rows: admin_value_to_json(Value::UInt64(inspection.total_rows)),
             },
         ),
         Err(error) => admin_engine_error(error),
     }
 }
 
-async fn count_table_rows(engine: &crate::core::Engine, table: &str) -> Result<u64, EngineError> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LogicalTableScope {
+    Sharded,
+    Global,
+    EmptyCatalog,
+}
+
+impl LogicalTableScope {
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Sharded => "logical_sharded_table",
+            Self::Global => "logical_global_table",
+            Self::EmptyCatalog => "empty_catalog_all_physical_shards",
+        }
+    }
+}
+
+struct TableTargets {
+    scope: LogicalTableScope,
+    shards: Vec<u16>,
+}
+
+struct ShardTableInspection {
+    shard: u16,
+    rows: u64,
+    columns: Vec<Column>,
+}
+
+struct LogicalTableInspection {
+    scope: &'static str,
+    schema_generation: u64,
+    context: RequestContext,
+    result_limits: ResultLimits,
+    shards: Vec<ShardTableInspection>,
+    total_rows: u64,
+}
+
+impl LogicalTableInspection {
+    fn visited_shards(&self) -> Vec<u16> {
+        self.shards.iter().map(|shard| shard.shard).collect()
+    }
+
+    fn columns(&self) -> &[Column] {
+        self.shards
+            .first()
+            .map_or(&[], |inspection| inspection.columns.as_slice())
+    }
+}
+
+fn logical_table_targets(
+    engine: &crate::core::Engine,
+    table: &str,
+) -> Result<TableTargets, EngineError> {
+    let catalog = engine.catalog();
+    if catalog.tables().is_empty() {
+        return Ok(TableTargets {
+            scope: LogicalTableScope::EmptyCatalog,
+            shards: (0..engine.shard_count()).collect(),
+        });
+    }
+
+    let default_database = catalog.default_database().id();
+    let Some(metadata) = catalog
+        .tables()
+        .iter()
+        .find(|metadata| metadata.database_id() == default_database && metadata.name() == table)
+    else {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            "admin table is not registered in the default logical database",
+        ));
+    };
+    match metadata.placement() {
+        TablePlacement::Sharded(_) => Ok(TableTargets {
+            scope: LogicalTableScope::Sharded,
+            shards: (0..engine.shard_count()).collect(),
+        }),
+        TablePlacement::Global => Ok(TableTargets {
+            scope: LogicalTableScope::Global,
+            shards: vec![0],
+        }),
+        TablePlacement::Catalog => Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            "admin catalog tables are not browseable",
+        )),
+    }
+}
+
+async fn inspect_logical_table(
+    engine: &crate::core::Engine,
+    table: &str,
+) -> Result<LogicalTableInspection, EngineError> {
+    let targets = logical_table_targets(engine, table)?;
     let status_session = engine.session();
     let status = engine.status(&status_session).await?;
     let context = match status.request_timeout() {
         Some(timeout) => RequestContext::new().with_timeout(timeout)?,
         None => RequestContext::new(),
     };
+    let result_limits = ResultLimits::new(status.max_result_rows(), status.max_result_bytes())?;
     let schema_generation = engine.catalog().schema_generation();
-    let counts = stream::iter(0..engine.shard_count())
+    let inspections = stream::iter(targets.shards.iter().copied())
         .map(|shard| {
             let engine = engine.clone();
             let table = table.to_owned();
             let context = context.clone();
-            async move { count_table_rows_on_shard(&engine, shard, &table, context).await }
+            async move { inspect_table_on_shard(&engine, shard, &table, context).await }
         })
-        .buffer_unordered(MAX_COUNT_CONCURRENCY)
+        .buffer_unordered(MAX_INSPECTION_CONCURRENCY)
         .try_collect::<Vec<_>>()
         .await;
-    finish_row_counts(
+    ensure_schema_generation(schema_generation, engine.catalog().schema_generation())?;
+    let mut shards = inspections?;
+    shards.sort_unstable_by_key(|inspection| inspection.shard);
+    ensure_matching_columns(&shards)?;
+    let total_rows = sum_row_counts(shards.iter().map(|inspection| inspection.rows))?;
+    Ok(LogicalTableInspection {
+        scope: targets.scope.name(),
         schema_generation,
-        engine.catalog().schema_generation(),
-        counts,
-    )
-}
-
-fn finish_row_counts(
-    expected_generation: u64,
-    observed_generation: u64,
-    counts: Result<Vec<u64>, EngineError>,
-) -> Result<u64, EngineError> {
-    ensure_schema_generation(expected_generation, observed_generation)?;
-    sum_row_counts(counts?)
+        context,
+        result_limits,
+        shards,
+        total_rows,
+    })
 }
 
 fn sum_row_counts(counts: impl IntoIterator<Item = u64>) -> Result<u64, EngineError> {
@@ -354,7 +466,7 @@ fn sum_row_counts(counts: impl IntoIterator<Item = u64>) -> Result<u64, EngineEr
         total.checked_add(count).ok_or_else(|| {
             EngineError::new(
                 EngineErrorKind::NumericOutOfRange,
-                "admin all-shard row count exceeds the supported unsigned range",
+                "admin logical row count exceeds the supported unsigned range",
             )
         })
     })
@@ -366,19 +478,30 @@ fn ensure_schema_generation(expected: u64, observed: u64) -> Result<(), EngineEr
     } else {
         Err(EngineError::new(
             EngineErrorKind::Busy,
-            "admin all-shard row count crossed a completed schema migration",
+            "admin logical table inspection crossed a completed schema migration",
         ))
     }
 }
 
-async fn count_table_rows_on_shard(
+async fn inspect_table_on_shard(
     engine: &crate::core::Engine,
     shard: u16,
     table: &str,
     context: RequestContext,
-) -> Result<u64, EngineError> {
+) -> Result<ShardTableInspection, EngineError> {
     let session = engine.session();
     ensure_browseable_table_with_context(engine, &session, shard, table, context.clone()).await?;
+    let shape = engine
+        .inspect_shard_with_context(
+            &session,
+            shard,
+            Statement::new(
+                format!("SELECT * FROM {} LIMIT 0", quote_identifier(table)),
+                vec![],
+            ),
+            context.clone(),
+        )
+        .await?;
     let result = engine
         .inspect_shard_with_context(
             &session,
@@ -393,16 +516,31 @@ async fn count_table_rows_on_shard(
             context,
         )
         .await?;
-    row_count(result)
+    Ok(ShardTableInspection {
+        shard,
+        rows: row_count(result)?,
+        columns: shape.into_parts().0,
+    })
 }
 
-async fn ensure_browseable_table(
-    engine: &crate::core::Engine,
-    session: &crate::core::Session,
-    shard: u16,
-    table: &str,
-) -> Result<(), EngineError> {
-    ensure_browseable_table_with_context(engine, session, shard, table, RequestContext::new()).await
+fn ensure_matching_columns(shards: &[ShardTableInspection]) -> Result<(), EngineError> {
+    let Some(expected) = shards.first().map(|shard| shard.columns.as_slice()) else {
+        return Err(EngineError::new(
+            EngineErrorKind::Internal,
+            "admin logical table has no physical targets",
+        ));
+    };
+    if shards
+        .iter()
+        .all(|shard| shard.columns.as_slice() == expected)
+    {
+        Ok(())
+    } else {
+        Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "admin logical table has incompatible physical schemas",
+        ))
+    }
 }
 
 async fn ensure_browseable_table_with_context(
@@ -456,7 +594,6 @@ fn invalid_count_result() -> EngineError {
 
 #[derive(Deserialize)]
 struct RowsQuery {
-    shard: u16,
     table: String,
     #[serde(default)]
     limit: Option<u16>,
@@ -466,8 +603,10 @@ struct RowsQuery {
 
 #[derive(Serialize)]
 struct RowsResponse {
-    shard: u16,
     table: String,
+    scope: &'static str,
+    visited_shards: Vec<u16>,
+    ordering: &'static str,
     limit: u16,
     offset: u64,
     has_more: bool,
@@ -488,63 +627,156 @@ async fn rows(State(state): State<HttpState>, Query(query): Query<RowsQuery>) ->
         return invalid_argument("admin table name is not browseable");
     }
 
-    let session = state.engine.session();
-    if let Err(error) =
-        ensure_browseable_table(&state.engine, &session, query.shard, &query.table).await
-    {
-        return admin_engine_error(error);
-    }
-
-    let quoted_table = quote_identifier(&query.table);
-    let result = state
-        .engine
-        .inspect_shard(
-            &session,
-            query.shard,
-            Statement::new(
-                format!(
-                    "SELECT browse.* FROM {quoted_table} AS browse \
-                     WHERE EXISTS (\
-                         SELECT 1 FROM pragma_table_list \
-                         WHERE schema = 'main' AND type = 'table' \
-                           AND name = ?1 COLLATE BINARY \
-                           AND lower(name) NOT GLOB 'sqlite_*' \
-                           AND lower(name) != 'briskdb' \
-                           AND lower(name) NOT GLOB 'briskdb_*'\
-                     ) \
-                     LIMIT ?2 OFFSET ?3"
-                ),
-                vec![
-                    Value::Text(query.table.clone()),
-                    Value::Int64(i64::from(limit) + 1),
-                    Value::Int64(offset as i64),
-                ],
-            ),
-        )
-        .await;
-
-    match result {
-        Ok(result) => page_response(query.shard, query.table, limit, offset, result),
+    match logical_table_page(&state.engine, &query.table, limit, offset).await {
+        Ok(page) => page_response(query.table, page, limit, offset),
         Err(error) => admin_engine_error(error),
     }
 }
 
-fn page_response(
-    shard: u16,
-    table: String,
+struct LogicalTablePage {
+    scope: &'static str,
+    visited_shards: Vec<u16>,
+    columns: Vec<Column>,
+    rows: Vec<Row>,
+}
+
+async fn logical_table_page(
+    engine: &crate::core::Engine,
+    table: &str,
     limit: u16,
     offset: u64,
-    result: ResultSet,
-) -> Response {
-    let (columns, rows) = result.into_parts();
-    let columns = columns
+) -> Result<LogicalTablePage, EngineError> {
+    let inspection = inspect_logical_table(engine, table).await?;
+    let page_slices = page_slices(&inspection.shards, offset, u64::from(limit) + 1);
+    let quoted_table = quote_identifier(table);
+    let order_by = deterministic_order_by(inspection.columns());
+    let page_results = stream::iter(page_slices)
+        .map(|slice| {
+            let engine = engine.clone();
+            let table = table.to_owned();
+            let quoted_table = quoted_table.clone();
+            let order_by = order_by.clone();
+            let context = inspection.context.clone();
+            async move {
+                let session = engine.session();
+                let result = engine
+                    .inspect_shard_with_context(
+                        &session,
+                        slice.shard,
+                        Statement::new(
+                            format!(
+                                "SELECT browse.* FROM {quoted_table} AS browse \
+                                 WHERE EXISTS (\
+                                     SELECT 1 FROM pragma_table_list \
+                                     WHERE schema = 'main' AND type = 'table' \
+                                       AND name = ?1 COLLATE BINARY \
+                                       AND lower(name) NOT GLOB 'sqlite_*' \
+                                       AND lower(name) != 'briskdb' \
+                                       AND lower(name) NOT GLOB 'briskdb_*'\
+                                 ) {order_by} LIMIT ?2 OFFSET ?3"
+                            ),
+                            vec![
+                                Value::Text(table),
+                                Value::Int64(slice.limit as i64),
+                                Value::Int64(slice.offset as i64),
+                            ],
+                        ),
+                        context,
+                    )
+                    .await?;
+                Ok::<_, EngineError>(Routed {
+                    shard: slice.shard,
+                    value: result,
+                })
+            }
+        })
+        .buffer_unordered(MAX_INSPECTION_CONCURRENCY)
+        .try_collect::<Vec<_>>()
+        .await;
+    ensure_schema_generation(
+        inspection.schema_generation,
+        engine.catalog().schema_generation(),
+    )?;
+    let mut page_results = page_results?;
+    page_results.sort_unstable_by_key(|result| result.shard);
+    let rows = if page_results.is_empty() {
+        Vec::new()
+    } else {
+        let merged = merge_scatter_results(page_results, inspection.result_limits)?;
+        if merged.columns() != inspection.columns() {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "admin logical page observed incompatible physical columns",
+            ));
+        }
+        merged.into_parts().1
+    };
+    Ok(LogicalTablePage {
+        scope: inspection.scope,
+        visited_shards: inspection.visited_shards(),
+        columns: inspection.columns().to_vec(),
+        rows,
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PageSlice {
+    shard: u16,
+    offset: u64,
+    limit: u64,
+}
+
+fn page_slices(shards: &[ShardTableInspection], offset: u64, limit: u64) -> Vec<PageSlice> {
+    let mut remaining_offset = offset;
+    let mut remaining_limit = limit;
+    let mut slices = Vec::new();
+    for shard in shards {
+        if remaining_limit == 0 {
+            break;
+        }
+        if remaining_offset >= shard.rows {
+            remaining_offset -= shard.rows;
+            continue;
+        }
+        let available = shard.rows - remaining_offset;
+        let take = available.min(remaining_limit);
+        slices.push(PageSlice {
+            shard: shard.shard,
+            offset: remaining_offset,
+            limit: take,
+        });
+        remaining_limit -= take;
+        remaining_offset = 0;
+    }
+    slices
+}
+
+fn deterministic_order_by(columns: &[Column]) -> String {
+    if columns.is_empty() {
+        String::new()
+    } else {
+        format!(
+            "ORDER BY {}",
+            columns
+                .iter()
+                .map(|column| format!("browse.{}", quote_identifier(&column.name)))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    }
+}
+
+fn page_response(table: String, page: LogicalTablePage, limit: u16, offset: u64) -> Response {
+    let columns = page
+        .columns
         .into_iter()
         .map(|column| super::QueryColumn {
             name: column.name,
             data_type: super::data_type_name(column.data_type),
         })
         .collect();
-    let mut rows = rows
+    let mut rows = page
+        .rows
         .into_iter()
         .map(|row| {
             row.into_values()
@@ -561,8 +793,10 @@ fn page_response(
     admin_json(
         StatusCode::OK,
         &RowsResponse {
-            shard,
             table,
+            scope: page.scope,
+            visited_shards: page.visited_shards,
+            ordering: "shard_major_then_all_columns",
             limit,
             offset,
             has_more,
@@ -759,7 +993,9 @@ mod tests {
     use tower::ServiceExt;
 
     use super::*;
-    use crate::core::{Column, DataType, Database, Row};
+    use crate::core::{
+        Column, DataType, Database, Row, ShardKeyMetadata, ShardKeyType, TableDeclaration,
+    };
 
     fn token(character: char) -> String {
         std::iter::repeat_n(character, 64).collect()
@@ -967,7 +1203,7 @@ mod tests {
         for id in [
             "login-form",
             "browser-view",
-            "shard-select",
+            "scope-kicker",
             "table-list",
             "record-count",
             "status",
@@ -979,6 +1215,9 @@ mod tests {
             assert!(INDEX_HTML.contains(&format!("id=\"{id}\"")));
             assert!(APP_JS.contains(&format!("#{id}")));
         }
+        assert!(!INDEX_HTML.contains("shard-select"));
+        assert!(!APP_JS.contains("shard-select"));
+        assert!(!APP_JS.contains("selected_shard"));
         assert!(!APP_JS.contains("innerHTML"));
         assert!(APP_JS.contains("(empty table name)"));
         assert!(APP_JS.contains("(whitespace-only table name)"));
@@ -1065,12 +1304,11 @@ mod tests {
         let (_temp, app) = application();
         for uri in [
             "/admin/api/session",
-            "/admin/api/overview?shard=0",
+            "/admin/api/overview",
             "/admin/api/count?table=widgets",
             "/admin/api/count",
-            "/admin/api/rows?shard=0&table=widgets",
-            "/admin/api/overview?shard=not-a-number",
-            "/admin/api/rows?shard=not-a-number",
+            "/admin/api/rows?table=widgets",
+            "/admin/api/rows?table=widgets&shard=not-a-number",
         ] {
             let response = request(&app, Method::GET, uri, None, None).await;
             assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
@@ -1081,10 +1319,9 @@ mod tests {
         let cookie = set_cookie.to_str().unwrap().split(';').next().unwrap();
         for uri in [
             "/admin/api/count",
-            "/admin/api/rows?shard=0&table=widgets&limit=0",
-            "/admin/api/rows?shard=0&table=widgets&limit=201",
-            "/admin/api/rows?shard=0&table=widgets&offset=1000001",
-            "/admin/api/rows?shard=2&table=widgets",
+            "/admin/api/rows?table=widgets&limit=0",
+            "/admin/api/rows?table=widgets&limit=201",
+            "/admin/api/rows?table=widgets&offset=1000001",
         ] {
             let response = request(&app, Method::GET, uri, Some(cookie), None).await;
             assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{uri}");
@@ -1104,7 +1341,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn authenticated_browser_discovers_and_pages_only_the_selected_shard() {
+    async fn authenticated_browser_discovers_and_pages_the_logical_table_across_files() {
         let temp = tempfile::tempdir().unwrap();
         let database = Arc::new(Database::open(temp.path(), 2).unwrap());
         database
@@ -1117,6 +1354,7 @@ mod tests {
                  ); \
                  CREATE TABLE \"\" (value TEXT); \
                  CREATE TABLE \" \" (value TEXT); \
+                 CREATE TABLE dupes (value TEXT); \
                  CREATE TABLE \"odd\"\"table\" (value TEXT); \
                  CREATE VIEW widget_view AS SELECT id FROM widgets;",
             )
@@ -1138,6 +1376,13 @@ mod tests {
                     )
                     .unwrap();
             }
+            database
+                .execute(
+                    &routing_key,
+                    "INSERT INTO dupes (value) VALUES ('same')",
+                    &[],
+                )
+                .unwrap();
         }
         let app = super::super::router(database);
         let set_cookie = login_cookie(&app).await;
@@ -1158,9 +1403,10 @@ mod tests {
             (
                 StatusCode::OK,
                 json!({
+                    "scope": "empty_catalog_shard_zero_fallback",
                     "shard_count": 2,
-                    "selected_shard": 1,
-                    "tables": ["", " ", "odd\"table", "widgets"]
+                    "visited_shards": [0],
+                    "tables": ["", " ", "dupes", "odd\"table", "widgets"]
                 })
             )
         );
@@ -1181,8 +1427,8 @@ mod tests {
                 StatusCode::OK,
                 json!({
                     "table": "widgets",
-                    "scope": "all_physical_shards",
-                    "shard_count": 2,
+                    "scope": "empty_catalog_all_physical_shards",
+                    "visited_shards": [0, 1],
                     "total_rows": 5
                 })
             )
@@ -1204,18 +1450,31 @@ mod tests {
                 StatusCode::OK,
                 json!({
                     "table": "odd\"table",
-                    "scope": "all_physical_shards",
-                    "shard_count": 2,
+                    "scope": "empty_catalog_all_physical_shards",
+                    "visited_shards": [0, 1],
                     "total_rows": 0
                 })
             )
         );
 
+        let (_, duplicates) = response_json(
+            request(
+                &app,
+                Method::GET,
+                "/admin/api/rows?table=dupes&limit=50&offset=0",
+                Some(cookie),
+                None,
+            )
+            .await,
+        )
+        .await;
+        assert_eq!(duplicates["rows"], json!([["same"], ["same"]]));
+
         let (status, first_page) = response_json(
             request(
                 &app,
                 Method::GET,
-                "/admin/api/rows?shard=1&table=widgets&limit=2&offset=0",
+                "/admin/api/rows?table=widgets&limit=2&offset=0",
                 Some(cookie),
                 None,
             )
@@ -1223,8 +1482,10 @@ mod tests {
         )
         .await;
         assert_eq!(status, StatusCode::OK);
-        assert_eq!(first_page["shard"], 1);
         assert_eq!(first_page["table"], "widgets");
+        assert_eq!(first_page["scope"], "empty_catalog_all_physical_shards");
+        assert_eq!(first_page["visited_shards"], json!([0, 1]));
+        assert_eq!(first_page["ordering"], "shard_major_then_all_columns");
         assert_eq!(first_page["limit"], 2);
         assert_eq!(first_page["offset"], 0);
         assert_eq!(first_page["has_more"], true);
@@ -1240,8 +1501,8 @@ mod tests {
         assert_eq!(
             first_page["rows"],
             json!([
-                [1, "shard-1-row-1", [1, 1], null],
-                [2, "shard-1-row-2", [1, 2], null]
+                [1, "shard-0-row-1", [0, 1], null],
+                [2, "shard-0-row-2", [0, 2], null]
             ])
         );
 
@@ -1250,7 +1511,7 @@ mod tests {
                 request(
                     &app,
                     Method::GET,
-                    "/admin/api/rows?shard=1&table=widgets&limit=2&offset=2",
+                    "/admin/api/rows?table=widgets&limit=2&offset=2&shard=0",
                     Some(cookie),
                     None,
                 )
@@ -1260,65 +1521,87 @@ mod tests {
             (
                 StatusCode::OK,
                 json!({
-                    "shard": 1,
                     "table": "widgets",
+                    "scope": "empty_catalog_all_physical_shards",
+                    "visited_shards": [0, 1],
+                    "ordering": "shard_major_then_all_columns",
                     "limit": 2,
                     "offset": 2,
-                    "has_more": false,
+                    "has_more": true,
                     "columns": [
                         {"name":"id","data_type":"unknown"},
                         {"name":"label","data_type":"unknown"},
                         {"name":"payload","data_type":"unknown"},
                         {"name":"note","data_type":"unknown"}
                     ],
-                    "rows": [[3, "shard-1-row-3", [1, 3], null]]
+                    "rows": [
+                        [1, "shard-1-row-1", [1, 1], null],
+                        [2, "shard-1-row-2", [1, 2], null]
+                    ]
                 })
             )
         );
 
-        let odd_table = "/admin/api/rows?shard=0&table=odd%22table&limit=50&offset=0";
+        assert_eq!(
+            response_json(
+                request(
+                    &app,
+                    Method::GET,
+                    "/admin/api/rows?table=widgets&limit=2&offset=4",
+                    Some(cookie),
+                    None,
+                )
+                .await
+            )
+            .await
+            .1["rows"],
+            json!([[3, "shard-1-row-3", [1, 3], null]])
+        );
+
+        let odd_table = "/admin/api/rows?table=odd%22table&limit=50&offset=0";
         let (status, empty) =
             response_json(request(&app, Method::GET, odd_table, Some(cookie), None).await).await;
         assert_eq!(status, StatusCode::OK);
         assert_eq!(empty["rows"], json!([]));
         assert_eq!(empty["has_more"], false);
 
-        let empty_name = "/admin/api/rows?shard=0&table=&limit=50&offset=0";
+        let empty_name = "/admin/api/rows?table=&limit=50&offset=0";
         let (status, empty) =
             response_json(request(&app, Method::GET, empty_name, Some(cookie), None).await).await;
         assert_eq!(status, StatusCode::OK);
         assert_eq!(empty["table"], "");
         assert_eq!(empty["rows"], json!([]));
 
-        let whitespace_name = "/admin/api/rows?shard=0&table=%20&limit=50&offset=0";
+        let whitespace_name = "/admin/api/rows?table=%20&limit=50&offset=0";
         let (status, whitespace) =
             response_json(request(&app, Method::GET, whitespace_name, Some(cookie), None).await)
                 .await;
         assert_eq!(status, StatusCode::OK);
         assert_eq!(whitespace["table"], " ");
 
-        let shard_zero = request(
+        let ignored_shard_zero = request(
             &app,
             Method::GET,
             "/admin/api/rows?shard=0&table=widgets&limit=1&offset=0",
             Some(cookie),
             None,
         );
-        let shard_one = request(
+        let ignored_shard_one = request(
             &app,
             Method::GET,
             "/admin/api/rows?shard=1&table=widgets&limit=1&offset=0",
             Some(cookie),
             None,
         );
-        let (shard_zero, shard_one) = tokio::join!(shard_zero, shard_one);
-        let (_, shard_zero) = response_json(shard_zero).await;
-        let (_, shard_one) = response_json(shard_one).await;
-        assert_eq!(shard_zero["rows"][0][1], "shard-0-row-1");
-        assert_eq!(shard_one["rows"][0][1], "shard-1-row-1");
+        let (ignored_shard_zero, ignored_shard_one) =
+            tokio::join!(ignored_shard_zero, ignored_shard_one);
+        let (_, ignored_shard_zero) = response_json(ignored_shard_zero).await;
+        let (_, ignored_shard_one) = response_json(ignored_shard_one).await;
+        assert_eq!(ignored_shard_zero, ignored_shard_one);
+        assert_eq!(ignored_shard_zero["rows"][0][1], "shard-0-row-1");
 
         for table in ["briskdb_shard_metadata", "widget_view", "guessed_table"] {
-            let uri = format!("/admin/api/rows?shard=0&table={table}");
+            let uri = format!("/admin/api/rows?table={table}");
             let response = request(&app, Method::GET, &uri, Some(cookie), None).await;
             assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{table}");
             let uri = format!("/admin/api/count?table={table}");
@@ -1328,7 +1611,7 @@ mod tests {
         let recovered = request(
             &app,
             Method::GET,
-            "/admin/api/rows?shard=0&table=widgets&limit=1&offset=0",
+            "/admin/api/rows?table=widgets&limit=1&offset=0",
             Some(cookie),
             None,
         )
@@ -1337,7 +1620,176 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn all_shard_count_returns_no_partial_total_and_recovers_after_one_shard_failure() {
+    async fn populated_catalog_drives_sharded_and_global_browser_targets() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut database = Database::open(temp.path(), 2).unwrap();
+        database
+            .broadcast(
+                "CREATE TABLE events (\
+                    tenant_key TEXT NOT NULL PRIMARY KEY, \
+                    payload TEXT NOT NULL\
+                 ); \
+                 CREATE TABLE countries (\
+                    code TEXT NOT NULL PRIMARY KEY, \
+                    label TEXT NOT NULL\
+                 );",
+            )
+            .unwrap();
+        let logical_database = database.catalog().default_database().id();
+        database
+            .register_tables(vec![
+                TableDeclaration::sharded(
+                    logical_database,
+                    "events",
+                    ShardKeyMetadata::new("tenant_key", ShardKeyType::Text).unwrap(),
+                )
+                .unwrap(),
+                TableDeclaration::global(logical_database, "countries").unwrap(),
+                TableDeclaration::catalog(logical_database, "manifest_records").unwrap(),
+            ])
+            .unwrap();
+
+        let tenant_keys = [0_u16, 1_u16].map(|shard| routing_key_for_shard(&database, shard));
+        for (shard, tenant_key) in tenant_keys.iter().enumerate() {
+            let inserted = database
+                .execute_routed(
+                    tenant_key,
+                    "INSERT INTO events (tenant_key, payload) VALUES (?1, 'same payload')",
+                    &[Value::Text(tenant_key.clone())],
+                )
+                .unwrap();
+            assert_eq!(inserted.shard, shard as u16);
+        }
+
+        for (shard, label) in [(0_u16, "canonical"), (1_u16, "noncanonical copy")] {
+            rusqlite::Connection::open(temp.path().join(format!("shards/{shard:04}.sqlite")))
+                .unwrap()
+                .execute(
+                    "INSERT INTO countries (code, label) VALUES ('US', ?1)",
+                    [label],
+                )
+                .unwrap();
+        }
+
+        let app = super::super::router(Arc::new(database));
+        let set_cookie = login_cookie(&app).await;
+        let cookie = set_cookie.to_str().unwrap().split(';').next().unwrap();
+
+        assert_eq!(
+            response_json(
+                request(
+                    &app,
+                    Method::GET,
+                    "/admin/api/overview?shard=1",
+                    Some(cookie),
+                    None,
+                )
+                .await
+            )
+            .await,
+            (
+                StatusCode::OK,
+                json!({
+                    "scope": "logical_default_database",
+                    "shard_count": 2,
+                    "visited_shards": [],
+                    "tables": ["countries", "events"]
+                })
+            )
+        );
+
+        let (_, sharded) = response_json(
+            request(
+                &app,
+                Method::GET,
+                "/admin/api/rows?table=events&limit=50&offset=0&shard=1",
+                Some(cookie),
+                None,
+            )
+            .await,
+        )
+        .await;
+        assert_eq!(sharded["scope"], "logical_sharded_table");
+        assert_eq!(sharded["visited_shards"], json!([0, 1]));
+        assert_eq!(sharded["rows"].as_array().unwrap().len(), 2);
+        assert_eq!(sharded["rows"][0][1], "same payload");
+        assert_eq!(sharded["rows"][1][1], "same payload");
+
+        assert_eq!(
+            response_json(
+                request(
+                    &app,
+                    Method::GET,
+                    "/admin/api/count?table=events",
+                    Some(cookie),
+                    None,
+                )
+                .await
+            )
+            .await,
+            (
+                StatusCode::OK,
+                json!({
+                    "table": "events",
+                    "scope": "logical_sharded_table",
+                    "visited_shards": [0, 1],
+                    "total_rows": 2
+                })
+            )
+        );
+
+        let (_, global) = response_json(
+            request(
+                &app,
+                Method::GET,
+                "/admin/api/rows?table=countries&limit=50&offset=0",
+                Some(cookie),
+                None,
+            )
+            .await,
+        )
+        .await;
+        assert_eq!(global["scope"], "logical_global_table");
+        assert_eq!(global["visited_shards"], json!([0]));
+        assert_eq!(global["rows"], json!([["US", "canonical"]]));
+        assert_eq!(
+            response_json(
+                request(
+                    &app,
+                    Method::GET,
+                    "/admin/api/count?table=countries&shard=1",
+                    Some(cookie),
+                    None,
+                )
+                .await
+            )
+            .await,
+            (
+                StatusCode::OK,
+                json!({
+                    "table": "countries",
+                    "scope": "logical_global_table",
+                    "visited_shards": [0],
+                    "total_rows": 1
+                })
+            )
+        );
+
+        for endpoint in ["rows", "count"] {
+            let response = request(
+                &app,
+                Method::GET,
+                &format!("/admin/api/{endpoint}?table=manifest_records"),
+                Some(cookie),
+                None,
+            )
+            .await;
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        }
+    }
+
+    #[tokio::test]
+    async fn logical_count_and_rows_return_no_partial_data_after_one_file_fails() {
         let temp = tempfile::tempdir().unwrap();
         let database = Arc::new(Database::open(temp.path(), 2).unwrap());
         database
@@ -1378,6 +1830,19 @@ mod tests {
         assert_eq!(failed["code"], "invalid_argument");
         assert!(failed.get("total_rows").is_none());
 
+        let failed = request(
+            &app,
+            Method::GET,
+            "/admin/api/rows?table=counted&limit=50&offset=0",
+            Some(cookie),
+            None,
+        )
+        .await;
+        assert_eq!(failed.status(), StatusCode::BAD_REQUEST);
+        let failed = body_json(failed).await;
+        assert_eq!(failed["code"], "invalid_argument");
+        assert!(failed.get("rows").is_none());
+
         assert_eq!(
             response_json(
                 request(
@@ -1394,8 +1859,8 @@ mod tests {
                 StatusCode::OK,
                 json!({
                     "table": "control",
-                    "scope": "all_physical_shards",
-                    "shard_count": 2,
+                    "scope": "empty_catalog_all_physical_shards",
+                    "visited_shards": [0, 1],
                     "total_rows": 0
                 })
             )
@@ -1506,12 +1971,17 @@ mod tests {
             ],
         )
         .unwrap();
+        let (columns, rows) = result.into_parts();
         let body = body_json(page_response(
-            0,
             "widgets".to_owned(),
+            LogicalTablePage {
+                scope: "logical_sharded_table",
+                visited_shards: vec![0, 1],
+                columns,
+                rows,
+            },
             1,
             MAX_PAGE_OFFSET,
-            result,
         ))
         .await;
         assert_eq!(body["rows"], json!([[1]]));
@@ -1533,7 +2003,19 @@ mod tests {
             ])],
         )
         .unwrap();
-        let body = body_json(page_response(0, "numbers".to_owned(), 50, 0, result)).await;
+        let (columns, rows) = result.into_parts();
+        let body = body_json(page_response(
+            "numbers".to_owned(),
+            LogicalTablePage {
+                scope: "logical_sharded_table",
+                visited_shards: vec![0, 1],
+                columns,
+                rows,
+            },
+            50,
+            0,
+        ))
+        .await;
 
         assert_eq!(
             body["rows"],
@@ -1587,7 +2069,7 @@ mod tests {
     }
 
     #[test]
-    fn all_shard_count_validates_shapes_overflow_generation_and_exact_json() {
+    fn logical_count_and_page_helpers_validate_shapes_bounds_and_exact_json() {
         let result =
             |rows| ResultSet::new(vec![Column::new("row_count", DataType::Unknown)], rows).unwrap();
         assert_eq!(
@@ -1623,33 +2105,57 @@ mod tests {
         let changed = ensure_schema_generation(7, 8).unwrap_err();
         assert_eq!(changed.kind(), EngineErrorKind::Busy);
         assert!(changed.is_retryable());
-        let shard_error = || {
-            EngineError::new(
-                EngineErrorKind::InvalidArgument,
-                "one shard no longer has the table",
-            )
-        };
-        assert_eq!(
-            finish_row_counts(7, 7, Err(shard_error()))
-                .unwrap_err()
-                .kind(),
-            EngineErrorKind::InvalidArgument
-        );
-        let changed_wins = finish_row_counts(7, 8, Err(shard_error())).unwrap_err();
-        assert_eq!(changed_wins.kind(), EngineErrorKind::Busy);
-        assert!(changed_wins.is_retryable());
 
         let body = serde_json::to_value(CountResponse {
             table: "events".to_owned(),
-            scope: "all_physical_shards",
-            shard_count: 64,
+            scope: "logical_sharded_table",
+            visited_shards: (0..64).collect(),
             total_rows: admin_value_to_json(Value::UInt64(MAX_JAVASCRIPT_SAFE_INTEGER + 1)),
         })
         .unwrap();
-        assert_eq!(body["scope"], "all_physical_shards");
+        assert_eq!(body["scope"], "logical_sharded_table");
+        assert_eq!(body["visited_shards"].as_array().unwrap().len(), 64);
         assert_eq!(
             body["total_rows"],
             json!({"$briskdb_type":"uint64","value":"9007199254740992"})
+        );
+
+        let columns = vec![Column::new("value", DataType::Unknown)];
+        let shards = [2_u64, 3, 0, 4]
+            .into_iter()
+            .enumerate()
+            .map(|(shard, rows)| ShardTableInspection {
+                shard: shard as u16,
+                rows,
+                columns: columns.clone(),
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            page_slices(&shards, 1, 5),
+            vec![
+                PageSlice {
+                    shard: 0,
+                    offset: 1,
+                    limit: 1,
+                },
+                PageSlice {
+                    shard: 1,
+                    offset: 0,
+                    limit: 3,
+                },
+                PageSlice {
+                    shard: 3,
+                    offset: 0,
+                    limit: 1,
+                },
+            ]
+        );
+        assert_eq!(
+            deterministic_order_by(&[
+                Column::new("a", DataType::Unknown),
+                Column::new("odd\"name", DataType::Unknown),
+            ]),
+            "ORDER BY browse.\"a\", browse.\"odd\"\"name\""
         );
     }
 

--- a/src/protocol/http/admin/app.js
+++ b/src/protocol/http/admin/app.js
@@ -5,8 +5,6 @@
   const authEpoch = logic.createAuthEpoch();
 
   const state = {
-    shard: 0,
-    shardCount: 0,
     table: null,
     limit: 50,
     offset: 0,
@@ -24,8 +22,7 @@
     username: document.querySelector("#username"),
     password: document.querySelector("#password"),
     logout: document.querySelector("#logout-button"),
-    shard: document.querySelector("#shard-select"),
-    shardKicker: document.querySelector("#shard-kicker"),
+    scopeKicker: document.querySelector("#scope-kicker"),
     tableList: document.querySelector("#table-list"),
     tableCount: document.querySelector("#table-count"),
     tableTitle: document.querySelector("#table-title"),
@@ -121,17 +118,6 @@
     clearPage("No table selected", "Choose a table from the sidebar to browse a bounded, read-only page.");
   }
 
-  function renderShardOptions(count, selected) {
-    elements.shard.replaceChildren();
-    for (let shard = 0; shard < count; shard += 1) {
-      const option = document.createElement("option");
-      option.value = String(shard);
-      option.textContent = `Shard ${shard}`;
-      option.selected = shard === selected;
-      elements.shard.append(option);
-    }
-  }
-
   function displayTableName(table) {
     if (table.length === 0) return "(empty table name)";
     if (table.trim().length === 0) return "(whitespace-only table name)";
@@ -144,9 +130,9 @@
     if (tables.length === 0) {
       const note = document.createElement("p");
       note.className = "no-tables";
-      note.textContent = "No application tables on this shard.";
+      note.textContent = "No application tables in the default logical database.";
       elements.tableList.append(note);
-      resetTable("This physical shard has no browseable application tables.");
+      resetTable("The default logical database has no browseable application tables.");
       return;
     }
     for (const table of tables) {
@@ -162,25 +148,21 @@
     resetTable();
   }
 
-  async function loadOverview(shard) {
+  async function loadOverview() {
     const requestId = ++state.overviewRequest;
     state.rowsRequest += 1;
-    state.shard = shard;
     state.table = null;
     state.offset = 0;
     elements.tableList.replaceChildren();
     elements.tableCount.textContent = "…";
-    elements.shardKicker.textContent = `Physical shard ${shard}`;
-    resetTable(`Loading application tables from physical shard ${shard}.`);
-    setStatus(`Loading tables from physical shard ${shard}…`);
+    elements.scopeKicker.textContent = "Logical database · default";
+    resetTable("Loading application tables from the default logical database.");
+    setStatus("Loading logical tables…");
     try {
-      const overview = await api(`/admin/api/overview?shard=${encodeURIComponent(shard)}`);
+      const overview = await api("/admin/api/overview");
       if (requestId !== state.overviewRequest) return;
-      state.shardCount = overview.shard_count;
-      state.shard = overview.selected_shard;
-      renderShardOptions(overview.shard_count, overview.selected_shard);
       renderTables(overview.tables);
-      setStatus(`${overview.tables.length} application table${overview.tables.length === 1 ? "" : "s"} on physical shard ${overview.selected_shard}.`);
+      setStatus(`${overview.tables.length} logical application table${overview.tables.length === 1 ? "" : "s"}.`);
     } catch (error) {
       if (requestId !== state.overviewRequest) return;
       if (error.message !== "authentication_required") {
@@ -199,7 +181,7 @@
       item.setAttribute("aria-pressed", String(active));
     }
     elements.tableTitle.textContent = displayTableName(table);
-    elements.tableSubtitle.textContent = `Read-only rows from physical shard ${state.shard}.`;
+    elements.tableSubtitle.textContent = "Read-only logical rows across the table's metadata-selected files.";
     await Promise.all([loadRows(), loadCount()]);
   }
 
@@ -239,7 +221,7 @@
     }
 
     state.hasMore = page.has_more;
-    elements.tableCaption.textContent = `${displayTableName(page.table)} rows from physical shard ${page.shard}`;
+    elements.tableCaption.textContent = `${displayTableName(page.table)} logical rows`;
     elements.empty.classList.toggle("hidden", page.rows.length !== 0);
     elements.tableWrap.classList.toggle("hidden", page.rows.length === 0);
     if (page.rows.length === 0) {
@@ -255,12 +237,11 @@
     if (state.table === null) return;
     const requestId = ++state.rowsRequest;
     const displayTable = displayTableName(state.table);
-    clearPage("Loading rows…", `Reading ${displayTable} from physical shard ${state.shard}.`, "Loading…");
-    setStatus(`Loading ${displayTable} from physical shard ${state.shard}…`);
+    clearPage("Loading rows…", `Reading logical rows from ${displayTable}.`, "Loading…");
+    setStatus(`Loading logical rows from ${displayTable}…`);
     elements.previous.disabled = true;
     elements.next.disabled = true;
     const query = new URLSearchParams({
-      shard: String(state.shard),
       table: state.table,
       limit: String(state.limit),
       offset: String(state.offset),
@@ -269,7 +250,7 @@
       const page = await api(`/admin/api/rows?${query.toString()}`);
       if (requestId !== state.rowsRequest) return;
       renderPage(page);
-      setStatus(`${page.rows.length} row${page.rows.length === 1 ? "" : "s"} loaded from physical shard ${page.shard}.`);
+      setStatus(`${page.rows.length} logical row${page.rows.length === 1 ? "" : "s"} loaded from ${page.visited_shards.length} file${page.visited_shards.length === 1 ? "" : "s"}.`);
     } catch (error) {
       if (requestId !== state.rowsRequest) return;
       if (error.message !== "authentication_required") {
@@ -283,20 +264,23 @@
     if (state.table === null) return;
     const requestedTable = state.table;
     const requestId = ++state.countRequest;
-    setRecordCount("Calculating total records across all physical shards…", false, true);
+    setRecordCount("Calculating the exact logical record total…", false, true);
     const query = new URLSearchParams({ table: requestedTable });
     try {
       const count = await api(`/admin/api/count?${query.toString()}`);
       if (!logic.acceptsTableResponse(requestId, state.countRequest, requestedTable, state.table)) return;
-      if (count.table !== requestedTable || count.scope !== "all_physical_shards") {
-        throw new Error("Invalid all-shard row count response.");
+      if (
+        count.table !== requestedTable
+        || (!count.scope.startsWith("logical_") && !count.scope.startsWith("empty_catalog_"))
+      ) {
+        throw new Error("Invalid logical row count response.");
       }
-      const presentation = logic.rowCountPresentation(count.total_rows, count.shard_count);
+      const presentation = logic.rowCountPresentation(count.total_rows, count.visited_shards);
       setRecordCount(presentation.text, false, false, presentation.title);
     } catch (error) {
       if (!logic.acceptsTableResponse(requestId, state.countRequest, requestedTable, state.table)) return;
       if (error.message !== "authentication_required") {
-        setRecordCount("Total across all physical shards unavailable", true, false, error.message);
+        setRecordCount("Logical total unavailable", true, false, error.message);
       }
     }
   }
@@ -315,7 +299,7 @@
       });
       if (!authEpoch.isCurrent(loginAuthEpoch)) return;
       showBrowser();
-      await loadOverview(0);
+      await loadOverview();
     } catch (error) {
       if (authEpoch.isCurrent(loginAuthEpoch) && error.message !== "authentication_required") {
         elements.loginError.textContent = error.message;
@@ -340,7 +324,6 @@
     }
   });
 
-  elements.shard.addEventListener("change", () => loadOverview(Number(elements.shard.value)));
   elements.pageSize.addEventListener("change", () => {
     state.limit = Number(elements.pageSize.value);
     state.offset = 0;
@@ -362,7 +345,7 @@
     .then(() => {
       if (!authEpoch.isCurrent(sessionAuthEpoch)) return undefined;
       showBrowser();
-      return loadOverview(0);
+      return loadOverview();
     })
     .catch((error) => {
       if (!authEpoch.isCurrent(sessionAuthEpoch)) return;

--- a/src/protocol/http/admin/index.html
+++ b/src/protocol/http/admin/index.html
@@ -18,7 +18,7 @@
       <div class="brand-mark" aria-hidden="true">B</div>
       <p class="eyebrow">BriskDB</p>
       <h1 id="login-title">Open the data browser</h1>
-      <p class="muted">Inspect tables and rows on one physical shard at a time.</p>
+      <p class="muted">Inspect logical tables and rows across the files that store them.</p>
       <form id="login-form">
         <label for="username">Username</label>
         <input id="username" name="username" autocomplete="username" required>
@@ -48,9 +48,9 @@
     <div class="workspace">
       <aside class="sidebar" aria-label="Database navigation">
         <div class="sidebar-section">
-          <label for="shard-select" class="section-label">Physical shard</label>
-          <select id="shard-select"></select>
-          <p class="sidebar-note">Each table list and row page comes from this shard only.</p>
+          <p class="section-label">Logical database</p>
+          <strong class="database-name">default</strong>
+          <p class="sidebar-note">Sharded tables combine each row-owning file. Global tables are read once.</p>
         </div>
         <div class="sidebar-section tables-section">
           <div class="section-heading">
@@ -64,7 +64,7 @@
       <main class="content">
         <div class="content-header">
           <div>
-            <p id="shard-kicker" class="eyebrow">Physical shard 0</p>
+            <p id="scope-kicker" class="eyebrow">Logical database · default</p>
             <h1 id="table-title">Choose a table</h1>
             <p id="table-subtitle" class="muted">Select an application table to inspect its rows.</p>
             <p id="record-count" class="record-count" role="status" aria-live="polite" aria-atomic="true" aria-busy="false">No total loaded</p>
@@ -90,7 +90,7 @@
           </div>
           <div id="table-wrap" class="table-wrap hidden">
             <table>
-              <caption id="table-caption">Rows from the selected physical shard</caption>
+              <caption id="table-caption">Logical table rows</caption>
               <thead id="data-head"></thead>
               <tbody id="data-body"></tbody>
             </table>

--- a/src/protocol/http/admin/logic.js
+++ b/src/protocol/http/admin/logic.js
@@ -42,15 +42,24 @@
     return null;
   }
 
-  function rowCountPresentation(value, shardCount) {
+  function validVisitedShards(shards) {
+    return Array.isArray(shards)
+      && shards.length > 0
+      && shards.every((shard, index) => Number.isInteger(shard)
+        && shard >= 0
+        && (index === 0 || shard > shards[index - 1]));
+  }
+
+  function rowCountPresentation(value, visitedShards) {
     const exact = exactRowCount(value);
-    if (exact === null || !Number.isInteger(shardCount) || shardCount < 1) {
-      throw new Error("Invalid all-shard row count response.");
+    if (exact === null || !validVisitedShards(visitedShards)) {
+      throw new Error("Invalid logical row count response.");
     }
     const formatted = exact.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+    const files = visitedShards.length;
     return {
-      text: `${formatted} total record${exact === "1" ? "" : "s"} across ${shardCount} physical shard${shardCount === 1 ? "" : "s"}`,
-      title: "Exact sum of physical table rows. Replicated records are counted once per shard.",
+      text: `${formatted} logical record${exact === "1" ? "" : "s"} across ${files} storage file${files === 1 ? "" : "s"}`,
+      title: `Exact total from visited shard${files === 1 ? "" : "s"}: ${visitedShards.join(", ")}. Global tables are read once.`,
     };
   }
 
@@ -59,10 +68,10 @@
   }
 
   function pageSummary(page) {
-    if (page.rows.length === 0) return `No rows on physical shard ${page.shard}`;
+    if (page.rows.length === 0) return "No logical rows";
     const first = page.offset + 1;
     const last = page.offset + page.rows.length;
-    return `Showing rows ${first}–${last} on physical shard ${page.shard}`;
+    return `Showing logical rows ${first}–${last}`;
   }
 
   function createAuthEpoch() {
@@ -92,5 +101,6 @@
     pageSummary,
     rowCountPresentation,
     taggedInteger,
+    validVisitedShards,
   });
 })();

--- a/src/protocol/http/admin/styles.css
+++ b/src/protocol/http/admin/styles.css
@@ -148,6 +148,7 @@ select { min-height: 2.55rem; padding: 0 2.2rem 0 0.75rem; }
 .sidebar { padding: 1.5rem 1rem; border-right: 1px solid var(--border); background: rgba(8, 20, 18, 0.56); }
 .sidebar-section { padding: 0 0.35rem 1.5rem; }
 .sidebar-note { margin: 0.75rem 0 0; color: var(--muted); font-size: 0.75rem; line-height: 1.5; }
+.database-name { display: block; color: var(--text); font-size: 0.95rem; }
 .tables-section { border-top: 1px solid var(--border); padding-top: 1.4rem; }
 .section-heading { display: flex; align-items: center; justify-content: space-between; }
 .count-badge { min-width: 1.5rem; padding: 0.15rem 0.4rem; border-radius: 99px; color: var(--muted); background: var(--panel-raised); text-align: center; font-size: 0.7rem; }

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -14,6 +14,7 @@ mod dml;
 mod inference;
 mod normalizer;
 mod parser;
+mod scatter;
 mod subset;
 mod translator;
 
@@ -33,6 +34,7 @@ pub use parser::{
     MAX_PARSED_SQL_BYTES, MAX_PARSED_SQL_STATEMENTS, ParsedSql, SQL_PARSE_RECURSION_LIMIT,
     SqlDialect, parse,
 };
+pub(crate) use scatter::validate_scatter_safe;
 pub use subset::{CommonSql, MAX_COMMON_SQL_EXPRESSION_DEPTH, validate_common_subset};
 pub use translator::{SqlTranslationMode, TranslatedSql, translate_sql};
 
@@ -40,6 +42,7 @@ use rusqlite::{
     Connection, Statement as SqlStatement, params_from_iter,
     types::{Value as SqlValue, ValueRef},
 };
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use crate::{
     core::{
@@ -54,6 +57,97 @@ const TYPE_TAG_BYTES: u64 = 1;
 const LENGTH_BYTES: u64 = 8;
 const ROW_FRAME_BYTES: u64 = 8;
 const FIXED_VALUE_PAYLOAD_BYTES: u64 = 8;
+
+/// One result budget shared by every physical query in a scatter operation.
+///
+/// Clones refer to the same counters. Column metadata is charged once and must
+/// match exactly on every shard; rows and logical bytes are reserved atomically
+/// before SQLite values are copied into an owned [`ResultSet`].
+#[derive(Debug, Clone)]
+pub(crate) struct ScatterResultBudget {
+    limits: ResultLimits,
+    state: Arc<Mutex<ScatterResultBudgetState>>,
+}
+
+#[derive(Debug, Default)]
+struct ScatterResultBudgetState {
+    columns: Option<Vec<Column>>,
+    rows: u64,
+    logical_bytes: u64,
+}
+
+impl ScatterResultBudget {
+    pub(crate) fn new(limits: ResultLimits) -> Self {
+        Self {
+            limits,
+            state: Arc::new(Mutex::new(ScatterResultBudgetState::default())),
+        }
+    }
+
+    fn register_columns(&self, columns: &[Column]) -> EngineResult<()> {
+        let mut state = self.lock_state();
+        if let Some(expected) = &state.columns {
+            if expected != columns {
+                return Err(EngineError::new(
+                    EngineErrorKind::Internal,
+                    "scatter query returned inconsistent column metadata",
+                ));
+            }
+            return Ok(());
+        }
+
+        // Calculate against locals so a limit failure cannot partially commit
+        // metadata accounting to the shared operation.
+        let mut logical_bytes = account_bytes(
+            state.logical_bytes,
+            RESULT_ENVELOPE_BYTES,
+            self.limits.max_bytes(),
+        )?;
+        for column in columns {
+            logical_bytes = account_bytes(logical_bytes, TYPE_TAG_BYTES, self.limits.max_bytes())?;
+            logical_bytes = account_bytes(logical_bytes, LENGTH_BYTES, self.limits.max_bytes())?;
+            logical_bytes = account_bytes(
+                logical_bytes,
+                usize_to_u64(column.name.len())?,
+                self.limits.max_bytes(),
+            )?;
+        }
+
+        state.logical_bytes = logical_bytes;
+        state.columns = Some(columns.to_vec());
+        Ok(())
+    }
+
+    fn reserve_sqlite_row(&self, row: &rusqlite::Row<'_>, column_count: usize) -> EngineResult<()> {
+        let mut additional_bytes = ROW_FRAME_BYTES;
+        for index in 0..column_count {
+            let value = row.get_ref(index).map_err(sqlite_error::statement)?;
+            additional_bytes = additional_bytes
+                .checked_add(logical_value_bytes(value)?)
+                .ok_or_else(byte_limit_exceeded)?;
+        }
+
+        let mut state = self.lock_state();
+        let rows = account_row(state.rows, self.limits.max_rows())?;
+        let logical_bytes = account_bytes(
+            state.logical_bytes,
+            additional_bytes,
+            self.limits.max_bytes(),
+        )?;
+
+        // Commit both counters together only after both limits pass.
+        state.rows = rows;
+        state.logical_bytes = logical_bytes;
+        Ok(())
+    }
+
+    fn lock_state(&self) -> MutexGuard<'_, ScatterResultBudgetState> {
+        // A panic while another owner held the mutex must not turn every later
+        // request into a second panic. The accounting methods themselves only
+        // commit complete transitions, so recovering the guarded state is safe.
+        self.state.lock().unwrap_or_else(|error| error.into_inner())
+    }
+}
 
 /// Owned metadata collected while SQLite transiently prepares a statement.
 ///
@@ -226,6 +320,33 @@ pub(crate) fn query_with_limits(
     materialize_rows(&mut statement, metadata.columns, params, limits)
 }
 
+/// Execute one physical shard query against a budget shared by the complete
+/// scatter operation.
+///
+/// This deliberately parallels [`query_with_limits`] instead of changing its
+/// accounting contract: ordinary single-shard queries remain independently
+/// bounded, while scatter callers explicitly opt into operation-wide limits.
+pub(crate) fn query_with_scatter_budget(
+    connection: &Connection,
+    statement: &str,
+    params: &[Value],
+    budget: &ScatterResultBudget,
+) -> EngineResult<ResultSet> {
+    let params = sqlite_parameters(params)?;
+    let mut statement = connection
+        .prepare(statement)
+        .map_err(sqlite_error::statement)?;
+    if !statement.readonly() {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidQuery,
+            "query statements must be read-only",
+        ));
+    }
+
+    let metadata = statement_metadata(&statement);
+    materialize_rows_with_scatter_budget(&mut statement, metadata.columns, params, budget)
+}
+
 fn materialize_rows(
     statement: &mut SqlStatement<'_>,
     columns: Vec<Column>,
@@ -269,6 +390,42 @@ fn materialize_rows(
         rows.push(Row::new(values));
         logical_bytes = row_bytes;
     }
+    ResultSet::new(columns, rows).map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::Internal,
+            "SQLite returned rows that do not match their column metadata",
+            error,
+        )
+    })
+}
+
+fn materialize_rows_with_scatter_budget(
+    statement: &mut SqlStatement<'_>,
+    columns: Vec<Column>,
+    params: Vec<SqlValue>,
+    budget: &ScatterResultBudget,
+) -> EngineResult<ResultSet> {
+    budget.register_columns(&columns)?;
+
+    let mut sqlite_rows = statement
+        .query(params_from_iter(params))
+        .map_err(sqlite_error::statement)?;
+    let mut rows = Vec::new();
+
+    while let Some(sqlite_row) = sqlite_rows.next().map_err(sqlite_error::statement)? {
+        // Reservation examines every borrowed value and atomically commits the
+        // full row charge before any payload is cloned into owned memory.
+        budget.reserve_sqlite_row(sqlite_row, columns.len())?;
+
+        let mut values = Vec::with_capacity(columns.len());
+        for index in 0..columns.len() {
+            values.push(sql_to_value(
+                sqlite_row.get_ref(index).map_err(sqlite_error::statement)?,
+            ));
+        }
+        rows.push(Row::new(values));
+    }
+
     ResultSet::new(columns, rows).map_err(|error| {
         EngineError::from_source(
             EngineErrorKind::Internal,
@@ -918,6 +1075,136 @@ mod tests {
                 .get(0),
             Some(&Value::from(3_i64))
         );
+    }
+
+    #[test]
+    fn shared_scatter_budget_charges_metadata_once_across_queries() {
+        let first = Connection::open_in_memory().unwrap();
+        let second = Connection::open_in_memory().unwrap();
+        // One shared metadata envelope is 26 bytes and each integer row is 25.
+        let budget = ScatterResultBudget::new(ResultLimits::new(2, 76).unwrap());
+
+        let first_result =
+            query_with_scatter_budget(&first, "SELECT 1 AS v", &[], &budget).unwrap();
+        let second_result =
+            query_with_scatter_budget(&second, "SELECT 2 AS v", &[], &budget).unwrap();
+
+        assert_eq!(first_result.rows(), [Row::new(vec![Value::from(1_i64)])]);
+        assert_eq!(second_result.rows(), [Row::new(vec![Value::from(2_i64)])]);
+        let state = budget.lock_state();
+        assert_eq!(state.rows, 2);
+        assert_eq!(state.logical_bytes, 76);
+    }
+
+    #[test]
+    fn shared_scatter_budget_enforces_combined_row_limit_one_over() {
+        let first = Connection::open_in_memory().unwrap();
+        let second = Connection::open_in_memory().unwrap();
+        let budget = ScatterResultBudget::new(ResultLimits::new(1, 76).unwrap());
+
+        query_with_scatter_budget(&first, "SELECT 1 AS v", &[], &budget).unwrap();
+        let error = query_with_scatter_budget(&second, "SELECT 2 AS v", &[], &budget).unwrap_err();
+
+        assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+        assert_eq!(
+            error.to_string(),
+            "query result exceeds the configured row limit"
+        );
+        let state = budget.lock_state();
+        assert_eq!(state.rows, 1);
+        assert_eq!(state.logical_bytes, 51);
+    }
+
+    #[test]
+    fn shared_scatter_budget_enforces_combined_byte_limit_one_over_atomically() {
+        let first = Connection::open_in_memory().unwrap();
+        let second = Connection::open_in_memory().unwrap();
+        let budget = ScatterResultBudget::new(ResultLimits::new(2, 75).unwrap());
+
+        query_with_scatter_budget(&first, "SELECT 1 AS v", &[], &budget).unwrap();
+        let error = query_with_scatter_budget(&second, "SELECT 2 AS v", &[], &budget).unwrap_err();
+
+        assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+        assert_eq!(
+            error.to_string(),
+            "query result exceeds the configured logical byte limit"
+        );
+        // The failed row reserves neither of its counters.
+        let state = budget.lock_state();
+        assert_eq!(state.rows, 1);
+        assert_eq!(state.logical_bytes, 51);
+    }
+
+    #[test]
+    fn shared_scatter_budget_rejects_metadata_mismatch_without_consuming_budget() {
+        let first = Connection::open_in_memory().unwrap();
+        let second = Connection::open_in_memory().unwrap();
+        let budget = ScatterResultBudget::new(ResultLimits::new(1, 51).unwrap());
+
+        query_with_scatter_budget(&first, "SELECT 1 AS v WHERE 0", &[], &budget).unwrap();
+        let error =
+            query_with_scatter_budget(&second, "SELECT 1 AS other", &[], &budget).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Internal);
+        assert_eq!(
+            error.to_string(),
+            "scatter query returned inconsistent column metadata"
+        );
+
+        let result = query_with_scatter_budget(&second, "SELECT 1 AS v", &[], &budget).unwrap();
+        assert_eq!(result.rows(), [Row::new(vec![Value::from(1_i64)])]);
+    }
+
+    #[test]
+    fn cloned_scatter_budgets_serialize_concurrent_row_reservations() {
+        use std::sync::Barrier;
+
+        let budget = ScatterResultBudget::new(ResultLimits::new(1, 51).unwrap());
+        let barrier = Arc::new(Barrier::new(3));
+        let mut workers = Vec::new();
+        for value in [1_i64, 2_i64] {
+            let worker_budget = budget.clone();
+            let worker_barrier = Arc::clone(&barrier);
+            workers.push(std::thread::spawn(move || {
+                let connection = Connection::open_in_memory().unwrap();
+                worker_barrier.wait();
+                query_with_scatter_budget(
+                    &connection,
+                    "SELECT ?1 AS v",
+                    &[Value::from(value)],
+                    &worker_budget,
+                )
+            }));
+        }
+
+        barrier.wait();
+        let results: Vec<_> = workers
+            .into_iter()
+            .map(|worker| worker.join().unwrap())
+            .collect();
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        assert_eq!(
+            results
+                .iter()
+                .filter_map(|result| result.as_ref().err())
+                .map(EngineError::kind)
+                .collect::<Vec<_>>(),
+            [EngineErrorKind::LimitExceeded]
+        );
+    }
+
+    #[test]
+    fn shared_scatter_budget_recovers_a_poisoned_accounting_lock() {
+        let budget = ScatterResultBudget::new(ResultLimits::new(1, 51).unwrap());
+        let poisoner = budget.clone();
+        let poisoned = std::panic::catch_unwind(move || {
+            let _guard = poisoner.state.lock().unwrap();
+            panic!("poison shared result accounting for this test");
+        });
+        assert!(poisoned.is_err());
+
+        let connection = Connection::open_in_memory().unwrap();
+        let result = query_with_scatter_budget(&connection, "SELECT 1 AS v", &[], &budget).unwrap();
+        assert_eq!(result.rows(), [Row::new(vec![Value::from(1_i64)])]);
     }
 
     #[test]

--- a/src/sql/scatter.rs
+++ b/src/sql/scatter.rs
@@ -1,0 +1,493 @@
+//! Structural safety checks for unchanged scatter reads.
+//!
+//! Executing the same statement independently on every physical shard and
+//! concatenating the rows is equivalent to logical `UNION ALL` only when the
+//! statement transforms each input row independently. This module deliberately
+//! recognizes a narrow shape instead of trying to repair global semantics after
+//! execution. A later coordinator can add dedicated merge plans for ordering,
+//! aggregation, limits, joins, and other rejected forms.
+
+use sqlparser::ast::{
+    Distinct, Expr, GroupByExpr, Select, SelectFlavor, SelectItem, SetExpr,
+    Statement as AstStatement, TableFactor, TableWithJoins,
+};
+
+use super::TranslatedSql;
+use crate::core::{EngineError, EngineErrorKind, EngineResult};
+
+/// Validate that one translated read can run unchanged on every shard and have
+/// its result rows concatenated with logical `UNION ALL` semantics.
+///
+/// The accepted shape is intentionally limited to a single base-table
+/// `SELECT` with row-local projections and an optional row-local filter. The
+/// caller must still decide that the referenced table is sharded, select the
+/// physical shards, enforce deadlines and result limits, and verify schema
+/// compatibility. This function grants only structural scatter safety.
+pub(crate) fn validate_scatter_safe(sql: &TranslatedSql) -> EngineResult<()> {
+    validate_statement_batch(sql.normalized_sql().common().statements())
+}
+
+fn validate_statement_batch(statements: &[AstStatement]) -> EngineResult<()> {
+    let [statement] = statements else {
+        return Err(scatter_unsupported(
+            "exactly one top-level statement is required",
+        ));
+    };
+    let AstStatement::Query(query) = statement else {
+        return Err(scatter_unsupported("only SELECT statements are supported"));
+    };
+
+    if query.with.is_some() {
+        return Err(scatter_unsupported(
+            "common table expressions and subqueries require a merge plan",
+        ));
+    }
+    if query.order_by.is_some() {
+        return Err(scatter_unsupported("ORDER BY requires a global merge plan"));
+    }
+    if query.limit_clause.is_some() || query.fetch.is_some() {
+        return Err(scatter_unsupported(
+            "LIMIT, OFFSET, and FETCH require a global merge plan",
+        ));
+    }
+    if !query.locks.is_empty()
+        || query.for_clause.is_some()
+        || query.settings.is_some()
+        || query.format_clause.is_some()
+        || !query.pipe_operators.is_empty()
+    {
+        return Err(scatter_unsupported(
+            "query suffix clauses are not row-local",
+        ));
+    }
+
+    let SetExpr::Select(select) = query.body.as_ref() else {
+        return Err(scatter_unsupported(
+            "set operations, nested queries, and VALUES require a merge plan",
+        ));
+    };
+    validate_select(select)
+}
+
+fn validate_select(select: &Select) -> EngineResult<()> {
+    if matches!(&select.distinct, Some(Distinct::Distinct | Distinct::On(_))) {
+        return Err(scatter_unsupported(
+            "DISTINCT requires global duplicate elimination",
+        ));
+    }
+    if select.top.is_some() {
+        return Err(scatter_unsupported("TOP requires a global merge plan"));
+    }
+    if !select.optimizer_hints.is_empty()
+        || select.select_modifiers.is_some()
+        || select.top_before_distinct
+        || select.exclude.is_some()
+        || select.into.is_some()
+        || !select.lateral_views.is_empty()
+        || select.prewhere.is_some()
+        || !select.connect_by.is_empty()
+        || !select.cluster_by.is_empty()
+        || !select.distribute_by.is_empty()
+        || !select.sort_by.is_empty()
+        || !select.named_window.is_empty()
+        || select.qualify.is_some()
+        || select.window_before_qualify
+        || select.value_table_mode.is_some()
+        || !matches!(select.flavor, SelectFlavor::Standard)
+    {
+        return Err(scatter_unsupported("SELECT modifiers are not row-local"));
+    }
+    if select.projection.is_empty() {
+        return Err(scatter_unsupported("a projection is required"));
+    }
+
+    let [table] = select.from.as_slice() else {
+        return Err(scatter_unsupported(
+            "exactly one base table is required for a scatter read",
+        ));
+    };
+    validate_base_table(table)?;
+
+    match &select.group_by {
+        GroupByExpr::Expressions(expressions, modifiers)
+            if expressions.is_empty() && modifiers.is_empty() => {}
+        GroupByExpr::Expressions(_, _) | GroupByExpr::All(_) => {
+            return Err(scatter_unsupported("GROUP BY requires global aggregation"));
+        }
+    }
+    if select.having.is_some() {
+        return Err(scatter_unsupported("HAVING requires global aggregation"));
+    }
+
+    for item in &select.projection {
+        match item {
+            SelectItem::UnnamedExpr(expression)
+            | SelectItem::ExprWithAlias {
+                expr: expression, ..
+            } => validate_row_local_expression(expression)?,
+            SelectItem::Wildcard(_) | SelectItem::QualifiedWildcard(_, _) => {}
+            SelectItem::ExprWithAliases { .. } => {
+                return Err(scatter_unsupported(
+                    "projection alias lists are not row-local",
+                ));
+            }
+        }
+    }
+    if let Some(selection) = &select.selection {
+        validate_row_local_expression(selection)?;
+    }
+    Ok(())
+}
+
+fn validate_base_table(table: &TableWithJoins) -> EngineResult<()> {
+    if !table.joins.is_empty() {
+        return Err(scatter_unsupported("joins require a distributed join plan"));
+    }
+    let TableFactor::Table {
+        alias,
+        args,
+        with_hints,
+        version,
+        with_ordinality,
+        partitions,
+        json_path,
+        sample,
+        index_hints,
+        ..
+    } = &table.relation
+    else {
+        return Err(scatter_unsupported(
+            "derived tables, subqueries, and table functions are not row-local",
+        ));
+    };
+    if args.is_some()
+        || !with_hints.is_empty()
+        || version.is_some()
+        || *with_ordinality
+        || !partitions.is_empty()
+        || json_path.is_some()
+        || sample.is_some()
+        || !index_hints.is_empty()
+    {
+        return Err(scatter_unsupported(
+            "table reference options are not supported by unchanged scatter",
+        ));
+    }
+    if alias
+        .as_ref()
+        .is_some_and(|alias| !alias.columns.is_empty() || alias.at.is_some())
+    {
+        return Err(scatter_unsupported(
+            "table alias column lists are not row-local",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_row_local_expression(expression: &Expr) -> EngineResult<()> {
+    match expression {
+        Expr::Identifier(_) | Expr::CompoundIdentifier(_) | Expr::Value(_) => Ok(()),
+        Expr::Nested(expression)
+        | Expr::IsNull(expression)
+        | Expr::IsNotNull(expression)
+        | Expr::IsTrue(expression)
+        | Expr::IsNotTrue(expression)
+        | Expr::IsFalse(expression)
+        | Expr::IsNotFalse(expression)
+        | Expr::UnaryOp {
+            expr: expression, ..
+        } => validate_row_local_expression(expression),
+        Expr::BinaryOp { left, right, .. } => {
+            validate_row_local_expression(left)?;
+            validate_row_local_expression(right)
+        }
+        Expr::Between {
+            expr, low, high, ..
+        } => {
+            validate_row_local_expression(expr)?;
+            validate_row_local_expression(low)?;
+            validate_row_local_expression(high)
+        }
+        Expr::InList { expr, list, .. } => {
+            validate_row_local_expression(expr)?;
+            for item in list {
+                validate_row_local_expression(item)?;
+            }
+            Ok(())
+        }
+        Expr::Like {
+            expr,
+            pattern,
+            any: false,
+            escape_char: None,
+            ..
+        } => {
+            validate_row_local_expression(expr)?;
+            validate_row_local_expression(pattern)
+        }
+        Expr::Case {
+            operand,
+            conditions,
+            else_result,
+            ..
+        } => {
+            if let Some(operand) = operand {
+                validate_row_local_expression(operand)?;
+            }
+            for branch in conditions {
+                validate_row_local_expression(&branch.condition)?;
+                validate_row_local_expression(&branch.result)?;
+            }
+            if let Some(else_result) = else_result {
+                validate_row_local_expression(else_result)?;
+            }
+            Ok(())
+        }
+        Expr::Function(_) => Err(scatter_unsupported(
+            "aggregate, window, and scalar functions need an explicit scatter policy",
+        )),
+        _ => Err(scatter_unsupported(
+            "subqueries and non-row-local expression forms are not supported",
+        )),
+    }
+}
+
+fn scatter_unsupported(feature: &'static str) -> EngineError {
+    EngineError::new(
+        EngineErrorKind::Unsupported,
+        format!("statement is not safe for unchanged scatter execution: {feature}"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sql::{
+        SqlDialect, SqlTranslationMode, normalize_placeholders, parse, translate_sql,
+        validate_common_subset,
+    };
+
+    fn translated(dialect: SqlDialect, source: &str) -> TranslatedSql {
+        let parsed = parse(dialect, source).unwrap();
+        let common = validate_common_subset(parsed).unwrap();
+        let normalized = normalize_placeholders(common).unwrap();
+        translate_sql(normalized, SqlTranslationMode::Compatibility).unwrap()
+    }
+
+    fn validate_raw(dialect: SqlDialect, source: &str) -> EngineResult<()> {
+        let parsed = parse(dialect, source)?;
+        validate_statement_batch(parsed.statements())
+    }
+
+    fn assert_unsupported(result: EngineResult<()>, expected: &str) {
+        let error = result.unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Unsupported);
+        assert!(
+            error.to_string().contains(expected),
+            "expected {expected:?} in {error}"
+        );
+    }
+
+    #[test]
+    fn row_local_projection_and_filter_are_safe_in_every_dialect() {
+        let cases = [
+            (
+                SqlDialect::Sqlite,
+                "SELECT e.tenant_id, e.tenant_id + ?1 AS adjusted FROM events AS e WHERE e.tenant_id >= ?2 AND e.payload IS NOT NULL",
+            ),
+            (
+                SqlDialect::PostgreSql,
+                "SELECT e.tenant_id, e.tenant_id + $1 AS adjusted FROM events AS e WHERE e.tenant_id >= $2 AND e.payload IS NOT NULL",
+            ),
+            (
+                SqlDialect::MySql,
+                "SELECT e.tenant_id, e.tenant_id + ? AS adjusted FROM events AS e WHERE e.tenant_id >= ? AND e.payload IS NOT NULL",
+            ),
+        ];
+
+        for (dialect, source) in cases {
+            validate_scatter_safe(&translated(dialect, source))
+                .unwrap_or_else(|error| panic!("{dialect} rejected {source}: {error}"));
+        }
+    }
+
+    #[test]
+    fn wildcards_aliases_and_row_local_conditionals_are_safe() {
+        for source in [
+            "SELECT * FROM events",
+            "SELECT ALL tenant_id FROM events",
+            "SELECT e.* FROM events AS e WHERE e.tenant_id BETWEEN 2 AND 9",
+            "SELECT CASE WHEN payload IS NULL THEN 'missing' ELSE payload END AS display FROM events WHERE tenant_id IN (1, 2, 3)",
+            "SELECT tenant_id + 1 AS next_id FROM events WHERE payload LIKE 'ok%'",
+        ] {
+            validate_scatter_safe(&translated(SqlDialect::Sqlite, source))
+                .unwrap_or_else(|error| panic!("rejected {source}: {error}"));
+        }
+    }
+
+    #[test]
+    fn strict_sqlite_translation_is_supported() {
+        let parsed = parse(
+            SqlDialect::Sqlite,
+            "SELECT tenant_id FROM events WHERE tenant_id = ?1",
+        )
+        .unwrap();
+        let common = validate_common_subset(parsed).unwrap();
+        let normalized = normalize_placeholders(common).unwrap();
+        let translated = translate_sql(normalized, SqlTranslationMode::StrictSqlite).unwrap();
+
+        validate_scatter_safe(&translated).unwrap();
+    }
+
+    #[test]
+    fn constants_without_a_base_table_are_not_scattered_once_per_shard() {
+        assert_unsupported(
+            validate_scatter_safe(&translated(SqlDialect::Sqlite, "SELECT 1")),
+            "exactly one base table",
+        );
+    }
+
+    #[test]
+    fn multiple_statements_and_non_queries_are_rejected() {
+        assert_unsupported(
+            validate_scatter_safe(&translated(
+                SqlDialect::Sqlite,
+                "SELECT id FROM events; SELECT id FROM events",
+            )),
+            "exactly one top-level statement",
+        );
+        assert_unsupported(
+            validate_scatter_safe(&translated(
+                SqlDialect::Sqlite,
+                "UPDATE events SET payload = 'changed' WHERE tenant_id = 7",
+            )),
+            "only SELECT",
+        );
+    }
+
+    #[test]
+    fn distinct_and_aggregates_are_rejected() {
+        for (source, expected) in [
+            ("SELECT DISTINCT payload FROM events", "DISTINCT"),
+            ("SELECT COUNT(*) FROM events", "aggregate"),
+            ("SELECT SUM(tenant_id) FROM events", "aggregate"),
+            ("SELECT MIN(payload) FROM events", "aggregate"),
+        ] {
+            assert_unsupported(
+                validate_scatter_safe(&translated(SqlDialect::Sqlite, source)),
+                expected,
+            );
+        }
+    }
+
+    #[test]
+    fn grouping_and_having_are_rejected() {
+        assert_unsupported(
+            validate_scatter_safe(&translated(
+                SqlDialect::Sqlite,
+                "SELECT payload FROM events GROUP BY payload",
+            )),
+            "GROUP BY",
+        );
+        assert_unsupported(
+            validate_scatter_safe(&translated(
+                SqlDialect::Sqlite,
+                "SELECT COUNT(*) FROM events HAVING COUNT(*) > 1",
+            )),
+            "HAVING",
+        );
+    }
+
+    #[test]
+    fn ordering_and_every_row_cap_form_are_rejected() {
+        for (dialect, source, expected) in [
+            (
+                SqlDialect::Sqlite,
+                "SELECT payload FROM events ORDER BY payload",
+                "ORDER BY",
+            ),
+            (
+                SqlDialect::Sqlite,
+                "SELECT payload FROM events LIMIT 5",
+                "LIMIT",
+            ),
+            (
+                SqlDialect::Sqlite,
+                "SELECT payload FROM events LIMIT 5 OFFSET 2",
+                "LIMIT",
+            ),
+            (
+                SqlDialect::MySql,
+                "SELECT payload FROM events LIMIT 2, 5",
+                "LIMIT",
+            ),
+        ] {
+            assert_unsupported(
+                validate_scatter_safe(&translated(dialect, source)),
+                expected,
+            );
+        }
+        assert_unsupported(
+            validate_raw(
+                SqlDialect::PostgreSql,
+                "SELECT payload FROM events OFFSET 2 ROWS FETCH FIRST 5 ROWS ONLY",
+            ),
+            "LIMIT",
+        );
+    }
+
+    #[test]
+    fn joins_multiple_tables_and_derived_tables_are_rejected() {
+        for (source, expected) in [
+            (
+                "SELECT e.id FROM events e JOIN tenants t ON t.id = e.tenant_id",
+                "joins",
+            ),
+            (
+                "SELECT events.id FROM events, tenants WHERE events.tenant_id = tenants.id",
+                "exactly one base table",
+            ),
+            (
+                "SELECT nested.id FROM (SELECT id FROM events) AS nested",
+                "derived tables",
+            ),
+        ] {
+            assert_unsupported(validate_raw(SqlDialect::Sqlite, source), expected);
+        }
+    }
+
+    #[test]
+    fn ctes_subqueries_and_set_operations_are_rejected() {
+        for (source, expected) in [
+            (
+                "WITH selected AS (SELECT id FROM events) SELECT id FROM selected",
+                "common table expressions",
+            ),
+            (
+                "SELECT id FROM events WHERE tenant_id IN (SELECT id FROM tenants)",
+                "subqueries",
+            ),
+            (
+                "SELECT id FROM events UNION ALL SELECT id FROM archived_events",
+                "set operations",
+            ),
+        ] {
+            assert_unsupported(validate_raw(SqlDialect::Sqlite, source), expected);
+        }
+    }
+
+    #[test]
+    fn window_functions_and_scalar_functions_are_conservatively_rejected() {
+        assert_unsupported(
+            validate_raw(
+                SqlDialect::PostgreSql,
+                "SELECT row_number() OVER (ORDER BY id) FROM events",
+            ),
+            "function",
+        );
+        assert_unsupported(
+            validate_raw(SqlDialect::Sqlite, "SELECT lower(payload) FROM events"),
+            "function",
+        );
+    }
+}

--- a/tests/admin_browser_js.rs
+++ b/tests/admin_browser_js.rs
@@ -22,3 +22,22 @@ fn embedded_admin_browser_scripts_are_valid_and_logic_tests_pass() {
     assert_node_success(&["--check", "src/protocol/http/admin/app.js"]);
     assert_node_success(&["--test", "tests/admin_browser_logic.test.js"]);
 }
+
+#[test]
+fn admin_browser_exposes_only_the_logical_table_view() {
+    let shell = include_str!("../src/protocol/http/admin/index.html");
+    let application = include_str!("../src/protocol/http/admin/app.js");
+
+    for forbidden in ["shard-select", "selected_shard", "Physical shard"] {
+        assert!(!shell.contains(forbidden), "shell contains {forbidden}");
+        assert!(
+            !application.contains(forbidden),
+            "application contains {forbidden}"
+        );
+    }
+    assert!(!application.contains("shard: String("));
+    assert!(!application.contains("overview?shard="));
+    assert!(shell.contains("Logical database"));
+    assert!(application.contains("/admin/api/rows?"));
+    assert!(application.contains("page.visited_shards"));
+}

--- a/tests/admin_browser_logic.test.js
+++ b/tests/admin_browser_logic.test.js
@@ -49,40 +49,44 @@ test("ordinary cells keep their existing browser presentation", () => {
   assert.equal(logic.cellPresentation([0, 15, 255]).text, "0x000fff");
 });
 
-test("all-shard row counts are formatted without losing integer precision", () => {
+test("logical row counts are formatted without losing integer precision", () => {
   assert.equal(logic.exactRowCount(1536282), "1536282");
-  let presentation = logic.rowCountPresentation(1536282, 2);
-  assert.equal(presentation.text, "1,536,282 total records across 2 physical shards");
-  assert.match(presentation.title, /Replicated records/);
+  let presentation = logic.rowCountPresentation(1536282, [0, 1]);
+  assert.equal(presentation.text, "1,536,282 logical records across 2 storage files");
+  assert.match(presentation.title, /visited shards: 0, 1/i);
+  assert.match(presentation.title, /Global tables are read once/);
 
   const maximum = { $briskdb_type: "uint64", value: "18446744073709551615" };
   assert.equal(logic.exactRowCount(maximum), "18446744073709551615");
-  presentation = logic.rowCountPresentation(maximum, 64);
+  presentation = logic.rowCountPresentation(maximum, Array.from({ length: 64 }, (_, shard) => shard));
   assert.equal(
     presentation.text,
-    "18,446,744,073,709,551,615 total records across 64 physical shards",
+    "18,446,744,073,709,551,615 logical records across 64 storage files",
   );
 
-  assert.equal(logic.rowCountPresentation(1, 1).text, "1 total record across 1 physical shard");
+  assert.equal(logic.rowCountPresentation(1, [0]).text, "1 logical record across 1 storage file");
   for (const invalid of [-1, Number.MAX_SAFE_INTEGER + 1, { $briskdb_type: "int64", value: "-1" }]) {
     assert.equal(logic.exactRowCount(invalid), null);
   }
-  assert.throws(() => logic.rowCountPresentation(-1, 2), /Invalid all-shard/);
-  assert.throws(() => logic.rowCountPresentation(0, 0), /Invalid all-shard/);
+  assert.throws(() => logic.rowCountPresentation(-1, [0, 1]), /Invalid logical/);
+  for (const invalidShards of [[], [1, 0], [0, 0], [0, 1.5], "0,1"]) {
+    assert.equal(logic.validVisitedShards(invalidShards), false);
+    assert.throws(() => logic.rowCountPresentation(0, invalidShards), /Invalid logical/);
+  }
 });
 
-test("page summaries retain their selected physical-shard scope", () => {
+test("page summaries describe one logical row stream", () => {
   assert.equal(
-    logic.pageSummary({ shard: 1, offset: 50, rows: [[1], [2]] }),
-    "Showing rows 51–52 on physical shard 1",
+    logic.pageSummary({ visited_shards: [0, 1], offset: 50, rows: [[1], [2]] }),
+    "Showing logical rows 51–52",
   );
   assert.equal(
-    logic.pageSummary({ shard: 0, offset: 0, rows: [] }),
-    "No rows on physical shard 0",
+    logic.pageSummary({ visited_shards: [0], offset: 0, rows: [] }),
+    "No logical rows",
   );
 });
 
-test("table response guards reject stale counts after table or shard changes", () => {
+test("table response guards reject stale counts after table changes", () => {
   assert.equal(logic.acceptsTableResponse(4, 4, "orders", "orders"), true);
   assert.equal(logic.acceptsTableResponse(3, 4, "orders", "orders"), false);
   assert.equal(logic.acceptsTableResponse(4, 4, "orders", "payments"), false);

--- a/tests/logical_scatter.rs
+++ b/tests/logical_scatter.rs
@@ -1,0 +1,376 @@
+use std::{collections::BTreeSet, sync::Arc};
+
+use briskdb::{core, sql};
+
+const SHARD_COUNT: u16 = 4;
+
+struct Fixture {
+    _temp: tempfile::TempDir,
+    database: Arc<core::Database>,
+    engine: core::Engine,
+    keys: [i64; SHARD_COUNT as usize],
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let temp = tempfile::tempdir().unwrap();
+        let mut database = core::Database::open(temp.path(), SHARD_COUNT).unwrap();
+        database
+            .broadcast(
+                "CREATE TABLE events (
+                    tenant_id INTEGER NOT NULL,
+                    event_id INTEGER NOT NULL,
+                    payload TEXT NOT NULL,
+                    PRIMARY KEY (tenant_id, event_id)
+                 );
+                 CREATE TABLE global_settings (
+                    code TEXT PRIMARY KEY,
+                    label TEXT NOT NULL
+                 );",
+            )
+            .unwrap();
+        let logical_database = database.catalog().default_database().id();
+        database
+            .register_tables(vec![
+                core::TableDeclaration::sharded(
+                    logical_database,
+                    "events",
+                    core::ShardKeyMetadata::new("tenant_id", core::ShardKeyType::Int64).unwrap(),
+                )
+                .unwrap(),
+                core::TableDeclaration::global(logical_database, "global_settings").unwrap(),
+            ])
+            .unwrap();
+
+        // Global rows are deliberately replicated in every physical file. A
+        // logical Global read must still visit only canonical shard zero.
+        for shard in 0..SHARD_COUNT {
+            let connection =
+                rusqlite::Connection::open(temp.path().join(format!("shards/{shard:04}.sqlite")))
+                    .unwrap();
+            connection
+                .execute_batch(
+                    "INSERT INTO global_settings (code, label)
+                     VALUES ('CA', 'Canada'), ('US', 'United States')",
+                )
+                .unwrap();
+        }
+
+        let keys = std::array::from_fn(|shard| integer_key_for_shard(&database, shard as u16));
+        let database = Arc::new(database);
+        let engine = core::Engine::from_database(Arc::clone(&database));
+        Self {
+            _temp: temp,
+            database,
+            engine,
+            keys,
+        }
+    }
+
+    async fn seed_sharded_rows(&self) {
+        let session = self.engine.session();
+        for (shard, key) in self.keys.iter().copied().enumerate() {
+            session.set_routing_key(key.to_string()).await.unwrap();
+            let inserted = self
+                .engine
+                .execute(
+                    &session,
+                    core::Statement::new(
+                        "INSERT INTO events (tenant_id, event_id, payload)
+                         VALUES (?1, 1, 'shared'), (?1, 2, ?2)",
+                        vec![
+                            core::Value::from(key),
+                            core::Value::from(format!("only-{shard}")),
+                        ],
+                    ),
+                )
+                .await
+                .unwrap();
+            assert_eq!(inserted.shard, shard as u16);
+            assert_eq!(inserted.value, 2);
+        }
+    }
+}
+
+fn integer_key_for_shard(database: &core::Database, expected: u16) -> i64 {
+    (1_i64..)
+        .find(|value| database.shard_for_key(value.to_string().as_bytes()) == expected)
+        .expect("the finite shard map has an integer key for every shard")
+}
+
+fn event_rows(result: &core::ResultSet) -> BTreeSet<(i64, i64, String)> {
+    result
+        .rows()
+        .iter()
+        .map(|row| {
+            (
+                row.get(0).and_then(core::Value::as_i64).unwrap(),
+                row.get(1).and_then(core::Value::as_i64).unwrap(),
+                row.get(2).and_then(core::Value::as_str).unwrap().to_owned(),
+            )
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn logical_reads_union_all_metadata_selected_files_and_keep_legacy_routing() {
+    let fixture = Fixture::new();
+    fixture.seed_sharded_rows().await;
+    let session = fixture.engine.session();
+
+    let all = fixture
+        .engine
+        .query_logical(
+            &session,
+            core::Statement::new("SELECT tenant_id, event_id, payload FROM events", vec![]),
+        )
+        .await
+        .unwrap();
+    assert_eq!(all.shards(), [0, 1, 2, 3]);
+
+    let expected = fixture
+        .keys
+        .iter()
+        .copied()
+        .enumerate()
+        .flat_map(|(shard, key)| {
+            [
+                (key, 1, "shared".to_owned()),
+                (key, 2, format!("only-{shard}")),
+            ]
+        })
+        .collect::<BTreeSet<_>>();
+    assert_eq!(all.value.len(), expected.len());
+    assert_eq!(event_rows(&all.value), expected);
+
+    let duplicates = fixture
+        .engine
+        .query_logical(
+            &session,
+            core::Statement::new(
+                "SELECT payload FROM events WHERE event_id = ?1",
+                vec![core::Value::from(1_i64)],
+            ),
+        )
+        .await
+        .unwrap();
+    assert_eq!(duplicates.shards(), [0, 1, 2, 3]);
+    assert_eq!(duplicates.value.len(), SHARD_COUNT as usize);
+    assert!(
+        duplicates
+            .value
+            .rows()
+            .iter()
+            .all(|row| { row.get(0).and_then(core::Value::as_str) == Some("shared") })
+    );
+
+    let exact_key = fixture.keys[2];
+    let exact = fixture
+        .engine
+        .query_logical(
+            &session,
+            core::Statement::new(
+                "SELECT tenant_id, event_id, payload FROM events WHERE tenant_id = ?1",
+                vec![core::Value::from(exact_key)],
+            ),
+        )
+        .await
+        .unwrap();
+    assert_eq!(exact.shards(), [2]);
+    assert_eq!(exact.value.len(), 2);
+    assert!(
+        exact
+            .value
+            .rows()
+            .iter()
+            .all(|row| row.get(0).and_then(core::Value::as_i64) == Some(exact_key))
+    );
+
+    let finite = fixture
+        .engine
+        .query_logical(
+            &session,
+            core::Statement::new(
+                "SELECT tenant_id, event_id, payload FROM events
+                 WHERE tenant_id = ?1 OR tenant_id = ?2 OR tenant_id = ?3",
+                vec![
+                    core::Value::from(fixture.keys[3]),
+                    core::Value::from(fixture.keys[1]),
+                    core::Value::from(fixture.keys[3]),
+                ],
+            ),
+        )
+        .await
+        .unwrap();
+    assert_eq!(finite.shards(), [1, 3]);
+    assert_eq!(finite.value.len(), 4);
+
+    let global = fixture
+        .engine
+        .query_logical(
+            &session,
+            core::Statement::new(
+                "SELECT code, label FROM global_settings ORDER BY code",
+                vec![],
+            ),
+        )
+        .await
+        .unwrap();
+    assert_eq!(global.shards(), [0]);
+    assert_eq!(global.value.len(), 2, "replicas must not be unioned");
+
+    // The established query API is still explicitly routed and keeps its
+    // single-shard result shape.
+    session
+        .set_routing_key(exact_key.to_string())
+        .await
+        .unwrap();
+    let routed = fixture
+        .engine
+        .query(
+            &session,
+            core::Statement::new(
+                "SELECT tenant_id, event_id, payload FROM events WHERE tenant_id = ?1",
+                vec![core::Value::from(exact_key)],
+            ),
+        )
+        .await
+        .unwrap();
+    assert_eq!(routed.shard, 2);
+    assert_eq!(routed.value.len(), 2);
+}
+
+#[tokio::test]
+async fn unsafe_multi_shard_shapes_are_rejected_before_execution() {
+    let fixture = Fixture::new();
+    fixture.seed_sharded_rows().await;
+    let session = fixture.engine.session();
+
+    for statement in [
+        "SELECT COUNT(*) FROM events",
+        "SELECT tenant_id FROM events ORDER BY tenant_id",
+        "SELECT tenant_id FROM events LIMIT 1",
+        "SELECT DISTINCT payload FROM events",
+        "SELECT a.tenant_id FROM events AS a JOIN events AS b ON b.tenant_id = a.tenant_id",
+        "SELECT tenant_id FROM (SELECT tenant_id FROM events) AS nested",
+    ] {
+        let error = fixture
+            .engine
+            .query_logical(&session, core::Statement::new(statement, vec![]))
+            .await
+            .unwrap_err();
+        assert_eq!(
+            error.kind(),
+            core::EngineErrorKind::Unsupported,
+            "unexpected rejection for {statement:?}: {}",
+            error.diagnostic()
+        );
+    }
+}
+
+#[tokio::test]
+async fn scatter_has_one_shared_row_and_byte_budget_and_recovers_after_failure() {
+    let fixture = Fixture::new();
+    fixture.seed_sharded_rows().await;
+    let session = fixture.engine.session();
+    let statement = || {
+        core::Statement::new(
+            "SELECT tenant_id AS v FROM events
+             WHERE (tenant_id = ?1 OR tenant_id = ?2) AND event_id = ?3",
+            vec![
+                core::Value::from(fixture.keys[0]),
+                core::Value::from(fixture.keys[1]),
+                core::Value::from(1_i64),
+            ],
+        )
+    };
+
+    // Metadata is 26 logical bytes and each integer row is 25. The logical
+    // two-shard result is therefore exactly two rows and 76 bytes.
+    let exact = fixture
+        .engine
+        .query_logical_with_context(
+            &session,
+            statement(),
+            core::RequestContext::new().with_result_limits(core::ResultLimits::new(2, 76).unwrap()),
+        )
+        .await
+        .unwrap();
+    assert_eq!(exact.shards(), [0, 1]);
+    assert_eq!(exact.value.len(), 2);
+
+    let row_error = fixture
+        .engine
+        .query_logical_with_context(
+            &session,
+            statement(),
+            core::RequestContext::new().with_result_limits(core::ResultLimits::new(1, 76).unwrap()),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(row_error.kind(), core::EngineErrorKind::LimitExceeded);
+    assert!(row_error.diagnostic().contains("row limit"));
+
+    let byte_error = fixture
+        .engine
+        .query_logical_with_context(
+            &session,
+            statement(),
+            core::RequestContext::new().with_result_limits(core::ResultLimits::new(2, 75).unwrap()),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(byte_error.kind(), core::EngineErrorKind::LimitExceeded);
+    assert!(byte_error.diagnostic().contains("logical byte limit"));
+
+    let recovered = fixture
+        .engine
+        .query_logical(&session, statement())
+        .await
+        .unwrap();
+    assert_eq!(recovered.shards(), [0, 1]);
+    assert_eq!(recovered.value.len(), 2);
+}
+
+#[tokio::test]
+async fn prepared_logical_portal_fans_out_with_the_same_union_all_semantics() {
+    let fixture = Fixture::new();
+    fixture.seed_sharded_rows().await;
+    let session = fixture.engine.session();
+    let logical_database = fixture.database.catalog().default_database().id();
+
+    let statement = fixture
+        .engine
+        .prepare_statement(
+            &session,
+            core::PrepareRequest::new(
+                logical_database,
+                sql::SqlDialect::PostgreSql,
+                sql::SqlTranslationMode::Compatibility,
+                "SELECT tenant_id, event_id, payload FROM events WHERE payload = $1",
+            ),
+        )
+        .await
+        .unwrap();
+    let portal = fixture
+        .engine
+        .bind_statement(&session, statement, vec![core::Value::from("shared")])
+        .await
+        .unwrap();
+
+    let executed = fixture
+        .engine
+        .execute_portal_logical(&session, portal)
+        .await
+        .unwrap();
+    assert_eq!(executed.shards(), [0, 1, 2, 3]);
+    let core::PreparedExecution::Rows(rows) = executed.value else {
+        panic!("logical read portal must return rows")
+    };
+    assert_eq!(rows.len(), SHARD_COUNT as usize);
+    assert!(
+        rows.rows()
+            .iter()
+            .all(|row| row.get(2).and_then(core::Value::as_str) == Some("shared"))
+    );
+}


### PR DESCRIPTION
Closes #57

## What changed

- Resolve logical read targets from the metadata catalog: exact owner, finite owner set, every Sharded owner, or shard 0 for Global tables.
- Execute supported read-only plans across independent SQLite file pools with bounded concurrency, one deadline/cancellation scope, shared result limits, and all-or-nothing failure.
- Merge rows deterministically in shard order with UNION ALL semantics so duplicates are retained.
- Keep legacy single-shard routed APIs compatible while adding logical query and prepared-portal paths.
- Make HTTP queries and the admin browser logical by default; remove the physical shard selector and report exact cross-shard table totals.
- Document the supported SQL shape and add unit, integration, concurrency, recovery, and browser coverage.

## Why

Rows are owned by one shard file, but clients query the logical database. Reads therefore need to gather the relevant files transparently without duplicating storage or serializing writers through one SQLite connection.

## Validation

- cargo fmt --all --check
- cargo test --all-targets --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- 648 library tests passed, 1 ignored; all integration, browser, storage, and engine concurrency suites passed.