### PR TITLE
Reuse SQLite connections for HTTP writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,14 @@ accepts SQL and should only be exposed on a trusted network. The HTTP adapter
 creates an ephemeral session for each data request, so session state and
 transactions cannot span HTTP requests. Each shard has its own bounded pool, so
 routed work queued for one shard does not consume another shard's capacity.
+After a populated catalog validates `/v1/execute` as one routed common-subset
+write, those ephemeral requests share a stateless physical-handle ownership
+domain. This keeps the logical sessions separate while allowing clean
+autocommit write handles to remain warm. Empty-catalog pass-through SQL and all
+other session surfaces retain unique ownership. Registration, startup, import,
+and migration validation also reject `last_insert_rowid()`, `changes()`, and
+`total_changes()` inside persistent table or index expressions, so a stored
+`DEFAULT`, `CHECK`, generated expression, or index cannot bypass that boundary.
 Pool admission happens before blocking SQLite work: once a shard's active slots
 and queue are full, the engine returns retryable `Busy` (HTTP 503) instead of
 growing work without bound. Connections are opened lazily and reused. Broadcast
@@ -399,9 +407,15 @@ allowed to invalidate the storage layout. Persistent DDL, including
 the journaled migration path, where BriskDB protects and revalidates its
 reserved `briskdb` and `briskdb_*` namespaces.
 A handle that performed an ordinary write may return to the same session,
-preserving SQLite write counters, but is replaced before a different session can
-observe `last_insert_rowid()`, `changes()`, or `total_changes()`. Those functions
-remain uncontracted across calls until sessions gain connection pinning.
+preserving SQLite write counters, but is replaced before a different observable
+session can inspect `last_insert_rowid()`, `changes()`, or `total_changes()`.
+Planner-validated populated-catalog HTTP writes are the narrow exception: they
+may reuse a shared stateless write handle because that SQL boundary rejects
+connection-local functions and session state before checkout, while catalog
+validation rejects the same functions in stored schema expressions. Older
+catalogs are rechecked at startup. A later ordinary session still replaces the
+handle before inspection. Those functions remain uncontracted across calls
+until sessions gain connection pinning.
 Dropping queued work skips it before SQLite starts. Dropping in-flight work
 interrupts its exact leased handle and retains lifecycle, worker, pool, and
 session permits until SQLite cleanup finishes. Explicit cancellation behaves

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -756,13 +756,22 @@ also prevent reuse. Thus connection-local state and observer metadata such as
 
 Ordinary writes require a narrower rule because SQLite exposes per-connection
 `last_insert_rowid()`, `changes()`, and `total_changes()` state. The pool records
-the owning BriskDB session after any authorizer-observed insert, update, or
-delete. That physical handle remains reusable by the same session, preserving
-its SQLite semantics, but a checkout for any other session retires and replaces
-it before SQL runs. Handles used only for reads remain reusable across sessions.
-This ownership is a leakage-prevention rule, not connection pinning: a competing
-session can replace an idle write-bearing handle, so write-counter functions
-remain uncontracted across calls until transaction/session pinning is added.
+the owning BriskDB domain after any authorizer-observed insert, update, or
+delete. Ordinary engine sessions have unique domains. A populated-catalog HTTP
+write receives the shared stateless catalog-write domain only after planning
+proves it is one routed common-subset write; that boundary rejects scalar
+counter functions, session SQL, PRAGMAs, attachments, temporary objects, and
+schema SQL. Catalog registration, import, post-migration validation, and
+ordinary startup parse every persistent table and index definition and reject
+those same functions inside `DEFAULT`, `CHECK`, generated-column, and index
+expressions. Clean handles can therefore remain warm across those ephemeral
+write requests without making their logical sessions shared. Empty-catalog HTTP
+SQL retains its unique session owner. A later ordinary owner retires and
+replaces a stateless write handle before SQL runs, and handles used only for
+reads remain reusable across sessions. This ownership is a leakage-prevention
+rule, not connection pinning: a competing ordinary session can replace an idle
+write-bearing handle, so write-counter functions remain uncontracted across
+calls until transaction/session pinning is added.
 
 Every operation acquires a lifecycle lease before its first await. Dropping a
 queued future removes the operation before SQLite starts. Once work is running,

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -143,3 +143,40 @@ Criterion classified all three changes as statistically significant
 improvements (`p < 0.05`). These local results primarily quantify removal of
 per-operation SQLite connection opening and configuration; they remain a
 hardware-specific engineering comparison, not a production capacity promise.
+
+## Issue #121 ephemeral HTTP write comparison
+
+Issue #121 was measured on 2026-08-11 against base commit `f5ab846` and the
+release build of the completed change. The host was the Apple M1 Pro described
+above (10 cores, 16 GiB RAM), running macOS 26.2 with Rust and Cargo 1.94.1.
+
+Each run used an independent APFS clone of the same imported LARGE_Data
+database with ten shards. One persistent HTTP/1.1 client per worker repeatedly
+toggled `work_order_items.is_highlight` on an existing primary-key row. Workers
+were assigned distinct rows and explicit routing keys on distinct shards. The
+server used one SQLite connection per shard, queue capacity 32, two asynchronous
+Tokio worker threads, and a Tokio blocking-thread cap equal to the tested worker
+count. Only 2, 4, 8, and 10 workers were tested. Every result is the median of
+three 10-second trials after 100 untimed warm-up writes per active shard.
+
+| HTTP writers | Base writes/s | Fixed writes/s | Speedup | Base p50 | Fixed p50 | Base CPU | Fixed CPU |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 2 | 776 | 13,352 | 17.20x | 2,545 µs | 137 µs | 152% | 108% |
+| 4 | 704 | 12,664 | 17.99x | 5,716 µs | 299 µs | 295% | 147% |
+| 8 | 634 | 11,194 | 17.65x | 12,465 µs | 677 µs | 673% | 145% |
+| 10 | 690 | 11,229 | 16.27x | 14,256 µs | 837 µs | 808% | 143% |
+
+All timed requests returned the expected shard and affected-row count; timed
+errors were zero. Fixed-path p95 latency was 211, 454, 1,135, and 1,477 µs for
+2, 4, 8, and 10 writers respectively. Peak resident memory remained below
+12.9 MiB, process thread count never exceeded the requested blocking cap plus
+the two runtime threads and main thread, and total observed WAL size remained
+below 39.3 MiB.
+
+The process monitor also recorded about 60 KiB of physical writes per completed
+operation on the base path versus 20 KiB after the fix, a 66-67% reduction.
+Together with the CPU and latency change, this supports the code and stack-sample
+finding: repeated opening, schema validation, and closing of SQLite handles was
+the dominant HTTP bottleneck, not a lock-selection race. The fix keeps clean
+planner-validated write handles warm; it does not reroute a row or reuse a
+handle while that handle is checked out.

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -206,11 +206,18 @@ tables, invalid unique keys, and any table-placement or shard-key change.
 
 SQLite also retains `last_insert_rowid()`, `changes()`, and `total_changes()` on
 the physical connection after ordinary writes. A write-bearing handle may be
-reused by its owning BriskDB `Session`, but the pool closes and replaces it
-before checkout by a different session. Read-only handles can cross sessions.
-This preserves same-session write metadata without exposing one HTTP request's
-connection-local counters to the next request when the owned handle remains
-available. It does not pin that handle, so these observer functions remain
+reused by its owning BriskDB `Session`. Planner-validated populated-catalog HTTP
+writes use a shared stateless ownership domain so separate ephemeral requests
+can reuse clean autocommit handles; the admitted SQL cannot contain observer
+functions or session-local forms. Persistent table and index definitions are
+also checked during registration, import, migration, and startup; `DEFAULT`,
+`CHECK`, generated-column, and index expressions cannot call
+`last_insert_rowid()`, `changes()`, or `total_changes()`. Empty-catalog
+pass-through writes keep unique session owners. Before an ordinary different
+owner can inspect a write-bearing handle, the pool closes and replaces it.
+Read-only handles can cross sessions. This preserves same-session write
+metadata without exposing one HTTP request's connection-local counters to the
+next request. It does not pin that handle, so these observer functions remain
 uncontracted across calls in the current SQL surface.
 
 Dropping or explicitly cancelling a request before its queued operation starts

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -31,6 +31,12 @@ use crate::{
 static NEXT_ENGINE_ID: AtomicU64 = AtomicU64::new(1);
 const MAX_SCATTER_CONCURRENCY: usize = 8;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExecuteOwnerPolicy {
+    Session,
+    ReuseValidatedCatalogWrite,
+}
+
 /// An owned SQL statement and its protocol-neutral parameters.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Statement {
@@ -300,9 +306,24 @@ impl Engine {
         self.inner.database.shard_count()
     }
 
+    /// Return the engine admission bound for concurrently blocking SQLite tasks.
+    ///
+    /// This is not Tokio's runtime thread count; embedding runtimes configure
+    /// their own blocking-thread capacity independently.
+    pub(crate) fn blocking_task_admission_limit(&self) -> usize {
+        self.inner.workers.limit()
+    }
+
     /// Return the immutable logical database and table catalog.
     pub fn catalog(&self) -> &super::Catalog {
         self.inner.database.catalog()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pool_snapshot_for_test(
+        &self,
+    ) -> EngineResult<crate::storage::pool::PoolSnapshot> {
+        self.inner.connections.snapshot()
     }
 
     /// Plan one normalized statement from its actual bound parameter values.
@@ -544,7 +565,7 @@ impl Engine {
             let result_limits = self.inner.options.result_limits();
             Ok(EngineStatus {
                 shard_count: self.shard_count(),
-                max_blocking_workers: self.inner.workers.limit(),
+                max_blocking_workers: self.blocking_task_admission_limit(),
                 connections_per_shard: self.inner.options.connections_per_shard(),
                 queue_capacity_per_shard: self.inner.options.queue_capacity_per_shard(),
                 max_result_rows: result_limits.max_rows(),
@@ -1011,12 +1032,49 @@ impl Engine {
             .await
     }
 
+    /// Execute one ephemeral HTTP write while allowing safe physical-handle
+    /// reuse after authoritative catalog validation.
+    ///
+    /// An empty catalog retains ordinary unique-session ownership. With a
+    /// populated catalog, raw planning proves that the request is one routed
+    /// common-subset write before the shared stateless ownership domain is
+    /// selected.
+    pub(crate) async fn execute_http_request(
+        &self,
+        session: &Session,
+        statement: Statement,
+    ) -> EngineResult<Routed<usize>> {
+        self.execute_with_context_and_owner(
+            session,
+            statement,
+            RequestContext::new(),
+            ExecuteOwnerPolicy::ReuseValidatedCatalogWrite,
+        )
+        .await
+    }
+
     /// Execute a routed statement with explicit request controls.
     pub async fn execute_with_context(
         &self,
         session: &Session,
         statement: Statement,
         context: RequestContext,
+    ) -> EngineResult<Routed<usize>> {
+        self.execute_with_context_and_owner(
+            session,
+            statement,
+            context,
+            ExecuteOwnerPolicy::Session,
+        )
+        .await
+    }
+
+    async fn execute_with_context_and_owner(
+        &self,
+        session: &Session,
+        statement: Statement,
+        context: RequestContext,
+        owner_policy: ExecuteOwnerPolicy,
     ) -> EngineResult<Routed<usize>> {
         let mut operation = self.operation(context)?;
         let schema_operation = match self.inner.database.storage.enter_schema_operation() {
@@ -1027,7 +1085,6 @@ impl Engine {
             Ok(guard) => guard,
             Err(error) => return operation.finish(Err(error)),
         };
-        let owner = ConnectionOwner::new(session.id().get());
         let routing_key = match required_routing_key(&guard) {
             Ok(key) => key.to_owned(),
             Err(error) => return operation.finish(Err(error)),
@@ -1041,6 +1098,14 @@ impl Engine {
         ) {
             Ok(plan) => plan,
             Err(error) => return operation.finish(Err(error)),
+        };
+        let owner = match (owner_policy, plan.is_some()) {
+            (ExecuteOwnerPolicy::ReuseValidatedCatalogWrite, true) => {
+                ConnectionOwner::stateless_catalog_write()
+            }
+            (ExecuteOwnerPolicy::Session | ExecuteOwnerPolicy::ReuseValidatedCatalogWrite, _) => {
+                ConnectionOwner::new(session.id().get())
+            }
         };
         let (shard, sql) = match plan {
             Some(plan) => (plan.shard, plan.sqlite_sql),

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -710,4 +710,49 @@ mod tests {
         assert_eq!(report.tables[0].physical_rows.iter().sum::<u64>(), 3);
         assert!(destination.join("manifest.sqlite").is_file());
     }
+
+    #[test]
+    fn import_rejects_connection_local_stored_expressions_before_publish() {
+        let temporary = tempfile::tempdir().unwrap();
+        let source = temporary.path().join("source.sqlite");
+        let destination = temporary.path().join("imported");
+        let connection = rusqlite::Connection::open(&source).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE records (
+                     id INTEGER PRIMARY KEY,
+                     observed INTEGER DEFAULT (total_changes())
+                 );
+                 INSERT INTO records (id) VALUES (1);",
+            )
+            .unwrap();
+        connection.close().unwrap();
+        let plan = SqliteImportPlan::new(vec![SqliteTableImportPlan::sharded_by_primary_key(
+            "records",
+        )]);
+
+        let error = import_sqlite_database(
+            &source,
+            &destination,
+            &plan,
+            SqliteImportOptions::new(2).unwrap(),
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert!(
+            error
+                .diagnostic()
+                .contains("cannot participate in stateless catalog write reuse"),
+            "{}",
+            error.diagnostic()
+        );
+        assert!(!destination.exists());
+        assert!(std::fs::read_dir(temporary.path()).unwrap().all(|entry| {
+            !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".briskdb-import-stage-")
+        }));
+    }
 }

--- a/src/protocol/http.rs
+++ b/src/protocol/http.rs
@@ -124,7 +124,7 @@ async fn execute(
         shard,
         value: rows_affected,
     } = engine
-        .execute(&session, Statement::new(request.sql, params))
+        .execute_http_request(&session, Statement::new(request.sql, params))
         .await?;
 
     Ok(Json(ExecuteResponse {
@@ -444,6 +444,221 @@ mod tests {
                 }),
             )
         );
+    }
+
+    #[tokio::test]
+    async fn validated_catalog_http_writes_reuse_one_handle_and_keep_counters_isolated() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut database = Database::open(temp.path(), 2).unwrap();
+        database
+            .broadcast(
+                "CREATE TABLE widgets (
+                    id TEXT NOT NULL PRIMARY KEY,
+                    value INTEGER NOT NULL
+                 )",
+            )
+            .unwrap();
+        let logical_database = database.catalog().default_database().id();
+        database
+            .register_tables(vec![
+                TableDeclaration::sharded(
+                    logical_database,
+                    "widgets",
+                    ShardKeyMetadata::new("id", ShardKeyType::Text).unwrap(),
+                )
+                .unwrap(),
+            ])
+            .unwrap();
+        let database = Arc::new(database);
+        let routing_key = "reused-http-write";
+        let expected_shard = database.shard_for_key(routing_key.as_bytes());
+        let options = EngineOptions::new(1, 64).unwrap();
+        let engine = Engine::from_database_with_options(Arc::clone(&database), options).unwrap();
+        let application = router_with_engine(engine.clone());
+
+        let rejected = request_json(
+            &application,
+            Method::POST,
+            "/v1/execute",
+            Some(json!({
+                "shard_key": routing_key,
+                "sql": "INSERT INTO widgets (id, value) VALUES (?1, total_changes())",
+                "params": [routing_key]
+            })),
+        )
+        .await;
+        assert_eq!(rejected.0, StatusCode::NOT_IMPLEMENTED);
+        assert!(
+            engine
+                .pool_snapshot_for_test()
+                .unwrap()
+                .shards
+                .iter()
+                .all(|shard| shard.checkouts == 0 && shard.opened == 0),
+            "connection-local functions must be rejected before pool checkout"
+        );
+
+        assert_eq!(
+            request_json(
+                &application,
+                Method::POST,
+                "/v1/execute",
+                Some(json!({
+                    "shard_key": routing_key,
+                    "sql": "INSERT INTO widgets (id, value) VALUES (?1, ?2)",
+                    "params": [routing_key, 0]
+                })),
+            )
+            .await,
+            (
+                StatusCode::OK,
+                json!({"shard": expected_shard, "rows_affected": 1})
+            )
+        );
+        for _ in 0..99 {
+            assert_eq!(
+                request_json(
+                    &application,
+                    Method::POST,
+                    "/v1/execute",
+                    Some(json!({
+                        "shard_key": routing_key,
+                        "sql": "UPDATE widgets SET value = value + 1 WHERE id = ?1",
+                        "params": [routing_key]
+                    })),
+                )
+                .await,
+                (
+                    StatusCode::OK,
+                    json!({"shard": expected_shard, "rows_affected": 1})
+                )
+            );
+        }
+
+        let mut concurrent = tokio::task::JoinSet::new();
+        for _ in 0..32 {
+            let application = application.clone();
+            concurrent.spawn(async move {
+                request_json(
+                    &application,
+                    Method::POST,
+                    "/v1/execute",
+                    Some(json!({
+                        "shard_key": "reused-http-write",
+                        "sql": "UPDATE widgets SET value = value + 1 WHERE id = ?1",
+                        "params": ["reused-http-write"]
+                    })),
+                )
+                .await
+            });
+        }
+        while let Some(result) = concurrent.join_next().await {
+            assert_eq!(
+                result.unwrap(),
+                (
+                    StatusCode::OK,
+                    json!({"shard": expected_shard, "rows_affected": 1})
+                )
+            );
+        }
+
+        let snapshot = engine.pool_snapshot_for_test().unwrap();
+        let shard = snapshot.shards[usize::from(expected_shard)];
+        assert_eq!(shard.opened, 1);
+        assert_eq!(shard.checkouts, 132);
+        assert_eq!(shard.reused, 131);
+        assert_eq!(shard.retired, 0);
+        assert_eq!(shard.active, 0);
+        assert_eq!(shard.queued, 0);
+        assert_eq!(shard.idle, 1);
+
+        let stored = database
+            .query_routed(
+                routing_key,
+                "SELECT value FROM widgets WHERE id = ?1",
+                &[Value::from(routing_key)],
+            )
+            .unwrap();
+        assert_eq!(stored.value.rows()[0].get(0), Some(&Value::from(131_i64)));
+
+        let observer = engine.session();
+        let counters = engine
+            .inspect_shard(
+                &observer,
+                expected_shard,
+                Statement::new(
+                    "SELECT last_insert_rowid(), changes(), total_changes()",
+                    vec![],
+                ),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            counters.rows()[0].values(),
+            [Value::from(0_i64), Value::from(0_i64), Value::from(0_i64)]
+        );
+        let isolated = engine.pool_snapshot_for_test().unwrap().shards[usize::from(expected_shard)];
+        assert_eq!(isolated.opened, 2);
+        assert_eq!(isolated.retired, 1);
+    }
+
+    #[tokio::test]
+    async fn empty_catalog_http_writes_keep_unique_owners_and_raw_sqlite_isolation() {
+        let temp = tempfile::tempdir().unwrap();
+        let database = Arc::new(Database::open(temp.path(), 2).unwrap());
+        database
+            .broadcast("CREATE TABLE raw_items (id INTEGER PRIMARY KEY)")
+            .unwrap();
+        let routing_key = "raw-http-write";
+        let expected_shard = database.shard_for_key(routing_key.as_bytes());
+        let options = EngineOptions::new(1, 4).unwrap();
+        let engine = Engine::from_database_with_options(database, options).unwrap();
+        let application = router_with_engine(engine.clone());
+
+        for id in [1, 2] {
+            assert_eq!(
+                request_json(
+                    &application,
+                    Method::POST,
+                    "/v1/execute",
+                    Some(json!({
+                        "shard_key": routing_key,
+                        "sql": "INSERT INTO raw_items (id) VALUES (?1)",
+                        "params": [id]
+                    })),
+                )
+                .await,
+                (
+                    StatusCode::OK,
+                    json!({"shard": expected_shard, "rows_affected": 1})
+                )
+            );
+        }
+        let after_writes =
+            engine.pool_snapshot_for_test().unwrap().shards[usize::from(expected_shard)];
+        assert_eq!(after_writes.opened, 2);
+        assert_eq!(after_writes.checkouts, 2);
+        assert_eq!(after_writes.reused, 0);
+        assert_eq!(after_writes.retired, 1);
+
+        let (status, body) = request_json(
+            &application,
+            Method::POST,
+            "/v1/query",
+            Some(json!({
+                "shard_key": routing_key,
+                "sql": "SELECT last_insert_rowid(), changes(), total_changes(), (SELECT COUNT(*) FROM raw_items)"
+            })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["rows"], json!([[0, 0, 0, 2]]));
+
+        let after_observer =
+            engine.pool_snapshot_for_test().unwrap().shards[usize::from(expected_shard)];
+        assert_eq!(after_observer.opened, 3);
+        assert_eq!(after_observer.checkouts, 3);
+        assert_eq!(after_observer.retired, 2);
     }
 
     #[tokio::test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -103,7 +103,8 @@ pub async fn run_with_engine_options(config: Config, options: EngineOptions) -> 
         postgres_listen = ?config.postgres_listen,
         data_dir = %config.data_dir.display(),
         shards = engine.shard_count(),
-        max_blocking_workers = engine.options().connections_per_shard()
+        engine_blocking_task_admission_limit = engine.blocking_task_admission_limit(),
+        max_active_sqlite_connections = engine.options().connections_per_shard()
             * usize::from(engine.shard_count()),
         connections_per_shard = engine.options().connections_per_shard(),
         queue_capacity_per_shard = engine.options().queue_capacity_per_shard(),

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -29,10 +29,12 @@ pub use inference::{ShardKeyInference, ShardKeyInferenceKind, ShardKeyValue, inf
 pub use normalizer::{
     MAX_SQL_PARAMETERS, NormalizedSql, StatementParameters, normalize_placeholders,
 };
-pub(crate) use parser::validate_authoritative_schema_migration;
 pub use parser::{
     MAX_PARSED_SQL_BYTES, MAX_PARSED_SQL_STATEMENTS, ParsedSql, SQL_PARSE_RECURSION_LIMIT,
     SqlDialect, parse,
+};
+pub(crate) use parser::{
+    validate_authoritative_schema_migration, validate_stateless_catalog_schema_sql,
 };
 pub(crate) use scatter::validate_scatter_safe;
 pub use subset::{CommonSql, MAX_COMMON_SQL_EXPRESSION_DEPTH, validate_common_subset};

--- a/src/sql/parser.rs
+++ b/src/sql/parser.rs
@@ -1,7 +1,7 @@
-use std::{borrow::Cow, fmt};
+use std::{borrow::Cow, fmt, ops::ControlFlow};
 
 use sqlparser::{
-    ast::{ObjectType, Statement as AstStatement},
+    ast::{Expr, ObjectNamePart, ObjectType, Statement as AstStatement, visit_expressions},
     dialect::{Dialect, MySqlDialect, PostgreSqlDialect, SQLiteDialect},
     parser::{Parser, ParserError},
 };
@@ -166,6 +166,50 @@ pub(crate) fn validate_authoritative_schema_migration(source: &str) -> EngineRes
     } else {
         Ok(())
     }
+}
+
+/// Reject stored schema expressions that can observe SQLite write history on
+/// a physical connection reused by stateless catalog writes.
+pub(crate) fn validate_stateless_catalog_schema_sql(source: &str) -> EngineResult<()> {
+    let parsed = parse(SqlDialect::Sqlite, source).map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::FailedPrecondition,
+            "persistent SQLite schema SQL could not be validated for stateless write reuse",
+            error,
+        )
+    })?;
+    let found = parsed.statements().iter().any(|statement| {
+        visit_expressions(statement, |expression| {
+            let is_connection_local = match expression {
+                Expr::Function(function) => match function.name.0.as_slice() {
+                    [ObjectNamePart::Identifier(name)] => {
+                        connection_local_counter_function(&name.value)
+                    }
+                    _ => false,
+                },
+                _ => false,
+            };
+            if is_connection_local {
+                ControlFlow::Break(())
+            } else {
+                ControlFlow::Continue(())
+            }
+        })
+        .is_break()
+    });
+    if found {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "persistent SQLite schema expressions cannot use connection-local counter functions",
+        ));
+    }
+    Ok(())
+}
+
+fn connection_local_counter_function(function: &str) -> bool {
+    ["last_insert_rowid", "changes", "total_changes"]
+        .iter()
+        .any(|counter| function.eq_ignore_ascii_case(counter))
 }
 
 fn parse_with(dialect: &dyn Dialect, source: &str) -> Result<Vec<AstStatement>, ParserError> {
@@ -363,6 +407,36 @@ mod tests {
             "CREATE VIEW widget_ids AS SELECT id FROM widgets",
         ] {
             validate_authoritative_schema_migration(source)
+                .unwrap_or_else(|error| panic!("{source}: {error}"));
+        }
+    }
+
+    #[test]
+    fn stateless_catalog_schema_rejects_only_connection_local_function_calls() {
+        for source in [
+            "CREATE TABLE records(id INTEGER, previous INTEGER DEFAULT (last_insert_rowid()))",
+            "CREATE TABLE records(id INTEGER, CHECK (ChAnGeS() >= 0))",
+            "CREATE TABLE records(id INTEGER, CHECK (\"TOTAL_CHANGES\"() >= 0))",
+            "CREATE TABLE records(id INTEGER, CHECK ([changes]() >= 0))",
+            "CREATE TABLE records(id INTEGER, CHECK (`last_insert_rowid`() >= 0))",
+            "CREATE TABLE records(id INTEGER, observed INTEGER GENERATED ALWAYS AS (changes()) STORED)",
+            "CREATE INDEX records_recent ON records(id) WHERE total_changes() >= 0",
+        ] {
+            assert_eq!(
+                validate_stateless_catalog_schema_sql(source)
+                    .unwrap_err()
+                    .kind(),
+                EngineErrorKind::FailedPrecondition,
+                "{source}"
+            );
+        }
+
+        for source in [
+            "CREATE TABLE changes(changes TEXT DEFAULT 'total_changes()', last_insert_rowid INTEGER, CHECK(changes <> 'changes()'))",
+            "CREATE TABLE records(id INTEGER, normalized TEXT DEFAULT (lower('CHANGES')))",
+            "CREATE INDEX total_changes ON records(id)",
+        ] {
+            validate_stateless_catalog_schema_sql(source)
                 .unwrap_or_else(|error| panic!("{source}: {error}"));
         }
     }

--- a/src/storage/migration.rs
+++ b/src/storage/migration.rs
@@ -1866,19 +1866,35 @@ mod tests {
             .unwrap();
         let generations_before = shard_generations(temp.path());
 
-        for sql in [
-            "DROP TABLE accounts",
-            "DROP TABLE accounts;
+        for (sql, expected_kind) in [
+            ("DROP TABLE accounts", EngineErrorKind::FailedPrecondition),
+            (
+                "DROP TABLE accounts;
              CREATE TABLE accounts (
                  id TEXT PRIMARY KEY,
                  display_name TEXT NOT NULL
              ) STRICT",
-            "CREATE TABLE undeclared (id INTEGER PRIMARY KEY) STRICT",
-            "CREATE TABLE audit_catalog (id INTEGER PRIMARY KEY) STRICT",
-            "CREATE VIEW audit_catalog AS SELECT id FROM accounts",
+                EngineErrorKind::FailedPrecondition,
+            ),
+            (
+                "CREATE TABLE undeclared (id INTEGER PRIMARY KEY) STRICT",
+                EngineErrorKind::FailedPrecondition,
+            ),
+            (
+                "CREATE TABLE audit_catalog (id INTEGER PRIMARY KEY) STRICT",
+                EngineErrorKind::FailedPrecondition,
+            ),
+            (
+                "CREATE VIEW audit_catalog AS SELECT id FROM accounts",
+                EngineErrorKind::FailedPrecondition,
+            ),
+            (
+                "ALTER TABLE accounts ADD COLUMN observed INTEGER CHECK(total_changes() >= 0)",
+                EngineErrorKind::PermissionDenied,
+            ),
         ] {
             let error = run_sql_with_hook(&storage, sql, |_| Ok(())).unwrap_err();
-            assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition, "{sql}");
+            assert_eq!(error.kind(), expected_kind, "{sql}");
             assert_eq!(storage.schema_gate_snapshot().state, SchemaGateState::Ready);
             assert_eq!(active_journal_snapshot(temp.path()), None, "{sql}");
             assert_eq!(shard_generations(temp.path()), generations_before, "{sql}");

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -766,6 +766,7 @@ impl Storage {
                     ),
                 ));
             }
+            shard::validate_stateless_catalog_schema(&connection)?;
             let physical_names = application_table_names(&connection)?;
             let relation_names = application_relation_names(&connection)?;
             if let Some(shadow) = catalog_declarations.iter().find(|name| {
@@ -919,6 +920,7 @@ impl Storage {
         let generation = self.catalog.logical().schema_generation();
         let trusted = integrity.committed_schema_digest();
         let mut consensus = None;
+        let mut verified_connections = Vec::with_capacity(usize::from(self.shard_count()));
         for shard_id in 0..self.shard_count() {
             let path = self.shard_path(shard_id);
             let connection = shard::open_existing(&path, shard_id, generation, &self.shard_layout)?;
@@ -936,13 +938,22 @@ impl Storage {
                 ));
             }
             consensus = Some(observed);
+            verified_connections.push(connection);
         }
-        consensus.ok_or_else(|| {
+        let consensus = consensus.ok_or_else(|| {
             EngineError::new(
                 EngineErrorKind::Internal,
                 "schema verification requires at least one configured shard",
             )
-        })
+        })?;
+
+        // Establish trusted and cross-shard digest agreement everywhere before
+        // enforcing compatibility policy. Otherwise a policy error on an early
+        // shard could mask later corruption and prevent terminal degradation.
+        for connection in &verified_connections {
+            shard::validate_registered_table_schema(connection, self.catalog.logical())?;
+        }
+        Ok(consensus)
     }
 
     fn open_unconfigured_shard(&self, shard: u16) -> EngineResult<Connection> {
@@ -3495,6 +3506,136 @@ mod tests {
                 .unwrap_err()
                 .kind(),
             EngineErrorKind::FailedPrecondition
+        );
+    }
+
+    #[test]
+    fn table_registration_rejects_connection_local_functions_in_stored_expressions() {
+        for expression in [
+            "value INTEGER DEFAULT (total_changes())",
+            "value INTEGER CHECK (changes() >= 0)",
+            "value INTEGER CHECK (last_insert_rowid() >= 0)",
+        ] {
+            let temp = tempfile::tempdir().unwrap();
+            let mut database = Database::open(temp.path(), 2).unwrap();
+            database
+                .broadcast(&format!(
+                    "CREATE TABLE records (
+                         tenant_id TEXT NOT NULL PRIMARY KEY,
+                         {expression}
+                     )"
+                ))
+                .unwrap();
+            let logical_database = database.catalog().default_database().id();
+            let declaration = TableDeclaration::sharded(
+                logical_database,
+                "records",
+                crate::core::ShardKeyMetadata::new("tenant_id", ShardKeyType::Text).unwrap(),
+            )
+            .unwrap();
+
+            let error = database.register_tables(vec![declaration]).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+            assert!(
+                error
+                    .diagnostic()
+                    .contains("cannot participate in stateless catalog write reuse"),
+                "{expression}: {}",
+                error.diagnostic()
+            );
+            assert!(database.catalog().tables().is_empty());
+        }
+    }
+
+    #[test]
+    fn startup_rejects_a_preexisting_catalog_with_connection_local_schema_functions() {
+        let temp = tempfile::tempdir().unwrap();
+        let database = Database::open(temp.path(), 2).unwrap();
+        database
+            .broadcast(
+                "CREATE TABLE records (
+                     tenant_id TEXT NOT NULL PRIMARY KEY,
+                     value INTEGER CHECK(total_changes() >= 0)
+                 )",
+            )
+            .unwrap();
+        let logical_database = database.catalog().default_database().id();
+        let declaration = TableDeclaration::sharded(
+            logical_database,
+            "records",
+            crate::core::ShardKeyMetadata::new("tenant_id", ShardKeyType::Text).unwrap(),
+        )
+        .unwrap();
+        drop(database);
+
+        let mut manifest_connection =
+            open_existing_manifest(&temp.path().join("manifest.sqlite")).unwrap();
+        configure_manifest_connection(&manifest_connection).unwrap();
+        let simulated_older_catalog =
+            manifest::register_table_catalog(&mut manifest_connection, 2, vec![declaration], || {})
+                .unwrap();
+        drop(simulated_older_catalog);
+        drop(manifest_connection);
+
+        let error = Database::open(temp.path(), 2).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert!(
+            error
+                .diagnostic()
+                .contains("cannot participate in stateless catalog write reuse"),
+            "{}",
+            error.diagnostic()
+        );
+    }
+
+    #[test]
+    fn later_schema_corruption_is_not_masked_by_an_earlier_unsafe_legacy_schema() {
+        let temp = tempfile::tempdir().unwrap();
+        let database = Database::open(temp.path(), 2).unwrap();
+        database
+            .broadcast(
+                "CREATE TABLE records (
+                     tenant_id TEXT NOT NULL PRIMARY KEY,
+                     value INTEGER CHECK(total_changes() >= 0)
+                 )",
+            )
+            .unwrap();
+        let logical_database = database.catalog().default_database().id();
+        let declaration = TableDeclaration::sharded(
+            logical_database,
+            "records",
+            crate::core::ShardKeyMetadata::new("tenant_id", ShardKeyType::Text).unwrap(),
+        )
+        .unwrap();
+        drop(database);
+
+        let manifest_path = temp.path().join("manifest.sqlite");
+        let mut manifest_connection = open_existing_manifest(&manifest_path).unwrap();
+        configure_manifest_connection(&manifest_connection).unwrap();
+        let simulated_older_catalog =
+            manifest::register_table_catalog(&mut manifest_connection, 2, vec![declaration], || {})
+                .unwrap();
+        drop(simulated_older_catalog);
+        drop(manifest_connection);
+
+        Connection::open(temp.path().join("shards/0001.sqlite"))
+            .unwrap()
+            .execute_batch("CREATE TABLE later_shard_tamper(id INTEGER PRIMARY KEY)")
+            .unwrap();
+
+        let error = Database::open(temp.path(), 2).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+        assert_eq!(
+            Connection::open(manifest_path)
+                .unwrap()
+                .query_row(
+                    "SELECT database_state FROM briskdb_integrity WHERE singleton = 1",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            4,
+            "trusted later-shard corruption must persist terminal Degraded state"
         );
     }
 

--- a/src/storage/pool.rs
+++ b/src/storage/pool.rs
@@ -78,13 +78,25 @@ fn cancellable_busy_handler(attempt: i32) -> bool {
     })
 }
 
-/// Identity of the engine session allowed to observe a connection's write-local state.
+/// Identity of the frontend ownership domain allowed to reuse a connection
+/// that contains SQLite write-local state.
+///
+/// Ordinary sessions always receive a unique identity. The stateless catalog
+/// write domain is shared only by planner-validated HTTP writes, whose SQL
+/// surface cannot observe connection-local counters or leave session state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct ConnectionOwner(u64);
+pub(crate) enum ConnectionOwner {
+    Session(u64),
+    StatelessCatalogWrite,
+}
 
 impl ConnectionOwner {
     pub(crate) const fn new(session_id: u64) -> Self {
-        Self(session_id)
+        Self::Session(session_id)
+    }
+
+    pub(crate) const fn stateless_catalog_write() -> Self {
+        Self::StatelessCatalogWrite
     }
 }
 
@@ -1300,6 +1312,88 @@ mod tests {
         assert_eq!(snapshot.reused, 2);
         assert_eq!(snapshot.retired, 0);
         assert_eq!(snapshot.idle, 1);
+    }
+
+    #[tokio::test]
+    async fn shared_stateless_write_owner_reuses_distinct_handles_at_pool_capacity() {
+        let (_temp, pools) =
+            pools_with_schema(2, 0, "CREATE TABLE widgets (id INTEGER PRIMARY KEY)");
+        let owner = ConnectionOwner::stateless_catalog_write();
+
+        let first = pools
+            .acquire_for_owner(0, owner)
+            .await
+            .unwrap()
+            .checkout()
+            .unwrap();
+        let second = pools
+            .acquire_for_owner(0, owner)
+            .await
+            .unwrap()
+            .checkout()
+            .unwrap();
+        let mut original_ids = [first.connection_id(), second.connection_id()];
+        assert_ne!(original_ids[0], original_ids[1]);
+        assert_eq!(
+            pools.snapshot().unwrap().shards[0],
+            ShardPoolSnapshot {
+                shard: 0,
+                active: 2,
+                queued: 0,
+                idle: 0,
+                opened: 2,
+                checkouts: 2,
+                reused: 0,
+                retired: 0,
+            }
+        );
+
+        first
+            .execute_batch("INSERT INTO widgets (id) VALUES (1)")
+            .unwrap();
+        second
+            .execute_batch("INSERT INTO widgets (id) VALUES (2)")
+            .unwrap();
+        drop(first);
+        drop(second);
+
+        let reused_first = pools
+            .acquire_for_owner(0, owner)
+            .await
+            .unwrap()
+            .checkout()
+            .unwrap();
+        let reused_second = pools
+            .acquire_for_owner(0, owner)
+            .await
+            .unwrap()
+            .checkout()
+            .unwrap();
+        let mut reused_ids = [reused_first.connection_id(), reused_second.connection_id()];
+        assert_ne!(reused_ids[0], reused_ids[1]);
+        original_ids.sort_unstable();
+        reused_ids.sort_unstable();
+        assert_eq!(reused_ids, original_ids);
+
+        assert_eq!(
+            pools.snapshot().unwrap().shards[0],
+            ShardPoolSnapshot {
+                shard: 0,
+                active: 2,
+                queued: 0,
+                idle: 0,
+                opened: 2,
+                checkouts: 4,
+                reused: 2,
+                retired: 0,
+            }
+        );
+        drop(reused_first);
+        drop(reused_second);
+
+        let final_snapshot = pools.snapshot().unwrap().shards[0];
+        assert_eq!(final_snapshot.active, 0);
+        assert_eq!(final_snapshot.idle, 2);
     }
 
     #[tokio::test]

--- a/src/storage/shard.rs
+++ b/src/storage/shard.rs
@@ -695,7 +695,7 @@ fn preflight_schema_migration_on_connection_with_digest_inner(
 /// such declaration must have a physical table, and Catalog declarations must
 /// remain manifest-only. Sharded keys additionally retain the representation
 /// required by deterministic routing.
-fn validate_registered_table_schema(
+pub(super) fn validate_registered_table_schema(
     connection: &Connection,
     catalog: &Catalog,
 ) -> EngineResult<()> {
@@ -735,6 +735,7 @@ fn validate_registered_table_schema(
             "schema migration violates the authoritative table catalog: virtual tables are not supported",
         ));
     }
+    validate_stateless_catalog_schema(connection)?;
 
     let expected = catalog
         .tables()
@@ -977,6 +978,42 @@ pub(super) fn validate_authoritative_table_constraints(
                 ),
             ));
         }
+    }
+    Ok(())
+}
+
+/// Reject persistent expressions that could observe a previous stateless
+/// catalog write through SQLite's connection-local counters.
+pub(super) fn validate_stateless_catalog_schema(connection: &Connection) -> EngineResult<()> {
+    let mut statement = connection
+        .prepare(
+            "SELECT type, name, sql
+             FROM main.sqlite_schema
+             WHERE type IN ('table', 'index') AND sql IS NOT NULL
+               AND name NOT GLOB 'sqlite_*'
+             ORDER BY type, name COLLATE BINARY",
+        )
+        .map_err(sqlite_error::storage)?;
+    let objects = statement
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })
+        .map_err(sqlite_error::storage)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(sqlite_error::storage)?;
+
+    for (object_type, name, sql) in objects {
+        crate::sql::validate_stateless_catalog_schema_sql(&sql).map_err(|error| {
+            EngineError::from_source(
+                EngineErrorKind::FailedPrecondition,
+                format!("{object_type} {name} cannot participate in stateless catalog write reuse"),
+                error,
+            )
+        })?;
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Reuse clean SQLite handles across ephemeral HTTP execute requests only after the authoritative catalog planner proves one routed common-subset write.
- Preserve unique ownership for empty-catalog SQL and every ordinary session surface; active handles still obey bounded pool admission and are never shared concurrently.
- Reject connection-local counter functions in persistent schema expressions during registration, startup, import, and migration, with digest verification completing before compatibility policy checks.
- Clarify service capacity logging and document the monitored ten-shard results.

## Safety and tests

- Added sequential and concurrent HTTP reuse/isolation coverage, including a capacity-two regression proving simultaneous callers receive distinct handles.
- Added counter-function coverage for DEFAULT, CHECK, generated columns, indexes, case variants, and SQLite quoting forms.
- Added registration, legacy-startup, later-shard corruption, import, and migration regressions.
- Broken, cancelled, tainted, transactional, and schema-stale connections retain the existing conservative retirement behavior.

## Monitored HTTP benchmark

Ten LARGE_Data shards, one existing row on each active shard, persistent HTTP clients, one connection per shard, and exactly 2, 4, 8, or 10 client/blocking workers. Values are medians of three 10-second release trials.

| Writers | Before | After | Speedup |
| ---: | ---: | ---: | ---: |
| 2 | 776 writes/s | 13,352 writes/s | 17.20x |
| 4 | 704 writes/s | 12,664 writes/s | 17.99x |
| 8 | 634 writes/s | 11,194 writes/s | 17.65x |
| 10 | 690 writes/s | 11,229 writes/s | 16.27x |

Timed errors were zero. CPU fell from 152-808% before to 108-145% after, peak RSS stayed below 12.9 MiB, and physical writes per operation fell by 66-67%.

## Verification

- cargo fmt --all -- --check
- cargo test --locked --all-targets --all-features
- cargo test --locked --doc
- cargo clippy --locked --all-targets --all-features -- -D warnings
- git diff --check

Fixes #121