### PR TITLE
Implement explicit-key single-shard virtual table writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,8 +252,9 @@ declaration also names a visible, physically non-null column with compatible
 `Int64`, text, or binary affinity. SQLite's non-null `INTEGER PRIMARY KEY`
 rowid alias is accepted; nullable legacy primary-key forms are not. Text keys
 use SQLite `BINARY` collation, and every primary/unique key on a sharded table
-must include its shard key with `BINARY` collation. Application foreign keys,
-triggers, and virtual tables are temporarily unsupported. An exact repeat is
+must include its shard key with `BINARY` collation. Application foreign keys
+are accepted only for conservatively proven local placement; unsafe foreign
+keys, triggers, and virtual tables are unsupported. An exact repeat is
 idempotent, but a different or partial replacement is rejected. Registration
 is an initialization boundary, not an online catalog-editing API; close and
 reopen the registering handle after an ambiguous manifest-commit error.
@@ -435,8 +436,8 @@ After durable partial progress, ordinary work receives non-retryable
 retained permanently for recovery and idempotency, so migration batches must
 not contain passwords, tokens, or other sensitive literals. Once the catalog is
 registered, migration rejects row-moving DML, table drops, trigger creation,
-foreign keys, virtual tables, and any change that breaks declared placement,
-Text collation, or one-owner uniqueness.
+unsafe or malformed foreign keys, virtual tables, and any change that breaks
+declared placement, Text collation, or one-owner uniqueness.
 
 The initial shard count is immutable, so resharding will require an explicit
 migration workflow. Opening upgrades exact version-1 through version-8
@@ -487,8 +488,11 @@ it preserves logical databases, routing, schema history, shard files, and rows.
 `Database::register_tables` can then install one complete declaration set only
 after its matching physical tables are empty. Once installed, migrations must
 preserve that exact physical table set and every sharded key's required column
-and affinity. Text shard keys use SQLite `BINARY` collation. Application
-foreign keys, triggers, and virtual tables are temporarily unsupported; every
+and affinity. Text shard keys use SQLite `BINARY` collation. Foreign keys are
+accepted only when authoritative placement proves local enforcement (matching
+co-sharded keys with the same generated-ID routing domain, Sharded-to-Global,
+or Global-to-Global); unsafe relationships, triggers, and virtual tables remain
+unsupported. Every
 `PRIMARY KEY` or `UNIQUE` key on a sharded table must include its shard key with
 `BINARY` collation so uniqueness has one physical owner. The public catalog
 returned by `Database::catalog()` and `Engine::catalog()` remains read-only to

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -546,8 +546,12 @@ is `Sharded` or `Global`, each `Catalog` declaration remains manifest-only, and
 every sharded key is a visible, physically non-null column with compatible
 SQLite affinity. The non-null `INTEGER PRIMARY KEY` rowid alias is accepted,
 but SQLite's nullable legacy primary-key forms are not. Text keys must use
-SQLite `BINARY` collation. Application foreign keys, triggers, and virtual
-tables are temporarily rejected. Every primary or unique key on a sharded
+SQLite `BINARY` collation. Foreign keys are accepted only when catalog
+placement proves that the parent is present in the same physical file:
+matching Sharded keys with the same generated-ID routing domain,
+Sharded-to-Global, or Global-to-Global. Missing, Catalog, or cross-placement
+relationships, triggers, and virtual tables are rejected.
+Every primary or unique key on a sharded
 table must contain the shard-key column with `BINARY` collation, which keeps
 that constraint's complete equality domain on one owner. The coordinator
 validates physical state before opening an immediate manifest transaction,
@@ -568,9 +572,9 @@ replicated, and `Catalog` data is not an application-shard table. Registration
 accepts only empty physical tables, so it cannot bless or repartition existing
 duplicates. Every later schema-migration preflight must preserve the exact
 registered table set on all shards and each sharded key's required column and
-affinity and `BINARY` Text collation. It also preserves one-owner unique keys
-and the temporary foreign-key, trigger, and virtual-table restrictions before a
-journal can be published.
+affinity and `BINARY` Text collation. It also preserves one-owner unique keys,
+the conservative foreign-key co-location and SQLite-enforcement rules, and the
+trigger and virtual-table restrictions before a journal can be published.
 
 Core routing still hashes the exact key bytes, derives a versioned virtual
 bucket, and reads the final physical shard from the snapshot without querying
@@ -612,8 +616,8 @@ reserved-state access. Before registration, its legacy batch may also contain
 DML. With a populated authoritative catalog, an additional parser gate rejects
 row-moving DML, `CREATE TABLE AS SELECT`, `DROP TABLE`, and `CREATE TRIGGER`;
 postflight validation also rejects any resulting trigger, virtual table,
-foreign key, invalid unique key, or placement/key change. Because SQLite does
-not reveal an
+unsafe or malformed foreign key, invalid unique key, or placement/key change.
+Because SQLite does not reveal an
 `ALTER TABLE ... RENAME TO` destination to the authorizer, the coordinator also
 compares the reserved schema before and after the batch. The exact format,
 numeric codes, downgrade policy, recovery cases, and tests are documented in
@@ -669,11 +673,12 @@ validates the policy, codec, and owner slots only; physical
 `sqlite_sequence` validation and seeding belong to issue #128, and omitted-key
 SQL translation belongs to issue #130.
 
-The opt-in `experimental-vtab` feature adds a separate, read-only SQLite
-coordinator that statically registers `brisk_shard`. It proves a no-fork logical
-table boundary while leaving the manifest, physical schemas, protocol behavior,
-and established scatter executor unchanged. It opens validated physical children
-through OS-level SQLite read-only handles, never attaches a shard, and never
+The opt-in `experimental-vtab` feature adds separate read-only and narrowly
+writable SQLite coordinators that statically register `brisk_shard`. They prove
+a no-fork logical table boundary while leaving the manifest, physical schemas,
+protocol behavior, and established scatter executor unchanged. The read-only
+coordinator opens validated physical children through OS-level SQLite read-only
+handles, never attaches a shard, and never
 dynamically loads an extension. Trusted metadata supplies each declared
 schema. An exact, storage-class-compatible `Int64`, `Text`, or `Binary`
 shard-key equality can open only its owner and bind the equality on that
@@ -688,6 +693,18 @@ protocol SQL contract. Cursor ownership, schema admission, cancellation,
 bounded materialization, static-loading policy, and rejected alternatives are
 specified in the
 [experimental sharded virtual-table facade](SHARDED_VIRTUAL_TABLE.md).
+
+The writable coordinator accepts explicit-key INSERT and exactly routed
+UPDATE/DELETE only. Its first operation pins one `BEGIN IMMEDIATE` child shard;
+reads used to locate UPDATE/DELETE rows reuse that child, and a second-shard
+attempt aborts the whole transaction. A hidden versioned locator carries the
+physical rowid or complete `WITHOUT ROWID` key without changing shard files.
+The wrapper reconciles stock-SQLite transaction and savepoint callbacks, then
+performs the fallible child commit before acknowledging success. Physical
+constraints and conservatively admitted co-located foreign keys remain
+authoritative. Missing/generated keys, Global writes, multi-shard
+transactions, `RETURNING`, defaults, generated columns, triggers, and public
+protocol integration remain later work.
 
 ## Session and asynchronous engine boundary
 
@@ -783,9 +800,10 @@ not a distributed coordination mechanism.
 Every-shard preflight executes the complete batch inside a rollback-only
 transaction. When the authoritative table catalog is populated, that tentative
 schema must still contain exactly its declared physical tables, compatible
-sharded keys, `BINARY` Text collation, and one-owner unique constraints, with no
-application foreign key, trigger, or virtual table. The catalog-aware migration
-gate also rejects row-moving DML, table drops, and trigger creation before
+sharded keys, `BINARY` Text collation, one-owner unique constraints, and only
+conservatively co-located, SQLite-enforceable foreign keys, with no application
+trigger or virtual table. The catalog-aware migration gate also rejects
+row-moving DML, table drops, and trigger creation before
 preflight. Only after all preflights succeed does the coordinator record the
 exact SQL and its BLAKE3 identity, then visit shards in ascending order. One
 shard's complete batch and target `user_version` commit atomically, followed by a separate

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -339,17 +339,18 @@ detail never includes the retained SQL.
 
 With a populated authoritative catalog, row-moving DML,
 `CREATE TABLE ... AS SELECT`, `DROP TABLE`, `CREATE TRIGGER`, or a final schema
-containing an application foreign key, trigger, virtual table, invalid
-primary/unique key, or changed placement/key invariant is
+containing an unsafe or SQLite-unenforceable foreign key, trigger, virtual table,
+invalid primary/unique key, or changed placement/key invariant is
 `FailedPrecondition` before journal publication.
 
 Manifest v8 table registration reports malformed, empty, duplicate, or
 unknown-database declarations as `InvalidArgument` and an oversized catalog as
 `LimitExceeded`. A nonempty physical table, an incomplete or differing physical
 table set, a catalog-table shadow, an invalid sharded key or Text collation, a
-sharded primary/unique key without its `BINARY` shard-key term, any application
-foreign key, trigger, or virtual table, another live owner, or an attempted
-replacement of an already populated catalog is `FailedPrecondition`. The same
+sharded primary/unique key without its `BINARY` shard-key term, an unsafe or
+SQLite-unenforceable foreign key, trigger, or virtual table, another live owner,
+or an attempted replacement of an already populated catalog is
+`FailedPrecondition`. The same
 complete declaration set is idempotent. Schema SQL that would violate a
 populated authoritative catalog is also `FailedPrecondition` before a journal
 or shard mutation is published.

--- a/docs/SHARDED_VIRTUAL_TABLE.md
+++ b/docs/SHARDED_VIRTUAL_TABLE.md
@@ -19,6 +19,27 @@ The read contract is:
   replicated physically; and
 - `Catalog` placement is never declared in the coordinator schema.
 
+Issue #127 adds a separate internal writable coordinator. Its explicit-key
+contract is deliberately narrower:
+
+- `INSERT` routes from an exact catalog shard-key value and returns both the
+  SQLite affected-row count and the caller's explicit key to BriskDB;
+- `UPDATE` and `DELETE` require an exact shard-key equality, read the selected
+  row through the pinned writable child transaction, and identify it with a
+  hidden, versioned, table-bound locator containing the shard and physical
+  rowid or complete `WITHOUT ROWID` primary key;
+- the first read or write pins the transaction to one validated physical shard,
+  and any attempt to enlist a second shard or move a shard key aborts the whole
+  logical transaction without a partial durable effect; and
+- explicit transactions, nested savepoints, rollback, SQLite conflict modes,
+  cancellation, connection loss, and child commit failures are reconciled by a
+  wrapper that never exposes the raw writable coordinator connection.
+
+Cancellation and child commit have one explicit durability boundary. If
+cancellation wins before physical `COMMIT`, the child rolls back; once physical
+`COMMIT` begins, it wins and is allowed to finish so BriskDB never reports a
+cancelled result for a write that may already be durable.
+
 For a usable equality constraint on the exact declared shard-key column,
 `xBestIndex` requests one argument but deliberately does not set `omit`.
 `xFilter` prunes to one physical child only when the bound SQLite storage class
@@ -96,6 +117,26 @@ including attempts to turn `query_only` back off. The Cargo feature adds only
 rusqlite's virtual-table bindings; it does not add loader bindings or enable the
 bundled SQLite library's disabled-by-default extension-loading capability.
 
+The writable coordinator instead registers a stock-SQLite version-2 module.
+rusqlite supplies the normal `xUpdate` and transaction callbacks; a small
+in-tree bridge fills SQLite's public `xSavepoint`, `xRelease`, and
+`xRollbackTo` slots. This is an API adapter, not an SQLite patch or fork. The
+writable coordinator enables virtual-table constraint support, leaves
+`query_only` off only on itself, and opens exactly one validated writable child
+with `BEGIN IMMEDIATE`, `synchronous=FULL`, WAL, and `foreign_keys=ON` verified.
+Its fail-closed authorizer permits top-level DML only against registered virtual
+tables. DDL, `ATTACH`, `DETACH`, caller transaction SQL, unsafe PRAGMAs,
+indirect trigger/view execution, and extension loading remain denied.
+
+All physical SQLite constraints and indexes remain authoritative. Registration
+accepts a local foreign key only when placement proves co-location: a Sharded
+child may reference a co-sharded parent through corresponding shard keys in the
+same generated-ID routing domain or a Global parent, and a Global child may
+reference only a Global parent. Unsafe, missing, Catalog, cross-placement, or
+SQLite-unenforceable relationships fail closed. Physical
+`UNIQUE`, primary-key, `NOT NULL`, `CHECK`, strict typing, and admitted local
+foreign-key errors retain their SQLite result codes through the facade.
+
 ## Why the physical format stays ordinary SQLite
 
 All virtual objects live in the coordinator database. A physical shard still
@@ -117,14 +158,23 @@ This is why several alternatives are excluded:
 
 ## Current non-goals
 
-This boundary does not provide writes, generated-ID allocation, distributed
-transactions, aggregate/order/limit/join pushdown, parallel shard scans, or a
-public query API. It does not change protocol behavior. The current `Engine`,
-HTTP surface, and protocol planner remain authoritative. Advanced filter,
-aggregate, order, and limit pushdown remains owned by issues #58 through #61.
-Issues #127 through #131 separately cover explicit-key writes, native and
-optional hi/lo generated IDs, generated-key SQL integration, and the final
-rollout gate.
+The internal writable coordinator now provides explicit-key DML on one pinned
+Sharded child. It does not provide missing/generated keys, replicated Global
+writes, multi-shard transactions, `RETURNING`, physical defaults, generated
+columns, physical triggers, client-created virtual-table indexes or triggers,
+`ALTER TABLE`, aggregate/order/limit/join pushdown, parallel shard scans, or a
+public query API. The physical-default restriction is intentional: SQLite's
+`xUpdate` arguments do not distinguish an omitted column from explicit `NULL`.
+Generated keys and omitted-key SQL integration remain owned by issues #128
+through #130, and rollout remains owned by #131.
+
+This does not change protocol behavior. The current `Engine`, HTTP surface,
+query app, and protocol planner remain authoritative. The writable coordinator
+is kept behind `experimental-vtab` and cannot be reached through a raw
+connection. Additional indexes continue to live on the ordinary physical
+tables and are used by child SQLite statements; SQLite does not permit adding
+indexes or triggers directly to a virtual table. Schema changes remain the
+journaled migration system's responsibility.
 
 Only the exact typed shard-key equality described above narrows a scan. Other
 predicates, and a type-mismatched equality whose SQLite affinity semantics

--- a/docs/SQLITE_IMPORT.md
+++ b/docs/SQLITE_IMPORT.md
@@ -65,9 +65,10 @@ the importer does not weaken uniqueness silently.
 
 ## Foreign-key normalization
 
-Authoritative foreign-key placement is not implemented yet. A source table
-with any foreign key is rejected by default before a staging directory is
-created. A plan may explicitly select `"foreign_keys":"omit"` for that table:
+The importer does not yet retain and prove the catalog's conservative
+foreign-key co-location matrix. A source table with any foreign key is
+therefore rejected by default before a staging directory is created. A plan may
+explicitly select `"foreign_keys":"omit"` for that table:
 
 ```json
 {

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -106,14 +106,18 @@ not make that prepared pipeline public wire behavior. Authoritative table
 registration composes the SQLite frontend and planner into the existing HTTP
 execute/query rows as described above; it adds no HTTP field or route.
 
-The `experimental-vtab` Cargo feature also contains a read-only, internal
-`brisk_shard` coordinator for evaluating the no-fork virtual-table boundary. It
-is not an HTTP, PostgreSQL, or MySQL query interface and does not expand the
-table above. The module is statically registered into stock SQLite and opens
-validated physical children through OS-level SQLite read-only handles; it does
-not use `ATTACH`, runtime extension loading, a SQLite fork, or a storage-format
-change. Writes, schema operations, attachments, unsafe PRAGMAs, and extension
-loading are rejected.
+The `experimental-vtab` Cargo feature also contains internal read-only and
+explicit-key writable `brisk_shard` coordinators for evaluating the no-fork
+virtual-table boundary. They are not HTTP, PostgreSQL, or MySQL query interfaces
+and do not expand the table above. The module is statically registered into
+stock SQLite and opens validated physical children through OS-level SQLite
+handles; it does not use `ATTACH`, runtime extension loading, a SQLite fork, or
+a storage-format change. The writable wrapper accepts explicit-key Sharded
+INSERT and exactly routed UPDATE/DELETE, pins one physical transaction, and
+rejects cross-shard or Global writes. Schema operations, attachments, unsafe
+PRAGMAs, extension loading, generated/missing keys, defaults, generated
+columns, triggers, and `RETURNING` remain rejected. This surface is internal
+and cannot be reached by the query app or protocol adapters.
 
 Within that feature gate only, a usable equality on the exact cataloged shard
 key requests one virtual-table argument without `omit`. Exact SQLite `INTEGER`,
@@ -224,8 +228,9 @@ also compares the reserved schema before and after the migration transaction.
 When the authoritative catalog is populated, migration parsing additionally
 rejects `INSERT`, `UPDATE`, `DELETE`, `MERGE`, `TRUNCATE`,
 `CREATE TABLE ... AS SELECT`, `DROP TABLE`, and `CREATE TRIGGER`. Final
-rollback-only validation rejects application foreign keys, triggers, virtual
-tables, invalid unique keys, and any table-placement or shard-key change.
+rollback-only validation accepts only conservatively co-located foreign keys
+and rejects unsafe foreign keys, triggers, virtual tables, invalid unique keys,
+and any table-placement or shard-key change.
 
 SQLite also retains `last_insert_rowid()`, `changes()`, and `total_changes()` on
 the physical connection after ordinary writes. A write-bearing handle may be
@@ -286,9 +291,11 @@ authoritative catalog is populated, however, every tentative shard schema must
 still contain exactly the declared `Sharded` and `Global` tables, no physical
 `Catalog` table, and each sharded key with its required column, affinity, and
 `BINARY` Text collation. Every sharded primary/unique key must still include the
-shard key with `BINARY` collation, and application foreign keys, triggers, and
-virtual tables remain prohibited. Row-moving DML, table drops, and trigger
-creation are rejected before this rollback-only check. A violation fails
+shard key with `BINARY` collation. Foreign keys must prove matching co-sharded
+keys in the same generated-ID routing domain, Sharded-to-Global, or
+Global-to-Global placement, and SQLite must accept the referenced parent key;
+triggers and virtual tables remain prohibited. Row-moving DML, table drops, and
+trigger creation are rejected before this rollback-only check. A violation fails
 preflight before journal publication. Richer
 migration/history APIs remain issue #53. Manifest v8 retains the v7
 generation-bound persistent-schema fingerprint requirement in addition to this
@@ -849,8 +856,9 @@ underlying execution semantics.
   has the same complete, empty physical table set. A sharded declaration names
   one visible, physically non-null `Int64`, text, or binary key column; the
   `INTEGER PRIMARY KEY` rowid alias qualifies, but nullable legacy primary-key
-  forms do not. Text keys must use SQLite `BINARY` collation. Application
-  foreign keys, triggers, and virtual tables are temporarily unsupported, and
+  forms do not. Text keys must use SQLite `BINARY` collation. Foreign keys must
+  satisfy the conservative local-enforcement matrix; triggers and virtual
+  tables remain unsupported, and
   every sharded primary/unique key must contain the shard key with `BINARY`
   collation.
 - Registration changes schema admission to `Pending` before manifest commit.
@@ -901,8 +909,8 @@ underlying execution semantics.
   serving work. Once tables are registered, preflight also rejects a migration
   that changes the complete physical table set or a sharded key's required
   column, affinity, or Text collation; creates row-moving DML, drops a table, or
-  creates a trigger; introduces a foreign key, trigger, or virtual table; or
-  breaks one-owner unique-key locality.
+  creates a trigger; introduces an unsafe or malformed foreign key, trigger, or
+  virtual table; or breaks one-owner unique-key locality.
 
 ### Planned stable contract
 

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -388,8 +388,11 @@ non-null `INTEGER PRIMARY KEY` rowid alias qualifies; nullable legacy
 primary-key forms do not. A Text shard key must use SQLite `BINARY` collation.
 Every primary or unique key on a sharded table must include its shard-key column
 with `BINARY` collation, so every possible collision has one physical owner.
-Application foreign keys, triggers, and virtual tables are temporarily
-unsupported for every registered physical table. Registration assigns table IDs
+Foreign keys are accepted only when authoritative placement proves local
+enforcement: matching co-sharded keys in the same generated-ID routing domain,
+Sharded-to-Global, or Global-to-Global. Missing, Catalog, cross-placement, or
+SQLite-unenforceable relationships, triggers, and virtual tables are
+unsupported. Registration assigns table IDs
 after sorting by logical database and canonical table name, commits each table
 and its explicit generated-ID policy row, refreshes the manifest root
 atomically, and publishes the replacement catalog only after revalidation.
@@ -401,8 +404,9 @@ declarations fail without replacing the catalog. Once populated, the catalog
 cannot be edited in place. A later journaled schema migration must preserve the
 exact registered physical table set on every shard and retain every sharded
 key's visible, physically non-null column, compatible affinity, Text collation,
-and one-owner unique keys. It must not introduce an application foreign key,
-trigger, or virtual table. A populated-catalog migration also rejects row-moving
+and one-owner unique keys. Foreign-key changes must retain the same conservative
+co-location rules; a migration must not introduce a trigger or virtual table.
+A populated-catalog migration also rejects row-moving
 DML, `CREATE TABLE ... AS SELECT`, `DROP TABLE`, and `CREATE TRIGGER`. A
 violation is rejected before journal or shard publication.
 
@@ -672,8 +676,8 @@ After registration, BriskDB parses the exact submitted SQLite batch before
 preflight and rejects row-moving `INSERT`, `UPDATE`, `DELETE`, `MERGE`, or
 `TRUNCATE`, `CREATE TABLE ... AS SELECT`, `DROP TABLE`, and `CREATE TRIGGER`.
 Rollback-only postflight then rechecks the complete authoritative table set,
-key affinity/nullability/collation, unique-key locality, and the ban on
-application foreign keys, triggers, and virtual tables. Parsing never replaces
+key affinity/nullability/collation, unique-key locality, conservative
+foreign-key co-location, and the ban on triggers and virtual tables. Parsing never replaces
 the exact submitted bytes used for migration identity.
 
 ### Routing catalog

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -126,9 +126,10 @@ impl Database {
     /// database before it is wrapped in an [`Engine`]. Every declared physical
     /// table must already exist with the same empty schema on all shards.
     /// Sharded text keys use `BINARY` collation, every unique key must include
-    /// the shard key, and foreign keys, triggers, and virtual tables are not yet
-    /// supported. The catalog can be registered exactly once; later table
-    /// changes belong to a journaled schema-and-catalog migration.
+    /// the shard key, and foreign keys must prove authoritative co-location.
+    /// Triggers and virtual tables are not yet supported. The catalog can be
+    /// registered exactly once; later table changes belong to a journaled
+    /// schema-and-catalog migration.
     pub fn register_tables(&mut self, declarations: Vec<TableDeclaration>) -> EngineResult<()> {
         self.storage.register_tables(declarations)
     }

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -75,8 +75,8 @@ pub enum SqliteImportPlacement {
     Global,
 }
 
-/// Policy for source foreign-key clauses, which authoritative catalogs do not
-/// yet support.
+/// Policy for source foreign-key clauses, whose authoritative co-location is
+/// not yet planned and retained by the importer.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SqliteForeignKeyPolicy {

--- a/src/storage/migration.rs
+++ b/src/storage/migration.rs
@@ -1890,7 +1890,7 @@ mod tests {
             ),
             (
                 "ALTER TABLE accounts ADD COLUMN observed INTEGER CHECK(total_changes() >= 0)",
-                EngineErrorKind::PermissionDenied,
+                EngineErrorKind::FailedPrecondition,
             ),
         ] {
             let error = run_sql_with_hook(&storage, sql, |_| Ok(())).unwrap_err();

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -804,7 +804,12 @@ impl Storage {
             }
             for declaration in declarations {
                 if !matches!(declaration.placement(), TablePlacement::Catalog) {
-                    validate_empty_table_declaration(&connection, shard_id, declaration)?;
+                    validate_empty_table_declaration(
+                        &connection,
+                        shard_id,
+                        declaration,
+                        declarations,
+                    )?;
                 }
             }
         }
@@ -1168,6 +1173,7 @@ fn validate_empty_table_declaration(
     connection: &Connection,
     shard_id: u16,
     declaration: &TableDeclaration,
+    declarations: &[TableDeclaration],
 ) -> EngineResult<()> {
     let quoted_table = quote_identifier(declaration.name());
     let has_rows = connection
@@ -1188,7 +1194,7 @@ fn validate_empty_table_declaration(
     }
 
     let TablePlacement::Sharded(shard_key) = declaration.placement() else {
-        shard::validate_authoritative_table_constraints(connection, declaration.name(), None)?;
+        shard::validate_declared_table_constraints(connection, declaration, declarations)?;
         return Ok(());
     };
     let mut statement = connection
@@ -1275,11 +1281,7 @@ fn validate_empty_table_declaration(
             ),
         ));
     }
-    shard::validate_authoritative_table_constraints(
-        connection,
-        declaration.name(),
-        Some(shard_key),
-    )?;
+    shard::validate_declared_table_constraints(connection, declaration, declarations)?;
     Ok(())
 }
 
@@ -3577,34 +3579,6 @@ mod tests {
 
         let temp = tempfile::tempdir().unwrap();
         let mut database = Database::open(temp.path(), 2).unwrap();
-        database
-            .broadcast(
-                "CREATE TABLE parents (tenant_id TEXT PRIMARY KEY NOT NULL);
-                 CREATE TABLE children (
-                     tenant_id TEXT PRIMARY KEY NOT NULL,
-                     FOREIGN KEY (tenant_id) REFERENCES parents (tenant_id)
-                 );",
-            )
-            .unwrap();
-        let logical_database = database.catalog().default_database().id();
-        let declarations = ["parents", "children"]
-            .into_iter()
-            .map(|table| {
-                TableDeclaration::sharded(
-                    logical_database,
-                    table,
-                    crate::core::ShardKeyMetadata::new("tenant_id", ShardKeyType::Text).unwrap(),
-                )
-                .unwrap()
-            })
-            .collect();
-        assert_eq!(
-            database.register_tables(declarations).unwrap_err().kind(),
-            EngineErrorKind::FailedPrecondition
-        );
-
-        let temp = tempfile::tempdir().unwrap();
-        let mut database = Database::open(temp.path(), 2).unwrap();
         create_registered_table_schema(&database);
         database
             .broadcast(
@@ -3620,6 +3594,295 @@ mod tests {
                 .kind(),
             EngineErrorKind::FailedPrecondition
         );
+    }
+
+    #[test]
+    fn registration_accepts_colocated_foreign_keys_and_sqlite_enforces_them_locally() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut database = Database::open(temp.path(), 2).unwrap();
+        database
+            .broadcast(
+                "CREATE TABLE countries (
+                     code TEXT PRIMARY KEY,
+                     label TEXT NOT NULL
+                 );
+                 CREATE TABLE regions (
+                     code TEXT PRIMARY KEY,
+                     country_code TEXT NOT NULL REFERENCES countries(code)
+                 );
+                 CREATE TABLE parents (
+                     tenant_id TEXT PRIMARY KEY NOT NULL
+                 );
+                 CREATE TABLE children (
+                     tenant_id TEXT PRIMARY KEY NOT NULL,
+                     country_code TEXT NOT NULL REFERENCES countries(code),
+                     FOREIGN KEY (tenant_id) REFERENCES parents
+                 );",
+            )
+            .unwrap();
+        let logical_database = database.catalog().default_database().id();
+        let text_key =
+            || crate::core::ShardKeyMetadata::new("tenant_id", ShardKeyType::Text).unwrap();
+        database
+            .register_tables(vec![
+                TableDeclaration::global(logical_database, "countries").unwrap(),
+                TableDeclaration::sharded(logical_database, "children", text_key()).unwrap(),
+                TableDeclaration::sharded(logical_database, "parents", text_key()).unwrap(),
+                TableDeclaration::global(logical_database, "regions").unwrap(),
+            ])
+            .unwrap();
+
+        let tenant = (0_u64..)
+            .map(|candidate| format!("tenant-{candidate}"))
+            .find(|candidate| database.shard_for_key(candidate.as_bytes()) == 0)
+            .unwrap();
+        for shard in 0..2 {
+            let physical = Connection::open(shard_file(temp.path(), shard)).unwrap();
+            physical.pragma_update(None, "foreign_keys", "ON").unwrap();
+            assert_eq!(
+                physical
+                    .pragma_query_value(None, "foreign_keys", |row| row.get::<_, i64>(0))
+                    .unwrap(),
+                1
+            );
+            physical
+                .execute("INSERT INTO countries VALUES ('US', 'United States')", [])
+                .unwrap();
+        }
+        Connection::open(shard_file(temp.path(), 1))
+            .unwrap()
+            .execute("INSERT INTO parents VALUES (?1)", [&tenant])
+            .unwrap();
+
+        let values = [
+            crate::core::Value::from(tenant.clone()),
+            crate::core::Value::from("US"),
+        ];
+        let error = database
+            .execute(
+                &tenant,
+                "INSERT INTO children (tenant_id, country_code) VALUES (?1, ?2)",
+                &values,
+            )
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::ForeignKeyViolation);
+        assert_eq!(
+            Connection::open(shard_file(temp.path(), 0))
+                .unwrap()
+                .query_row("SELECT COUNT(*) FROM children", [], |row| row
+                    .get::<_, i64>(0))
+                .unwrap(),
+            0
+        );
+
+        database
+            .execute(
+                &tenant,
+                "INSERT INTO parents (tenant_id) VALUES (?1)",
+                &[crate::core::Value::from(tenant.clone())],
+            )
+            .unwrap();
+        assert_eq!(
+            database
+                .execute(
+                    &tenant,
+                    "INSERT INTO children (tenant_id, country_code) VALUES (?1, ?2)",
+                    &values,
+                )
+                .unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn registration_rejects_colocated_foreign_keys_with_different_generated_id_routing_domains() {
+        for native_child in [false, true] {
+            let temp = tempfile::tempdir().unwrap();
+            let mut database = Database::open(temp.path(), 2).unwrap();
+            database
+                .broadcast(
+                    "CREATE TABLE parents (id INTEGER PRIMARY KEY);
+                     CREATE TABLE children (
+                         id INTEGER PRIMARY KEY REFERENCES parents(id)
+                     );",
+                )
+                .unwrap();
+
+            // A native ID owned by shard 0 need not hash to shard 0 under the
+            // legacy None policy. Equal SQLite values therefore prove
+            // co-location only when both tables use the same routing domain.
+            let owner = crate::core::generated_id::AllocationOwnerSlot::new(0).unwrap();
+            let divergent = (1_u64..10_000)
+                .map(|sequence| {
+                    crate::core::generated_id::NativeRangeV1Id::new(owner, sequence)
+                        .unwrap()
+                        .encode()
+                })
+                .find(|id| database.shard_for_key(id.to_string().as_bytes()) != 0)
+                .unwrap();
+            assert_ne!(database.shard_for_key(divergent.to_string().as_bytes()), 0);
+
+            let logical_database = database.catalog().default_database().id();
+            let int_key = || crate::core::ShardKeyMetadata::new("id", ShardKeyType::Int64).unwrap();
+            let mut child =
+                TableDeclaration::sharded(logical_database, "children", int_key()).unwrap();
+            let mut parent =
+                TableDeclaration::sharded(logical_database, "parents", int_key()).unwrap();
+            if native_child {
+                child = child
+                    .with_generated_id_policy(
+                        crate::core::GeneratedIdPolicy::native_range_v1("id").unwrap(),
+                    )
+                    .unwrap();
+            } else {
+                parent = parent
+                    .with_generated_id_policy(
+                        crate::core::GeneratedIdPolicy::native_range_v1("id").unwrap(),
+                    )
+                    .unwrap();
+            }
+
+            let error = database.register_tables(vec![child, parent]).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+            assert!(
+                error
+                    .diagnostic()
+                    .contains("different generated-ID routing domains"),
+                "{}",
+                error.diagnostic()
+            );
+            assert!(database.catalog().tables().is_empty());
+        }
+    }
+
+    #[test]
+    fn registration_rejects_foreign_keys_without_a_safe_placement_proof() {
+        #[derive(Clone, Copy)]
+        enum Placement<'a> {
+            Sharded(&'a str, ShardKeyType),
+            Global,
+            Catalog,
+        }
+
+        let scenarios = [
+            (
+                "CREATE TABLE parents (
+                     tenant_id TEXT NOT NULL,
+                     parent_id INTEGER NOT NULL,
+                     PRIMARY KEY (tenant_id, parent_id)
+                 );
+                 CREATE TABLE children (
+                     tenant_id TEXT PRIMARY KEY NOT NULL,
+                     parent_tenant TEXT NOT NULL,
+                     parent_id INTEGER NOT NULL,
+                     FOREIGN KEY (parent_tenant, parent_id)
+                         REFERENCES parents (tenant_id, parent_id)
+                 );",
+                vec![
+                    Placement::Sharded("tenant_id", ShardKeyType::Text),
+                    Placement::Sharded("tenant_id", ShardKeyType::Text),
+                ],
+                vec!["children", "parents"],
+                "does not map child shard key",
+            ),
+            (
+                "CREATE TABLE parents (id INTEGER PRIMARY KEY);
+                 CREATE TABLE children (
+                     tenant_id TEXT PRIMARY KEY NOT NULL,
+                     FOREIGN KEY (tenant_id) REFERENCES parents(id)
+                 );",
+                vec![
+                    Placement::Sharded("tenant_id", ShardKeyType::Text),
+                    Placement::Sharded("id", ShardKeyType::Int64),
+                ],
+                vec!["children", "parents"],
+                "different authoritative types",
+            ),
+            (
+                "CREATE TABLE parents (tenant_id TEXT PRIMARY KEY NOT NULL);
+                 CREATE TABLE children (
+                     id INTEGER PRIMARY KEY,
+                     tenant_id TEXT NOT NULL REFERENCES parents(tenant_id)
+                 );",
+                vec![
+                    Placement::Global,
+                    Placement::Sharded("tenant_id", ShardKeyType::Text),
+                ],
+                vec!["children", "parents"],
+                "Global child cannot reference a Sharded parent",
+            ),
+            (
+                "CREATE TABLE children (
+                     tenant_id TEXT PRIMARY KEY NOT NULL,
+                     FOREIGN KEY (tenant_id) REFERENCES missing_parent(tenant_id)
+                 );",
+                vec![Placement::Sharded("tenant_id", ShardKeyType::Text)],
+                vec!["children"],
+                "missing authoritative table",
+            ),
+            (
+                "CREATE TABLE children (
+                     tenant_id TEXT PRIMARY KEY NOT NULL,
+                     FOREIGN KEY (tenant_id) REFERENCES audit_catalog(id)
+                 );",
+                vec![
+                    Placement::Catalog,
+                    Placement::Sharded("tenant_id", ShardKeyType::Text),
+                ],
+                vec!["audit_catalog", "children"],
+                "catalog-only table",
+            ),
+            (
+                "CREATE TABLE parents (tenant_id TEXT PRIMARY KEY NOT NULL);
+                 CREATE TABLE children (
+                     tenant_id TEXT PRIMARY KEY NOT NULL,
+                     FOREIGN KEY (tenant_id) REFERENCES parents(tenant_id)
+                         ON UPDATE CASCADE
+                 );",
+                vec![
+                    Placement::Sharded("tenant_id", ShardKeyType::Text),
+                    Placement::Sharded("tenant_id", ShardKeyType::Text),
+                ],
+                vec!["children", "parents"],
+                "ON UPDATE CASCADE",
+            ),
+        ];
+
+        for (schema, placements, names, diagnostic) in scenarios {
+            let temp = tempfile::tempdir().unwrap();
+            let mut database = Database::open(temp.path(), 2).unwrap();
+            database.broadcast(schema).unwrap();
+            let logical_database = database.catalog().default_database().id();
+            let declarations = names
+                .into_iter()
+                .zip(placements)
+                .map(|(name, placement)| match placement {
+                    Placement::Sharded(column, key_type) => TableDeclaration::sharded(
+                        logical_database,
+                        name,
+                        crate::core::ShardKeyMetadata::new(column, key_type).unwrap(),
+                    )
+                    .unwrap(),
+                    Placement::Global => TableDeclaration::global(logical_database, name).unwrap(),
+                    Placement::Catalog => {
+                        TableDeclaration::catalog(logical_database, name).unwrap()
+                    }
+                })
+                .collect();
+
+            let error = database.register_tables(declarations).unwrap_err();
+            assert_eq!(
+                error.kind(),
+                EngineErrorKind::FailedPrecondition,
+                "{schema}"
+            );
+            assert!(
+                error.diagnostic().contains(diagnostic),
+                "{schema}: {}",
+                error.diagnostic()
+            );
+            assert!(database.catalog().tables().is_empty());
+        }
     }
 
     #[test]

--- a/src/storage/shard.rs
+++ b/src/storage/shard.rs
@@ -1,7 +1,7 @@
 //! Physical-shard identity, provisioning, and strict reopen validation.
 
 use std::{
-    collections::{BTreeSet, HashSet},
+    collections::{BTreeMap, BTreeSet, HashSet},
     fs,
     path::{Path, PathBuf},
 };
@@ -12,7 +12,10 @@ use rusqlite::{
 };
 
 use crate::{
-    core::{Catalog, EngineError, EngineErrorKind, EngineResult, ShardKeyType, TablePlacement},
+    core::{
+        Catalog, EngineError, EngineErrorKind, EngineResult, GeneratedIdPolicy, ShardKeyType,
+        TableDeclaration, TablePlacement,
+    },
     sqlite_error,
 };
 
@@ -682,10 +685,10 @@ fn preflight_schema_migration_on_connection_with_digest_inner(
     let reserved_before = reserved_schema_snapshot(&transaction)?;
     execute_schema_migration_batch(&transaction, sql)?;
     ensure_reserved_schema_unchanged(&reserved_before, &transaction)?;
-    ensure_no_foreign_key_violations(&transaction)?;
     if let Some(catalog) = catalog {
         validate_registered_table_schema(&transaction, catalog)?;
     }
+    ensure_no_foreign_key_violations(&transaction)?;
     let target_digest = calculate_schema_digest(&transaction, target_generation)?;
     transaction.rollback().map_err(sqlite_error::storage)?;
 
@@ -811,7 +814,26 @@ pub(super) fn validate_registered_table_schema(
             continue;
         }
         let TablePlacement::Sharded(shard_key) = table.placement() else {
-            validate_authoritative_table_constraints(connection, table.name(), None)?;
+            validate_authoritative_table_constraints(
+                connection,
+                table.name(),
+                AuthoritativeTableConstraints::new(table.placement(), table.generated_id_policy()),
+                |parent| {
+                    catalog
+                        .tables()
+                        .iter()
+                        .find(|candidate| {
+                            candidate.database_id() == table.database_id()
+                                && candidate.name().eq_ignore_ascii_case(parent)
+                        })
+                        .map(|candidate| {
+                            AuthoritativeTableConstraints::new(
+                                candidate.placement(),
+                                candidate.generated_id_policy(),
+                            )
+                        })
+                },
+            )?;
             continue;
         };
         let mut statement = connection
@@ -875,39 +897,497 @@ pub(super) fn validate_registered_table_schema(
                 "must retain SQLite BINARY collation",
             ));
         }
-        validate_authoritative_table_constraints(connection, table.name(), Some(shard_key))?;
+        validate_authoritative_table_constraints(
+            connection,
+            table.name(),
+            AuthoritativeTableConstraints::new(table.placement(), table.generated_id_policy()),
+            |parent| {
+                catalog
+                    .tables()
+                    .iter()
+                    .find(|candidate| {
+                        candidate.database_id() == table.database_id()
+                            && candidate.name().eq_ignore_ascii_case(parent)
+                    })
+                    .map(|candidate| {
+                        AuthoritativeTableConstraints::new(
+                            candidate.placement(),
+                            candidate.generated_id_policy(),
+                        )
+                    })
+            },
+        )?;
     }
     Ok(())
 }
 
+/// Validate one registration candidate against the complete authoritative
+/// declaration set. Foreign-key safety depends on both sides' placements, so
+/// validating declarations independently would admit unresolved relationships.
+pub(super) fn validate_declared_table_constraints(
+    connection: &Connection,
+    declaration: &TableDeclaration,
+    declarations: &[TableDeclaration],
+) -> EngineResult<()> {
+    validate_authoritative_table_constraints(
+        connection,
+        declaration.name(),
+        AuthoritativeTableConstraints::new(
+            declaration.placement(),
+            declaration.generated_id_policy(),
+        ),
+        |parent| {
+            declarations
+                .iter()
+                .find(|candidate| {
+                    candidate.database_id() == declaration.database_id()
+                        && candidate.name().eq_ignore_ascii_case(parent)
+                })
+                .map(|candidate| {
+                    AuthoritativeTableConstraints::new(
+                        candidate.placement(),
+                        candidate.generated_id_policy(),
+                    )
+                })
+        },
+    )
+}
+
+#[derive(Debug, Clone, Copy)]
+struct AuthoritativeTableConstraints<'a> {
+    placement: &'a TablePlacement,
+    generated_id_policy: &'a GeneratedIdPolicy,
+}
+
+impl<'a> AuthoritativeTableConstraints<'a> {
+    const fn new(
+        placement: &'a TablePlacement,
+        generated_id_policy: &'a GeneratedIdPolicy,
+    ) -> Self {
+        Self {
+            placement,
+            generated_id_policy,
+        }
+    }
+}
+
 /// Enforce constraints that SQLite can only check inside one physical file.
-/// Foreign keys need an explicit co-location policy that is not implemented
-/// yet. Every unique key of a Sharded table must contain its routing key using
+/// Every unique key of a Sharded table must contain its routing key using
 /// BINARY collation so two different owners cannot both accept the same value.
-pub(super) fn validate_authoritative_table_constraints(
+/// Foreign keys are accepted only when authoritative placements prove that the
+/// referenced parent row is present in the same physical file.
+fn validate_authoritative_table_constraints<'a, T>(
     connection: &Connection,
     table: &str,
-    shard_key: Option<&crate::core::ShardKeyMetadata>,
-) -> EngineResult<()> {
-    let has_foreign_key = connection
-        .query_row(
-            "SELECT EXISTS(SELECT 1 FROM pragma_foreign_key_list(?1))",
-            [table],
-            |row| row.get::<_, bool>(0),
+    authoritative: AuthoritativeTableConstraints<'_>,
+    authoritative_table: T,
+) -> EngineResult<()>
+where
+    T: Fn(&str) -> Option<AuthoritativeTableConstraints<'a>>,
+{
+    require_foreign_keys_enabled(connection)?;
+    validate_authoritative_foreign_keys(connection, table, authoritative, authoritative_table)?;
+
+    let TablePlacement::Sharded(shard_key) = authoritative.placement else {
+        return Ok(());
+    };
+    validate_authoritative_unique_constraints(connection, table, shard_key)
+}
+
+fn require_foreign_keys_enabled(connection: &Connection) -> EngineResult<()> {
+    let enabled = connection
+        .pragma_query_value(None, "foreign_keys", |row| row.get::<_, i64>(0))
+        .map_err(sqlite_error::storage)?;
+    if enabled != 1 {
+        return Err(EngineError::new(
+            EngineErrorKind::Internal,
+            "SQLite foreign-key enforcement is not enabled on a validated shard connection",
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+struct ForeignKeyBuilder {
+    parent_table: String,
+    on_update: String,
+    on_delete: String,
+    match_name: String,
+    terms: Vec<ForeignKeyTerm>,
+}
+
+#[derive(Debug)]
+struct ForeignKeyTerm {
+    sequence: i64,
+    child_column: String,
+    parent_column: Option<String>,
+}
+
+fn validate_authoritative_foreign_keys<'a, T>(
+    connection: &Connection,
+    child_table: &str,
+    child: AuthoritativeTableConstraints<'_>,
+    authoritative_table: T,
+) -> EngineResult<()>
+where
+    T: Fn(&str) -> Option<AuthoritativeTableConstraints<'a>>,
+{
+    let mut statement = connection
+        .prepare(
+            "SELECT id, seq, \"table\", \"from\", \"to\", on_update, on_delete, \"match\"
+             FROM pragma_foreign_key_list(?1)
+             ORDER BY id, seq",
         )
         .map_err(sqlite_error::storage)?;
-    if has_foreign_key {
+    let rows = statement
+        .query_map([child_table], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, Option<String>>(4)?,
+                row.get::<_, String>(5)?,
+                row.get::<_, String>(6)?,
+                row.get::<_, String>(7)?,
+            ))
+        })
+        .map_err(sqlite_error::storage)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(sqlite_error::storage)?;
+
+    let mut foreign_keys = BTreeMap::<i64, ForeignKeyBuilder>::new();
+    for (
+        id,
+        sequence,
+        parent_table,
+        child_column,
+        parent_column,
+        on_update,
+        on_delete,
+        match_name,
+    ) in rows
+    {
+        let foreign_key = foreign_keys.entry(id).or_insert_with(|| ForeignKeyBuilder {
+            parent_table: parent_table.clone(),
+            on_update: on_update.clone(),
+            on_delete: on_delete.clone(),
+            match_name: match_name.clone(),
+            terms: Vec::new(),
+        });
+        if !foreign_key.parent_table.eq_ignore_ascii_case(&parent_table)
+            || !foreign_key.on_update.eq_ignore_ascii_case(&on_update)
+            || !foreign_key.on_delete.eq_ignore_ascii_case(&on_delete)
+            || !foreign_key.match_name.eq_ignore_ascii_case(&match_name)
+        {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!("foreign-key metadata for table {child_table} is inconsistent"),
+            ));
+        }
+        foreign_key.terms.push(ForeignKeyTerm {
+            sequence,
+            child_column,
+            parent_column,
+        });
+    }
+
+    let has_foreign_keys = !foreign_keys.is_empty();
+    for (id, mut foreign_key) in foreign_keys {
+        if !foreign_key.match_name.eq_ignore_ascii_case("NONE") {
+            return Err(foreign_key_precondition(
+                child_table,
+                id,
+                format!("uses unsupported MATCH mode {}", foreign_key.match_name),
+            ));
+        }
+        foreign_key.terms.sort_by_key(|term| term.sequence);
+        if foreign_key
+            .terms
+            .iter()
+            .enumerate()
+            .any(|(expected, term)| term.sequence != expected as i64)
+        {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!("foreign-key metadata for table {child_table} has invalid term order"),
+            ));
+        }
+
+        let Some(parent) = authoritative_table(&foreign_key.parent_table) else {
+            return Err(foreign_key_precondition(
+                child_table,
+                id,
+                format!(
+                    "references missing authoritative table {}",
+                    foreign_key.parent_table
+                ),
+            ));
+        };
+        if matches!(parent.placement, TablePlacement::Catalog) {
+            return Err(foreign_key_precondition(
+                child_table,
+                id,
+                format!("references catalog-only table {}", foreign_key.parent_table),
+            ));
+        }
+
+        resolve_implicit_parent_columns(
+            connection,
+            child_table,
+            &foreign_key.parent_table,
+            &mut foreign_key.terms,
+        )?;
+        validate_foreign_key_placement(child_table, id, child, parent, &foreign_key)?;
+    }
+    if has_foreign_keys {
+        validate_sqlite_foreign_key_schema(connection, child_table)?;
+    }
+    Ok(())
+}
+
+/// Ask SQLite to compile, but not execute, DML against a foreign-key child.
+/// SQLite resolves every referenced parent key while building this program, so
+/// malformed parent columns, missing UNIQUE keys, and incompatible parent-index
+/// collations fail here instead of surfacing later as generic `SQLITE_ERROR`.
+fn validate_sqlite_foreign_key_schema(
+    connection: &Connection,
+    child_table: &str,
+) -> EngineResult<()> {
+    let quoted_table = format!("\"{}\"", child_table.replace('"', "\"\""));
+    let sql = format!("EXPLAIN DELETE FROM {quoted_table} WHERE 0");
+    match connection.prepare(&sql) {
+        Ok(_) => Ok(()),
+        Err(error) => {
+            let classified = sqlite_error::storage(error);
+            if matches!(
+                classified.kind(),
+                EngineErrorKind::Busy
+                    | EngineErrorKind::Cancelled
+                    | EngineErrorKind::PermissionDenied
+                    | EngineErrorKind::ReadOnly
+                    | EngineErrorKind::StorageFull
+                    | EngineErrorKind::OutOfMemory
+                    | EngineErrorKind::StorageUnavailable
+                    | EngineErrorKind::DataCorruption
+            ) {
+                return Err(classified.context(format!(
+                    "failed to validate foreign-key schema involving table {child_table}"
+                )));
+            }
+            Err(EngineError::from_source(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "foreign-key schema involving table {child_table} cannot be enforced by SQLite"
+                ),
+                classified,
+            ))
+        }
+    }
+}
+
+fn resolve_implicit_parent_columns(
+    connection: &Connection,
+    child_table: &str,
+    parent_table: &str,
+    terms: &mut [ForeignKeyTerm],
+) -> EngineResult<()> {
+    if terms.iter().all(|term| term.parent_column.is_some()) {
+        return Ok(());
+    }
+    if terms.iter().any(|term| term.parent_column.is_some()) {
         return Err(EngineError::new(
-            EngineErrorKind::FailedPrecondition,
+            EngineErrorKind::DataCorruption,
             format!(
-                "table {table} declares a foreign key, but authoritative foreign-key co-location is not supported"
+                "foreign key from {child_table} to {parent_table} mixes explicit and implicit parent columns"
             ),
         ));
     }
 
-    let Some(shard_key) = shard_key else {
-        return Ok(());
-    };
+    let mut statement = connection
+        .prepare("SELECT name FROM pragma_table_xinfo(?1) WHERE pk <> 0 ORDER BY pk")
+        .map_err(sqlite_error::storage)?;
+    let parent_key = statement
+        .query_map([parent_table], |row| row.get::<_, String>(0))
+        .map_err(sqlite_error::storage)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(sqlite_error::storage)?;
+    if parent_key.is_empty() || parent_key.len() != terms.len() {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!(
+                "foreign key from {child_table} to {parent_table} omits referenced columns, but the parent has no matching resolvable primary key"
+            ),
+        ));
+    }
+    for (term, parent_column) in terms.iter_mut().zip(parent_key) {
+        term.parent_column = Some(parent_column);
+    }
+    Ok(())
+}
+
+fn validate_foreign_key_placement(
+    child_table: &str,
+    id: i64,
+    child: AuthoritativeTableConstraints<'_>,
+    parent: AuthoritativeTableConstraints<'_>,
+    foreign_key: &ForeignKeyBuilder,
+) -> EngineResult<()> {
+    #[allow(unreachable_patterns)]
+    match (child.placement, parent.placement) {
+        (TablePlacement::Sharded(child_key), TablePlacement::Sharded(parent_key)) => {
+            if child_key.key_type() != parent_key.key_type() {
+                return Err(foreign_key_precondition(
+                    child_table,
+                    id,
+                    "maps shard keys with different authoritative types",
+                ));
+            }
+            if !generated_id_routing_domains_match(
+                child.generated_id_policy,
+                parent.generated_id_policy,
+            ) {
+                return Err(foreign_key_precondition(
+                    child_table,
+                    id,
+                    "maps shard keys with different generated-ID routing domains",
+                ));
+            }
+            let mapped_terms = foreign_key
+                .terms
+                .iter()
+                .filter(|term| term.child_column.eq_ignore_ascii_case(child_key.column()))
+                .collect::<Vec<_>>();
+            let parent_key_terms = foreign_key
+                .terms
+                .iter()
+                .filter(|term| {
+                    term.parent_column
+                        .as_deref()
+                        .is_some_and(|column| column.eq_ignore_ascii_case(parent_key.column()))
+                })
+                .count();
+            if mapped_terms.len() != 1
+                || parent_key_terms != 1
+                || !mapped_terms[0]
+                    .parent_column
+                    .as_deref()
+                    .is_some_and(|column| column.eq_ignore_ascii_case(parent_key.column()))
+            {
+                return Err(foreign_key_precondition(
+                    child_table,
+                    id,
+                    format!(
+                        "does not map child shard key {} exactly once to parent shard key {}",
+                        child_key.column(),
+                        parent_key.column()
+                    ),
+                ));
+            }
+            validate_shard_key_foreign_key_actions(child_table, id, child_key.column(), foreign_key)
+        }
+        (TablePlacement::Sharded(child_key), TablePlacement::Global) => {
+            if foreign_key
+                .terms
+                .iter()
+                .any(|term| term.child_column.eq_ignore_ascii_case(child_key.column()))
+            {
+                validate_shard_key_foreign_key_actions(
+                    child_table,
+                    id,
+                    child_key.column(),
+                    foreign_key,
+                )?;
+            }
+            Ok(())
+        }
+        (TablePlacement::Global, TablePlacement::Global) => Ok(()),
+        (TablePlacement::Global, TablePlacement::Sharded(_)) => Err(foreign_key_precondition(
+            child_table,
+            id,
+            "a Global child cannot reference a Sharded parent",
+        )),
+        (TablePlacement::Catalog, _) => Err(foreign_key_precondition(
+            child_table,
+            id,
+            "a Catalog child cannot have a physical foreign key",
+        )),
+        (_, TablePlacement::Catalog) => Err(foreign_key_precondition(
+            child_table,
+            id,
+            "a physical child cannot reference a Catalog parent",
+        )),
+        (_, _) => Err(foreign_key_precondition(
+            child_table,
+            id,
+            "uses an unsupported authoritative placement relationship",
+        )),
+    }
+}
+
+fn generated_id_routing_domains_match(
+    child: &GeneratedIdPolicy,
+    parent: &GeneratedIdPolicy,
+) -> bool {
+    matches!(
+        (child, parent),
+        (GeneratedIdPolicy::None, GeneratedIdPolicy::None)
+            | (
+                GeneratedIdPolicy::NativeRangeV1 { .. },
+                GeneratedIdPolicy::NativeRangeV1 { .. }
+            )
+    )
+}
+
+fn validate_shard_key_foreign_key_actions(
+    child_table: &str,
+    id: i64,
+    shard_key: &str,
+    foreign_key: &ForeignKeyBuilder,
+) -> EngineResult<()> {
+    if !foreign_key.on_update.eq_ignore_ascii_case("NO ACTION")
+        && !foreign_key.on_update.eq_ignore_ascii_case("RESTRICT")
+    {
+        return Err(foreign_key_precondition(
+            child_table,
+            id,
+            format!(
+                "uses ON UPDATE {} on shard key {shard_key}",
+                foreign_key.on_update
+            ),
+        ));
+    }
+    if foreign_key.on_delete.eq_ignore_ascii_case("SET NULL")
+        || foreign_key.on_delete.eq_ignore_ascii_case("SET DEFAULT")
+    {
+        return Err(foreign_key_precondition(
+            child_table,
+            id,
+            format!(
+                "uses ON DELETE {} on shard key {shard_key}",
+                foreign_key.on_delete
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn foreign_key_precondition(
+    child_table: &str,
+    id: i64,
+    detail: impl std::fmt::Display,
+) -> EngineError {
+    EngineError::new(
+        EngineErrorKind::FailedPrecondition,
+        format!("foreign key {id} on table {child_table} {detail}"),
+    )
+}
+
+fn validate_authoritative_unique_constraints(
+    connection: &Connection,
+    table: &str,
+    shard_key: &crate::core::ShardKeyMetadata,
+) -> EngineResult<()> {
     let mut statement = connection
         .prepare(
             "SELECT name, origin
@@ -2488,7 +2968,10 @@ fn denies_schema_migration_action(context: AuthContext<'_>) -> bool {
         AuthAction::Pragma {
             pragma_name,
             pragma_value,
-        } => pragma_value.is_some() || matches_persistent_pragma(pragma_name),
+        } => {
+            (pragma_value.is_some() && !pragma_name.eq_ignore_ascii_case("quick_check"))
+                || matches_persistent_pragma(pragma_name)
+        }
         AuthAction::Insert { table_name } | AuthAction::Delete { table_name } => {
             is_reserved_name(table_name)
         }
@@ -3027,13 +3510,15 @@ mod tests {
         let connection = Connection::open(&path).unwrap();
         connection
             .execute_batch(
-                "CREATE TABLE accounts (
-                     id INTEGER PRIMARY KEY,
+                "CREATE TABLE countries (
+                     code TEXT NOT NULL,
                      display_name TEXT NOT NULL
                  ) STRICT;
-                 CREATE TABLE countries (
-                     code TEXT PRIMARY KEY,
-                     display_name TEXT NOT NULL
+                 CREATE UNIQUE INDEX countries_code_unique ON countries(code);
+                 CREATE TABLE accounts (
+                     id INTEGER PRIMARY KEY,
+                     display_name TEXT NOT NULL,
+                     country_code TEXT REFERENCES countries(code)
                  ) STRICT;",
             )
             .unwrap();
@@ -3049,6 +3534,29 @@ mod tests {
         .unwrap();
         assert_eq!(state, SchemaMigrationShardState::Source);
         assert!(!schema_object_exists(&path, "accounts_display_name_idx"));
+
+        let (state, _) = preflight_with_catalog(
+            &path,
+            &ready,
+            "ALTER TABLE accounts ADD COLUMN billing_country TEXT REFERENCES countries(code)",
+            &catalog,
+        )
+        .unwrap();
+        assert_eq!(state, SchemaMigrationShardState::Source);
+        let connection = Connection::open(&path).unwrap();
+        assert!(
+            !connection
+                .query_row(
+                    "SELECT EXISTS(
+                         SELECT 1 FROM pragma_table_xinfo('accounts')
+                         WHERE name = 'billing_country'
+                     )",
+                    [],
+                    |row| row.get::<_, bool>(0),
+                )
+                .unwrap()
+        );
+        drop(connection);
 
         for (sql, transient_object) in [
             (
@@ -3106,6 +3614,7 @@ mod tests {
                 "CREATE UNIQUE INDEX accounts_display_unique ON accounts (display_name)",
                 Some("accounts_display_unique"),
             ),
+            ("DROP INDEX countries_code_unique", None),
             (
                 "CREATE TRIGGER accounts_move AFTER INSERT ON accounts
                  BEGIN DELETE FROM accounts WHERE id = NEW.id; END",
@@ -3129,6 +3638,7 @@ mod tests {
             }
             assert_eq!(identity(&path), (SHARD_APPLICATION_ID, 0), "{sql}");
         }
+        assert!(schema_object_exists(&path, "countries_code_unique"));
 
         let empty = empty_catalog();
         let (state, _) = preflight_with_catalog(
@@ -3140,6 +3650,100 @@ mod tests {
         .unwrap();
         assert_eq!(state, SchemaMigrationShardState::Source);
         assert!(!schema_object_exists(&path, "legacy_unregistered"));
+    }
+
+    #[test]
+    fn catalog_aware_schema_validation_accepts_only_colocated_foreign_keys() {
+        let catalog = catalog_with_registered_tables();
+        let safe = Connection::open_in_memory().unwrap();
+        safe.pragma_update(None, "foreign_keys", "ON").unwrap();
+        safe.execute_batch(
+            "CREATE TABLE countries (
+                 code TEXT PRIMARY KEY,
+                 display_name TEXT NOT NULL
+             ) STRICT;
+             CREATE TABLE accounts (
+                 id INTEGER PRIMARY KEY,
+                 display_name TEXT NOT NULL,
+                 country_code TEXT REFERENCES countries
+             ) STRICT;",
+        )
+        .unwrap();
+        validate_registered_table_schema(&safe, &catalog).unwrap();
+
+        let unsafe_catalog_parent = Connection::open_in_memory().unwrap();
+        unsafe_catalog_parent
+            .pragma_update(None, "foreign_keys", "ON")
+            .unwrap();
+        unsafe_catalog_parent
+            .execute_batch(
+                "CREATE TABLE countries (
+                     code TEXT PRIMARY KEY,
+                     display_name TEXT NOT NULL
+                 ) STRICT;
+                 CREATE TABLE accounts (
+                     id INTEGER PRIMARY KEY,
+                     display_name TEXT NOT NULL,
+                     catalog_id INTEGER REFERENCES audit_catalog(id)
+                 ) STRICT;",
+            )
+            .unwrap();
+        let error = validate_registered_table_schema(&unsafe_catalog_parent, &catalog).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert!(error.diagnostic().contains("catalog-only table"));
+    }
+
+    #[test]
+    fn declared_foreign_keys_must_have_a_sqlite_enforceable_parent_key() {
+        for schema in [
+            "CREATE TABLE countries (code TEXT NOT NULL);
+             CREATE TABLE children (
+                 tenant_id TEXT PRIMARY KEY NOT NULL,
+                 country_code TEXT REFERENCES countries(code)
+             );",
+            "CREATE TABLE countries (code TEXT PRIMARY KEY);
+             CREATE TABLE children (
+                 tenant_id TEXT PRIMARY KEY NOT NULL,
+                 country_code TEXT REFERENCES countries(missing_code)
+             );",
+            "CREATE TABLE countries (code TEXT COLLATE NOCASE NOT NULL);
+             CREATE UNIQUE INDEX countries_code_unique
+                 ON countries(code COLLATE BINARY);
+             CREATE TABLE children (
+                 tenant_id TEXT PRIMARY KEY NOT NULL,
+                 country_code TEXT REFERENCES countries(code)
+             );",
+        ] {
+            let connection = Connection::open_in_memory().unwrap();
+            connection
+                .pragma_update(None, "foreign_keys", "ON")
+                .unwrap();
+            connection.execute_batch(schema).unwrap();
+            let database = crate::core::LogicalDatabaseId::new(1).unwrap();
+            let child = TableDeclaration::sharded(
+                database,
+                "children",
+                ShardKeyMetadata::new("tenant_id", ShardKeyType::Text).unwrap(),
+            )
+            .unwrap();
+            let declarations = [
+                child.clone(),
+                TableDeclaration::global(database, "countries").unwrap(),
+            ];
+
+            let error = validate_declared_table_constraints(&connection, &child, &declarations)
+                .unwrap_err();
+            assert_eq!(
+                error.kind(),
+                EngineErrorKind::FailedPrecondition,
+                "{schema}"
+            );
+            assert!(
+                error.diagnostic().contains("cannot be enforced by SQLite"),
+                "{schema}: {}",
+                error.diagnostic()
+            );
+        }
     }
 
     #[test]
@@ -3161,7 +3765,7 @@ mod tests {
         let shard_key =
             ShardKeyMetadata::from_validated("tenant_id".to_owned(), ShardKeyType::Text);
 
-        validate_authoritative_table_constraints(&connection, "records", Some(&shard_key)).unwrap();
+        validate_authoritative_unique_constraints(&connection, "records", &shard_key).unwrap();
     }
 
     #[test]
@@ -4227,6 +4831,13 @@ mod tests {
             },
             None,
         )));
+        assert!(!denies_schema_migration_action(context(
+            AuthAction::Pragma {
+                pragma_name: "quick_check",
+                pragma_value: Some("widgets"),
+            },
+            Some("main"),
+        )));
         assert!(denies_schema_migration_action(context(
             AuthAction::Transaction {
                 operation: TransactionOperation::Begin,
@@ -4271,5 +4882,42 @@ mod tests {
             },
             None,
         )));
+    }
+
+    #[test]
+    fn migration_authorizer_allows_sqlites_strict_table_quick_check_for_a_new_foreign_key() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        connection
+            .pragma_update(None, "foreign_keys", "ON")
+            .unwrap();
+        connection.execute_batch(SHARD_METADATA_TABLE_SQL).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE parents (id INTEGER PRIMARY KEY) STRICT;
+                 CREATE TABLE children (id INTEGER PRIMARY KEY) STRICT;",
+            )
+            .unwrap();
+
+        let transaction = connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .unwrap();
+        execute_schema_migration_batch(
+            &transaction,
+            "ALTER TABLE children ADD COLUMN parent_id INTEGER REFERENCES parents(id)",
+        )
+        .unwrap();
+        transaction.rollback().unwrap();
+        assert!(
+            !connection
+                .query_row(
+                    "SELECT EXISTS(
+                         SELECT 1 FROM pragma_table_xinfo('children')
+                         WHERE name = 'parent_id'
+                     )",
+                    [],
+                    |row| row.get::<_, bool>(0),
+                )
+                .unwrap()
+        );
     }
 }

--- a/src/storage/sharded_vtab.rs
+++ b/src/storage/sharded_vtab.rs
@@ -5,7 +5,7 @@
 //! changing any physical shard schema.
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     ffi::c_int,
     sync::{
         Arc, Mutex,
@@ -21,8 +21,9 @@ use rusqlite::{
     hooks::{AuthAction, AuthContext, Authorization},
     types::{ToSql, ToSqlOutput, ValueRef},
     vtab::{
-        Context, CreateVTab, Filters, IndexConstraintOp, IndexInfo, VTab, VTabConfig,
-        VTabConnection, VTabCursor, VTabKind, read_only_module,
+        ConflictMode, Context, CreateVTab, Filters, IndexConstraintOp, IndexInfo, Inserts,
+        TransactionVTab, UpdateVTab, Updates, VTab, VTabConfig, VTabConnection, VTabCursor,
+        VTabKind, read_only_module,
     },
 };
 
@@ -44,6 +45,14 @@ const ROW_ACCOUNTING_BYTES: usize = size_of::<Vec<RawCell>>() * 4 + ALLOCATION_O
 const VALUE_ACCOUNTING_BYTES: usize = size_of::<RawCell>();
 const SCAN_PLAN: c_int = 0;
 const SHARD_KEY_EQUALITY_PLAN: c_int = 1;
+const LOCATOR_COLUMN_NAME: &str = "__briskdb_locator";
+
+mod locator;
+mod module_v2;
+mod write;
+
+#[allow(unused_imports)]
+pub(crate) use write::{CoordinatorWriteResult, WriteCoordinator};
 
 /// A separate SQLite coordinator whose logical tables are backed by BriskDB
 /// shard files. The coordinator never attaches those files to its own schema.
@@ -116,6 +125,7 @@ impl ReadCoordinator {
             epoch: Arc::clone(&registry.cancellation_epoch),
             active_child_scans: Arc::clone(&registry.active_child_scans),
             interrupt: Arc::new(connection.get_interrupt_handle()),
+            write_state: registry.write_state.clone(),
         };
         Ok(Self {
             connection,
@@ -181,15 +191,29 @@ pub(crate) struct CoordinatorCancellation {
     epoch: Arc<AtomicU64>,
     active_child_scans: Arc<Mutex<usize>>,
     interrupt: Arc<InterruptHandle>,
+    write_state: Option<Arc<write::WriteState>>,
 }
 
 impl CoordinatorCancellation {
     pub(crate) fn cancel(&self) {
+        // Child COMMIT is the durability linearization point: cancellation
+        // either wins this mutex before COMMIT and forces rollback through the
+        // epoch check, or waits until a completed COMMIT has won. Interrupting
+        // an in-flight durable commit could only turn a known result into an
+        // ambiguous one, so that narrow finalization window is deliberately
+        // non-cancellable.
+        let _commit = self
+            .write_state
+            .as_ref()
+            .map(|state| state.lock_commit_linearization());
         let _active_child_scans = self
             .active_child_scans
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         self.epoch.fetch_add(1, Ordering::AcqRel);
+        if let Some(write_state) = &self.write_state {
+            write_state.interrupt_child();
+        }
         self.interrupt.interrupt();
     }
 }
@@ -280,6 +304,63 @@ fn attach_coordinator_authorizer(connection: &Connection) -> EngineResult<()> {
         .map_err(sqlite_error::storage)
 }
 
+fn attach_writable_coordinator_authorizer(
+    connection: &Connection,
+    registry: &Registry,
+    allow_transaction_control: Arc<std::sync::atomic::AtomicBool>,
+) -> EngineResult<()> {
+    let registered_tables = registry
+        .tables
+        .values()
+        .map(|table| table.name.clone())
+        .collect::<BTreeSet<_>>();
+    connection
+        .authorizer(Some(move |context: AuthContext<'_>| {
+            if context
+                .database_name
+                .is_some_and(|database| !database.eq_ignore_ascii_case("main"))
+                || context.accessor.is_some()
+            {
+                return Authorization::Deny;
+            }
+            match context.action {
+                AuthAction::Select | AuthAction::Recursive => Authorization::Allow,
+                AuthAction::Read { table_name, .. } => {
+                    if registered_tables.contains(table_name) {
+                        Authorization::Allow
+                    } else {
+                        Authorization::Deny
+                    }
+                }
+                AuthAction::Insert { table_name }
+                | AuthAction::Delete { table_name }
+                | AuthAction::Update { table_name, .. } => {
+                    if registered_tables.contains(table_name) {
+                        Authorization::Allow
+                    } else {
+                        Authorization::Deny
+                    }
+                }
+                AuthAction::Function { function_name }
+                    if !function_name.eq_ignore_ascii_case("load_extension") =>
+                {
+                    Authorization::Allow
+                }
+                AuthAction::Transaction { .. } | AuthAction::Savepoint { .. }
+                    if allow_transaction_control.load(Ordering::Acquire) =>
+                {
+                    Authorization::Allow
+                }
+                AuthAction::Pragma {
+                    pragma_name,
+                    pragma_value: None,
+                } if pragma_name.eq_ignore_ascii_case("database_list") => Authorization::Allow,
+                _ => Authorization::Deny,
+            }
+        }))
+        .map_err(sqlite_error::storage)
+}
+
 fn register_module(connection: &Connection, registry: Arc<Registry>) -> SqliteResult<()> {
     connection.create_module(
         c"brisk_shard",
@@ -292,6 +373,8 @@ struct Registry {
     storage: Storage,
     schema_generation: u64,
     tables: BTreeMap<u64, Arc<TableSpec>>,
+    mode: CoordinatorMode,
+    write_state: Option<Arc<write::WriteState>>,
     limits: CursorLimits,
     cancellation_epoch: Arc<AtomicU64>,
     active_child_scans: Arc<Mutex<usize>>,
@@ -302,6 +385,12 @@ struct Registry {
     child_scan_gate: Mutex<Option<TestChildScanGate>>,
     #[cfg(test)]
     child_scan_complete_gate: Mutex<Option<TestChildScanGate>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CoordinatorMode {
+    ReadOnly,
+    Writable,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -321,12 +410,28 @@ impl Default for CursorLimits {
 
 impl Registry {
     fn build_admitted(storage: Storage) -> EngineResult<Arc<Self>> {
-        Self::build_admitted_with_limits(storage, CursorLimits::default())
+        Self::build_admitted_with_limits_and_mode(
+            storage,
+            CursorLimits::default(),
+            CoordinatorMode::ReadOnly,
+        )
     }
 
     fn build_admitted_with_limits(
         storage: Storage,
         limits: CursorLimits,
+    ) -> EngineResult<Arc<Self>> {
+        Self::build_admitted_with_limits_and_mode(storage, limits, CoordinatorMode::ReadOnly)
+    }
+
+    fn build_writable(storage: Storage, limits: CursorLimits) -> EngineResult<Arc<Self>> {
+        Self::build_admitted_with_limits_and_mode(storage, limits, CoordinatorMode::Writable)
+    }
+
+    fn build_admitted_with_limits_and_mode(
+        storage: Storage,
+        limits: CursorLimits,
+        mode: CoordinatorMode,
     ) -> EngineResult<Arc<Self>> {
         if limits.rows == 0 || limits.bytes == 0 {
             return Err(EngineError::new(
@@ -369,10 +474,14 @@ impl Registry {
             tables.insert(table.id().get(), Arc::new(spec));
         }
 
+        let write_state =
+            matches!(mode, CoordinatorMode::Writable).then(|| Arc::new(write::WriteState::new()));
         Ok(Arc::new(Self {
             storage,
             schema_generation,
             tables,
+            mode,
+            write_state,
             limits,
             cancellation_epoch: Arc::new(AtomicU64::new(0)),
             active_child_scans: Arc::new(Mutex::new(0)),
@@ -388,6 +497,12 @@ impl Registry {
 
     fn table(&self, id: u64) -> Option<Arc<TableSpec>> {
         self.tables.get(&id).cloned()
+    }
+
+    fn write_state(&self) -> &Arc<write::WriteState> {
+        self.write_state
+            .as_ref()
+            .expect("writable coordinator registry has shared write state")
     }
 
     fn equality_scan(
@@ -477,6 +592,100 @@ impl Registry {
         Ok(target.map_or(EqualityTargets::All, EqualityTargets::One))
     }
 
+    fn write_target(&self, spec: &TableSpec, value: ValueRef<'_>) -> EngineResult<u16> {
+        let shard_key = spec.shard_key.as_ref().ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::Unsupported,
+                format!("registered table {} has no writable shard key", spec.name),
+            )
+        })?;
+        #[allow(unreachable_patterns)]
+        let target = match (shard_key.key_type, value) {
+            (_, ValueRef::Null) => {
+                return Err(EngineError::new(
+                    EngineErrorKind::NotNullViolation,
+                    format!("registered table {} shard key cannot be NULL", spec.name),
+                ));
+            }
+            (ShardKeyType::Int64, ValueRef::Integer(value)) => {
+                match classify_generated_id(&spec.generated_id_policy, value)? {
+                    GeneratedIdClassification::Legacy(value) => self.storage.shard_for_key(
+                        &canonical_shard_key_bytes(CanonicalShardKeyRef::Int64(value)),
+                    ),
+                    GeneratedIdClassification::NativeRangeV1(id) => spec
+                        .allocation_owners
+                        .as_ref()
+                        .ok_or_else(|| {
+                            EngineError::new(
+                                EngineErrorKind::DataCorruption,
+                                format!(
+                                    "registered native-ID table {} has no allocation-owner map",
+                                    spec.name
+                                ),
+                            )
+                        })?
+                        .physical_shard(id.owner())
+                        .ok_or_else(|| {
+                            EngineError::new(
+                                EngineErrorKind::FailedPrecondition,
+                                format!(
+                                    "native ID for {} refers to an unassigned allocation owner",
+                                    spec.name
+                                ),
+                            )
+                        })?,
+                }
+            }
+            (ShardKeyType::Text, ValueRef::Text(value)) => {
+                let value = std::str::from_utf8(value).map_err(|error| {
+                    EngineError::from_source(
+                        EngineErrorKind::InvalidTextEncoding,
+                        format!(
+                            "registered table {} shard key is not valid UTF-8",
+                            spec.name
+                        ),
+                        error,
+                    )
+                })?;
+                self.storage
+                    .shard_for_key(&canonical_shard_key_bytes(CanonicalShardKeyRef::Text(
+                        value,
+                    )))
+            }
+            (ShardKeyType::Binary, ValueRef::Blob(value)) => self.storage.shard_for_key(
+                &canonical_shard_key_bytes(CanonicalShardKeyRef::Binary(value)),
+            ),
+            (ShardKeyType::Int64, _) | (ShardKeyType::Text, _) | (ShardKeyType::Binary, _) => {
+                return Err(EngineError::new(
+                    EngineErrorKind::TypeMismatch,
+                    format!(
+                        "registered table {} shard key has the wrong SQLite storage class",
+                        spec.name
+                    ),
+                ));
+            }
+            (_, _) => {
+                return Err(EngineError::new(
+                    EngineErrorKind::Unsupported,
+                    format!(
+                        "registered table {} uses an unsupported shard-key type",
+                        spec.name
+                    ),
+                ));
+            }
+        };
+        if !spec.targets.contains(&target) {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!(
+                    "registered table {} routed outside its declared writable target set",
+                    spec.name
+                ),
+            ));
+        }
+        Ok(target)
+    }
+
     fn cancelled(&self, scan_epoch: u64) -> bool {
         self.cancellation_epoch.load(Ordering::Acquire) != scan_epoch
     }
@@ -492,6 +701,17 @@ impl Registry {
     ) -> EngineResult<(Vec<Vec<RawCell>>, usize)> {
         if self.cancelled(scan_epoch) {
             return Err(cancelled_error());
+        }
+        if self.mode == CoordinatorMode::Writable {
+            return self.write_state().read_shard_rows(
+                self,
+                spec,
+                shard_id,
+                equality,
+                scan_epoch,
+                remaining_rows,
+                remaining_bytes,
+            );
         }
 
         let connection = self.storage.open_shard_read_only(shard_id)?;
@@ -691,14 +911,60 @@ impl Drop for TrackedChildConnection {
 struct TableSpec {
     id: u64,
     name: String,
-    declared_schema: String,
+    read_declared_schema: String,
+    write_declared_schema: String,
     select_sql: String,
     point_select_sql: Option<String>,
+    locator_select_sql: Option<String>,
+    locator_point_select_sql: Option<String>,
+    columns: Box<[PhysicalColumnSpec]>,
+    locator: Option<PhysicalLocatorSpec>,
+    write_unsupported: Option<String>,
     column_count: usize,
     targets: Box<[u16]>,
     shard_key: Option<ShardKeySpec>,
     generated_id_policy: GeneratedIdPolicy,
     allocation_owners: Option<Arc<AllocationOwnerMap>>,
+}
+
+#[derive(Debug, Clone)]
+struct PhysicalColumnSpec {
+    name: String,
+    default_sql: Option<String>,
+    generated: bool,
+}
+
+#[derive(Debug, Clone)]
+enum PhysicalLocatorSpec {
+    Rowid { expression: String },
+    PrimaryKey { columns: Box<[String]> },
+}
+
+impl PhysicalLocatorSpec {
+    fn expressions(&self) -> Box<[String]> {
+        match self {
+            Self::Rowid { expression } => vec![expression.clone()].into_boxed_slice(),
+            Self::PrimaryKey { columns } => columns.clone(),
+        }
+    }
+
+    fn value_count(&self) -> usize {
+        match self {
+            Self::Rowid { .. } => 1,
+            Self::PrimaryKey { columns } => columns.len(),
+        }
+    }
+
+    fn predicate_sql(&self) -> String {
+        match self {
+            Self::Rowid { expression } => format!("{expression} = ?"),
+            Self::PrimaryKey { columns } => columns
+                .iter()
+                .map(|column| format!("{} IS ?", quote_identifier(column)))
+                .collect::<Vec<_>>()
+                .join(" AND "),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -716,18 +982,18 @@ impl TableSpec {
     ) -> EngineResult<Self> {
         let id = table.id().get();
         let name = table.name();
-        let strict = connection
+        let (strict, without_rowid) = connection
             .query_row(
-                "SELECT strict
+                "SELECT strict, wr
                  FROM pragma_table_list
                  WHERE schema = 'main' AND name = ?1 COLLATE BINARY AND type = 'table'",
                 [name],
-                |row| row.get::<_, bool>(0),
+                |row| Ok((row.get::<_, bool>(0)?, row.get::<_, bool>(1)?)),
             )
             .map_err(sqlite_error::storage)?;
         let mut statement = connection
             .prepare(
-                "SELECT name, type, hidden
+                "SELECT name, type, \"notnull\", dflt_value, pk, hidden
                  FROM pragma_table_xinfo(?1)
                  ORDER BY cid",
             )
@@ -738,6 +1004,9 @@ impl TableSpec {
                     row.get::<_, String>(0)?,
                     row.get::<_, String>(1)?,
                     row.get::<_, i64>(2)?,
+                    row.get::<_, Option<String>>(3)?,
+                    row.get::<_, i64>(4)?,
+                    row.get::<_, i64>(5)?,
                 ))
             })
             .map_err(sqlite_error::storage)?
@@ -749,7 +1018,7 @@ impl TableSpec {
                 format!("registered table {name} has no physical columns"),
             ));
         }
-        if columns.iter().any(|(_, _, hidden)| *hidden == 1) {
+        if columns.iter().any(|(_, _, _, _, _, hidden)| *hidden == 1) {
             return Err(EngineError::new(
                 EngineErrorKind::Unsupported,
                 format!("registered table {name} has a hidden virtual-table column"),
@@ -758,7 +1027,7 @@ impl TableSpec {
 
         let declared_columns = columns
             .iter()
-            .map(|(column, declared_type, _)| {
+            .map(|(column, declared_type, not_null, default_sql, _, _)| {
                 let (_, collation, _, _, _) = connection
                     .column_metadata(None::<&str>, name, column)
                     .map_err(sqlite_error::storage)?;
@@ -786,18 +1055,32 @@ impl TableSpec {
                 } else {
                     sqlite_affinity(declared_type)
                 };
-                Ok(format!(
+                let mut declaration = format!(
                     "{} {} COLLATE {}",
                     quote_identifier(column),
                     affinity_name(affinity),
                     quote_identifier(collation)
-                ))
+                );
+                if *not_null != 0 {
+                    declaration.push_str(" NOT NULL");
+                }
+                if let Some(default_sql) = default_sql {
+                    declaration.push_str(" DEFAULT (");
+                    declaration.push_str(default_sql);
+                    declaration.push(')');
+                }
+                Ok(declaration)
             })
-            .collect::<EngineResult<Vec<_>>>()?
-            .join(", ");
+            .collect::<EngineResult<Vec<_>>>()?;
+        let read_declared_schema = format!("CREATE TABLE x({})", declared_columns.join(", "));
+        let write_declared_schema = format!(
+            "CREATE TABLE x({}, {} BLOB HIDDEN PRIMARY KEY NOT NULL) WITHOUT ROWID",
+            declared_columns.join(", "),
+            quote_identifier(LOCATOR_COLUMN_NAME)
+        );
         let projected_columns = columns
             .iter()
-            .map(|(column, _, _)| quote_identifier(column))
+            .map(|(column, _, _, _, _, _)| quote_identifier(column))
             .collect::<Vec<_>>()
             .join(", ");
 
@@ -806,7 +1089,7 @@ impl TableSpec {
             TablePlacement::Sharded(metadata) => {
                 let column_index = columns
                     .iter()
-                    .position(|(column, _, _)| column == metadata.column())
+                    .position(|(column, _, _, _, _, _)| column == metadata.column())
                     .ok_or_else(|| {
                         EngineError::new(
                             EngineErrorKind::DataCorruption,
@@ -846,15 +1129,129 @@ impl TableSpec {
             _ => None,
         };
 
+        let physical_columns = columns
+            .iter()
+            .map(
+                |(column, _, _, default_sql, _, hidden)| PhysicalColumnSpec {
+                    name: column.clone(),
+                    default_sql: default_sql.clone(),
+                    generated: matches!(*hidden, 2 | 3),
+                },
+            )
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+
+        let locator = if without_rowid {
+            let mut primary_key = columns
+                .iter()
+                .filter(|(_, _, _, _, primary_key, _)| *primary_key > 0)
+                .map(|(column, _, _, _, primary_key, _)| (*primary_key, column.clone()))
+                .collect::<Vec<_>>();
+            primary_key.sort_unstable_by_key(|(position, _)| *position);
+            (!primary_key.is_empty()).then(|| PhysicalLocatorSpec::PrimaryKey {
+                columns: primary_key
+                    .into_iter()
+                    .map(|(_, column)| column)
+                    .collect::<Vec<_>>()
+                    .into_boxed_slice(),
+            })
+        } else {
+            let physical_names = columns
+                .iter()
+                .map(|(column, _, _, _, _, _)| column.as_str())
+                .collect::<Vec<_>>();
+            ["rowid", "_rowid_", "oid"]
+                .into_iter()
+                .find(|candidate| {
+                    physical_names
+                        .iter()
+                        .all(|column| !column.eq_ignore_ascii_case(candidate))
+                })
+                .map(|expression| PhysicalLocatorSpec::Rowid {
+                    expression: expression.to_owned(),
+                })
+        };
+
+        let has_trigger = connection
+            .query_row(
+                "SELECT EXISTS(
+                     SELECT 1
+                     FROM main.sqlite_schema
+                     WHERE type = 'trigger' AND tbl_name = ?1 COLLATE BINARY
+                 )",
+                [name],
+                |row| row.get::<_, bool>(0),
+            )
+            .map_err(sqlite_error::storage)?;
+        let write_unsupported = if !matches!(table.placement(), TablePlacement::Sharded(_)) {
+            Some(format!(
+                "registered table {name} is not Sharded; the writable facade does not mutate replicated or catalog placement"
+            ))
+        } else if columns
+            .iter()
+            .any(|(column, _, _, _, _, _)| column.eq_ignore_ascii_case(LOCATOR_COLUMN_NAME))
+        {
+            Some(format!(
+                "registered table {name} conflicts with the reserved writable row locator"
+            ))
+        } else if physical_columns
+            .iter()
+            .any(|column| column.default_sql.is_some())
+        {
+            Some(format!(
+                "registered table {name} has physical defaults; SQLite xUpdate cannot distinguish an omitted value from explicit NULL"
+            ))
+        } else if physical_columns.iter().any(|column| column.generated) {
+            Some(format!(
+                "registered table {name} has generated columns, which are not writable through the explicit-key facade"
+            ))
+        } else if has_trigger {
+            Some(format!(
+                "registered table {name} has physical triggers, which are not supported by the writable facade"
+            ))
+        } else if locator.is_none() {
+            Some(format!(
+                "registered table {name} has no unambiguous physical row identity for writable scans"
+            ))
+        } else {
+            None
+        };
+
+        let (locator_select_sql, locator_point_select_sql) = locator
+            .as_ref()
+            .map(|locator| {
+                let locator_columns = locator.expressions().join(", ");
+                let select = format!(
+                    "SELECT {projected_columns}, {locator_columns} FROM main.{}",
+                    quote_identifier(name)
+                );
+                let point = match table.placement() {
+                    TablePlacement::Sharded(metadata) => Some(format!(
+                        "SELECT {projected_columns}, {locator_columns} FROM main.{} WHERE {} = ?1",
+                        quote_identifier(name),
+                        quote_identifier(metadata.column())
+                    )),
+                    _ => None,
+                };
+                (select, point)
+            })
+            .map_or((None, None), |(select, point)| (Some(select), point));
+
         Ok(Self {
             id,
             name: name.to_owned(),
-            declared_schema: format!("CREATE TABLE x({declared_columns})"),
+            read_declared_schema,
+            write_declared_schema,
             select_sql: format!(
                 "SELECT {projected_columns} FROM main.{}",
                 quote_identifier(name)
             ),
             point_select_sql,
+            locator_select_sql,
+            locator_point_select_sql,
+            columns: physical_columns,
+            locator,
+            write_unsupported,
             column_count: columns.len(),
             targets,
             shard_key,
@@ -869,6 +1266,190 @@ impl TableSpec {
             quote_identifier(&self.name),
             self.id
         )
+    }
+
+    fn ensure_writable(&self) -> EngineResult<()> {
+        if let Some(reason) = &self.write_unsupported {
+            Err(EngineError::new(
+                EngineErrorKind::Unsupported,
+                reason.clone(),
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn write_shard_key<'a>(&self, values: &'a [ValueRef<'a>]) -> EngineResult<ValueRef<'a>> {
+        self.ensure_writable()?;
+        if values.len() != self.column_count {
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                format!(
+                    "brisk_shard received {} values for {} physical columns on {}",
+                    values.len(),
+                    self.column_count,
+                    self.name
+                ),
+            ));
+        }
+        let shard_key = self.shard_key.as_ref().ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::Unsupported,
+                format!("registered table {} has no writable shard key", self.name),
+            )
+        })?;
+        values
+            .get(usize::try_from(shard_key.column_index).map_err(|_| {
+                EngineError::new(
+                    EngineErrorKind::Internal,
+                    format!(
+                        "registered table {} has an invalid shard-key index",
+                        self.name
+                    ),
+                )
+            })?)
+            .copied()
+            .ok_or_else(|| {
+                EngineError::new(
+                    EngineErrorKind::Internal,
+                    format!("registered table {} shard-key value is missing", self.name),
+                )
+            })
+    }
+
+    fn insert_sql(&self, conflict: ConflictMode) -> EngineResult<String> {
+        self.ensure_writable()?;
+        let columns = self
+            .columns
+            .iter()
+            .map(|column| quote_identifier(&column.name))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let placeholders = (1..=self.column_count)
+            .map(|position| format!("?{position}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        Ok(format!(
+            "INSERT{} INTO main.{} ({columns}) VALUES ({placeholders})",
+            write_conflict_clause(conflict),
+            quote_identifier(&self.name)
+        ))
+    }
+
+    fn delete_sql(&self) -> EngineResult<String> {
+        self.ensure_writable()?;
+        let locator = self.locator.as_ref().ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::Unsupported,
+                format!("registered table {} has no writable row locator", self.name),
+            )
+        })?;
+        Ok(format!(
+            "DELETE FROM main.{} WHERE {}",
+            quote_identifier(&self.name),
+            locator.predicate_sql()
+        ))
+    }
+
+    fn update_sql_and_values(
+        &self,
+        values: &[ValueRef<'_>],
+        no_change: &[bool],
+        conflict: ConflictMode,
+    ) -> EngineResult<(String, Vec<RawCell>)> {
+        self.ensure_writable()?;
+        if values.len() != self.column_count || no_change.len() != self.column_count {
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                format!(
+                    "brisk_shard received an invalid update shape for {}",
+                    self.name
+                ),
+            ));
+        }
+        let mut assignments = Vec::new();
+        let mut parameters = Vec::new();
+        for ((column, value), unchanged) in self.columns.iter().zip(values).zip(no_change) {
+            if *unchanged {
+                continue;
+            }
+            if column.generated {
+                return Err(EngineError::new(
+                    EngineErrorKind::ReadOnly,
+                    format!(
+                        "generated column {}.{} is read-only through brisk_shard",
+                        self.name, column.name
+                    ),
+                ));
+            }
+            parameters.push(RawCell::try_copy_from(*value)?);
+            assignments.push(format!(
+                "{} = ?{}",
+                quote_identifier(&column.name),
+                parameters.len()
+            ));
+        }
+        if assignments.is_empty() {
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                format!("brisk_shard update for {} changed no columns", self.name),
+            ));
+        }
+        let locator = self.locator.as_ref().ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::Unsupported,
+                format!("registered table {} has no writable row locator", self.name),
+            )
+        })?;
+        Ok((
+            format!(
+                "UPDATE{} main.{} SET {} WHERE {}",
+                write_conflict_clause(conflict),
+                quote_identifier(&self.name),
+                assignments.join(", "),
+                locator.predicate_sql()
+            ),
+            parameters,
+        ))
+    }
+
+    fn decode_locator(&self, value: ValueRef<'_>) -> EngineResult<locator::DecodedLocator> {
+        self.ensure_writable()?;
+        let ValueRef::Blob(bytes) = value else {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "brisk_shard row locator must be an opaque BLOB",
+            ));
+        };
+        let decoded = locator::decode(self.id, bytes)?;
+        let expected_values = self
+            .locator
+            .as_ref()
+            .ok_or_else(|| {
+                EngineError::new(
+                    EngineErrorKind::Unsupported,
+                    format!("registered table {} has no writable row locator", self.name),
+                )
+            })?
+            .value_count();
+        if decoded.values.len() != expected_values || !self.targets.contains(&decoded.shard) {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "brisk_shard row locator does not match the registered physical table",
+            ));
+        }
+        Ok(decoded)
+    }
+}
+
+const fn write_conflict_clause(conflict: ConflictMode) -> &'static str {
+    if matches!(conflict, ConflictMode::Replace) {
+        " OR REPLACE"
+    } else {
+        // The physical schema may declare its own ON CONFLICT policy. Force
+        // each child operation to ABORT so the coordinator's conflict mode,
+        // reported through sqlite3_vtab_on_conflict(), remains authoritative.
+        " OR ABORT"
     }
 }
 
@@ -937,6 +1518,7 @@ impl LifecycleCounters {
 struct BriskShardTable {
     // SQLite requires its base object to be the first field.
     _base: ffi::sqlite3_vtab,
+    database_handle: *mut ffi::sqlite3,
     registry: Arc<Registry>,
     spec: Arc<TableSpec>,
 }
@@ -967,11 +1549,34 @@ unsafe impl<'vtab> VTab<'vtab> for BriskShardTable {
             .ok_or_else(|| module_error(format!("unknown brisk_shard table ID {id}")))?;
 
         database.config(VTabConfig::DirectOnly)?;
+        if registry.mode == CoordinatorMode::Writable {
+            // rusqlite's safe wrapper omits the required third vararg for
+            // SQLITE_VTAB_CONSTRAINT_SUPPORT. Use stock SQLite's supported C
+            // API directly so conflict modes can be delegated correctly.
+            let result_code = unsafe {
+                ffi::sqlite3_vtab_config(
+                    database.handle(),
+                    ffi::SQLITE_VTAB_CONSTRAINT_SUPPORT,
+                    1_i32,
+                )
+            };
+            if result_code != ffi::SQLITE_OK {
+                return Err(SqliteError::SqliteFailure(
+                    ffi::Error::new(result_code),
+                    Some("could not enable brisk_shard constraint support".to_owned()),
+                ));
+            }
+        }
         registry.lifecycle.connects.fetch_add(1, Ordering::Relaxed);
+        let database_handle = unsafe { database.handle() };
         Ok((
-            spec.declared_schema.clone(),
+            match registry.mode {
+                CoordinatorMode::ReadOnly => spec.read_declared_schema.clone(),
+                CoordinatorMode::Writable => spec.write_declared_schema.clone(),
+            },
             Self {
                 _base: ffi::sqlite3_vtab::default(),
+                database_handle,
                 registry,
                 spec,
             },
@@ -1048,6 +1653,131 @@ impl<'vtab> CreateVTab<'vtab> for BriskShardTable {
     }
 }
 
+impl<'vtab> UpdateVTab<'vtab> for BriskShardTable {
+    fn delete(&mut self, locator: ValueRef<'_>) -> SqliteResult<()> {
+        self.registry
+            .write_state()
+            .execute_delete(&self.registry, &self.spec, locator)
+            .map_err(vtab_error)
+    }
+
+    fn insert(&mut self, arguments: &Inserts<'_>) -> SqliteResult<i64> {
+        let expected = self
+            .spec
+            .column_count
+            .checked_add(3)
+            .ok_or_else(|| module_error("brisk_shard writable column count overflowed"))?;
+        let values = arguments.iter().collect::<Vec<_>>();
+        if values.len() != expected || !matches!(values[0], ValueRef::Null) {
+            return Err(module_error(format!(
+                "brisk_shard INSERT received an invalid argument shape for {}",
+                self.spec.name
+            )));
+        }
+        if !matches!(values[1], ValueRef::Null)
+            || !matches!(values[2 + self.spec.column_count], ValueRef::Null)
+        {
+            return Err(vtab_error(EngineError::new(
+                EngineErrorKind::ReadOnly,
+                "brisk_shard opaque row locator cannot be supplied by INSERT",
+            )));
+        }
+        let conflict = unsafe { arguments.on_conflict(self.database_handle) };
+        self.registry
+            .write_state()
+            .execute_insert(
+                &self.registry,
+                &self.spec,
+                &values[2..2 + self.spec.column_count],
+                conflict,
+            )
+            .map_err(vtab_error)
+    }
+
+    fn update(&mut self, arguments: &Updates<'_>) -> SqliteResult<()> {
+        let expected = self
+            .spec
+            .column_count
+            .checked_add(3)
+            .ok_or_else(|| module_error("brisk_shard writable column count overflowed"))?;
+        let values = arguments.iter().collect::<Vec<_>>();
+        if values.len() != expected || matches!(values[0], ValueRef::Null) {
+            return Err(module_error(format!(
+                "brisk_shard UPDATE received an invalid argument shape for {}",
+                self.spec.name
+            )));
+        }
+        let hidden_value = values[2 + self.spec.column_count];
+        if !matches!(
+            (values[0], values[1], hidden_value),
+            (ValueRef::Blob(old), ValueRef::Blob(new), ValueRef::Blob(hidden))
+                if old == new && old == hidden
+        ) {
+            return Err(vtab_error(EngineError::new(
+                EngineErrorKind::ReadOnly,
+                "brisk_shard opaque row locator cannot be changed",
+            )));
+        }
+        let no_change = (0..self.spec.column_count)
+            .map(|column| arguments.no_change(column + 2))
+            .collect::<Vec<_>>();
+        let conflict = unsafe { arguments.on_conflict(self.database_handle) };
+        self.registry
+            .write_state()
+            .execute_update(
+                &self.registry,
+                &self.spec,
+                values[0],
+                values[1],
+                &values[2..2 + self.spec.column_count],
+                &no_change,
+                conflict,
+            )
+            .map_err(vtab_error)
+    }
+}
+
+impl<'vtab> TransactionVTab<'vtab> for BriskShardTable {
+    fn begin(&mut self) -> SqliteResult<()> {
+        write::map_callback(self.registry.write_state().begin(&self.registry))
+    }
+
+    fn sync(&mut self) -> SqliteResult<()> {
+        write::map_callback(self.registry.write_state().sync(&self.registry))
+    }
+
+    fn commit(&mut self) -> SqliteResult<()> {
+        write::map_callback(self.registry.write_state().mark_commit(&self.registry))
+    }
+
+    fn rollback(&mut self) -> SqliteResult<()> {
+        self.registry.write_state().mark_rollback();
+        Ok(())
+    }
+}
+
+impl BriskShardTable {
+    fn savepoint(&mut self, number: c_int) -> SqliteResult<()> {
+        write::map_callback(
+            self.registry
+                .write_state()
+                .savepoint(&self.registry, number),
+        )
+    }
+
+    fn release(&mut self, number: c_int) -> SqliteResult<()> {
+        write::map_callback(self.registry.write_state().release(&self.registry, number))
+    }
+
+    fn rollback_to(&mut self, number: c_int) -> SqliteResult<()> {
+        write::map_callback(
+            self.registry
+                .write_state()
+                .rollback_to(&self.registry, number),
+        )
+    }
+}
+
 impl Drop for BriskShardTable {
     fn drop(&mut self) {
         self.registry
@@ -1097,6 +1827,15 @@ impl BriskShardCursor {
     }
 
     fn begin_scan(&mut self) -> SqliteResult<()> {
+        if self.registry.mode == CoordinatorMode::Writable {
+            self.spec.ensure_writable().map_err(vtab_error)?;
+            if self.targets.len() != 1 {
+                return Err(vtab_error(EngineError::new(
+                    EngineErrorKind::Unsupported,
+                    "writable brisk_shard UPDATE and DELETE require an exact shard-key equality",
+                )));
+            }
+        }
         let operation = self
             .registry
             .storage
@@ -1250,6 +1989,14 @@ unsafe impl VTabCursor for BriskShardCursor {
             .fetch_add(1, Ordering::Relaxed);
         let column = usize::try_from(column)
             .map_err(|_| module_error("negative brisk_shard column index"))?;
+        if self.registry.mode == CoordinatorMode::Writable
+            && column < self.spec.column_count
+            && context.no_change()
+        {
+            // Leaving the result unset is the signal that lets SQLite mark
+            // this argv slot with sqlite3_value_nochange() for xUpdate.
+            return Ok(());
+        }
         let value = self
             .rows
             .get(self.row_index)
@@ -1473,6 +2220,7 @@ mod tests {
         collections::BTreeSet,
         sync::{Arc, mpsc},
         thread,
+        time::Instant,
     };
 
     use rusqlite::{ErrorCode, MAIN_DB, params, types::ValueRef};
@@ -1523,6 +2271,12 @@ mod tests {
     }
 
     struct Fixture {
+        temp: tempfile::TempDir,
+        storage: Storage,
+        keys: [i64; 2],
+    }
+
+    struct WritableFixture {
         temp: tempfile::TempDir,
         storage: Storage,
         keys: [i64; 2],
@@ -1619,6 +2373,92 @@ mod tests {
                         .query_row("SELECT COUNT(*) FROM events", [], |row| {
                             row.get::<_, i64>(0)
                         })
+                        .unwrap()
+                })
+                .sum()
+        }
+    }
+
+    impl WritableFixture {
+        fn new() -> Self {
+            let temp = tempfile::tempdir().unwrap();
+            let mut storage = Storage::open(temp.path(), 2).unwrap();
+            let mut migration = storage.begin_schema_migration().unwrap();
+            migration.wait_for_quiescence_blocking();
+            storage
+                .apply_schema_migration(
+                    "CREATE TABLE parents (
+                         tenant_id INTEGER NOT NULL,
+                         parent_id INTEGER NOT NULL,
+                         label TEXT NOT NULL,
+                         PRIMARY KEY (tenant_id, parent_id)
+                     );
+                     CREATE TABLE items (
+                         tenant_id INTEGER NOT NULL,
+                         item_id INTEGER NOT NULL,
+                         parent_id INTEGER NOT NULL,
+                         code TEXT NOT NULL,
+                         quantity INTEGER NOT NULL CHECK (quantity > 0),
+                         PRIMARY KEY (tenant_id, item_id),
+                         UNIQUE (tenant_id, code),
+                         FOREIGN KEY (tenant_id, parent_id)
+                             REFERENCES parents (tenant_id, parent_id)
+                     );
+                     CREATE INDEX items_quantity_idx
+                         ON items (tenant_id, quantity);",
+                    &mut migration,
+                    None,
+                )
+                .unwrap();
+            migration.publish_ready().unwrap();
+            let database_id = storage.logical_catalog().default_database().id();
+            storage
+                .register_tables(vec![
+                    TableDeclaration::sharded(
+                        database_id,
+                        "parents",
+                        ShardKeyMetadata::new("tenant_id", ShardKeyType::Int64).unwrap(),
+                    )
+                    .unwrap(),
+                    TableDeclaration::sharded(
+                        database_id,
+                        "items",
+                        ShardKeyMetadata::new("tenant_id", ShardKeyType::Int64).unwrap(),
+                    )
+                    .unwrap(),
+                ])
+                .unwrap();
+            let keys = std::array::from_fn(|expected| {
+                (1_i64..)
+                    .find(|key| {
+                        storage.shard_for_key(key.to_string().as_bytes()) == expected as u16
+                    })
+                    .unwrap()
+            });
+            for (shard, key) in keys.into_iter().enumerate() {
+                storage
+                    .open_shard(u16::try_from(shard).unwrap())
+                    .unwrap()
+                    .execute(
+                        "INSERT INTO parents VALUES (?1, 1, ?2)",
+                        params![key, format!("parent-{shard}")],
+                    )
+                    .unwrap();
+            }
+            Self {
+                temp,
+                storage,
+                keys,
+            }
+        }
+
+        fn item_count(&self) -> i64 {
+            (0..2)
+                .map(|shard| {
+                    self.storage
+                        .open_shard(shard)
+                        .unwrap()
+                        .query_row("SELECT COUNT(*) FROM items", [], |row| row.get::<_, i64>(0))
                         .unwrap()
                 })
                 .sum()
@@ -3545,5 +4385,1409 @@ mod tests {
             .copied()
             .collect::<BTreeSet<_>>();
         assert_eq!(opened, BTreeSet::from([0, 1]));
+    }
+
+    #[test]
+    fn writable_coordinator_inserts_an_explicit_key_on_its_owner_shard() {
+        let fixture = Fixture::new();
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+        let result = coordinator
+            .execute_dml(
+                "INSERT INTO events
+                 (tenant_id, event_id, payload, amount, raw, optional, category)
+                 VALUES (?1, 2, 'written', 3.5, x'01', NULL, 'beta')",
+                [fixture.keys[0]],
+            )
+            .unwrap();
+        assert_eq!(result.affected_rows, 1);
+        assert_eq!(result.explicit_key, Some(Value::Int64(fixture.keys[0])));
+        assert_eq!(fixture.physical_row_count(), 3);
+        assert_eq!(
+            fixture
+                .storage
+                .open_shard(0)
+                .unwrap()
+                .query_row(
+                    "SELECT payload FROM events WHERE tenant_id = ?1 AND event_id = 2",
+                    [fixture.keys[0]],
+                    |row| row.get::<_, String>(0),
+                )
+                .unwrap(),
+            "written"
+        );
+        assert_eq!(fixture.storage.schema_gate_snapshot().active_operations, 0);
+    }
+
+    #[test]
+    fn writable_coordinator_updates_and_deletes_through_opaque_locators() {
+        let fixture = Fixture::new();
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+        let updated = coordinator
+            .execute_dml(
+                "UPDATE events
+                 SET payload = 'updated', optional = 'present'
+                 WHERE tenant_id = ?1 AND event_id = 1",
+                [fixture.keys[0]],
+            )
+            .unwrap();
+        assert_eq!(updated.affected_rows, 1);
+        assert_eq!(updated.explicit_key, None);
+        assert_eq!(
+            fixture
+                .storage
+                .open_shard(0)
+                .unwrap()
+                .query_row(
+                    "SELECT payload || ':' || optional FROM events
+                     WHERE tenant_id = ?1 AND event_id = 1",
+                    [fixture.keys[0]],
+                    |row| row.get::<_, String>(0),
+                )
+                .unwrap(),
+            "updated:present"
+        );
+
+        let deleted = coordinator
+            .execute_dml(
+                "DELETE FROM events WHERE tenant_id = ?1 AND event_id = 1",
+                [fixture.keys[0]],
+            )
+            .unwrap();
+        assert_eq!(deleted.affected_rows, 1);
+        assert_eq!(fixture.physical_row_count(), 1);
+        assert_eq!(fixture.storage.schema_gate_snapshot().active_operations, 0);
+    }
+
+    #[test]
+    fn writable_explicit_transactions_commit_rollback_and_nested_savepoints() {
+        let fixture = Fixture::new();
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+
+        coordinator.begin().unwrap();
+        coordinator
+            .execute_dml(
+                "INSERT INTO events VALUES (?1, 2, 'kept', 2.0, x'02', NULL, 'beta')",
+                [fixture.keys[0]],
+            )
+            .unwrap();
+        coordinator.savepoint("outer").unwrap();
+        coordinator
+            .execute_dml(
+                "INSERT INTO events VALUES (?1, 3, 'discarded', 3.0, x'03', NULL, 'gamma')",
+                [fixture.keys[0]],
+            )
+            .unwrap();
+        coordinator.savepoint("inner").unwrap();
+        coordinator
+            .execute_dml(
+                "UPDATE events SET payload = 'also-discarded'
+                 WHERE tenant_id = ?1 AND event_id = 1",
+                [fixture.keys[0]],
+            )
+            .unwrap();
+        coordinator.rollback_to("outer").unwrap();
+        coordinator.release("outer").unwrap();
+        coordinator.commit().unwrap();
+        assert!(!coordinator.in_transaction());
+
+        let shard = fixture.storage.open_shard(0).unwrap();
+        assert_eq!(
+            shard
+                .query_row(
+                    "SELECT GROUP_CONCAT(event_id || ':' || payload, ',')
+                     FROM events WHERE tenant_id = ?1 ORDER BY event_id",
+                    [fixture.keys[0]],
+                    |row| row.get::<_, String>(0),
+                )
+                .unwrap(),
+            "1:zero,2:kept"
+        );
+
+        coordinator.begin().unwrap();
+        coordinator
+            .execute_dml(
+                "DELETE FROM events WHERE tenant_id = ?1 AND event_id = 2",
+                [fixture.keys[0]],
+            )
+            .unwrap();
+        coordinator.rollback().unwrap();
+        assert_eq!(fixture.physical_row_count(), 3);
+        assert_eq!(fixture.storage.schema_gate_snapshot().active_operations, 0);
+    }
+
+    #[test]
+    fn writable_late_enlistment_preserves_preexisting_nested_savepoints() {
+        let fixture = Fixture::new();
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+
+        coordinator.begin().unwrap();
+        coordinator.savepoint("outer").unwrap();
+        coordinator.savepoint("inner").unwrap();
+        coordinator
+            .execute_dml(
+                "INSERT INTO events VALUES
+                 (?1, 2, 'rolled-back', 2.0, x'02', NULL, 'beta')",
+                [fixture.keys[0]],
+            )
+            .unwrap();
+
+        // SQLite late-enlists the virtual table at only the deepest level.
+        // Releasing that level must not erase the physical boundary for an
+        // outer savepoint that existed before the first virtual-table write.
+        coordinator.release("inner").unwrap();
+        coordinator.rollback_to("outer").unwrap();
+        coordinator
+            .execute_dml(
+                "INSERT INTO events VALUES
+                 (?1, 3, 'kept-after-rollback', 3.0, x'03', NULL, 'gamma')",
+                [fixture.keys[0]],
+            )
+            .unwrap();
+        coordinator.release("outer").unwrap();
+        coordinator.commit().unwrap();
+
+        let shard = fixture.storage.open_shard(0).unwrap();
+        assert_eq!(
+            shard
+                .query_row(
+                    "SELECT COUNT(*) FROM events WHERE tenant_id = ?1 AND event_id = 2",
+                    [fixture.keys[0]],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            shard
+                .query_row(
+                    "SELECT COUNT(*) FROM events WHERE tenant_id = ?1 AND event_id = 3",
+                    [fixture.keys[0]],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            1
+        );
+        assert_eq!(fixture.physical_row_count(), 3);
+        assert_eq!(fixture.storage.schema_gate_snapshot().active_operations, 0);
+    }
+
+    #[test]
+    fn writable_savepoint_callback_failures_abort_both_transaction_layers() {
+        for operation in [
+            write::SavepointOperation::Savepoint,
+            write::SavepointOperation::Release,
+            write::SavepointOperation::RollbackTo,
+        ] {
+            let fixture = Fixture::new();
+            let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+
+            coordinator.begin().unwrap();
+            coordinator
+                .execute_dml(
+                    "INSERT INTO events VALUES
+                     (?1, 2, 'must-roll-back', 2.0, x'02', NULL, 'beta')",
+                    [fixture.keys[0]],
+                )
+                .unwrap();
+            if operation != write::SavepointOperation::Savepoint {
+                coordinator.savepoint("guard").unwrap();
+            }
+
+            coordinator.fail_next_savepoint_operation_for_test(operation);
+            let error = match operation {
+                write::SavepointOperation::Savepoint => coordinator.savepoint("guard"),
+                write::SavepointOperation::Release => coordinator.release("guard"),
+                write::SavepointOperation::RollbackTo => coordinator.rollback_to("guard"),
+            }
+            .unwrap_err();
+
+            assert_eq!(error.kind(), EngineErrorKind::StorageUnavailable);
+            assert!(!coordinator.in_transaction(), "operation={operation:?}");
+            assert!(
+                !coordinator.write_state_for_test().has_active_child(),
+                "operation={operation:?}"
+            );
+            assert_eq!(fixture.physical_row_count(), 2, "operation={operation:?}");
+
+            // A proven rollback restores the wrapper to an idle, reusable
+            // state; only an unprovable rollback marks it broken.
+            coordinator
+                .execute_dml(
+                    "INSERT INTO events VALUES
+                     (?1, 2, 'recovered', 2.0, x'02', NULL, 'beta')",
+                    [fixture.keys[0]],
+                )
+                .unwrap();
+            assert_eq!(fixture.physical_row_count(), 3, "operation={operation:?}");
+        }
+    }
+
+    #[test]
+    fn writable_savepoint_corruption_marks_storage_degraded_and_rolls_back() {
+        let fixture = Fixture::new();
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+
+        coordinator.begin().unwrap();
+        coordinator
+            .execute_dml(
+                "INSERT INTO events VALUES
+                 (?1, 2, 'must-roll-back', 2.0, x'02', NULL, 'beta')",
+                [fixture.keys[0]],
+            )
+            .unwrap();
+        coordinator.savepoint("guard").unwrap();
+        coordinator.fail_next_savepoint_corruption_for_test(write::SavepointOperation::Release);
+
+        let error = coordinator.release("guard").unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+        assert!(!coordinator.in_transaction());
+        assert_eq!(
+            fixture.storage.schema_gate_snapshot().state,
+            crate::storage::SchemaGateState::Degraded
+        );
+        assert_eq!(fixture.storage.schema_gate_snapshot().active_operations, 0);
+        assert_eq!(
+            Connection::open(fixture.temp.path().join("shards/0000.sqlite"))
+                .unwrap()
+                .query_row("SELECT COUNT(*) FROM events", [], |row| {
+                    row.get::<_, i64>(0)
+                })
+                .unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn writable_cross_shard_attempts_roll_back_without_partial_effects() {
+        let fixture = Fixture::new();
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+
+        let error = coordinator
+            .execute_dml(
+                "INSERT INTO events VALUES
+                 (?1, 2, 'first', 1.0, x'01', NULL, 'one'),
+                 (?2, 2, 'second', 2.0, x'02', NULL, 'two')",
+                params![fixture.keys[0], fixture.keys[1]],
+            )
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::InvalidQuery);
+        assert_eq!(fixture.physical_row_count(), 2);
+
+        let moved = coordinator
+            .execute_dml(
+                "UPDATE OR IGNORE events SET tenant_id = ?2
+                 WHERE tenant_id = ?1 AND event_id = 1",
+                params![fixture.keys[0], fixture.keys[1]],
+            )
+            .unwrap_err();
+        assert_eq!(moved.kind(), EngineErrorKind::InvalidQuery);
+        assert_eq!(fixture.physical_row_count(), 2);
+        assert_eq!(
+            fixture
+                .storage
+                .open_shard(0)
+                .unwrap()
+                .query_row(
+                    "SELECT tenant_id FROM events WHERE event_id = 1",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            fixture.keys[0]
+        );
+
+        coordinator.begin().unwrap();
+        coordinator
+            .execute_dml(
+                "INSERT INTO events VALUES (?1, 2, 'first', 1.0, x'01', NULL, 'one')",
+                [fixture.keys[0]],
+            )
+            .unwrap();
+        let error = coordinator
+            .execute_dml(
+                "INSERT INTO events VALUES (?1, 2, 'second', 2.0, x'02', NULL, 'two')",
+                [fixture.keys[1]],
+            )
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::InvalidQuery);
+        assert!(!coordinator.in_transaction());
+        assert_eq!(fixture.physical_row_count(), 2);
+        assert_eq!(fixture.storage.schema_gate_snapshot().active_operations, 0);
+    }
+
+    #[test]
+    fn writable_physical_checks_nullability_and_local_foreign_keys_are_authoritative() {
+        let fixture = WritableFixture::new();
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+        let inserted = coordinator
+            .execute_dml(
+                "INSERT INTO items VALUES (?1, 1, 1, 'first-code', 5)",
+                [fixture.keys[0]],
+            )
+            .unwrap();
+        assert_eq!(inserted.affected_rows, 1);
+        assert_eq!(inserted.explicit_key, Some(Value::Int64(fixture.keys[0])));
+        assert_eq!(
+            fixture
+                .storage
+                .open_shard(0)
+                .unwrap()
+                .query_row(
+                    "SELECT code FROM items WHERE tenant_id = ?1 AND item_id = 1",
+                    [fixture.keys[0]],
+                    |row| row.get::<_, String>(0),
+                )
+                .unwrap(),
+            "first-code"
+        );
+
+        let check = coordinator
+            .execute_dml(
+                "INSERT INTO items VALUES (?1, 2, 1, 'bad-check', 0)",
+                [fixture.keys[0]],
+            )
+            .unwrap_err();
+        assert_eq!(check.kind(), EngineErrorKind::CheckViolation);
+
+        let not_null = coordinator
+            .execute_dml(
+                "INSERT INTO items VALUES (?1, 2, 1, NULL, 1)",
+                [fixture.keys[0]],
+            )
+            .unwrap_err();
+        assert_eq!(not_null.kind(), EngineErrorKind::NotNullViolation);
+
+        let foreign_key = coordinator
+            .execute_dml(
+                "INSERT INTO items VALUES (?1, 2, 999, 'bad-parent', 1)",
+                [fixture.keys[0]],
+            )
+            .unwrap_err();
+        assert_eq!(foreign_key.kind(), EngineErrorKind::ForeignKeyViolation);
+        assert_eq!(fixture.item_count(), 1);
+    }
+
+    #[test]
+    fn writable_two_tables_share_one_pinned_child_and_read_uncommitted_writes() {
+        let fixture = WritableFixture::new();
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+        coordinator.begin().unwrap();
+        coordinator
+            .execute_dml(
+                "INSERT INTO parents VALUES (?1, 2, 'new-parent')",
+                [fixture.keys[0]],
+            )
+            .unwrap();
+        coordinator
+            .execute_dml(
+                "INSERT INTO items VALUES (?1, 10, 2, 'new-item', 1)",
+                [fixture.keys[0]],
+            )
+            .unwrap();
+        coordinator
+            .execute_dml(
+                "UPDATE items SET quantity = 7
+                 WHERE tenant_id = ?1 AND item_id = 10",
+                [fixture.keys[0]],
+            )
+            .unwrap();
+        coordinator.commit().unwrap();
+
+        assert_eq!(
+            fixture
+                .storage
+                .open_shard(0)
+                .unwrap()
+                .query_row(
+                    "SELECT quantity FROM items WHERE tenant_id = ?1 AND item_id = 10",
+                    [fixture.keys[0]],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            7
+        );
+    }
+
+    #[test]
+    fn writable_conflict_modes_preserve_sqlite_statement_semantics() {
+        for (mode, expected_count) in [("ABORT", 1), ("FAIL", 2), ("IGNORE", 2)] {
+            let fixture = WritableFixture::new();
+            let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+            coordinator
+                .execute_dml(
+                    "INSERT INTO items VALUES (?1, 1, 1, 'duplicate', 1)",
+                    [fixture.keys[0]],
+                )
+                .unwrap();
+            let sql = format!(
+                "INSERT OR {mode} INTO items VALUES
+                 (?1, 2, 1, 'first-in-statement', 1),
+                 (?1, 3, 1, 'duplicate', 1)"
+            );
+            let result = coordinator.execute_dml(&sql, [fixture.keys[0]]);
+            if mode == "IGNORE" {
+                assert_eq!(result.unwrap().affected_rows, 1);
+            } else {
+                assert_eq!(result.unwrap_err().kind(), EngineErrorKind::UniqueViolation);
+            }
+            assert_eq!(fixture.item_count(), expected_count, "mode={mode}");
+        }
+
+        let fixture = WritableFixture::new();
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+        coordinator
+            .execute_dml(
+                "INSERT INTO items VALUES (?1, 1, 1, 'duplicate', 1)",
+                [fixture.keys[0]],
+            )
+            .unwrap();
+        assert_eq!(
+            coordinator
+                .execute_dml(
+                    "INSERT OR REPLACE INTO items VALUES (?1, 2, 1, 'duplicate', 9)",
+                    [fixture.keys[0]],
+                )
+                .unwrap()
+                .affected_rows,
+            1
+        );
+        assert_eq!(fixture.item_count(), 1);
+        assert_eq!(
+            fixture
+                .storage
+                .open_shard(0)
+                .unwrap()
+                .query_row(
+                    "SELECT item_id FROM items WHERE tenant_id = ?1 AND code = 'duplicate'",
+                    [fixture.keys[0]],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            2
+        );
+
+        let fixture = WritableFixture::new();
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+        coordinator
+            .execute_dml(
+                "INSERT INTO items VALUES (?1, 1, 1, 'duplicate', 1)",
+                [fixture.keys[0]],
+            )
+            .unwrap();
+        coordinator.begin().unwrap();
+        coordinator
+            .execute_dml(
+                "INSERT INTO items VALUES (?1, 2, 1, 'before-rollback', 1)",
+                [fixture.keys[0]],
+            )
+            .unwrap();
+        let error = coordinator
+            .execute_dml(
+                "INSERT OR ROLLBACK INTO items VALUES (?1, 3, 1, 'duplicate', 1)",
+                [fixture.keys[0]],
+            )
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::UniqueViolation);
+        assert!(!coordinator.in_transaction());
+        assert_eq!(fixture.item_count(), 1);
+    }
+
+    #[test]
+    fn writable_child_sql_overrides_physical_schema_conflict_policies() {
+        let fixture = WritableFixture::new();
+        let operation = fixture.storage.enter_schema_operation().unwrap();
+        let registry =
+            Registry::build_writable(fixture.storage.clone(), CursorLimits::default()).unwrap();
+        drop(operation);
+        let spec = registry
+            .tables
+            .values()
+            .find(|spec| spec.name == "items")
+            .unwrap();
+
+        let physical = Connection::open_in_memory().unwrap();
+        physical
+            .execute_batch(
+                "CREATE TABLE items (
+                     tenant_id INTEGER NOT NULL,
+                     item_id INTEGER NOT NULL,
+                     parent_id INTEGER NOT NULL,
+                     code TEXT NOT NULL,
+                     quantity INTEGER NOT NULL,
+                     PRIMARY KEY (tenant_id, item_id),
+                     UNIQUE (tenant_id, code) ON CONFLICT IGNORE
+                 );
+                 INSERT INTO items VALUES (1, 1, 1, 'first', 1);",
+            )
+            .unwrap();
+
+        let insert_abort = spec.insert_sql(ConflictMode::Abort).unwrap();
+        assert!(insert_abort.starts_with("INSERT OR ABORT INTO"));
+        assert_eq!(
+            physical
+                .execute(&insert_abort, params![1, 2, 1, "first", 1])
+                .unwrap_err()
+                .sqlite_error_code(),
+            Some(ErrorCode::ConstraintViolation)
+        );
+        let insert_ignore = spec.insert_sql(ConflictMode::Ignore).unwrap();
+        assert_eq!(insert_ignore, insert_abort);
+        assert_eq!(
+            physical
+                .execute(&insert_ignore, params![1, 2, 1, "first", 1])
+                .unwrap_err()
+                .sqlite_error_code(),
+            Some(ErrorCode::ConstraintViolation)
+        );
+        assert_eq!(
+            physical
+                .execute(
+                    &spec.insert_sql(ConflictMode::Replace).unwrap(),
+                    params![1, 2, 1, "first", 1],
+                )
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            physical
+                .query_row("SELECT item_id FROM items", [], |row| row.get::<_, i64>(0))
+                .unwrap(),
+            2
+        );
+
+        physical
+            .execute_batch(
+                "DELETE FROM items;
+                 INSERT INTO items VALUES (1, 1, 1, 'first', 1);
+                 INSERT INTO items VALUES (1, 2, 1, 'second', 1);",
+            )
+            .unwrap();
+        let second_rowid = physical
+            .query_row(
+                "SELECT rowid FROM items WHERE tenant_id = 1 AND item_id = 2",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap();
+        let update_values = [
+            ValueRef::Integer(1),
+            ValueRef::Integer(2),
+            ValueRef::Integer(1),
+            ValueRef::Text(b"first"),
+            ValueRef::Integer(1),
+        ];
+        let no_change = [true, true, true, false, true];
+        let (update_abort, mut update_parameters) = spec
+            .update_sql_and_values(&update_values, &no_change, ConflictMode::Abort)
+            .unwrap();
+        assert!(update_abort.starts_with("UPDATE OR ABORT"));
+        update_parameters.push(RawCell::Integer(second_rowid));
+        assert_eq!(
+            physical
+                .execute(
+                    &update_abort,
+                    rusqlite::params_from_iter(&update_parameters),
+                )
+                .unwrap_err()
+                .sqlite_error_code(),
+            Some(ErrorCode::ConstraintViolation)
+        );
+
+        let (update_replace, mut replace_parameters) = spec
+            .update_sql_and_values(&update_values, &no_change, ConflictMode::Replace)
+            .unwrap();
+        assert!(update_replace.starts_with("UPDATE OR REPLACE"));
+        replace_parameters.push(RawCell::Integer(second_rowid));
+        assert_eq!(
+            physical
+                .execute(
+                    &update_replace,
+                    rusqlite::params_from_iter(&replace_parameters),
+                )
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            physical
+                .query_row("SELECT item_id FROM items", [], |row| row.get::<_, i64>(0))
+                .unwrap(),
+            2
+        );
+    }
+
+    #[test]
+    fn writable_surface_rejects_global_multishard_ddl_returning_and_locator_mutation() {
+        let fixture = Fixture::new();
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+
+        let global = coordinator
+            .execute_dml("INSERT INTO countries VALUES ('CA', 'Canada')", [])
+            .unwrap_err();
+        assert_eq!(global.kind(), EngineErrorKind::InvalidQuery);
+        for shard in 0..2 {
+            assert_eq!(
+                fixture
+                    .storage
+                    .open_shard(shard)
+                    .unwrap()
+                    .query_row("SELECT COUNT(*) FROM countries", [], |row| {
+                        row.get::<_, i64>(0)
+                    })
+                    .unwrap(),
+                1
+            );
+        }
+
+        let scan = coordinator
+            .execute_dml("UPDATE events SET payload = 'unsafe-scan'", [])
+            .unwrap_err();
+        assert_eq!(scan.kind(), EngineErrorKind::InvalidQuery);
+        assert_eq!(fixture.physical_row_count(), 2);
+
+        let returning = coordinator
+            .execute_dml(
+                "INSERT INTO events VALUES
+                 (?1, 2, 'returning', 1.0, x'01', NULL, 'one')
+                 RETURNING event_id",
+                [fixture.keys[0]],
+            )
+            .unwrap_err();
+        assert_eq!(returning.kind(), EngineErrorKind::Unsupported);
+        assert_eq!(fixture.physical_row_count(), 2);
+
+        for sql in [
+            "DROP TABLE events",
+            "ATTACH DATABASE ':memory:' AS escaped",
+            "BEGIN",
+        ] {
+            assert_eq!(
+                coordinator.execute_dml(sql, []).unwrap_err().kind(),
+                EngineErrorKind::PermissionDenied,
+                "sql={sql}"
+            );
+        }
+
+        let locator = coordinator
+            .execute_dml(
+                "INSERT INTO events
+                 (tenant_id, event_id, payload, amount, raw, optional, category,
+                  __briskdb_locator)
+                 VALUES (?1, 2, 'locator', 1.0, x'01', NULL, 'one', x'00')",
+                [fixture.keys[0]],
+            )
+            .unwrap_err();
+        assert_eq!(locator.kind(), EngineErrorKind::ReadOnly);
+        assert_eq!(fixture.physical_row_count(), 2);
+
+        let null_locator = coordinator
+            .execute_dml(
+                "UPDATE events
+                 SET payload = 'must-not-land', __briskdb_locator = NULL
+                 WHERE tenant_id = ?1 AND event_id = 1",
+                [fixture.keys[0]],
+            )
+            .unwrap_err();
+        assert_eq!(null_locator.kind(), EngineErrorKind::ReadOnly);
+        assert_eq!(
+            fixture
+                .storage
+                .open_shard(0)
+                .unwrap()
+                .query_row(
+                    "SELECT payload FROM events WHERE tenant_id = ?1 AND event_id = 1",
+                    [fixture.keys[0]],
+                    |row| row.get::<_, String>(0),
+                )
+                .unwrap(),
+            "zero"
+        );
+
+        // Rejections that did not poison a physical transaction leave the
+        // wrapper reusable.
+        assert_eq!(
+            coordinator
+                .execute_dml(
+                    "INSERT INTO events VALUES
+                     (?1, 2, 'after-errors', 1.0, x'01', NULL, 'one')",
+                    [fixture.keys[0]],
+                )
+                .unwrap()
+                .affected_rows,
+            1
+        );
+    }
+
+    #[test]
+    fn writable_update_conflict_ignore_and_replace_are_delegated_physically() {
+        let fixture = WritableFixture::new();
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+        for (item_id, code) in [(1, "first"), (2, "second")] {
+            coordinator
+                .execute_dml(
+                    "INSERT INTO items VALUES (?1, ?2, 1, ?3, 1)",
+                    params![fixture.keys[0], item_id, code],
+                )
+                .unwrap();
+        }
+        assert_eq!(
+            coordinator
+                .execute_dml(
+                    "UPDATE OR IGNORE items SET code = 'first'
+                     WHERE tenant_id = ?1 AND item_id = 2",
+                    [fixture.keys[0]],
+                )
+                .unwrap()
+                .affected_rows,
+            0
+        );
+        assert_eq!(fixture.item_count(), 2);
+
+        assert_eq!(
+            coordinator
+                .execute_dml(
+                    "UPDATE OR REPLACE items SET code = 'first'
+                     WHERE tenant_id = ?1 AND item_id = 2",
+                    [fixture.keys[0]],
+                )
+                .unwrap()
+                .affected_rows,
+            1
+        );
+        assert_eq!(fixture.item_count(), 1);
+        assert_eq!(
+            fixture
+                .storage
+                .open_shard(0)
+                .unwrap()
+                .query_row(
+                    "SELECT item_id FROM items WHERE tenant_id = ?1 AND code = 'first'",
+                    [fixture.keys[0]],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            2
+        );
+    }
+
+    #[test]
+    fn writable_multirow_replace_skips_a_later_invalidated_locator_and_counts_physical_updates() {
+        let fixture = WritableFixture::new();
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+        for (item_id, code) in [(1, "first"), (2, "second")] {
+            coordinator
+                .execute_dml(
+                    "INSERT INTO items VALUES (?1, ?2, 1, ?3, 1)",
+                    params![fixture.keys[0], item_id, code],
+                )
+                .unwrap();
+        }
+
+        // Whichever materialized row SQLite updates first takes the other
+        // row's unique code, so OR REPLACE removes the still-pending row.
+        // Native SQLite then treats that later stale row identity as a no-op.
+        let updated = coordinator
+            .execute_dml(
+                "UPDATE OR REPLACE items
+                 SET code = CASE item_id
+                     WHEN 1 THEN 'second'
+                     ELSE 'first'
+                 END
+                 WHERE tenant_id = ?1 AND item_id IN (1, 2)",
+                [fixture.keys[0]],
+            )
+            .unwrap();
+
+        assert_eq!(updated.affected_rows, 1);
+        assert_eq!(fixture.item_count(), 1);
+    }
+
+    #[test]
+    fn writable_fk_cascade_skips_later_invalidated_locator_and_counts_direct_delete() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut storage = Storage::open(temp.path(), 2).unwrap();
+        let mut migration = storage.begin_schema_migration().unwrap();
+        migration.wait_for_quiescence_blocking();
+        storage
+            .apply_schema_migration(
+                "CREATE TABLE cascade_nodes (
+                     tenant_id INTEGER NOT NULL,
+                     node_id INTEGER NOT NULL,
+                     parent_id INTEGER,
+                     PRIMARY KEY (tenant_id, node_id),
+                     FOREIGN KEY (tenant_id, parent_id)
+                         REFERENCES cascade_nodes (tenant_id, node_id)
+                         ON DELETE CASCADE
+                 );",
+                &mut migration,
+                None,
+            )
+            .unwrap();
+        migration.publish_ready().unwrap();
+        let database_id = storage.logical_catalog().default_database().id();
+        storage
+            .register_tables(vec![
+                TableDeclaration::sharded(
+                    database_id,
+                    "cascade_nodes",
+                    ShardKeyMetadata::new("tenant_id", ShardKeyType::Int64).unwrap(),
+                )
+                .unwrap(),
+            ])
+            .unwrap();
+        let key = (1_i64..)
+            .find(|key| storage.shard_for_key(key.to_string().as_bytes()) == 0)
+            .unwrap();
+        let shard = storage.open_shard(0).unwrap();
+        shard
+            .execute("INSERT INTO cascade_nodes VALUES (?1, 1, NULL)", [key])
+            .unwrap();
+        shard
+            .execute("INSERT INTO cascade_nodes VALUES (?1, 2, 1)", [key])
+            .unwrap();
+        shard
+            .execute(
+                "UPDATE cascade_nodes SET parent_id = 2
+                 WHERE tenant_id = ?1 AND node_id = 1",
+                [key],
+            )
+            .unwrap();
+        drop(shard);
+
+        let mut coordinator = WriteCoordinator::open(storage.clone()).unwrap();
+        let deleted = coordinator
+            .execute_dml("DELETE FROM cascade_nodes WHERE tenant_id = ?1", [key])
+            .unwrap();
+
+        // The first direct delete cascades to the second materialized row.
+        // Like sqlite3_changes(), affected_rows excludes the FK side effect.
+        assert_eq!(deleted.affected_rows, 1);
+        assert_eq!(
+            storage
+                .open_shard(0)
+                .unwrap()
+                .query_row("SELECT COUNT(*) FROM cascade_nodes", [], |row| {
+                    row.get::<_, i64>(0)
+                })
+                .unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn writable_affected_rows_are_per_statement_for_bulk_single_shard_dml() {
+        let fixture = WritableFixture::new();
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+        let inserted = coordinator
+            .execute_dml(
+                "INSERT INTO items VALUES
+                 (?1, 1, 1, 'one', 1),
+                 (?1, 2, 1, 'two', 2),
+                 (?1, 3, 1, 'three', 3)",
+                [fixture.keys[0]],
+            )
+            .unwrap();
+        assert_eq!(inserted.affected_rows, 3);
+        assert_eq!(inserted.explicit_key, Some(Value::Int64(fixture.keys[0])));
+        assert_eq!(
+            coordinator
+                .execute_dml(
+                    "UPDATE items SET quantity = quantity + 10 WHERE tenant_id = ?1",
+                    [fixture.keys[0]],
+                )
+                .unwrap()
+                .affected_rows,
+            3
+        );
+        assert_eq!(
+            coordinator
+                .execute_dml("DELETE FROM items WHERE tenant_id = ?1", [fixture.keys[0]])
+                .unwrap()
+                .affected_rows,
+            3
+        );
+        assert_eq!(fixture.item_count(), 0);
+    }
+
+    #[test]
+    fn writable_locators_cover_without_rowid_text_blob_and_explicit_native_ids() {
+        let fixture = TypedRoutingFixture::new(2);
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+
+        assert_eq!(
+            coordinator
+                .execute_dml(
+                    "UPDATE text_events SET payload = 'text-updated' WHERE id = ?1",
+                    [&fixture.text_keys[0]],
+                )
+                .unwrap()
+                .affected_rows,
+            1
+        );
+        assert_eq!(
+            coordinator
+                .execute_dml(
+                    "DELETE FROM blob_events WHERE id = ?1",
+                    [&fixture.blob_keys[1]]
+                )
+                .unwrap()
+                .affected_rows,
+            1
+        );
+        let decoded = NativeRangeV1Id::decode(fixture.native_ids[0]).unwrap();
+        let second_native = NativeRangeV1Id::new(decoded.owner(), 2).unwrap().encode();
+        let inserted = coordinator
+            .execute_dml(
+                "INSERT INTO native_events VALUES (?1, 'native-explicit')",
+                [second_native],
+            )
+            .unwrap();
+        assert_eq!(inserted.explicit_key, Some(Value::Int64(second_native)));
+
+        assert_eq!(
+            fixture
+                .storage
+                .open_shard(0)
+                .unwrap()
+                .query_row(
+                    "SELECT payload FROM text_events WHERE id = ?1",
+                    [&fixture.text_keys[0]],
+                    |row| row.get::<_, String>(0),
+                )
+                .unwrap(),
+            "text-updated"
+        );
+        assert_eq!(
+            fixture
+                .storage
+                .open_shard(1)
+                .unwrap()
+                .query_row("SELECT COUNT(*) FROM blob_events", [], |row| {
+                    row.get::<_, i64>(0)
+                })
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            fixture
+                .storage
+                .open_shard(0)
+                .unwrap()
+                .query_row(
+                    "SELECT payload FROM native_events WHERE id = ?1",
+                    [second_native],
+                    |row| row.get::<_, String>(0),
+                )
+                .unwrap(),
+            "native-explicit"
+        );
+    }
+
+    #[test]
+    fn writable_distinct_shards_progress_while_same_shard_writer_is_locked() {
+        let fixture = Fixture::new();
+        let blocker = fixture.storage.open_shard(0).unwrap();
+        blocker.execute_batch("BEGIN IMMEDIATE").unwrap();
+
+        let (completed_tx, completed_rx) = mpsc::channel();
+        let mut workers = Vec::new();
+        for shard in 0..2_u16 {
+            let storage = fixture.storage.clone();
+            let key = fixture.keys[usize::from(shard)];
+            let completed = completed_tx.clone();
+            workers.push(thread::spawn(move || {
+                let mut coordinator = WriteCoordinator::open(storage).unwrap();
+                let result = coordinator.execute_dml(
+                    "INSERT INTO events VALUES
+                     (?1, 2, 'concurrent', 1.0, x'01', NULL, 'one')",
+                    [key],
+                );
+                completed.send((shard, result)).unwrap();
+            }));
+        }
+        drop(completed_tx);
+
+        let (first_shard, first_result) = completed_rx
+            .recv_timeout(Duration::from_secs(3))
+            .expect("the unlocked shard writer did not complete independently");
+        assert_eq!(first_shard, 1);
+        assert_eq!(first_result.unwrap().affected_rows, 1);
+
+        blocker.execute_batch("COMMIT").unwrap();
+        let (second_shard, second_result) = completed_rx
+            .recv_timeout(TEST_SYNC_TIMEOUT)
+            .expect("the blocked same-shard writer did not resume");
+        assert_eq!(second_shard, 0);
+        assert_eq!(second_result.unwrap().affected_rows, 1);
+        for worker in workers {
+            worker.join().unwrap();
+        }
+        assert_eq!(fixture.physical_row_count(), 4);
+    }
+
+    #[test]
+    fn writable_cancellation_interrupts_lock_wait_rolls_back_and_allows_reuse() {
+        let fixture = Fixture::new();
+        let blocker = fixture.storage.open_shard(0).unwrap();
+        blocker.execute_batch("BEGIN IMMEDIATE").unwrap();
+
+        let coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+        let cancellation = coordinator.cancellation_handle();
+        let write_state = coordinator.write_state_for_test();
+        let key = fixture.keys[0];
+        let worker = thread::spawn(move || {
+            let mut coordinator = coordinator;
+            let result = coordinator.execute_dml(
+                "INSERT INTO events VALUES
+                 (?1, 2, 'cancelled', 1.0, x'01', NULL, 'one')",
+                [key],
+            );
+            (coordinator, result)
+        });
+
+        let deadline = Instant::now() + TEST_SYNC_TIMEOUT;
+        while !write_state.has_active_child() {
+            assert!(
+                Instant::now() < deadline,
+                "writable child did not reach its cancellable lock wait"
+            );
+            thread::sleep(Duration::from_millis(5));
+        }
+        cancellation.cancel();
+        let (mut coordinator, result) = worker.join().unwrap();
+        assert_eq!(result.unwrap_err().kind(), EngineErrorKind::Cancelled);
+        assert_eq!(fixture.physical_row_count(), 2);
+
+        blocker.execute_batch("COMMIT").unwrap();
+        assert_eq!(
+            coordinator
+                .execute_dml(
+                    "INSERT INTO events VALUES
+                     (?1, 2, 'after-cancel', 1.0, x'01', NULL, 'one')",
+                    [fixture.keys[0]],
+                )
+                .unwrap()
+                .affected_rows,
+            1
+        );
+        assert_eq!(fixture.physical_row_count(), 3);
+    }
+
+    #[test]
+    fn writable_cancellation_after_statement_arm_cannot_be_lost_before_first_callback() {
+        let fixture = Fixture::new();
+        let coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+        let cancellation = coordinator.cancellation_handle();
+        let mut gate = coordinator.install_statement_arm_gate_for_test();
+        let key = fixture.keys[0];
+        let worker = thread::spawn(move || {
+            let mut coordinator = coordinator;
+            let result = coordinator.execute_dml(
+                "INSERT INTO events VALUES
+                 (?1, 2, 'cancelled-before-callback', 1.0, x'01', NULL, 'one')",
+                [key],
+            );
+            (coordinator, result)
+        });
+
+        gate.wait_until_started();
+        cancellation.cancel();
+        gate.release();
+
+        let (mut coordinator, result) = worker.join().unwrap();
+        assert_eq!(result.unwrap_err().kind(), EngineErrorKind::Cancelled);
+        assert_eq!(fixture.physical_row_count(), 2);
+
+        assert_eq!(
+            coordinator
+                .execute_dml(
+                    "INSERT INTO events VALUES
+                     (?1, 2, 'after-cancel', 1.0, x'01', NULL, 'one')",
+                    [fixture.keys[0]],
+                )
+                .unwrap()
+                .affected_rows,
+            1
+        );
+        assert_eq!(fixture.physical_row_count(), 3);
+    }
+
+    #[test]
+    fn writable_drop_rolls_back_connection_loss_and_commits_survive_reopen() {
+        let fixture = Fixture::new();
+        {
+            let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+            coordinator.begin().unwrap();
+            coordinator
+                .execute_dml(
+                    "INSERT INTO events VALUES
+                     (?1, 2, 'lost-connection', 1.0, x'01', NULL, 'one')",
+                    [fixture.keys[0]],
+                )
+                .unwrap();
+            // Dropping the only wrapper is the supported connection-loss path.
+        }
+        assert_eq!(fixture.physical_row_count(), 2);
+
+        {
+            let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+            coordinator
+                .execute_dml(
+                    "INSERT INTO events VALUES
+                     (?1, 2, 'durable', 1.0, x'01', NULL, 'one')",
+                    [fixture.keys[0]],
+                )
+                .unwrap();
+        }
+        let reopened = Storage::open(fixture.temp.path(), 2).unwrap();
+        assert_eq!(
+            reopened
+                .open_shard(0)
+                .unwrap()
+                .query_row(
+                    "SELECT payload FROM events WHERE tenant_id = ?1 AND event_id = 2",
+                    [fixture.keys[0]],
+                    |row| row.get::<_, String>(0),
+                )
+                .unwrap(),
+            "durable"
+        );
+    }
+
+    #[test]
+    fn writable_child_commit_failure_is_surfaced_before_acknowledgement_and_recovers_on_reopen() {
+        let fixture = Fixture::new();
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+        coordinator.fail_next_commit_for_test();
+        let error = coordinator
+            .execute_dml(
+                "INSERT INTO events VALUES
+                 (?1, 2, 'must-not-commit', 1.0, x'01', NULL, 'one')",
+                [fixture.keys[0]],
+            )
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::StorageUnavailable);
+        assert_eq!(fixture.physical_row_count(), 2);
+        assert_eq!(
+            coordinator
+                .execute_dml(
+                    "INSERT INTO events VALUES
+                     (?1, 2, 'not-reusable', 1.0, x'01', NULL, 'one')",
+                    [fixture.keys[0]],
+                )
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+        drop(coordinator);
+
+        let mut reopened = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+        assert_eq!(
+            reopened
+                .execute_dml(
+                    "INSERT INTO events VALUES
+                     (?1, 2, 'recovered', 1.0, x'01', NULL, 'one')",
+                    [fixture.keys[0]],
+                )
+                .unwrap()
+                .affected_rows,
+            1
+        );
+        assert_eq!(fixture.physical_row_count(), 3);
+    }
+
+    #[test]
+    fn writable_child_operation_corruption_marks_storage_degraded() {
+        let fixture = Fixture::new();
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+        coordinator.begin().unwrap();
+        coordinator.fail_next_write_corruption_for_test();
+        let error = coordinator
+            .execute_dml(
+                "INSERT INTO events VALUES
+                 (?1, 2, 'must-not-land', 1.0, x'01', NULL, 'one')",
+                [fixture.keys[0]],
+            )
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+        assert!(!coordinator.in_transaction());
+        assert_eq!(
+            fixture.storage.schema_gate_snapshot().state,
+            crate::storage::SchemaGateState::Degraded
+        );
+        assert_eq!(fixture.storage.schema_gate_snapshot().active_operations, 0);
+        assert_eq!(
+            Connection::open(fixture.temp.path().join("shards/0000.sqlite"))
+                .unwrap()
+                .query_row("SELECT COUNT(*) FROM events", [], |row| {
+                    row.get::<_, i64>(0)
+                })
+                .unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn writable_child_commit_corruption_marks_storage_degraded_before_acknowledgement() {
+        let fixture = Fixture::new();
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+        coordinator.fail_next_commit_corruption_for_test();
+        let error = coordinator
+            .execute_dml(
+                "INSERT INTO events VALUES
+                 (?1, 2, 'must-roll-back', 1.0, x'01', NULL, 'one')",
+                [fixture.keys[0]],
+            )
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+        assert_eq!(
+            fixture.storage.schema_gate_snapshot().state,
+            crate::storage::SchemaGateState::Degraded
+        );
+        assert_eq!(fixture.storage.schema_gate_snapshot().active_operations, 0);
+        assert_eq!(
+            Connection::open(fixture.temp.path().join("shards/0000.sqlite"))
+                .unwrap()
+                .query_row("SELECT COUNT(*) FROM events", [], |row| {
+                    row.get::<_, i64>(0)
+                })
+                .unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn writable_local_foreign_key_does_not_accept_a_parent_on_the_wrong_shard() {
+        let fixture = WritableFixture::new();
+        fixture
+            .storage
+            .open_shard(0)
+            .unwrap()
+            .execute(
+                "DELETE FROM parents WHERE tenant_id = ?1",
+                [fixture.keys[0]],
+            )
+            .unwrap();
+        fixture
+            .storage
+            .open_shard(1)
+            .unwrap()
+            .execute(
+                "INSERT INTO parents VALUES (?1, 1, 'wrong-owner')",
+                [fixture.keys[0]],
+            )
+            .unwrap();
+
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+        let error = coordinator
+            .execute_dml(
+                "INSERT INTO items VALUES (?1, 1, 1, 'must-fail', 1)",
+                [fixture.keys[0]],
+            )
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::ForeignKeyViolation);
+        assert_eq!(fixture.item_count(), 0);
+    }
+
+    #[test]
+    fn writable_defaults_and_generated_columns_fail_closed_until_their_issues_land() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut storage = Storage::open(temp.path(), 2).unwrap();
+        let mut migration = storage.begin_schema_migration().unwrap();
+        migration.wait_for_quiescence_blocking();
+        storage
+            .apply_schema_migration(
+                "CREATE TABLE default_events (
+                     id INTEGER PRIMARY KEY,
+                     payload TEXT NOT NULL DEFAULT 'defaulted'
+                 );
+                 CREATE TABLE generated_events (
+                     id INTEGER PRIMARY KEY,
+                     base INTEGER NOT NULL,
+                     doubled INTEGER GENERATED ALWAYS AS (base * 2) STORED
+                 );",
+                &mut migration,
+                None,
+            )
+            .unwrap();
+        migration.publish_ready().unwrap();
+        let database_id = storage.logical_catalog().default_database().id();
+        storage
+            .register_tables(vec![
+                TableDeclaration::sharded(
+                    database_id,
+                    "default_events",
+                    ShardKeyMetadata::new("id", ShardKeyType::Int64).unwrap(),
+                )
+                .unwrap(),
+                TableDeclaration::sharded(
+                    database_id,
+                    "generated_events",
+                    ShardKeyMetadata::new("id", ShardKeyType::Int64).unwrap(),
+                )
+                .unwrap(),
+            ])
+            .unwrap();
+        let key = (1_i64..)
+            .find(|key| storage.shard_for_key(key.to_string().as_bytes()) == 0)
+            .unwrap();
+        let mut coordinator = WriteCoordinator::open(storage.clone()).unwrap();
+
+        for (sql, parameters) in [
+            (
+                "INSERT INTO default_events (id, payload) VALUES (?1, 'explicit')",
+                [key],
+            ),
+            (
+                "INSERT INTO generated_events (id, base) VALUES (?1, 3)",
+                [key],
+            ),
+        ] {
+            assert_eq!(
+                coordinator.execute_dml(sql, parameters).unwrap_err().kind(),
+                EngineErrorKind::InvalidQuery,
+                "sql={sql}"
+            );
+        }
+        for table in ["default_events", "generated_events"] {
+            assert_eq!(
+                storage
+                    .open_shard(0)
+                    .unwrap()
+                    .query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |row| {
+                        row.get::<_, i64>(0)
+                    })
+                    .unwrap(),
+                0
+            );
+        }
+    }
+
+    #[test]
+    fn writable_stale_coordinator_fails_before_opening_or_mutating_a_child() {
+        let fixture = Fixture::new();
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+        let mut migration = fixture.storage.begin_schema_migration().unwrap();
+        migration.wait_for_quiescence_blocking();
+        fixture
+            .storage
+            .apply_schema_migration(
+                "ALTER TABLE events ADD COLUMN note TEXT",
+                &mut migration,
+                None,
+            )
+            .unwrap();
+        migration.publish_ready().unwrap();
+
+        let error = coordinator
+            .execute_dml(
+                "INSERT INTO events
+                 (tenant_id, event_id, payload, amount, raw, optional, category)
+                 VALUES (?1, 2, 'stale', 1.0, x'01', NULL, 'one')",
+                [fixture.keys[0]],
+            )
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Busy);
+        assert_eq!(fixture.physical_row_count(), 2);
+        assert_eq!(fixture.storage.schema_gate_snapshot().active_operations, 0);
     }
 }

--- a/src/storage/sharded_vtab/locator.rs
+++ b/src/storage/sharded_vtab/locator.rs
@@ -1,0 +1,411 @@
+//! Opaque physical-row locators used by the writable virtual-table facade.
+//!
+//! Locators are never interpreted as SQL values. They identify the registered
+//! table, the physical shard, and the row identity values selected from that
+//! shard. The representation is deliberately versioned and length-delimited so
+//! future versions can be rejected safely instead of being misinterpreted.
+
+use super::RawCell;
+use crate::core::{EngineError, EngineErrorKind, EngineResult};
+
+const VERSION: u8 = 1;
+const HEADER_BYTES: usize = 1 + size_of::<u64>() + size_of::<u16>() + size_of::<u16>();
+const VALUE_HEADER_BYTES: usize = 1 + size_of::<u32>();
+
+const TAG_NULL: u8 = 0;
+const TAG_INTEGER: u8 = 1;
+const TAG_REAL: u8 = 2;
+const TAG_TEXT: u8 = 3;
+const TAG_BLOB: u8 = 4;
+
+/// Hard bound for both encoded and accepted locator values.
+pub(super) const MAX_LOCATOR_BYTES: usize = 1024 * 1024;
+
+#[derive(Debug)]
+pub(super) struct DecodedLocator {
+    pub(super) shard: u16,
+    pub(super) values: Vec<RawCell>,
+}
+
+/// Encode a physical row identity into a bounded, table-specific locator.
+pub(super) fn encode(table_id: u64, shard: u16, values: &[RawCell]) -> EngineResult<Vec<u8>> {
+    let value_count = u16::try_from(values.len()).map_err(|_| {
+        EngineError::new(
+            EngineErrorKind::LimitExceeded,
+            "brisk_shard locator contains more than 65535 identity values",
+        )
+    })?;
+
+    let mut encoded_len = HEADER_BYTES;
+    for value in values {
+        let payload_len = payload_len(value);
+        u32::try_from(payload_len).map_err(|_| locator_size_error())?;
+        encoded_len = encoded_len
+            .checked_add(VALUE_HEADER_BYTES)
+            .and_then(|len| len.checked_add(payload_len))
+            .ok_or_else(locator_size_error)?;
+        if encoded_len > MAX_LOCATOR_BYTES {
+            return Err(locator_size_error());
+        }
+    }
+
+    let mut encoded = Vec::new();
+    encoded
+        .try_reserve_exact(encoded_len)
+        .map_err(allocation_error)?;
+    encoded.push(VERSION);
+    encoded.extend_from_slice(&table_id.to_be_bytes());
+    encoded.extend_from_slice(&shard.to_be_bytes());
+    encoded.extend_from_slice(&value_count.to_be_bytes());
+
+    for value in values {
+        let (tag, payload_len) = match value {
+            RawCell::Null => (TAG_NULL, 0),
+            RawCell::Integer(_) => (TAG_INTEGER, size_of::<i64>()),
+            RawCell::Real(_) => (TAG_REAL, size_of::<u64>()),
+            RawCell::Text(value) => (TAG_TEXT, value.len()),
+            RawCell::Blob(value) => (TAG_BLOB, value.len()),
+        };
+        let payload_len = u32::try_from(payload_len).map_err(|_| locator_size_error())?;
+        encoded.push(tag);
+        encoded.extend_from_slice(&payload_len.to_be_bytes());
+        match value {
+            RawCell::Null => {}
+            RawCell::Integer(value) => encoded.extend_from_slice(&value.to_be_bytes()),
+            RawCell::Real(value) => encoded.extend_from_slice(&value.to_bits().to_be_bytes()),
+            RawCell::Text(value) | RawCell::Blob(value) => encoded.extend_from_slice(value),
+        }
+    }
+
+    debug_assert_eq!(encoded.len(), encoded_len);
+    Ok(encoded)
+}
+
+/// Decode and validate a locator for `expected_table_id`.
+pub(super) fn decode(expected_table_id: u64, bytes: &[u8]) -> EngineResult<DecodedLocator> {
+    if bytes.len() > MAX_LOCATOR_BYTES {
+        return Err(locator_size_error());
+    }
+
+    let mut input = Input::new(bytes);
+    let version = input.byte()?;
+    if version != VERSION {
+        return Err(locator_corruption(
+            "brisk_shard locator has an unsupported format version",
+        ));
+    }
+
+    let table_id = u64::from_be_bytes(input.array()?);
+    if table_id != expected_table_id {
+        return Err(locator_corruption(
+            "brisk_shard locator belongs to a different registered table",
+        ));
+    }
+    let shard = u16::from_be_bytes(input.array()?);
+    let value_count = usize::from(u16::from_be_bytes(input.array()?));
+    let minimum_value_bytes = value_count
+        .checked_mul(VALUE_HEADER_BYTES)
+        .ok_or_else(|| locator_corruption("brisk_shard locator value count overflowed"))?;
+    if input.remaining() < minimum_value_bytes {
+        return Err(locator_corruption("brisk_shard locator is truncated"));
+    }
+
+    let mut values = Vec::new();
+    values
+        .try_reserve_exact(value_count)
+        .map_err(allocation_error)?;
+    for _ in 0..value_count {
+        let tag = input.byte()?;
+        let payload_len_u32 = u32::from_be_bytes(input.array()?);
+        let payload_len = usize::try_from(payload_len_u32).map_err(|_| locator_size_error())?;
+        let payload = input.take(payload_len)?;
+
+        let value = match tag {
+            TAG_NULL => {
+                require_payload_len(payload, 0, "NULL")?;
+                RawCell::Null
+            }
+            TAG_INTEGER => {
+                require_payload_len(payload, size_of::<i64>(), "integer")?;
+                RawCell::Integer(i64::from_be_bytes(payload.try_into().map_err(|_| {
+                    locator_corruption("brisk_shard locator has an invalid integer payload")
+                })?))
+            }
+            TAG_REAL => {
+                require_payload_len(payload, size_of::<u64>(), "real")?;
+                let bits = u64::from_be_bytes(payload.try_into().map_err(|_| {
+                    locator_corruption("brisk_shard locator has an invalid real payload")
+                })?);
+                RawCell::Real(f64::from_bits(bits))
+            }
+            TAG_TEXT => RawCell::Text(copy_payload(payload)?),
+            TAG_BLOB => RawCell::Blob(copy_payload(payload)?),
+            _ => {
+                return Err(locator_corruption(
+                    "brisk_shard locator has an unknown storage-class tag",
+                ));
+            }
+        };
+        values.push(value);
+    }
+
+    if !input.is_empty() {
+        return Err(locator_corruption("brisk_shard locator has trailing bytes"));
+    }
+
+    Ok(DecodedLocator { shard, values })
+}
+
+fn payload_len(value: &RawCell) -> usize {
+    match value {
+        RawCell::Null => 0,
+        RawCell::Integer(_) | RawCell::Real(_) => size_of::<u64>(),
+        RawCell::Text(value) | RawCell::Blob(value) => value.len(),
+    }
+}
+
+fn require_payload_len(payload: &[u8], expected: usize, storage_class: &str) -> EngineResult<()> {
+    if payload.len() == expected {
+        Ok(())
+    } else {
+        Err(locator_corruption(format!(
+            "brisk_shard locator has a non-canonical {storage_class} payload length"
+        )))
+    }
+}
+
+fn copy_payload(payload: &[u8]) -> EngineResult<Vec<u8>> {
+    let mut copy = Vec::new();
+    copy.try_reserve_exact(payload.len())
+        .map_err(allocation_error)?;
+    copy.extend_from_slice(payload);
+    Ok(copy)
+}
+
+fn locator_size_error() -> EngineError {
+    EngineError::new(
+        EngineErrorKind::LimitExceeded,
+        "brisk_shard locator exceeds its 1 MiB encoded-size limit",
+    )
+}
+
+fn locator_corruption(diagnostic: impl Into<String>) -> EngineError {
+    EngineError::new(EngineErrorKind::DataCorruption, diagnostic)
+}
+
+fn allocation_error(error: std::collections::TryReserveError) -> EngineError {
+    EngineError::from_source(
+        EngineErrorKind::OutOfMemory,
+        "brisk_shard could not reserve bounded locator memory",
+        error,
+    )
+}
+
+struct Input<'a> {
+    bytes: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> Input<'a> {
+    const fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, offset: 0 }
+    }
+
+    fn byte(&mut self) -> EngineResult<u8> {
+        Ok(self.take(1)?[0])
+    }
+
+    fn array<const N: usize>(&mut self) -> EngineResult<[u8; N]> {
+        let mut result = [0; N];
+        result.copy_from_slice(self.take(N)?);
+        Ok(result)
+    }
+
+    fn take(&mut self, len: usize) -> EngineResult<&'a [u8]> {
+        let end = self
+            .offset
+            .checked_add(len)
+            .ok_or_else(|| locator_corruption("brisk_shard locator length overflowed"))?;
+        if end > self.bytes.len() {
+            return Err(locator_corruption("brisk_shard locator is truncated"));
+        }
+        let value = &self.bytes[self.offset..end];
+        self.offset = end;
+        Ok(value)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.offset == self.bytes.len()
+    }
+
+    fn remaining(&self) -> usize {
+        self.bytes.len() - self.offset
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_every_storage_class_losslessly() {
+        let nan_bits = 0x7ff8_0000_0000_0042;
+        let values = vec![
+            RawCell::Null,
+            RawCell::Integer(i64::MIN),
+            RawCell::Integer(i64::MAX),
+            RawCell::Real(-0.0),
+            RawCell::Real(f64::from_bits(nan_bits)),
+            RawCell::Text(vec![0xff, 0x00, b'a']),
+            RawCell::Blob(vec![0x00, 0x80, 0xff]),
+        ];
+
+        let encoded = encode(0x1020_3040_5060_7080, u16::MAX, &values).unwrap();
+        let decoded = decode(0x1020_3040_5060_7080, &encoded).unwrap();
+
+        assert_eq!(decoded.shard, u16::MAX);
+        assert_eq!(decoded.values.len(), values.len());
+        assert!(matches!(decoded.values[0], RawCell::Null));
+        assert!(matches!(decoded.values[1], RawCell::Integer(i64::MIN)));
+        assert!(matches!(decoded.values[2], RawCell::Integer(i64::MAX)));
+        assert_real_bits(&decoded.values[3], (-0.0_f64).to_bits());
+        assert_real_bits(&decoded.values[4], nan_bits);
+        assert_bytes(&decoded.values[5], true, &[0xff, 0x00, b'a']);
+        assert_bytes(&decoded.values[6], false, &[0x00, 0x80, 0xff]);
+    }
+
+    #[test]
+    fn empty_identity_is_valid_and_table_specific() {
+        let encoded = encode(7, 0, &[]).unwrap();
+        assert_eq!(encoded.len(), HEADER_BYTES);
+
+        let decoded = decode(7, &encoded).unwrap();
+        assert_eq!(decoded.shard, 0);
+        assert!(decoded.values.is_empty());
+
+        let error = decode(8, &encoded).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+    }
+
+    #[test]
+    fn rejects_every_truncation_boundary_without_panicking() {
+        let encoded = encode(
+            9,
+            3,
+            &[
+                RawCell::Integer(-27),
+                RawCell::Text(b"identity".to_vec()),
+                RawCell::Blob(vec![1, 2, 3]),
+            ],
+        )
+        .unwrap();
+
+        for end in 0..encoded.len() {
+            let error = decode(9, &encoded[..end]).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::DataCorruption, "end={end}");
+        }
+        assert!(decode(9, &encoded).is_ok());
+    }
+
+    #[test]
+    fn rejects_wrong_version_unknown_tag_and_trailing_bytes() {
+        let mut wrong_version = encode(1, 2, &[]).unwrap();
+        wrong_version[0] = VERSION.wrapping_add(1);
+        assert_corrupt(decode(1, &wrong_version));
+
+        let mut unknown_tag = encode(1, 2, &[RawCell::Null]).unwrap();
+        unknown_tag[HEADER_BYTES] = 0xfe;
+        assert_corrupt(decode(1, &unknown_tag));
+
+        let mut trailing = encode(1, 2, &[]).unwrap();
+        trailing.push(0);
+        assert_corrupt(decode(1, &trailing));
+    }
+
+    #[test]
+    fn rejects_noncanonical_fixed_width_payload_lengths() {
+        for value in [RawCell::Null, RawCell::Integer(1), RawCell::Real(1.0)] {
+            let mut encoded = encode(4, 5, &[value]).unwrap();
+            let original_len = u32::from_be_bytes(
+                encoded[HEADER_BYTES + 1..HEADER_BYTES + VALUE_HEADER_BYTES]
+                    .try_into()
+                    .unwrap(),
+            );
+            let invalid_len = if original_len == 0 {
+                1_u32
+            } else {
+                original_len - 1
+            };
+            encoded[HEADER_BYTES + 1..HEADER_BYTES + VALUE_HEADER_BYTES]
+                .copy_from_slice(&invalid_len.to_be_bytes());
+            if original_len == 0 {
+                encoded.push(0);
+            } else {
+                encoded.pop();
+            }
+            assert_corrupt(decode(4, &encoded));
+        }
+    }
+
+    #[test]
+    fn rejects_declared_payload_larger_than_remaining_input() {
+        let mut encoded = encode(12, 6, &[RawCell::Blob(vec![1, 2, 3])]).unwrap();
+        encoded[HEADER_BYTES + 1..HEADER_BYTES + VALUE_HEADER_BYTES]
+            .copy_from_slice(&100_u32.to_be_bytes());
+        assert_corrupt(decode(12, &encoded));
+    }
+
+    #[test]
+    fn enforces_exact_one_mibibyte_boundary() {
+        let payload_len = MAX_LOCATOR_BYTES - HEADER_BYTES - VALUE_HEADER_BYTES;
+        let payload = vec![0xa5; payload_len];
+        let encoded = encode(15, 8, &[RawCell::Blob(payload.clone())]).unwrap();
+        assert_eq!(encoded.len(), MAX_LOCATOR_BYTES);
+        let decoded = decode(15, &encoded).unwrap();
+        assert_bytes(&decoded.values[0], false, &payload);
+
+        let error = encode(15, 8, &[RawCell::Blob(vec![0; payload_len + 1])]).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+
+        let oversized = vec![0; MAX_LOCATOR_BYTES + 1];
+        let error = decode(15, &oversized).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+    }
+
+    #[test]
+    fn supports_maximum_value_count_and_rejects_count_overflow() {
+        let max_values = (0..usize::from(u16::MAX))
+            .map(|_| RawCell::Null)
+            .collect::<Vec<_>>();
+        let encoded = encode(22, 11, &max_values).unwrap();
+        let decoded = decode(22, &encoded).unwrap();
+        assert_eq!(decoded.values.len(), usize::from(u16::MAX));
+
+        let too_many = (0..=usize::from(u16::MAX))
+            .map(|_| RawCell::Null)
+            .collect::<Vec<_>>();
+        let error = encode(22, 11, &too_many).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+    }
+
+    fn assert_corrupt(result: EngineResult<DecodedLocator>) {
+        let error = result.unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+    }
+
+    fn assert_real_bits(value: &RawCell, expected: u64) {
+        match value {
+            RawCell::Real(value) => assert_eq!(value.to_bits(), expected),
+            value => panic!("expected real, got {value:?}"),
+        }
+    }
+
+    fn assert_bytes(value: &RawCell, text: bool, expected: &[u8]) {
+        match (value, text) {
+            (RawCell::Text(value), true) | (RawCell::Blob(value), false) => {
+                assert_eq!(value, expected)
+            }
+            (value, _) => panic!("unexpected storage class: {value:?}"),
+        }
+    }
+}

--- a/src/storage/sharded_vtab/module_v2.rs
+++ b/src/storage/sharded_vtab/module_v2.rs
@@ -1,0 +1,266 @@
+//! Stock-SQLite virtual-table module bridge with transaction savepoints.
+//!
+//! rusqlite exposes writable virtual-table transaction callbacks through
+//! a version-1 `sqlite3_module`, but does not expose SQLite's version-2
+//! `xSavepoint`, `xRelease`, or `xRollbackTo` slots. This bridge preserves
+//! rusqlite's callback implementation and ownership model while filling only
+//! those three supported SQLite API slots. It does not patch or fork SQLite.
+
+use std::{
+    ffi::{CStr, c_int, c_void},
+    panic::{AssertUnwindSafe, catch_unwind},
+    ptr,
+    sync::{Arc, OnceLock},
+};
+
+use rusqlite::{Connection, Error as SqliteError, Result as SqliteResult, ffi};
+
+use super::{BriskShardTable, Registry};
+
+const MAX_VTAB_ERROR_MESSAGE_BYTES: usize = 4 * 1024;
+
+/// Register the writable `brisk_shard` module through SQLite's supported
+/// version-2 module API.
+pub(super) fn register_module(
+    connection: &Connection,
+    registry: Arc<Registry>,
+) -> SqliteResult<()> {
+    let registry = Box::into_raw(Box::new(registry)).cast::<c_void>();
+    // SAFETY: `Connection::handle` is valid for the lifetime of `connection`.
+    // `writable_module_v2` has static storage, the module name is NUL
+    // terminated, and `registry` is a boxed `Arc<Registry>`. SQLite owns that
+    // box after this call and invokes `drop_registry` both on registration
+    // failure and when the module is no longer needed.
+    let result_code = unsafe {
+        ffi::sqlite3_create_module_v2(
+            connection.handle(),
+            c"brisk_shard".as_ptr(),
+            writable_module_v2(),
+            registry,
+            Some(drop_registry),
+        )
+    };
+    if result_code == ffi::SQLITE_OK {
+        Ok(())
+    } else {
+        Err(connection_error(connection, result_code))
+    }
+}
+
+fn writable_module_v2() -> &'static ffi::sqlite3_module {
+    static MODULE: OnceLock<ffi::sqlite3_module> = OnceLock::new();
+    MODULE.get_or_init(|| {
+        let rusqlite_module = rusqlite::vtab::update_module_with_tx::<BriskShardTable>();
+        // SAFETY: rusqlite documents `Module` as `#[repr(transparent)]` over
+        // `ffi::sqlite3_module`. The returned module is static and its raw
+        // callback table is `Copy`; copying it preserves every stock rusqlite
+        // callback and its ABI.
+        let mut module = unsafe { *ptr::from_ref(rusqlite_module).cast::<ffi::sqlite3_module>() };
+        module.iVersion = 2;
+        module.xSavepoint = Some(savepoint_callback);
+        module.xRelease = Some(release_callback);
+        module.xRollbackTo = Some(rollback_to_callback);
+        module
+    })
+}
+
+unsafe extern "C" fn drop_registry(registry: *mut c_void) {
+    if !registry.is_null() {
+        // SAFETY: `register_module` created exactly one `Box<Arc<Registry>>`
+        // for this pointer and SQLite invokes this destructor at most once.
+        drop(unsafe { Box::from_raw(registry.cast::<Arc<Registry>>()) });
+    }
+}
+
+unsafe extern "C" fn savepoint_callback(table: *mut ffi::sqlite3_vtab, savepoint: c_int) -> c_int {
+    run_callback(table, |table| table.savepoint(savepoint))
+}
+
+unsafe extern "C" fn release_callback(table: *mut ffi::sqlite3_vtab, savepoint: c_int) -> c_int {
+    run_callback(table, |table| table.release(savepoint))
+}
+
+unsafe extern "C" fn rollback_to_callback(
+    table: *mut ffi::sqlite3_vtab,
+    savepoint: c_int,
+) -> c_int {
+    run_callback(table, |table| table.rollback_to(savepoint))
+}
+
+fn run_callback(
+    table: *mut ffi::sqlite3_vtab,
+    callback: impl FnOnce(&mut BriskShardTable) -> SqliteResult<()>,
+) -> c_int {
+    if table.is_null() {
+        return ffi::SQLITE_MISUSE;
+    }
+
+    // A panic must never cross SQLite's C ABI boundary. The table allocation
+    // is a `BriskShardTable` because every other callback in this module table
+    // is the stock rusqlite callback specialized for that same type.
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        // SAFETY: SQLite passes the live virtual-table object created by
+        // rusqlite. `BriskShardTable` has `sqlite3_vtab` as its first field and
+        // the callback is serialized by the owning SQLite connection.
+        let result = callback(unsafe { &mut *table.cast::<BriskShardTable>() });
+        callback_result(table, result)
+    }));
+    match result {
+        Ok(result_code) => result_code,
+        Err(_) => {
+            // SAFETY: `table` was checked non-null and is live for this
+            // callback. Allocation uses SQLite's allocator as required for
+            // `sqlite3_vtab.zErrMsg`.
+            unsafe {
+                set_error_message(table, "brisk_shard savepoint callback panicked");
+            }
+            ffi::SQLITE_ABORT
+        }
+    }
+}
+
+fn callback_result(table: *mut ffi::sqlite3_vtab, result: SqliteResult<()>) -> c_int {
+    match result {
+        Ok(()) => ffi::SQLITE_OK,
+        Err(SqliteError::SqliteFailure(error, message)) => {
+            if let Some(message) = message {
+                // SAFETY: `run_callback` validated the live table pointer.
+                unsafe {
+                    set_error_message(table, &message);
+                }
+            }
+            if error.extended_code == ffi::SQLITE_OK {
+                ffi::SQLITE_ERROR
+            } else {
+                error.extended_code
+            }
+        }
+        Err(error) => {
+            // SAFETY: `run_callback` validated the live table pointer.
+            unsafe {
+                set_error_message(table, &error.to_string());
+            }
+            ffi::SQLITE_ERROR
+        }
+    }
+}
+
+unsafe fn set_error_message(table: *mut ffi::sqlite3_vtab, message: &str) {
+    let mut length = message.len().min(MAX_VTAB_ERROR_MESSAGE_BYTES);
+    while !message.is_char_boundary(length) {
+        length -= 1;
+    }
+    let allocation_size = u64::try_from(length.saturating_add(1))
+        .expect("the bounded virtual-table error allocation fits in u64");
+    // SAFETY: SQLite owns and later frees `zErrMsg`, so it must be allocated
+    // with SQLite's allocator. The bounded size always fits in `u64`.
+    let allocation = unsafe { ffi::sqlite3_malloc64(allocation_size) }.cast::<u8>();
+    if allocation.is_null() {
+        // Preserve no stale diagnostic when replacing the message fails.
+        if !unsafe { (*table).zErrMsg }.is_null() {
+            // SAFETY: an existing zErrMsg is owned by SQLite's allocator.
+            unsafe { ffi::sqlite3_free((*table).zErrMsg.cast::<c_void>()) };
+            unsafe { (*table).zErrMsg = ptr::null_mut() };
+        }
+        return;
+    }
+
+    for (index, byte) in message.as_bytes()[..length].iter().copied().enumerate() {
+        // Interior NUL bytes would truncate SQLite's diagnostic. Rust strings
+        // can contain NUL, so replace them with a harmless printable byte.
+        unsafe {
+            allocation
+                .add(index)
+                .write(if byte == 0 { b'?' } else { byte })
+        };
+    }
+    unsafe { allocation.add(length).write(0) };
+
+    if !unsafe { (*table).zErrMsg }.is_null() {
+        // SAFETY: an existing zErrMsg is owned by SQLite's allocator.
+        unsafe { ffi::sqlite3_free((*table).zErrMsg.cast::<c_void>()) };
+    }
+    unsafe { (*table).zErrMsg = allocation.cast() };
+}
+
+fn connection_error(connection: &Connection, result_code: c_int) -> SqliteError {
+    // SAFETY: the connection remains live after a failed module registration.
+    let handle = unsafe { connection.handle() };
+    let extended_code = unsafe { ffi::sqlite3_extended_errcode(handle) };
+    let effective_code = if extended_code == ffi::SQLITE_OK {
+        result_code
+    } else {
+        extended_code
+    };
+    let message = unsafe {
+        let message = ffi::sqlite3_errmsg(handle);
+        (!message.is_null()).then(|| CStr::from_ptr(message).to_string_lossy().into_owned())
+    };
+    SqliteError::SqliteFailure(ffi::Error::new(effective_code), message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bridge_preserves_writable_callbacks_and_adds_only_v2_savepoints() {
+        let base = rusqlite::vtab::update_module_with_tx::<BriskShardTable>();
+        // SAFETY: the same repr-transparent invariant used by the bridge.
+        let base = unsafe { &*ptr::from_ref(base).cast::<ffi::sqlite3_module>() };
+        let bridged = writable_module_v2();
+
+        assert_eq!(base.iVersion, 1);
+        assert!(base.xUpdate.is_some());
+        assert!(base.xBegin.is_some());
+        assert!(base.xSync.is_some());
+        assert!(base.xCommit.is_some());
+        assert!(base.xRollback.is_some());
+        assert!(base.xSavepoint.is_none());
+        assert!(base.xRelease.is_none());
+        assert!(base.xRollbackTo.is_none());
+
+        assert_eq!(bridged.iVersion, 2);
+        assert!(bridged.xUpdate.is_some());
+        assert!(bridged.xBegin.is_some());
+        assert!(bridged.xSync.is_some());
+        assert!(bridged.xCommit.is_some());
+        assert!(bridged.xRollback.is_some());
+        assert!(bridged.xSavepoint.is_some());
+        assert!(bridged.xRelease.is_some());
+        assert!(bridged.xRollbackTo.is_some());
+    }
+
+    #[test]
+    fn error_messages_use_sqlite_ownership_and_sanitize_nul_bytes() {
+        let mut table = ffi::sqlite3_vtab::default();
+        unsafe {
+            set_error_message(&mut table, "first\0message");
+        }
+        assert!(!table.zErrMsg.is_null());
+        let first = unsafe { CStr::from_ptr(table.zErrMsg) };
+        assert_eq!(first.to_bytes(), b"first?message");
+
+        unsafe {
+            set_error_message(&mut table, "replacement");
+        }
+        assert!(!table.zErrMsg.is_null());
+        let replacement = unsafe { CStr::from_ptr(table.zErrMsg) };
+        assert_eq!(replacement.to_bytes(), b"replacement");
+
+        unsafe {
+            ffi::sqlite3_free(table.zErrMsg.cast::<c_void>());
+        }
+    }
+
+    #[test]
+    fn null_table_callback_fails_without_invoking_rust() {
+        let invoked = std::cell::Cell::new(false);
+        let result = run_callback(ptr::null_mut(), |_| {
+            invoked.set(true);
+            Ok(())
+        });
+        assert_eq!(result, ffi::SQLITE_MISUSE);
+        assert!(!invoked.get());
+    }
+}

--- a/src/storage/sharded_vtab/write.rs
+++ b/src/storage/sharded_vtab/write.rs
@@ -1,0 +1,1780 @@
+//! Writable coordinator execution and one-shard transaction state.
+
+use std::{
+    sync::{
+        Arc, Mutex, MutexGuard,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+use rusqlite::{
+    Connection, InterruptHandle, Params, Result as SqliteResult, types::ValueRef,
+    vtab::ConflictMode,
+};
+
+use super::{
+    ALLOCATION_OVERHEAD_BYTES, CoordinatorCancellation, CursorLimits, ROW_ACCOUNTING_BYTES,
+    RawCell, Registry, TableSpec, VALUE_ACCOUNTING_BYTES, allocation_error,
+    attach_writable_coordinator_authorizer, bootstrap_coordinator_schema, cancelled_error,
+    limit_error, locator, module_v2,
+};
+#[cfg(test)]
+use super::{TestChildScanControl, TestChildScanGate};
+use crate::{
+    core::{EngineError, EngineErrorKind, EngineResult, Value},
+    sqlite_error,
+    storage::{CONNECTION_BUSY_TIMEOUT, SchemaOperationGuard, Storage},
+};
+
+const CANCELLABLE_BUSY_SLICE: Duration = Duration::from_millis(25);
+
+#[derive(Debug, PartialEq)]
+pub(crate) struct CoordinatorWriteResult {
+    pub(crate) affected_rows: usize,
+    pub(crate) explicit_key: Option<Value>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum SavepointOperation {
+    Savepoint,
+    Release,
+    RollbackTo,
+}
+
+impl SavepointOperation {
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Savepoint => "SAVEPOINT",
+            Self::Release => "RELEASE",
+            Self::RollbackTo => "ROLLBACK TO",
+        }
+    }
+}
+
+fn injected_savepoint_error(operation: SavepointOperation, kind: EngineErrorKind) -> EngineError {
+    EngineError::new(
+        kind,
+        format!("injected physical child {} failure", operation.name()),
+    )
+}
+
+/// The only supported owner of a writable coordinator connection.
+///
+/// The underlying SQLite handle is intentionally private: every statement has
+/// to pass through reconciliation so a fallible physical child commit is
+/// observed before success is acknowledged.
+pub(crate) struct WriteCoordinator {
+    connection: Connection,
+    registry: Arc<Registry>,
+    cancellation: CoordinatorCancellation,
+    allow_transaction_control: Arc<AtomicBool>,
+    broken: bool,
+    #[cfg(test)]
+    statement_arm_gate: Mutex<Option<TestChildScanGate>>,
+}
+
+impl WriteCoordinator {
+    pub(crate) fn open(storage: Storage) -> EngineResult<Self> {
+        let bootstrap_operation = storage.enter_schema_operation()?;
+        let connection = Connection::open_in_memory().map_err(sqlite_error::storage)?;
+        let registry = Registry::build_writable(storage, CursorLimits::default())?;
+        module_v2::register_module(&connection, Arc::clone(&registry))
+            .map_err(sqlite_error::storage)?;
+        let bootstrap_epoch = registry.cancellation_epoch.load(Ordering::Acquire);
+        let bootstrap_arm = registry.write_state().arm_statement(bootstrap_epoch)?;
+        bootstrap_coordinator_schema(&connection, &registry)?;
+
+        connection
+            .pragma_update(None, "trusted_schema", "OFF")
+            .map_err(sqlite_error::storage)?;
+
+        // CREATE VIRTUAL TABLE can enlist the module in the coordinator's
+        // bootstrap transaction. Drain that callback-only, childless state
+        // before exposing the execution wrapper.
+        match registry.write_state().finalize_terminal(&registry)? {
+            FinalizedWrite::None | FinalizedWrite::Committed(_) | FinalizedWrite::RolledBack => {}
+        }
+        drop(bootstrap_arm);
+
+        let allow_transaction_control = Arc::new(AtomicBool::new(false));
+        attach_writable_coordinator_authorizer(
+            &connection,
+            &registry,
+            Arc::clone(&allow_transaction_control),
+        )?;
+        if registry.storage.current_schema_generation() != registry.schema_generation {
+            return Err(EngineError::new(
+                EngineErrorKind::Busy,
+                "application schema changed while the writable brisk_shard coordinator was opening",
+            ));
+        }
+        drop(bootstrap_operation);
+
+        let cancellation = CoordinatorCancellation {
+            epoch: Arc::clone(&registry.cancellation_epoch),
+            active_child_scans: Arc::clone(&registry.active_child_scans),
+            interrupt: Arc::new(connection.get_interrupt_handle()),
+            write_state: registry.write_state.clone(),
+        };
+        Ok(Self {
+            connection,
+            registry,
+            cancellation,
+            allow_transaction_control,
+            broken: false,
+            #[cfg(test)]
+            statement_arm_gate: Mutex::new(None),
+        })
+    }
+
+    pub(crate) fn execute_dml<P: Params>(
+        &mut self,
+        sql: &str,
+        parameters: P,
+    ) -> EngineResult<CoordinatorWriteResult> {
+        self.ensure_usable()?;
+        let epoch = self.registry.cancellation_epoch.load(Ordering::Acquire);
+        let statement_arm = self.registry.write_state().arm_statement(epoch)?;
+        self.registry.write_state().reset_statement_outcome()?;
+
+        let execution = (|| {
+            #[cfg(test)]
+            self.wait_after_statement_arm_for_test()?;
+            let mut statement = self
+                .connection
+                .prepare(sql)
+                .map_err(sqlite_error::statement)?;
+            if statement.readonly() {
+                return Err(EngineError::new(
+                    EngineErrorKind::Unsupported,
+                    "writable brisk_shard execution accepts one INSERT, UPDATE, or DELETE statement",
+                ));
+            }
+            if statement.column_count() != 0 {
+                return Err(EngineError::new(
+                    EngineErrorKind::Unsupported,
+                    "RETURNING is not supported by the experimental writable brisk_shard facade",
+                ));
+            }
+            statement
+                .execute(parameters)
+                .map_err(sqlite_error::statement)
+        })();
+
+        let result = self.reconcile_statement(execution);
+        drop(statement_arm);
+        result
+    }
+
+    pub(crate) fn begin(&mut self) -> EngineResult<()> {
+        self.ensure_usable()?;
+        if !self.connection.is_autocommit() {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "writable brisk_shard coordinator already has an explicit transaction",
+            ));
+        }
+        self.execute_transaction_control("BEGIN")?;
+        if self.connection.is_autocommit() {
+            self.broken = true;
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                "SQLite did not enter the requested coordinator transaction",
+            ));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn commit(&mut self) -> EngineResult<()> {
+        self.ensure_usable()?;
+        if self.connection.is_autocommit() {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "writable brisk_shard coordinator has no explicit transaction to commit",
+            ));
+        }
+
+        if let Err(error) = self.execute_transaction_control("COMMIT") {
+            if self.registry.write_state().abort_required(&self.registry) {
+                self.abort_explicit_transaction();
+            }
+            return Err(error);
+        }
+        if !self.connection.is_autocommit() {
+            self.broken = true;
+            self.abort_explicit_transaction();
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                "SQLite coordinator commit completed without leaving transaction mode",
+            ));
+        }
+
+        match self
+            .registry
+            .write_state()
+            .finalize_terminal(&self.registry)
+        {
+            Ok(FinalizedWrite::None | FinalizedWrite::Committed(_)) => Ok(()),
+            Ok(FinalizedWrite::RolledBack) => Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "writable brisk_shard transaction was rolled back instead of committed",
+            )),
+            Err(error) => {
+                self.broken = true;
+                Err(error)
+            }
+        }
+    }
+
+    pub(crate) fn rollback(&mut self) -> EngineResult<()> {
+        if self.connection.is_autocommit() {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "writable brisk_shard coordinator has no explicit transaction to roll back",
+            ));
+        }
+        let outer = self.execute_transaction_control("ROLLBACK");
+        let child = self
+            .registry
+            .write_state()
+            .finalize_terminal(&self.registry);
+        match (outer, child) {
+            (Ok(()), Ok(FinalizedWrite::None | FinalizedWrite::RolledBack)) => Ok(()),
+            (Ok(()), Ok(FinalizedWrite::Committed(_))) => {
+                self.broken = true;
+                Err(EngineError::new(
+                    EngineErrorKind::Internal,
+                    "writable brisk_shard rollback unexpectedly committed its physical child",
+                ))
+            }
+            (Err(error), _) | (_, Err(error)) => {
+                self.broken = true;
+                let _ = self.registry.write_state().force_rollback(&self.registry);
+                Err(error)
+            }
+        }
+    }
+
+    pub(crate) fn savepoint(&mut self, name: &str) -> EngineResult<()> {
+        self.ensure_explicit_transaction()?;
+        let name = transaction_identifier(name)?;
+        self.execute_savepoint_control(&format!("SAVEPOINT {name}"))
+    }
+
+    pub(crate) fn release(&mut self, name: &str) -> EngineResult<()> {
+        self.ensure_explicit_transaction()?;
+        let name = transaction_identifier(name)?;
+        self.execute_savepoint_control(&format!("RELEASE SAVEPOINT {name}"))
+    }
+
+    pub(crate) fn rollback_to(&mut self, name: &str) -> EngineResult<()> {
+        self.ensure_explicit_transaction()?;
+        let name = transaction_identifier(name)?;
+        self.execute_savepoint_control(&format!("ROLLBACK TO SAVEPOINT {name}"))
+    }
+
+    pub(crate) fn in_transaction(&self) -> bool {
+        !self.connection.is_autocommit()
+    }
+
+    pub(crate) fn cancellation_handle(&self) -> CoordinatorCancellation {
+        self.cancellation.clone()
+    }
+
+    #[cfg(test)]
+    pub(super) fn write_state_for_test(&self) -> Arc<WriteState> {
+        Arc::clone(self.registry.write_state())
+    }
+
+    #[cfg(test)]
+    pub(super) fn install_statement_arm_gate_for_test(&self) -> TestChildScanControl {
+        let (gate, control) = TestChildScanGate::channel();
+        *self
+            .statement_arm_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(gate);
+        control
+    }
+
+    #[cfg(test)]
+    pub(super) fn fail_next_commit_for_test(&self) {
+        self.registry.write_state().fail_next_commit();
+    }
+
+    #[cfg(test)]
+    pub(super) fn fail_next_write_corruption_for_test(&self) {
+        self.registry.write_state().fail_next_write_corruption();
+    }
+
+    #[cfg(test)]
+    pub(super) fn fail_next_commit_corruption_for_test(&self) {
+        self.registry.write_state().fail_next_commit_corruption();
+    }
+
+    #[cfg(test)]
+    pub(super) fn fail_next_savepoint_operation_for_test(&self, operation: SavepointOperation) {
+        self.registry
+            .write_state()
+            .fail_next_savepoint_operation(operation, EngineErrorKind::StorageUnavailable);
+    }
+
+    #[cfg(test)]
+    pub(super) fn fail_next_savepoint_corruption_for_test(&self, operation: SavepointOperation) {
+        self.registry
+            .write_state()
+            .fail_next_savepoint_operation(operation, EngineErrorKind::DataCorruption);
+    }
+
+    fn reconcile_statement(
+        &mut self,
+        execution: EngineResult<usize>,
+    ) -> EngineResult<CoordinatorWriteResult> {
+        if self.connection.is_autocommit() {
+            let finalized = self
+                .registry
+                .write_state()
+                .finalize_terminal(&self.registry);
+            return match finalized {
+                Err(error) => {
+                    self.broken = true;
+                    Err(error)
+                }
+                Ok(FinalizedWrite::RolledBack) => execution.and_then(|_| {
+                    Err(EngineError::new(
+                        EngineErrorKind::FailedPrecondition,
+                        "writable brisk_shard statement rolled back",
+                    ))
+                }),
+                Ok(FinalizedWrite::None) => execution.map(|_| CoordinatorWriteResult {
+                    affected_rows: 0,
+                    explicit_key: None,
+                }),
+                Ok(FinalizedWrite::Committed(outcome)) => {
+                    execution.map(|_| CoordinatorWriteResult {
+                        affected_rows: outcome.affected_rows,
+                        explicit_key: outcome.explicit_key,
+                    })
+                }
+            };
+        }
+
+        if self.registry.write_state().has_terminal_state() {
+            self.broken = true;
+            self.abort_explicit_transaction();
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                "writable brisk_shard callback reached a terminal child state inside an outer transaction",
+            ));
+        }
+        if self.registry.write_state().abort_required(&self.registry) {
+            let original = execution.err().unwrap_or_else(|| {
+                EngineError::new(
+                    EngineErrorKind::FailedPrecondition,
+                    "writable brisk_shard transaction was aborted",
+                )
+            });
+            self.abort_explicit_transaction();
+            return Err(original);
+        }
+        let outcome = self.registry.write_state().take_statement_outcome()?;
+        execution.map(|_| CoordinatorWriteResult {
+            affected_rows: outcome.affected_rows,
+            explicit_key: outcome.explicit_key,
+        })
+    }
+
+    fn execute_transaction_control(&self, sql: &str) -> EngineResult<()> {
+        let epoch = self.registry.cancellation_epoch.load(Ordering::Acquire);
+        let _statement_arm = self.registry.write_state().arm_statement(epoch)?;
+        let _authorization = TransactionAuthorization::enter(&self.allow_transaction_control);
+        self.connection
+            .execute_batch(sql)
+            .map_err(sqlite_error::statement)
+    }
+
+    fn execute_savepoint_control(&mut self, sql: &str) -> EngineResult<()> {
+        let result = self.execute_transaction_control(sql);
+        if result.is_err() && self.registry.write_state().abort_required(&self.registry) {
+            // A failed xSavepoint/xRelease/xRollbackTo may leave SQLite's
+            // coordinator stack and the physical child stack out of sync.
+            // Once the child reports that uncertainty, abandon both sides
+            // before allowing this wrapper to execute another statement.
+            self.abort_explicit_transaction();
+        }
+        result
+    }
+
+    fn ensure_usable(&self) -> EngineResult<()> {
+        if self.broken {
+            Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "writable brisk_shard coordinator must be reopened after a reconciliation failure",
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn ensure_explicit_transaction(&self) -> EngineResult<()> {
+        self.ensure_usable()?;
+        if self.connection.is_autocommit() {
+            Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "writable brisk_shard savepoints require an explicit transaction",
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn abort_explicit_transaction(&mut self) {
+        if !self.connection.is_autocommit() {
+            let _authorization = TransactionAuthorization::enter(&self.allow_transaction_control);
+            let _ = self.connection.execute_batch("ROLLBACK");
+        }
+        if !self.connection.is_autocommit() {
+            self.broken = true;
+        }
+        if self
+            .registry
+            .write_state()
+            .force_rollback(&self.registry)
+            .is_err()
+        {
+            self.broken = true;
+        }
+    }
+
+    #[cfg(test)]
+    fn wait_after_statement_arm_for_test(&self) -> EngineResult<()> {
+        let gate = self
+            .statement_arm_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        if gate.is_some_and(|gate| !gate.wait_for_release()) {
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                "writable statement-arm test gate timed out or disconnected",
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl Drop for WriteCoordinator {
+    fn drop(&mut self) {
+        self.abort_explicit_transaction();
+    }
+}
+
+struct TransactionAuthorization<'a> {
+    flag: &'a AtomicBool,
+}
+
+impl<'a> TransactionAuthorization<'a> {
+    fn enter(flag: &'a AtomicBool) -> Self {
+        let was_enabled = flag.swap(true, Ordering::AcqRel);
+        debug_assert!(!was_enabled, "transaction authorization cannot be nested");
+        Self { flag }
+    }
+}
+
+impl Drop for TransactionAuthorization<'_> {
+    fn drop(&mut self) {
+        self.flag.store(false, Ordering::Release);
+    }
+}
+
+fn transaction_identifier(name: &str) -> EngineResult<String> {
+    if name.is_empty()
+        || name.len() > 63
+        || !name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            "savepoint names must be 1 to 63 ASCII letters, digits, or underscores",
+        ));
+    }
+    Ok(format!("\"{}\"", name.replace('"', "\"\"")))
+}
+
+pub(super) struct WriteState {
+    inner: Mutex<WriteTransactionState>,
+    armed_statement_epoch: Mutex<Option<u64>>,
+    active_interrupt: Mutex<Option<Arc<InterruptHandle>>>,
+    commit_linearization: Mutex<()>,
+    #[cfg(test)]
+    fail_next_commit: AtomicBool,
+    #[cfg(test)]
+    fail_next_write_corruption: AtomicBool,
+    #[cfg(test)]
+    fail_next_commit_corruption: AtomicBool,
+    #[cfg(test)]
+    fail_next_savepoint_operation: Mutex<Option<(SavepointOperation, EngineErrorKind)>>,
+}
+
+impl WriteState {
+    pub(super) fn new() -> Self {
+        Self {
+            inner: Mutex::new(WriteTransactionState::Idle),
+            armed_statement_epoch: Mutex::new(None),
+            active_interrupt: Mutex::new(None),
+            commit_linearization: Mutex::new(()),
+            #[cfg(test)]
+            fail_next_commit: AtomicBool::new(false),
+            #[cfg(test)]
+            fail_next_write_corruption: AtomicBool::new(false),
+            #[cfg(test)]
+            fail_next_commit_corruption: AtomicBool::new(false),
+            #[cfg(test)]
+            fail_next_savepoint_operation: Mutex::new(None),
+        }
+    }
+
+    fn lock(&self) -> MutexGuard<'_, WriteTransactionState> {
+        self.inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn arm_statement(self: &Arc<Self>, epoch: u64) -> EngineResult<StatementEpochArm> {
+        let mut armed = self
+            .armed_statement_epoch
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if armed.is_some() {
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                "writable brisk_shard statement cancellation epoch is already armed",
+            ));
+        }
+        *armed = Some(epoch);
+        Ok(StatementEpochArm {
+            state: Arc::clone(self),
+            epoch,
+        })
+    }
+
+    fn statement_epoch(&self, registry: &Registry) -> EngineResult<u64> {
+        let epoch = self
+            .armed_statement_epoch
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .ok_or_else(|| {
+                EngineError::new(
+                    EngineErrorKind::Internal,
+                    "writable brisk_shard callback ran without an armed statement epoch",
+                )
+            })?;
+        if registry.cancelled(epoch) {
+            return Err(cancelled_error());
+        }
+        Ok(epoch)
+    }
+
+    fn clear_statement_epoch(&self, epoch: u64) {
+        let mut armed = self
+            .armed_statement_epoch
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if *armed == Some(epoch) {
+            *armed = None;
+        }
+    }
+
+    pub(super) fn lock_commit_linearization(&self) -> MutexGuard<'_, ()> {
+        self.commit_linearization
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    pub(super) fn interrupt_child(&self) {
+        let interrupt = self
+            .active_interrupt
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        if let Some(interrupt) = interrupt {
+            interrupt.interrupt();
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn has_active_child(&self) -> bool {
+        self.active_interrupt
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .is_some()
+    }
+
+    #[cfg(test)]
+    pub(super) fn fail_next_commit(&self) {
+        self.fail_next_commit.store(true, Ordering::Release);
+    }
+
+    #[cfg(test)]
+    pub(super) fn fail_next_write_corruption(&self) {
+        self.fail_next_write_corruption
+            .store(true, Ordering::Release);
+    }
+
+    #[cfg(test)]
+    pub(super) fn fail_next_commit_corruption(&self) {
+        self.fail_next_commit_corruption
+            .store(true, Ordering::Release);
+    }
+
+    #[cfg(test)]
+    pub(super) fn fail_next_savepoint_operation(
+        &self,
+        operation: SavepointOperation,
+        kind: EngineErrorKind,
+    ) {
+        *self
+            .fail_next_savepoint_operation
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some((operation, kind));
+    }
+
+    pub(super) fn begin(&self, registry: &Registry) -> EngineResult<()> {
+        let mut state = self.lock();
+        self.ensure_active(&mut state, registry).map(|_| ())
+    }
+
+    pub(super) fn savepoint(&self, registry: &Registry, number: i32) -> EngineResult<()> {
+        let result = {
+            let mut state = self.lock();
+            let transaction = self.ensure_active(&mut state, registry)?;
+            transaction.ensure_healthy(registry)?;
+            let result = match self.take_savepoint_failure(SavepointOperation::Savepoint) {
+                Some(kind) => Err(injected_savepoint_error(
+                    SavepointOperation::Savepoint,
+                    kind,
+                )),
+                None => transaction.savepoint(number),
+            };
+            transaction.poison_savepoint_failure(SavepointOperation::Savepoint, &result);
+            result
+        };
+        registry.storage.fail_closed_on_corruption(result)
+    }
+
+    pub(super) fn release(&self, registry: &Registry, number: i32) -> EngineResult<()> {
+        let result = {
+            let mut state = self.lock();
+            let WriteTransactionState::Active(transaction) = &mut *state else {
+                return Ok(());
+            };
+            transaction.ensure_healthy(registry)?;
+            let result = match self.take_savepoint_failure(SavepointOperation::Release) {
+                Some(kind) => Err(injected_savepoint_error(SavepointOperation::Release, kind)),
+                None => transaction.release(number),
+            };
+            transaction.poison_savepoint_failure(SavepointOperation::Release, &result);
+            result
+        };
+        registry.storage.fail_closed_on_corruption(result)
+    }
+
+    pub(super) fn rollback_to(&self, registry: &Registry, number: i32) -> EngineResult<()> {
+        let result = {
+            let mut state = self.lock();
+            let WriteTransactionState::Active(transaction) = &mut *state else {
+                return Ok(());
+            };
+            transaction.ensure_healthy(registry)?;
+            let result = match self.take_savepoint_failure(SavepointOperation::RollbackTo) {
+                Some(kind) => Err(injected_savepoint_error(
+                    SavepointOperation::RollbackTo,
+                    kind,
+                )),
+                None => transaction.rollback_to(number),
+            };
+            transaction.poison_savepoint_failure(SavepointOperation::RollbackTo, &result);
+            result
+        };
+        registry.storage.fail_closed_on_corruption(result)
+    }
+
+    pub(super) fn sync(&self, registry: &Registry) -> EngineResult<()> {
+        let state = self.lock();
+        match &*state {
+            WriteTransactionState::Idle => Ok(()),
+            WriteTransactionState::Active(transaction) => {
+                transaction.ensure_healthy(registry)?;
+                if transaction
+                    .child
+                    .as_ref()
+                    .is_some_and(|child| child.connection.is_autocommit())
+                {
+                    return Err(EngineError::new(
+                        EngineErrorKind::Internal,
+                        "brisk_shard child transaction ended before coordinator sync",
+                    ));
+                }
+                Ok(())
+            }
+            WriteTransactionState::PendingCommit(_) | WriteTransactionState::PendingRollback(_) => {
+                Ok(())
+            }
+        }
+    }
+
+    pub(super) fn mark_commit(&self, registry: &Registry) -> EngineResult<()> {
+        let mut state = self.lock();
+        match std::mem::replace(&mut *state, WriteTransactionState::Idle) {
+            WriteTransactionState::Idle => Ok(()),
+            WriteTransactionState::PendingCommit(transaction) => {
+                *state = WriteTransactionState::PendingCommit(transaction);
+                Ok(())
+            }
+            WriteTransactionState::PendingRollback(transaction) => {
+                *state = WriteTransactionState::PendingRollback(transaction);
+                Err(EngineError::new(
+                    EngineErrorKind::FailedPrecondition,
+                    "brisk_shard transaction is already rolling back",
+                ))
+            }
+            WriteTransactionState::Active(mut transaction) => {
+                if let Err(error) = transaction.ensure_healthy(registry) {
+                    transaction.poison(error.to_string());
+                    *state = WriteTransactionState::PendingRollback(transaction);
+                    return Err(error);
+                }
+                *state = WriteTransactionState::PendingCommit(transaction);
+                Ok(())
+            }
+        }
+    }
+
+    pub(super) fn mark_rollback(&self) {
+        let mut state = self.lock();
+        match std::mem::replace(&mut *state, WriteTransactionState::Idle) {
+            WriteTransactionState::Idle => {}
+            WriteTransactionState::Active(transaction)
+            | WriteTransactionState::PendingCommit(transaction)
+            | WriteTransactionState::PendingRollback(transaction) => {
+                *state = WriteTransactionState::PendingRollback(transaction);
+            }
+        }
+    }
+
+    pub(super) fn finalize_terminal(&self, registry: &Registry) -> EngineResult<FinalizedWrite> {
+        let _linearization = self.lock_commit_linearization();
+        let state = {
+            let mut state = self.lock();
+            std::mem::replace(&mut *state, WriteTransactionState::Idle)
+        };
+        let result = match state {
+            WriteTransactionState::Idle => Ok(FinalizedWrite::None),
+            WriteTransactionState::PendingRollback(mut transaction) => {
+                transaction.rollback().map(|()| FinalizedWrite::RolledBack)
+            }
+            WriteTransactionState::PendingCommit(mut transaction) => {
+                if let Err(error) = transaction.ensure_healthy(registry) {
+                    let _ = transaction.rollback();
+                    Err(error)
+                } else if self.take_commit_corruption_for_test() {
+                    let _ = transaction.rollback();
+                    Err(EngineError::new(
+                        EngineErrorKind::DataCorruption,
+                        "injected writable child commit corruption",
+                    ))
+                } else if self.take_commit_failure_for_test() {
+                    let _ = transaction.rollback();
+                    Err(EngineError::new(
+                        EngineErrorKind::StorageUnavailable,
+                        "injected writable child commit failure",
+                    ))
+                } else {
+                    transaction.commit().map(FinalizedWrite::Committed)
+                }
+            }
+            WriteTransactionState::Active(mut transaction) => {
+                transaction.rollback().and_then(|()| {
+                    Err(EngineError::new(
+                        EngineErrorKind::Internal,
+                        "brisk_shard child remained active after the outer transaction ended",
+                    ))
+                })
+            }
+        };
+        self.clear_active_interrupt();
+        registry.storage.fail_closed_on_corruption(result)
+    }
+
+    pub(super) fn force_rollback(&self, registry: &Registry) -> EngineResult<()> {
+        let _linearization = self.lock_commit_linearization();
+        let state = {
+            let mut state = self.lock();
+            std::mem::replace(&mut *state, WriteTransactionState::Idle)
+        };
+        let result = match state {
+            WriteTransactionState::Idle => Ok(()),
+            WriteTransactionState::Active(mut transaction)
+            | WriteTransactionState::PendingCommit(mut transaction)
+            | WriteTransactionState::PendingRollback(mut transaction) => transaction.rollback(),
+        };
+        self.clear_active_interrupt();
+        registry.storage.fail_closed_on_corruption(result)
+    }
+
+    pub(super) fn reset_statement_outcome(&self) -> EngineResult<()> {
+        let mut state = self.lock();
+        match &mut *state {
+            WriteTransactionState::Idle => Ok(()),
+            WriteTransactionState::Active(transaction) => {
+                transaction.affected_rows = 0;
+                transaction.explicit_key = None;
+                Ok(())
+            }
+            WriteTransactionState::PendingCommit(_) | WriteTransactionState::PendingRollback(_) => {
+                Err(EngineError::new(
+                    EngineErrorKind::Internal,
+                    "brisk_shard cannot start a statement while child finalization is pending",
+                ))
+            }
+        }
+    }
+
+    pub(super) fn take_statement_outcome(&self) -> EngineResult<WriteOutcome> {
+        let mut state = self.lock();
+        match &mut *state {
+            WriteTransactionState::Idle => Ok(WriteOutcome::default()),
+            WriteTransactionState::Active(transaction) => Ok(WriteOutcome {
+                affected_rows: std::mem::take(&mut transaction.affected_rows),
+                explicit_key: transaction.explicit_key.take(),
+            }),
+            WriteTransactionState::PendingCommit(_) | WriteTransactionState::PendingRollback(_) => {
+                Err(EngineError::new(
+                    EngineErrorKind::Internal,
+                    "brisk_shard statement outcome is unavailable during child finalization",
+                ))
+            }
+        }
+    }
+
+    pub(super) fn has_terminal_state(&self) -> bool {
+        matches!(
+            &*self.lock(),
+            WriteTransactionState::PendingCommit(_) | WriteTransactionState::PendingRollback(_)
+        )
+    }
+
+    pub(super) fn abort_required(&self, registry: &Registry) -> bool {
+        match &*self.lock() {
+            WriteTransactionState::Idle => false,
+            WriteTransactionState::Active(transaction)
+            | WriteTransactionState::PendingCommit(transaction) => {
+                transaction.ensure_healthy(registry).is_err()
+            }
+            WriteTransactionState::PendingRollback(_) => true,
+        }
+    }
+
+    pub(super) fn execute_insert(
+        &self,
+        registry: &Registry,
+        spec: &TableSpec,
+        values: &[ValueRef<'_>],
+        conflict: ConflictMode,
+    ) -> EngineResult<i64> {
+        self.with_active(registry, |transaction| {
+            transaction.insert(registry, spec, values, conflict, &self.active_interrupt)
+        })
+    }
+
+    pub(super) fn execute_delete(
+        &self,
+        registry: &Registry,
+        spec: &TableSpec,
+        locator: ValueRef<'_>,
+    ) -> EngineResult<()> {
+        self.with_active(registry, |transaction| {
+            transaction.delete(registry, spec, locator, &self.active_interrupt)
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn execute_update(
+        &self,
+        registry: &Registry,
+        spec: &TableSpec,
+        old_locator: ValueRef<'_>,
+        new_locator: ValueRef<'_>,
+        values: &[ValueRef<'_>],
+        no_change: &[bool],
+        conflict: ConflictMode,
+    ) -> EngineResult<()> {
+        self.with_active(registry, |transaction| {
+            transaction.update(
+                registry,
+                spec,
+                old_locator,
+                new_locator,
+                values,
+                no_change,
+                conflict,
+                &self.active_interrupt,
+            )
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn read_shard_rows(
+        &self,
+        registry: &Registry,
+        spec: &TableSpec,
+        shard: u16,
+        equality: Option<&RawCell>,
+        scan_epoch: u64,
+        remaining_rows: usize,
+        remaining_bytes: usize,
+    ) -> EngineResult<(Vec<Vec<RawCell>>, usize)> {
+        let mut state = self.lock();
+        let transaction = self.ensure_active(&mut state, registry)?;
+        transaction.read_rows(
+            registry,
+            spec,
+            shard,
+            equality,
+            scan_epoch,
+            remaining_rows,
+            remaining_bytes,
+            &self.active_interrupt,
+        )
+    }
+
+    fn with_active<T>(
+        &self,
+        registry: &Registry,
+        operation: impl FnOnce(&mut WriteTransaction) -> EngineResult<T>,
+    ) -> EngineResult<T> {
+        let result = (|| {
+            let mut state = self.lock();
+            let transaction = self.ensure_active(&mut state, registry)?;
+            transaction.ensure_healthy(registry)?;
+            let result = if self.take_write_corruption_for_test() {
+                Err(EngineError::new(
+                    EngineErrorKind::DataCorruption,
+                    "injected writable child operation corruption",
+                ))
+            } else {
+                operation(transaction)
+            };
+            if let Err(error) = &result {
+                if error.kind() == EngineErrorKind::DataCorruption {
+                    transaction.poison(error.to_string());
+                }
+            }
+            result
+        })();
+        registry.storage.fail_closed_on_corruption(result)
+    }
+
+    fn ensure_active<'a>(
+        &self,
+        state: &'a mut WriteTransactionState,
+        registry: &Registry,
+    ) -> EngineResult<&'a mut WriteTransaction> {
+        if matches!(state, WriteTransactionState::Idle) {
+            let operation = registry.storage.enter_schema_operation()?;
+            if registry.storage.current_schema_generation() != registry.schema_generation {
+                return Err(EngineError::new(
+                    EngineErrorKind::Busy,
+                    "brisk_shard writable coordinator schema is stale; reopen the coordinator",
+                ));
+            }
+            let epoch = self.statement_epoch(registry)?;
+            *state = WriteTransactionState::Active(WriteTransaction::new(operation, epoch));
+        }
+        match state {
+            WriteTransactionState::Active(transaction) => Ok(transaction),
+            WriteTransactionState::Idle => unreachable!(),
+            WriteTransactionState::PendingCommit(_) | WriteTransactionState::PendingRollback(_) => {
+                Err(EngineError::new(
+                    EngineErrorKind::Internal,
+                    "brisk_shard write callback ran while child finalization was pending",
+                ))
+            }
+        }
+    }
+
+    fn clear_active_interrupt(&self) {
+        *self
+            .active_interrupt
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+    }
+
+    fn take_commit_failure_for_test(&self) -> bool {
+        #[cfg(test)]
+        {
+            self.fail_next_commit.swap(false, Ordering::AcqRel)
+        }
+        #[cfg(not(test))]
+        {
+            false
+        }
+    }
+
+    fn take_write_corruption_for_test(&self) -> bool {
+        #[cfg(test)]
+        {
+            self.fail_next_write_corruption
+                .swap(false, Ordering::AcqRel)
+        }
+        #[cfg(not(test))]
+        {
+            false
+        }
+    }
+
+    fn take_commit_corruption_for_test(&self) -> bool {
+        #[cfg(test)]
+        {
+            self.fail_next_commit_corruption
+                .swap(false, Ordering::AcqRel)
+        }
+        #[cfg(not(test))]
+        {
+            false
+        }
+    }
+
+    fn take_savepoint_failure(&self, operation: SavepointOperation) -> Option<EngineErrorKind> {
+        #[cfg(test)]
+        {
+            let mut pending = self
+                .fail_next_savepoint_operation
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if pending
+                .as_ref()
+                .is_some_and(|(pending_operation, _)| *pending_operation == operation)
+            {
+                let (_, kind) = pending.take().expect("matched pending savepoint failure");
+                return Some(kind);
+            }
+        }
+        #[cfg(not(test))]
+        let _ = operation;
+        None
+    }
+}
+
+struct StatementEpochArm {
+    state: Arc<WriteState>,
+    epoch: u64,
+}
+
+impl Drop for StatementEpochArm {
+    fn drop(&mut self) {
+        self.state.clear_statement_epoch(self.epoch);
+    }
+}
+
+impl Drop for WriteState {
+    fn drop(&mut self) {
+        let state = self
+            .inner
+            .get_mut()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        match state {
+            WriteTransactionState::Idle => {}
+            WriteTransactionState::Active(transaction)
+            | WriteTransactionState::PendingCommit(transaction)
+            | WriteTransactionState::PendingRollback(transaction) => {
+                let _ = transaction.rollback();
+            }
+        }
+    }
+}
+
+enum WriteTransactionState {
+    Idle,
+    Active(WriteTransaction),
+    PendingCommit(WriteTransaction),
+    PendingRollback(WriteTransaction),
+}
+
+struct WriteTransaction {
+    _operation: SchemaOperationGuard,
+    epoch: u64,
+    child: Option<WriteChild>,
+    savepoints: Vec<SavepointMark>,
+    poison: Option<String>,
+    affected_rows: usize,
+    explicit_key: Option<Value>,
+}
+
+struct SavepointMark {
+    number: i32,
+    affected_rows: usize,
+    explicit_key: Option<Value>,
+}
+
+impl WriteTransaction {
+    fn new(operation: SchemaOperationGuard, epoch: u64) -> Self {
+        Self {
+            _operation: operation,
+            epoch,
+            child: None,
+            savepoints: Vec::new(),
+            poison: None,
+            affected_rows: 0,
+            explicit_key: None,
+        }
+    }
+
+    fn ensure_healthy(&self, registry: &Registry) -> EngineResult<()> {
+        if registry.cancelled(self.epoch) {
+            return Err(cancelled_error());
+        }
+        if registry.storage.current_schema_generation() != registry.schema_generation {
+            return Err(EngineError::new(
+                EngineErrorKind::Busy,
+                "brisk_shard writable coordinator schema became stale",
+            ));
+        }
+        if let Some(reason) = &self.poison {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!("brisk_shard transaction is aborted: {reason}"),
+            ));
+        }
+        Ok(())
+    }
+
+    fn poison(&mut self, reason: impl Into<String>) {
+        if self.poison.is_none() {
+            self.poison = Some(reason.into());
+        }
+    }
+
+    fn record_physical_changes(&mut self, changed: usize) -> EngineResult<()> {
+        let Some(affected_rows) = self.affected_rows.checked_add(changed) else {
+            self.poison("physical affected-row count overflowed");
+            return Err(EngineError::new(
+                EngineErrorKind::LimitExceeded,
+                "brisk_shard physical affected-row count overflowed",
+            ));
+        };
+        self.affected_rows = affected_rows;
+        Ok(())
+    }
+
+    fn poison_savepoint_failure(
+        &mut self,
+        operation: SavepointOperation,
+        result: &EngineResult<()>,
+    ) {
+        if let Err(error) = result {
+            self.poison(format!(
+                "physical child {} failed: {error}",
+                operation.name()
+            ));
+        }
+    }
+
+    fn pin<'a>(
+        &'a mut self,
+        registry: &Registry,
+        shard: u16,
+        active_interrupt: &Mutex<Option<Arc<InterruptHandle>>>,
+    ) -> EngineResult<&'a mut WriteChild> {
+        self.ensure_healthy(registry)?;
+        if self
+            .child
+            .as_ref()
+            .is_some_and(|child| child.shard != shard)
+        {
+            self.poison("a second physical shard was requested");
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "brisk_shard transaction cannot write more than one physical shard",
+            ));
+        }
+        if self.child.is_none() {
+            let connection = registry.storage.open_shard(shard)?;
+            connection
+                .busy_timeout(CANCELLABLE_BUSY_SLICE)
+                .map_err(sqlite_error::storage)?;
+            let cancellation_epoch = Arc::clone(&registry.cancellation_epoch);
+            let epoch = self.epoch;
+            connection
+                .progress_handler(
+                    64,
+                    Some(move || cancellation_epoch.load(Ordering::Acquire) != epoch),
+                )
+                .map_err(sqlite_error::storage)?;
+            let interrupt = Arc::new(connection.get_interrupt_handle());
+            *active_interrupt
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Arc::clone(&interrupt));
+
+            let begin_deadline = Instant::now()
+                .checked_add(CONNECTION_BUSY_TIMEOUT)
+                .unwrap_or_else(Instant::now);
+            let begin_result = loop {
+                if registry.cancelled(self.epoch) {
+                    break Err(cancelled_error());
+                }
+                match connection.execute_batch("BEGIN IMMEDIATE") {
+                    Ok(()) => break Ok(()),
+                    Err(error) => {
+                        let error = sqlite_error::statement(error);
+                        if error.kind() == EngineErrorKind::Busy && Instant::now() < begin_deadline
+                        {
+                            continue;
+                        }
+                        break Err(error);
+                    }
+                }
+            };
+            if let Err(error) = begin_result {
+                *active_interrupt
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+                return Err(error);
+            }
+
+            let foreign_keys = connection
+                .pragma_query_value(None, "foreign_keys", |row| row.get::<_, i64>(0))
+                .map_err(sqlite_error::storage)?;
+            if foreign_keys != 1 {
+                let _ = connection.execute_batch("ROLLBACK");
+                *active_interrupt
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+                return Err(EngineError::new(
+                    EngineErrorKind::Internal,
+                    "SQLite foreign-key enforcement is not enabled on a writable shard child",
+                ));
+            }
+            for savepoint in &self.savepoints {
+                if let Err(error) = connection
+                    .execute_batch(&format!("SAVEPOINT brisk_vtab_{}", savepoint.number))
+                    .map_err(sqlite_error::statement)
+                {
+                    let _ = connection.execute_batch("ROLLBACK");
+                    *active_interrupt
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+                    self.poison(format!("physical child SAVEPOINT replay failed: {error}"));
+                    return Err(error);
+                }
+            }
+            if registry.cancelled(self.epoch) {
+                let _ = connection.execute_batch("ROLLBACK");
+                *active_interrupt
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+                return Err(cancelled_error());
+            }
+            self.child = Some(WriteChild {
+                shard,
+                connection,
+                _interrupt: interrupt,
+            });
+        }
+        Ok(self.child.as_mut().expect("write child was installed"))
+    }
+
+    fn savepoint(&mut self, number: i32) -> EngineResult<()> {
+        if number < 0 {
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                "brisk_shard received a negative savepoint number",
+            ));
+        }
+        if self.savepoints.iter().any(|saved| saved.number == number) {
+            return Ok(());
+        }
+        let first_missing = match self.savepoints.last() {
+            Some(saved) => saved.number.checked_add(1).ok_or_else(|| {
+                EngineError::new(
+                    EngineErrorKind::LimitExceeded,
+                    "brisk_shard savepoint number overflowed",
+                )
+            })?,
+            None => 0,
+        };
+        if first_missing > number {
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                "brisk_shard received an invalid savepoint sequence",
+            ));
+        }
+
+        // A virtual table first enlisted below existing SQLite savepoints
+        // receives only xSavepoint(N), not callbacks for 0..N-1. No writes
+        // through this shared state happened before enlistment, so all of
+        // those missing levels have the same baseline. Materializing every
+        // level lets a later RELEASE of N followed by ROLLBACK TO an outer
+        // level still reach the correct physical boundary.
+        let affected_rows = self.affected_rows;
+        let explicit_key = self.explicit_key.clone();
+        for missing in first_missing..=number {
+            if let Some(child) = &self.child {
+                child
+                    .connection
+                    .execute_batch(&format!("SAVEPOINT brisk_vtab_{missing}"))
+                    .map_err(sqlite_error::statement)?;
+            }
+            self.savepoints.push(SavepointMark {
+                number: missing,
+                affected_rows,
+                explicit_key: explicit_key.clone(),
+            });
+        }
+        Ok(())
+    }
+
+    fn release(&mut self, number: i32) -> EngineResult<()> {
+        let Some(position) = self
+            .savepoints
+            .iter()
+            .position(|saved| saved.number == number)
+        else {
+            // Multiple participating virtual tables receive the same callback.
+            return Ok(());
+        };
+        if let Some(child) = &self.child {
+            child
+                .connection
+                .execute_batch(&format!("RELEASE SAVEPOINT brisk_vtab_{number}"))
+                .map_err(sqlite_error::statement)?;
+        }
+        self.savepoints.truncate(position);
+        Ok(())
+    }
+
+    fn rollback_to(&mut self, number: i32) -> EngineResult<()> {
+        let Some(position) = self
+            .savepoints
+            .iter()
+            .position(|saved| saved.number == number)
+        else {
+            return Ok(());
+        };
+        if let Some(child) = &self.child {
+            child
+                .connection
+                .execute_batch(&format!("ROLLBACK TO SAVEPOINT brisk_vtab_{number}"))
+                .map_err(sqlite_error::statement)?;
+        }
+        self.affected_rows = self.savepoints[position].affected_rows;
+        self.explicit_key = self.savepoints[position].explicit_key.clone();
+        self.savepoints.truncate(position + 1);
+        Ok(())
+    }
+
+    fn insert(
+        &mut self,
+        registry: &Registry,
+        spec: &TableSpec,
+        values: &[ValueRef<'_>],
+        conflict: ConflictMode,
+        active_interrupt: &Mutex<Option<Arc<InterruptHandle>>>,
+    ) -> EngineResult<i64> {
+        spec.ensure_writable()?;
+        let shard_key = spec.write_shard_key(values)?;
+        let shard = registry.write_target(spec, shard_key)?;
+        let sql = spec.insert_sql(conflict)?;
+        let parameters = values
+            .iter()
+            .copied()
+            .map(RawCell::try_copy_from)
+            .collect::<EngineResult<Vec<_>>>()?;
+        let explicit_key = RawCell::try_copy_from(shard_key)?;
+        let child = self.pin(registry, shard, active_interrupt)?;
+        let changed = match child
+            .connection
+            .execute(&sql, rusqlite::params_from_iter(&parameters))
+            .map_err(sqlite_error::statement)
+        {
+            Ok(changed) => changed,
+            Err(error) => {
+                self.poison_if_uncertain(&error);
+                return Err(error);
+            }
+        };
+        if changed != 1 {
+            self.poison("physical INSERT did not report exactly one changed row");
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                "brisk_shard physical INSERT did not change exactly one row",
+            ));
+        }
+        self.record_physical_changes(changed)?;
+        let rowid = match &explicit_key {
+            RawCell::Integer(value) => *value,
+            _ => 0,
+        };
+        self.explicit_key = Some(raw_cell_to_value(explicit_key)?);
+        self.ensure_healthy(registry)?;
+        Ok(rowid)
+    }
+
+    fn delete(
+        &mut self,
+        registry: &Registry,
+        spec: &TableSpec,
+        locator_value: ValueRef<'_>,
+        active_interrupt: &Mutex<Option<Arc<InterruptHandle>>>,
+    ) -> EngineResult<()> {
+        let decoded = spec.decode_locator(locator_value)?;
+        let child = self.pin(registry, decoded.shard, active_interrupt)?;
+        let changed = match child.connection.execute(
+            &spec.delete_sql()?,
+            rusqlite::params_from_iter(&decoded.values),
+        ) {
+            Ok(changed) => changed,
+            Err(error) => {
+                let error = sqlite_error::statement(error);
+                self.poison_if_uncertain(&error);
+                return Err(error);
+            }
+        };
+        if changed > 1 {
+            self.poison("physical DELETE locator identified more than one row");
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                "brisk_shard DELETE locator identified more than one physical row",
+            ));
+        }
+        // SQLite materializes every target before calling xUpdate. An
+        // earlier REPLACE or foreign-key action may legitimately remove this
+        // row before its callback arrives, in which case native SQLite skips
+        // the stale identity and reports no additional direct change.
+        self.record_physical_changes(changed)?;
+        self.ensure_healthy(registry)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn update(
+        &mut self,
+        registry: &Registry,
+        spec: &TableSpec,
+        old_locator: ValueRef<'_>,
+        new_locator: ValueRef<'_>,
+        values: &[ValueRef<'_>],
+        no_change: &[bool],
+        conflict: ConflictMode,
+        active_interrupt: &Mutex<Option<Arc<InterruptHandle>>>,
+    ) -> EngineResult<()> {
+        match (old_locator, new_locator) {
+            (ValueRef::Blob(old), ValueRef::Blob(new)) if old == new => {}
+            _ => {
+                self.poison("the opaque row locator was changed");
+                return Err(EngineError::new(
+                    EngineErrorKind::ReadOnly,
+                    "brisk_shard opaque row locator cannot be changed",
+                ));
+            }
+        }
+        let decoded = spec.decode_locator(old_locator)?;
+        let shard_key = spec.shard_key.as_ref().ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::Unsupported,
+                format!("registered table {} has no writable shard key", spec.name),
+            )
+        })?;
+        let shard_key_index = usize::try_from(shard_key.column_index).map_err(|_| {
+            EngineError::new(
+                EngineErrorKind::Internal,
+                format!(
+                    "registered table {} has an invalid shard-key index",
+                    spec.name
+                ),
+            )
+        })?;
+        let new_shard = if no_change.get(shard_key_index).copied().unwrap_or(false) {
+            decoded.shard
+        } else {
+            registry.write_target(spec, spec.write_shard_key(values)?)?
+        };
+        if decoded.shard != new_shard {
+            self.poison("a shard-key update attempted to move a row to another file");
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "brisk_shard shard-key updates cannot move a row between physical shards",
+            ));
+        }
+        let (sql, mut parameters) = spec.update_sql_and_values(values, no_change, conflict)?;
+        parameters.extend(decoded.values);
+        let child = self.pin(registry, decoded.shard, active_interrupt)?;
+        let changed = match child
+            .connection
+            .execute(&sql, rusqlite::params_from_iter(&parameters))
+            .map_err(sqlite_error::statement)
+        {
+            Ok(changed) => changed,
+            Err(error) => {
+                self.poison_if_uncertain(&error);
+                return Err(error);
+            }
+        };
+        if changed > 1 {
+            self.poison("physical UPDATE locator identified more than one row");
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                "brisk_shard UPDATE locator identified more than one physical row",
+            ));
+        }
+        // A prior callback in this materialized UPDATE can replace, cascade
+        // away, or relocate the row. Treat its old locator as SQLite treats a
+        // stale rowid: a successful zero-row no-op.
+        self.record_physical_changes(changed)?;
+        self.ensure_healthy(registry)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn read_rows(
+        &mut self,
+        registry: &Registry,
+        spec: &TableSpec,
+        shard: u16,
+        equality: Option<&RawCell>,
+        scan_epoch: u64,
+        remaining_rows: usize,
+        remaining_bytes: usize,
+        active_interrupt: &Mutex<Option<Arc<InterruptHandle>>>,
+    ) -> EngineResult<(Vec<Vec<RawCell>>, usize)> {
+        spec.ensure_writable()?;
+        if scan_epoch != self.epoch || registry.cancelled(scan_epoch) {
+            return Err(cancelled_error());
+        }
+        let child = self.pin(registry, shard, active_interrupt)?;
+        let select_sql = equality
+            .and(spec.locator_point_select_sql.as_deref())
+            .or(spec.locator_select_sql.as_deref())
+            .ok_or_else(|| {
+                EngineError::new(
+                    EngineErrorKind::Unsupported,
+                    format!(
+                        "registered table {} has no writable locator scan",
+                        spec.name
+                    ),
+                )
+            })?;
+        let mut statement = child
+            .connection
+            .prepare(select_sql)
+            .map_err(sqlite_error::statement)?;
+        let mut sqlite_rows = match equality {
+            Some(value) => statement.query([value]).map_err(sqlite_error::statement)?,
+            None => statement.query([]).map_err(sqlite_error::statement)?,
+        };
+        let locator_spec = spec.locator.as_ref().ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::Unsupported,
+                format!("registered table {} has no writable row locator", spec.name),
+            )
+        })?;
+        let result = (|| {
+            let mut rows = Vec::new();
+            let mut used_bytes = 0_usize;
+            while let Some(row) = sqlite_rows.next().map_err(sqlite_error::statement)? {
+                if registry.cancelled(scan_epoch) {
+                    return Err(cancelled_error());
+                }
+                if rows.len() == remaining_rows {
+                    return Err(limit_error("row", registry.limits.rows));
+                }
+                let returned_cells = spec
+                    .column_count
+                    .checked_add(1)
+                    .ok_or_else(|| limit_error("byte", registry.limits.bytes))?;
+                let mut row_bytes = returned_cells
+                    .checked_mul(VALUE_ACCOUNTING_BYTES)
+                    .and_then(|bytes| bytes.checked_add(ROW_ACCOUNTING_BYTES))
+                    .ok_or_else(|| limit_error("byte", registry.limits.bytes))?;
+                if used_bytes
+                    .checked_add(row_bytes)
+                    .is_none_or(|bytes| bytes > remaining_bytes)
+                {
+                    return Err(limit_error("byte", registry.limits.bytes));
+                }
+                let mut cells = Vec::new();
+                cells
+                    .try_reserve_exact(returned_cells)
+                    .map_err(allocation_error)?;
+                for column in 0..spec.column_count {
+                    let value = row.get_ref(column).map_err(sqlite_error::statement)?;
+                    row_bytes = row_bytes
+                        .checked_add(RawCell::accounted_payload_bytes(value))
+                        .ok_or_else(|| limit_error("byte", registry.limits.bytes))?;
+                    if used_bytes
+                        .checked_add(row_bytes)
+                        .is_none_or(|bytes| bytes > remaining_bytes)
+                    {
+                        return Err(limit_error("byte", registry.limits.bytes));
+                    }
+                    cells.push(RawCell::try_copy_from(value)?);
+                }
+                let identity_count = locator_spec.value_count();
+                let mut identity = Vec::new();
+                identity
+                    .try_reserve_exact(identity_count)
+                    .map_err(allocation_error)?;
+                for offset in 0..identity_count {
+                    let value = row
+                        .get_ref(spec.column_count + offset)
+                        .map_err(sqlite_error::statement)?;
+                    row_bytes = row_bytes
+                        .checked_add(RawCell::accounted_payload_bytes(value))
+                        .and_then(|bytes| bytes.checked_add(VALUE_ACCOUNTING_BYTES))
+                        .ok_or_else(|| limit_error("byte", registry.limits.bytes))?;
+                    if used_bytes
+                        .checked_add(row_bytes)
+                        .is_none_or(|bytes| bytes > remaining_bytes)
+                    {
+                        return Err(limit_error("byte", registry.limits.bytes));
+                    }
+                    identity.push(RawCell::try_copy_from(value)?);
+                }
+                let encoded = locator::encode(spec.id, shard, &identity)?;
+                row_bytes = row_bytes
+                    .checked_add(encoded.len())
+                    .and_then(|bytes| bytes.checked_add(ALLOCATION_OVERHEAD_BYTES))
+                    .ok_or_else(|| limit_error("byte", registry.limits.bytes))?;
+                if used_bytes
+                    .checked_add(row_bytes)
+                    .is_none_or(|bytes| bytes > remaining_bytes)
+                {
+                    return Err(limit_error("byte", registry.limits.bytes));
+                }
+                cells.push(RawCell::Blob(encoded));
+                used_bytes = used_bytes
+                    .checked_add(row_bytes)
+                    .ok_or_else(|| limit_error("byte", registry.limits.bytes))?;
+                rows.try_reserve(1).map_err(allocation_error)?;
+                rows.push(cells);
+            }
+            if registry.cancelled(scan_epoch) {
+                return Err(cancelled_error());
+            }
+            Ok((rows, used_bytes))
+        })();
+        registry.storage.fail_closed_on_corruption(result)
+    }
+
+    fn poison_if_uncertain(&mut self, error: &EngineError) {
+        if !matches!(
+            error.kind(),
+            EngineErrorKind::ConstraintViolation
+                | EngineErrorKind::UniqueViolation
+                | EngineErrorKind::NotNullViolation
+                | EngineErrorKind::ForeignKeyViolation
+                | EngineErrorKind::CheckViolation
+                | EngineErrorKind::Busy
+                | EngineErrorKind::TypeMismatch
+                | EngineErrorKind::NumericOutOfRange
+        ) {
+            self.poison(error.to_string());
+        }
+    }
+
+    fn commit(&mut self) -> EngineResult<WriteOutcome> {
+        if let Some(child) = self.child.take() {
+            if let Err(error) = child
+                .connection
+                .execute_batch("COMMIT")
+                .map_err(sqlite_error::statement)
+            {
+                if !child.connection.is_autocommit() {
+                    let _ = child.connection.execute_batch("ROLLBACK");
+                }
+                return Err(error);
+            }
+        }
+        Ok(WriteOutcome {
+            affected_rows: std::mem::take(&mut self.affected_rows),
+            explicit_key: self.explicit_key.take(),
+        })
+    }
+
+    fn rollback(&mut self) -> EngineResult<()> {
+        if let Some(child) = self.child.take() {
+            if !child.connection.is_autocommit() {
+                child
+                    .connection
+                    .execute_batch("ROLLBACK")
+                    .map_err(sqlite_error::statement)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+struct WriteChild {
+    shard: u16,
+    connection: Connection,
+    _interrupt: Arc<InterruptHandle>,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct WriteOutcome {
+    pub(super) affected_rows: usize,
+    pub(super) explicit_key: Option<Value>,
+}
+
+pub(super) enum FinalizedWrite {
+    None,
+    Committed(WriteOutcome),
+    RolledBack,
+}
+
+fn raw_cell_to_value(value: RawCell) -> EngineResult<Value> {
+    Ok(match value {
+        RawCell::Null => Value::Null,
+        RawCell::Integer(value) => Value::Int64(value),
+        RawCell::Real(value) => Value::Float64(value),
+        RawCell::Text(value) => match String::from_utf8(value) {
+            Ok(value) => Value::Text(value),
+            Err(error) => Value::InvalidText(error.into_bytes()),
+        },
+        RawCell::Blob(value) => Value::Binary(value),
+    })
+}
+
+pub(super) fn map_callback(result: EngineResult<()>) -> SqliteResult<()> {
+    result.map_err(super::vtab_error)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transaction_identifier_is_bounded_and_injection_safe() {
+        assert_eq!(transaction_identifier("save_1").unwrap(), "\"save_1\"");
+        for invalid in ["", "bad-name", "x;ROLLBACK", "space name"] {
+            assert_eq!(
+                transaction_identifier(invalid).unwrap_err().kind(),
+                EngineErrorKind::InvalidArgument
+            );
+        }
+        assert_eq!(
+            transaction_identifier(&"x".repeat(64)).unwrap_err().kind(),
+            EngineErrorKind::InvalidArgument
+        );
+    }
+
+    #[test]
+    fn coordinator_result_is_protocol_neutral() {
+        let result = CoordinatorWriteResult {
+            affected_rows: 1,
+            explicit_key: Some(Value::Int64(7)),
+        };
+        assert_eq!(result.affected_rows, 1);
+        assert_eq!(result.explicit_key, Some(Value::Int64(7)));
+        assert_eq!(super::super::MODULE_NAME, "brisk_shard");
+    }
+}


### PR DESCRIPTION
## Summary

- add a stock-SQLite version-2 `brisk_shard` module bridge with writable and savepoint callbacks, without forking SQLite
- route explicit-key INSERT and exactly routed UPDATE/DELETE to one pinned physical shard using bounded, opaque row locators
- reconcile outer and child transactions across commit, rollback, nested savepoints, conflict modes, cancellation, connection loss, and injected failures
- return physical affected-row counts and explicit keys while preserving native REPLACE and foreign-key cascade behavior
- admit only SQLite-enforceable, conservatively co-located foreign keys, including generated-ID routing-domain validation
- document the experimental boundary and its remaining limitations

## Why

Issue #127 requires proving that a logical SQLite table can write concurrently to independent shard files through supported stock-SQLite APIs. The existing issue #126 facade was intentionally read-only, and rusqlite did not expose the version-2 savepoint slots needed for complete transaction behavior.

## Impact

This adds an internal `experimental-vtab` writable coordinator for explicit-key Sharded tables. It does not change the public HTTP, PostgreSQL, MySQL, query-app, manifest, or physical shard format. Missing/generated keys, Global writes, multi-shard transactions, defaults, generated columns, triggers, and RETURNING remain later work.

## Validation

- `cargo test --locked --all-targets --all-features`
- `cargo test --locked --doc --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo +1.85.0 test --locked --all-targets --all-features`
- `cargo +1.85.0 test --locked --doc --all-features`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #127