### PR TITLE
Persist generated ID policies and owner slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,8 +439,8 @@ foreign keys, virtual tables, and any change that breaks declared placement,
 Text collation, or one-owner uniqueness.
 
 The initial shard count is immutable, so resharding will require an explicit
-migration workflow. Opening upgrades exact version-1 through version-7
-manifests to version 8 through ordered, resumable steps.
+migration workflow. Opening upgrades exact version-1 through version-8
+manifests to version 9 through ordered, resumable steps.
 Version 3 introduced the versioned, generation-stamped 4,096-bucket routing
 map. Version 4 adds schema generation 0 and immutable logical metadata with
 default database ID 1 named `default`; identifier encoding version 1 accepts
@@ -493,6 +493,15 @@ foreign keys, triggers, and virtual tables are temporarily unsupported; every
 `BINARY` collation so uniqueness has one physical owner. The public catalog
 returned by `Database::catalog()` and `Engine::catalog()` remains read-only to
 observers.
+
+Version 9 adds one explicit generated-ID policy row per registered table and an
+immutable allocation-owner slot for every physical shard. The v8-to-v9
+migration preserves routing, placement, schema history, shard files, and rows;
+it assigns existing tables policy `None`, seeds `owner_slot = physical_shard_id`,
+raises the downgrade fence, and moves the semantic manifest checksum to version
+2 so both new catalogs are covered. This version defines and validates the
+`native_range_v1` ID format, but does not yet rewrite inserts or seed physical
+`sqlite_sequence` state.
 
 Registration marks schema admission `Pending` before its manifest commit. If
 that commit reports an ambiguous cleanup or I/O failure, close the registering

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -29,9 +29,9 @@ server ---------> protocol::http
 
 | Module | Responsibility | Must not own |
 | --- | --- | --- |
-| `core` | Protocol-neutral `Engine`, `Session`, statements, immutable bound portals, values, results, errors, read-only catalog views and initialization declarations, synchronous bound-value-aware plans, prepared lifecycle, explicit-shard read-only inspection, logical Sharded read target selection and scatter/gather, and sharded routing policy; stable key routing; bounded per-session and per-shard admission; routed execution and journaled schema migration | JSON/HTTP types, listeners, or Axum handlers |
-| `storage` | Versioned routing and authoritative logical manifest, one-time table registration, shard layout, migration journal and recovery, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
-| `import` | Offline source-schema preflight, explicit placement-plan validation, exact-value row routing into private staging, independent verification, durable receipt creation, and atomic publication | Network handlers, live/incremental migration, implicit Global placement, or protocol-specific behavior |
+| `core` | Protocol-neutral `Engine`, `Session`, statements, immutable bound portals, values, results, errors, read-only catalog views and initialization declarations, generated-ID policy and codec types, synchronous bound-value-aware plans, prepared lifecycle, explicit-shard read-only inspection, logical Sharded read target selection and scatter/gather, and sharded routing policy; stable key routing; bounded per-session and per-shard admission; routed execution and journaled schema migration | JSON/HTTP types, listeners, or Axum handlers |
+| `storage` | Versioned routing and authoritative logical manifest, persisted generated-ID policies and immutable allocation-owner slots, one-time table registration, shard layout, migration journal and recovery, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
+| `import` | Offline source-schema preflight, explicit placement-plan validation, exact-value row routing into private staging, explicit no-generation catalog declarations, independent verification, durable receipt creation, and atomic publication | Network handlers, live/incremental migration, generated-ID inference, implicit Global placement, or protocol-specific behavior |
 | `sql` | Dialect-explicit SQL syntax parsing, recursive common-subset validation, protocol-neutral statement/batch classification, source-preserving placeholder normalization, explicit strict/compatibility translation, catalog-aware typed shard-key inference, and narrow crate-private DML-shape inspection behind BriskDB-owned boundaries; exact source retention; SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, key hashing or shard selection, mutable session state, physical write-routing policy, filesystem layout, protocol responses, protocol-buffer ownership, or protocol-specific support policy |
 | `protocol::http` | Existing HTTP request extraction, shared JSON/BriskDB value and RFC 9457 problem-detail encoding, and the embedded admin shell/assets, temporary browser sessions, metadata-driven logical discovery, exact logical counts, and bounded shard-major page handlers | BLAKE3 routing, shard files, direct SQLite access, or rusqlite calls |
 | `protocol::postgres` | BriskDB-owned bounded protocol-3.0 framing, finite parameter validation, selected identity/status, per-connection core-session ownership, query-deferral responses, and private compile/query-parser seam around the exactly pinned `pgwire` library | Listener binding, direct SQLite access, routing, unbounded authoritative prepared state, or public dependency-owned types |
@@ -458,6 +458,15 @@ v7-to-v8 transaction clears all legacy advisory table rows, reseals the
 manifest, and preserves routing, logical databases, migration history, shard
 schema, and application data.
 
+Version 9 adds the authoritative `briskdb_generated_ids` catalog and immutable
+`briskdb_allocation_owners` map. The v8-to-v9 transaction assigns every existing
+table explicit policy `None`, seeds each physical shard's same-numbered owner
+slot, raises the downgrade fence, and changes the semantic manifest checksum to
+version 2 so both new tables are covered. It preserves routing, placement,
+schema history, shard files, and application rows. Version 9 freezes and
+validates the `native_range_v1` ID encoding; insert rewriting and physical
+`sqlite_sequence` seeding remain later work.
+
 Each manifest version retains an intentionally incompatible
 `briskdb_metadata` definition and row as a downgrade fence. The v3-to-v4
 migration remains manifest-atomic. The v4-to-v5 step first validates the v4
@@ -475,6 +484,8 @@ an empty journal, and fencing v5 readers. The v6-to-v7 step is also
 manifest-only and begins in `Verifying`; it cannot manufacture a historical
 checksum that v6 never stored. The v7-to-v8 step is likewise manifest-only and
 clears advisory table rows before installing the authoritative-catalog fence.
+The v8-to-v9 step is also manifest-only: it adds explicit generated-ID policies
+and stable owner slots, installs checksum version 2, and changes no shard file.
 There is no automatic downgrade; an older binary requires a backup from before
 the newer format.
 
@@ -613,6 +624,50 @@ ordinary operations, status calls, and migrations then fail with
 possible. BriskDB exposes no repair, rebaseline, or detailed integrity status
 API here; richer migration administration and status surfaces remain issue
 #53.
+
+## Generated-ID boundary
+
+Generated IDs are authoritative catalog policy, never a conclusion drawn from
+mutable shard DDL. `GeneratedIdPolicy::None` means BriskDB classifies every
+stored signed integer as a legacy value and claims no generation authority for
+it; that includes caller-supplied and previously imported SQLite-generated
+values. `NativeRangeV1` is valid only when its
+named column is the same physically non-null Int64 key that owns a `Sharded`
+table. Import and every legacy manifest upgrade select `None` explicitly, so an
+old `AUTOINCREMENT` clause or a marker-looking imported value cannot silently
+enable BriskDB generation.
+
+The version-1 native value is a positive signed 64-bit integer with bit 62 set,
+an immutable 10-bit allocation-owner slot in bits 61 through 52, and a 52-bit
+owner-local sequence in bits 51 through 0:
+
+```text
+0 | 1 | owner slot (10 bits) | local sequence (52 bits)
+63  62       61..52                    51..0
+```
+
+Owner slots are stable identities rather than a live shard-count ordinal. The
+manifest initially assigns each physical shard its same-numbered slot, but a
+future shard-map change must retain every allocated slot rather than
+renumbering IDs. Local sequence zero is reserved; valid native sequences are
+`1..=2^52-1`, slots are `0..=1023`, and the greatest encoding is `i64::MAX`.
+Policy-aware classification treats values without the marker, including
+negative imported values, as legacy. A marker with reserved local sequence zero
+is corrupt. The strict native decoder instead rejects every non-native value,
+and unsupported persisted encoding versions fail closed before decoding.
+
+This design keeps SQLite upstream. In particular, a schema function cannot
+replace the allocator for an exact `INTEGER PRIMARY KEY`: that declaration is a
+rowid alias, and SQLite's special insert path chooses an omitted or NULL rowid
+without evaluating a column `DEFAULT`. Moving allocation into a side-effecting
+UDF would also put durable allocator state behind connection-local registration
+and retry-sensitive schema evaluation, while a single shared allocator would
+serialize the writers sharding is meant to separate. The later native allocator
+therefore reserves one disjoint range per owner and lets unmodified SQLite
+advance its own shard-local `AUTOINCREMENT` state. This issue persists and
+validates the policy, codec, and owner slots only; physical
+`sqlite_sequence` validation and seeding belong to issue #128, and omitted-key
+SQL translation belongs to issue #130.
 
 The opt-in `experimental-vtab` feature adds a separate, read-only SQLite
 coordinator that statically registers `brisk_shard`. It proves a no-fork logical

--- a/docs/SQLITE_IMPORT.md
+++ b/docs/SQLITE_IMPORT.md
@@ -104,7 +104,10 @@ staging. The source file identity is retained and rechecked so a path
 replacement cannot silently change which database is imported. Cancellation
 interrupts SQLite work during this preflight. Tables and supported indexes are
 then created identically on every target shard and the complete authoritative
-catalog is registered while all tables are empty.
+catalog is registered while all tables are empty. Every imported table is
+registered with the explicit `GeneratedIdPolicy::None` policy. The importer
+never infers generated-ID authority from `INTEGER PRIMARY KEY`,
+`AUTOINCREMENT`, a `DEFAULT` expression, or `sqlite_sequence`.
 
 Rows retain their SQLite storage classes. Sharded rows use separate physical
 connections and visit one selected shard; the implementation does not use
@@ -112,8 +115,12 @@ connections and visit one selected shard; the implementation does not use
 SQLite commits as one transaction. Global rows visit every shard only by their
 declaration. Generated columns are recomputed from copied ordinary columns.
 The source `sqlite_sequence` high-water mark is installed on every physical
-copy. Automatic generation of a Sharded key remains unsupported because
-independent SQLite allocators cannot choose one globally owned value.
+copy as source-schema state; it is not generated-ID catalog metadata and does
+not opt the table into `native_range_v1`. Existing integer keys, including
+values copied from an `AUTOINCREMENT` table, remain explicit legacy values and
+route through the ordinary Int64 shard-key encoding. Enabling a generated-ID
+policy for imported data requires a future explicit conversion that proves the
+key domain and seeds every allocator; import never guesses.
 Preserved implicit `rowid` values remain shard-local physical locators after
 import; they are neither globally unique logical identities nor authoritative
 shard keys. Declared primary and unique constraints retain global meaning

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -817,9 +817,9 @@ underlying execution semantics.
   prefix selects one of 4,096 virtual buckets through the versioned
   compatibility algorithm.
 - The final physical shard is read from the validated, generation-stamped
-  bucket map retained in manifest version 8. Routing generation 1 preserves
+  bucket map retained in manifest version 9. Routing generation 1 preserves
   the earlier modulo placement for every supported shard count.
-- Manifest version 8 retains the read-only catalog view introduced in v4, with
+- Manifest version 9 retains the read-only catalog view introduced in v4, with
   a journaled schema generation from 0 through 2,147,483,647 and default
   database ID 1 named `default`. `Database::register_tables` may populate its
   table rows exactly once during initialization after proving that every shard
@@ -920,7 +920,9 @@ than cross-file atomicity. Version 7 adds the semantic manifest root, explicit
 integrity states, and generation-bound shard-schema fingerprints; journal,
 state, checksum, and catalog changes reseal atomically within the manifest.
 Version 8 retains those integrity rules and includes authoritative table
-registration in the same semantic root.
+registration in the same semantic root. Version 9 adds explicit generated-ID
+policies and immutable allocation-owner slots, upgrades the manifest root to
+checksum version 2, and preserves every existing table as policy `None`.
 See the [manifest storage-format contract](STORAGE_FORMAT.md).
 
 Scatter reads combine committed results from multiple SQLite files. They do not

--- a/docs/SQL_PREPARED_STATEMENTS.md
+++ b/docs/SQL_PREPARED_STATEMENTS.md
@@ -446,7 +446,7 @@ interpolate values into SQL, or choose a physical shard itself.
 ## Storage-format boundary
 
 Issue #26 adds only process-memory session state and execution orchestration.
-It does not change manifest version 8, a manifest table, routing encoding,
+It does not change the manifest format, a manifest table, routing encoding,
 shard identity, schema fingerprint, migration journal, SQLite header field,
 WAL/synchronous mode, or filename. Prepared statements and portals disappear
 when their owning process/session ends. Preparing, describing, or gathering a

--- a/docs/SQL_STATEMENT_CLASSIFICATION.md
+++ b/docs/SQL_STATEMENT_CLASSIFICATION.md
@@ -230,7 +230,7 @@ SQL layer until issue #31.
 ## Storage-format and configuration boundary
 
 Classification is process-memory analysis over an already owned AST. It does
-not change manifest format version 8, manifest tables, logical catalog rows,
+not change the manifest format, manifest tables, logical catalog rows,
 routing-key encoding, virtual buckets, shard identity, SQLite headers,
 application-schema fingerprints, migration-journal records, WAL/synchronous
 mode, or filenames. It opens no database connection and performs no recovery

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -11,24 +11,24 @@ permitted; later migration opens never create a missing replacement, use
 SQLite's no-follow mode, and revalidate the freshly opened layout identity
 inside the same manifest transaction before changing journal state.
 
-## Current format: version 8
+## Current format: version 9
 
 SQLite header fields identify the file and its format:
 
 | Header field | Value | Meaning |
 | --- | --- | --- |
 | `PRAGMA application_id` | `0x42524442` (`BRDB`) | Permanent BriskDB manifest-family marker |
-| `PRAGMA user_version` | `8` | Authoritative manifest schema version |
+| `PRAGMA user_version` | `9` | Authoritative manifest schema version |
 
 The application ID prevents an accidental foreign SQLite file from being
 adopted as a manifest. It is not authentication or tamper protection: a process
 that can write the data directory can forge it and the unkeyed checksums
 described below.
 
-Version 8 has eleven strict manifest tables. It retains the v7 routing,
-logical-catalog, physical-layout, application-schema migration, and integrity
-tables; replaces the downgrade fence; and makes newly registered table rows
-authoritative.
+Version 9 has thirteen strict manifest tables. It retains the v8 routing,
+authoritative logical catalog, physical layout, application-schema migration,
+and integrity tables; replaces the downgrade fence; and adds generated-ID
+policy and immutable allocation-owner metadata without changing a shard file.
 
 ```sql
 CREATE TABLE briskdb_manifest (
@@ -38,7 +38,7 @@ CREATE TABLE briskdb_manifest (
 
 CREATE TABLE briskdb_metadata (
     requires_manifest_version INTEGER NOT NULL
-        CHECK (requires_manifest_version >= 8)
+        CHECK (requires_manifest_version >= 9)
 ) STRICT;
 
 CREATE TABLE briskdb_routing (
@@ -132,6 +132,50 @@ CREATE TABLE briskdb_tables (
     )
 ) STRICT;
 
+CREATE TABLE briskdb_generated_ids (
+    table_id INTEGER PRIMARY KEY CHECK (table_id > 0),
+    policy INTEGER NOT NULL CHECK (policy >= 0),
+    generated_column TEXT COLLATE BINARY
+        CHECK (
+            generated_column IS NULL OR (
+                length(generated_column) BETWEEN 1 AND 63
+                AND instr(generated_column, char(0)) = 0
+                AND generated_column NOT GLOB '*[^a-z0-9_]*'
+                AND substr(generated_column, 1, 1) GLOB '[a-z_]'
+                AND generated_column <> 'briskdb'
+                AND generated_column NOT GLOB 'briskdb_*'
+                AND generated_column NOT GLOB 'sqlite_*'
+            )
+        ),
+    encoding_version INTEGER
+        CHECK (encoding_version IS NULL OR encoding_version > 0),
+    FOREIGN KEY (table_id)
+        REFERENCES briskdb_tables (table_id)
+        ON DELETE RESTRICT,
+    CHECK (
+        (
+            policy = 0
+            AND generated_column IS NULL
+            AND encoding_version IS NULL
+        )
+        OR
+        (
+            policy > 0
+            AND generated_column IS NOT NULL
+            AND encoding_version IS NOT NULL
+        )
+    )
+) STRICT;
+
+CREATE TABLE briskdb_allocation_owners (
+    owner_slot INTEGER PRIMARY KEY CHECK (owner_slot BETWEEN 0 AND 1023),
+    physical_shard_id INTEGER NOT NULL UNIQUE
+        CHECK (physical_shard_id BETWEEN 0 AND 63),
+    FOREIGN KEY (physical_shard_id)
+        REFERENCES briskdb_physical_shards (shard_id)
+        ON DELETE RESTRICT
+) STRICT;
+
 CREATE TABLE briskdb_shard_layout (
     singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
     layout_id BLOB NOT NULL
@@ -202,27 +246,28 @@ CREATE TABLE briskdb_integrity (
 ```
 
 The manifest, metadata, routing, schema-catalog, shard-layout, and integrity
-tables each contain exactly one row. The v8 downgrade-fence row is exactly `8`.
+tables each contain exactly one row. The v9 downgrade-fence row is exactly `9`.
 The two integrity-version columns deliberately accept any positive integer so
 a future digest encoding can remain structurally readable long enough for an
-older binary to reject it as `FailedPrecondition`; v8 writers emit only `1`.
+older binary to reject it as `FailedPrecondition`; v9 writers emit manifest
+digest version `2` and schema digest version `1`.
 Zero or negative versions are malformed and are `DataCorruption`.
 `briskdb_manifest.shard_count` is immutable and is the initial routing modulus;
 it is also the live physical-shard count. Physical IDs are exactly
 `0..shard_count - 1`. Filenames remain derived by trusted code as
 `shards/{shard_id:04}.sqlite` and are never read from catalog-controlled paths.
-Version 8 supports only the `active` physical-shard lifecycle state. Adding
+Version 9 supports only the `active` physical-shard lifecycle state. Adding
 provisioning, draining, or retirement states to the routing catalog requires a
 later format and state-machine change. The separate shard-layout state governs
 only startup identity reconciliation.
 
 ### Logical catalog
 
-Every fresh or upgraded v8 manifest contains logical database ID `1` named
+Every fresh or upgraded v9 manifest contains logical database ID `1` named
 `default`. A fresh or pre-v6 upgrade begins at application-schema
 generation `0`; each completed journal row advances it by exactly one, through
 a maximum of `2,147,483,647`. The schema-catalog singleton also contains
-identifier encoding version `1` and default database ID `1`. Version 8 permits
+identifier encoding version `1` and default database ID `1`. Version 9 permits
 at most 64 logical databases and 4,096 table rows. Database and table IDs are
 positive; table names are unique within their owning database, and every table
 references an existing database.
@@ -264,7 +309,74 @@ shard key and every possible collision meets on one owner. An `INTEGER PRIMARY
 KEY` rowid alias is different: it is a visible declared key and is validated by
 the ordinary shard-key and unique-locality rules.
 
-The loaded `Catalog` remains read-only to observers. Version 8 adds the one-time
+### Generated-ID policies and allocation owners
+
+`briskdb_generated_ids` contains exactly one row for every
+`briskdb_tables` row and no others. Policy is stored separately from physical
+SQLite DDL so a mutable `AUTOINCREMENT` clause, `DEFAULT`, or `sqlite_sequence`
+row can never grant allocation authority by inference. The stable codes are:
+
+| `policy` | Rust policy | `generated_column` | `encoding_version` |
+| --- | --- | --- | --- |
+| `0` | `GeneratedIdPolicy::None` | null | null |
+| `1` | `GeneratedIdPolicy::NativeRangeV1` | The table's canonical Int64 shard-key column | `1` |
+
+The SQL shape permits a positive future policy or encoding so an older binary
+can distinguish an unsupported format from malformed storage. The reader first
+verifies the version-2 semantic root, so an unsealed change remains
+`DataCorruption`; with a valid root, it returns `FailedPrecondition` as soon as
+a structurally admitted positive policy or encoding is newer than it supports.
+It does not apply current-version relational semantics to that future format.
+For supported policy and encoding
+codes, zero or negative encodings, null native fields, a noncanonical column,
+missing or extra policy rows, and relational disagreement are `DataCorruption`.
+Current cross-table validation accepts `native_range_v1` only for a `Sharded`
+table whose generated column exactly equals its visible, physically non-null
+`Int64` shard key. `Global`, `Catalog`, Text, Binary, and a different generated
+column fail closed. Registration persists the policy in the same manifest
+transaction as its table row; an exact retry compares it as part of
+idempotency.
+
+`briskdb_allocation_owners` contains exactly one row for every active physical
+shard and maps each physical shard to one unique slot. Version 9 seeds
+`owner_slot = physical_shard_id`, so current slots are the contiguous range
+`0..shard_count - 1`. The slot is an immutable ID namespace, not a value that
+may be recomputed from a later shard count or bucket map. Version 9 exposes no
+owner-map mutation. A future resharding format must preserve every allocated
+slot and explicitly add any new owner; reassigning a used slot would make old
+IDs ambiguous. Missing, duplicate, out-of-range, noncontiguous initial, or
+foreign-shard mappings are corruption.
+
+Native range encoding version 1 uses these signed 64-bit fields:
+
+```text
+bit       63  62  61................52  51........................0
+meaning    0   1    owner slot (10)       local sequence (52)
+mask           0x4000_0000_0000_0000      0x000f_ffff_ffff_ffff
+```
+
+Owner slots are `0..=1023`. Local sequence zero is reserved as the allocator
+floor and is not a valid row ID; valid values are `1..=2^52-1`. Thus every
+native ID is positive, disjoint per owner, and the maximum owner and local
+sequence encode to `i64::MAX`. Encoding rejects an owner or sequence outside
+those bounds before arithmetic. Under `NativeRangeV1`, negative values and
+marker-clear positive values classify as explicit legacy IDs, while a
+marker-set value with local sequence zero is `DataCorruption`; all other
+marker-set values decode to their owner and local sequence. Under `None`, every
+signed integer—including a marker-looking imported value—is legacy. The strict
+native decoder rejects rather than classifies negative and marker-clear values.
+
+Version 9 only defines the policy and stable namespace; it does not rewrite an
+insert or seed physical `sqlite_sequence`. That work belongs to issue #128.
+Exact `INTEGER PRIMARY KEY` cannot be replaced by a schema `DEFAULT` function:
+it is a rowid alias, and SQLite chooses an omitted or NULL rowid through its
+special insert path instead of evaluating a column default. A side-effecting
+allocation UDF would also make schema evaluation connection-local and
+retry-sensitive; putting its counter in one central file would recreate one
+serialized writer. The no-fork design instead lets unmodified SQLite allocate
+inside disjoint shard-local ranges after those ranges are explicitly installed.
+
+The loaded `Catalog` remains read-only to observers. Version 8 added the one-time
 `Database::register_tables` mutation boundary for an empty table catalog. The
 caller supplies the complete declaration set for the storage-default logical
 database. On every shard, the ordinary application-table names must exactly
@@ -278,9 +390,9 @@ Every primary or unique key on a sharded table must include its shard-key column
 with `BINARY` collation, so every possible collision has one physical owner.
 Application foreign keys, triggers, and virtual tables are temporarily
 unsupported for every registered physical table. Registration assigns table IDs
-after sorting by logical database and canonical table name, commits the rows
-and refreshed manifest root atomically, and publishes the replacement catalog
-only after revalidation.
+after sorting by logical database and canonical table name, commits each table
+and its explicit generated-ID policy row, refreshes the manifest root
+atomically, and publishes the replacement catalog only after revalidation.
 
 Registration is initialization-only and requires exclusive live ownership of
 the data root. An exact complete repeat is a read-only idempotent success;
@@ -304,7 +416,8 @@ the committed replacement fails `FailedPrecondition` rather than publishing
 conflicting catalog snapshots. A new registration must not be attempted through
 the pending handle.
 
-Fresh v8 initialization leaves `briskdb_tables` empty. The v7-to-v8 migration
+Fresh v9 initialization leaves `briskdb_tables` and `briskdb_generated_ids`
+empty. The v7-to-v8 migration
 also clears all v7 table rows because those rows were advisory and were never
 proved against the physical schema; silently promoting them would create false
 routing authority. The upgrade preserves logical databases, routing, schema
@@ -349,7 +462,7 @@ additional `Applying` row may exist, and it must target
 `schema_generation + 1`. Its stored source generation, shard count, SQL text,
 digest, state, and progress are validated on every manifest open. Any journal
 history requires the physical layout to be `Ready`; `Creating` and `Adopting`
-manifests have an empty journal. Fresh v8 initialization and pre-v6 upgrades
+manifests have an empty journal. Fresh v9 initialization and pre-v6 upgrades
 begin with an empty journal at generation 0.
 
 The retained journal proves which exact batches BriskDB coordinated; it does
@@ -391,8 +504,8 @@ restart as repair after any reported `DataCorruption`; whole-shard corruption
 drills and failure handling remain issue #68. Those storage failures retain
 their own error kinds and do not themselves justify rebaselining data.
 
-Manifest digest version 1 is a full 32-byte, unkeyed BLAKE3 digest. The stream
-begins with `briskdb.manifest.semantic-root.v1` plus its terminating NUL. It
+Manifest digest version 2 is a full 32-byte, unkeyed BLAKE3 digest. The stream
+begins with `briskdb.manifest.semantic-root.v2` plus its terminating NUL. It
 then encodes the length-prefixed name `application_id` and its tagged integer,
 followed by the length-prefixed name `user_version` and its tagged integer.
 These tables and columns follow in fixed order:
@@ -403,10 +516,12 @@ These tables and columns follow in fixed order:
 | `briskdb_metadata` | `requires_manifest_version` |
 | `briskdb_routing` | `singleton`, `hash_version`, `key_encoding_version`, `bucket_algorithm_version`, `virtual_bucket_count`, `map_generation` |
 | `briskdb_physical_shards` | `shard_id`, `lifecycle_state` |
+| `briskdb_allocation_owners` | `owner_slot`, `physical_shard_id` |
 | `briskdb_virtual_buckets` | `bucket_id`, `physical_shard_id` |
 | `briskdb_logical_databases` | `database_id`, `database_name` |
 | `briskdb_schema_catalog` | `singleton`, `identifier_encoding_version`, `schema_generation`, `default_database_id` |
 | `briskdb_tables` | `table_id`, `database_id`, `table_name`, `placement`, `shard_key_column`, `shard_key_type` |
+| `briskdb_generated_ids` | `table_id`, `policy`, `generated_column`, `encoding_version` |
 | `briskdb_shard_layout` | `singleton`, `layout_id`, `shard_application_id`, `shard_metadata_version`, `layout_state` |
 | `briskdb_schema_migrations` | `target_generation`, `source_generation`, `migration_id`, `digest_version`, `sql_text`, `shard_count`, `migration_state`, `next_shard` |
 | `briskdb_integrity` | `singleton`, `manifest_digest_version`, `schema_digest_version`, `database_state`, `committed_schema_digest`, `target_schema_digest` |
@@ -424,7 +539,7 @@ self-reference; its version, database state, and schema digest fields are
 covered. Frozen SQL definitions, STRICT flags, indexes, and foreign keys are
 validated separately rather than encoded as semantic rows.
 
-Every BriskDB-owned v8 manifest mutation recalculates the root after its row
+Every BriskDB-owned v9 manifest mutation recalculates the root after its row
 changes and before the same transaction commits. Progress acknowledgement,
 migration publication/finalization, layout publication, state changes, and
 catalog changes therefore cannot commit with a stale root through supported
@@ -432,7 +547,14 @@ code. Hashing semantic values instead of the raw SQLite file makes the root
 stable across WAL checkpoints, page relocation, and `VACUUM`; it deliberately
 does not cover SQLite page bytes, rollback journals, WAL, or shared memory.
 
-The frozen four-shard v8 fixture with layout ID
+Digest version 1 remains frozen solely to verify and migrate version-7 and
+version-8 manifests. It uses the
+`briskdb.manifest.semantic-root.v1` domain and the same encoding, but omits the
+two version-9 tables. A v9 manifest must store version 2; storing version 1 in
+an otherwise v9 shape is corruption, and an unsupported future positive digest
+version is a failed precondition.
+
+The frozen four-shard v8/version-1 fixture with layout ID
 `000102030405060708090a0b0c0d0e0f`, committed schema fingerprint `5a` repeated
 32 times, and the catalog rows in
 `manifest_semantic_digest_v1_has_a_frozen_golden_vector` hashes to
@@ -564,7 +686,7 @@ The routing singleton contains exactly these generation-1 values:
 | `key_encoding_version` | `1` | Canonical bytes defined below for raw, explicit, and typed inferred routing keys |
 | `bucket_algorithm_version` | `1` | Compatibility-preserving range algorithm below |
 | `virtual_bucket_count` | `4096` | Fixed virtual bucket space `0..4095` |
-| `map_generation` | `1` | Initial committed bucket map and the only generation version 8 can interpret |
+| `map_generation` | `1` | Initial committed bucket map and the only generation version 9 can interpret |
 
 Every bucket ID exists exactly once and references an active physical shard.
 Every physical shard owns at least one bucket. The generation-1 map partitions
@@ -606,7 +728,7 @@ vectors freeze the exact key bytes, BLAKE3 prefix, little-endian hash integer,
 bucket ID, and persisted physical shard.
 
 `map_generation` is separate from manifest `user_version` and from
-`schema_generation`. Version 8 accepts only routing generation 1 and validates
+`schema_generation`. Version 9 accepts only routing generation 1 and validates
 its exact deterministic assignment; no public map-mutation operation exists
 yet. A future format that can commit a changed map must bump `user_version` and
 its downgrade fence as well as `map_generation`. That requirement makes this
@@ -617,12 +739,32 @@ At each open, BriskDB validates the exact objects, columns, strict flags, frozen
 schema SQL, singleton rows, logical identifiers and limits, metadata codes,
 supported algorithm values, contiguous physical and bucket IDs, active
 lifecycle states, assignments, coverage, and foreign keys. A recognized
-version-8 manifest that violates any invariant is `DataCorruption` and is
+version-9 manifest that violates any invariant is `DataCorruption` and is
 rejected before shard connections are opened. The same locked transaction
 returns routing and logical rows as one coherent shared snapshot. Request
 routing performs no manifest query and cannot fall back to modulo after a failed
 validation; only successful migration finalization publishes a newer logical
 schema generation into the snapshot.
+
+## Previous version 8
+
+Version 8 has the eleven manifest tables retained from version 7. It has no
+`briskdb_generated_ids` or `briskdb_allocation_owners` table, its exact
+downgrade fence requires version 8, and it stores semantic manifest digest
+version 1. Its authoritative `briskdb_tables` rows have no generated-ID field;
+every such table therefore migrates as explicit `GeneratedIdPolicy::None`.
+
+The atomic v8-to-v9 transaction creates one `None` policy row for every table,
+creates one allocation-owner row for every active physical shard with
+`owner_slot = physical_shard_id`, replaces the downgrade fence, changes the
+integrity row to manifest digest version 2, stamps `user_version = 9`, and
+reseals the version-2 semantic root. It preserves all table placement and shard
+keys, routing and map generation, logical database and schema generation,
+migration history and progress, layout and durable integrity state,
+application-schema fingerprints, shard files, and application rows. All of
+those manifest changes commit or roll back together; the migration neither
+opens nor mutates a shard. A version-8 reader rejects the version-9 header
+before it could ignore generated-ID policy or owner-slot authority.
 
 ## Previous version 7
 
@@ -752,8 +894,8 @@ CREATE TABLE briskdb_metadata (
 ```
 
 The fence contains exactly `2`. A current opener validates this complete format
-before applying the numbered v2-to-v3, v3-to-v4, v4-to-v5, v5-to-v6, and
-v6-to-v7 and v7-to-v8 transactions.
+before applying the numbered v2-to-v3, v3-to-v4, v4-to-v5, v5-to-v6,
+v6-to-v7, v7-to-v8, and v8-to-v9 transactions.
 
 ## Legacy version 1
 
@@ -802,22 +944,26 @@ returning:
    Reject a foreign file, a newer version, a requested shard-count mismatch, a
    stale root, or another invalid recognized state before changing it.
 5. Apply each compile-time registered manifest migration with static SQL and
-   bound data. The destination application ID and `user_version` are the final
-   mutations; validate the complete destination and commit one numbered step at
-   a time. The v6-to-v7 transaction adds an integrity row in `Verifying`; the
+   bound data. Stamp the destination application ID and `user_version` only
+   after the schema/data change, then refresh the version-selected semantic
+   root, validate the complete destination, and commit one numbered step at a
+   time. The v6-to-v7 transaction adds an integrity row in `Verifying`; the
    v7-to-v8 transaction clears advisory table rows and installs the
-   authoritative-catalog downgrade fence. Older formats therefore cannot be
-   mistaken for checksummed or authoritative-catalog data.
+   authoritative-catalog downgrade fence; and v8-to-v9 installs explicit
+   generated-ID policies, allocation-owner slots, and semantic digest version
+   2. Older formats therefore cannot be mistaken for checksummed,
+   authoritative-catalog, or allocator-authority data.
 6. Fresh initialization is allowed only beside an otherwise empty physical
-   layout and commits v8 physical state `Creating`, integrity state
+   layout and commits v9 physical state `Creating`, integrity state
    `Verifying`, generation 0, and an empty migration journal. An existing
    v1/v2/v3 manifest first advances through v4; the v4-to-v5 transaction commits
    a random 16-byte layout ID and physical state `Adopting` before any shard
    file changes. The v5-to-v6 step creates the journal, v6-to-v7 establishes
    the unsealed integrity row, and v7-to-v8 establishes an empty authoritative
-   table catalog.
+   table catalog. The v8-to-v9 step adds the empty generated-policy catalog and
+   immutable owner map.
 7. If the validated integrity state is `Degraded`, fail startup without
-   changing it. Otherwise, if a validated v8 manifest contains one `Applying`
+   changing it. Otherwise, if a validated v9 manifest contains one `Applying`
    migration, require state `Migrating`, validate every shard against the
    trusted source/target fingerprint for its exact journal-prefix position,
    and resume it in ascending order. The final transaction publishes the
@@ -843,8 +989,9 @@ returning:
     `Database`, or `Engine`.
 
 SQLite transactional DDL keeps each numbered manifest step atomic within
-`manifest.sqlite`. A version-1 upgrade commits versions 2, 3, 4, 5, 6, 7, and
-then 8; a version-2 upgrade begins at 3, and so on. The v3-to-v4 step still creates the
+`manifest.sqlite`. A version-1 upgrade commits versions 2 through 9; a
+version-2 upgrade begins at 3, and so on. The v3-to-v4 step
+still creates the
 logical catalog, inserts database ID 1 named `default` plus the
 schema-generation-0 singleton, and leaves the table catalog empty.
 
@@ -865,7 +1012,9 @@ schema generation 0 and has no journal history. The v6-to-v7 step also changes
 no shard; it establishes a first fingerprint only after later cross-file
 consensus verification. The v7-to-v8 step changes no shard and clears advisory
 `briskdb_tables` rows rather than inferring or blessing declarations from
-physical DDL.
+physical DDL. The v8-to-v9 step likewise changes no shard: it records every
+existing authoritative table as `None`, seeds owner slots from immutable
+physical shard IDs, and changes the manifest checksum domain.
 
 A new application-schema migration follows a separate durable protocol:
 
@@ -935,11 +1084,13 @@ later storage-hardening certification.
 
 ## Compatibility and operations
 
-- Version 1 upgrades through versions 2, 3, 4, 5, 6, 7, and 8; later versions
+- Version 1 upgrades through versions 2, 3, 4, 5, 6, 7, 8, and 9; later versions
   begin at the next numbered transaction. Opening is therefore potentially
   mutating. An active v6 journal is completed before its v7 transaction.
 - There is no automatic downgrade. Older readers are fenced by the incompatible
-  metadata schema and authoritative header. In particular, a version-7 reader
+  metadata schema and authoritative header. In particular, a version-8 reader
+  rejects `user_version = 9` before it can ignore generated-ID policy and owner
+  mappings, a version-7 reader
   rejects `user_version = 8` before it can treat authoritative table rows as
   advisory, and a version-6 reader rejects version 7 before it can ignore
   integrity state.
@@ -992,7 +1143,7 @@ header value, format version, digest input, routing metadata, schema
 fingerprint, journal record, or recovery step. Listener settings are not
 persisted. Because engine open and its existing recovery precede listener
 binding, a later bind failure does not undo a migration or recovery transaction
-that already committed; a subsequent startup revalidates the same version-8
+that already committed; a subsequent startup revalidates the same version-9
 layout normally.
 
 Issue #29's pinned `pgwire` dependency and issue #30's production startup,
@@ -1037,7 +1188,8 @@ the in-process coordination is intentionally not a distributed lock.
 
 ## Verification contract
 
-Tests cover fresh creation and every v1/v2/v3/v4/v5/v6/v7-to-v8 upgrade, every
+Tests cover fresh creation and every v1/v2/v3/v4/v5/v6/v7/v8 upgrade path to
+v9, every
 manifest layout and integrity state, the exact shard header and metadata row,
 dynamic schema generations, retained migration history, checksum golden
 vectors, and no-op ready reopen. Failure
@@ -1052,10 +1204,12 @@ being published before full strict revalidation. Concurrent openers exercise
 matching and conflicting shard counts and layout transitions.
 
 Catalog tests continue to cover default logical metadata, every placement and
-shard-key type code, identifier and relational corruption, row limits,
-v7 advisory-row clearing, atomic registration and commit ambiguity, exact
-idempotency, empty-schema and key/constraint validation, immutable public
-lookups, stale-handle exclusion, and migration enforcement. Routing tests
+shard-key type code, every generated-ID policy and encoding boundary,
+legacy/native classification, immutable allocation-owner coverage, identifier
+and relational corruption, row limits, v7 advisory-row clearing, v8 explicit
+`None` migration, atomic registration and commit ambiguity, exact idempotency,
+empty-schema and key/constraint validation, immutable public lookups,
+stale-handle exclusion, and migration enforcement. Routing tests
 freeze golden hash/bucket/shard vectors,
 cover every algorithm state for every supported shard count, prove the final
 map lookup with a synthetic reassignment, and exercise parallel and reopen

--- a/src/core/catalog.rs
+++ b/src/core/catalog.rs
@@ -5,7 +5,7 @@ use std::{
     sync::atomic::{AtomicU64, Ordering},
 };
 
-use super::{EngineError, EngineErrorKind, EngineResult, RoutingCatalog};
+use super::{AllocationOwnerMap, EngineError, EngineErrorKind, EngineResult, RoutingCatalog};
 
 pub(crate) const IDENTIFIER_ENCODING_VERSION: u32 = 1;
 pub(crate) const DEFAULT_LOGICAL_DATABASE_ID: u64 = 1;
@@ -121,6 +121,80 @@ pub enum ShardKeyType {
     Binary,
 }
 
+/// Versioned policy for values BriskDB may generate for one logical table.
+///
+/// A policy is authoritative catalog metadata. BriskDB never infers it from a
+/// physical SQLite `DEFAULT`, `AUTOINCREMENT` clause, or `sqlite_sequence`
+/// row. New policy variants may be added in later releases, so callers must
+/// retain a wildcard arm when matching it.
+///
+/// ```compile_fail
+/// use briskdb::core::GeneratedIdPolicy;
+///
+/// fn policy_name(policy: GeneratedIdPolicy) -> &'static str {
+///     match policy {
+///         GeneratedIdPolicy::None => "none",
+///         GeneratedIdPolicy::NativeRangeV1 { .. } => "native_range_v1",
+///     }
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use briskdb::core::GeneratedIdPolicy;
+///
+/// let _ = GeneratedIdPolicy::NativeRangeV1 {
+///     column: "id".to_owned(),
+/// };
+/// ```
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum GeneratedIdPolicy {
+    /// BriskDB does not generate an ID for this table.
+    #[default]
+    None,
+    /// SQLite allocates from a positive signed 64-bit range namespaced by an
+    /// immutable allocation-owner slot.
+    ///
+    /// Construction is intentionally restricted to
+    /// [`GeneratedIdPolicy::native_range_v1`] so the stored column name always
+    /// satisfies the canonical catalog-identifier contract.
+    #[non_exhaustive]
+    NativeRangeV1 {
+        /// Canonical generated column name.
+        column: String,
+    },
+}
+
+impl GeneratedIdPolicy {
+    /// Construct the first native shard-range policy for a canonical column.
+    pub fn native_range_v1(column: impl Into<String>) -> EngineResult<Self> {
+        let column = column.into();
+        ensure_catalog_identifier(&column)?;
+        Ok(Self::NativeRangeV1 { column })
+    }
+
+    pub(crate) fn native_range_v1_from_validated(column: String) -> Self {
+        debug_assert!(validate_catalog_identifier(&column));
+        Self::NativeRangeV1 { column }
+    }
+
+    /// Return the generated column, or `None` when generation is disabled.
+    pub fn column(&self) -> Option<&str> {
+        match self {
+            Self::None => None,
+            Self::NativeRangeV1 { column } => Some(column),
+        }
+    }
+
+    /// Return the persisted codec version, or `None` for the `None` policy.
+    pub const fn encoding_version(&self) -> Option<u32> {
+        match self {
+            Self::None => None,
+            Self::NativeRangeV1 { .. } => Some(1),
+        }
+    }
+}
+
 /// Single-column shard-key declaration for a sharded table.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ShardKeyMetadata {
@@ -175,6 +249,7 @@ pub struct TableDeclaration {
     database_id: LogicalDatabaseId,
     name: String,
     placement: TablePlacement,
+    generated_id_policy: GeneratedIdPolicy,
 }
 
 impl TableDeclaration {
@@ -207,7 +282,16 @@ impl TableDeclaration {
             database_id,
             name,
             placement,
+            generated_id_policy: GeneratedIdPolicy::None,
         })
+    }
+
+    /// Replace this table's generated-ID policy after validating it against
+    /// the declared placement and shard key.
+    pub fn with_generated_id_policy(mut self, policy: GeneratedIdPolicy) -> EngineResult<Self> {
+        ensure_generated_id_policy_compatible(&self.placement, &policy)?;
+        self.generated_id_policy = policy;
+        Ok(self)
     }
 
     /// Return the owning logical database.
@@ -225,8 +309,20 @@ impl TableDeclaration {
         &self.placement
     }
 
-    pub(crate) fn into_parts(self) -> (LogicalDatabaseId, String, TablePlacement) {
-        (self.database_id, self.name, self.placement)
+    /// Return the authoritative generated-ID policy.
+    pub const fn generated_id_policy(&self) -> &GeneratedIdPolicy {
+        &self.generated_id_policy
+    }
+
+    pub(crate) fn into_parts(
+        self,
+    ) -> (LogicalDatabaseId, String, TablePlacement, GeneratedIdPolicy) {
+        (
+            self.database_id,
+            self.name,
+            self.placement,
+            self.generated_id_policy,
+        )
     }
 }
 
@@ -237,23 +333,46 @@ pub struct TableMetadata {
     database_id: LogicalDatabaseId,
     name: String,
     placement: TablePlacement,
+    generated_id_policy: GeneratedIdPolicy,
 }
 
 impl TableMetadata {
+    #[allow(dead_code)]
     pub(crate) fn from_validated(
         id: u64,
         database_id: u64,
         name: String,
         placement: TablePlacement,
     ) -> Self {
+        Self::from_validated_with_generated_id_policy(
+            id,
+            database_id,
+            name,
+            placement,
+            GeneratedIdPolicy::None,
+        )
+    }
+
+    pub(crate) fn from_validated_with_generated_id_policy(
+        id: u64,
+        database_id: u64,
+        name: String,
+        placement: TablePlacement,
+        generated_id_policy: GeneratedIdPolicy,
+    ) -> Self {
         debug_assert!(id > 0);
         debug_assert!(database_id > 0);
         debug_assert!(validate_catalog_identifier(&name));
+        debug_assert!(generated_id_policy_is_compatible(
+            &placement,
+            &generated_id_policy
+        ));
         Self {
             id: TableId::from_validated(id),
             database_id: LogicalDatabaseId::from_validated(database_id),
             name,
             placement,
+            generated_id_policy,
         }
     }
 
@@ -275,6 +394,62 @@ impl TableMetadata {
     /// Return the table placement and any shard-key declaration.
     pub const fn placement(&self) -> &TablePlacement {
         &self.placement
+    }
+
+    /// Return the authoritative generated-ID policy loaded from the manifest.
+    pub const fn generated_id_policy(&self) -> &GeneratedIdPolicy {
+        &self.generated_id_policy
+    }
+}
+
+fn ensure_generated_id_policy_compatible(
+    placement: &TablePlacement,
+    policy: &GeneratedIdPolicy,
+) -> EngineResult<()> {
+    if generated_id_policy_is_compatible(placement, policy) {
+        return Ok(());
+    }
+
+    let diagnostic = match (placement, policy) {
+        (TablePlacement::Sharded(shard_key), GeneratedIdPolicy::NativeRangeV1 { column: _ })
+            if shard_key.key_type() != ShardKeyType::Int64 =>
+        {
+            format!(
+                "native_range_v1 generated IDs require an Int64 shard key, but table shard key {} has a different type",
+                shard_key.column()
+            )
+        }
+        (TablePlacement::Sharded(shard_key), GeneratedIdPolicy::NativeRangeV1 { column }) => {
+            format!(
+                "native_range_v1 generated column {column} must be the table shard key {}",
+                shard_key.column()
+            )
+        }
+        (_, GeneratedIdPolicy::NativeRangeV1 { .. }) => {
+            "native_range_v1 generated IDs require Sharded table placement".to_owned()
+        }
+        (_, GeneratedIdPolicy::None) => {
+            "the None generated-ID policy is unexpectedly incompatible".to_owned()
+        }
+    };
+    Err(EngineError::new(
+        EngineErrorKind::InvalidArgument,
+        diagnostic,
+    ))
+}
+
+fn generated_id_policy_is_compatible(
+    placement: &TablePlacement,
+    policy: &GeneratedIdPolicy,
+) -> bool {
+    match policy {
+        GeneratedIdPolicy::None => true,
+        GeneratedIdPolicy::NativeRangeV1 { column } => matches!(
+            placement,
+            TablePlacement::Sharded(shard_key)
+                if shard_key.key_type() == ShardKeyType::Int64
+                    && shard_key.column() == column
+        ),
     }
 }
 
@@ -477,11 +652,34 @@ impl Catalog {
 pub(crate) struct CatalogSnapshot {
     routing: RoutingCatalog,
     logical: Catalog,
+    allocation_owners: Option<AllocationOwnerMap>,
 }
 
 impl CatalogSnapshot {
+    /// Construct a pre-v9 snapshot that has no durable generated-ID owner map.
     pub(crate) fn from_validated_parts(routing: RoutingCatalog, logical: Catalog) -> Self {
-        Self { routing, logical }
+        Self {
+            routing,
+            logical,
+            allocation_owners: None,
+        }
+    }
+
+    /// Construct a v9 snapshot retaining its validated durable owner map.
+    pub(crate) fn from_validated_parts_with_allocation_owners(
+        routing: RoutingCatalog,
+        logical: Catalog,
+        allocation_owners: AllocationOwnerMap,
+    ) -> Self {
+        debug_assert_eq!(
+            allocation_owners.physical_shard_count(),
+            routing.shard_count()
+        );
+        Self {
+            routing,
+            logical,
+            allocation_owners: Some(allocation_owners),
+        }
     }
 
     pub(crate) const fn routing(&self) -> &RoutingCatalog {
@@ -490,6 +688,10 @@ impl CatalogSnapshot {
 
     pub(crate) const fn logical(&self) -> &Catalog {
         &self.logical
+    }
+
+    pub(crate) const fn allocation_owners(&self) -> Option<&AllocationOwnerMap> {
+        self.allocation_owners.as_ref()
     }
 }
 
@@ -528,6 +730,11 @@ mod tests {
         atomic::{AtomicBool, Ordering},
     };
 
+    use crate::core::{
+        BUCKET_ALGORITHM_VERSION, HASH_VERSION, INITIAL_MAP_GENERATION, KEY_ENCODING_VERSION,
+        VIRTUAL_BUCKET_COUNT, initial_physical_shard,
+    };
+
     use super::*;
 
     fn sample_catalog() -> Catalog {
@@ -559,6 +766,20 @@ mod tests {
                 ),
             ]
             .into_boxed_slice(),
+        )
+    }
+
+    fn sample_routing_catalog(shard_count: u16) -> RoutingCatalog {
+        RoutingCatalog::from_validated_parts(
+            shard_count,
+            HASH_VERSION,
+            KEY_ENCODING_VERSION,
+            BUCKET_ALGORITHM_VERSION,
+            INITIAL_MAP_GENERATION,
+            (0..VIRTUAL_BUCKET_COUNT)
+                .map(|bucket| initial_physical_shard(bucket, shard_count))
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
         )
     }
 
@@ -600,6 +821,7 @@ mod tests {
         assert_eq!(declaration.database_id(), database);
         assert_eq!(declaration.name(), "accounts");
         assert_eq!(declaration.placement(), &TablePlacement::Sharded(shard_key));
+        assert_eq!(declaration.generated_id_policy(), &GeneratedIdPolicy::None);
 
         assert_eq!(
             TableDeclaration::global(database, "countries")
@@ -628,6 +850,93 @@ mod tests {
                 EngineErrorKind::InvalidArgument
             );
         }
+    }
+
+    #[test]
+    fn generated_id_policies_are_owned_versioned_and_shard_key_scoped() {
+        let database = LogicalDatabaseId::new(9).unwrap();
+        let policy = GeneratedIdPolicy::native_range_v1("id").unwrap();
+        assert_eq!(policy.column(), Some("id"));
+        assert_eq!(policy.encoding_version(), Some(1));
+        assert_eq!(GeneratedIdPolicy::None.column(), None);
+        assert_eq!(GeneratedIdPolicy::None.encoding_version(), None);
+        assert_eq!(GeneratedIdPolicy::default(), GeneratedIdPolicy::None);
+
+        let declaration = TableDeclaration::sharded(
+            database,
+            "events",
+            ShardKeyMetadata::new("id", ShardKeyType::Int64).unwrap(),
+        )
+        .unwrap()
+        .with_generated_id_policy(policy.clone())
+        .unwrap();
+        assert_eq!(declaration.generated_id_policy(), &policy);
+
+        let metadata = TableMetadata::from_validated_with_generated_id_policy(
+            1,
+            database.get(),
+            "events".to_owned(),
+            declaration.placement().clone(),
+            policy.clone(),
+        );
+        assert_eq!(metadata.generated_id_policy(), &policy);
+
+        let (_, name, placement, recovered_policy) = declaration.into_parts();
+        assert_eq!(name, "events");
+        assert!(matches!(placement, TablePlacement::Sharded(_)));
+        assert_eq!(recovered_policy, policy);
+
+        for invalid in ["", "GeneratedId", "two-words", "sqlite_sequence"] {
+            assert_eq!(
+                GeneratedIdPolicy::native_range_v1(invalid)
+                    .unwrap_err()
+                    .kind(),
+                EngineErrorKind::InvalidArgument
+            );
+        }
+    }
+
+    #[test]
+    fn generated_id_policy_rejects_incompatible_table_declarations() {
+        let database = LogicalDatabaseId::new(9).unwrap();
+
+        let mismatched = TableDeclaration::sharded(
+            database,
+            "events",
+            ShardKeyMetadata::new("tenant_id", ShardKeyType::Int64).unwrap(),
+        )
+        .unwrap()
+        .with_generated_id_policy(GeneratedIdPolicy::native_range_v1("id").unwrap())
+        .unwrap_err();
+        assert_eq!(mismatched.kind(), EngineErrorKind::InvalidArgument);
+
+        for key_type in [ShardKeyType::Text, ShardKeyType::Binary] {
+            let error = TableDeclaration::sharded(
+                database,
+                "events",
+                ShardKeyMetadata::new("id", key_type).unwrap(),
+            )
+            .unwrap()
+            .with_generated_id_policy(GeneratedIdPolicy::native_range_v1("id").unwrap())
+            .unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::InvalidArgument);
+        }
+
+        for declaration in [
+            TableDeclaration::global(database, "events").unwrap(),
+            TableDeclaration::catalog(database, "events").unwrap(),
+        ] {
+            let error = declaration
+                .with_generated_id_policy(GeneratedIdPolicy::native_range_v1("id").unwrap())
+                .unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::InvalidArgument);
+        }
+
+        let disabled = TableDeclaration::global(database, "events")
+            .unwrap()
+            .with_generated_id_policy(GeneratedIdPolicy::None)
+            .unwrap();
+        assert_eq!(disabled.generated_id_policy(), &GeneratedIdPolicy::None);
     }
 
     #[test]
@@ -716,6 +1025,28 @@ mod tests {
         assert_send_sync_static::<TableDeclaration>();
         assert_send_sync_static::<ShardKeyMetadata>();
         assert_send_sync_static::<ShardKeyType>();
+        assert_send_sync_static::<GeneratedIdPolicy>();
+    }
+
+    #[test]
+    fn catalog_snapshot_distinguishes_pre_v9_and_persisted_owner_metadata() {
+        let legacy =
+            CatalogSnapshot::from_validated_parts(sample_routing_catalog(4), sample_catalog());
+        assert_eq!(legacy.allocation_owners(), None);
+
+        let owners = AllocationOwnerMap::try_from_pairs(
+            4,
+            vec![(0, 0), (1, 1), (2, 2), (3, 3)].into_boxed_slice(),
+        )
+        .unwrap();
+        let current = CatalogSnapshot::from_validated_parts_with_allocation_owners(
+            sample_routing_catalog(4),
+            sample_catalog(),
+            owners.clone(),
+        );
+        assert_eq!(current.allocation_owners(), Some(&owners));
+        assert_ne!(legacy, current);
+        assert_eq!(current.clone(), current);
     }
 
     #[test]

--- a/src/core/generated_id.rs
+++ b/src/core/generated_id.rs
@@ -1,0 +1,462 @@
+//! Stable generated-ID encodings shared by planning and storage.
+//!
+//! Issue #125 freezes the codec and its failure boundaries before issue #128
+//! lets SQLite allocate from these ranges. Production execution does not use
+//! every helper yet.
+
+#![allow(dead_code)]
+
+use super::{EngineError, EngineErrorKind, EngineResult, GeneratedIdPolicy};
+
+pub(crate) const NATIVE_RANGE_V1_FORMAT_MARKER: u64 = 0x4000_0000_0000_0000;
+pub(crate) const NATIVE_RANGE_V1_OWNER_BITS: u32 = 10;
+pub(crate) const NATIVE_RANGE_V1_LOCAL_SEQUENCE_BITS: u32 = 52;
+pub(crate) const NATIVE_RANGE_V1_OWNER_SHIFT: u32 = NATIVE_RANGE_V1_LOCAL_SEQUENCE_BITS;
+pub(crate) const MAX_ALLOCATION_OWNER_SLOT: u16 = (1_u16 << NATIVE_RANGE_V1_OWNER_BITS) - 1;
+pub(crate) const MAX_NATIVE_RANGE_V1_LOCAL_SEQUENCE: u64 =
+    (1_u64 << NATIVE_RANGE_V1_LOCAL_SEQUENCE_BITS) - 1;
+
+const NATIVE_RANGE_V1_OWNER_MASK: u64 =
+    ((1_u64 << NATIVE_RANGE_V1_OWNER_BITS) - 1) << NATIVE_RANGE_V1_OWNER_SHIFT;
+
+/// Stable allocation namespace encoded into a native generated ID.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) struct AllocationOwnerSlot(u16);
+
+impl AllocationOwnerSlot {
+    pub(crate) fn new(value: u16) -> EngineResult<Self> {
+        if value > MAX_ALLOCATION_OWNER_SLOT {
+            return Err(EngineError::new(
+                EngineErrorKind::NumericOutOfRange,
+                format!(
+                    "allocation-owner slot {value} exceeds the native-range limit {MAX_ALLOCATION_OWNER_SLOT}"
+                ),
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    pub(crate) const fn from_validated(value: u16) -> Self {
+        debug_assert!(value <= MAX_ALLOCATION_OWNER_SLOT);
+        Self(value)
+    }
+
+    pub(crate) const fn get(self) -> u16 {
+        self.0
+    }
+}
+
+/// Immutable, bidirectional assignment of generated-ID owner slots to
+/// physical SQLite shards.
+///
+/// Owner slots are part of the durable ID format and therefore cannot be
+/// inferred from a mutable shard position. The manifest validates and loads
+/// this map once; native ID routing and shard-local allocation then consult
+/// the same immutable runtime snapshot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AllocationOwnerMap {
+    by_owner: Box<[(AllocationOwnerSlot, u16)]>,
+    by_physical_shard: Box<[AllocationOwnerSlot]>,
+}
+
+impl AllocationOwnerMap {
+    /// Validate a complete one-to-one mapping for the current physical shard
+    /// set and normalize entries into owner-slot order.
+    pub(crate) fn try_from_pairs(
+        physical_shard_count: u16,
+        pairs: Box<[(u16, u16)]>,
+    ) -> EngineResult<Self> {
+        if physical_shard_count == 0 {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "an allocation-owner map requires at least one physical shard",
+            ));
+        }
+        if pairs.len() != usize::from(physical_shard_count) {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "an allocation-owner map must contain exactly one entry per physical shard",
+            ));
+        }
+
+        let mut by_owner = pairs
+            .into_vec()
+            .into_iter()
+            .map(|(owner, physical_shard)| {
+                AllocationOwnerSlot::new(owner).map(|owner| (owner, physical_shard))
+            })
+            .collect::<EngineResult<Vec<_>>>()?;
+        by_owner.sort_unstable_by_key(|(owner, _)| *owner);
+        if by_owner
+            .windows(2)
+            .any(|entries| entries[0].0 == entries[1].0)
+        {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "an allocation-owner slot cannot be assigned more than once",
+            ));
+        }
+
+        let mut by_physical_shard = vec![None; usize::from(physical_shard_count)];
+        for &(owner, physical_shard) in &by_owner {
+            let Some(entry) = by_physical_shard.get_mut(usize::from(physical_shard)) else {
+                return Err(EngineError::new(
+                    EngineErrorKind::InvalidArgument,
+                    format!(
+                        "allocation owner {} references physical shard {physical_shard}, outside the current shard set",
+                        owner.get()
+                    ),
+                ));
+            };
+            if entry.replace(owner).is_some() {
+                return Err(EngineError::new(
+                    EngineErrorKind::InvalidArgument,
+                    format!(
+                        "physical shard {physical_shard} cannot have more than one allocation owner"
+                    ),
+                ));
+            }
+        }
+        let by_physical_shard = by_physical_shard
+            .into_iter()
+            .enumerate()
+            .map(|(physical_shard, owner)| {
+                owner.ok_or_else(|| {
+                    EngineError::new(
+                        EngineErrorKind::InvalidArgument,
+                        format!("physical shard {physical_shard} is missing its allocation owner"),
+                    )
+                })
+            })
+            .collect::<EngineResult<Vec<_>>>()?;
+
+        Ok(Self {
+            by_owner: by_owner.into_boxed_slice(),
+            by_physical_shard: by_physical_shard.into_boxed_slice(),
+        })
+    }
+
+    pub(crate) fn physical_shard(&self, owner: AllocationOwnerSlot) -> Option<u16> {
+        self.by_owner
+            .binary_search_by_key(&owner, |(candidate, _)| *candidate)
+            .ok()
+            .map(|index| self.by_owner[index].1)
+    }
+
+    pub(crate) fn owner_for_physical_shard(
+        &self,
+        physical_shard: u16,
+    ) -> Option<AllocationOwnerSlot> {
+        self.by_physical_shard
+            .get(usize::from(physical_shard))
+            .copied()
+    }
+
+    pub(crate) fn physical_shard_count(&self) -> u16 {
+        u16::try_from(self.by_physical_shard.len())
+            .expect("a validated allocation-owner map fits the physical shard ID range")
+    }
+
+    pub(crate) fn pairs(&self) -> impl ExactSizeIterator<Item = (u16, u16)> + '_ {
+        self.by_owner
+            .iter()
+            .map(|(owner, physical_shard)| (owner.get(), *physical_shard))
+    }
+}
+
+/// Decoded fields of one valid `native_range_v1` ID.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct NativeRangeV1Id {
+    owner: AllocationOwnerSlot,
+    local_sequence: u64,
+}
+
+impl NativeRangeV1Id {
+    pub(crate) fn new(owner: AllocationOwnerSlot, local_sequence: u64) -> EngineResult<Self> {
+        if local_sequence == 0 {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "native_range_v1 local sequence zero is reserved for the SQLite sequence floor",
+            ));
+        }
+        if local_sequence > MAX_NATIVE_RANGE_V1_LOCAL_SEQUENCE {
+            return Err(EngineError::new(
+                EngineErrorKind::NumericOutOfRange,
+                format!(
+                    "native_range_v1 local sequence {local_sequence} exceeds {MAX_NATIVE_RANGE_V1_LOCAL_SEQUENCE}"
+                ),
+            ));
+        }
+        Ok(Self {
+            owner,
+            local_sequence,
+        })
+    }
+
+    pub(crate) const fn owner(self) -> AllocationOwnerSlot {
+        self.owner
+    }
+
+    pub(crate) const fn local_sequence(self) -> u64 {
+        self.local_sequence
+    }
+
+    pub(crate) fn encode(self) -> i64 {
+        let encoded = sequence_floor_bits(self.owner) | self.local_sequence;
+        i64::try_from(encoded).expect("native_range_v1 reserves the signed high bit")
+    }
+
+    /// Decode a generated value strictly as `native_range_v1`.
+    ///
+    /// Legacy values return `NumericOutOfRange`; callers that accept both
+    /// formats should use [`classify_generated_id`] instead.
+    pub(crate) fn decode(encoded: i64) -> EngineResult<Self> {
+        decode_native_range_v1(encoded)?.ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::NumericOutOfRange,
+                "value does not contain the native_range_v1 format marker",
+            )
+        })
+    }
+}
+
+/// Policy-aware interpretation of a stored logical key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GeneratedIdClassification {
+    /// A caller-supplied or imported value routed by the legacy key codec.
+    Legacy(i64),
+    /// A valid value allocated from one native owner range.
+    NativeRangeV1(NativeRangeV1Id),
+}
+
+/// Classify one value without inferring generation policy from its bits.
+///
+/// A table whose policy is `None` treats every signed 64-bit value as legacy,
+/// including values that resemble a native marker. A native-range table keeps
+/// negative and pre-marker values on the legacy routing path, allowing an
+/// explicitly validated transition without changing existing keys.
+pub(crate) fn classify_generated_id(
+    policy: &GeneratedIdPolicy,
+    encoded: i64,
+) -> EngineResult<GeneratedIdClassification> {
+    match policy {
+        GeneratedIdPolicy::None => Ok(GeneratedIdClassification::Legacy(encoded)),
+        GeneratedIdPolicy::NativeRangeV1 { .. } => decode_native_range_v1(encoded).map(|decoded| {
+            decoded.map_or(
+                GeneratedIdClassification::Legacy(encoded),
+                GeneratedIdClassification::NativeRangeV1,
+            )
+        }),
+    }
+}
+
+/// SQLite `sqlite_sequence` floor for an empty owner-local table.
+///
+/// This sentinel contains the v1 marker and owner but local sequence zero, so
+/// it is deliberately not a valid row ID. SQLite's first automatic allocation
+/// advances it to local sequence one.
+pub(crate) fn native_range_v1_sequence_floor(owner: AllocationOwnerSlot) -> i64 {
+    i64::try_from(sequence_floor_bits(owner)).expect("native_range_v1 reserves the signed high bit")
+}
+
+fn sequence_floor_bits(owner: AllocationOwnerSlot) -> u64 {
+    NATIVE_RANGE_V1_FORMAT_MARKER | (u64::from(owner.get()) << NATIVE_RANGE_V1_OWNER_SHIFT)
+}
+
+fn decode_native_range_v1(encoded: i64) -> EngineResult<Option<NativeRangeV1Id>> {
+    if encoded < 0 {
+        return Ok(None);
+    }
+    let bits = u64::try_from(encoded).expect("non-negative i64 fits u64");
+    if bits & NATIVE_RANGE_V1_FORMAT_MARKER == 0 {
+        return Ok(None);
+    }
+
+    let local_sequence = bits & MAX_NATIVE_RANGE_V1_LOCAL_SEQUENCE;
+    if local_sequence == 0 {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "native_range_v1 row ID contains the reserved local sequence zero",
+        ));
+    }
+    let owner = u16::try_from((bits & NATIVE_RANGE_V1_OWNER_MASK) >> NATIVE_RANGE_V1_OWNER_SHIFT)
+        .expect("the native owner field contains ten bits");
+    Ok(Some(NativeRangeV1Id {
+        owner: AllocationOwnerSlot::from_validated(owner),
+        local_sequence,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn native_policy() -> GeneratedIdPolicy {
+        GeneratedIdPolicy::native_range_v1("id").unwrap()
+    }
+
+    #[test]
+    fn every_owner_round_trips_at_both_local_boundaries() {
+        for owner in 0..=MAX_ALLOCATION_OWNER_SLOT {
+            let owner = AllocationOwnerSlot::new(owner).unwrap();
+            for local_sequence in [1, MAX_NATIVE_RANGE_V1_LOCAL_SEQUENCE] {
+                let id = NativeRangeV1Id::new(owner, local_sequence).unwrap();
+                let encoded = id.encode();
+                assert!(encoded > 0);
+                assert_eq!(NativeRangeV1Id::decode(encoded).unwrap(), id);
+                assert_eq!(
+                    classify_generated_id(&native_policy(), encoded).unwrap(),
+                    GeneratedIdClassification::NativeRangeV1(id)
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn golden_vectors_freeze_marker_owner_and_sequence_bits() {
+        let vectors = [
+            (0, 1, 0x4000_0000_0000_0001_i64),
+            (0, MAX_NATIVE_RANGE_V1_LOCAL_SEQUENCE, 0x400f_ffff_ffff_ffff),
+            (1, 1, 0x4010_0000_0000_0001),
+            (63, 1, 0x43f0_0000_0000_0001),
+            (1_023, 1, 0x7ff0_0000_0000_0001),
+            (1_023, MAX_NATIVE_RANGE_V1_LOCAL_SEQUENCE, i64::MAX),
+        ];
+
+        for (owner, local_sequence, expected) in vectors {
+            let owner = AllocationOwnerSlot::new(owner).unwrap();
+            let id = NativeRangeV1Id::new(owner, local_sequence).unwrap();
+            assert_eq!(id.encode(), expected);
+            assert_eq!(id.owner(), owner);
+            assert_eq!(id.local_sequence(), local_sequence);
+        }
+    }
+
+    #[test]
+    fn sqlite_sequence_floors_are_reserved_and_advance_to_the_first_id() {
+        for owner in [0, 1, 63, MAX_ALLOCATION_OWNER_SLOT] {
+            let owner = AllocationOwnerSlot::new(owner).unwrap();
+            let floor = native_range_v1_sequence_floor(owner);
+            assert_eq!(
+                classify_generated_id(&native_policy(), floor)
+                    .unwrap_err()
+                    .kind(),
+                EngineErrorKind::DataCorruption
+            );
+            assert_eq!(
+                floor.checked_add(1).unwrap(),
+                NativeRangeV1Id::new(owner, 1).unwrap().encode()
+            );
+        }
+    }
+
+    #[test]
+    fn owner_and_local_overflow_fail_before_encoding() {
+        assert_eq!(
+            AllocationOwnerSlot::new(MAX_ALLOCATION_OWNER_SLOT + 1)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::NumericOutOfRange
+        );
+        let owner = AllocationOwnerSlot::new(0).unwrap();
+        assert_eq!(
+            NativeRangeV1Id::new(owner, 0).unwrap_err().kind(),
+            EngineErrorKind::InvalidArgument
+        );
+        assert_eq!(
+            NativeRangeV1Id::new(owner, MAX_NATIVE_RANGE_V1_LOCAL_SEQUENCE + 1)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::NumericOutOfRange
+        );
+    }
+
+    #[test]
+    fn policy_context_keeps_imported_marker_values_legacy() {
+        for value in [
+            i64::MIN,
+            -1,
+            0,
+            1,
+            NATIVE_RANGE_V1_FORMAT_MARKER as i64,
+            0x4000_0000_0000_0001,
+            i64::MAX,
+        ] {
+            assert_eq!(
+                classify_generated_id(&GeneratedIdPolicy::None, value).unwrap(),
+                GeneratedIdClassification::Legacy(value)
+            );
+        }
+    }
+
+    #[test]
+    fn native_policy_classifies_pre_marker_and_negative_values_as_legacy() {
+        for value in [
+            i64::MIN,
+            -1,
+            0,
+            1,
+            (NATIVE_RANGE_V1_FORMAT_MARKER - 1) as i64,
+        ] {
+            assert_eq!(
+                classify_generated_id(&native_policy(), value).unwrap(),
+                GeneratedIdClassification::Legacy(value)
+            );
+            assert_eq!(
+                NativeRangeV1Id::decode(value).unwrap_err().kind(),
+                EngineErrorKind::NumericOutOfRange
+            );
+        }
+    }
+
+    #[test]
+    fn codec_types_are_owned_send_and_sync() {
+        fn assert_owned<T: Clone + Send + Sync + 'static>() {}
+        assert_owned::<AllocationOwnerSlot>();
+        assert_owned::<AllocationOwnerMap>();
+        assert_owned::<NativeRangeV1Id>();
+        assert_owned::<GeneratedIdClassification>();
+    }
+
+    #[test]
+    fn allocation_owner_map_normalizes_and_routes_in_both_directions() {
+        let map = AllocationOwnerMap::try_from_pairs(
+            4,
+            vec![(19, 2), (7, 0), (MAX_ALLOCATION_OWNER_SLOT, 3), (11, 1)].into_boxed_slice(),
+        )
+        .unwrap();
+
+        assert_eq!(map.physical_shard_count(), 4);
+        assert_eq!(
+            map.pairs().collect::<Vec<_>>(),
+            [(7, 0), (11, 1), (19, 2), (MAX_ALLOCATION_OWNER_SLOT, 3)]
+        );
+        for (owner, shard) in [(7, 0), (11, 1), (19, 2), (MAX_ALLOCATION_OWNER_SLOT, 3)] {
+            let owner = AllocationOwnerSlot::new(owner).unwrap();
+            assert_eq!(map.physical_shard(owner), Some(shard));
+            assert_eq!(map.owner_for_physical_shard(shard), Some(owner));
+        }
+        assert_eq!(
+            map.physical_shard(AllocationOwnerSlot::new(1).unwrap()),
+            None
+        );
+        assert_eq!(map.owner_for_physical_shard(4), None);
+    }
+
+    #[test]
+    fn allocation_owner_map_rejects_incomplete_duplicate_and_out_of_range_rows() {
+        let cases = [
+            (0, vec![]),
+            (2, vec![(0, 0)]),
+            (2, vec![(0, 0), (0, 1)]),
+            (2, vec![(0, 0), (1, 0)]),
+            (2, vec![(0, 0), (1, 2)]),
+            (2, vec![(0, 0), (MAX_ALLOCATION_OWNER_SLOT + 1, 1)]),
+        ];
+        for (shard_count, pairs) in cases {
+            assert!(
+                AllocationOwnerMap::try_from_pairs(shard_count, pairs.into_boxed_slice()).is_err()
+            );
+        }
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -7,6 +7,7 @@ mod catalog;
 mod control;
 mod engine;
 mod error;
+pub(crate) mod generated_id;
 mod lifecycle;
 mod options;
 mod planner;
@@ -18,8 +19,8 @@ mod types;
 pub(crate) mod worker;
 
 pub use catalog::{
-    Catalog, LogicalDatabaseId, LogicalDatabaseMetadata, ShardKeyMetadata, ShardKeyType,
-    TableDeclaration, TableId, TableMetadata, TablePlacement,
+    Catalog, GeneratedIdPolicy, LogicalDatabaseId, LogicalDatabaseMetadata, ShardKeyMetadata,
+    ShardKeyType, TableDeclaration, TableId, TableMetadata, TablePlacement,
 };
 pub(crate) use catalog::{
     CatalogSnapshot, DEFAULT_LOGICAL_DATABASE_ID, DEFAULT_LOGICAL_DATABASE_NAME,
@@ -31,6 +32,7 @@ pub(crate) use control::{
 pub use control::{CancellationToken, RequestContext};
 pub use engine::{Engine, EngineStatus, Statement};
 pub use error::{EngineError, EngineErrorKind, EngineResult};
+pub(crate) use generated_id::AllocationOwnerMap;
 pub use lifecycle::{EngineState, ShutdownReport};
 pub(crate) use lifecycle::{Lifecycle, OperationLease};
 pub use options::{

--- a/src/import/schema.rs
+++ b/src/import/schema.rs
@@ -17,8 +17,8 @@ use super::{
 };
 use crate::{
     core::{
-        CancellationToken, EngineError, EngineErrorKind, EngineResult, LogicalDatabaseId,
-        MAX_TABLES, ShardKeyMetadata, ShardKeyType, TableDeclaration,
+        CancellationToken, EngineError, EngineErrorKind, EngineResult, GeneratedIdPolicy,
+        LogicalDatabaseId, MAX_TABLES, ShardKeyMetadata, ShardKeyType, TableDeclaration,
     },
     sqlite_error,
 };
@@ -332,13 +332,16 @@ impl SourceSnapshot {
     ) -> EngineResult<Vec<TableDeclaration>> {
         self.tables
             .iter()
-            .map(|table| match table.shard_key() {
-                Some(key) => TableDeclaration::sharded(
-                    database_id,
-                    table.name(),
-                    ShardKeyMetadata::new(key.column(), core_key_type(key.key_type()))?,
-                ),
-                None => TableDeclaration::global(database_id, table.name()),
+            .map(|table| {
+                let declaration = match table.shard_key() {
+                    Some(key) => TableDeclaration::sharded(
+                        database_id,
+                        table.name(),
+                        ShardKeyMetadata::new(key.column(), core_key_type(key.key_type()))?,
+                    ),
+                    None => TableDeclaration::global(database_id, table.name()),
+                }?;
+                declaration.with_generated_id_policy(GeneratedIdPolicy::None)
             })
             .collect()
     }

--- a/src/storage/manifest.rs
+++ b/src/storage/manifest.rs
@@ -7,12 +7,13 @@ use std::cell::Cell;
 
 use crate::{
     core::{
-        BUCKET_ALGORITHM_VERSION, Catalog, CatalogSnapshot, DEFAULT_LOGICAL_DATABASE_ID,
-        DEFAULT_LOGICAL_DATABASE_NAME, EngineError, EngineErrorKind, EngineResult, HASH_VERSION,
-        IDENTIFIER_ENCODING_VERSION, INITIAL_MAP_GENERATION, KEY_ENCODING_VERSION,
-        LogicalDatabaseMetadata, MAX_LOGICAL_DATABASES, MAX_TABLES, RoutingCatalog,
-        ShardKeyMetadata, ShardKeyType, TableDeclaration, TableMetadata, TablePlacement,
-        VIRTUAL_BUCKET_COUNT, initial_physical_shard, validate_catalog_identifier,
+        AllocationOwnerMap, BUCKET_ALGORITHM_VERSION, Catalog, CatalogSnapshot,
+        DEFAULT_LOGICAL_DATABASE_ID, DEFAULT_LOGICAL_DATABASE_NAME, EngineError, EngineErrorKind,
+        EngineResult, GeneratedIdPolicy, HASH_VERSION, IDENTIFIER_ENCODING_VERSION,
+        INITIAL_MAP_GENERATION, KEY_ENCODING_VERSION, LogicalDatabaseMetadata,
+        MAX_LOGICAL_DATABASES, MAX_TABLES, RoutingCatalog, ShardKeyMetadata, ShardKeyType,
+        TableDeclaration, TableMetadata, TablePlacement, VIRTUAL_BUCKET_COUNT,
+        initial_physical_shard, validate_catalog_identifier,
     },
     sqlite_error,
 };
@@ -29,7 +30,8 @@ const V5_SCHEMA_VERSION: u32 = 5;
 const V6_SCHEMA_VERSION: u32 = 6;
 const V7_SCHEMA_VERSION: u32 = 7;
 const V8_SCHEMA_VERSION: u32 = 8;
-pub(super) const CURRENT_SCHEMA_VERSION: u32 = V8_SCHEMA_VERSION;
+const V9_SCHEMA_VERSION: u32 = 9;
+pub(super) const CURRENT_SCHEMA_VERSION: u32 = V9_SCHEMA_VERSION;
 const MAX_TABLE_SQL_BYTES: i64 = 4_096;
 
 pub(super) const MAX_SCHEMA_MIGRATION_SQL_BYTES: usize = 65_536;
@@ -37,9 +39,11 @@ pub(super) const MAX_SCHEMA_GENERATION: u64 = i32::MAX as u64;
 const SCHEMA_MIGRATION_DIGEST_VERSION: u32 = 1;
 const SCHEMA_MIGRATION_APPLYING: i64 = 1;
 const SCHEMA_MIGRATION_COMPLETE: i64 = 2;
-const MANIFEST_DIGEST_VERSION: u32 = 1;
+const V1_MANIFEST_DIGEST_VERSION: u32 = 1;
+const V2_MANIFEST_DIGEST_VERSION: u32 = 2;
 pub(super) const SCHEMA_DIGEST_VERSION: u32 = 1;
-const MANIFEST_DIGEST_DOMAIN: &[u8] = b"briskdb.manifest.semantic-root.v1\0";
+const V1_MANIFEST_DIGEST_DOMAIN: &[u8] = b"briskdb.manifest.semantic-root.v1\0";
+const V2_MANIFEST_DIGEST_DOMAIN: &[u8] = b"briskdb.manifest.semantic-root.v2\0";
 
 const DATABASE_STATE_VERIFYING: i64 = 1;
 const DATABASE_STATE_READY: i64 = 2;
@@ -53,6 +57,10 @@ const CATALOG_PLACEMENT: i64 = 3;
 const INT64_SHARD_KEY_TYPE: i64 = 1;
 const TEXT_SHARD_KEY_TYPE: i64 = 2;
 const BINARY_SHARD_KEY_TYPE: i64 = 3;
+const GENERATED_ID_POLICY_NONE: i64 = 0;
+const GENERATED_ID_POLICY_NATIVE_RANGE_V1: i64 = 1;
+const NATIVE_RANGE_V1_ENCODING_VERSION: u32 = 1;
+const MAX_ALLOCATION_OWNER_SLOT: i64 = 1_023;
 
 const ACTIVE_LIFECYCLE_STATE: &str = "active";
 
@@ -108,6 +116,10 @@ const V7_DOWNGRADE_FENCE_SQL: &str = "CREATE TABLE briskdb_metadata (
 const V8_DOWNGRADE_FENCE_SQL: &str = "CREATE TABLE briskdb_metadata (
     requires_manifest_version INTEGER NOT NULL
         CHECK (requires_manifest_version >= 8)
+) STRICT";
+const V9_DOWNGRADE_FENCE_SQL: &str = "CREATE TABLE briskdb_metadata (
+    requires_manifest_version INTEGER NOT NULL
+        CHECK (requires_manifest_version >= 9)
 ) STRICT";
 const V3_ROUTING_TABLE_SQL: &str = "CREATE TABLE briskdb_routing (
     singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
@@ -201,6 +213,48 @@ const V4_TABLES_TABLE_SQL: &str = "CREATE TABLE briskdb_tables (
             AND shard_key_type IS NULL
         )
     )
+) STRICT";
+const V9_GENERATED_IDS_TABLE_SQL: &str = "CREATE TABLE briskdb_generated_ids (
+    table_id INTEGER PRIMARY KEY CHECK (table_id > 0),
+    policy INTEGER NOT NULL CHECK (policy >= 0),
+    generated_column TEXT COLLATE BINARY
+        CHECK (
+            generated_column IS NULL OR (
+                length(generated_column) BETWEEN 1 AND 63
+                AND instr(generated_column, char(0)) = 0
+                AND generated_column NOT GLOB '*[^a-z0-9_]*'
+                AND substr(generated_column, 1, 1) GLOB '[a-z_]'
+                AND generated_column <> 'briskdb'
+                AND generated_column NOT GLOB 'briskdb_*'
+                AND generated_column NOT GLOB 'sqlite_*'
+            )
+        ),
+    encoding_version INTEGER
+        CHECK (encoding_version IS NULL OR encoding_version > 0),
+    FOREIGN KEY (table_id)
+        REFERENCES briskdb_tables (table_id)
+        ON DELETE RESTRICT,
+    CHECK (
+        (
+            policy = 0
+            AND generated_column IS NULL
+            AND encoding_version IS NULL
+        )
+        OR
+        (
+            policy > 0
+            AND generated_column IS NOT NULL
+            AND encoding_version IS NOT NULL
+        )
+    )
+) STRICT";
+const V9_ALLOCATION_OWNERS_TABLE_SQL: &str = "CREATE TABLE briskdb_allocation_owners (
+    owner_slot INTEGER PRIMARY KEY CHECK (owner_slot BETWEEN 0 AND 1023),
+    physical_shard_id INTEGER NOT NULL UNIQUE
+        CHECK (physical_shard_id BETWEEN 0 AND 63),
+    FOREIGN KEY (physical_shard_id)
+        REFERENCES briskdb_physical_shards (shard_id)
+        ON DELETE RESTRICT
 ) STRICT";
 const V5_SHARD_LAYOUT_TABLE_SQL: &str = "CREATE TABLE briskdb_shard_layout (
     singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
@@ -428,6 +482,7 @@ struct ManifestSnapshot {
     shard_layout: Option<ShardLayout>,
     active_migration: Option<SchemaMigration>,
     integrity: Option<ManifestIntegrity>,
+    allocation_owners: Option<AllocationOwnerMap>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -529,6 +584,13 @@ const MIGRATIONS: &[Migration] = &[
         apply: migrate_v7_to_v8,
         validate: validate_v8,
     },
+    Migration {
+        from: V8_SCHEMA_VERSION,
+        to: V9_SCHEMA_VERSION,
+        name: "generated_id_policies_and_allocation_owners",
+        apply: migrate_v8_to_v9,
+        validate: validate_v9,
+    },
 ];
 
 #[derive(Clone, Copy)]
@@ -542,8 +604,8 @@ struct MigrationPlan<'a> {
 const CURRENT_PLAN: MigrationPlan<'static> = MigrationPlan {
     current_version: CURRENT_SCHEMA_VERSION,
     migrations: MIGRATIONS,
-    initialize_current: create_v8_schema,
-    initialize_interrupted_legacy: migrate_interrupted_legacy_to_v8,
+    initialize_current: create_v9_schema,
+    initialize_interrupted_legacy: migrate_interrupted_legacy_to_v9,
 };
 
 // Startup uses this frozen plan only to finish an already-active v6 journal
@@ -606,25 +668,18 @@ pub(super) fn load_or_create_manifest_with_fresh_layout(
     requested_shards: u16,
     fresh_layout_allowed: bool,
 ) -> EngineResult<LoadedManifest> {
-    let snapshot = load_or_create_snapshot_with_plan(
+    let mut snapshot = load_or_create_snapshot_with_plan(
         connection,
         requested_shards,
         CURRENT_PLAN,
         fresh_layout_allowed,
         &mut |_| Ok(()),
     )?;
-    let routing = snapshot.routing_catalog.ok_or_else(|| {
-        EngineError::new(
-            EngineErrorKind::Internal,
-            "current manifest validation did not produce a routing catalog",
-        )
-    })?;
-    let logical = snapshot.logical_catalog.ok_or_else(|| {
-        EngineError::new(
-            EngineErrorKind::Internal,
-            "current manifest validation did not produce a logical catalog",
-        )
-    })?;
+    let catalog = catalog_snapshot_from_parts(
+        snapshot.routing_catalog.take(),
+        snapshot.logical_catalog.take(),
+        snapshot.allocation_owners.take(),
+    )?;
     let shard_layout = snapshot.shard_layout.ok_or_else(|| {
         EngineError::new(
             EngineErrorKind::Internal,
@@ -638,7 +693,7 @@ pub(super) fn load_or_create_manifest_with_fresh_layout(
         )
     })?;
     Ok(LoadedManifest {
-        catalog: CatalogSnapshot::from_validated_parts(routing, logical),
+        catalog,
         shard_layout,
         active_migration: snapshot.active_migration,
         integrity,
@@ -1222,7 +1277,7 @@ pub(super) fn advance_schema_migration_in_transaction(
             ],
         )
         .map_err(sqlite_error::storage)?;
-    refresh_manifest_digest_if_v7(transaction)?;
+    refresh_manifest_digest_if_checksummed(transaction)?;
     let advanced = current_manifest_snapshot(transaction, requested_shards)?
         .active_migration
         .ok_or_else(|| {
@@ -1383,7 +1438,7 @@ fn current_manifest_snapshot(
 ///
 /// Physical-table and emptiness validation belongs to the storage coordinator,
 /// which holds the root schema gate before entering this manifest transaction.
-/// This layer revalidates the checksummed v8 manifest under its write lock,
+/// This layer revalidates the current checksummed manifest under its write lock,
 /// assigns deterministic IDs, refreshes the semantic root in the same
 /// transaction, and returns only the fully revalidated replacement snapshot.
 /// An exact repeat is a read-only idempotent success. Every other attempt to
@@ -1436,7 +1491,7 @@ where
             "current manifest validation omitted its logical catalog",
         )
     })?;
-    for (database_id, table_name, _) in &declarations {
+    for (database_id, table_name, _, _) in &declarations {
         if current_catalog.database_by_id(*database_id).is_none() {
             return Err(EngineError::new(
                 EngineErrorKind::InvalidArgument,
@@ -1470,7 +1525,9 @@ where
                  ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
             )
             .map_err(sqlite_error::storage)?;
-        for (index, (database_id, table_name, placement)) in declarations.iter().enumerate() {
+        for (index, (database_id, table_name, placement, generated_id_policy)) in
+            declarations.iter().enumerate()
+        {
             let table_id = i64::try_from(index + 1).expect("bounded table ID fits in SQLite");
             let database_id = i64::try_from(database_id.get()).map_err(|error| {
                 EngineError::from_source(
@@ -1489,6 +1546,19 @@ where
                     shard_key_column,
                     shard_key_type,
                 ])
+                .map_err(sqlite_error::storage)?;
+            let (policy, generated_column, encoding_version) =
+                encoded_generated_id_policy(generated_id_policy);
+            transaction
+                .execute(
+                    "INSERT INTO briskdb_generated_ids (
+                        table_id,
+                        policy,
+                        generated_column,
+                        encoding_version
+                     ) VALUES (?1, ?2, ?3, ?4)",
+                    rusqlite::params![table_id, policy, generated_column, encoding_version,],
+                )
                 .map_err(sqlite_error::storage)?;
         }
     }
@@ -1550,33 +1620,69 @@ fn ensure_table_registration_ready(snapshot: &ManifestSnapshot) -> EngineResult<
 }
 
 fn catalog_snapshot_from_manifest(snapshot: ManifestSnapshot) -> EngineResult<CatalogSnapshot> {
-    let routing = snapshot.routing_catalog.ok_or_else(|| {
+    catalog_snapshot_from_parts(
+        snapshot.routing_catalog,
+        snapshot.logical_catalog,
+        snapshot.allocation_owners,
+    )
+}
+
+fn catalog_snapshot_from_parts(
+    routing: Option<RoutingCatalog>,
+    logical: Option<Catalog>,
+    allocation_owners: Option<AllocationOwnerMap>,
+) -> EngineResult<CatalogSnapshot> {
+    let routing = routing.ok_or_else(|| {
         EngineError::new(
             EngineErrorKind::Internal,
             "current manifest validation omitted its routing catalog",
         )
     })?;
-    let logical = snapshot.logical_catalog.ok_or_else(|| {
+    let logical = logical.ok_or_else(|| {
         EngineError::new(
             EngineErrorKind::Internal,
             "current manifest validation omitted its logical catalog",
         )
     })?;
-    Ok(CatalogSnapshot::from_validated_parts(routing, logical))
+    Ok(match allocation_owners {
+        Some(allocation_owners) => CatalogSnapshot::from_validated_parts_with_allocation_owners(
+            routing,
+            logical,
+            allocation_owners,
+        ),
+        None => CatalogSnapshot::from_validated_parts(routing, logical),
+    })
 }
 
 fn declarations_match_catalog(
-    declarations: &[(crate::core::LogicalDatabaseId, String, TablePlacement)],
+    declarations: &[(
+        crate::core::LogicalDatabaseId,
+        String,
+        TablePlacement,
+        GeneratedIdPolicy,
+    )],
     catalog: &Catalog,
 ) -> bool {
     declarations.len() == catalog.tables().len()
         && declarations.iter().zip(catalog.tables()).all(
-            |((database_id, name, placement), table)| {
+            |((database_id, name, placement, generated_id_policy), table)| {
                 *database_id == table.database_id()
                     && name == table.name()
                     && placement == table.placement()
+                    && generated_id_policy == table.generated_id_policy()
             },
         )
+}
+
+fn encoded_generated_id_policy(policy: &GeneratedIdPolicy) -> (i64, Option<&str>, Option<i64>) {
+    match policy {
+        GeneratedIdPolicy::None => (GENERATED_ID_POLICY_NONE, None, None),
+        GeneratedIdPolicy::NativeRangeV1 { column } => (
+            GENERATED_ID_POLICY_NATIVE_RANGE_V1,
+            Some(column),
+            Some(i64::from(NATIVE_RANGE_V1_ENCODING_VERSION)),
+        ),
+    }
 }
 
 fn encoded_table_placement(placement: &TablePlacement) -> (i64, Option<&str>, Option<i64>) {
@@ -1730,7 +1836,7 @@ where
                 ],
             )
             .map_err(sqlite_error::storage)?;
-        refresh_manifest_digest_if_v7(&transaction)?;
+        refresh_manifest_digest_if_checksummed(&transaction)?;
 
         let ready = match inspect_with_plan(&transaction, requested_shards, CURRENT_PLAN)? {
             ManifestState::Versioned { version, snapshot } if version == CURRENT_SCHEMA_VERSION => {
@@ -2005,6 +2111,11 @@ fn create_v8_schema(transaction: &Transaction<'_>, shard_count: u16) -> EngineRe
     migrate_v7_to_v8(transaction, shard_count)
 }
 
+fn create_v9_schema(transaction: &Transaction<'_>, shard_count: u16) -> EngineResult<()> {
+    create_v8_schema(transaction, shard_count)?;
+    migrate_v8_to_v9(transaction, shard_count)
+}
+
 fn migrate_interrupted_legacy_to_v6(
     transaction: &Transaction<'_>,
     shard_count: u16,
@@ -2026,6 +2137,8 @@ fn migrate_interrupted_legacy_to_v7(
     create_v7_schema(transaction, shard_count)
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
 fn migrate_interrupted_legacy_to_v8(
     transaction: &Transaction<'_>,
     shard_count: u16,
@@ -2034,6 +2147,16 @@ fn migrate_interrupted_legacy_to_v8(
         .execute_batch("DROP TABLE briskdb_metadata;")
         .map_err(sqlite_error::storage)?;
     create_v8_schema(transaction, shard_count)
+}
+
+fn migrate_interrupted_legacy_to_v9(
+    transaction: &Transaction<'_>,
+    shard_count: u16,
+) -> EngineResult<()> {
+    transaction
+        .execute_batch("DROP TABLE briskdb_metadata;")
+        .map_err(sqlite_error::storage)?;
+    create_v9_schema(transaction, shard_count)
 }
 
 #[cfg(test)]
@@ -2287,7 +2410,7 @@ fn migrate_v6_to_v7(transaction: &Transaction<'_>, _shard_count: u16) -> EngineR
                 target_schema_digest
              ) VALUES (1, ?1, zeroblob(32), ?2, ?3, NULL, NULL)",
             rusqlite::params![
-                MANIFEST_DIGEST_VERSION,
+                V1_MANIFEST_DIGEST_VERSION,
                 SCHEMA_DIGEST_VERSION,
                 DATABASE_STATE_VERIFYING,
             ],
@@ -2313,6 +2436,61 @@ fn migrate_v7_to_v8(transaction: &Transaction<'_>, _shard_count: u16) -> EngineR
         .execute(
             "INSERT INTO briskdb_metadata (requires_manifest_version) VALUES (?1)",
             [V8_SCHEMA_VERSION],
+        )
+        .map_err(sqlite_error::storage)?;
+    Ok(())
+}
+
+fn migrate_v8_to_v9(transaction: &Transaction<'_>, _shard_count: u16) -> EngineResult<()> {
+    transaction
+        .execute_batch("DROP TABLE briskdb_metadata;")
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch(V9_DOWNGRADE_FENCE_SQL)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "INSERT INTO briskdb_metadata (requires_manifest_version) VALUES (?1)",
+            [V9_SCHEMA_VERSION],
+        )
+        .map_err(sqlite_error::storage)?;
+
+    transaction
+        .execute_batch(V9_GENERATED_IDS_TABLE_SQL)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "INSERT INTO briskdb_generated_ids (
+                table_id,
+                policy,
+                generated_column,
+                encoding_version
+             )
+             SELECT table_id, ?1, NULL, NULL
+             FROM briskdb_tables
+             ORDER BY table_id",
+            [GENERATED_ID_POLICY_NONE],
+        )
+        .map_err(sqlite_error::storage)?;
+
+    transaction
+        .execute_batch(V9_ALLOCATION_OWNERS_TABLE_SQL)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "INSERT INTO briskdb_allocation_owners (owner_slot, physical_shard_id)
+             SELECT shard_id, shard_id
+             FROM briskdb_physical_shards
+             ORDER BY shard_id",
+            [],
+        )
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "UPDATE briskdb_integrity
+             SET manifest_digest_version = ?1
+             WHERE singleton = 1",
+            [V2_MANIFEST_DIGEST_VERSION],
         )
         .map_err(sqlite_error::storage)?;
     Ok(())
@@ -2607,6 +2785,20 @@ fn v7_objects() -> Vec<SchemaObject> {
     objects
 }
 
+fn v9_objects() -> Vec<SchemaObject> {
+    let mut objects = v7_objects();
+    for name in ["briskdb_allocation_owners", "briskdb_generated_ids"] {
+        objects.push(SchemaObject {
+            object_type: "table".to_owned(),
+            name: name.to_owned(),
+        });
+    }
+    objects.sort_by(|left, right| {
+        (&left.object_type, &left.name).cmp(&(&right.object_type, &right.name))
+    });
+    objects
+}
+
 fn schema_objects(connection: &Connection) -> EngineResult<Vec<SchemaObject>> {
     let mut statement = connection
         .prepare(
@@ -2715,6 +2907,14 @@ fn validate_table(
         "briskdb_integrity" => {
             "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden
              FROM pragma_table_xinfo('briskdb_integrity') LIMIT ?1"
+        }
+        "briskdb_generated_ids" => {
+            "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden
+             FROM pragma_table_xinfo('briskdb_generated_ids') LIMIT ?1"
+        }
+        "briskdb_allocation_owners" => {
+            "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden
+             FROM pragma_table_xinfo('briskdb_allocation_owners') LIMIT ?1"
         }
         _ => {
             return Err(EngineError::new(
@@ -2905,6 +3105,7 @@ fn validate_v2(
         shard_layout: None,
         active_migration: None,
         integrity: None,
+        allocation_owners: None,
     })
 }
 
@@ -2934,6 +3135,7 @@ fn validate_v3(
         shard_layout: None,
         active_migration: None,
         integrity: None,
+        allocation_owners: None,
     })
 }
 
@@ -3042,6 +3244,7 @@ fn validate_v4(
             expected_objects: &v4_objects(),
             schema_catalog_sql: V4_SCHEMA_CATALOG_TABLE_SQL,
             generation_policy: SchemaGenerationPolicy::InitialOnly,
+            generated_ids: false,
         },
     )
 }
@@ -3061,6 +3264,7 @@ fn validate_v5(
             expected_objects: &v5_objects(),
             schema_catalog_sql: V4_SCHEMA_CATALOG_TABLE_SQL,
             generation_policy: SchemaGenerationPolicy::InitialOnly,
+            generated_ids: false,
         },
     )?;
     validate_table(
@@ -3099,6 +3303,7 @@ fn validate_v6(
             expected_objects: &v6_objects(),
             schema_catalog_sql: V6_SCHEMA_CATALOG_TABLE_SQL,
             generation_policy: SchemaGenerationPolicy::Journaled,
+            generated_ids: false,
         },
     )?;
     validate_table(
@@ -3201,6 +3406,30 @@ fn validate_v8(
     )
 }
 
+fn validate_v9(
+    connection: &Connection,
+    requested_shards: u16,
+    objects: &[SchemaObject],
+) -> EngineResult<ManifestSnapshot> {
+    let mut snapshot = validate_integrity_manifest_with_definition(
+        connection,
+        requested_shards,
+        objects,
+        IntegrityManifestDefinition {
+            version: V9_SCHEMA_VERSION,
+            downgrade_fence_sql: V9_DOWNGRADE_FENCE_SQL,
+            expected_objects: &v9_objects(),
+            expected_manifest_digest_version: V2_MANIFEST_DIGEST_VERSION,
+            generated_ids: true,
+        },
+    )?;
+    snapshot.allocation_owners = Some(validate_allocation_owners(
+        connection,
+        snapshot.shard_count,
+    )?);
+    Ok(snapshot)
+}
+
 fn validate_integrity_manifest(
     connection: &Connection,
     requested_shards: u16,
@@ -3208,16 +3437,62 @@ fn validate_integrity_manifest(
     version: u32,
     downgrade_fence_sql: &str,
 ) -> EngineResult<ManifestSnapshot> {
+    validate_integrity_manifest_with_definition(
+        connection,
+        requested_shards,
+        objects,
+        IntegrityManifestDefinition {
+            version,
+            downgrade_fence_sql,
+            expected_objects: &v7_objects(),
+            expected_manifest_digest_version: V1_MANIFEST_DIGEST_VERSION,
+            generated_ids: false,
+        },
+    )
+}
+
+#[derive(Debug, Clone, Copy)]
+struct IntegrityManifestDefinition<'a> {
+    version: u32,
+    downgrade_fence_sql: &'a str,
+    expected_objects: &'a [SchemaObject],
+    expected_manifest_digest_version: u32,
+    generated_ids: bool,
+}
+
+fn validate_integrity_manifest_with_definition(
+    connection: &Connection,
+    requested_shards: u16,
+    objects: &[SchemaObject],
+    definition: IntegrityManifestDefinition<'_>,
+) -> EngineResult<ManifestSnapshot> {
+    if objects != definition.expected_objects {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!(
+                "manifest schema version {} has unexpected database objects",
+                definition.version
+            ),
+        ));
+    }
+
+    // Establish the semantic root's authority before interpreting extensible
+    // catalog fields. This distinguishes an unsealed bit flip (corruption)
+    // from a correctly sealed policy written by a newer compatible build
+    // (failed precondition when that field is decoded below).
+    validate_manifest_semantic_root(connection, definition.expected_manifest_digest_version)?;
+
     let mut snapshot = validate_catalog_manifest(
         connection,
         requested_shards,
         objects,
         CatalogManifestDefinition {
-            version,
-            downgrade_fence_sql,
-            expected_objects: &v7_objects(),
+            version: definition.version,
+            downgrade_fence_sql: definition.downgrade_fence_sql,
+            expected_objects: definition.expected_objects,
             schema_catalog_sql: V6_SCHEMA_CATALOG_TABLE_SQL,
             generation_policy: SchemaGenerationPolicy::Journaled,
+            generated_ids: definition.generated_ids,
         },
     )?;
     validate_table(
@@ -3287,11 +3562,78 @@ fn validate_integrity_manifest(
         .schema_generation();
     let active =
         validate_schema_migration_history(connection, snapshot.shard_count, catalog_generation)?;
-    let integrity = validate_manifest_integrity(connection, &layout, active.as_ref())?;
+    let integrity = validate_manifest_integrity(
+        connection,
+        &layout,
+        active.as_ref(),
+        definition.expected_manifest_digest_version,
+    )?;
     snapshot.shard_layout = Some(layout);
     snapshot.active_migration = active;
     snapshot.integrity = Some(integrity);
     Ok(snapshot)
+}
+
+fn validate_manifest_semantic_root(
+    connection: &Connection,
+    expected_manifest_digest_version: u32,
+) -> EngineResult<()> {
+    let rows = connection
+        .prepare(
+            "SELECT singleton, manifest_digest_version, manifest_digest
+             FROM briskdb_integrity
+             ORDER BY singleton
+             LIMIT 3",
+        )
+        .and_then(|mut statement| {
+            statement
+                .query_map([], |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, Vec<u8>>(2)?,
+                    ))
+                })?
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .map_err(|error| {
+            manifest_read_error(error, "failed to read manifest checksum authority")
+        })?;
+    if rows.len() != 1 || rows[0].0 != 1 {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "manifest integrity metadata must contain exactly its singleton row",
+        ));
+    }
+    let (_, version, stored_root) = &rows[0];
+    if *version <= 0 {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "manifest checksum version must be positive",
+        ));
+    }
+    if *version > i64::from(V2_MANIFEST_DIGEST_VERSION) {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "manifest checksum version is newer than this BriskDB build supports",
+        ));
+    }
+    if *version != i64::from(expected_manifest_digest_version) {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "manifest checksum version does not match its schema version",
+        ));
+    }
+    let stored_root = digest_from_blob(stored_root, "manifest semantic checksum")?;
+    if manifest_semantic_digest_for_version(connection, expected_manifest_digest_version)?
+        != stored_root
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "manifest semantic checksum does not match its authoritative contents",
+        ));
+    }
+    Ok(())
 }
 
 struct ManifestDigestQuery {
@@ -3300,7 +3642,7 @@ struct ManifestDigestQuery {
     sql: &'static str,
 }
 
-const MANIFEST_DIGEST_QUERIES: &[ManifestDigestQuery] = &[
+const V1_MANIFEST_DIGEST_QUERIES: &[ManifestDigestQuery] = &[
     ManifestDigestQuery {
         table: "briskdb_manifest",
         columns: &["singleton", "shard_count"],
@@ -3399,16 +3741,63 @@ const MANIFEST_DIGEST_QUERIES: &[ManifestDigestQuery] = &[
     },
 ];
 
-fn manifest_semantic_digest(connection: &Connection) -> EngineResult<[u8; 32]> {
+const V2_ALLOCATION_OWNERS_DIGEST_QUERY: ManifestDigestQuery = ManifestDigestQuery {
+    table: "briskdb_allocation_owners",
+    columns: &["owner_slot", "physical_shard_id"],
+    sql: "SELECT owner_slot, physical_shard_id FROM briskdb_allocation_owners ORDER BY owner_slot",
+};
+const V2_GENERATED_IDS_DIGEST_QUERY: ManifestDigestQuery = ManifestDigestQuery {
+    table: "briskdb_generated_ids",
+    columns: &["table_id", "policy", "generated_column", "encoding_version"],
+    sql: "SELECT table_id, policy, generated_column, encoding_version FROM briskdb_generated_ids ORDER BY table_id",
+};
+
+fn manifest_semantic_digest_for_version(
+    connection: &Connection,
+    digest_version: u32,
+) -> EngineResult<[u8; 32]> {
+    let (domain, queries) = match digest_version {
+        V1_MANIFEST_DIGEST_VERSION => (
+            V1_MANIFEST_DIGEST_DOMAIN,
+            V1_MANIFEST_DIGEST_QUERIES.iter().collect::<Vec<_>>(),
+        ),
+        V2_MANIFEST_DIGEST_VERSION => {
+            let mut queries = Vec::with_capacity(V1_MANIFEST_DIGEST_QUERIES.len() + 2);
+            for query in V1_MANIFEST_DIGEST_QUERIES {
+                queries.push(query);
+                if query.table == "briskdb_physical_shards" {
+                    queries.push(&V2_ALLOCATION_OWNERS_DIGEST_QUERY);
+                }
+                if query.table == "briskdb_tables" {
+                    queries.push(&V2_GENERATED_IDS_DIGEST_QUERY);
+                }
+            }
+            (V2_MANIFEST_DIGEST_DOMAIN, queries)
+        }
+        0 => {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "manifest checksum version must be positive",
+            ));
+        }
+        version => {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "manifest checksum version {version} is newer than this BriskDB build supports"
+                ),
+            ));
+        }
+    };
     let (application_id, user_version) = read_identity(connection)?;
     let mut hasher = blake3::Hasher::new();
-    hasher.update(MANIFEST_DIGEST_DOMAIN);
+    hasher.update(domain);
     hash_manifest_name(&mut hasher, b"application_id");
     hash_manifest_value(&mut hasher, ValueRef::Integer(application_id))?;
     hash_manifest_name(&mut hasher, b"user_version");
     hash_manifest_value(&mut hasher, ValueRef::Integer(user_version))?;
 
-    for query in MANIFEST_DIGEST_QUERIES {
+    for query in queries {
         hasher.update(&[0x10]);
         hash_manifest_name(&mut hasher, query.table.as_bytes());
         hasher.update(
@@ -3441,6 +3830,24 @@ fn manifest_semantic_digest(connection: &Connection) -> EngineResult<[u8; 32]> {
     }
     hasher.update(&[0xff]);
     Ok(*hasher.finalize().as_bytes())
+}
+
+fn manifest_semantic_digest(connection: &Connection) -> EngineResult<[u8; 32]> {
+    let digest_version = connection
+        .query_row(
+            "SELECT manifest_digest_version FROM briskdb_integrity WHERE singleton = 1",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .map_err(|error| manifest_read_error(error, "failed to read manifest checksum version"))?;
+    let digest_version = u32::try_from(digest_version).map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::DataCorruption,
+            "manifest checksum version is outside the supported numeric range",
+            error,
+        )
+    })?;
+    manifest_semantic_digest_for_version(connection, digest_version)
 }
 
 fn hash_manifest_name(hasher: &mut blake3::Hasher, value: &[u8]) {
@@ -3496,12 +3903,12 @@ fn refresh_manifest_digest(connection: &Connection) -> EngineResult<[u8; 32]> {
     Ok(digest)
 }
 
-fn refresh_manifest_digest_if_v7(connection: &Connection) -> EngineResult<()> {
+fn refresh_manifest_digest_if_checksummed(connection: &Connection) -> EngineResult<()> {
     let (application_id, version) = read_identity(connection)?;
     if application_id == MANIFEST_APPLICATION_ID
         && matches!(
             u32::try_from(version),
-            Ok(V7_SCHEMA_VERSION | V8_SCHEMA_VERSION)
+            Ok(V7_SCHEMA_VERSION | V8_SCHEMA_VERSION | V9_SCHEMA_VERSION)
         )
     {
         let _ = refresh_manifest_digest(connection)?;
@@ -3518,6 +3925,7 @@ fn validate_manifest_integrity(
     connection: &Connection,
     layout: &ShardLayout,
     active_migration: Option<&SchemaMigration>,
+    expected_manifest_digest_version: u32,
 ) -> EngineResult<ManifestIntegrity> {
     let rows = connection
         .prepare(
@@ -3564,10 +3972,16 @@ fn validate_manifest_integrity(
             "manifest checksum version must be positive",
         ));
     }
-    if *manifest_version > i64::from(MANIFEST_DIGEST_VERSION) {
+    if *manifest_version > i64::from(V2_MANIFEST_DIGEST_VERSION) {
         return Err(EngineError::new(
             EngineErrorKind::FailedPrecondition,
             "manifest checksum version is newer than this BriskDB build supports",
+        ));
+    }
+    if *manifest_version != i64::from(expected_manifest_digest_version) {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "manifest checksum version does not match its schema version",
         ));
     }
     if *schema_version <= 0 {
@@ -3591,7 +4005,9 @@ fn validate_manifest_integrity(
         .as_deref()
         .map(|digest| digest_from_blob(digest, "target application-schema checksum"))
         .transpose()?;
-    if manifest_semantic_digest(connection)? != stored_root {
+    if manifest_semantic_digest_for_version(connection, expected_manifest_digest_version)?
+        != stored_root
+    {
         return Err(EngineError::new(
             EngineErrorKind::DataCorruption,
             "manifest semantic checksum does not match its authoritative contents",
@@ -3668,6 +4084,7 @@ struct CatalogManifestDefinition<'a> {
     expected_objects: &'a [SchemaObject],
     schema_catalog_sql: &'a str,
     generation_policy: SchemaGenerationPolicy,
+    generated_ids: bool,
 }
 
 fn validate_catalog_manifest(
@@ -3736,12 +4153,30 @@ fn validate_catalog_manifest(
         true,
     )?;
     validate_table_sql(connection, "briskdb_tables", V4_TABLES_TABLE_SQL)?;
+    if definition.generated_ids {
+        validate_table(
+            connection,
+            "briskdb_generated_ids",
+            &[
+                TableColumn::expected(0, "table_id", "INTEGER", false, 1),
+                TableColumn::expected(1, "policy", "INTEGER", true, 0),
+                TableColumn::expected(2, "generated_column", "TEXT", false, 0),
+                TableColumn::expected(3, "encoding_version", "INTEGER", false, 0),
+            ],
+            true,
+        )?;
+        validate_table_sql(
+            connection,
+            "briskdb_generated_ids",
+            V9_GENERATED_IDS_TABLE_SQL,
+        )?;
+    }
 
     let catalog_configuration =
         validate_schema_catalog_configuration(connection, definition.generation_policy)?;
     let databases =
         validate_logical_databases(connection, catalog_configuration.default_database_id)?;
-    let tables = validate_table_metadata(connection, &databases)?;
+    let tables = validate_table_metadata(connection, &databases, definition.generated_ids)?;
     validate_foreign_keys(connection)?;
 
     Ok(ManifestSnapshot {
@@ -3757,6 +4192,7 @@ fn validate_catalog_manifest(
         shard_layout: None,
         active_migration: None,
         integrity: None,
+        allocation_owners: None,
     })
 }
 
@@ -3828,6 +4264,86 @@ fn validate_shard_layout(connection: &Connection) -> EngineResult<ShardLayout> {
         metadata_version,
         state,
     ))
+}
+
+fn validate_allocation_owners(
+    connection: &Connection,
+    shard_count: u16,
+) -> EngineResult<AllocationOwnerMap> {
+    validate_table(
+        connection,
+        "briskdb_allocation_owners",
+        &[
+            TableColumn::expected(0, "owner_slot", "INTEGER", false, 1),
+            TableColumn::expected(1, "physical_shard_id", "INTEGER", true, 0),
+        ],
+        true,
+    )?;
+    validate_table_sql(
+        connection,
+        "briskdb_allocation_owners",
+        V9_ALLOCATION_OWNERS_TABLE_SQL,
+    )?;
+
+    let rows = connection
+        .prepare(
+            "SELECT owner_slot, physical_shard_id
+             FROM briskdb_allocation_owners
+             ORDER BY owner_slot
+             LIMIT 1025",
+        )
+        .and_then(|mut statement| {
+            statement
+                .query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)))?
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .map_err(|error| manifest_read_error(error, "failed to read allocation-owner metadata"))?;
+    if rows.len() != usize::from(shard_count) {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "allocation-owner metadata must contain exactly one row per physical shard",
+        ));
+    }
+
+    let mut owners = Vec::with_capacity(rows.len());
+    for (expected, (owner_slot, physical_shard_id)) in (0..shard_count).zip(rows) {
+        if !(0..=MAX_ALLOCATION_OWNER_SLOT).contains(&owner_slot) {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "allocation-owner slot is outside the supported range",
+            ));
+        }
+        let owner_slot = u16::try_from(owner_slot).map_err(|error| {
+            EngineError::from_source(
+                EngineErrorKind::DataCorruption,
+                "allocation-owner slot is outside the supported range",
+                error,
+            )
+        })?;
+        let physical_shard_id = u16::try_from(physical_shard_id).map_err(|error| {
+            EngineError::from_source(
+                EngineErrorKind::DataCorruption,
+                "allocation owner references an invalid physical shard",
+                error,
+            )
+        })?;
+        // Version 9 establishes the immutable initial mapping. A future shard
+        // lifecycle version may append owners, but v9 never infers or remaps.
+        if owner_slot != expected || physical_shard_id != expected {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "allocation-owner metadata does not match the immutable v9 owner mapping",
+            ));
+        }
+        owners.push((owner_slot, physical_shard_id));
+    }
+    AllocationOwnerMap::try_from_pairs(shard_count, owners.into_boxed_slice()).map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::DataCorruption,
+            "allocation-owner metadata is not a complete one-to-one mapping",
+            error,
+        )
+    })
 }
 
 fn validate_schema_catalog_configuration(
@@ -4243,19 +4759,39 @@ fn validate_logical_databases(
 fn validate_table_metadata(
     connection: &Connection,
     databases: &[LogicalDatabaseMetadata],
+    generated_ids: bool,
 ) -> EngineResult<Box<[TableMetadata]>> {
+    let sql = if generated_ids {
+        "SELECT tables.table_id,
+                tables.database_id,
+                tables.table_name,
+                tables.placement,
+                tables.shard_key_column,
+                tables.shard_key_type,
+                generated.policy,
+                generated.generated_column,
+                generated.encoding_version
+         FROM briskdb_tables AS tables
+         LEFT JOIN briskdb_generated_ids AS generated
+           ON generated.table_id = tables.table_id
+         ORDER BY tables.database_id, tables.table_name, tables.table_id
+         LIMIT ?1"
+    } else {
+        "SELECT table_id,
+                database_id,
+                table_name,
+                placement,
+                shard_key_column,
+                shard_key_type,
+                0 AS policy,
+                NULL AS generated_column,
+                NULL AS encoding_version
+         FROM briskdb_tables
+         ORDER BY database_id, table_name, table_id
+         LIMIT ?1"
+    };
     let mut statement = connection
-        .prepare(
-            "SELECT table_id,
-                    database_id,
-                    table_name,
-                    placement,
-                    shard_key_column,
-                    shard_key_type
-             FROM briskdb_tables
-             ORDER BY database_id, table_name, table_id
-             LIMIT ?1",
-        )
+        .prepare(sql)
         .map_err(|error| manifest_read_error(error, "failed to read table metadata catalog"))?;
     let limit = i64::try_from(MAX_TABLES + 1).expect("table inspection limit fits in SQLite");
     let rows = statement
@@ -4267,6 +4803,9 @@ fn validate_table_metadata(
                 row.get::<_, i64>(3)?,
                 row.get::<_, Option<String>>(4)?,
                 row.get::<_, Option<i64>>(5)?,
+                row.get::<_, Option<i64>>(6)?,
+                row.get::<_, Option<String>>(7)?,
+                row.get::<_, Option<i64>>(8)?,
             ))
         })
         .map_err(|error| manifest_read_error(error, "failed to read table metadata catalog"))?
@@ -4280,7 +4819,18 @@ fn validate_table_metadata(
     }
 
     let mut tables = Vec::with_capacity(rows.len());
-    for (stored_table_id, stored_database_id, name, placement, column, key_type) in rows {
+    for (
+        stored_table_id,
+        stored_database_id,
+        name,
+        placement,
+        column,
+        key_type,
+        generated_policy,
+        generated_column,
+        generated_encoding_version,
+    ) in rows
+    {
         let table_id = positive_catalog_id(stored_table_id, "table")?;
         let database_id = positive_catalog_id(stored_database_id, "logical database")?;
         if databases
@@ -4327,15 +4877,80 @@ fn validate_table_metadata(
                 ));
             }
         };
-        tables.push(TableMetadata::from_validated(
+        let generated_id_policy = decode_generated_id_policy(
+            table_id,
+            &placement,
+            generated_policy,
+            generated_column,
+            generated_encoding_version,
+        )?;
+        tables.push(TableMetadata::from_validated_with_generated_id_policy(
             table_id,
             database_id,
             name,
             placement,
+            generated_id_policy,
         ));
     }
 
     Ok(tables.into_boxed_slice())
+}
+
+fn decode_generated_id_policy(
+    table_id: u64,
+    placement: &TablePlacement,
+    policy: Option<i64>,
+    column: Option<String>,
+    encoding_version: Option<i64>,
+) -> EngineResult<GeneratedIdPolicy> {
+    match (policy, column, encoding_version) {
+        (Some(GENERATED_ID_POLICY_NONE), None, None) => Ok(GeneratedIdPolicy::None),
+        (Some(GENERATED_ID_POLICY_NATIVE_RANGE_V1), Some(column), Some(version)) => {
+            if !validate_catalog_identifier(&column) {
+                return Err(EngineError::new(
+                    EngineErrorKind::DataCorruption,
+                    format!("table {table_id} has an invalid generated-ID column"),
+                ));
+            }
+            if version <= 0 {
+                return Err(EngineError::new(
+                    EngineErrorKind::DataCorruption,
+                    format!("table {table_id} has an invalid generated-ID encoding version"),
+                ));
+            }
+            if version > i64::from(NATIVE_RANGE_V1_ENCODING_VERSION) {
+                return Err(EngineError::new(
+                    EngineErrorKind::FailedPrecondition,
+                    format!("table {table_id} uses a newer generated-ID encoding version"),
+                ));
+            }
+            let TablePlacement::Sharded(shard_key) = placement else {
+                return Err(inconsistent_generated_id_policy(table_id));
+            };
+            if shard_key.key_type() != ShardKeyType::Int64 || shard_key.column() != column {
+                return Err(inconsistent_generated_id_policy(table_id));
+            }
+            Ok(GeneratedIdPolicy::native_range_v1_from_validated(column))
+        }
+        (Some(policy), _, _) if policy > GENERATED_ID_POLICY_NATIVE_RANGE_V1 => {
+            Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!("table {table_id} uses a newer generated-ID policy"),
+            ))
+        }
+        (Some(policy), _, _) if policy < GENERATED_ID_POLICY_NONE => Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!("table {table_id} has an invalid generated-ID policy code"),
+        )),
+        _ => Err(inconsistent_generated_id_policy(table_id)),
+    }
+}
+
+fn inconsistent_generated_id_policy(table_id: u64) -> EngineError {
+    EngineError::new(
+        EngineErrorKind::DataCorruption,
+        format!("table {table_id} has inconsistent generated-ID policy metadata"),
+    )
 }
 
 fn positive_catalog_id(value: i64, entity: &str) -> EngineResult<u64> {
@@ -4716,6 +5331,14 @@ mod tests {
     use super::*;
 
     type StoredTableMetadataRow = (i64, i64, String, i64, Option<String>, Option<i64>);
+    type StoredGeneratedIdRow = (i64, i64, Option<String>, Option<i64>);
+
+    const V8_PLAN: MigrationPlan<'static> = MigrationPlan {
+        current_version: V8_SCHEMA_VERSION,
+        migrations: MIGRATIONS,
+        initialize_current: create_v8_schema,
+        initialize_interrupted_legacy: migrate_interrupted_legacy_to_v8,
+    };
 
     fn create_legacy_manifest(connection: &Connection, shards: u16, version: u32) {
         create_empty_legacy_manifest(connection);
@@ -4803,6 +5426,33 @@ mod tests {
         set_identity(&transaction, V7_SCHEMA_VERSION).unwrap();
         refresh_manifest_digest(&transaction).unwrap();
         validate_v7(&transaction, shards, &schema_objects(&transaction).unwrap()).unwrap();
+        transaction.commit().unwrap();
+    }
+
+    fn create_ready_v8_manifest(connection: &mut Connection, shards: u16) {
+        let transaction = connection.transaction().unwrap();
+        create_v8_schema(&transaction, shards).unwrap();
+        transaction
+            .execute(
+                "UPDATE briskdb_shard_layout
+                 SET layout_state = ?1
+                 WHERE singleton = 1",
+                [ShardLayoutState::Ready.code()],
+            )
+            .unwrap();
+        transaction
+            .execute(
+                "UPDATE briskdb_integrity
+                 SET database_state = ?1,
+                     committed_schema_digest = ?2,
+                     target_schema_digest = NULL
+                 WHERE singleton = 1",
+                rusqlite::params![DATABASE_STATE_READY, [0x5a_u8; 32].as_slice()],
+            )
+            .unwrap();
+        set_identity(&transaction, V8_SCHEMA_VERSION).unwrap();
+        refresh_manifest_digest(&transaction).unwrap();
+        validate_v8(&transaction, shards, &schema_objects(&transaction).unwrap()).unwrap();
         transaction.commit().unwrap();
     }
 
@@ -4949,6 +5599,38 @@ mod tests {
             .unwrap()
     }
 
+    fn generated_id_rows(connection: &Connection) -> Vec<StoredGeneratedIdRow> {
+        let mut statement = connection
+            .prepare(
+                "SELECT table_id, policy, generated_column, encoding_version
+                 FROM briskdb_generated_ids
+                 ORDER BY table_id",
+            )
+            .unwrap();
+        statement
+            .query_map([], |row| {
+                Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+            })
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+    }
+
+    fn allocation_owner_rows(connection: &Connection) -> Vec<(i64, i64)> {
+        let mut statement = connection
+            .prepare(
+                "SELECT owner_slot, physical_shard_id
+                 FROM briskdb_allocation_owners
+                 ORDER BY owner_slot",
+            )
+            .unwrap();
+        statement
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+    }
+
     fn stored_manifest_digest(connection: &Connection) -> [u8; 32] {
         let digest = connection
             .query_row(
@@ -4971,7 +5653,33 @@ mod tests {
                  INSERT INTO briskdb_tables VALUES (55, 9, 'counters', 1, 'counter_id', 1);",
             )
             .unwrap();
-        refresh_manifest_digest_if_v7(connection).unwrap();
+        let has_generated_ids = connection
+            .query_row(
+                "SELECT EXISTS(
+                     SELECT 1 FROM sqlite_schema
+                     WHERE type = 'table' AND name = 'briskdb_generated_ids'
+                 )",
+                [],
+                |row| row.get::<_, bool>(0),
+            )
+            .unwrap();
+        if has_generated_ids {
+            connection
+                .execute(
+                    "INSERT INTO briskdb_generated_ids (
+                        table_id,
+                        policy,
+                        generated_column,
+                        encoding_version
+                     )
+                     SELECT table_id, ?1, NULL, NULL
+                     FROM briskdb_tables
+                     ORDER BY table_id",
+                    [GENERATED_ID_POLICY_NONE],
+                )
+                .unwrap();
+        }
+        refresh_manifest_digest_if_checksummed(connection).unwrap();
     }
 
     fn assert_generation_one_catalog(connection: &Connection, shard_count: u16) {
@@ -4979,7 +5687,7 @@ mod tests {
             identity(connection),
             (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
         );
-        assert_eq!(schema_objects(connection).unwrap(), v7_objects());
+        assert_eq!(schema_objects(connection).unwrap(), v9_objects());
         assert_eq!(
             connection
                 .query_row(
@@ -5007,6 +5715,12 @@ mod tests {
                 .map(|shard| (i64::from(shard), ACTIVE_LIFECYCLE_STATE.to_owned()))
                 .collect::<Vec<_>>()
         );
+        assert_eq!(
+            allocation_owner_rows(connection),
+            (0..shard_count)
+                .map(|shard| (i64::from(shard), i64::from(shard)))
+                .collect::<Vec<_>>()
+        );
 
         let buckets = virtual_buckets(connection);
         assert_eq!(buckets.len(), usize::from(VIRTUAL_BUCKET_COUNT));
@@ -5029,6 +5743,19 @@ mod tests {
             [(1, DEFAULT_LOGICAL_DATABASE_NAME.to_owned())]
         );
         assert!(table_metadata_rows(connection).is_empty());
+        assert!(generated_id_rows(connection).is_empty());
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT manifest_digest_version
+                     FROM briskdb_integrity
+                     WHERE singleton = 1",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            i64::from(V2_MANIFEST_DIGEST_VERSION)
+        );
         let (layout_id, application_id, metadata_version, state) = shard_layout_row(connection);
         assert_eq!(layout_id.len(), 16);
         assert_eq!(application_id, SHARD_APPLICATION_ID);
@@ -5135,7 +5862,7 @@ mod tests {
         );
         assert_eq!(
             resumed_steps,
-            [(2, 3), (3, 4), (4, 5), (5, 6), (6, 7), (7, 8)]
+            [(2, 3), (3, 4), (4, 5), (5, 6), (6, 7), (7, 8), (8, 9),]
         );
         assert_generation_one_catalog(&connection, 4);
         assert_eq!(quick_check(&connection), "ok");
@@ -5178,7 +5905,11 @@ mod tests {
         assert_eq!(table_metadata_rows(&connection).len(), 5);
         assert_eq!(logical_databases(&connection).len(), 2);
 
-        let loaded = load_or_create_catalog(&mut connection, 4).unwrap();
+        let mut no_hook = |_| Ok(());
+        let snapshot =
+            load_or_create_snapshot_with_plan(&mut connection, 4, V8_PLAN, true, &mut no_hook)
+                .unwrap();
+        let loaded = catalog_snapshot_from_manifest(snapshot).unwrap();
         assert!(loaded.logical().tables().is_empty());
         assert_eq!(loaded.logical().logical_databases().len(), 2);
         assert_eq!(
@@ -5221,7 +5952,7 @@ mod tests {
                 let original_objects = schema_objects(&connection).unwrap();
 
                 let attempt = catch_unwind(AssertUnwindSafe(|| {
-                    load_or_create_with_hook(&mut connection, 4, |point| {
+                    let mut hook = |point: MigrationPoint| {
                         if point.from == V7_SCHEMA_VERSION && point.phase == failing_phase {
                             if inject_panic {
                                 panic!("injected v7 to v8 migration panic");
@@ -5232,7 +5963,8 @@ mod tests {
                             ));
                         }
                         Ok(())
-                    })
+                    };
+                    load_or_create_snapshot_with_plan(&mut connection, 4, V8_PLAN, true, &mut hook)
                 }));
                 if inject_panic {
                     assert!(attempt.is_err());
@@ -5266,12 +5998,177 @@ mod tests {
                     i64::from(V7_SCHEMA_VERSION)
                 );
 
-                let loaded = load_or_create_catalog(&mut connection, 4).unwrap();
+                let mut no_hook = |_| Ok(());
+                let snapshot = load_or_create_snapshot_with_plan(
+                    &mut connection,
+                    4,
+                    V8_PLAN,
+                    true,
+                    &mut no_hook,
+                )
+                .unwrap();
+                let loaded = catalog_snapshot_from_manifest(snapshot).unwrap();
                 assert!(loaded.logical().tables().is_empty());
                 assert_eq!(
                     identity(&connection),
                     (MANIFEST_APPLICATION_ID, i64::from(V8_SCHEMA_VERSION))
                 );
+            }
+        }
+    }
+
+    #[test]
+    fn v8_to_v9_persists_explicit_none_policies_and_owner_slots() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        create_ready_v8_manifest(&mut connection, 4);
+        insert_valid_table_catalog(&connection);
+        let tables_before = table_metadata_rows(&connection);
+        let databases_before = logical_databases(&connection);
+        let routing_before = routing_configuration(&connection);
+        let physical_shards_before = physical_shards(&connection);
+        let virtual_buckets_before = virtual_buckets(&connection);
+        let layout_before = shard_layout_row(&connection);
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT manifest_digest_version
+                     FROM briskdb_integrity
+                     WHERE singleton = 1",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            i64::from(V1_MANIFEST_DIGEST_VERSION)
+        );
+
+        let loaded = load_or_create_catalog(&mut connection, 4).unwrap();
+
+        assert_eq!(
+            identity(&connection),
+            (MANIFEST_APPLICATION_ID, i64::from(V9_SCHEMA_VERSION))
+        );
+        assert_eq!(schema_objects(&connection).unwrap(), v9_objects());
+        assert_eq!(table_metadata_rows(&connection), tables_before);
+        assert_eq!(logical_databases(&connection), databases_before);
+        assert_eq!(routing_configuration(&connection), routing_before);
+        assert_eq!(physical_shards(&connection), physical_shards_before);
+        assert_eq!(virtual_buckets(&connection), virtual_buckets_before);
+        assert_eq!(shard_layout_row(&connection), layout_before);
+        assert_eq!(
+            generated_id_rows(&connection),
+            tables_before
+                .iter()
+                .map(|row| (row.0, GENERATED_ID_POLICY_NONE, None, None))
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            allocation_owner_rows(&connection),
+            [(0, 0), (1, 1), (2, 2), (3, 3)]
+        );
+        assert_eq!(
+            loaded
+                .allocation_owners()
+                .unwrap()
+                .pairs()
+                .collect::<Vec<_>>(),
+            [(0, 0), (1, 1), (2, 2), (3, 3)]
+        );
+        assert!(
+            loaded
+                .logical()
+                .tables()
+                .iter()
+                .all(|table| table.generated_id_policy() == &GeneratedIdPolicy::None)
+        );
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT manifest_digest_version
+                     FROM briskdb_integrity
+                     WHERE singleton = 1",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            i64::from(V2_MANIFEST_DIGEST_VERSION)
+        );
+        assert_eq!(
+            manifest_semantic_digest(&connection).unwrap(),
+            stored_manifest_digest(&connection)
+        );
+
+        let identity_before = identity(&connection);
+        let root_before = stored_manifest_digest(&connection);
+        assert_eq!(
+            inspect_with_plan(&connection, 4, V8_PLAN)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+        assert_eq!(identity(&connection), identity_before);
+        assert_eq!(stored_manifest_digest(&connection), root_before);
+    }
+
+    #[test]
+    fn v8_to_v9_failures_and_panics_roll_back_exactly_and_retry() {
+        for failing_phase in [
+            MigrationPhase::AfterSchemaChange,
+            MigrationPhase::AfterVersionStamp,
+        ] {
+            for inject_panic in [false, true] {
+                let mut connection = Connection::open_in_memory().unwrap();
+                create_ready_v8_manifest(&mut connection, 4);
+                insert_valid_table_catalog(&connection);
+                let root_before = stored_manifest_digest(&connection);
+                let tables_before = table_metadata_rows(&connection);
+                let objects_before = schema_objects(&connection).unwrap();
+
+                let attempt = catch_unwind(AssertUnwindSafe(|| {
+                    load_or_create_with_hook(&mut connection, 4, |point| {
+                        if point.from == V8_SCHEMA_VERSION && point.phase == failing_phase {
+                            if inject_panic {
+                                panic!("injected v8 to v9 migration panic");
+                            }
+                            return Err(EngineError::new(
+                                EngineErrorKind::Internal,
+                                "injected v8 to v9 migration failure",
+                            ));
+                        }
+                        Ok(())
+                    })
+                }));
+                if inject_panic {
+                    assert!(attempt.is_err());
+                } else {
+                    assert_eq!(
+                        attempt.unwrap().unwrap_err().kind(),
+                        EngineErrorKind::Internal
+                    );
+                }
+
+                assert_eq!(
+                    identity(&connection),
+                    (MANIFEST_APPLICATION_ID, i64::from(V8_SCHEMA_VERSION))
+                );
+                assert_eq!(schema_objects(&connection).unwrap(), objects_before);
+                assert_eq!(table_metadata_rows(&connection), tables_before);
+                assert_eq!(stored_manifest_digest(&connection), root_before);
+                assert_eq!(manifest_semantic_digest(&connection).unwrap(), root_before);
+                assert_eq!(quick_check(&connection), "ok");
+
+                let loaded = load_or_create_catalog(&mut connection, 4).unwrap();
+                assert!(
+                    loaded
+                        .logical()
+                        .tables()
+                        .iter()
+                        .all(|table| table.generated_id_policy() == &GeneratedIdPolicy::None)
+                );
+                assert_eq!(
+                    allocation_owner_rows(&connection),
+                    [(0, 0), (1, 1), (2, 2), (3, 3)]
+                );
+                assert_eq!(generated_id_rows(&connection).len(), tables_before.len());
             }
         }
     }
@@ -5284,6 +6181,14 @@ mod tests {
         let declarations = vec![
             TableDeclaration::catalog(database, "internal_catalog").unwrap(),
             TableDeclaration::global(database, "countries").unwrap(),
+            TableDeclaration::sharded(
+                database,
+                "events",
+                ShardKeyMetadata::new("id", ShardKeyType::Int64).unwrap(),
+            )
+            .unwrap()
+            .with_generated_id_policy(GeneratedIdPolicy::native_range_v1("id").unwrap())
+            .unwrap(),
             TableDeclaration::sharded(
                 database,
                 "accounts",
@@ -5305,7 +6210,12 @@ mod tests {
                 .iter()
                 .map(|table| (table.id().get(), table.name()))
                 .collect::<Vec<_>>(),
-            [(1, "accounts"), (2, "countries"), (3, "internal_catalog")]
+            [
+                (1, "accounts"),
+                (2, "countries"),
+                (3, "events"),
+                (4, "internal_catalog")
+            ]
         );
         assert_eq!(
             table_metadata_rows(&connection),
@@ -5322,12 +6232,43 @@ mod tests {
                 (
                     3,
                     1,
+                    "events".to_owned(),
+                    SHARDED_PLACEMENT,
+                    Some("id".to_owned()),
+                    Some(INT64_SHARD_KEY_TYPE),
+                ),
+                (
+                    4,
+                    1,
                     "internal_catalog".to_owned(),
                     CATALOG_PLACEMENT,
                     None,
                     None,
                 ),
             ]
+        );
+        assert_eq!(
+            generated_id_rows(&connection),
+            [
+                (1, GENERATED_ID_POLICY_NONE, None, None),
+                (2, GENERATED_ID_POLICY_NONE, None, None),
+                (
+                    3,
+                    GENERATED_ID_POLICY_NATIVE_RANGE_V1,
+                    Some("id".to_owned()),
+                    Some(i64::from(NATIVE_RANGE_V1_ENCODING_VERSION)),
+                ),
+                (4, GENERATED_ID_POLICY_NONE, None, None),
+            ]
+        );
+        assert_eq!(
+            registered
+                .logical()
+                .table("default", "events")
+                .unwrap()
+                .unwrap()
+                .generated_id_policy(),
+            &GeneratedIdPolicy::native_range_v1("id").unwrap()
         );
         let registered_root = stored_manifest_digest(&connection);
         assert_eq!(
@@ -5342,6 +6283,26 @@ mod tests {
         .unwrap();
         assert!(!repeated_commit);
         assert_eq!(repeated, registered);
+        assert_eq!(stored_manifest_digest(&connection), registered_root);
+
+        let policy_conflict = vec![
+            TableDeclaration::sharded(
+                database,
+                "accounts",
+                ShardKeyMetadata::new("tenant_id", ShardKeyType::Text).unwrap(),
+            )
+            .unwrap(),
+            TableDeclaration::global(database, "countries").unwrap(),
+            TableDeclaration::sharded(
+                database,
+                "events",
+                ShardKeyMetadata::new("id", ShardKeyType::Int64).unwrap(),
+            )
+            .unwrap(),
+            TableDeclaration::catalog(database, "internal_catalog").unwrap(),
+        ];
+        let error = register_table_catalog(&mut connection, 4, policy_conflict, || {}).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
         assert_eq!(stored_manifest_digest(&connection), registered_root);
 
         let conflict = vec![
@@ -5393,7 +6354,7 @@ mod tests {
     }
 
     #[test]
-    fn v7_integrity_root_is_deterministic_across_reopen_checkpoint_and_vacuum() {
+    fn current_integrity_root_is_deterministic_across_reopen_checkpoint_and_vacuum() {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("manifest.sqlite");
         let mut connection = Connection::open(&path).unwrap();
@@ -5420,7 +6381,7 @@ mod tests {
     #[test]
     fn manifest_semantic_digest_v1_has_a_frozen_golden_vector() {
         let mut connection = Connection::open_in_memory().unwrap();
-        create_ready_current_manifest(&mut connection, 4);
+        create_ready_v8_manifest(&mut connection, 4);
         connection
             .execute(
                 "UPDATE briskdb_shard_layout
@@ -5430,6 +6391,18 @@ mod tests {
             )
             .unwrap();
         insert_valid_table_catalog(&connection);
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT manifest_digest_version
+                     FROM briskdb_integrity
+                     WHERE singleton = 1",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            i64::from(V1_MANIFEST_DIGEST_VERSION)
+        );
         let digest = refresh_manifest_digest(&connection).unwrap();
         assert_eq!(
             digest,
@@ -5443,7 +6416,7 @@ mod tests {
     }
 
     #[test]
-    fn manifest_semantic_digest_orders_catalog_rows_by_frozen_keys() {
+    fn manifest_semantic_digest_v2_orders_catalog_rows_by_frozen_keys() {
         let mut forward = Connection::open_in_memory().unwrap();
         let mut reverse = Connection::open_in_memory().unwrap();
         for connection in [&mut forward, &mut reverse] {
@@ -5465,13 +6438,24 @@ mod tests {
                  INSERT INTO briskdb_tables VALUES (34, 9, 'binary_keys', 1, 'key_bytes', 3);
                  INSERT INTO briskdb_tables VALUES (21, 9, 'audit_log', 3, NULL, NULL);
                  INSERT INTO briskdb_tables VALUES (8, 1, 'countries', 2, NULL, NULL);
-                 INSERT INTO briskdb_tables VALUES (3, 1, 'accounts', 1, 'tenant_id', 2);",
+                 INSERT INTO briskdb_tables VALUES (3, 1, 'accounts', 1, 'tenant_id', 2);
+                 INSERT INTO briskdb_generated_ids VALUES (55, 0, NULL, NULL);
+                 INSERT INTO briskdb_generated_ids VALUES (34, 0, NULL, NULL);
+                 INSERT INTO briskdb_generated_ids VALUES (21, 0, NULL, NULL);
+                 INSERT INTO briskdb_generated_ids VALUES (8, 0, NULL, NULL);
+                 INSERT INTO briskdb_generated_ids VALUES (3, 0, NULL, NULL);",
             )
             .unwrap();
 
+        let digest = refresh_manifest_digest(&forward).unwrap();
+        assert_eq!(digest, refresh_manifest_digest(&reverse).unwrap());
         assert_eq!(
-            refresh_manifest_digest(&forward).unwrap(),
-            refresh_manifest_digest(&reverse).unwrap()
+            digest,
+            [
+                0xb4, 0xc6, 0xcb, 0x52, 0x95, 0xc1, 0x43, 0xf8, 0xe5, 0xf9, 0x3c, 0x96, 0xa3, 0x96,
+                0x84, 0xa7, 0xca, 0xd3, 0x72, 0x50, 0x13, 0x68, 0x7b, 0x07, 0x94, 0xd8, 0x2f, 0x58,
+                0x0f, 0x0e, 0xed, 0xf0,
+            ]
         );
     }
 
@@ -5479,13 +6463,15 @@ mod tests {
     fn semantic_root_covers_every_authoritative_manifest_table_and_integrity_state() {
         let mutations = [
             "UPDATE briskdb_manifest SET singleton = 2 WHERE singleton = 1",
-            "UPDATE briskdb_metadata SET requires_manifest_version = 9",
+            "UPDATE briskdb_metadata SET requires_manifest_version = 10",
             "UPDATE briskdb_routing SET hash_version = 2 WHERE singleton = 1",
             "UPDATE briskdb_physical_shards SET lifecycle_state = 'retired' WHERE shard_id = 0",
+            "UPDATE briskdb_allocation_owners SET owner_slot = 100 WHERE owner_slot = 0",
             "UPDATE briskdb_virtual_buckets SET physical_shard_id = 1 WHERE bucket_id = 0",
             "UPDATE briskdb_logical_databases SET database_name = 'primary' WHERE database_id = 1",
             "UPDATE briskdb_schema_catalog SET identifier_encoding_version = 2 WHERE singleton = 1",
             "INSERT INTO briskdb_tables VALUES (1, 1, 'widgets', 2, NULL, NULL)",
+            "INSERT INTO briskdb_generated_ids VALUES (1, 0, NULL, NULL)",
             "UPDATE briskdb_shard_layout SET layout_id = randomblob(16) WHERE singleton = 1",
             "INSERT INTO briskdb_schema_migrations VALUES (1, 0, randomblob(32), 1, 'SELECT 1', 4, 2, 4)",
             "UPDATE briskdb_integrity SET database_state = 4 WHERE singleton = 1",
@@ -5525,19 +6511,132 @@ mod tests {
     }
 
     #[test]
+    fn generated_id_future_fields_require_a_valid_v2_root_before_compatibility_errors() {
+        for (mutation, expected_diagnostic) in [
+            (
+                "UPDATE briskdb_generated_ids
+                 SET policy = 2, generated_column = 'tenant_id', encoding_version = 1
+                 WHERE table_id = 3",
+                "table 3 uses a newer generated-ID policy",
+            ),
+            (
+                "UPDATE briskdb_generated_ids
+                 SET policy = 1, generated_column = 'tenant_id', encoding_version = 2
+                 WHERE table_id = 3",
+                "table 3 uses a newer generated-ID encoding version",
+            ),
+        ] {
+            let mut unsealed = Connection::open_in_memory().unwrap();
+            create_ready_current_manifest(&mut unsealed, 4);
+            insert_valid_table_catalog(&unsealed);
+            unsealed.execute_batch(mutation).unwrap();
+            let error = load_or_create_manifest(&mut unsealed, 4).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::DataCorruption, "{mutation}");
+            assert_eq!(
+                error.diagnostic(),
+                "manifest semantic checksum does not match its authoritative contents",
+                "{mutation}"
+            );
+
+            let mut sealed = Connection::open_in_memory().unwrap();
+            create_ready_current_manifest(&mut sealed, 4);
+            insert_valid_table_catalog(&sealed);
+            sealed.execute_batch(mutation).unwrap();
+            refresh_manifest_digest(&sealed).unwrap();
+            let error = load_or_create_manifest(&mut sealed, 4).unwrap_err();
+            assert_eq!(
+                error.kind(),
+                EngineErrorKind::FailedPrecondition,
+                "{mutation}"
+            );
+            assert_eq!(error.diagnostic(), expected_diagnostic, "{mutation}");
+        }
+    }
+
+    #[test]
+    fn resealed_generated_id_relational_tampering_fails_closed() {
+        for mutation in [
+            "DELETE FROM briskdb_generated_ids WHERE table_id = 3",
+            "INSERT INTO briskdb_generated_ids VALUES (999, 0, NULL, NULL)",
+            "UPDATE briskdb_generated_ids
+             SET policy = 1, generated_column = 'id', encoding_version = 1
+             WHERE table_id = 8",
+            "UPDATE briskdb_generated_ids
+             SET policy = 1, generated_column = 'tenant_id', encoding_version = 1
+             WHERE table_id = 3",
+            "UPDATE briskdb_generated_ids
+             SET policy = 1, generated_column = 'wrong_id', encoding_version = 1
+             WHERE table_id = 55",
+            "UPDATE briskdb_generated_ids
+             SET policy = 1, generated_column = NULL, encoding_version = 1
+             WHERE table_id = 55",
+        ] {
+            let mut connection = Connection::open_in_memory().unwrap();
+            create_ready_current_manifest(&mut connection, 4);
+            insert_valid_table_catalog(&connection);
+            connection
+                .execute_batch(
+                    "PRAGMA foreign_keys = OFF;
+                     PRAGMA ignore_check_constraints = ON;",
+                )
+                .unwrap();
+            connection.execute_batch(mutation).unwrap();
+            connection
+                .execute_batch("PRAGMA ignore_check_constraints = OFF;")
+                .unwrap();
+            refresh_manifest_digest(&connection).unwrap();
+
+            let error = load_or_create_manifest(&mut connection, 4).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::DataCorruption, "{mutation}");
+        }
+    }
+
+    #[test]
+    fn resealed_allocation_owner_relational_tampering_fails_closed() {
+        for mutation in [
+            "DELETE FROM briskdb_allocation_owners WHERE owner_slot = 0",
+            "UPDATE briskdb_allocation_owners SET owner_slot = 100 WHERE owner_slot = 0",
+            "UPDATE briskdb_allocation_owners SET physical_shard_id = 63 WHERE owner_slot = 0",
+        ] {
+            let mut connection = Connection::open_in_memory().unwrap();
+            create_ready_current_manifest(&mut connection, 4);
+            connection
+                .execute_batch(
+                    "PRAGMA foreign_keys = OFF;
+                     PRAGMA ignore_check_constraints = ON;",
+                )
+                .unwrap();
+            connection.execute_batch(mutation).unwrap();
+            connection
+                .execute_batch("PRAGMA ignore_check_constraints = OFF;")
+                .unwrap();
+            refresh_manifest_digest(&connection).unwrap();
+
+            let error = load_or_create_manifest(&mut connection, 4).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::DataCorruption, "{mutation}");
+        }
+    }
+
+    #[test]
     fn integrity_versions_lengths_and_forged_state_invariants_fail_closed() {
-        for version_column in ["manifest_digest_version", "schema_digest_version"] {
+        for (version_column, unsupported_version) in
+            [("manifest_digest_version", 3), ("schema_digest_version", 2)]
+        {
             let mut unsupported = Connection::open_in_memory().unwrap();
             create_ready_current_manifest(&mut unsupported, 4);
             unsupported
                 .execute(
                     &format!(
-                        "UPDATE briskdb_integrity SET {version_column} = 2 WHERE singleton = 1"
+                        "UPDATE briskdb_integrity
+                         SET {version_column} = {unsupported_version}
+                         WHERE singleton = 1"
                     ),
                     [],
                 )
                 .unwrap();
-            refresh_manifest_digest(&unsupported).unwrap();
+            if version_column == "schema_digest_version" {
+                refresh_manifest_digest(&unsupported).unwrap();
+            }
             assert_eq!(
                 load_or_create_manifest(&mut unsupported, 4)
                     .unwrap_err()
@@ -5559,7 +6658,6 @@ mod tests {
                     [],
                 )
                 .unwrap();
-            refresh_manifest_digest(&invalid).unwrap();
             invalid
                 .pragma_update(None, "ignore_check_constraints", "OFF")
                 .unwrap();
@@ -5750,7 +6848,7 @@ mod tests {
             identity(&connection),
             (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
         );
-        assert_eq!(schema_objects(&connection).unwrap(), v7_objects());
+        assert_eq!(schema_objects(&connection).unwrap(), v9_objects());
         assert_eq!(
             shard_layout_row(&connection).3,
             ShardLayoutState::Adopting.code()
@@ -5774,7 +6872,7 @@ mod tests {
             identity(&connection),
             (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
         );
-        assert_eq!(schema_objects(&connection).unwrap(), v7_objects());
+        assert_eq!(schema_objects(&connection).unwrap(), v9_objects());
         assert_eq!(layout.state(), ShardLayoutState::Ready);
         assert_eq!(shard_layout_row(&connection), layout_before);
         assert_eq!(catalog.logical().schema_generation(), 0);
@@ -5866,7 +6964,7 @@ mod tests {
                 identity(&connection),
                 (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
             );
-            assert_eq!(schema_objects(&connection).unwrap(), v7_objects());
+            assert_eq!(schema_objects(&connection).unwrap(), v9_objects());
         }
 
         let mut connection = Connection::open_in_memory().unwrap();
@@ -6574,6 +7672,7 @@ mod tests {
                  PRAGMA ignore_check_constraints = OFF;",
             )
             .unwrap();
+        refresh_manifest_digest(&connection).unwrap();
 
         let error = load_or_create(&mut connection, 4).unwrap_err();
         assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
@@ -7485,7 +8584,7 @@ mod tests {
         for mutation in [
             "DELETE FROM briskdb_metadata",
             "DELETE FROM briskdb_manifest",
-            "INSERT INTO briskdb_metadata VALUES (8)",
+            "INSERT INTO briskdb_metadata VALUES (9)",
             "DELETE FROM briskdb_routing",
             "DELETE FROM briskdb_virtual_buckets WHERE bucket_id = 4095",
             "DELETE FROM briskdb_physical_shards WHERE shard_id = 3",
@@ -7700,6 +8799,20 @@ mod tests {
                     .unwrap();
             }
             drop(insert);
+            transaction
+                .execute(
+                    "INSERT INTO briskdb_generated_ids (
+                        table_id,
+                        policy,
+                        generated_column,
+                        encoding_version
+                     )
+                     SELECT table_id, 0, NULL, NULL
+                     FROM briskdb_tables
+                     ORDER BY table_id",
+                    [],
+                )
+                .unwrap();
             transaction.commit().unwrap();
         }
         refresh_manifest_digest(&tables).unwrap();

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -64,10 +64,11 @@ impl CatalogReplacementGuard<'_> {
     ) -> EngineResult<Arc<CatalogSnapshot>> {
         if current.routing() != replacement.routing()
             || current.logical().schema_generation() != replacement.logical().schema_generation()
+            || current.allocation_owners() != replacement.allocation_owners()
         {
             return Err(EngineError::new(
                 EngineErrorKind::Internal,
-                "table registration changed routing or schema-generation metadata",
+                "table registration changed routing, allocation-owner, or schema-generation metadata",
             ));
         }
         let replacement = Arc::new(replacement);
@@ -302,6 +303,7 @@ fn immutable_catalog_metadata_matches(left: &CatalogSnapshot, right: &CatalogSna
     let left_logical = left.logical();
     let right_logical = right.logical();
     left.routing() == right.routing()
+        && left.allocation_owners() == right.allocation_owners()
         && left_logical.identifier_encoding_version() == right_logical.identifier_encoding_version()
         && left_logical.default_database().id() == right_logical.default_database().id()
         && left_logical.logical_databases() == right_logical.logical_databases()
@@ -1065,6 +1067,7 @@ fn declarations_match_catalog(catalog: &Catalog, declarations: &[TableDeclaratio
             table.database_id() == declaration.database_id()
                 && table.name() == declaration.name()
                 && table.placement() == declaration.placement()
+                && table.generated_id_policy() == declaration.generated_id_policy()
         })
 }
 
@@ -2065,6 +2068,8 @@ mod tests {
             manifest
                 .execute_batch(
                     "BEGIN IMMEDIATE;
+                     DROP TABLE briskdb_generated_ids;
+                     DROP TABLE briskdb_allocation_owners;
                      DROP TABLE briskdb_integrity;
                      DROP TABLE briskdb_metadata;
                      CREATE TABLE briskdb_metadata (
@@ -2162,6 +2167,8 @@ mod tests {
             .unwrap()
             .execute_batch(
                 "BEGIN IMMEDIATE;
+                 DROP TABLE briskdb_generated_ids;
+                 DROP TABLE briskdb_allocation_owners;
                  DROP TABLE briskdb_integrity;
                  DROP TABLE briskdb_metadata;
                  CREATE TABLE briskdb_metadata (
@@ -2253,6 +2260,8 @@ mod tests {
             .unwrap()
             .execute_batch(
                 "BEGIN IMMEDIATE;
+                 DROP TABLE briskdb_generated_ids;
+                 DROP TABLE briskdb_allocation_owners;
                  DROP TABLE briskdb_integrity;
                  DROP TABLE briskdb_metadata;
                  CREATE TABLE briskdb_metadata (
@@ -2702,7 +2711,7 @@ mod tests {
         assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
         assert_eq!(
             error.to_string(),
-            "manifest table briskdb_manifest has an incompatible definition"
+            "manifest semantic checksum does not match its authoritative contents"
         );
     }
 
@@ -3107,6 +3116,76 @@ mod tests {
                 crate::core::ShardKeyMetadata::new("tenant_id", ShardKeyType::Text).unwrap()
             )
         );
+    }
+
+    #[test]
+    fn native_generated_id_policy_registers_and_reopens_exactly() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut database = Database::open(temp.path(), 3).unwrap();
+        database
+            .broadcast(
+                "CREATE TABLE events (
+                     id INTEGER PRIMARY KEY,
+                     payload BLOB
+                 )",
+            )
+            .unwrap();
+        let logical_database = database.catalog().default_database().id();
+        let policy = crate::core::GeneratedIdPolicy::native_range_v1("id").unwrap();
+        let declaration = TableDeclaration::sharded(
+            logical_database,
+            "events",
+            crate::core::ShardKeyMetadata::new("id", ShardKeyType::Int64).unwrap(),
+        )
+        .unwrap()
+        .with_generated_id_policy(policy.clone())
+        .unwrap();
+
+        database.register_tables(vec![declaration.clone()]).unwrap();
+        assert_eq!(
+            database
+                .catalog()
+                .table("default", "events")
+                .unwrap()
+                .unwrap()
+                .generated_id_policy(),
+            &policy
+        );
+        database.register_tables(vec![declaration]).unwrap();
+        drop(database);
+
+        let reopened = Database::open(temp.path(), 3).unwrap();
+        assert_eq!(
+            reopened
+                .catalog()
+                .table("default", "events")
+                .unwrap()
+                .unwrap()
+                .generated_id_policy(),
+            &policy
+        );
+    }
+
+    #[test]
+    fn native_generated_id_policy_rejects_a_nullable_physical_key() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut database = Database::open(temp.path(), 2).unwrap();
+        database
+            .broadcast("CREATE TABLE events (id INTEGER, payload BLOB)")
+            .unwrap();
+        let logical_database = database.catalog().default_database().id();
+        let declaration = TableDeclaration::sharded(
+            logical_database,
+            "events",
+            crate::core::ShardKeyMetadata::new("id", ShardKeyType::Int64).unwrap(),
+        )
+        .unwrap()
+        .with_generated_id_policy(crate::core::GeneratedIdPolicy::native_range_v1("id").unwrap())
+        .unwrap();
+
+        let error = database.register_tables(vec![declaration]).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert!(database.catalog().tables().is_empty());
     }
 
     #[test]

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -70,6 +70,12 @@ fn assert_catalog_fixture(catalog: &core::Catalog) {
     assert_eq!(catalog.default_database().name(), "default");
     assert_eq!(catalog.logical_databases().len(), 1);
     assert_eq!(catalog.tables().len(), 3);
+    assert!(
+        catalog
+            .tables()
+            .iter()
+            .all(|table| table.generated_id_policy() == &core::GeneratedIdPolicy::None)
+    );
 
     let logical_database = catalog.default_database();
     assert_eq!(
@@ -889,12 +895,30 @@ fn logical_catalog_types_and_access_are_public_and_protocol_neutral() {
     assert_public_metadata::<core::TablePlacement>();
     assert_public_metadata::<core::ShardKeyMetadata>();
     assert_public_metadata::<core::ShardKeyType>();
+    assert_public_metadata::<core::GeneratedIdPolicy>();
 
     let _signed = core::ShardKeyType::Int64;
     let _text = core::ShardKeyType::Text;
     let _binary = core::ShardKeyType::Binary;
     let _global = core::TablePlacement::Global;
     let _catalog = core::TablePlacement::Catalog;
+    let generated_policy = core::GeneratedIdPolicy::native_range_v1("id").unwrap();
+    assert_eq!(generated_policy.column(), Some("id"));
+    assert_eq!(generated_policy.encoding_version(), Some(1));
+    assert_eq!(core::GeneratedIdPolicy::None.column(), None);
+
+    let generated_declaration = core::TableDeclaration::sharded(
+        core::LogicalDatabaseId::new(1).unwrap(),
+        "generated_rows",
+        core::ShardKeyMetadata::new("id", core::ShardKeyType::Int64).unwrap(),
+    )
+    .unwrap()
+    .with_generated_id_policy(generated_policy.clone())
+    .unwrap();
+    assert_eq!(
+        generated_declaration.generated_id_policy(),
+        &generated_policy
+    );
 
     let temp = tempfile::tempdir().unwrap();
     let database = Arc::new(core::Database::open(temp.path(), 4).unwrap());

--- a/tests/sqlite_import.rs
+++ b/tests/sqlite_import.rs
@@ -5,7 +5,10 @@ use std::{
 };
 
 use briskdb::{
-    core::{CancellationToken, Database, EngineErrorKind, ShardKeyType, TablePlacement},
+    core::{
+        CancellationToken, Database, EngineErrorKind, GeneratedIdPolicy, ShardKeyType,
+        TablePlacement,
+    },
     import::{
         SQLITE_IMPORT_RECEIPT_VERSION, SqliteImportKeyType, SqliteImportOptions,
         SqliteImportPlacement, SqliteImportPlan, SqliteImportReport, SqliteImportTableReport,
@@ -505,6 +508,11 @@ fn assert_sharded_catalog(database: &Database, table: &str, column: &str, key_ty
         "wrong catalog placement for {table}: {:?}",
         metadata.placement(),
     );
+    assert_eq!(
+        metadata.generated_id_policy(),
+        &GeneratedIdPolicy::None,
+        "SQLite import must never infer generated-ID authority for {table}",
+    );
 }
 
 fn assert_global_catalog(database: &Database, table: &str) {
@@ -515,6 +523,11 @@ fn assert_global_catalog(database: &Database, table: &str) {
         .find(|candidate| candidate.name() == table)
         .unwrap_or_else(|| panic!("missing catalog table {table}"));
     assert!(matches!(metadata.placement(), TablePlacement::Global));
+    assert_eq!(
+        metadata.generated_id_policy(),
+        &GeneratedIdPolicy::None,
+        "SQLite import must persist no generated-ID authority for {table}",
+    );
 }
 
 fn integer_routes(database: &Database, ids: impl IntoIterator<Item = i64>) -> BTreeMap<i64, u16> {


### PR DESCRIPTION
Closes #125

## Summary

- add the public non-exhaustive `GeneratedIdPolicy` declaration and metadata API
- freeze the positive signed `native_range_v1` codec and immutable allocation-owner mapping
- migrate manifests atomically from v8 to v9 with explicit `None` policies, owner slots, downgrade fencing, and checksum-v2 authority
- preserve policy and owner metadata through registration, reopen, import, and live catalog publication
- document the stock-SQLite/no-fork allocation boundary and why an `INTEGER PRIMARY KEY` default UDF is not viable

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features`
- `cargo test --locked --doc --all-features`
- `cargo +1.85.0 test --locked --all-targets --all-features`
- `cargo +1.85.0 test --locked --doc --all-features`

The suite covers codec boundaries for all 1,024 owners, legacy/native classification, v8-to-v9 migration/rollback/panic/retry/downgrade behavior, frozen v1 and v2 checksum vectors, resealed and unsealed tampering, registration idempotency/conflicts, runtime owner-map retention, nullable physical keys, import defaults, and close/reopen persistence.
