### PR TITLE
Implement read-only sharded virtual-table routing

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -672,9 +672,21 @@ SQL translation belongs to issue #130.
 The opt-in `experimental-vtab` feature adds a separate, read-only SQLite
 coordinator that statically registers `brisk_shard`. It proves a no-fork logical
 table boundary while leaving the manifest, physical schemas, protocol behavior,
-and established scatter executor unchanged. Cursor ownership, schema admission,
-cancellation, bounded materialization, static-loading policy, and rejected
-alternatives are specified in the
+and established scatter executor unchanged. It opens validated physical children
+through OS-level SQLite read-only handles, never attaches a shard, and never
+dynamically loads an extension. Trusted metadata supplies each declared
+schema. An exact, storage-class-compatible `Int64`, `Text`, or `Binary`
+shard-key equality can open only its owner and bind the equality on that
+physical child; `native_range_v1` IDs use the immutable owner map while legacy
+integers retain ordinary hash routing. `NULL` is empty and a type mismatch
+falls back to a full scan so SQLite can retain its comparison semantics.
+Unconstrained scans visit shards in ascending order with `UNION ALL` duplicate
+semantics. Remaining filters, aggregation, ordering, limits, and feature-local
+joins execute in the stock SQLite coordinator without pushdown. That delegation
+is internal to the experimental coordinator and does not expand the Engine or
+protocol SQL contract. Cursor ownership, schema admission, cancellation,
+bounded materialization, static-loading policy, and rejected alternatives are
+specified in the
 [experimental sharded virtual-table facade](SHARDED_VIRTUAL_TABLE.md).
 
 ## Session and asynchronous engine boundary

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -102,6 +102,126 @@ and investigate correctness separately from performance. Record the exact
 branch or commit and `EngineOptions` for engine comparisons; the canonical
 warm-pool control uses four connections and 32 queued operations per shard.
 
+## Experimental sharded virtual-table decision workload
+
+The `experimental-vtab` feature includes a no-fork, read-only `brisk_shard`
+candidate that must be compared with the established Rust scatter path before
+any rollout decision. The comparison uses equivalent registered fixtures and
+reports point lookup, full scan, `COUNT(*)`, and ordered limited-read results.
+Point lookup binds an exact typed shard-key equality; the other workloads expose
+the cost of reading through the virtual table before stock SQLite evaluates
+non-pushed aggregation, ordering, or limits.
+
+Run the virtual-table correctness tests and benchmark harness with the feature
+enabled. Record the exact command, revision, shard count, fixture row count,
+database size, filesystem, toolchain, and warm/cold-cache policy alongside any
+measurements. At minimum, exercise 2-, 10-, and 64-shard fixtures. Compare the
+same returned rows and duplicate semantics before comparing elapsed time or
+throughput.
+
+```bash
+cargo test --locked --all-features storage::sharded_vtab
+cargo test --release --locked --features experimental-vtab --lib \
+  storage::sharded_vtab::benchmarks::release_benchmark_matrix_reports_issue_126_comparison \
+  -- --ignored --exact --nocapture --test-threads=1
+```
+
+The issue #126 implementation was measured on 2026-08-12 from branch
+`issue-126-read-only-vtab`, based on `f71f705`, on the repository's Apple M1 Pro
+(10 cores, 16 GiB RAM), internal APFS volume, macOS/Darwin 25.2.0, and Rust
+1.94.1 `aarch64-apple-darwin`. Each fresh fixture contained 256 deterministic
+rows per shard in both a hash-routed table and a native-ID table. The measured
+facade used validated OS-level `SQLITE_OPEN_READ_ONLY` handles for both bootstrap
+and child-shard access. The harness performed an untimed result/routing
+preflight and then took one fixture-size snapshot before any timed sample. It
+counts the logical file lengths reported by the filesystem for
+`manifest.sqlite`, an optional `manifest.sqlite-wal`, all expected
+`shards/NNNN.sqlite` files, and their optional `-wal` files. Missing WAL files
+count as zero. Volatile `-shm` files, directory metadata, filesystem block
+rounding, and unrelated temporary files are deliberately excluded.
+
+For every workload and path, the harness performs three untimed warm-up
+operations and an untimed calibration probe. Point probes start at 100
+operations; scan probes start with enough operations to process about 100,000
+logical rows. Calibration targets 500 ms and any measured sample shorter than
+250 ms is repeated with more iterations. The reported result is the median by
+throughput of five measured samples. Paired vtab/Engine samples alternate which
+path runs first; coordinator-only samples have no comparison path to alternate.
+Caches were warm; setup, schema migration, seeding, coordinator construction,
+correctness preflight, warm-up, and calibration were not timed.
+
+| Shards | Rows/shard/table | Manifest DB | Manifest WAL | Shard DBs | Shard WALs | Counted total |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 2 | 256 | 118,784 B | 0 B | 90,112 B | 0 B | 208,896 B |
+| 10 | 256 | 122,880 B | 0 B | 450,560 B | 0 B | 573,440 B |
+| 64 | 256 | 122,880 B | 0 B | 2,883,584 B | 0 B | 3,006,464 B |
+
+| Shards | Hash point: vtab | Hash point: Engine | vtab/Engine | Full scan: vtab | Full scan: Engine | vtab/Engine |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 2 | 4,957.00 ops/s | 37,967.69 ops/s | 0.131x | 1,130,050.19 rows/s | 3,184,983.99 rows/s | 0.355x |
+| 10 | 5,096.96 ops/s | 39,902.11 ops/s | 0.128x | 1,202,843.36 rows/s | 2,050,456.15 rows/s | 0.587x |
+| 64 | 4,754.41 ops/s | 32,304.24 ops/s | 0.147x | 1,162,523.00 rows/s | 2,061,907.79 rows/s | 0.564x |
+
+The coordinator-only workloads measured as follows. `COUNT(*)` and ordered
+`LIMIT` represent all logical input rows, even though they return one and 50
+rows respectively. The current Engine scatter surface rejects those forms, so
+the report does not invent a benchmark-only reducer for a false comparison.
+
+| Shards | `COUNT(*)` input rows/s | `ORDER BY ... LIMIT 50` input rows/s | Native-ID point ops/s |
+| ---: | ---: | ---: | ---: |
+| 2 | 1,448,435.79 | 1,229,253.95 | 7,147.31 |
+| 10 | 1,290,473.27 | 1,191,658.33 | 6,868.60 |
+| 64 | 1,332,706.05 | 1,366,877.11 | 7,323.54 |
+
+Exact harness records from the command above follow. The final test result was
+`1 passed; 0 failed` in 56.24 seconds.
+
+```text
+record	shards	rows_per_shard	path	workload	samples	median_iterations	median_elapsed_ms	median_ops_per_sec	median_logical_rows_per_sec
+fixture_record	shards	rows_per_shard	manifest_db_bytes	manifest_wal_bytes	shard_db_bytes	shard_wal_bytes	total_db_and_wal_bytes
+issue126_fixture_bytes	2	256	118784	0	90112	0	208896
+issue126_benchmark	2	256	vtab	hash_point	5	2221	448.053	4957.00	4957.00
+issue126_benchmark	2	256	engine_logical	hash_point	5	15774	415.459	37967.69	37967.69
+issue126_benchmark	2	256	vtab	hash_full	5	1036	469.388	2207.13	1130050.19
+issue126_benchmark	2	256	engine_logical	hash_full	5	3264	524.702	6220.67	3184983.99
+issue126_benchmark	2	256	vtab	count	5	1341	474.023	2828.98	1448435.79
+issue126_benchmark	2	256	vtab	order_limit_50	5	1221	508.562	2400.89	1229253.95
+issue126_benchmark	2	256	vtab	native_point	5	3662	512.361	7147.31	7147.31
+issue126_comparison	2	256	hash_point	0.131	hash_full	0.355
+issue126_fixture_bytes	10	256	122880	0	450560	0	573440
+issue126_benchmark	10	256	vtab	hash_point	5	2589	507.950	5096.96	5096.96
+issue126_benchmark	10	256	engine_logical	hash_point	5	21410	536.563	39902.11	39902.11
+issue126_benchmark	10	256	vtab	hash_full	5	235	500.148	469.86	1202843.36
+issue126_benchmark	10	256	engine_logical	hash_full	5	420	524.371	800.96	2050456.15
+issue126_benchmark	10	256	vtab	count	5	225	446.348	504.09	1290473.27
+issue126_benchmark	10	256	vtab	order_limit_50	5	236	506.991	465.49	1191658.33
+issue126_benchmark	10	256	vtab	native_point	5	3235	470.984	6868.60	6868.60
+issue126_comparison	10	256	hash_point	0.128	hash_full	0.587
+issue126_fixture_bytes	64	256	122880	0	2883584	0	3006464
+issue126_benchmark	64	256	vtab	hash_point	5	2455	516.363	4754.41	4754.41
+issue126_benchmark	64	256	engine_logical	hash_point	5	17959	555.933	32304.24	32304.24
+issue126_benchmark	64	256	vtab	hash_full	5	35	493.272	70.95	1162523.00
+issue126_benchmark	64	256	engine_logical	hash_full	5	66	524.439	125.85	2061907.79
+issue126_benchmark	64	256	vtab	count	5	42	516.339	81.34	1332706.05
+issue126_benchmark	64	256	vtab	order_limit_50	5	44	527.404	83.43	1366877.11
+issue126_benchmark	64	256	vtab	native_point	5	2894	395.164	7323.54	7323.54
+issue126_comparison	64	256	hash_point	0.147	hash_full	0.564
+```
+
+These are one-host engineering measurements rather than CI thresholds or a
+statistical capacity claim. They show that correctness and scale are viable,
+but the connection-per-child, materializing facade is currently about 6.8-7.8x
+slower for hash point reads and 1.7-2.8x slower for full scans than the pooled
+Rust Engine path. The issue #126 decision is therefore to retain the facade as
+an experimental complement and optimization foundation. It must not replace
+the Engine/protocol query path at this stage. Streaming child cursors and pooled
+read handles are the clearest measured follow-up opportunities.
+
+The decision record must report measurements for both paths, including startup
+where relevant, and explain whether the virtual-table boundary advances,
+remains experimental, or is rejected. The feature remains off the authoritative
+Engine and protocol paths until the separate rollout gate is approved.
+
 ## Initial snapshot
 
 The initial issue #3 branch was measured on 2026-08-07 with `cargo bench

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -126,9 +126,10 @@ cargo test --release --locked --features experimental-vtab --lib \
   -- --ignored --exact --nocapture --test-threads=1
 ```
 
-The issue #126 implementation was measured on 2026-08-12 from branch
-`issue-126-read-only-vtab`, based on `f71f705`, on the repository's Apple M1 Pro
-(10 cores, 16 GiB RAM), internal APFS volume, macOS/Darwin 25.2.0, and Rust
+The issue #126 implementation was measured on 2026-08-12 at implementation
+commit `7f0d598` (from branch `issue-126-read-only-vtab`, based on `f71f705`) on
+the repository's Apple M1 Pro (10 cores, 16 GiB RAM), internal APFS volume,
+macOS/Darwin 25.2.0, and Rust
 1.94.1 `aarch64-apple-darwin`. Each fresh fixture contained 256 deterministic
 rows per shard in both a hash-routed table and a native-ID table. The measured
 facade used validated OS-level `SQLITE_OPEN_READ_ONLY` handles for both bootstrap

--- a/docs/SHARDED_VIRTUAL_TABLE.md
+++ b/docs/SHARDED_VIRTUAL_TABLE.md
@@ -5,19 +5,45 @@ module named `brisk_shard`. The prototype is compiled only with the
 `experimental-vtab` Cargo feature and does not replace the current logical
 scatter/gather executor.
 
-The coordinator is a separate SQLite connection. It contains one virtual table
-for each catalog-authoritative `Sharded` or `Global` application table:
+The coordinator is a separate, ephemeral stock-SQLite connection. It contains
+one virtual table for each catalog-authoritative `Sharded` or `Global`
+application table. `xConnect` declares the exact column schema derived from
+trusted, already-validated catalog and shard metadata; submitted SQL never
+supplies a shard filename, table declaration, or module argument.
 
-- a `Sharded` cursor visits the validated physical shard files in shard order;
+The read contract is:
+
+- a `Sharded` scan visits the validated physical shard files in ascending
+  shard order and preserves duplicates as deterministic `UNION ALL`;
 - a `Global` cursor visits canonical shard 0 once, even though the data is
   replicated physically; and
 - `Catalog` placement is never declared in the coordinator schema.
 
-Normal SQLite SQL runs above those tables. The prototype therefore proves that
-filtering, ordering, aggregates, limits, joins, and other SQLite operators can
-have global semantics without teaching a frontend about shard files. Constraint
-routing and pushdown are intentionally deferred to issue #126; the initial
-`xBestIndex` consumes no predicates, so SQLite rechecks every condition.
+For a usable equality constraint on the exact declared shard-key column,
+`xBestIndex` requests one argument but deliberately does not set `omit`.
+`xFilter` prunes to one physical child only when the bound SQLite storage class
+exactly matches the catalog key type: `INTEGER` for `Int64`, valid UTF-8 `TEXT`
+for `Text`, or `BLOB` for `Binary`. The child statement binds that same value to
+`WHERE <physical-shard-key> = ?1`, allowing ordinary per-file SQLite indexes to
+serve the lookup. The coordinator rechecks the predicate because the virtual
+table did not claim omission.
+
+An equality argument of `NULL` produces an empty cursor. A non-null storage
+class mismatch is not a routing proof: it conservatively visits every normal
+target and leaves SQLite to apply its affinity and comparison rules. With
+`native_range_v1`, a valid encoded native integer maps its immutable owner slot
+through the catalog's allocation-owner map. An integer classified as legacy
+under that policy uses the ordinary canonical Int64 hash route instead. No ID
+allocation occurs on this read path.
+
+Normal SQLite evaluates remaining filtering, aggregation, ordering, limits, and
+feature-local joins above the virtual table. None of those operations is pushed
+down, so every row reached by the routed or full scan still counts against the
+facade's bounded cursor budgets before an aggregate, `LIMIT`, or join can reduce
+the result. This is delegation to stock SQLite inside the experimental
+coordinator, not an expansion of BriskDB's supported Engine or protocol SQL
+surface. Advanced multi-shard forms rejected or delegated by that existing
+surface remain rejected or delegated there.
 
 ## Ownership and lifecycle
 
@@ -32,11 +58,13 @@ Each cursor:
 
 1. acquires an owned BriskDB schema-operation guard;
 2. verifies that the coordinator's declared schema generation is still current;
-3. opens one child shard through `Storage::open_shard`, retaining all identity,
-   schema-digest, authorizer, and fail-closed checks;
-4. marks that private child connection query-only and materializes a bounded
-   shard batch while preserving all five SQLite storage classes, non-UTF-8
-   `TEXT` bytes, column affinity, and declared collation;
+3. opens the next selected child shard through a validated OS-level SQLite
+   `READ_ONLY | NOFOLLOW` handle, retaining all identity, schema-digest,
+   authorizer, and fail-closed checks;
+4. also marks that private child connection query-only, optionally binds the
+   exact shard-key equality to its indexed physical column, and materializes a
+   bounded shard batch while preserving all five SQLite storage classes,
+   non-UTF-8 `TEXT` result bytes, column affinity, and declared collation;
 5. closes the child before advancing to the next file; and
 6. releases schema admission at EOF, error, cancellation, or cursor close.
 
@@ -44,18 +72,24 @@ No child `Connection`, `Statement`, or `Rows` object crosses a callback or
 thread boundary. A cursor is not self-referential, and the coordinator is never
 called recursively from a child scan. The spike bounds a complete cursor to
 65,536 rows and a conservative 64 MiB allocation budget. It checks cell sizes
-before copying payloads, uses fallible allocation, and discards an exhausted
-shard batch before allocating the next. Later streaming work must preserve
+before copying payloads, charges an owned equality argument to the same budget,
+uses fallible result allocation, and discards an exhausted shard batch before
+allocating the next. Later streaming work must preserve
 operation-wide result budgets while replacing this bounded materialization.
 
 A cancellation handle increments a scan epoch observed by child progress
-handlers. It interrupts the coordinator only while a child callback is active;
-the same mutex that publishes active child handles prevents a late interrupt
-from reaching the next query. Cancellation of outer SQLite work after every
-child callback has completed belongs with the future request-scoped query API.
+handlers and by `xNext` before it serves another materialized row. It always
+interrupts the coordinator as well, covering stock-SQLite filtering, sorting,
+aggregation, and join work after a child handle has closed; SQLite specifies
+that an interrupt issued while idle does not affect statements started later.
+The epoch is rechecked after every child, including an empty child that did not
+invoke the progress hook. Cancellation releases both the child and schema guard,
+and the coordinator can be reused because cancellation is scoped to one scan
+epoch.
 
 The module uses `SQLITE_VTAB_DIRECTONLY` and rusqlite's read-only module table,
-which has no `xUpdate`. The coordinator also enables `query_only` and disables
+which has no `xUpdate`. Every physical child is opened with SQLite's OS-level
+read-only flag, then also receives `query_only`; the coordinator disables
 trusted schema execution after bootstrap. A fail-closed authorizer denies DML,
 DDL, `ATTACH`, `DETACH`, unsafe PRAGMAs, and the SQL `load_extension` function,
 including attempts to turn `query_only` back off. The Cargo feature adds only
@@ -83,16 +117,21 @@ This is why several alternatives are excluded:
 
 ## Current non-goals
 
-This boundary does not yet provide writes, generated IDs, distributed
-transactions, predicate routing, aggregate pushdown, parallel shard scans, or a
-public query API. It does not change protocol behavior. Those capabilities are
-split across issues #125 through #131 so each can be tested and reviewed without
-silently replacing the established executor.
+This boundary does not provide writes, generated-ID allocation, distributed
+transactions, aggregate/order/limit/join pushdown, parallel shard scans, or a
+public query API. It does not change protocol behavior. The current `Engine`,
+HTTP surface, and protocol planner remain authoritative. Advanced filter,
+aggregate, order, and limit pushdown remains owned by issues #58 through #61.
+Issues #127 through #131 separately cover explicit-key writes, native and
+optional hi/lo generated IDs, generated-key SQL integration, and the final
+rollout gate.
 
-Because this spike consumes no `xBestIndex` constraints, even a point predicate
-or `LIMIT 1` materializes each reached shard before SQLite applies the outer
-operation. A shard over the prototype budget can therefore fail a small-looking
-query. Separate child connections also observe independent SQLite snapshots, so
-the facade does not yet promise one cross-shard snapshot while writers commit.
-It must not be wired to the query app until routing, streaming, request controls,
-and consistency policy are completed and gated in #126 and #131.
+Only the exact typed shard-key equality described above narrows a scan. Other
+predicates, and a type-mismatched equality whose SQLite affinity semantics
+might still match, materialize every reached shard before SQLite applies the
+outer operation. A shard over the prototype budget can therefore fail a
+small-looking aggregate or limited query. Separate child connections also
+observe independent SQLite snapshots, so the facade does not promise one
+cross-shard snapshot while writers commit. It must not be wired to the query
+app until streaming, request controls, consistency policy, and the rollout gate
+in #131 are complete.

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -106,6 +106,29 @@ not make that prepared pipeline public wire behavior. Authoritative table
 registration composes the SQLite frontend and planner into the existing HTTP
 execute/query rows as described above; it adds no HTTP field or route.
 
+The `experimental-vtab` Cargo feature also contains a read-only, internal
+`brisk_shard` coordinator for evaluating the no-fork virtual-table boundary. It
+is not an HTTP, PostgreSQL, or MySQL query interface and does not expand the
+table above. The module is statically registered into stock SQLite and opens
+validated physical children through OS-level SQLite read-only handles; it does
+not use `ATTACH`, runtime extension loading, a SQLite fork, or a storage-format
+change. Writes, schema operations, attachments, unsafe PRAGMAs, and extension
+loading are rejected.
+
+Within that feature gate only, a usable equality on the exact cataloged shard
+key requests one virtual-table argument without `omit`. Exact SQLite `INTEGER`,
+UTF-8 `TEXT`, and `BLOB` values can route matching `Int64`, `Text`, and `Binary`
+keys to one child, where the value is bound against the indexed physical key.
+A valid `native_range_v1` value uses its allocation owner; a legacy integer
+under that policy uses normal hash routing. `NULL` is empty, while a non-null
+type mismatch conservatively scans all placement targets. Unconstrained scans
+visit shards in ascending order and preserve duplicates as `UNION ALL`.
+SQLite applies remaining filters, aggregation, ordering, limits, and
+feature-local joins above the facade without pushdown. That stock-SQLite
+delegation is internal to the experimental coordinator; it does not expand the
+Engine or protocol contracts documented elsewhere in this file, including
+their rejection or delegation of unsupported advanced multi-shard SQL.
+
 Every HTTP database operation now calls the same protocol-neutral async engine
 used by PostgreSQL startup status and intended for issue-31 PostgreSQL SQL flow
 and the future MySQL adapter. Execute and query requests create a fresh `Ready`

--- a/docs/SQL_PLANNING.md
+++ b/docs/SQL_PLANNING.md
@@ -70,6 +70,26 @@ sets: every shard for `Unconstrained`, or each distinct inferred owner for a
 finite multi-owner result. Catalog placement remains denied. This execution
 integration does not change this planner's meaning of `assigned_shard()`.
 
+The feature-gated `brisk_shard` coordinator is a separate experimental read
+path, not another `BoundStatementPlan` consumer and not a replacement for this
+authoritative Engine policy. Its `xBestIndex` requests one argument for a
+usable equality on the registered shard-key column without claiming `omit`.
+At `xFilter`, exact SQLite `INTEGER`, UTF-8 `TEXT`, and `BLOB` values route the
+matching `Int64`, `Text`, and `Binary` key types to one owner. A valid
+`native_range_v1` integer resolves through the immutable allocation-owner map;
+a legacy integer under the same policy follows normal hash routing. `NULL`
+produces no rows, while a storage-class mismatch scans all selected placement
+targets and lets SQLite recheck the predicate. The child equality is bound on
+the physical shard-key column so its local index remains available.
+
+Unconstrained virtual-table reads scan in ascending shard order and retain
+duplicates as `UNION ALL`. Stock SQLite evaluates other filtering, aggregation,
+ordering, limits, and feature-local joins above that scan without pushdown.
+This internal delegation does not expand the Engine's accepted multi-shard
+forms or change protocol behavior; those paths continue to reject or delegate
+forms outside their documented subset. Advanced filter, aggregate, order, and
+limit pushdown remains owned by issues #58 through #61.
+
 Populated-catalog raw execute/query uses the same internal planning result after
 SQLite parsing, common-subset validation, placeholder normalization, and strict
 translation. Execute still requires one assigned Sharded owner. Query uses one

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -42,6 +42,9 @@ use crate::{
     sqlite_error,
 };
 
+#[cfg(feature = "experimental-vtab")]
+use crate::core::AllocationOwnerMap;
+
 pub(crate) const CONNECTION_BUSY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 pub(crate) const MAX_SCHEMA_MIGRATION_SQL_BYTES: usize = manifest::MAX_SCHEMA_MIGRATION_SQL_BYTES;
 
@@ -626,6 +629,11 @@ impl Storage {
         self.catalog.logical()
     }
 
+    #[cfg(feature = "experimental-vtab")]
+    pub(crate) fn allocation_owner_map(&self) -> Option<&AllocationOwnerMap> {
+        self.catalog.allocation_owners()
+    }
+
     pub(crate) fn register_tables(
         &mut self,
         declarations: Vec<TableDeclaration>,
@@ -892,6 +900,29 @@ impl Storage {
             self.ensure_shard_in_range(shard)?;
             let path = self.shard_path(shard);
             let connection = shard::open_existing(
+                &path,
+                shard,
+                self.catalog.logical().schema_generation(),
+                &self.shard_layout,
+            )?;
+            let expected_digest = self.schema_coordination.committed_schema_digest()?;
+            shard::verify_schema_digest(
+                &connection,
+                self.catalog.logical().schema_generation(),
+                &expected_digest,
+            )?;
+            attach_storage_authorizer(&connection)?;
+            Ok(connection)
+        })();
+        self.fail_closed_on_corruption(result)
+    }
+
+    #[cfg(feature = "experimental-vtab")]
+    pub(crate) fn open_shard_read_only(&self, shard: u16) -> EngineResult<Connection> {
+        let result = (|| {
+            self.ensure_shard_in_range(shard)?;
+            let path = self.shard_path(shard);
+            let connection = shard::open_existing_read_only(
                 &path,
                 shard,
                 self.catalog.logical().schema_generation(),

--- a/src/storage/shard.rs
+++ b/src/storage/shard.rs
@@ -260,6 +260,26 @@ pub(super) fn open_existing(
     Ok(connection)
 }
 
+/// Open and validate a required shard through an OS-level read-only SQLite
+/// handle. This retains the same no-create, no-follow, identity, generation,
+/// metadata, WAL-mode, and schema-integrity preconditions as a writable open.
+#[cfg(feature = "experimental-vtab")]
+pub(super) fn open_existing_read_only(
+    path: &Path,
+    shard_id: u16,
+    schema_generation: u64,
+    layout: &ShardLayout,
+) -> EngineResult<Connection> {
+    validate_existing_file(path)?;
+    let connection = open_existing_read_only_connection(path)?;
+    configure_busy_timeout(&connection)?;
+    validate_shard_id(shard_id)?;
+    let expected_user_version = expected_user_version(schema_generation)?;
+    require_read_only(&connection)?;
+    validate_exact_shard(&connection, path, shard_id, expected_user_version, layout)?;
+    Ok(connection)
+}
+
 /// Open the required path with strict filesystem and SQLite no-create/no-follow
 /// semantics, but leave database validation to the caller. The controlled pool
 /// path uses this split to install cancellation hooks before validation can
@@ -1773,6 +1793,21 @@ fn open_existing_connection(path: &Path) -> EngineResult<Connection> {
     Ok(connection)
 }
 
+#[cfg(feature = "experimental-vtab")]
+fn open_existing_read_only_connection(path: &Path) -> EngineResult<Connection> {
+    let flags = OpenFlags::SQLITE_OPEN_READ_ONLY
+        | OpenFlags::SQLITE_OPEN_NO_MUTEX
+        | OpenFlags::SQLITE_OPEN_NOFOLLOW
+        | OpenFlags::SQLITE_OPEN_EXRESCODE;
+    let open_path = canonical_open_path(path)?;
+    let connection = Connection::open_with_flags(open_path, flags).map_err(|error| {
+        sqlite_error::storage(error)
+            .context(format!("failed to open read-only shard {}", path.display()))
+    })?;
+    configure_cell_size_check(&connection)?;
+    Ok(connection)
+}
+
 fn open_creating_connection(path: &Path) -> EngineResult<Connection> {
     let flags = OpenFlags::SQLITE_OPEN_READ_WRITE
         | OpenFlags::SQLITE_OPEN_CREATE
@@ -1869,6 +1904,21 @@ fn require_writable(connection: &Connection) -> EngineResult<()> {
         ));
     }
     Ok(())
+}
+
+#[cfg(feature = "experimental-vtab")]
+fn require_read_only(connection: &Connection) -> EngineResult<()> {
+    if connection
+        .is_readonly(MAIN_DB)
+        .map_err(sqlite_error::storage)?
+    {
+        Ok(())
+    } else {
+        Err(EngineError::new(
+            EngineErrorKind::Internal,
+            "read-only shard unexpectedly opened through a writable SQLite handle",
+        ))
+    }
 }
 
 fn configure_connection_pragmas(connection: &Connection) -> EngineResult<()> {

--- a/src/storage/sharded_vtab.rs
+++ b/src/storage/sharded_vtab.rs
@@ -13,19 +13,26 @@ use std::{
     },
 };
 
+#[cfg(test)]
+use std::{sync::mpsc, time::Duration};
+
 use rusqlite::{
     Connection, Error as SqliteError, InterruptHandle, Result as SqliteResult, ffi,
     hooks::{AuthAction, AuthContext, Authorization},
     types::{ToSql, ToSqlOutput, ValueRef},
     vtab::{
-        Context, CreateVTab, Filters, IndexInfo, VTab, VTabConfig, VTabConnection, VTabCursor,
-        VTabKind, read_only_module,
+        Context, CreateVTab, Filters, IndexConstraintOp, IndexInfo, VTab, VTabConfig,
+        VTabConnection, VTabCursor, VTabKind, read_only_module,
     },
 };
 
 use super::{SchemaOperationGuard, SqliteAffinity, Storage, quote_identifier, sqlite_affinity};
 use crate::{
-    core::{EngineError, EngineErrorKind, EngineResult, TablePlacement},
+    core::generated_id::{GeneratedIdClassification, classify_generated_id},
+    core::{
+        AllocationOwnerMap, CanonicalShardKeyRef, EngineError, EngineErrorKind, EngineResult,
+        GeneratedIdPolicy, ShardKeyType, TableMetadata, TablePlacement, canonical_shard_key_bytes,
+    },
     sqlite_error,
 };
 
@@ -35,6 +42,8 @@ const MAX_CURSOR_BYTES: usize = 64 * 1024 * 1024;
 const ALLOCATION_OVERHEAD_BYTES: usize = 16;
 const ROW_ACCOUNTING_BYTES: usize = size_of::<Vec<RawCell>>() * 4 + ALLOCATION_OVERHEAD_BYTES;
 const VALUE_ACCOUNTING_BYTES: usize = size_of::<RawCell>();
+const SCAN_PLAN: c_int = 0;
+const SHARD_KEY_EQUALITY_PLAN: c_int = 1;
 
 /// A separate SQLite coordinator whose logical tables are backed by BriskDB
 /// shard files. The coordinator never attaches those files to its own schema.
@@ -66,10 +75,24 @@ impl ReadCoordinator {
     }
 
     fn open_connection(storage: Storage, connection: Connection) -> EngineResult<Self> {
+        Self::open_connection_with_limits(storage, connection, CursorLimits::default())
+    }
+
+    #[cfg(test)]
+    fn open_with_limits(storage: Storage, limits: CursorLimits) -> EngineResult<Self> {
+        let connection = Connection::open_in_memory().map_err(sqlite_error::storage)?;
+        Self::open_connection_with_limits(storage, connection, limits)
+    }
+
+    fn open_connection_with_limits(
+        storage: Storage,
+        connection: Connection,
+        limits: CursorLimits,
+    ) -> EngineResult<Self> {
         // Hold schema admission through discovery and coordinator bootstrap so
         // open cannot return an already-stale declaration.
         let bootstrap_operation = storage.enter_schema_operation()?;
-        let registry = Registry::build_admitted(storage)?;
+        let registry = Registry::build_admitted_with_limits(storage, limits)?;
         register_module(&connection, Arc::clone(&registry)).map_err(sqlite_error::storage)?;
         bootstrap_coordinator_schema(&connection, &registry)?;
 
@@ -115,38 +138,44 @@ impl ReadCoordinator {
     }
 
     #[cfg(test)]
-    fn install_child_scan_gate(
-        &self,
-        started: Arc<std::sync::Barrier>,
-        release: Arc<std::sync::Barrier>,
-    ) {
+    fn take_opened_shards(&self) -> Vec<u16> {
+        std::mem::take(
+            &mut *self
+                .registry
+                .opened_shards
+                .lock()
+                .expect("virtual-table shard diagnostics are not poisoned"),
+        )
+    }
+
+    #[cfg(test)]
+    fn install_child_scan_gate(&self) -> TestChildScanControl {
+        let (gate, control) = TestChildScanGate::channel();
         *self
             .registry
             .child_scan_gate
             .lock()
-            .expect("child-scan test gate is not poisoned") =
-            Some(TestChildScanGate { started, release });
+            .expect("child-scan test gate is not poisoned") = Some(gate);
+        control
     }
 
     #[cfg(test)]
-    fn install_child_scan_complete_gate(
-        &self,
-        started: Arc<std::sync::Barrier>,
-        release: Arc<std::sync::Barrier>,
-    ) {
+    fn install_child_scan_complete_gate(&self) -> TestChildScanControl {
+        let (gate, control) = TestChildScanGate::channel();
         *self
             .registry
             .child_scan_complete_gate
             .lock()
-            .expect("child-scan completion test gate is not poisoned") =
-            Some(TestChildScanGate { started, release });
+            .expect("child-scan completion test gate is not poisoned") = Some(gate);
+        control
     }
 }
 
 /// Cancels a child-shard scan currently inside an `xFilter`/`xNext` callback.
 /// Incrementing the epoch does not poison later queries; each new filter
-/// captures the then-current epoch. The active-child mutex closes the race in
-/// which a late coordinator interrupt could otherwise hit the next query.
+/// captures the then-current epoch. SQLite defines an interrupt issued while
+/// the coordinator is idle as harmless to statements started later, so every
+/// cancellation also interrupts stock-SQLite work above the virtual table.
 #[derive(Clone)]
 pub(crate) struct CoordinatorCancellation {
     epoch: Arc<AtomicU64>,
@@ -156,14 +185,12 @@ pub(crate) struct CoordinatorCancellation {
 
 impl CoordinatorCancellation {
     pub(crate) fn cancel(&self) {
-        let active_child_scans = self
+        let _active_child_scans = self
             .active_child_scans
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         self.epoch.fetch_add(1, Ordering::AcqRel);
-        if *active_child_scans != 0 {
-            self.interrupt.interrupt();
-        }
+        self.interrupt.interrupt();
     }
 }
 
@@ -243,7 +270,11 @@ fn attach_coordinator_authorizer(connection: &Connection) -> EngineResult<()> {
             AuthAction::Pragma {
                 pragma_name,
                 pragma_value: None,
-            } if pragma_name.eq_ignore_ascii_case("query_only") => Authorization::Allow,
+            } if pragma_name.eq_ignore_ascii_case("query_only")
+                || pragma_name.eq_ignore_ascii_case("database_list") =>
+            {
+                Authorization::Allow
+            }
             _ => Authorization::Deny,
         }))
         .map_err(sqlite_error::storage)
@@ -261,6 +292,7 @@ struct Registry {
     storage: Storage,
     schema_generation: u64,
     tables: BTreeMap<u64, Arc<TableSpec>>,
+    limits: CursorLimits,
     cancellation_epoch: Arc<AtomicU64>,
     active_child_scans: Arc<Mutex<usize>>,
     lifecycle: Arc<LifecycleCounters>,
@@ -272,27 +304,66 @@ struct Registry {
     child_scan_complete_gate: Mutex<Option<TestChildScanGate>>,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct CursorLimits {
+    rows: usize,
+    bytes: usize,
+}
+
+impl Default for CursorLimits {
+    fn default() -> Self {
+        Self {
+            rows: MAX_CURSOR_ROWS,
+            bytes: MAX_CURSOR_BYTES,
+        }
+    }
+}
+
 impl Registry {
     fn build_admitted(storage: Storage) -> EngineResult<Arc<Self>> {
+        Self::build_admitted_with_limits(storage, CursorLimits::default())
+    }
+
+    fn build_admitted_with_limits(
+        storage: Storage,
+        limits: CursorLimits,
+    ) -> EngineResult<Arc<Self>> {
+        if limits.rows == 0 || limits.bytes == 0 {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "brisk_shard result limits must be non-zero",
+            ));
+        }
         let schema_generation = storage.current_schema_generation();
-        let shard = storage.open_shard(0)?;
+        let shard = storage.open_shard_read_only(0)?;
         shard
             .pragma_update(None, "query_only", "ON")
             .map_err(sqlite_error::storage)?;
 
+        let allocation_owners = storage.allocation_owner_map().cloned().map(Arc::new);
         let mut tables = BTreeMap::new();
         for table in storage.logical_catalog().tables() {
+            #[allow(unreachable_patterns)]
             let targets = match table.placement() {
                 TablePlacement::Sharded(_) => (0..storage.shard_count()).collect::<Vec<_>>(),
                 // Global rows are replicated physically but exposed once from
                 // their canonical read owner.
                 TablePlacement::Global => vec![0],
                 TablePlacement::Catalog => continue,
+                _ => {
+                    return Err(EngineError::new(
+                        EngineErrorKind::Unsupported,
+                        format!(
+                            "registered table {} has an unsupported placement",
+                            table.name()
+                        ),
+                    ));
+                }
             };
             let spec = TableSpec::from_physical_table(
                 &shard,
-                table.id().get(),
-                table.name(),
+                table,
+                allocation_owners.clone(),
                 targets.into_boxed_slice(),
             )?;
             tables.insert(table.id().get(), Arc::new(spec));
@@ -302,6 +373,7 @@ impl Registry {
             storage,
             schema_generation,
             tables,
+            limits,
             cancellation_epoch: Arc::new(AtomicU64::new(0)),
             active_child_scans: Arc::new(Mutex::new(0)),
             lifecycle: Arc::new(LifecycleCounters::default()),
@@ -318,6 +390,93 @@ impl Registry {
         self.tables.get(&id).cloned()
     }
 
+    fn equality_scan(
+        &self,
+        spec: &TableSpec,
+        value: ValueRef<'_>,
+    ) -> EngineResult<(RawCell, Box<[u16]>, usize)> {
+        let equality_bytes = RawCell::accounted_payload_bytes(value)
+            .checked_add(VALUE_ACCOUNTING_BYTES)
+            .and_then(|bytes| bytes.checked_add(ALLOCATION_OVERHEAD_BYTES))
+            .ok_or_else(|| limit_error("byte", self.limits.bytes))?;
+        if equality_bytes > self.limits.bytes {
+            return Err(limit_error("byte", self.limits.bytes));
+        }
+        let equality = RawCell::try_copy_from(value)?;
+        let targets = match self.equality_targets(spec, value)? {
+            EqualityTargets::Empty => Box::default(),
+            EqualityTargets::One(shard) => {
+                if !spec.targets.contains(&shard) {
+                    return Err(EngineError::new(
+                        EngineErrorKind::DataCorruption,
+                        format!(
+                            "registered table {} routed outside its declared target set",
+                            spec.name
+                        ),
+                    ));
+                }
+                vec![shard].into_boxed_slice()
+            }
+            EqualityTargets::All => spec.targets.clone(),
+        };
+        Ok((equality, targets, equality_bytes))
+    }
+
+    fn equality_targets(
+        &self,
+        spec: &TableSpec,
+        value: ValueRef<'_>,
+    ) -> EngineResult<EqualityTargets> {
+        let Some(shard_key) = &spec.shard_key else {
+            return Ok(EqualityTargets::All);
+        };
+        if matches!(value, ValueRef::Null) {
+            return Ok(EqualityTargets::Empty);
+        }
+
+        #[allow(unreachable_patterns)]
+        let target = match (shard_key.key_type, value) {
+            (ShardKeyType::Int64, ValueRef::Integer(value)) => {
+                match classify_generated_id(&spec.generated_id_policy, value)? {
+                    GeneratedIdClassification::Legacy(value) => Some(self.storage.shard_for_key(
+                        &canonical_shard_key_bytes(CanonicalShardKeyRef::Int64(value)),
+                    )),
+                    GeneratedIdClassification::NativeRangeV1(id) => {
+                        let owners = spec.allocation_owners.as_ref().ok_or_else(|| {
+                            EngineError::new(
+                                EngineErrorKind::DataCorruption,
+                                format!(
+                                    "registered native-ID table {} has no allocation-owner map",
+                                    spec.name
+                                ),
+                            )
+                        })?;
+                        return Ok(owners
+                            .physical_shard(id.owner())
+                            .map_or(EqualityTargets::Empty, EqualityTargets::One));
+                    }
+                }
+            }
+            (ShardKeyType::Text, ValueRef::Text(value)) => {
+                std::str::from_utf8(value).ok().map(|value| {
+                    self.storage.shard_for_key(&canonical_shard_key_bytes(
+                        CanonicalShardKeyRef::Text(value),
+                    ))
+                })
+            }
+            (ShardKeyType::Binary, ValueRef::Blob(value)) => Some(self.storage.shard_for_key(
+                &canonical_shard_key_bytes(CanonicalShardKeyRef::Binary(value)),
+            )),
+            (ShardKeyType::Int64, _) | (ShardKeyType::Text, _) | (ShardKeyType::Binary, _) => {
+                return Ok(EqualityTargets::All);
+            }
+            // ShardKeyType is non-exhaustive. A future type is not safe to
+            // single-route until this feature learns its canonical encoding.
+            (_, _) => return Ok(EqualityTargets::All),
+        };
+        Ok(target.map_or(EqualityTargets::All, EqualityTargets::One))
+    }
+
     fn cancelled(&self, scan_epoch: u64) -> bool {
         self.cancellation_epoch.load(Ordering::Acquire) != scan_epoch
     }
@@ -326,6 +485,7 @@ impl Registry {
         self: &Arc<Self>,
         spec: &TableSpec,
         shard_id: u16,
+        equality: Option<&RawCell>,
         scan_epoch: u64,
         remaining_rows: usize,
         remaining_bytes: usize,
@@ -334,7 +494,7 @@ impl Registry {
             return Err(cancelled_error());
         }
 
-        let connection = self.storage.open_shard(shard_id)?;
+        let connection = self.storage.open_shard_read_only(shard_id)?;
         let connection =
             TrackedChildConnection::new(connection, Arc::clone(&self.active_child_scans))?;
         connection
@@ -364,15 +524,20 @@ impl Registry {
                 )
             })?
             .take();
+        #[cfg(test)]
+        let progress_interval = if child_scan_gate.is_some() { 1 } else { 128 };
+        #[cfg(not(test))]
+        let progress_interval = 128;
         connection
             .connection()
             .progress_handler(
-                if cfg!(test) { 1 } else { 128 },
+                progress_interval,
                 Some(move || {
                     #[cfg(test)]
                     if let Some(gate) = child_scan_gate.take() {
-                        gate.started.wait();
-                        gate.release.wait();
+                        if !gate.wait_for_release() {
+                            return true;
+                        }
                     }
                     cancellation_epoch.load(Ordering::Acquire) != scan_epoch
                 }),
@@ -380,11 +545,17 @@ impl Registry {
             .map_err(sqlite_error::storage)?;
 
         let result = (|| {
+            let select_sql = equality
+                .and(spec.point_select_sql.as_deref())
+                .unwrap_or(&spec.select_sql);
             let mut statement = connection
                 .connection()
-                .prepare(&spec.select_sql)
+                .prepare(select_sql)
                 .map_err(sqlite_error::statement)?;
-            let mut sqlite_rows = statement.query([]).map_err(sqlite_error::statement)?;
+            let mut sqlite_rows = match equality {
+                Some(value) => statement.query([value]).map_err(sqlite_error::statement)?,
+                None => statement.query([]).map_err(sqlite_error::statement)?,
+            };
             let mut rows = Vec::new();
             let mut used_bytes = 0_usize;
 
@@ -393,19 +564,19 @@ impl Registry {
                     return Err(cancelled_error());
                 }
                 if rows.len() == remaining_rows {
-                    return Err(limit_error("row", MAX_CURSOR_ROWS));
+                    return Err(limit_error("row", self.limits.rows));
                 }
 
                 let mut row_bytes = spec
                     .column_count
                     .checked_mul(VALUE_ACCOUNTING_BYTES)
                     .and_then(|bytes| bytes.checked_add(ROW_ACCOUNTING_BYTES))
-                    .ok_or_else(|| limit_error("byte", MAX_CURSOR_BYTES))?;
+                    .ok_or_else(|| limit_error("byte", self.limits.bytes))?;
                 if used_bytes
                     .checked_add(row_bytes)
                     .is_none_or(|bytes| bytes > remaining_bytes)
                 {
-                    return Err(limit_error("byte", MAX_CURSOR_BYTES));
+                    return Err(limit_error("byte", self.limits.bytes));
                 }
                 let mut cells = Vec::new();
                 cells
@@ -415,19 +586,19 @@ impl Registry {
                     let value = row.get_ref(column).map_err(sqlite_error::statement)?;
                     row_bytes = row_bytes
                         .checked_add(RawCell::accounted_payload_bytes(value))
-                        .ok_or_else(|| limit_error("byte", MAX_CURSOR_BYTES))?;
+                        .ok_or_else(|| limit_error("byte", self.limits.bytes))?;
                     let projected_bytes = used_bytes
                         .checked_add(row_bytes)
-                        .ok_or_else(|| limit_error("byte", MAX_CURSOR_BYTES))?;
+                        .ok_or_else(|| limit_error("byte", self.limits.bytes))?;
                     if projected_bytes > remaining_bytes {
-                        return Err(limit_error("byte", MAX_CURSOR_BYTES));
+                        return Err(limit_error("byte", self.limits.bytes));
                     }
                     cells.push(RawCell::try_copy_from(value)?);
                 }
                 used_bytes = used_bytes
                     .checked_add(row_bytes)
                     .filter(|bytes| *bytes <= remaining_bytes)
-                    .ok_or_else(|| limit_error("byte", MAX_CURSOR_BYTES))?;
+                    .ok_or_else(|| limit_error("byte", self.limits.bytes))?;
                 rows.try_reserve(1).map_err(allocation_error)?;
                 rows.push(cells);
             }
@@ -443,8 +614,12 @@ impl Registry {
                 })?
                 .take()
             {
-                gate.started.wait();
-                gate.release.wait();
+                if !gate.wait_for_release() {
+                    return Err(EngineError::new(
+                        EngineErrorKind::Internal,
+                        "child-scan completion test gate timed out or disconnected",
+                    ));
+                }
             }
             // The progress callback is deliberately coarse in production. A
             // short or empty query can complete without invoking it, so close
@@ -457,6 +632,12 @@ impl Registry {
 
         self.storage.fail_closed_on_corruption(result)
     }
+}
+
+enum EqualityTargets {
+    Empty,
+    One(u16),
+    All,
 }
 
 struct TrackedChildConnection {
@@ -512,17 +693,29 @@ struct TableSpec {
     name: String,
     declared_schema: String,
     select_sql: String,
+    point_select_sql: Option<String>,
     column_count: usize,
     targets: Box<[u16]>,
+    shard_key: Option<ShardKeySpec>,
+    generated_id_policy: GeneratedIdPolicy,
+    allocation_owners: Option<Arc<AllocationOwnerMap>>,
+}
+
+#[derive(Debug, Clone)]
+struct ShardKeySpec {
+    column_index: c_int,
+    key_type: ShardKeyType,
 }
 
 impl TableSpec {
     fn from_physical_table(
         connection: &Connection,
-        id: u64,
-        name: &str,
+        table: &TableMetadata,
+        allocation_owners: Option<Arc<AllocationOwnerMap>>,
         targets: Box<[u16]>,
     ) -> EngineResult<Self> {
+        let id = table.id().get();
+        let name = table.name();
         let strict = connection
             .query_row(
                 "SELECT strict
@@ -608,6 +801,51 @@ impl TableSpec {
             .collect::<Vec<_>>()
             .join(", ");
 
+        #[allow(unreachable_patterns)]
+        let shard_key = match table.placement() {
+            TablePlacement::Sharded(metadata) => {
+                let column_index = columns
+                    .iter()
+                    .position(|(column, _, _)| column == metadata.column())
+                    .ok_or_else(|| {
+                        EngineError::new(
+                            EngineErrorKind::DataCorruption,
+                            format!(
+                                "registered shard key {}.{} is absent from the physical schema",
+                                name,
+                                metadata.column()
+                            ),
+                        )
+                    })?;
+                let column_index = c_int::try_from(column_index).map_err(|error| {
+                    EngineError::from_source(
+                        EngineErrorKind::LimitExceeded,
+                        format!("registered table {name} has too many columns"),
+                        error,
+                    )
+                })?;
+                Some(ShardKeySpec {
+                    column_index,
+                    key_type: metadata.key_type(),
+                })
+            }
+            TablePlacement::Global | TablePlacement::Catalog => None,
+            _ => {
+                return Err(EngineError::new(
+                    EngineErrorKind::Unsupported,
+                    format!("registered table {name} has an unsupported placement"),
+                ));
+            }
+        };
+        let point_select_sql = match table.placement() {
+            TablePlacement::Sharded(metadata) => Some(format!(
+                "SELECT {projected_columns} FROM main.{} WHERE {} = ?1",
+                quote_identifier(name),
+                quote_identifier(metadata.column())
+            )),
+            _ => None,
+        };
+
         Ok(Self {
             id,
             name: name.to_owned(),
@@ -616,8 +854,12 @@ impl TableSpec {
                 "SELECT {projected_columns} FROM main.{}",
                 quote_identifier(name)
             ),
+            point_select_sql,
             column_count: columns.len(),
             targets,
+            shard_key,
+            generated_id_policy: table.generated_id_policy().clone(),
+            allocation_owners,
         })
     }
 
@@ -737,11 +979,36 @@ unsafe impl<'vtab> VTab<'vtab> for BriskShardTable {
     }
 
     fn best_index(&self, information: &mut IndexInfo) -> SqliteResult<()> {
-        // This boundary spike deliberately consumes no constraints. SQLite
-        // rechecks every predicate. Routing and pushdown belong to issue #126.
-        information.set_idx_num(0);
-        information.set_estimated_cost(1_000_000.0);
-        information.set_estimated_rows(1_000_000);
+        let mut shard_key_equality = None;
+        if let Some(shard_key) = &self.spec.shard_key {
+            for (index, constraint) in information.constraints().enumerate() {
+                if constraint.is_usable()
+                    && constraint.column() == shard_key.column_index
+                    && constraint.operator() == IndexConstraintOp::SQLITE_INDEX_CONSTRAINT_EQ
+                    && !information.is_in_constraint(index)?
+                    && (shard_key.key_type != ShardKeyType::Text
+                        || information.collation(index)?.eq_ignore_ascii_case("binary"))
+                {
+                    shard_key_equality = Some(index);
+                    break;
+                }
+            }
+        }
+
+        if let Some(index) = shard_key_equality {
+            let mut usage = information.constraint_usage(index);
+            usage.set_argv_index(1);
+            // The child receives the same equality, but the coordinator keeps
+            // SQLite's outer comparison as the final affinity/collation check.
+            usage.set_omit(false);
+            information.set_idx_num(SHARD_KEY_EQUALITY_PLAN);
+            information.set_estimated_cost(10.0);
+            information.set_estimated_rows(100);
+        } else {
+            information.set_idx_num(SCAN_PLAN);
+            information.set_estimated_cost(1_000_000.0);
+            information.set_estimated_rows(1_000_000);
+        }
         Ok(())
     }
 
@@ -798,6 +1065,8 @@ struct BriskShardCursor {
     spec: Arc<TableSpec>,
     operation: Option<SchemaOperationGuard>,
     rows: Vec<Vec<RawCell>>,
+    equality: Option<RawCell>,
+    targets: Box<[u16]>,
     row_index: usize,
     next_target: usize,
     row_id: i64,
@@ -815,6 +1084,8 @@ impl BriskShardCursor {
             spec,
             operation: None,
             rows: Vec::new(),
+            equality: None,
+            targets: Box::default(),
             row_index: 0,
             next_target: 0,
             row_id: 0,
@@ -848,15 +1119,16 @@ impl BriskShardCursor {
         // Drop the exhausted shard batch before allocating the next one.
         self.rows = Vec::new();
         self.row_index = 0;
-        while let Some(&shard_id) = self.spec.targets.get(self.next_target) {
+        while let Some(&shard_id) = self.targets.get(self.next_target) {
             self.next_target += 1;
-            let remaining_rows = MAX_CURSOR_ROWS.saturating_sub(self.total_rows);
-            let remaining_bytes = MAX_CURSOR_BYTES.saturating_sub(self.total_bytes);
+            let remaining_rows = self.registry.limits.rows.saturating_sub(self.total_rows);
+            let remaining_bytes = self.registry.limits.bytes.saturating_sub(self.total_bytes);
             let (rows, used_bytes) = self
                 .registry
                 .read_shard_rows(
                     &self.spec,
                     shard_id,
+                    self.equality.as_ref(),
                     self.scan_epoch,
                     remaining_rows,
                     remaining_bytes,
@@ -878,6 +1150,8 @@ impl BriskShardCursor {
 
     fn finish(&mut self) {
         self.rows = Vec::new();
+        self.equality = None;
+        self.targets = Box::default();
         self.row_index = 0;
         self.eof = true;
         self.operation = None;
@@ -892,9 +1166,9 @@ impl BriskShardCursor {
 unsafe impl VTabCursor for BriskShardCursor {
     fn filter(
         &mut self,
-        _index_number: c_int,
+        index_number: c_int,
         _index_string: Option<&str>,
-        _arguments: &Filters<'_>,
+        arguments: &Filters<'_>,
     ) -> SqliteResult<()> {
         self.registry
             .lifecycle
@@ -905,6 +1179,39 @@ unsafe impl VTabCursor for BriskShardCursor {
         self.row_id = 1;
         self.total_rows = 0;
         self.total_bytes = 0;
+        match index_number {
+            SCAN_PLAN => {
+                if !arguments.is_empty() {
+                    return Err(module_error(
+                        "brisk_shard scan plan received unexpected filter arguments",
+                    ));
+                }
+                self.targets = self.spec.targets.clone();
+            }
+            SHARD_KEY_EQUALITY_PLAN => {
+                let mut values = arguments.iter();
+                let value = values.next().ok_or_else(|| {
+                    module_error("brisk_shard equality plan is missing its filter argument")
+                })?;
+                if values.next().is_some() {
+                    return Err(module_error(
+                        "brisk_shard equality plan received too many filter arguments",
+                    ));
+                }
+                let (equality, targets, equality_bytes) = self
+                    .registry
+                    .equality_scan(&self.spec, value)
+                    .map_err(vtab_error)?;
+                self.equality = Some(equality);
+                self.targets = targets;
+                self.total_bytes = equality_bytes;
+            }
+            other => {
+                return Err(module_error(format!(
+                    "unknown brisk_shard filter plan {other}"
+                )));
+            }
+        }
         self.begin_scan().map_err(|error| self.fail(error))
     }
 
@@ -915,6 +1222,9 @@ unsafe impl VTabCursor for BriskShardCursor {
             .fetch_add(1, Ordering::Relaxed);
         if self.eof {
             return Ok(());
+        }
+        if self.registry.cancelled(self.scan_epoch) {
+            return Err(self.fail(vtab_error(cancelled_error())));
         }
         self.row_id = self
             .row_id
@@ -1078,23 +1388,139 @@ fn limit_error(resource: &str, limit: usize) -> EngineError {
 }
 
 #[cfg(test)]
+const TEST_SYNC_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[cfg(test)]
 struct TestChildScanGate {
-    started: Arc<std::sync::Barrier>,
-    release: Arc<std::sync::Barrier>,
+    started: mpsc::SyncSender<()>,
+    release: mpsc::Receiver<()>,
 }
+
+#[cfg(test)]
+impl TestChildScanGate {
+    fn channel() -> (Self, TestChildScanControl) {
+        let (started_sender, started) = mpsc::sync_channel(1);
+        let (release_sender, release) = mpsc::sync_channel(1);
+        (
+            Self {
+                started: started_sender,
+                release,
+            },
+            TestChildScanControl {
+                started,
+                release: TestRelease::new(release_sender),
+            },
+        )
+    }
+
+    fn wait_for_release(self) -> bool {
+        self.started.send(()).is_ok() && self.release.recv_timeout(TEST_SYNC_TIMEOUT).is_ok()
+    }
+}
+
+#[cfg(test)]
+struct TestChildScanControl {
+    started: mpsc::Receiver<()>,
+    release: TestRelease,
+}
+
+#[cfg(test)]
+impl TestChildScanControl {
+    fn wait_until_started(&self) {
+        self.started
+            .recv_timeout(TEST_SYNC_TIMEOUT)
+            .expect("child scan did not reach its test gate before the timeout");
+    }
+
+    fn release(&mut self) {
+        self.release.signal();
+    }
+}
+
+#[cfg(test)]
+struct TestRelease {
+    sender: Option<mpsc::SyncSender<()>>,
+}
+
+#[cfg(test)]
+impl TestRelease {
+    const fn new(sender: mpsc::SyncSender<()>) -> Self {
+        Self {
+            sender: Some(sender),
+        }
+    }
+
+    fn signal(&mut self) {
+        if let Some(sender) = self.sender.take() {
+            let _ = sender.send(());
+        }
+    }
+}
+
+#[cfg(test)]
+impl Drop for TestRelease {
+    fn drop(&mut self) {
+        self.signal();
+    }
+}
+
+#[cfg(test)]
+mod benchmarks;
 
 #[cfg(test)]
 mod tests {
     use std::{
         collections::BTreeSet,
-        sync::{Arc, Barrier},
+        sync::{Arc, mpsc},
         thread,
     };
 
-    use rusqlite::{ErrorCode, params, types::ValueRef};
+    use rusqlite::{ErrorCode, MAIN_DB, params, types::ValueRef};
 
     use super::*;
-    use crate::core::{ShardKeyMetadata, ShardKeyType, TableDeclaration};
+    use crate::core::{
+        Database, Engine, GeneratedIdPolicy, ShardKeyMetadata, ShardKeyType, Statement,
+        TableDeclaration, Value,
+        generated_id::{AllocationOwnerSlot, NativeRangeV1Id, native_range_v1_sequence_floor},
+    };
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    enum ParityCell {
+        Null,
+        Integer(i64),
+        Real(u64),
+        Text(Vec<u8>),
+        Blob(Vec<u8>),
+    }
+
+    fn sqlite_parity_cell(value: ValueRef<'_>) -> ParityCell {
+        match value {
+            ValueRef::Null => ParityCell::Null,
+            ValueRef::Integer(value) => ParityCell::Integer(value),
+            ValueRef::Real(value) => ParityCell::Real(value.to_bits()),
+            ValueRef::Text(value) => ParityCell::Text(value.to_vec()),
+            ValueRef::Blob(value) => ParityCell::Blob(value.to_vec()),
+        }
+    }
+
+    fn engine_parity_cell(value: &Value) -> ParityCell {
+        match value {
+            Value::Null => ParityCell::Null,
+            Value::Int64(value) => ParityCell::Integer(*value),
+            Value::Float64(value) => ParityCell::Real(value.to_bits()),
+            Value::Text(value) => ParityCell::Text(value.as_bytes().to_vec()),
+            Value::InvalidText(value) => ParityCell::Text(value.clone()),
+            Value::Binary(value) => ParityCell::Blob(value.clone()),
+            value => panic!("unexpected Engine value in SQLite parity fixture: {value:?}"),
+        }
+    }
+
+    fn sort_parity_rows(rows: &mut [Vec<ParityCell>]) {
+        rows.sort_unstable_by_key(|row| match row.first() {
+            Some(ParityCell::Integer(value)) => *value,
+            value => panic!("parity row has an invalid tenant key: {value:?}"),
+        });
+    }
 
     struct Fixture {
         temp: tempfile::TempDir,
@@ -1199,6 +1625,231 @@ mod tests {
         }
     }
 
+    struct TypedRoutingFixture {
+        _temp: tempfile::TempDir,
+        storage: Storage,
+        int_keys: Vec<i64>,
+        text_keys: Vec<String>,
+        blob_keys: Vec<Vec<u8>>,
+        native_ids: Vec<i64>,
+    }
+
+    struct ScaleFixture {
+        temp: tempfile::TempDir,
+        storage: Storage,
+        keys: Vec<i64>,
+    }
+
+    impl ScaleFixture {
+        fn new(shard_count: u16) -> Self {
+            let temp = tempfile::tempdir().unwrap();
+            let mut storage = Storage::open(temp.path(), shard_count).unwrap();
+            let mut migration = storage.begin_schema_migration().unwrap();
+            migration.wait_for_quiescence_blocking();
+            storage
+                .apply_schema_migration(
+                    "CREATE TABLE scale_events (
+                         id INTEGER PRIMARY KEY,
+                         payload TEXT NOT NULL
+                     ) STRICT;",
+                    &mut migration,
+                    None,
+                )
+                .unwrap();
+            migration.publish_ready().unwrap();
+            let database_id = storage.logical_catalog().default_database().id();
+            storage
+                .register_tables(vec![
+                    TableDeclaration::sharded(
+                        database_id,
+                        "scale_events",
+                        ShardKeyMetadata::new("id", ShardKeyType::Int64).unwrap(),
+                    )
+                    .unwrap(),
+                ])
+                .unwrap();
+            let keys = keys_for_shards(&storage, shard_count, |candidate| {
+                candidate.to_string().into_bytes()
+            });
+            for shard in 0..shard_count {
+                storage
+                    .open_shard(shard)
+                    .unwrap()
+                    .execute(
+                        "INSERT INTO scale_events VALUES (?1, ?2)",
+                        params![keys[usize::from(shard)], format!("shard-{shard}")],
+                    )
+                    .unwrap();
+            }
+            Self {
+                temp,
+                storage,
+                keys,
+            }
+        }
+
+        fn physical_rows(&self) -> Vec<(i64, String)> {
+            let mut rows = Vec::new();
+            for shard in 0..self.storage.shard_count() {
+                let connection = self.storage.open_shard(shard).unwrap();
+                let mut statement = connection
+                    .prepare("SELECT id, payload FROM scale_events")
+                    .unwrap();
+                rows.extend(
+                    statement
+                        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+                        .unwrap()
+                        .collect::<Result<Vec<_>, _>>()
+                        .unwrap(),
+                );
+            }
+            rows.sort_unstable();
+            rows
+        }
+    }
+
+    impl TypedRoutingFixture {
+        fn new(shard_count: u16) -> Self {
+            let temp = tempfile::tempdir().unwrap();
+            let mut storage = Storage::open(temp.path(), shard_count).unwrap();
+            let mut migration = storage.begin_schema_migration().unwrap();
+            migration.wait_for_quiescence_blocking();
+            storage
+                .apply_schema_migration(
+                    "CREATE TABLE int_events (id INTEGER PRIMARY KEY, payload TEXT NOT NULL);
+                     CREATE TABLE text_events (
+                         id TEXT PRIMARY KEY COLLATE BINARY,
+                         payload TEXT NOT NULL
+                     ) WITHOUT ROWID;
+                     CREATE TABLE blob_events (
+                         id BLOB PRIMARY KEY,
+                         payload TEXT NOT NULL
+                     ) WITHOUT ROWID;
+                     CREATE TABLE native_events (
+                         id INTEGER PRIMARY KEY NOT NULL,
+                         payload TEXT NOT NULL
+                     ) STRICT;",
+                    &mut migration,
+                    None,
+                )
+                .unwrap();
+            migration.publish_ready().unwrap();
+
+            let database_id = storage.logical_catalog().default_database().id();
+            storage
+                .register_tables(vec![
+                    TableDeclaration::sharded(
+                        database_id,
+                        "int_events",
+                        ShardKeyMetadata::new("id", ShardKeyType::Int64).unwrap(),
+                    )
+                    .unwrap(),
+                    TableDeclaration::sharded(
+                        database_id,
+                        "text_events",
+                        ShardKeyMetadata::new("id", ShardKeyType::Text).unwrap(),
+                    )
+                    .unwrap(),
+                    TableDeclaration::sharded(
+                        database_id,
+                        "blob_events",
+                        ShardKeyMetadata::new("id", ShardKeyType::Binary).unwrap(),
+                    )
+                    .unwrap(),
+                    TableDeclaration::sharded(
+                        database_id,
+                        "native_events",
+                        ShardKeyMetadata::new("id", ShardKeyType::Int64).unwrap(),
+                    )
+                    .unwrap()
+                    .with_generated_id_policy(GeneratedIdPolicy::native_range_v1("id").unwrap())
+                    .unwrap(),
+                ])
+                .unwrap();
+
+            let int_keys = keys_for_shards(&storage, shard_count, |candidate| {
+                candidate.to_string().into_bytes()
+            });
+            let text_keys = keys_for_shards(&storage, shard_count, |candidate| {
+                format!("tenant-{candidate}").into_bytes()
+            })
+            .into_iter()
+            .map(|candidate| format!("tenant-{candidate}"))
+            .collect::<Vec<_>>();
+            let blob_candidates = keys_for_shards(&storage, shard_count, |candidate| {
+                candidate.to_be_bytes().to_vec()
+            });
+            let blob_keys = blob_candidates
+                .iter()
+                .map(|candidate| candidate.to_be_bytes().to_vec())
+                .collect::<Vec<_>>();
+            let owners = storage.allocation_owner_map().unwrap();
+            let native_ids = (0..shard_count)
+                .map(|shard| {
+                    NativeRangeV1Id::new(owners.owner_for_physical_shard(shard).unwrap(), 1)
+                        .unwrap()
+                        .encode()
+                })
+                .collect::<Vec<_>>();
+
+            for shard in 0..shard_count {
+                let connection = storage.open_shard(shard).unwrap();
+                let index = usize::from(shard);
+                connection
+                    .execute(
+                        "INSERT INTO int_events VALUES (?1, ?2)",
+                        params![int_keys[index], format!("int-{shard}")],
+                    )
+                    .unwrap();
+                connection
+                    .execute(
+                        "INSERT INTO text_events VALUES (?1, ?2)",
+                        params![text_keys[index], format!("text-{shard}")],
+                    )
+                    .unwrap();
+                connection
+                    .execute(
+                        "INSERT INTO blob_events VALUES (?1, ?2)",
+                        params![blob_keys[index], format!("blob-{shard}")],
+                    )
+                    .unwrap();
+                connection
+                    .execute(
+                        "INSERT INTO native_events VALUES (?1, ?2)",
+                        params![native_ids[index], format!("native-{shard}")],
+                    )
+                    .unwrap();
+            }
+
+            Self {
+                _temp: temp,
+                storage,
+                int_keys,
+                text_keys,
+                blob_keys,
+                native_ids,
+            }
+        }
+    }
+
+    fn keys_for_shards(
+        storage: &Storage,
+        shard_count: u16,
+        encoded: impl Fn(i64) -> Vec<u8>,
+    ) -> Vec<i64> {
+        let mut keys = vec![None; usize::from(shard_count)];
+        for candidate in 1_i64.. {
+            let shard = usize::from(storage.shard_for_key(&encoded(candidate)));
+            if keys[shard].is_none() {
+                keys[shard] = Some(candidate);
+                if keys.iter().all(Option::is_some) {
+                    break;
+                }
+            }
+        }
+        keys.into_iter().map(Option::unwrap).collect()
+    }
+
     #[test]
     fn normal_select_unions_typed_rows_from_two_stock_sqlite_files() {
         let fixture = Fixture::new();
@@ -1274,6 +1925,758 @@ mod tests {
                     .unwrap(),
                 1
             );
+        }
+    }
+
+    #[test]
+    fn coordinator_children_are_validated_os_level_read_only_handles() {
+        let fixture = Fixture::new();
+        for shard in 0..2 {
+            let child = fixture.storage.open_shard_read_only(shard).unwrap();
+            assert!(child.is_readonly(MAIN_DB).unwrap());
+            assert!(
+                child
+                    .execute_batch("CREATE TABLE forbidden_on_read_only_child(id INTEGER)")
+                    .is_err()
+            );
+        }
+
+        let coordinator = ReadCoordinator::open(fixture.storage.clone()).unwrap();
+        assert_eq!(
+            coordinator
+                .connection()
+                .query_row("SELECT COUNT(*) FROM events", [], |row| row
+                    .get::<_, i64>(0))
+                .unwrap(),
+            2
+        );
+        assert_eq!(coordinator.take_opened_shards(), [0, 1]);
+    }
+
+    #[tokio::test]
+    async fn normal_select_rows_and_storage_types_match_the_engine_scatter_path() {
+        let fixture = Fixture::new();
+        let coordinator = ReadCoordinator::open(fixture.storage.clone()).unwrap();
+        let mut coordinator_rows = coordinator
+            .connection()
+            .prepare(
+                "SELECT tenant_id, event_id, payload, amount, raw, optional
+                 FROM events",
+            )
+            .unwrap()
+            .query_map([], |row| {
+                (0..6)
+                    .map(|column| row.get_ref(column).map(sqlite_parity_cell))
+                    .collect::<SqliteResult<Vec<_>>>()
+            })
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(coordinator.take_opened_shards(), [0, 1]);
+
+        let database = Arc::new(Database::open(fixture.temp.path(), 2).unwrap());
+        let engine = Engine::from_database(database);
+        let executed = engine
+            .query_logical(
+                &engine.session(),
+                Statement::new(
+                    "SELECT tenant_id, event_id, payload, amount, raw, optional FROM events",
+                    vec![],
+                ),
+            )
+            .await
+            .unwrap();
+        assert_eq!(executed.shards(), [0, 1]);
+        let mut engine_rows = executed
+            .value
+            .rows()
+            .iter()
+            .map(|row| row.values().iter().map(engine_parity_cell).collect())
+            .collect::<Vec<Vec<_>>>();
+
+        sort_parity_rows(&mut coordinator_rows);
+        sort_parity_rows(&mut engine_rows);
+        assert_eq!(coordinator_rows, engine_rows);
+        assert!(
+            coordinator_rows
+                .iter()
+                .flatten()
+                .any(|cell| { matches!(cell, ParityCell::Text(bytes) if bytes == &[0x80, 0xff]) })
+        );
+        assert!(
+            coordinator_rows
+                .iter()
+                .flatten()
+                .any(|cell| matches!(cell, ParityCell::Null))
+        );
+        assert!(
+            coordinator_rows.iter().flatten().any(|cell| {
+                matches!(cell, ParityCell::Real(bits) if *bits == 1.5_f64.to_bits())
+            })
+        );
+        assert!(
+            coordinator_rows
+                .iter()
+                .flatten()
+                .any(|cell| { matches!(cell, ParityCell::Blob(bytes) if bytes == &[0x00, 0x01]) })
+        );
+    }
+
+    #[test]
+    fn exact_typed_equalities_prune_to_one_shard_and_bind_the_child_predicate() {
+        let fixture = TypedRoutingFixture::new(10);
+        let coordinator = ReadCoordinator::open(fixture.storage.clone()).unwrap();
+        for shard in [0_u16, 4, 9] {
+            let index = usize::from(shard);
+            let cases: [(&str, &dyn ToSql, String); 3] = [
+                (
+                    "int_events",
+                    &fixture.int_keys[index],
+                    format!("int-{shard}"),
+                ),
+                (
+                    "text_events",
+                    &fixture.text_keys[index],
+                    format!("text-{shard}"),
+                ),
+                (
+                    "blob_events",
+                    &fixture.blob_keys[index],
+                    format!("blob-{shard}"),
+                ),
+            ];
+            for (table, key, expected) in cases {
+                let _ = coordinator.take_opened_shards();
+                let payload = coordinator
+                    .connection()
+                    .query_row(
+                        &format!("SELECT payload FROM {table} WHERE id = ?1"),
+                        [key],
+                        |row| row.get::<_, String>(0),
+                    )
+                    .unwrap();
+                assert_eq!(payload, expected);
+                assert_eq!(coordinator.take_opened_shards(), [shard]);
+            }
+        }
+
+        // A second predicate must be evaluated by the indexed child query and
+        // then rechecked by the coordinator, yielding no false-positive row.
+        let _ = coordinator.take_opened_shards();
+        assert_eq!(
+            coordinator
+                .connection()
+                .query_row(
+                    "SELECT COUNT(*) FROM int_events WHERE id = ?1 AND payload = 'absent'",
+                    [fixture.int_keys[4]],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            0
+        );
+        assert_eq!(coordinator.take_opened_shards(), [4]);
+
+        let decoys = (1_000_i64..)
+            .filter(|candidate| {
+                fixture
+                    .storage
+                    .shard_for_key(candidate.to_string().as_bytes())
+                    == 4
+                    && *candidate != fixture.int_keys[4]
+            })
+            .take(2)
+            .collect::<Vec<_>>();
+        for decoy in decoys {
+            fixture
+                .storage
+                .open_shard(4)
+                .unwrap()
+                .execute(
+                    "INSERT INTO int_events VALUES (?1, 'same-shard-decoy')",
+                    [decoy],
+                )
+                .unwrap();
+        }
+        let tight = ReadCoordinator::open_with_limits(
+            fixture.storage.clone(),
+            CursorLimits {
+                rows: 1,
+                bytes: MAX_CURSOR_BYTES,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            tight
+                .connection()
+                .query_row(
+                    "SELECT payload FROM int_events WHERE id = ?1",
+                    [fixture.int_keys[4]],
+                    |row| row.get::<_, String>(0),
+                )
+                .unwrap(),
+            "int-4"
+        );
+        assert_eq!(tight.take_opened_shards(), [4]);
+    }
+
+    #[test]
+    fn null_and_mismatched_equalities_preserve_sqlite_semantics() {
+        let fixture = TypedRoutingFixture::new(10);
+        let coordinator = ReadCoordinator::open(fixture.storage.clone()).unwrap();
+
+        assert_eq!(
+            coordinator
+                .connection()
+                .query_row(
+                    "SELECT COUNT(*) FROM int_events WHERE id = NULL",
+                    [],
+                    |row| { row.get::<_, i64>(0) }
+                )
+                .unwrap(),
+            0
+        );
+        assert!(coordinator.take_opened_shards().is_empty());
+
+        // SQLite may coerce a TEXT RHS using INTEGER affinity. The router must
+        // conservatively visit every shard when the incoming storage class is
+        // not the catalog's exact shard-key type.
+        let key = fixture.int_keys[4].to_string();
+        assert_eq!(
+            coordinator
+                .connection()
+                .query_row(
+                    "SELECT COUNT(*) FROM int_events WHERE id = ?1",
+                    [&key],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            coordinator.take_opened_shards(),
+            (0..10).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn nonbinary_text_collations_scan_all_shards_before_sqlite_rechecks() {
+        let fixture = TypedRoutingFixture::new(10);
+        let (stored_case, query_case, case_shard) = (1_i64..)
+            .find_map(|candidate| {
+                let stored = format!("Case-{candidate}");
+                let query = stored.to_ascii_lowercase();
+                let stored_shard = fixture.storage.shard_for_key(stored.as_bytes());
+                (stored_shard != fixture.storage.shard_for_key(query.as_bytes())).then_some((
+                    stored,
+                    query,
+                    stored_shard,
+                ))
+            })
+            .unwrap();
+        fixture
+            .storage
+            .open_shard(case_shard)
+            .unwrap()
+            .execute(
+                "INSERT INTO text_events VALUES (?1, 'nocase')",
+                [&stored_case],
+            )
+            .unwrap();
+
+        let (stored_trim, query_trim, trim_shard) = (1_i64..)
+            .find_map(|candidate| {
+                let query = format!("trim-{candidate}");
+                let stored = format!("{query}   ");
+                let stored_shard = fixture.storage.shard_for_key(stored.as_bytes());
+                (stored_shard != fixture.storage.shard_for_key(query.as_bytes())).then_some((
+                    stored,
+                    query,
+                    stored_shard,
+                ))
+            })
+            .unwrap();
+        fixture
+            .storage
+            .open_shard(trim_shard)
+            .unwrap()
+            .execute(
+                "INSERT INTO text_events VALUES (?1, 'rtrim')",
+                [&stored_trim],
+            )
+            .unwrap();
+
+        let coordinator = ReadCoordinator::open(fixture.storage.clone()).unwrap();
+        for (collation, query, expected) in [
+            ("NOCASE", query_case, "nocase"),
+            ("RTRIM", query_trim, "rtrim"),
+        ] {
+            let payloads = coordinator
+                .connection()
+                .prepare(&format!(
+                    "SELECT payload FROM text_events WHERE id COLLATE {collation} = ?1"
+                ))
+                .unwrap()
+                .query_map([&query], |row| row.get::<_, String>(0))
+                .unwrap()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap();
+            assert_eq!(payloads, [expected]);
+            assert_eq!(
+                coordinator.take_opened_shards(),
+                (0..10).collect::<Vec<_>>()
+            );
+        }
+    }
+
+    #[test]
+    fn native_ids_route_by_owner_while_legacy_ids_use_the_hash_map() {
+        let fixture = TypedRoutingFixture::new(10);
+        let coordinator = ReadCoordinator::open(fixture.storage.clone()).unwrap();
+        for shard in [0_u16, 4, 9] {
+            let id = fixture.native_ids[usize::from(shard)];
+            let _ = coordinator.take_opened_shards();
+            assert_eq!(
+                coordinator
+                    .connection()
+                    .query_row(
+                        "SELECT payload FROM native_events WHERE id = ?1",
+                        [id],
+                        |row| row.get::<_, String>(0),
+                    )
+                    .unwrap(),
+                format!("native-{shard}")
+            );
+            assert_eq!(coordinator.take_opened_shards(), [shard]);
+        }
+
+        let legacy = fixture.int_keys[4];
+        fixture
+            .storage
+            .open_shard(4)
+            .unwrap()
+            .execute("INSERT INTO native_events VALUES (?1, 'legacy')", [legacy])
+            .unwrap();
+        assert_eq!(
+            coordinator
+                .connection()
+                .query_row(
+                    "SELECT payload FROM native_events WHERE id = ?1",
+                    [legacy],
+                    |row| row.get::<_, String>(0),
+                )
+                .unwrap(),
+            "legacy"
+        );
+        assert_eq!(coordinator.take_opened_shards(), [4]);
+
+        let reserved = native_range_v1_sequence_floor(AllocationOwnerSlot::new(0).unwrap());
+        let error = coordinator
+            .connection()
+            .query_row(
+                "SELECT payload FROM native_events WHERE id = ?1",
+                [reserved],
+                |row| row.get::<_, String>(0),
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            SqliteError::SqliteFailure(detail, _) if detail.code == ErrorCode::DatabaseCorrupt
+        ));
+        assert!(coordinator.take_opened_shards().is_empty());
+
+        let unknown_owner = NativeRangeV1Id::new(AllocationOwnerSlot::new(1000).unwrap(), 1)
+            .unwrap()
+            .encode();
+        assert_eq!(
+            coordinator
+                .connection()
+                .query_row(
+                    "SELECT COUNT(*) FROM native_events WHERE id = ?1",
+                    [unknown_owner],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            0
+        );
+        assert!(coordinator.take_opened_shards().is_empty());
+    }
+
+    #[test]
+    fn scans_match_physical_union_all_at_two_ten_and_sixty_four_shards() {
+        for shard_count in [2_u16, 10, 64] {
+            let fixture = ScaleFixture::new(shard_count);
+            let duplicate_id = -9_000_000_000_i64 - i64::from(shard_count);
+            for shard in 0..shard_count {
+                fixture
+                    .storage
+                    .open_shard(shard)
+                    .unwrap()
+                    .execute(
+                        "INSERT INTO scale_events VALUES (?1, 'duplicate')",
+                        [duplicate_id],
+                    )
+                    .unwrap();
+            }
+
+            let coordinator = ReadCoordinator::open(fixture.storage.clone()).unwrap();
+            let mut rows = coordinator
+                .connection()
+                .prepare("SELECT id, payload FROM scale_events")
+                .unwrap()
+                .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+                .unwrap()
+                .collect::<Result<Vec<(i64, String)>, _>>()
+                .unwrap();
+            rows.sort_unstable();
+            assert_eq!(rows, fixture.physical_rows());
+            assert_eq!(
+                rows.iter()
+                    .filter(|row| row == &&(duplicate_id, "duplicate".to_owned()))
+                    .count(),
+                usize::from(shard_count)
+            );
+            assert_eq!(
+                coordinator.take_opened_shards(),
+                (0..shard_count).collect::<Vec<_>>()
+            );
+
+            let point_shard = shard_count - 1;
+            assert_eq!(
+                coordinator
+                    .connection()
+                    .query_row(
+                        "SELECT payload FROM scale_events WHERE id = ?1",
+                        [fixture.keys[usize::from(point_shard)]],
+                        |row| row.get::<_, String>(0),
+                    )
+                    .unwrap(),
+                format!("shard-{point_shard}")
+            );
+            assert_eq!(coordinator.take_opened_shards(), [point_shard]);
+
+            let empty_shard = if shard_count == 2 { 0 } else { shard_count / 2 };
+            fixture
+                .storage
+                .open_shard(empty_shard)
+                .unwrap()
+                .execute("DELETE FROM scale_events", [])
+                .unwrap();
+            let scan_after_empty = coordinator
+                .connection()
+                .prepare("SELECT payload FROM scale_events")
+                .unwrap()
+                .query_map([], |row| row.get::<_, String>(0))
+                .unwrap()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap();
+            assert_eq!(
+                scan_after_empty.len(),
+                fixture.physical_rows().len(),
+                "scan must skip an empty middle child and continue to later shards"
+            );
+            assert!(
+                scan_after_empty
+                    .iter()
+                    .any(|payload| payload == &format!("shard-{}", shard_count - 1)),
+                "scan stopped before the last non-empty shard"
+            );
+            assert_eq!(
+                coordinator.take_opened_shards(),
+                (0..shard_count).collect::<Vec<_>>()
+            );
+
+            for shard in 0..shard_count {
+                fixture
+                    .storage
+                    .open_shard(shard)
+                    .unwrap()
+                    .execute("DELETE FROM scale_events", [])
+                    .unwrap();
+            }
+            assert_eq!(
+                coordinator
+                    .connection()
+                    .query_row("SELECT COUNT(*) FROM scale_events", [], |row| {
+                        row.get::<_, i64>(0)
+                    })
+                    .unwrap(),
+                0
+            );
+            assert_eq!(
+                coordinator.take_opened_shards(),
+                (0..shard_count).collect::<Vec<_>>()
+            );
+            assert_eq!(fixture.storage.schema_gate_snapshot().active_operations, 0);
+        }
+    }
+
+    #[test]
+    fn stale_coordinators_fail_closed_and_fresh_reopens_work_at_scale() {
+        for shard_count in [2_u16, 10, 64] {
+            let fixture = ScaleFixture::new(shard_count);
+            let stale = ReadCoordinator::open(fixture.storage.clone()).unwrap();
+            let _ = stale.take_opened_shards();
+
+            let mut migration = fixture.storage.begin_schema_migration().unwrap();
+            migration.wait_for_quiescence_blocking();
+            fixture
+                .storage
+                .apply_schema_migration(
+                    "CREATE INDEX scale_events_payload_idx ON scale_events(payload)",
+                    &mut migration,
+                    None,
+                )
+                .unwrap();
+            migration.publish_ready().unwrap();
+
+            let error = stale
+                .connection()
+                .query_row("SELECT COUNT(*) FROM scale_events", [], |row| {
+                    row.get::<_, i64>(0)
+                })
+                .unwrap_err();
+            assert!(error.to_string().contains("coordinator schema is stale"));
+            assert!(stale.take_opened_shards().is_empty());
+
+            let fresh = ReadCoordinator::open(fixture.storage.clone()).unwrap();
+            assert_eq!(
+                fresh
+                    .connection()
+                    .query_row("SELECT COUNT(*) FROM scale_events", [], |row| {
+                        row.get::<_, i64>(0)
+                    })
+                    .unwrap(),
+                i64::from(shard_count)
+            );
+            assert_eq!(
+                fresh.take_opened_shards(),
+                (0..shard_count).collect::<Vec<_>>()
+            );
+            assert_eq!(fixture.storage.schema_gate_snapshot().active_operations, 0);
+        }
+    }
+
+    #[test]
+    fn cancellation_releases_scaled_scans_and_allows_reuse() {
+        for shard_count in [2_u16, 10, 64] {
+            let fixture = ScaleFixture::new(shard_count);
+            let coordinator = ReadCoordinator::open(fixture.storage.clone()).unwrap();
+            let mut gate = coordinator.install_child_scan_gate();
+            let cancellation = coordinator.cancellation_handle();
+            let worker = thread::spawn(move || {
+                let error = coordinator
+                    .connection()
+                    .query_row("SELECT COUNT(*) FROM scale_events", [], |row| {
+                        row.get::<_, i64>(0)
+                    })
+                    .unwrap_err();
+                (coordinator, error)
+            });
+
+            gate.wait_until_started();
+            cancellation.cancel();
+            gate.release();
+            let (coordinator, error) = worker.join().unwrap();
+            assert!(matches!(
+                error,
+                SqliteError::SqliteFailure(detail, _)
+                    if detail.code == ErrorCode::OperationInterrupted
+            ));
+            assert_eq!(
+                *cancellation
+                    .active_child_scans
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner),
+                0
+            );
+            assert_eq!(fixture.storage.schema_gate_snapshot().active_operations, 0);
+
+            assert_eq!(coordinator.take_opened_shards(), [0]);
+
+            let point_shard = shard_count - 1;
+            assert_eq!(
+                coordinator
+                    .connection()
+                    .query_row(
+                        "SELECT payload FROM scale_events WHERE id = ?1",
+                        [fixture.keys[usize::from(point_shard)]],
+                        |row| row.get::<_, String>(0),
+                    )
+                    .unwrap(),
+                format!("shard-{point_shard}")
+            );
+            assert_eq!(coordinator.take_opened_shards(), [point_shard]);
+        }
+    }
+
+    #[test]
+    fn a_slow_scan_does_not_block_an_independent_point_reader_at_scale() {
+        for shard_count in [2_u16, 10, 64] {
+            let fixture = ScaleFixture::new(shard_count);
+            let slow = ReadCoordinator::open(fixture.storage.clone()).unwrap();
+            let mut gate = slow.install_child_scan_gate();
+            let worker = thread::spawn(move || {
+                let count = slow
+                    .connection()
+                    .query_row("SELECT COUNT(*) FROM scale_events", [], |row| {
+                        row.get::<_, i64>(0)
+                    })
+                    .unwrap();
+                (slow, count)
+            });
+
+            gate.wait_until_started();
+            let point_shard = shard_count - 1;
+            let fast = ReadCoordinator::open(fixture.storage.clone()).unwrap();
+            assert_eq!(
+                fast.connection()
+                    .query_row(
+                        "SELECT payload FROM scale_events WHERE id = ?1",
+                        [fixture.keys[usize::from(point_shard)]],
+                        |row| row.get::<_, String>(0),
+                    )
+                    .unwrap(),
+                format!("shard-{point_shard}")
+            );
+            assert_eq!(fast.take_opened_shards(), [point_shard]);
+            gate.release();
+            let (_slow, count) = worker.join().unwrap();
+            assert_eq!(count, i64::from(shard_count));
+            assert_eq!(fixture.storage.schema_gate_snapshot().active_operations, 0);
+        }
+    }
+
+    #[test]
+    fn separate_concurrent_readers_are_consistent_at_scale() {
+        for shard_count in [2_u16, 10, 64] {
+            let fixture = ScaleFixture::new(shard_count);
+            let reader_count = if shard_count == 64 { 4 } else { 8 };
+            let (ready_sender, ready) = mpsc::sync_channel(reader_count);
+            let mut start_releases = Vec::with_capacity(reader_count);
+            let mut readers = Vec::new();
+            for reader in 0..reader_count {
+                let storage = fixture.storage.clone();
+                let ready_sender = ready_sender.clone();
+                let (start_sender, start) = mpsc::sync_channel(1);
+                start_releases.push(TestRelease::new(start_sender));
+                let point_key = fixture.keys[usize::from(shard_count - 1)];
+                readers.push(thread::spawn(move || {
+                    let coordinator = ReadCoordinator::open(storage).unwrap();
+                    ready_sender
+                        .send(())
+                        .expect("concurrent-reader test coordinator dropped its ready receiver");
+                    start
+                        .recv_timeout(TEST_SYNC_TIMEOUT)
+                        .expect("concurrent reader was not released before the timeout");
+                    if reader % 2 == 0 {
+                        coordinator
+                            .connection()
+                            .query_row("SELECT COUNT(*) FROM scale_events", [], |row| {
+                                row.get::<_, i64>(0)
+                            })
+                            .unwrap()
+                    } else {
+                        coordinator
+                            .connection()
+                            .query_row(
+                                "SELECT COUNT(*) FROM scale_events WHERE id = ?1",
+                                [point_key],
+                                |row| row.get::<_, i64>(0),
+                            )
+                            .unwrap()
+                    }
+                }));
+            }
+            drop(ready_sender);
+
+            let mut ready_error = None;
+            for _ in 0..reader_count {
+                if let Err(error) = ready.recv_timeout(TEST_SYNC_TIMEOUT) {
+                    ready_error = Some(error);
+                    break;
+                }
+            }
+            for release in &mut start_releases {
+                release.signal();
+            }
+            let outcomes = readers
+                .into_iter()
+                .enumerate()
+                .map(|(reader, handle)| (reader, handle.join()))
+                .collect::<Vec<_>>();
+
+            assert!(
+                ready_error.is_none(),
+                "concurrent readers did not all become ready before the timeout: {ready_error:?}"
+            );
+            for (reader, outcome) in outcomes {
+                assert_eq!(
+                    outcome.unwrap(),
+                    if reader % 2 == 0 {
+                        i64::from(shard_count)
+                    } else {
+                        1
+                    }
+                );
+            }
+            assert_eq!(fixture.storage.schema_gate_snapshot().active_operations, 0);
+        }
+    }
+
+    #[test]
+    fn a_middle_shard_error_stops_later_scans_and_marks_persistent_degradation() {
+        for shard_count in [2_u16, 10, 64] {
+            let fixture = ScaleFixture::new(shard_count);
+            let coordinator = ReadCoordinator::open(fixture.storage.clone()).unwrap();
+            let failed_shard = shard_count / 2;
+            let shard_path = fixture
+                .temp
+                .path()
+                .join(format!("shards/{failed_shard:04}.sqlite"));
+            let held_path = fixture
+                .temp
+                .path()
+                .join(format!("shards/{failed_shard:04}.sqlite.held"));
+            std::fs::rename(&shard_path, &held_path).unwrap();
+            let error = coordinator
+                .connection()
+                .query_row("SELECT COUNT(*) FROM scale_events", [], |row| {
+                    row.get::<_, i64>(0)
+                })
+                .unwrap_err();
+            std::fs::rename(&held_path, &shard_path).unwrap();
+            assert!(matches!(
+                error,
+                SqliteError::SqliteFailure(detail, _)
+                    if detail.code == ErrorCode::DatabaseCorrupt
+            ));
+            assert_eq!(
+                coordinator.take_opened_shards(),
+                (0..failed_shard).collect::<Vec<_>>()
+            );
+            assert_eq!(fixture.storage.schema_gate_snapshot().active_operations, 0);
+            let sticky_error = coordinator
+                .connection()
+                .query_row("SELECT COUNT(*) FROM scale_events", [], |row| {
+                    row.get::<_, i64>(0)
+                })
+                .unwrap_err();
+            assert!(matches!(
+                sticky_error,
+                SqliteError::SqliteFailure(detail, _)
+                    if detail.code == ErrorCode::DatabaseCorrupt
+            ));
+
+            let ScaleFixture {
+                temp,
+                storage,
+                keys: _,
+            } = fixture;
+            drop(coordinator);
+            drop(storage);
+            let reopen_error = Storage::open(temp.path(), shard_count).unwrap_err();
+            assert_eq!(reopen_error.kind(), EngineErrorKind::DataCorruption);
+            assert!(reopen_error.to_string().contains("persistently degraded"));
         }
     }
 
@@ -1369,10 +2772,36 @@ mod tests {
         let fixture = Fixture::new();
         let coordinator = ReadCoordinator::open(fixture.storage.clone()).unwrap();
         let before = fixture.physical_row_count();
+        let physical_schema_before = (0..fixture.storage.shard_count())
+            .map(|shard| {
+                let connection = fixture.storage.open_shard(shard).unwrap();
+                (
+                    connection
+                        .pragma_query_value(None, "schema_version", |row| row.get::<_, i64>(0))
+                        .unwrap(),
+                    connection
+                        .query_row(
+                            "SELECT group_concat(sql, char(10))
+                             FROM (
+                                 SELECT sql FROM sqlite_schema
+                                 WHERE sql IS NOT NULL ORDER BY name COLLATE BINARY
+                             )",
+                            [],
+                            |row| row.get::<_, String>(0),
+                        )
+                        .unwrap(),
+                )
+            })
+            .collect::<Vec<_>>();
         for sql in [
             "INSERT INTO events VALUES (99, 99, 'bad', 0, NULL, NULL, 'bad')",
             "UPDATE events SET payload = 'bad'",
             "DELETE FROM events",
+            "CREATE TABLE denied_table(id INTEGER)",
+            "ALTER TABLE events ADD COLUMN denied_column TEXT",
+            "DROP TABLE events",
+            "DETACH DATABASE main",
+            "PRAGMA writable_schema = ON",
         ] {
             assert!(coordinator.connection().execute(sql, []).is_err(), "{sql}");
         }
@@ -1400,6 +2829,15 @@ mod tests {
                 .is_err()
         );
         assert!(!attached_path.exists());
+        let databases = coordinator
+            .connection()
+            .prepare("PRAGMA database_list")
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(databases, ["main"]);
 
         let extension_error = coordinator
             .connection()
@@ -1413,6 +2851,28 @@ mod tests {
             ),
             "{extension_error:?}"
         );
+        let physical_schema_after = (0..fixture.storage.shard_count())
+            .map(|shard| {
+                let connection = fixture.storage.open_shard(shard).unwrap();
+                (
+                    connection
+                        .pragma_query_value(None, "schema_version", |row| row.get::<_, i64>(0))
+                        .unwrap(),
+                    connection
+                        .query_row(
+                            "SELECT group_concat(sql, char(10))
+                             FROM (
+                                 SELECT sql FROM sqlite_schema
+                                 WHERE sql IS NOT NULL ORDER BY name COLLATE BINARY
+                             )",
+                            [],
+                            |row| row.get::<_, String>(0),
+                        )
+                        .unwrap(),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(physical_schema_after, physical_schema_before);
     }
 
     #[test]
@@ -1436,9 +2896,7 @@ mod tests {
     fn cancellation_interrupts_child_scan_releases_guard_and_allows_reuse() {
         let fixture = Fixture::new();
         let coordinator = ReadCoordinator::open(fixture.storage.clone()).unwrap();
-        let started = Arc::new(Barrier::new(2));
-        let release = Arc::new(Barrier::new(2));
-        coordinator.install_child_scan_gate(Arc::clone(&started), Arc::clone(&release));
+        let mut gate = coordinator.install_child_scan_gate();
         let cancellation = coordinator.cancellation_handle();
 
         let worker = thread::spawn(move || {
@@ -1450,7 +2908,7 @@ mod tests {
                 .unwrap_err();
             (coordinator, error)
         });
-        started.wait();
+        gate.wait_until_started();
         assert_eq!(
             *cancellation
                 .active_child_scans
@@ -1459,7 +2917,7 @@ mod tests {
             1
         );
         cancellation.cancel();
-        release.wait();
+        gate.release();
         let (coordinator, error) = worker.join().unwrap();
         assert!(matches!(
             error,
@@ -1494,6 +2952,109 @@ mod tests {
     }
 
     #[test]
+    fn cancellation_between_materialized_rows_releases_guard_and_allows_reuse() {
+        let fixture = Fixture::new();
+        let coordinator = ReadCoordinator::open(fixture.storage.clone()).unwrap();
+        let cancellation = coordinator.cancellation_handle();
+        let mut statement = coordinator
+            .connection()
+            .prepare("SELECT payload FROM events")
+            .unwrap();
+        let mut rows = statement.query([]).unwrap();
+        assert!(rows.next().unwrap().is_some());
+        assert_eq!(fixture.storage.schema_gate_snapshot().active_operations, 1);
+
+        cancellation.cancel();
+        let error = rows.next().unwrap_err();
+        assert!(matches!(
+            error,
+            SqliteError::SqliteFailure(detail, _)
+                if detail.code == ErrorCode::OperationInterrupted
+        ));
+        drop(rows);
+        drop(statement);
+        assert_eq!(fixture.storage.schema_gate_snapshot().active_operations, 0);
+        assert_eq!(
+            coordinator
+                .connection()
+                .query_row("SELECT COUNT(*) FROM events", [], |row| row
+                    .get::<_, i64>(0))
+                .unwrap(),
+            2
+        );
+    }
+
+    #[test]
+    fn cancellation_interrupts_coordinator_work_after_the_child_handle_closes() {
+        let fixture = Fixture::new();
+        let coordinator = ReadCoordinator::open(fixture.storage.clone()).unwrap();
+        let mut child_gate = coordinator.install_child_scan_complete_gate();
+        let (outer_gate, mut outer_control) = TestChildScanGate::channel();
+        let outer_armed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let progress_armed = Arc::clone(&outer_armed);
+        let mut outer_gate = Some(outer_gate);
+        coordinator
+            .connection()
+            .progress_handler(
+                1,
+                Some(move || {
+                    if progress_armed.load(Ordering::Acquire) {
+                        if let Some(gate) = outer_gate.take() {
+                            return !gate.wait_for_release();
+                        }
+                    }
+                    false
+                }),
+            )
+            .unwrap();
+        let cancellation = coordinator.cancellation_handle();
+        let worker = thread::spawn(move || {
+            let error = coordinator
+                .connection()
+                .query_row("SELECT COUNT(*) FROM events", [], |row| {
+                    row.get::<_, i64>(0)
+                })
+                .unwrap_err();
+            (coordinator, error)
+        });
+
+        child_gate.wait_until_started();
+        outer_armed.store(true, Ordering::Release);
+        child_gate.release();
+        outer_control.wait_until_started();
+        assert_eq!(
+            *cancellation
+                .active_child_scans
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+            0,
+            "the cancellation must occur during coordinator work, not a child callback"
+        );
+        cancellation.cancel();
+        outer_control.release();
+
+        let (coordinator, error) = worker.join().unwrap();
+        assert!(matches!(
+            error,
+            SqliteError::SqliteFailure(detail, _)
+                if detail.code == ErrorCode::OperationInterrupted
+        ));
+        assert_eq!(fixture.storage.schema_gate_snapshot().active_operations, 0);
+        coordinator
+            .connection()
+            .progress_handler(0, None::<fn() -> bool>)
+            .unwrap();
+        assert_eq!(
+            coordinator
+                .connection()
+                .query_row("SELECT COUNT(*) FROM events", [], |row| row
+                    .get::<_, i64>(0))
+                .unwrap(),
+            2
+        );
+    }
+
+    #[test]
     fn cancellation_after_an_empty_child_scan_is_not_lost() {
         let fixture = Fixture::new();
         for shard in 0..fixture.storage.shard_count() {
@@ -1506,9 +3067,7 @@ mod tests {
         }
 
         let coordinator = ReadCoordinator::open(fixture.storage.clone()).unwrap();
-        let started = Arc::new(Barrier::new(2));
-        let release = Arc::new(Barrier::new(2));
-        coordinator.install_child_scan_complete_gate(Arc::clone(&started), Arc::clone(&release));
+        let mut gate = coordinator.install_child_scan_complete_gate();
         let cancellation = coordinator.cancellation_handle();
 
         let worker = thread::spawn(move || {
@@ -1520,11 +3079,11 @@ mod tests {
                 .unwrap_err();
             (coordinator, error)
         });
-        started.wait();
+        gate.wait_until_started();
         // Advance only the epoch so this test proves the post-scan check,
         // independently of both SQLite interrupt handles and progress hooks.
         cancellation.epoch.fetch_add(1, Ordering::AcqRel);
-        release.wait();
+        gate.release();
 
         let (coordinator, error) = worker.join().unwrap();
         assert!(matches!(
@@ -1757,7 +3316,7 @@ mod tests {
             .unwrap();
 
         let error = registry
-            .read_shard_rows(spec, 0, 0, MAX_CURSOR_ROWS, 1)
+            .read_shard_rows(spec, 0, None, 0, MAX_CURSOR_ROWS, 1)
             .unwrap_err();
         assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
         assert_eq!(
@@ -1767,6 +3326,175 @@ mod tests {
                 .unwrap_or_else(std::sync::PoisonError::into_inner),
             0
         );
+    }
+
+    #[test]
+    fn row_and_byte_limits_hold_at_the_boundary_and_recover_after_failure() {
+        let fixture = Fixture::new();
+        let operation = fixture.storage.enter_schema_operation().unwrap();
+        let registry = Registry::build_admitted(fixture.storage.clone()).unwrap();
+        drop(operation);
+        let spec = registry
+            .tables
+            .values()
+            .find(|spec| spec.name == "events")
+            .unwrap();
+
+        let (_, exact_bytes) = registry
+            .read_shard_rows(spec, 0, None, 0, 1, MAX_CURSOR_BYTES)
+            .unwrap();
+        assert_eq!(
+            registry
+                .read_shard_rows(spec, 0, None, 0, 1, exact_bytes)
+                .unwrap()
+                .0
+                .len(),
+            1
+        );
+        assert_eq!(
+            registry
+                .read_shard_rows(spec, 0, None, 0, 1, exact_bytes - 1)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::LimitExceeded
+        );
+
+        let equality_bytes = RawCell::accounted_payload_bytes(ValueRef::Integer(fixture.keys[0]))
+            + VALUE_ACCOUNTING_BYTES
+            + ALLOCATION_OVERHEAD_BYTES;
+        let combined_bytes = equality_bytes + exact_bytes;
+        let combined_exact = ReadCoordinator::open_with_limits(
+            fixture.storage.clone(),
+            CursorLimits {
+                rows: 1,
+                bytes: combined_bytes,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            combined_exact
+                .connection()
+                .query_row(
+                    "SELECT payload FROM events WHERE tenant_id = ?1",
+                    [fixture.keys[0]],
+                    |row| row.get::<_, String>(0),
+                )
+                .unwrap(),
+            "zero"
+        );
+        let combined_one_under = ReadCoordinator::open_with_limits(
+            fixture.storage.clone(),
+            CursorLimits {
+                rows: 1,
+                bytes: combined_bytes - 1,
+            },
+        )
+        .unwrap();
+        let error = combined_one_under
+            .connection()
+            .query_row(
+                "SELECT payload FROM events WHERE tenant_id = ?1",
+                [fixture.keys[0]],
+                |row| row.get::<_, String>(0),
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            SqliteError::SqliteFailure(detail, _) if detail.code == ErrorCode::TooBig
+        ));
+        assert_eq!(fixture.storage.schema_gate_snapshot().active_operations, 0);
+
+        assert_eq!(
+            registry
+                .read_shard_rows(spec, 0, None, 0, 0, MAX_CURSOR_BYTES)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::LimitExceeded
+        );
+
+        let exact = ReadCoordinator::open_with_limits(
+            fixture.storage.clone(),
+            CursorLimits {
+                rows: 2,
+                bytes: MAX_CURSOR_BYTES,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            exact
+                .connection()
+                .query_row("SELECT COUNT(*) FROM events", [], |row| row
+                    .get::<_, i64>(0))
+                .unwrap(),
+            2
+        );
+
+        let one = ReadCoordinator::open_with_limits(
+            fixture.storage.clone(),
+            CursorLimits {
+                rows: 1,
+                bytes: MAX_CURSOR_BYTES,
+            },
+        )
+        .unwrap();
+        let error = one
+            .connection()
+            .query_row("SELECT COUNT(*) FROM events", [], |row| {
+                row.get::<_, i64>(0)
+            })
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            SqliteError::SqliteFailure(detail, _) if detail.code == ErrorCode::TooBig
+        ));
+        assert_eq!(fixture.storage.schema_gate_snapshot().active_operations, 0);
+        assert_eq!(
+            one.connection()
+                .query_row(
+                    "SELECT payload FROM events WHERE tenant_id = ?1",
+                    [fixture.keys[0]],
+                    |row| row.get::<_, String>(0),
+                )
+                .unwrap(),
+            "zero"
+        );
+        assert_eq!(fixture.storage.schema_gate_snapshot().active_operations, 0);
+
+        let tiny_bytes = ReadCoordinator::open_with_limits(
+            fixture.storage.clone(),
+            CursorLimits {
+                rows: MAX_CURSOR_ROWS,
+                bytes: 64,
+            },
+        )
+        .unwrap();
+        let oversized = "x".repeat(65);
+        let error = tiny_bytes
+            .connection()
+            .query_row(
+                "SELECT COUNT(*) FROM events WHERE tenant_id = ?1",
+                [&oversized],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            SqliteError::SqliteFailure(detail, _) if detail.code == ErrorCode::TooBig
+        ));
+        assert!(tiny_bytes.take_opened_shards().is_empty());
+        assert_eq!(fixture.storage.schema_gate_snapshot().active_operations, 0);
+        assert_eq!(
+            tiny_bytes
+                .connection()
+                .query_row(
+                    "SELECT COUNT(*) FROM events WHERE tenant_id = NULL",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            0
+        );
+        assert!(tiny_bytes.take_opened_shards().is_empty());
     }
 
     #[test]

--- a/src/storage/sharded_vtab/benchmarks.rs
+++ b/src/storage/sharded_vtab/benchmarks.rs
@@ -1,0 +1,750 @@
+//! Manual release-mode benchmark matrix for the experimental shard facade.
+//!
+//! Run only when making the issue #126 rollout decision:
+//!
+//! ```text
+//! cargo test --release --locked --features experimental-vtab --lib \
+//!   storage::sharded_vtab::benchmarks::release_benchmark_matrix_reports_issue_126_comparison \
+//!   -- --ignored --exact --nocapture --test-threads=1
+//! ```
+
+use std::{
+    fs,
+    hint::black_box,
+    path::Path,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use rusqlite::params;
+use tokio::runtime::{Builder, Runtime};
+
+use super::{MAX_CURSOR_BYTES, MAX_CURSOR_ROWS, ReadCoordinator, Storage};
+use crate::core::{
+    Database, Engine, EngineOptions, GeneratedIdPolicy, ResultLimits, Session, ShardKeyMetadata,
+    ShardKeyType, Statement, TableDeclaration, Value, generated_id::NativeRangeV1Id,
+};
+
+const SHARD_MATRIX: [u16; 3] = [2, 10, 64];
+const ROWS_PER_SHARD: usize = 256;
+const POINT_PROBE_ITERATIONS: usize = 100;
+const TARGET_SCANNED_ROWS: usize = 100_000;
+const ORDER_LIMIT: usize = 50;
+const SAMPLE_COUNT: usize = 5;
+const WARMUP_OPERATIONS: usize = 3;
+const MIN_SAMPLE_DURATION: Duration = Duration::from_millis(250);
+const TARGET_SAMPLE_DURATION: Duration = Duration::from_millis(500);
+const MAX_CALIBRATED_ITERATIONS: usize = 1_000_000;
+
+const CREATE_BENCHMARK_TABLES: &str = "
+    CREATE TABLE benchmark_hash (
+        tenant_id INTEGER NOT NULL,
+        row_no INTEGER NOT NULL,
+        payload TEXT NOT NULL,
+        PRIMARY KEY (tenant_id, row_no)
+    ) STRICT;
+    CREATE TABLE benchmark_native (
+        id INTEGER PRIMARY KEY NOT NULL,
+        payload TEXT NOT NULL
+    ) STRICT;
+";
+
+const HASH_POINT_SQL: &str = "
+    SELECT tenant_id, row_no, payload
+    FROM benchmark_hash
+    WHERE tenant_id = ?1 AND row_no = ?2
+";
+const HASH_FULL_SQL: &str = "SELECT tenant_id, row_no, payload FROM benchmark_hash";
+const HASH_COUNT_SQL: &str = "SELECT COUNT(*) FROM benchmark_hash";
+const HASH_ORDER_LIMIT_SQL: &str = "
+    SELECT tenant_id, row_no, payload
+    FROM benchmark_hash
+    ORDER BY row_no DESC, tenant_id ASC
+    LIMIT 50
+";
+const NATIVE_POINT_SQL: &str = "SELECT id, payload FROM benchmark_native WHERE id = ?1";
+
+type HashRow = (i64, i64, String);
+
+struct BenchmarkFixture {
+    session: Session,
+    engine: Engine,
+    coordinator: ReadCoordinator,
+    runtime: Runtime,
+    hash_keys: Vec<i64>,
+    native_ids: Vec<i64>,
+    shard_count: u16,
+    temp: tempfile::TempDir,
+}
+
+impl BenchmarkFixture {
+    fn new(shard_count: u16) -> Self {
+        let temp = tempfile::tempdir().expect("create issue #126 benchmark directory");
+        let mut database =
+            Database::open(temp.path(), shard_count).expect("open issue #126 benchmark database");
+        database
+            .broadcast(CREATE_BENCHMARK_TABLES)
+            .expect("create issue #126 benchmark tables on every shard");
+        let logical_database = database.catalog().default_database().id();
+        database
+            .register_tables(vec![
+                TableDeclaration::sharded(
+                    logical_database,
+                    "benchmark_hash",
+                    ShardKeyMetadata::new("tenant_id", ShardKeyType::Int64)
+                        .expect("declare benchmark hash shard key"),
+                )
+                .expect("declare benchmark hash table"),
+                TableDeclaration::sharded(
+                    logical_database,
+                    "benchmark_native",
+                    ShardKeyMetadata::new("id", ShardKeyType::Int64)
+                        .expect("declare benchmark native shard key"),
+                )
+                .expect("declare benchmark native table")
+                .with_generated_id_policy(
+                    GeneratedIdPolicy::native_range_v1("id")
+                        .expect("declare benchmark native generated-ID policy"),
+                )
+                .expect("apply benchmark native generated-ID policy"),
+            ])
+            .expect("register issue #126 benchmark catalog");
+
+        let hash_keys = find_hash_key_for_each_shard(&database, shard_count);
+        let storage =
+            Storage::open(temp.path(), shard_count).expect("open benchmark storage for seeding");
+        let allocation_owners = storage
+            .allocation_owner_map()
+            .expect("current benchmark format has an allocation-owner map");
+        let native_ids = (0..shard_count)
+            .map(|shard| {
+                let owner = allocation_owners
+                    .owner_for_physical_shard(shard)
+                    .expect("every benchmark shard has an allocation owner");
+                NativeRangeV1Id::new(owner, 1)
+                    .expect("benchmark native ID is valid")
+                    .encode()
+            })
+            .collect::<Vec<_>>();
+        seed_rows(&storage, &hash_keys, &native_ids);
+
+        let coordinator = ReadCoordinator::open(storage).expect("open issue #126 read coordinator");
+        let limits = ResultLimits::new(MAX_CURSOR_ROWS as u64, MAX_CURSOR_BYTES as u64)
+            .expect("virtual-table result limits are valid engine limits");
+        let engine = Engine::from_database_with_options(
+            Arc::new(database),
+            EngineOptions::default().with_result_limits(limits),
+        )
+        .expect("open comparison Engine");
+        let session = engine.session();
+        let runtime = Builder::new_multi_thread()
+            .worker_threads(usize::from(shard_count).clamp(2, 8))
+            .enable_all()
+            .build()
+            .expect("create issue #126 benchmark runtime");
+
+        Self {
+            session,
+            engine,
+            coordinator,
+            runtime,
+            hash_keys,
+            native_ids,
+            shard_count,
+            temp,
+        }
+    }
+
+    fn logical_row_count(&self) -> usize {
+        usize::from(self.shard_count) * ROWS_PER_SHARD
+    }
+
+    fn point_shard(&self) -> u16 {
+        self.shard_count - 1
+    }
+
+    fn point_key(&self) -> i64 {
+        self.hash_keys[usize::from(self.point_shard())]
+    }
+
+    fn native_point_id(&self) -> i64 {
+        self.native_ids[usize::from(self.point_shard())]
+    }
+
+    fn on_disk_bytes(&self) -> FixtureDiskBytes {
+        FixtureDiskBytes::measure(self.temp.path(), self.shard_count)
+    }
+
+    fn vtab_hash_point(&self) -> HashRow {
+        self.coordinator
+            .connection()
+            .query_row(
+                HASH_POINT_SQL,
+                params![self.point_key(), (ROWS_PER_SHARD / 2) as i64],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("query vtab benchmark hash point")
+    }
+
+    fn vtab_hash_full(&self) -> Vec<HashRow> {
+        self.coordinator
+            .connection()
+            .prepare(HASH_FULL_SQL)
+            .expect("prepare vtab benchmark hash scan")
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+            .expect("query vtab benchmark hash scan")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("materialize vtab benchmark hash scan")
+    }
+
+    fn vtab_hash_count(&self) -> i64 {
+        self.coordinator
+            .connection()
+            .query_row(HASH_COUNT_SQL, [], |row| row.get(0))
+            .expect("query vtab benchmark count")
+    }
+
+    fn vtab_hash_order_limit(&self) -> Vec<HashRow> {
+        self.coordinator
+            .connection()
+            .prepare(HASH_ORDER_LIMIT_SQL)
+            .expect("prepare vtab benchmark ordered limit")
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+            .expect("query vtab benchmark ordered limit")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("materialize vtab benchmark ordered limit")
+    }
+
+    fn vtab_native_point(&self) -> (i64, String) {
+        self.coordinator
+            .connection()
+            .query_row(NATIVE_POINT_SQL, [self.native_point_id()], |row| {
+                Ok((row.get(0)?, row.get(1)?))
+            })
+            .expect("query vtab benchmark native point")
+    }
+
+    fn engine_hash_point(&self) -> (Vec<u16>, Vec<HashRow>) {
+        let result = self
+            .runtime
+            .block_on(self.engine.query_logical(
+                &self.session,
+                Statement::new(
+                    HASH_POINT_SQL,
+                    vec![
+                        Value::from(self.point_key()),
+                        Value::from((ROWS_PER_SHARD / 2) as i64),
+                    ],
+                ),
+            ))
+            .expect("query Engine benchmark hash point");
+        (result.shards, result_set_hash_rows(&result.value))
+    }
+
+    fn engine_hash_full(&self) -> (Vec<u16>, Vec<HashRow>) {
+        let result = self
+            .runtime
+            .block_on(
+                self.engine
+                    .query_logical(&self.session, Statement::new(HASH_FULL_SQL, vec![])),
+            )
+            .expect("query Engine benchmark hash scan");
+        (result.shards, result_set_hash_rows(&result.value))
+    }
+
+    fn correctness_preflight(&self) {
+        let _ = self.coordinator.take_opened_shards();
+        let vtab_point = self.vtab_hash_point();
+        assert_eq!(
+            self.coordinator.take_opened_shards(),
+            [self.point_shard()],
+            "vtab hash point must open one physical shard"
+        );
+        let (engine_point_shards, engine_point) = self.engine_hash_point();
+        assert_eq!(engine_point_shards, [self.point_shard()]);
+        assert_eq!(engine_point, [vtab_point]);
+
+        let mut vtab_full = self.vtab_hash_full();
+        assert_eq!(
+            self.coordinator.take_opened_shards(),
+            (0..self.shard_count).collect::<Vec<_>>(),
+            "vtab full scan must visit every physical shard once"
+        );
+        let (engine_full_shards, mut engine_full) = self.engine_hash_full();
+        assert_eq!(
+            engine_full_shards,
+            (0..self.shard_count).collect::<Vec<_>>()
+        );
+        assert_eq!(vtab_full.len(), self.logical_row_count());
+        vtab_full.sort_unstable();
+        engine_full.sort_unstable();
+        assert_eq!(engine_full, vtab_full);
+
+        let mut expected_ordered = vtab_full.clone();
+        expected_ordered.sort_unstable_by(|left, right| {
+            right.1.cmp(&left.1).then_with(|| left.0.cmp(&right.0))
+        });
+        expected_ordered.truncate(ORDER_LIMIT);
+
+        assert_eq!(
+            usize::try_from(self.vtab_hash_count()).expect("benchmark count is non-negative"),
+            self.logical_row_count()
+        );
+        assert_eq!(
+            self.coordinator.take_opened_shards(),
+            (0..self.shard_count).collect::<Vec<_>>(),
+            "vtab count must visit every physical shard"
+        );
+        let ordered = self.vtab_hash_order_limit();
+        assert_eq!(ordered, expected_ordered);
+        assert_eq!(
+            self.coordinator.take_opened_shards(),
+            (0..self.shard_count).collect::<Vec<_>>(),
+            "vtab ordered limit must visit every physical shard"
+        );
+
+        let _ = self.coordinator.take_opened_shards();
+        let native = self.vtab_native_point();
+        assert_eq!(native.0, self.native_point_id());
+        assert_eq!(
+            self.coordinator.take_opened_shards(),
+            [self.point_shard()],
+            "vtab native point must route through the allocation-owner map"
+        );
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FixtureDiskBytes {
+    manifest_database: u64,
+    manifest_wal: u64,
+    shard_databases: u64,
+    shard_wals: u64,
+}
+
+impl FixtureDiskBytes {
+    fn measure(root: &Path, shard_count: u16) -> Self {
+        let manifest = root.join("manifest.sqlite");
+        let manifest_database = required_file_bytes(&manifest);
+        let manifest_wal = optional_file_bytes(&root.join("manifest.sqlite-wal"));
+        let (shard_databases, shard_wals) =
+            (0..shard_count).fold((0_u64, 0_u64), |(database_bytes, wal_bytes), shard| {
+                let database = root.join("shards").join(format!("{shard:04}.sqlite"));
+                (
+                    database_bytes
+                        .checked_add(required_file_bytes(&database))
+                        .expect("benchmark shard database byte total fits u64"),
+                    wal_bytes
+                        .checked_add(optional_file_bytes(
+                            &root.join("shards").join(format!("{shard:04}.sqlite-wal")),
+                        ))
+                        .expect("benchmark shard WAL byte total fits u64"),
+                )
+            });
+        Self {
+            manifest_database,
+            manifest_wal,
+            shard_databases,
+            shard_wals,
+        }
+    }
+
+    fn total(self) -> u64 {
+        self.manifest_database
+            .checked_add(self.manifest_wal)
+            .and_then(|total| total.checked_add(self.shard_databases))
+            .and_then(|total| total.checked_add(self.shard_wals))
+            .expect("benchmark fixture byte total fits u64")
+    }
+
+    fn report(self, fixture: &BenchmarkFixture) {
+        println!(
+            "issue126_fixture_bytes\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            fixture.shard_count,
+            ROWS_PER_SHARD,
+            self.manifest_database,
+            self.manifest_wal,
+            self.shard_databases,
+            self.shard_wals,
+            self.total(),
+        );
+    }
+}
+
+fn required_file_bytes(path: &Path) -> u64 {
+    regular_file_bytes(path).unwrap_or_else(|error| {
+        panic!(
+            "inspect required benchmark byte-accounting path {}: {error}",
+            path.display()
+        )
+    })
+}
+
+fn optional_file_bytes(path: &Path) -> u64 {
+    match regular_file_bytes(path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => 0,
+        Err(error) => panic!(
+            "inspect optional benchmark byte-accounting path {}: {error}",
+            path.display()
+        ),
+    }
+}
+
+fn regular_file_bytes(path: &Path) -> std::io::Result<u64> {
+    match fs::metadata(path) {
+        Ok(metadata) => {
+            assert!(
+                metadata.is_file(),
+                "benchmark byte-accounting path is not a regular file: {}",
+                path.display()
+            );
+            Ok(metadata.len())
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn find_hash_key_for_each_shard(database: &Database, shard_count: u16) -> Vec<i64> {
+    let mut keys = vec![None; usize::from(shard_count)];
+    for candidate in 1_i64..=1_000_000 {
+        let shard = usize::from(database.shard_for_key(candidate.to_string().as_bytes()));
+        if keys[shard].is_none() {
+            keys[shard] = Some(candidate);
+            if keys.iter().all(Option::is_some) {
+                break;
+            }
+        }
+    }
+    keys.into_iter()
+        .map(|key| key.expect("deterministic search found a hash key for every shard"))
+        .collect()
+}
+
+fn seed_rows(storage: &Storage, hash_keys: &[i64], native_ids: &[i64]) {
+    for shard in 0..storage.shard_count() {
+        let mut connection = storage
+            .open_shard(shard)
+            .expect("open physical benchmark shard for seeding");
+        let transaction = connection
+            .transaction()
+            .expect("start physical benchmark seed transaction");
+        {
+            let mut hash_insert = transaction
+                .prepare(
+                    "INSERT INTO benchmark_hash (tenant_id, row_no, payload) VALUES (?1, ?2, ?3)",
+                )
+                .expect("prepare benchmark hash insert");
+            let mut native_insert = transaction
+                .prepare("INSERT INTO benchmark_native (id, payload) VALUES (?1, ?2)")
+                .expect("prepare benchmark native insert");
+            for row_no in 0..ROWS_PER_SHARD {
+                let payload = format!("hash-{shard:02}-{row_no:04}-briskdb-issue-126");
+                hash_insert
+                    .execute(params![
+                        hash_keys[usize::from(shard)],
+                        row_no as i64,
+                        payload
+                    ])
+                    .expect("insert benchmark hash row");
+
+                let owner = NativeRangeV1Id::decode(native_ids[usize::from(shard)])
+                    .expect("decode benchmark owner")
+                    .owner();
+                let native_id = NativeRangeV1Id::new(owner, row_no as u64 + 1)
+                    .expect("construct benchmark native row ID")
+                    .encode();
+                let payload = format!("native-{shard:02}-{row_no:04}-briskdb-issue-126");
+                native_insert
+                    .execute(params![native_id, payload])
+                    .expect("insert benchmark native row");
+            }
+        }
+        transaction
+            .commit()
+            .expect("commit physical benchmark seed transaction");
+    }
+}
+
+fn result_set_hash_rows(result: &crate::core::ResultSet) -> Vec<HashRow> {
+    result
+        .rows()
+        .iter()
+        .map(|row| {
+            (
+                row.get(0)
+                    .and_then(Value::as_i64)
+                    .expect("Engine benchmark tenant_id is an integer"),
+                row.get(1)
+                    .and_then(Value::as_i64)
+                    .expect("Engine benchmark row_no is an integer"),
+                row.get(2)
+                    .and_then(Value::as_str)
+                    .expect("Engine benchmark payload is text")
+                    .to_owned(),
+            )
+        })
+        .collect()
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Sample {
+    iterations: usize,
+    elapsed: Duration,
+}
+
+impl Sample {
+    fn operations_per_second(self) -> f64 {
+        self.iterations as f64 / self.elapsed.as_secs_f64()
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SampleSummary {
+    median: Sample,
+    sample_count: usize,
+}
+
+impl SampleSummary {
+    fn from_samples(mut samples: Vec<Sample>) -> Self {
+        assert_eq!(samples.len(), SAMPLE_COUNT);
+        samples.sort_unstable_by(|left, right| {
+            left.operations_per_second()
+                .total_cmp(&right.operations_per_second())
+        });
+        Self {
+            median: samples[samples.len() / 2],
+            sample_count: samples.len(),
+        }
+    }
+
+    fn operations_per_second(self) -> f64 {
+        self.median.operations_per_second()
+    }
+
+    fn report(
+        self,
+        fixture: &BenchmarkFixture,
+        path: &str,
+        workload: &str,
+        logical_rows_per_operation: usize,
+    ) {
+        let operations_per_second = self.operations_per_second();
+        println!(
+            "issue126_benchmark\t{}\t{}\t{path}\t{workload}\t{}\t{}\t{:.3}\t{operations_per_second:.2}\t{:.2}",
+            fixture.shard_count,
+            ROWS_PER_SHARD,
+            self.sample_count,
+            self.median.iterations,
+            self.median.elapsed.as_secs_f64() * 1_000.0,
+            operations_per_second * logical_rows_per_operation as f64,
+        );
+    }
+}
+
+fn measure_once(operation: &mut impl FnMut() -> usize, iterations: usize) -> Sample {
+    let started = Instant::now();
+    for _ in 0..iterations {
+        black_box(operation());
+    }
+    Sample {
+        iterations,
+        elapsed: started.elapsed(),
+    }
+}
+
+fn calibrated_iterations(sample: Sample) -> usize {
+    if sample.elapsed.is_zero() {
+        return sample
+            .iterations
+            .saturating_mul(10)
+            .clamp(1, MAX_CALIBRATED_ITERATIONS);
+    }
+    let scaled = (sample.iterations as u128)
+        .saturating_mul(TARGET_SAMPLE_DURATION.as_nanos())
+        .div_ceil(sample.elapsed.as_nanos());
+    usize::try_from(scaled)
+        .unwrap_or(MAX_CALIBRATED_ITERATIONS)
+        .clamp(1, MAX_CALIBRATED_ITERATIONS)
+}
+
+fn prepare_iterations(operation: &mut impl FnMut() -> usize, probe_iterations: usize) -> usize {
+    for _ in 0..WARMUP_OPERATIONS {
+        black_box(operation());
+    }
+    calibrated_iterations(measure_once(operation, probe_iterations.max(1)))
+}
+
+fn measure_at_least(operation: &mut impl FnMut() -> usize, iterations: &mut usize) -> Sample {
+    loop {
+        let sample = measure_once(operation, *iterations);
+        if sample.elapsed >= MIN_SAMPLE_DURATION {
+            return sample;
+        }
+        let calibrated = calibrated_iterations(sample);
+        assert!(
+            calibrated > *iterations,
+            "benchmark could not reach its minimum sample duration within the iteration cap"
+        );
+        *iterations = calibrated;
+    }
+}
+
+fn measure_series(mut operation: impl FnMut() -> usize, probe_iterations: usize) -> SampleSummary {
+    let mut iterations = prepare_iterations(&mut operation, probe_iterations);
+    let samples = (0..SAMPLE_COUNT)
+        .map(|_| measure_at_least(&mut operation, &mut iterations))
+        .collect();
+    SampleSummary::from_samples(samples)
+}
+
+fn measure_pair(
+    mut vtab: impl FnMut() -> usize,
+    mut engine: impl FnMut() -> usize,
+    probe_iterations: usize,
+) -> (SampleSummary, SampleSummary) {
+    let mut vtab_iterations = prepare_iterations(&mut vtab, probe_iterations);
+    let mut engine_iterations = prepare_iterations(&mut engine, probe_iterations);
+    let mut vtab_samples = Vec::with_capacity(SAMPLE_COUNT);
+    let mut engine_samples = Vec::with_capacity(SAMPLE_COUNT);
+    for sample in 0..SAMPLE_COUNT {
+        if sample % 2 == 0 {
+            vtab_samples.push(measure_at_least(&mut vtab, &mut vtab_iterations));
+            engine_samples.push(measure_at_least(&mut engine, &mut engine_iterations));
+        } else {
+            engine_samples.push(measure_at_least(&mut engine, &mut engine_iterations));
+            vtab_samples.push(measure_at_least(&mut vtab, &mut vtab_iterations));
+        }
+    }
+    (
+        SampleSummary::from_samples(vtab_samples),
+        SampleSummary::from_samples(engine_samples),
+    )
+}
+
+fn scan_iterations(logical_rows: usize) -> usize {
+    TARGET_SCANNED_ROWS.div_ceil(logical_rows).max(1)
+}
+
+#[test]
+fn fixture_disk_bytes_counts_database_and_wal_files_but_not_shm() {
+    let temp = tempfile::tempdir().expect("create fixture-byte unit-test directory");
+    fs::create_dir(temp.path().join("shards")).expect("create fixture-byte shard directory");
+    fs::write(temp.path().join("manifest.sqlite"), [0_u8; 11])
+        .expect("write fixture-byte manifest database");
+    fs::write(temp.path().join("manifest.sqlite-wal"), [0_u8; 13])
+        .expect("write fixture-byte manifest WAL");
+    fs::write(temp.path().join("manifest.sqlite-shm"), [0_u8; 17])
+        .expect("write excluded fixture-byte manifest SHM");
+    fs::write(temp.path().join("shards/0000.sqlite"), [0_u8; 19])
+        .expect("write fixture-byte first shard database");
+    fs::write(temp.path().join("shards/0000.sqlite-wal"), [0_u8; 23])
+        .expect("write fixture-byte first shard WAL");
+    fs::write(temp.path().join("shards/0000.sqlite-shm"), [0_u8; 29])
+        .expect("write excluded fixture-byte shard SHM");
+    fs::write(temp.path().join("shards/0001.sqlite"), [0_u8; 31])
+        .expect("write fixture-byte second shard database");
+
+    let measured = FixtureDiskBytes::measure(temp.path(), 2);
+
+    assert_eq!(
+        measured,
+        FixtureDiskBytes {
+            manifest_database: 11,
+            manifest_wal: 13,
+            shard_databases: 50,
+            shard_wals: 23,
+        }
+    );
+    assert_eq!(measured.total(), 97);
+}
+
+#[test]
+#[ignore = "manual release-mode issue #126 benchmark"]
+fn release_benchmark_matrix_reports_issue_126_comparison() {
+    if cfg!(debug_assertions) {
+        panic!("run this ignored benchmark with cargo test --release");
+    }
+    println!(
+        "record\tshards\trows_per_shard\tpath\tworkload\tsamples\tmedian_iterations\tmedian_elapsed_ms\tmedian_ops_per_sec\tmedian_logical_rows_per_sec"
+    );
+    println!(
+        "fixture_record\tshards\trows_per_shard\tmanifest_db_bytes\tmanifest_wal_bytes\tshard_db_bytes\tshard_wal_bytes\ttotal_db_and_wal_bytes"
+    );
+
+    for shard_count in SHARD_MATRIX {
+        let fixture = BenchmarkFixture::new(shard_count);
+        fixture.correctness_preflight();
+        fixture.on_disk_bytes().report(&fixture);
+        let logical_rows = fixture.logical_row_count();
+        let scan_iterations = scan_iterations(logical_rows);
+
+        let (vtab_point, engine_point) = measure_pair(
+            || {
+                let row = fixture.vtab_hash_point();
+                black_box(row);
+                1
+            },
+            || {
+                let (shards, rows) = fixture.engine_hash_point();
+                black_box((shards, rows));
+                1
+            },
+            POINT_PROBE_ITERATIONS,
+        );
+        vtab_point.report(&fixture, "vtab", "hash_point", 1);
+        engine_point.report(&fixture, "engine_logical", "hash_point", 1);
+
+        let (vtab_full, engine_full) = measure_pair(
+            || {
+                let rows = fixture.vtab_hash_full();
+                let len = rows.len();
+                black_box(rows);
+                len
+            },
+            || {
+                let (shards, rows) = fixture.engine_hash_full();
+                let len = rows.len();
+                black_box((shards, rows));
+                len
+            },
+            scan_iterations,
+        );
+        vtab_full.report(&fixture, "vtab", "hash_full", logical_rows);
+        engine_full.report(&fixture, "engine_logical", "hash_full", logical_rows);
+
+        measure_series(
+            || usize::try_from(fixture.vtab_hash_count()).expect("benchmark count is non-negative"),
+            scan_iterations,
+        )
+        .report(&fixture, "vtab", "count", logical_rows);
+
+        measure_series(
+            || {
+                let rows = fixture.vtab_hash_order_limit();
+                let len = rows.len();
+                black_box(rows);
+                len
+            },
+            scan_iterations,
+        )
+        .report(&fixture, "vtab", "order_limit_50", logical_rows);
+
+        measure_series(
+            || {
+                let row = fixture.vtab_native_point();
+                black_box(row);
+                1
+            },
+            POINT_PROBE_ITERATIONS,
+        )
+        .report(&fixture, "vtab", "native_point", 1);
+
+        println!(
+            "issue126_comparison\t{shard_count}\t{}\thash_point\t{:.3}\thash_full\t{:.3}",
+            ROWS_PER_SHARD,
+            vtab_point.operations_per_second() / engine_point.operations_per_second(),
+            vtab_full.operations_per_second() / engine_full.operations_per_second(),
+        );
+    }
+}


### PR DESCRIPTION
## What changed

- implements the feature-gated stock SQLite `brisk_shard` virtual table for registered logical tables
- routes exact binary shard-key equality to one validated read-only child connection
- scans shards in deterministic order with `UNION ALL` duplicate semantics
- preserves native generated-ID owner routing and legacy hash routing
- adds bounded materialization, cancellation, schema admission, corruption handling, and read-only authorizer defenses
- documents the supported SQL composition boundary and benchmark decision

## Validation

- stable: all targets and all features (708 library tests passed, 2 intentional ignores; all integrations and storage benchmarks passed)
- Rust 1.85 MSRV: serial library suite (708 passed, 2 ignored), binaries, integrations, docs, and storage benchmark
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- Node syntax checks and 7 admin-browser logic tests
- focused virtual-table suite: 30 passed on stable and Rust 1.85
- independent read-only WAL, identity, metadata, schema-digest, and fail-closed audit: no blockers

## Benchmark decision

The release harness compares 2, 10, and 64 shards. The virtual-table path is currently 6.8–7.8x slower for point reads and 1.7–2.8x slower for full scans than the Rust Engine path, so this remains an experimental complement rather than replacing the existing protocol path.

Closes #126