### PR TITLE
Integrate opt-in virtual-table Engine writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ PostgreSQL and MySQL wire interfaces, durable shard catalog, scatter/gather
 planner, APIs, and production-hardening milestones.
 The [architecture map](docs/ARCHITECTURE.md) defines the crate's module
 boundaries and dependency direction.
+The [experimental sharded virtual-table contract](docs/SHARDED_VIRTUAL_TABLE.md)
+defines the no-fork coordinator, its opt-in autocommit write path, and the
+features that deliberately remain on the established engine paths.
 
 The [SQL compatibility contract](docs/SQL_COMPATIBILITY.md) distinguishes the
 unregistered legacy SQLite pass-through from the authoritative-catalog HTTP
@@ -108,7 +111,9 @@ minimum supported Rust version (MSRV) and the latest stable toolchain.
   later schema migrations checked against its table and shard-key declarations
 - Identity-bound, WAL-enabled SQLite shard files that are never silently
   recreated after initialization
-- Routed writes and catalog-aware logical query execution
+- Routed writes and catalog-aware logical query execution, with a separately
+  compiled and runtime-enabled virtual-table coordinator for explicit-key
+  autocommit writes to registered Sharded tables
 - A crash-resumable, journaled schema-migration endpoint for every shard
 - A checksummed manifest, generation-bound shard-schema fingerprints, and
   fail-closed `Verifying`/`Ready`/`Migrating`/`Degraded` storage states
@@ -133,6 +138,27 @@ briskdb-data/
 ```bash
 cargo run -- --data-dir ./briskdb-data --shards 4
 ```
+
+The established physical-shard write path remains the default. To try the
+stock-SQLite virtual-table coordinator for registered, explicit-key autocommit
+writes, enable both its Cargo feature and runtime gate:
+
+```bash
+cargo run --features experimental-vtab -- \
+  --experimental-vtab-writes \
+  --data-dir ./briskdb-data \
+  --shards 4
+
+# The runtime gate is also available through the environment.
+BRISKDB_EXPERIMENTAL_VTAB_WRITES=true \
+  cargo run --features experimental-vtab -- --data-dir ./briskdb-data --shards 4
+```
+
+This opt-in changes only validated `Engine::execute` autocommit DML for a
+populated catalog, including the `/v1/execute` adapter. `/v1/query` and the
+admin browser continue to use the established metadata-driven scatter/gather
+readers. `BEGIN`, `COMMIT`, `ROLLBACK`, and transactions spanning HTTP requests
+are not enabled by this flag.
 
 To initialize a new data directory from an existing standard SQLite file, use
 the separate offline importer. The destination must not already exist, and the
@@ -305,12 +331,20 @@ accepts SQL and should only be exposed on a trusted network. The HTTP adapter
 creates an ephemeral session for each data request, so session state and
 transactions cannot span HTTP requests. Each shard has its own bounded pool, so
 routed work queued for one shard does not consume another shard's capacity.
-After a populated catalog validates `/v1/execute` as one routed common-subset
-write, those ephemeral requests share a stateless physical-handle ownership
-domain. This keeps the logical sessions separate while allowing clean
-autocommit write handles to remain warm. Empty-catalog pass-through SQL and all
-other session surfaces retain unique ownership. Registration, startup, import,
-and migration validation also reject `last_insert_rowid()`, `changes()`, and
+By default, after a populated catalog validates `/v1/execute` as one routed
+common-subset write, those ephemeral requests share a stateless physical-handle
+ownership domain. This keeps the logical sessions separate while allowing clean
+autocommit write handles to remain warm. When BriskDB is compiled with
+`experimental-vtab` and `--experimental-vtab-writes` is set, an accepted
+explicit-key write to a registered Sharded table instead executes through one
+ephemeral writable coordinator and commits its one physical child before HTTP
+success is returned. It keeps the same HTTP request, response, planner, shard
+assignment, admission, cancellation, and affected-row contracts. Each request
+is still one autocommit statement; the option does not add session transaction
+state, prepared-portal integration, Global writes, or a virtual-table read
+path. Empty-catalog pass-through SQL and all other session surfaces retain
+their existing behavior. Registration, startup, import, and migration
+validation also reject `last_insert_rowid()`, `changes()`, and
 `total_changes()` inside persistent table or index expressions, so a stored
 `DEFAULT`, `CHECK`, generated expression, or index cannot bypass that boundary.
 Pool admission happens before blocking SQLite work: once a shard's active slots

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -673,12 +673,11 @@ validates the policy, codec, and owner slots only; physical
 `sqlite_sequence` validation and seeding belong to issue #128, and omitted-key
 SQL translation belongs to issue #130.
 
-The opt-in `experimental-vtab` feature adds separate read-only and narrowly
-writable SQLite coordinators that statically register `brisk_shard`. They prove
-a no-fork logical table boundary while leaving the manifest, physical schemas,
-protocol behavior, and established scatter executor unchanged. The read-only
-coordinator opens validated physical children through OS-level SQLite read-only
-handles, never attaches a shard, and never
+The `experimental-vtab` feature adds separate read-only and narrowly writable
+SQLite coordinators that statically register `brisk_shard`. They prove a
+no-fork logical table boundary while leaving the manifest and physical schemas
+unchanged. The read-only coordinator opens validated physical children through
+OS-level SQLite read-only handles, never attaches a shard, and never
 dynamically loads an extension. Trusted metadata supplies each declared
 schema. An exact, storage-class-compatible `Int64`, `Text`, or `Binary`
 shard-key equality can open only its owner and bind the equality on that
@@ -687,11 +686,12 @@ integers retain ordinary hash routing. `NULL` is empty and a type mismatch
 falls back to a full scan so SQLite can retain its comparison semantics.
 Unconstrained scans visit shards in ascending order with `UNION ALL` duplicate
 semantics. Remaining filters, aggregation, ordering, limits, and feature-local
-joins execute in the stock SQLite coordinator without pushdown. That delegation
-is internal to the experimental coordinator and does not expand the Engine or
-protocol SQL contract. Cursor ownership, schema admission, cancellation,
-bounded materialization, static-loading policy, and rejected alternatives are
-specified in the
+joins execute in the stock SQLite coordinator without pushdown. That read
+delegation remains internal: Engine logical queries, `/v1/query`, and the admin
+browser continue to use the established metadata-driven scatter/gather
+executor. Cursor ownership, schema admission, cancellation, bounded
+materialization, static-loading policy, and rejected alternatives are specified
+in the
 [experimental sharded virtual-table facade](SHARDED_VIRTUAL_TABLE.md).
 
 The writable coordinator accepts explicit-key INSERT and exactly routed
@@ -702,9 +702,36 @@ physical rowid or complete `WITHOUT ROWID` key without changing shard files.
 The wrapper reconciles stock-SQLite transaction and savepoint callbacks, then
 performs the fallible child commit before acknowledging success. Physical
 constraints and conservatively admitted co-located foreign keys remain
-authoritative. Missing/generated keys, Global writes, multi-shard
-transactions, `RETURNING`, defaults, generated columns, triggers, and public
-protocol integration remain later work.
+authoritative. Missing/generated keys, Global writes, multi-shard transactions,
+`RETURNING`, defaults, generated columns, and triggers remain later work.
+
+Engine integration has two independent opt-ins. The binary must be compiled
+with `experimental-vtab`, and `EngineOptions::with_experimental_vtab_writes(true)`
+must enable the runtime gate; the server exposes that option as
+`--experimental-vtab-writes` and
+`BRISKDB_EXPERIMENTAL_VTAB_WRITES=true`. The gate is false by default even in an
+all-features build. When it is true, only a populated-catalog raw Engine write
+that planning has already proven to be one Sharded owner is dispatched through
+an ephemeral writable coordinator. The engine retains its lifecycle, schema,
+session, per-shard capacity, worker, cancellation, deadline, route-reporting,
+and error boundaries while the coordinator supplies the physical affected-row
+count and acknowledges success only after its child commit. Empty-catalog SQL,
+Global and Catalog placement, prepared portals, and all reads retain their
+established execution paths.
+
+Physical table descriptors discovered from shard 0 are immutable for one schema
+generation and cached per Engine. Cold discovery is serialized, cancellable,
+and charged to shard 0's connection capacity; warm coordinators open no shard-0
+handle and reserve only their target shard, so an occupied shard 0 cannot stall
+writers whose metadata is already warm. A published schema-generation mismatch
+invalidates the cache and forces controlled rediscovery before another write.
+
+This integration is intentionally autocommit-only. Each `Engine::execute` or
+HTTP `/v1/execute` request owns one statement and drops its coordinator after
+that statement reconciles. `Session` still has no transaction state, HTTP still
+creates a fresh Session per request, and `BEGIN`, `COMMIT`, `ROLLBACK`,
+read-your-writes, and transaction shard pinning are deferred to the later
+session-transaction work.
 
 ## Session and asynchronous engine boundary
 

--- a/docs/SHARDED_VIRTUAL_TABLE.md
+++ b/docs/SHARDED_VIRTUAL_TABLE.md
@@ -2,7 +2,8 @@
 
 BriskDB's no-fork direction is a statically registered SQLite virtual-table
 module named `brisk_shard`. The prototype is compiled only with the
-`experimental-vtab` Cargo feature and does not replace the current logical
+`experimental-vtab` Cargo feature. Its writable coordinator has a separate
+runtime gate; its read-only coordinator does not replace the current logical
 scatter/gather executor.
 
 The coordinator is a separate, ephemeral stock-SQLite connection. It contains
@@ -35,10 +36,52 @@ contract is deliberately narrower:
   cancellation, connection loss, and child commit failures are reconciled by a
   wrapper that never exposes the raw writable coordinator connection.
 
-Cancellation and child commit have one explicit durability boundary. If
-cancellation wins before physical `COMMIT`, the child rolls back; once physical
-`COMMIT` begins, it wins and is allowed to finish so BriskDB never reports a
-cancelled result for a write that may already be durable.
+Cancellation and child commit have one explicit linearization boundary. If
+cancellation claims that decision first, the child rolls back. Once finalization
+claims the commit decision, it wins and is allowed to finish, so BriskDB never
+reports a cancelled result for a write that may already be durable.
+
+## Engine and HTTP opt-in
+
+Compiling `experimental-vtab` makes the coordinator available but does not
+change execution by itself. The runtime default remains off. Rust embedders
+enable it with `EngineOptions::with_experimental_vtab_writes(true)`; the server
+maps `--experimental-vtab-writes` and
+`BRISKDB_EXPERIMENTAL_VTAB_WRITES=true` to that same option.
+
+With both gates enabled, `Engine::execute` and HTTP `/v1/execute` dispatch a
+write through the coordinator only after the authoritative catalog, common SQL
+frontend, bound values, caller route, and single-owner write policy
+have accepted one Sharded target. The returned `shard` remains the planner's
+assigned owner. `rows_affected` comes from the reconciled physical child, and a
+successful response is produced only after the autocommit child transaction
+commits under BriskDB's configured SQLite WAL and synchronous policy. The
+endpoint's request and response shapes do not change.
+
+The Engine caches the validated physical table descriptors for the current
+schema generation. One serialized cold bootstrap discovers them through a
+cancellable, shard-0-capacity-accounted read-only handle. Warm coordinator
+opens reuse those immutable descriptors and reserve only the DML target shard,
+preserving independent-shard writer progress. Schema-generation publication
+invalidates the cache and makes the next write rediscover descriptors.
+
+This Engine bridge currently rejects a target table that declares
+`native_range_v1`, including writes that supply an explicit ID. Issue #128 owns
+making Engine planning, returned-shard reporting, and per-shard admission use
+the encoded allocation owner consistently. The storage-internal coordinator's
+native-ID behavior is not exposed through Engine before that work lands.
+
+The integration opens an ephemeral coordinator for one statement. It does not
+retain a coordinator in `Session`, and it does not add `BEGIN`, `COMMIT`,
+`ROLLBACK`, read-your-writes, or any transaction spanning requests. Those need
+the later protocol-neutral transaction state machine and shard-pinning policy.
+Prepared portals are also unchanged in this step.
+
+Reads deliberately stay on the established paths. Engine logical reads and
+HTTP `/v1/query` still select physical targets from catalog metadata and use
+the bounded scatter/gather executor; the admin browser keeps its specialized
+logical count and page readers. The internal read-only virtual-table facade is
+not exposed to those surfaces yet.
 
 For a usable equality constraint on the exact declared shard-key column,
 `xBestIndex` requests one argument but deliberately does not set `omit`.
@@ -158,23 +201,24 @@ This is why several alternatives are excluded:
 
 ## Current non-goals
 
-The internal writable coordinator now provides explicit-key DML on one pinned
-Sharded child. It does not provide missing/generated keys, replicated Global
-writes, multi-shard transactions, `RETURNING`, physical defaults, generated
+The writable coordinator provides explicit-key DML on one pinned Sharded child,
+and the opt-in Engine/HTTP integration exposes only one-statement autocommit
+writes. It does not provide missing/generated keys, replicated Global writes,
+multi-shard or session transactions, `RETURNING`, physical defaults, generated
 columns, physical triggers, client-created virtual-table indexes or triggers,
 `ALTER TABLE`, aggregate/order/limit/join pushdown, parallel shard scans, or a
-public query API. The physical-default restriction is intentional: SQLite's
-`xUpdate` arguments do not distinguish an omitted column from explicit `NULL`.
-Generated keys and omitted-key SQL integration remain owned by issues #128
-through #130, and rollout remains owned by #131.
+public virtual-table query API. The physical-default restriction is
+intentional: SQLite's `xUpdate` arguments do not distinguish an omitted column
+from explicit `NULL`. Generated keys and omitted-key SQL integration remain
+owned by issues #128 through #130, and the broader rollout gate remains owned
+by #131.
 
-This does not change protocol behavior. The current `Engine`, HTTP surface,
-query app, and protocol planner remain authoritative. The writable coordinator
-is kept behind `experimental-vtab` and cannot be reached through a raw
-connection. Additional indexes continue to live on the ordinary physical
-tables and are used by child SQLite statements; SQLite does not permit adding
-indexes or triggers directly to a virtual table. Schema changes remain the
-journaled migration system's responsibility.
+The established protocol planner stays authoritative. The writable coordinator
+is kept behind both `experimental-vtab` and the runtime option and cannot be
+reached through a raw connection. Additional indexes continue to live on the
+ordinary physical tables and are used by child SQLite statements; SQLite does
+not permit adding indexes or triggers directly to a virtual table. Schema
+changes remain the journaled migration system's responsibility.
 
 Only the exact typed shard-key equality described above narrows a scan. Other
 predicates, and a type-mismatched equality whose SQLite affinity semantics

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -28,6 +28,9 @@ use crate::{
     storage::{ConnectionOwner, ConnectionPools, PooledConnection, SchemaOperationGuard},
 };
 
+#[cfg(feature = "experimental-vtab")]
+use crate::storage::{RegistrySchemaCache, WriteCoordinator};
+
 static NEXT_ENGINE_ID: AtomicU64 = AtomicU64::new(1);
 const MAX_SCATTER_CONCURRENCY: usize = 8;
 
@@ -141,6 +144,10 @@ struct EngineInner {
     lifecycle: Arc<Lifecycle>,
     shutdown_cancel: CancellationToken,
     shutdown_gate: Arc<tokio::sync::Mutex<()>>,
+    #[cfg(feature = "experimental-vtab")]
+    registry_schema_cache: Arc<RegistrySchemaCache>,
+    #[cfg(feature = "experimental-vtab")]
+    registry_bootstrap_gate: Arc<tokio::sync::Mutex<()>>,
 }
 
 struct Operation {
@@ -289,6 +296,10 @@ impl Engine {
                 lifecycle: Lifecycle::new(),
                 shutdown_cancel: CancellationToken::new(),
                 shutdown_gate: Arc::new(tokio::sync::Mutex::new(())),
+                #[cfg(feature = "experimental-vtab")]
+                registry_schema_cache: Arc::new(RegistrySchemaCache::new()),
+                #[cfg(feature = "experimental-vtab")]
+                registry_bootstrap_gate: Arc::new(tokio::sync::Mutex::new(())),
             }),
         })
     }
@@ -1099,6 +1110,17 @@ impl Engine {
             Ok(plan) => plan,
             Err(error) => return operation.finish(Err(error)),
         };
+        let catalog_authoritative = plan.is_some();
+        #[cfg(feature = "experimental-vtab")]
+        if catalog_authoritative
+            && self.inner.options.experimental_vtab_writes()
+            && plan.as_ref().is_some_and(|plan| plan.native_range_v1)
+        {
+            return operation.finish(Err(EngineError::new(
+                EngineErrorKind::Unsupported,
+                "experimental virtual-table Engine writes do not yet support native_range_v1 tables",
+            )));
+        }
         let owner = match (owner_policy, plan.is_some()) {
             (ExecuteOwnerPolicy::ReuseValidatedCatalogWrite, true) => {
                 ConnectionOwner::stateless_catalog_write()
@@ -1114,6 +1136,26 @@ impl Engine {
                 sql,
             ),
         };
+
+        #[cfg(feature = "experimental-vtab")]
+        if catalog_authoritative && self.inner.options.experimental_vtab_writes() {
+            let value = self
+                .run_coordinator_write(
+                    &mut operation,
+                    shard,
+                    owner,
+                    schema_operation,
+                    guard,
+                    sql,
+                    params,
+                )
+                .await;
+            let value = operation.finish_started(value)?;
+            return Ok(Routed { shard, value });
+        }
+
+        #[cfg(not(feature = "experimental-vtab"))]
+        let _ = catalog_authoritative;
 
         let value = self
             .run_on_shard(
@@ -1132,6 +1174,132 @@ impl Engine {
             .await;
         let value = operation.finish_started(value)?;
         Ok(Routed { shard, value })
+    }
+
+    /// Execute one catalog-authoritative autocommit write through the
+    /// experimental logical virtual-table facade.
+    ///
+    /// The pool permit is deliberately retained only as a capacity token. The
+    /// coordinator opens and validates its own child SQLite handle, so checking
+    /// out a pooled handle here would double-own the same per-shard capacity.
+    #[cfg(feature = "experimental-vtab")]
+    #[allow(clippy::too_many_arguments)]
+    async fn run_coordinator_write(
+        &self,
+        operation: &mut Operation,
+        shard: u16,
+        owner: ConnectionOwner,
+        schema_operation: SchemaOperationGuard,
+        session: OwnedMutexGuard<SessionInner>,
+        sql: String,
+        params: Vec<Value>,
+    ) -> EngineResult<usize> {
+        // A cold registry cache briefly owns an unpooled read-only shard-0
+        // handle; the physical DML child later owns the target-shard handle.
+        // Serialize that one-time discovery, reserve every real handle through
+        // the ordinary pool limits, and let warm coordinators use only their
+        // target shard. When shard 0 is also the cold target, one permit covers
+        // the sequential handles because discovery closes before DML starts.
+        let schema_generation = self.inner.database.storage.current_schema_generation();
+        let registry_bootstrap_gate = if self
+            .inner
+            .registry_schema_cache
+            .requires_bootstrap(schema_generation)
+        {
+            let gate = Arc::clone(&self.inner.registry_bootstrap_gate);
+            let acquired = match operation
+                .wait_pending(async move { Ok(gate.lock_owned().await) })
+                .await
+            {
+                Ok(acquired) => acquired,
+                Err(error) => return operation.control.complete(Err(error)),
+            };
+            if self
+                .inner
+                .registry_schema_cache
+                .requires_bootstrap(schema_generation)
+            {
+                Some(acquired)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        let bootstrap_required = registry_bootstrap_gate.is_some();
+        let shard_zero_capacity = if bootstrap_required {
+            match operation
+                .wait_pending(self.inner.connections.acquire_for_owner(0, owner))
+                .await
+            {
+                Ok(capacity) => Some(capacity),
+                Err(error) => return operation.control.complete(Err(error)),
+            }
+        } else {
+            None
+        };
+        let target_capacity = if shard == 0 && bootstrap_required {
+            None
+        } else {
+            match operation
+                .wait_pending(self.inner.connections.acquire_for_owner(shard, owner))
+                .await
+            {
+                Ok(capacity) => Some(capacity),
+                Err(error) => return operation.control.complete(Err(error)),
+            }
+        };
+        let worker = match operation.wait_pending(self.inner.workers.acquire()).await {
+            Ok(worker) => worker,
+            Err(error) => return operation.control.complete(Err(error)),
+        };
+        if let Err(error) = operation.check_before_start() {
+            return operation.control.complete(Err(error));
+        }
+
+        let lease = operation.take_lease();
+        let worker_control = Arc::clone(&operation.control);
+        let storage = self.inner.database.storage.clone();
+        let storage_for_corruption = storage.clone();
+        let registry_schema_cache = Arc::clone(&self.inner.registry_schema_cache);
+        let join = worker.spawn(move || {
+            let _lease = lease;
+            let _session = session;
+            let mut shard_zero_capacity = shard_zero_capacity;
+            let _target_capacity = target_capacity;
+            let mut registry_bootstrap_gate = registry_bootstrap_gate;
+            let result = (|| {
+                let mut coordinator = WriteCoordinator::open_admitted_controlled(
+                    storage,
+                    schema_operation,
+                    Arc::clone(&worker_control),
+                    registry_schema_cache,
+                )?;
+
+                // A nonzero write no longer owns a shard-0 handle after registry
+                // construction. Keep the same permit for shard-0 target writes.
+                if shard != 0 {
+                    drop(shard_zero_capacity.take());
+                }
+                drop(registry_bootstrap_gate.take());
+                let cancellation = coordinator.cancellation_handle();
+                worker_control
+                    .arm(Arc::new(move || cancellation.cancel_write_nonblocking()))
+                    .map_err(CancellationReason::error)?;
+                coordinator
+                    .execute_dml_values(&sql, &params)
+                    .map(|result| result.affected_rows())
+            })();
+            drop(registry_bootstrap_gate);
+            if result
+                .as_ref()
+                .is_err_and(|error| error.kind() == EngineErrorKind::DataCorruption)
+            {
+                storage_for_corruption.record_schema_degraded();
+            }
+            worker_control.complete(result)
+        });
+        operation.wait_started(join).await
     }
 
     /// Query a routed statement and return its selected shard and rows.
@@ -2210,6 +2378,8 @@ mod tests {
     use tokio::{sync::oneshot, time::timeout};
 
     use super::*;
+    #[cfg(feature = "experimental-vtab")]
+    use crate::core::GeneratedIdPolicy;
     use crate::core::{
         Column, DataType, Row, SessionState, ShardKeyMetadata, ShardKeyType, TableDeclaration,
     };
@@ -6812,5 +6982,907 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(recovered.value.len(), 2);
+    }
+
+    #[cfg(feature = "experimental-vtab")]
+    #[tokio::test]
+    async fn experimental_vtab_engine_writes_mutate_only_the_metadata_selected_shard() {
+        let options = EngineOptions::default().with_experimental_vtab_writes(true);
+        let (temp, engine) = engine_with_sharded_events(4, options);
+        let session = engine.session();
+
+        let keys = (0..4)
+            .map(|shard| integer_key_for_shard(&engine, shard, None))
+            .collect::<Vec<_>>();
+
+        session.set_routing_key(keys[1].to_string()).await.unwrap();
+        let mismatch = engine
+            .execute(
+                &session,
+                Statement::new(
+                    "INSERT INTO events (tenant_id, payload) VALUES (?1, ?2)",
+                    vec![Value::Int64(keys[0]), Value::from("wrong route")],
+                ),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(mismatch.kind(), EngineErrorKind::InvalidArgument);
+
+        for (shard, key) in keys.iter().copied().enumerate() {
+            session.set_routing_key(key.to_string()).await.unwrap();
+            let inserted = engine
+                .execute(
+                    &session,
+                    Statement::new(
+                        "INSERT INTO events (tenant_id, payload) VALUES (?1, ?2)",
+                        vec![Value::Int64(key), Value::from(format!("event-{shard}"))],
+                    ),
+                )
+                .await
+                .unwrap();
+            assert_eq!(inserted.shard, u16::try_from(shard).unwrap());
+            assert_eq!(inserted.value, 1);
+        }
+
+        for (owner, key) in keys.iter().copied().enumerate() {
+            for shard in 0..4 {
+                let connection = rusqlite::Connection::open(
+                    temp.path().join(format!("shards/{shard:04}.sqlite")),
+                )
+                .unwrap();
+                let count = connection
+                    .query_row(
+                        "SELECT COUNT(*) FROM events WHERE tenant_id = ?1",
+                        [key],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .unwrap();
+                assert_eq!(count, i64::from(shard == owner));
+            }
+        }
+
+        let key = keys[2];
+        session.set_routing_key(key.to_string()).await.unwrap();
+        assert_eq!(
+            engine
+                .execute(
+                    &session,
+                    Statement::new(
+                        "UPDATE events SET payload = ?2 WHERE tenant_id = ?1",
+                        vec![Value::Int64(key), Value::from("updated")],
+                    ),
+                )
+                .await
+                .unwrap()
+                .value,
+            1
+        );
+        assert_eq!(
+            engine
+                .execute(
+                    &session,
+                    Statement::new(
+                        "DELETE FROM events WHERE tenant_id = ?1",
+                        vec![Value::Int64(key)],
+                    ),
+                )
+                .await
+                .unwrap()
+                .value,
+            1
+        );
+        assert_eq!(
+            engine
+                .execute(
+                    &session,
+                    Statement::new(
+                        "DELETE FROM events WHERE tenant_id = ?1",
+                        vec![Value::Int64(key)],
+                    ),
+                )
+                .await
+                .unwrap()
+                .value,
+            0
+        );
+
+        let extra_zero = integer_key_for_shard(&engine, 0, Some(keys[0]));
+        let extra_one = integer_key_for_shard(&engine, 1, Some(keys[1]));
+        session
+            .set_routing_key(extra_zero.to_string())
+            .await
+            .unwrap();
+        let multiple_owners = engine
+            .execute(
+                &session,
+                Statement::new(
+                    "INSERT INTO events (tenant_id, payload) VALUES (?1, 'zero'), (?2, 'one')",
+                    vec![Value::Int64(extra_zero), Value::Int64(extra_one)],
+                ),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(multiple_owners.kind(), EngineErrorKind::InvalidArgument);
+        for shard in 0..4 {
+            let connection =
+                rusqlite::Connection::open(temp.path().join(format!("shards/{shard:04}.sqlite")))
+                    .unwrap();
+            let count = connection
+                .query_row(
+                    "SELECT COUNT(*) FROM events WHERE tenant_id IN (?1, ?2)",
+                    [extra_zero, extra_one],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap();
+            assert_eq!(count, 0);
+        }
+
+        let pools = engine.pool_snapshot_for_test().unwrap();
+        assert!(pools.shards.iter().all(|shard| {
+            shard.active == 0 && shard.queued == 0 && shard.opened == 0 && shard.checkouts == 0
+        }));
+    }
+
+    #[cfg(feature = "experimental-vtab")]
+    #[tokio::test]
+    async fn experimental_vtab_nonzero_write_accounts_for_shard_zero_bootstrap_capacity() {
+        let options = EngineOptions::new(1, 1)
+            .unwrap()
+            .with_request_timeout(None)
+            .unwrap()
+            .with_experimental_vtab_writes(true);
+        let (_temp, engine) = engine_with_sharded_events(4, options);
+        let held = engine
+            .inner
+            .connections
+            .acquire_for_owner(0, ConnectionOwner::new(u64::MAX))
+            .await
+            .unwrap();
+        let available_workers = engine.inner.workers.available_permits();
+        let key = integer_key_for_shard(&engine, 1, None);
+        let session = Arc::new(engine.session());
+        session.set_routing_key(key.to_string()).await.unwrap();
+
+        let write_engine = engine.clone();
+        let write_session = Arc::clone(&session);
+        let write = tokio::spawn(async move {
+            write_engine
+                .execute(
+                    &write_session,
+                    Statement::new(
+                        "INSERT INTO events (tenant_id, payload) VALUES (?1, 'accounted')",
+                        vec![Value::Int64(key)],
+                    ),
+                )
+                .await
+        });
+
+        wait_for_pool_occupancy(&engine, 0, 1, 1).await;
+        assert_eq!(engine.inner.workers.available_permits(), available_workers);
+        let target = engine.pool_snapshot_for_test().unwrap().shards[1];
+        assert_eq!(target.active, 0);
+        assert_eq!(target.queued, 0);
+
+        drop(held);
+        let inserted = timeout(Duration::from_secs(2), write)
+            .await
+            .expect("releasing shard-zero capacity should admit registry bootstrap")
+            .unwrap()
+            .unwrap();
+        assert_eq!(inserted.shard, 1);
+        assert_eq!(inserted.value, 1);
+        for shard in 0..4 {
+            wait_for_pool_occupancy(&engine, shard, 0, 0).await;
+        }
+        wait_for_worker_capacity(&engine, available_workers).await;
+    }
+
+    #[cfg(feature = "experimental-vtab")]
+    #[tokio::test]
+    async fn experimental_vtab_deadline_interrupts_locked_registry_bootstrap_promptly() {
+        let options = EngineOptions::new(1, 1)
+            .unwrap()
+            .with_request_timeout(None)
+            .unwrap()
+            .with_experimental_vtab_writes(true);
+        let (_temp, engine) = engine_with_sharded_events(4, options);
+        let blocker = engine.inner.database.storage.open_shard(0).unwrap();
+        blocker
+            .execute_batch("PRAGMA locking_mode = EXCLUSIVE; BEGIN EXCLUSIVE")
+            .unwrap();
+        let available_workers = engine.inner.workers.available_permits();
+        let key = integer_key_for_shard(&engine, 1, None);
+        let session = engine.session();
+        session.set_routing_key(key.to_string()).await.unwrap();
+        let context = RequestContext::new()
+            .with_timeout(Duration::from_millis(75))
+            .unwrap();
+
+        let started = std::time::Instant::now();
+        let error = timeout(
+            Duration::from_secs(1),
+            engine.execute_with_context(
+                &session,
+                Statement::new(
+                    "INSERT INTO events (tenant_id, payload) VALUES (?1, 'cancelled bootstrap')",
+                    vec![Value::Int64(key)],
+                ),
+                context,
+            ),
+        )
+        .await
+        .expect("the deadline must preempt SQLite's normal five-second bootstrap wait")
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DeadlineExceeded);
+        assert!(started.elapsed() < Duration::from_secs(1));
+
+        blocker.execute_batch("COMMIT").unwrap();
+        drop(blocker);
+        for shard in 0..4 {
+            wait_for_pool_occupancy(&engine, shard, 0, 0).await;
+        }
+        wait_for_worker_capacity(&engine, available_workers).await;
+        assert_eq!(engine.active_operations_for_test(), 0);
+
+        assert_eq!(
+            engine
+                .execute(
+                    &session,
+                    Statement::new(
+                        "INSERT INTO events (tenant_id, payload) VALUES (?1, 'recovered')",
+                        vec![Value::Int64(key)],
+                    ),
+                )
+                .await
+                .unwrap()
+                .value,
+            1
+        );
+    }
+
+    #[cfg(feature = "experimental-vtab")]
+    #[tokio::test]
+    async fn experimental_vtab_explicit_cancellation_interrupts_a_locked_child_write() {
+        let options = EngineOptions::new(1, 1)
+            .unwrap()
+            .with_request_timeout(None)
+            .unwrap()
+            .with_experimental_vtab_writes(true);
+        let (temp, engine) = engine_with_sharded_events(4, options);
+        let key = integer_key_for_shard(&engine, 1, None);
+        let session = Arc::new(engine.session());
+        session.set_routing_key(key.to_string()).await.unwrap();
+        let blocker = rusqlite::Connection::open(temp.path().join("shards/0001.sqlite")).unwrap();
+        blocker.execute_batch("BEGIN IMMEDIATE").unwrap();
+        let token = CancellationToken::new();
+        let context = RequestContext::new().with_cancellation_token(token.clone());
+        let child_busy_gate = engine.inner.registry_schema_cache.install_child_busy_gate();
+        let cancellation_observer = engine
+            .inner
+            .registry_schema_cache
+            .install_cancellation_observer();
+
+        let write_engine = engine.clone();
+        let write_session = Arc::clone(&session);
+        let write = tokio::spawn(async move {
+            write_engine
+                .execute_with_context(
+                    &write_session,
+                    Statement::new(
+                        "INSERT INTO events (tenant_id, payload) VALUES (?1, 'cancelled')",
+                        vec![Value::Int64(key)],
+                    ),
+                    context,
+                )
+                .await
+        });
+        let mut child_busy_gate = timeout(
+            Duration::from_secs(2),
+            tokio::task::spawn_blocking(move || {
+                child_busy_gate.wait_until_started();
+                child_busy_gate
+            }),
+        )
+        .await
+        .expect("the target child must reach a real SQLite busy result")
+        .unwrap();
+        assert!(token.cancel());
+        timeout(Duration::from_secs(2), async {
+            while !cancellation_observer.load(Ordering::Acquire) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the Engine cancellation callback must reach the active coordinator");
+        child_busy_gate.release();
+        let error = timeout(Duration::from_secs(2), write)
+            .await
+            .expect("explicit cancellation should interrupt the child lock wait")
+            .unwrap()
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Cancelled);
+
+        blocker.execute_batch("ROLLBACK").unwrap();
+        drop(blocker);
+        for shard in 0..4 {
+            wait_for_pool_occupancy(&engine, shard, 0, 0).await;
+        }
+        assert_eq!(engine.active_operations_for_test(), 0);
+        assert_eq!(
+            engine
+                .inner
+                .database
+                .storage
+                .open_shard(1)
+                .unwrap()
+                .query_row("SELECT COUNT(*) FROM events", [], |row| row
+                    .get::<_, i64>(0))
+                .unwrap(),
+            0
+        );
+    }
+
+    #[cfg(feature = "experimental-vtab")]
+    #[tokio::test]
+    async fn experimental_vtab_known_commit_wins_a_late_engine_cancellation() {
+        let options = EngineOptions::default()
+            .with_request_timeout(None)
+            .unwrap()
+            .with_experimental_vtab_writes(true);
+        let (temp, engine) = engine_with_sharded_events(2, options);
+        let key = integer_key_for_shard(&engine, 1, None);
+        let session = Arc::new(engine.session());
+        session.set_routing_key(key.to_string()).await.unwrap();
+        let token = CancellationToken::new();
+        let context = RequestContext::new().with_cancellation_token(token.clone());
+        let commit_gate = engine.inner.registry_schema_cache.install_commit_gate();
+        let cancellation_observer = engine
+            .inner
+            .registry_schema_cache
+            .install_cancellation_observer();
+
+        let write_engine = engine.clone();
+        let write_session = Arc::clone(&session);
+        let write = tokio::spawn(async move {
+            write_engine
+                .execute_with_context(
+                    &write_session,
+                    Statement::new(
+                        "INSERT INTO events (tenant_id, payload) VALUES (?1, 'committed')",
+                        vec![Value::Int64(key)],
+                    ),
+                    context,
+                )
+                .await
+        });
+        let mut commit_gate = timeout(
+            Duration::from_secs(2),
+            tokio::task::spawn_blocking(move || {
+                commit_gate.wait_until_started();
+                commit_gate
+            }),
+        )
+        .await
+        .expect("the child finalizer must claim the commit decision")
+        .unwrap();
+
+        assert!(token.cancel());
+        timeout(Duration::from_secs(2), async {
+            while !cancellation_observer.load(Ordering::Acquire) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("late cancellation must reach the commit linearization point");
+        commit_gate.release();
+
+        let inserted = timeout(Duration::from_secs(2), write)
+            .await
+            .expect("the known commit must finish after cancellation")
+            .unwrap()
+            .unwrap();
+        assert_eq!(inserted.shard, 1);
+        assert_eq!(inserted.value, 1);
+        assert_eq!(
+            rusqlite::Connection::open(temp.path().join("shards/0001.sqlite"))
+                .unwrap()
+                .query_row(
+                    "SELECT payload FROM events WHERE tenant_id = ?1",
+                    [key],
+                    |row| row.get::<_, String>(0),
+                )
+                .unwrap(),
+            "committed"
+        );
+        assert_eq!(engine.active_operations_for_test(), 0);
+    }
+
+    #[cfg(feature = "experimental-vtab")]
+    #[tokio::test]
+    async fn experimental_vtab_registry_cache_rebuilds_after_schema_generation_changes() {
+        let options = EngineOptions::default().with_experimental_vtab_writes(true);
+        let (temp, engine) = engine_with_sharded_events(2, options);
+        let key = integer_key_for_shard(&engine, 1, None);
+        let session = engine.session();
+        session.set_routing_key(key.to_string()).await.unwrap();
+
+        engine
+            .execute(
+                &session,
+                Statement::new(
+                    "INSERT INTO events (tenant_id, payload) VALUES (?1, 'warm')",
+                    vec![Value::Int64(key)],
+                ),
+            )
+            .await
+            .unwrap();
+        engine
+            .broadcast(
+                &session,
+                "ALTER TABLE events ADD COLUMN note TEXT".to_owned(),
+            )
+            .await
+            .unwrap();
+
+        let next_key = integer_key_for_shard(&engine, 1, Some(key));
+        session.set_routing_key(next_key.to_string()).await.unwrap();
+        let inserted = engine
+            .execute(
+                &session,
+                Statement::new(
+                    "INSERT INTO events (tenant_id, payload, note) VALUES (?1, 'new', 'fresh')",
+                    vec![Value::Int64(next_key)],
+                ),
+            )
+            .await
+            .unwrap();
+        assert_eq!(inserted.shard, 1);
+        assert_eq!(inserted.value, 1);
+        assert_eq!(
+            rusqlite::Connection::open(temp.path().join("shards/0001.sqlite"))
+                .unwrap()
+                .query_row(
+                    "SELECT note FROM events WHERE tenant_id = ?1",
+                    [next_key],
+                    |row| row.get::<_, String>(0),
+                )
+                .unwrap(),
+            "fresh"
+        );
+    }
+
+    #[cfg(feature = "experimental-vtab")]
+    #[tokio::test]
+    async fn experimental_vtab_engine_rejects_native_range_targets_before_coordinator_open() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut database = Database::open(temp.path(), 4).unwrap();
+        database
+            .broadcast(
+                "CREATE TABLE native_events (
+                     id INTEGER PRIMARY KEY NOT NULL,
+                     payload TEXT NOT NULL
+                 ) STRICT",
+            )
+            .unwrap();
+        let logical_database = database.catalog().default_database().id();
+        database
+            .register_tables(vec![
+                TableDeclaration::sharded(
+                    logical_database,
+                    "native_events",
+                    ShardKeyMetadata::new("id", ShardKeyType::Int64).unwrap(),
+                )
+                .unwrap()
+                .with_generated_id_policy(GeneratedIdPolicy::native_range_v1("id").unwrap())
+                .unwrap(),
+            ])
+            .unwrap();
+
+        let (owner_shard, native_id, reserved_floor) = {
+            let owners = database.storage.allocation_owner_map().unwrap();
+            (0..database.shard_count())
+                .find_map(|owner_shard| {
+                    let owner = owners.owner_for_physical_shard(owner_shard).unwrap();
+                    (1..=256_u64).find_map(|local_sequence| {
+                        let native_id =
+                            crate::core::generated_id::NativeRangeV1Id::new(owner, local_sequence)
+                                .unwrap()
+                                .encode();
+                        (database.shard_for_key(native_id.to_string().as_bytes()) != owner_shard)
+                            .then(|| {
+                                (
+                                    owner_shard,
+                                    native_id,
+                                    crate::core::generated_id::native_range_v1_sequence_floor(
+                                        owner,
+                                    ),
+                                )
+                            })
+                    })
+                })
+                .expect("a native owner route must differ from an ordinary hash route")
+        };
+        assert_ne!(
+            database.shard_for_key(native_id.to_string().as_bytes()),
+            owner_shard,
+            "the regression key must expose owner-map versus hash routing"
+        );
+
+        let options = EngineOptions::new(1, 1)
+            .unwrap()
+            .with_experimental_vtab_writes(true);
+        let engine = Engine::from_database_with_options(Arc::new(database), options).unwrap();
+        let session = engine.session();
+
+        // A valid explicit native ID would otherwise make the planner reserve
+        // and report its hash-selected shard while the coordinator writes to
+        // its encoded allocation owner. The reserved floor is more severe:
+        // the coordinator classifies it as corruption. Both must stop at the
+        // same client-facing Engine preflight while storage is still healthy.
+        for value in [native_id, reserved_floor] {
+            session.set_routing_key(value.to_string()).await.unwrap();
+            let error = engine
+                .execute(
+                    &session,
+                    Statement::new(
+                        "INSERT INTO native_events (id, payload) VALUES (?1, 'rejected')",
+                        vec![Value::Int64(value)],
+                    ),
+                )
+                .await
+                .unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::Unsupported);
+            assert!(error.diagnostic().contains("native_range_v1"));
+            assert_eq!(session.state().await, SessionState::Ready);
+            assert_eq!(
+                engine.inner.database.storage.schema_gate_snapshot().state,
+                crate::storage::SchemaGateState::Ready
+            );
+        }
+
+        for shard in 0..engine.shard_count() {
+            assert_eq!(
+                engine
+                    .inner
+                    .database
+                    .storage
+                    .open_shard(shard)
+                    .unwrap()
+                    .query_row("SELECT COUNT(*) FROM native_events", [], |row| {
+                        row.get::<_, i64>(0)
+                    })
+                    .unwrap(),
+                0,
+                "shard {shard}"
+            );
+        }
+        let pools = engine.pool_snapshot_for_test().unwrap();
+        assert!(pools.shards.iter().all(|shard| {
+            shard.active == 0 && shard.queued == 0 && shard.opened == 0 && shard.checkouts == 0
+        }));
+    }
+
+    #[cfg(feature = "experimental-vtab")]
+    #[tokio::test]
+    async fn experimental_vtab_deadline_interrupts_a_locked_write_and_releases_capacity() {
+        let options = EngineOptions::new(1, 1)
+            .unwrap()
+            .with_request_timeout(None)
+            .unwrap()
+            .with_experimental_vtab_writes(true);
+        let (temp, engine) = engine_with_sharded_events(4, options);
+        let key = integer_key_for_shard(&engine, 1, None);
+        let session = engine.session();
+        session.set_routing_key(key.to_string()).await.unwrap();
+
+        // Warm registry metadata first so the lock below targets the physical
+        // child-open window rather than cold shard-zero discovery.
+        let warm_key = integer_key_for_shard(&engine, 0, None);
+        session.set_routing_key(warm_key.to_string()).await.unwrap();
+        engine
+            .execute(
+                &session,
+                Statement::new(
+                    "INSERT INTO events (tenant_id, payload) VALUES (?1, 'warm')",
+                    vec![Value::Int64(warm_key)],
+                ),
+            )
+            .await
+            .unwrap();
+        session.set_routing_key(key.to_string()).await.unwrap();
+
+        let lock = rusqlite::Connection::open(temp.path().join("shards/0001.sqlite")).unwrap();
+        lock.execute_batch("PRAGMA locking_mode = EXCLUSIVE; BEGIN EXCLUSIVE")
+            .unwrap();
+        let context = RequestContext::new()
+            .with_timeout(Duration::from_millis(75))
+            .unwrap();
+        let error = engine
+            .execute_with_context(
+                &session,
+                Statement::new(
+                    "INSERT INTO events (tenant_id, payload) VALUES (?1, ?2)",
+                    vec![Value::Int64(key), Value::from("cancelled")],
+                ),
+                context,
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DeadlineExceeded);
+        lock.execute_batch("COMMIT").unwrap();
+        drop(lock);
+
+        let shard = engine.pool_snapshot_for_test().unwrap().shards[1];
+        assert_eq!(shard.active, 0);
+        assert_eq!(shard.queued, 0);
+        assert_eq!(engine.active_operations_for_test(), 0);
+
+        let inserted = engine
+            .execute(
+                &session,
+                Statement::new(
+                    "INSERT INTO events (tenant_id, payload) VALUES (?1, ?2)",
+                    vec![Value::Int64(key), Value::from("recovered")],
+                ),
+            )
+            .await
+            .unwrap();
+        assert_eq!(inserted.shard, 1);
+        assert_eq!(inserted.value, 1);
+    }
+
+    #[cfg(feature = "experimental-vtab")]
+    #[tokio::test]
+    async fn experimental_vtab_engine_preserves_constraint_kinds_and_session_recovery() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut database = Database::open(temp.path(), 2).unwrap();
+        database
+            .broadcast(
+                "CREATE TABLE parents (
+                     tenant_id INTEGER NOT NULL,
+                     parent_id INTEGER NOT NULL,
+                     label TEXT NOT NULL,
+                     PRIMARY KEY (tenant_id, parent_id)
+                 );
+                 CREATE TABLE items (
+                     tenant_id INTEGER NOT NULL,
+                     item_id INTEGER NOT NULL,
+                     parent_id INTEGER NOT NULL,
+                     code TEXT NOT NULL,
+                     quantity INTEGER NOT NULL CHECK (quantity > 0),
+                     PRIMARY KEY (tenant_id, item_id),
+                     UNIQUE (tenant_id, code),
+                     FOREIGN KEY (tenant_id, parent_id)
+                         REFERENCES parents (tenant_id, parent_id)
+                 );",
+            )
+            .unwrap();
+        let logical_database = database.catalog().default_database().id();
+        database
+            .register_tables(vec![
+                TableDeclaration::sharded(
+                    logical_database,
+                    "parents",
+                    ShardKeyMetadata::new("tenant_id", ShardKeyType::Int64).unwrap(),
+                )
+                .unwrap(),
+                TableDeclaration::sharded(
+                    logical_database,
+                    "items",
+                    ShardKeyMetadata::new("tenant_id", ShardKeyType::Int64).unwrap(),
+                )
+                .unwrap(),
+            ])
+            .unwrap();
+        let key = (1_i64..)
+            .find(|key| database.shard_for_key(key.to_string().as_bytes()) == 0)
+            .unwrap();
+        let options = EngineOptions::default().with_experimental_vtab_writes(true);
+        let engine = Engine::from_database_with_options(Arc::new(database), options).unwrap();
+        let session = engine.session();
+        session.set_routing_key(key.to_string()).await.unwrap();
+
+        assert_eq!(
+            engine
+                .execute(
+                    &session,
+                    Statement::new(
+                        "INSERT INTO parents (tenant_id, parent_id, label) VALUES (?1, 1, 'parent')",
+                        vec![Value::Int64(key)],
+                    ),
+                )
+                .await
+                .unwrap()
+                .value,
+            1
+        );
+        assert_eq!(
+            engine
+                .execute(
+                    &session,
+                    Statement::new(
+                        "INSERT INTO items
+                         (tenant_id, item_id, parent_id, code, quantity)
+                         VALUES (?1, 1, 1, 'first', 5)",
+                        vec![Value::Int64(key)],
+                    ),
+                )
+                .await
+                .unwrap()
+                .value,
+            1
+        );
+
+        for (sql, expected) in [
+            (
+                "INSERT INTO items
+                 (tenant_id, item_id, parent_id, code, quantity)
+                 VALUES (?1, 1, 1, 'duplicate', 5)",
+                EngineErrorKind::UniqueViolation,
+            ),
+            (
+                "INSERT INTO items
+                 (tenant_id, item_id, parent_id, code, quantity)
+                 VALUES (?1, 2, 1, NULL, 5)",
+                EngineErrorKind::NotNullViolation,
+            ),
+            (
+                "INSERT INTO items
+                 (tenant_id, item_id, parent_id, code, quantity)
+                 VALUES (?1, 2, 1, 'bad-check', 0)",
+                EngineErrorKind::CheckViolation,
+            ),
+            (
+                "INSERT INTO items
+                 (tenant_id, item_id, parent_id, code, quantity)
+                 VALUES (?1, 2, 999, 'bad-parent', 5)",
+                EngineErrorKind::ForeignKeyViolation,
+            ),
+        ] {
+            let error = engine
+                .execute(&session, Statement::new(sql, vec![Value::Int64(key)]))
+                .await
+                .unwrap_err();
+            assert_eq!(error.kind(), expected);
+            assert_eq!(session.state().await, SessionState::Ready);
+        }
+
+        let recovered = engine
+            .execute(
+                &session,
+                Statement::new(
+                    "INSERT INTO items
+                     (tenant_id, item_id, parent_id, code, quantity)
+                     VALUES (?1, 2, 1, 'second', 5)",
+                    vec![Value::Int64(key)],
+                ),
+            )
+            .await
+            .unwrap();
+        assert_eq!(recovered.value, 1);
+    }
+
+    #[cfg(feature = "experimental-vtab")]
+    #[tokio::test]
+    async fn experimental_vtab_writer_on_another_shard_progresses_while_one_is_locked() {
+        let options = EngineOptions::new(1, 2)
+            .unwrap()
+            .with_request_timeout(None)
+            .unwrap()
+            .with_experimental_vtab_writes(true);
+        let (temp, engine) = engine_with_sharded_events(2, options);
+        let key_zero = integer_key_for_shard(&engine, 0, None);
+        let key_one = integer_key_for_shard(&engine, 1, None);
+
+        let lock = rusqlite::Connection::open(temp.path().join("shards/0000.sqlite")).unwrap();
+        lock.execute_batch("BEGIN IMMEDIATE").unwrap();
+        let child_busy_gate = engine.inner.registry_schema_cache.install_child_busy_gate();
+        let blocked_engine = engine.clone();
+        let blocked = tokio::spawn(async move {
+            let session = blocked_engine.session();
+            session.set_routing_key(key_zero.to_string()).await.unwrap();
+            blocked_engine
+                .execute(
+                    &session,
+                    Statement::new(
+                        "INSERT INTO events (tenant_id, payload) VALUES (?1, 'blocked')",
+                        vec![Value::Int64(key_zero)],
+                    ),
+                )
+                .await
+        });
+        let mut child_busy_gate = timeout(
+            Duration::from_secs(2),
+            tokio::task::spawn_blocking(move || {
+                child_busy_gate.wait_until_started();
+                child_busy_gate
+            }),
+        )
+        .await
+        .expect("the shard-zero writer must reach a real SQLite busy result")
+        .unwrap();
+
+        let independent = engine.session();
+        independent
+            .set_routing_key(key_one.to_string())
+            .await
+            .unwrap();
+        let inserted = timeout(
+            Duration::from_secs(1),
+            engine.execute(
+                &independent,
+                Statement::new(
+                    "INSERT INTO events (tenant_id, payload) VALUES (?1, 'independent')",
+                    vec![Value::Int64(key_one)],
+                ),
+            ),
+        )
+        .await
+        .expect("a writer on shard one must not wait for shard zero")
+        .unwrap();
+        assert_eq!(inserted.shard, 1);
+        assert_eq!(inserted.value, 1);
+
+        lock.execute_batch("ROLLBACK").unwrap();
+        child_busy_gate.release();
+        let released = timeout(Duration::from_secs(2), blocked)
+            .await
+            .expect("the blocked writer should finish after its shard lock is released")
+            .unwrap()
+            .unwrap();
+        assert_eq!(released.shard, 0);
+        assert_eq!(released.value, 1);
+    }
+
+    #[cfg(feature = "experimental-vtab")]
+    #[tokio::test]
+    async fn experimental_vtab_shutdown_cancels_and_drains_an_inflight_coordinator() {
+        let options = EngineOptions::new(1, 1)
+            .unwrap()
+            .with_request_timeout(None)
+            .unwrap()
+            .with_shutdown_grace(Duration::from_millis(100))
+            .unwrap()
+            .with_experimental_vtab_writes(true);
+        let (temp, engine) = engine_with_sharded_events(2, options);
+        let key = integer_key_for_shard(&engine, 0, None);
+        let lock = rusqlite::Connection::open(temp.path().join("shards/0000.sqlite")).unwrap();
+        lock.execute_batch("BEGIN IMMEDIATE").unwrap();
+
+        let writer_engine = engine.clone();
+        let writer = tokio::spawn(async move {
+            let session = writer_engine.session();
+            session.set_routing_key(key.to_string()).await.unwrap();
+            writer_engine
+                .execute(
+                    &session,
+                    Statement::new(
+                        "INSERT INTO events (tenant_id, payload) VALUES (?1, 'shutdown')",
+                        vec![Value::Int64(key)],
+                    ),
+                )
+                .await
+        });
+        timeout(Duration::from_secs(1), async {
+            while engine.active_operations_for_test() != 1 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the coordinator write should enter Engine lifecycle accounting");
+
+        let report = timeout(Duration::from_secs(2), engine.shutdown())
+            .await
+            .expect("shutdown should cancel and drain the locked coordinator")
+            .unwrap();
+        assert!(report.forced());
+        let error = writer.await.unwrap().unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Cancelled);
+        assert_eq!(engine.active_operations_for_test(), 0);
+        assert_eq!(engine.state(), EngineState::Stopped);
+        let shard = engine.pool_snapshot_for_test().unwrap().shards[0];
+        assert_eq!(shard.active, 0);
+        assert_eq!(shard.queued, 0);
+        lock.execute_batch("ROLLBACK").unwrap();
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -78,6 +78,8 @@ pub(crate) enum RawDataOperation {
 pub(crate) struct RawDataPlan {
     pub(crate) shard: u16,
     pub(crate) sqlite_sql: String,
+    #[cfg(feature = "experimental-vtab")]
+    pub(crate) native_range_v1: bool,
 }
 
 #[derive(Debug)]
@@ -195,10 +197,23 @@ impl Database {
             |key| self.shard_for_key(key),
         )?;
         let shard = raw_data_execution_shard(&plan, catalog, operation)?;
+        #[cfg(feature = "experimental-vtab")]
+        let native_range_v1 = plan
+            .inference()
+            .table_id()
+            .and_then(|table| catalog.table_by_id(table))
+            .is_some_and(|table| {
+                matches!(
+                    table.generated_id_policy(),
+                    GeneratedIdPolicy::NativeRangeV1 { .. }
+                )
+            });
 
         Ok(Some(RawDataPlan {
             shard,
             sqlite_sql: translated.sqlite_sql().to_owned(),
+            #[cfg(feature = "experimental-vtab")]
+            native_range_v1,
         }))
     }
 

--- a/src/core/options.rs
+++ b/src/core/options.rs
@@ -213,6 +213,8 @@ pub struct EngineOptions {
     prepared_statement_limits: PreparedStatementLimits,
     request_timeout: Option<Duration>,
     shutdown_grace: Duration,
+    #[cfg(feature = "experimental-vtab")]
+    experimental_vtab_writes: bool,
 }
 
 impl EngineOptions {
@@ -243,6 +245,8 @@ impl EngineOptions {
             prepared_statement_limits: PreparedStatementLimits::default(),
             request_timeout: Some(Duration::from_millis(DEFAULT_REQUEST_TIMEOUT_MS)),
             shutdown_grace: Duration::from_millis(DEFAULT_SHUTDOWN_GRACE_MS),
+            #[cfg(feature = "experimental-vtab")]
+            experimental_vtab_writes: false,
         })
     }
 
@@ -313,6 +317,25 @@ impl EngineOptions {
         Ok(self)
     }
 
+    /// Return whether registered autocommit writes use the experimental
+    /// sharded virtual-table facade.
+    #[cfg(feature = "experimental-vtab")]
+    pub const fn experimental_vtab_writes(&self) -> bool {
+        self.experimental_vtab_writes
+    }
+
+    /// Enable or disable the experimental sharded virtual-table write path.
+    ///
+    /// This runtime opt-in is available only when BriskDB is compiled with the
+    /// `experimental-vtab` Cargo feature. The established pooled execution
+    /// path remains the default even in feature-enabled builds.
+    #[cfg(feature = "experimental-vtab")]
+    #[must_use]
+    pub const fn with_experimental_vtab_writes(mut self, enabled: bool) -> Self {
+        self.experimental_vtab_writes = enabled;
+        self
+    }
+
     /// Validate limits that depend on the database's physical shard count.
     ///
     /// The returned value is the maximum number of active SQLite connections
@@ -348,6 +371,8 @@ impl Default for EngineOptions {
             },
             request_timeout: Some(Duration::from_millis(DEFAULT_REQUEST_TIMEOUT_MS)),
             shutdown_grace: Duration::from_millis(DEFAULT_SHUTDOWN_GRACE_MS),
+            #[cfg(feature = "experimental-vtab")]
+            experimental_vtab_writes: false,
         }
     }
 }
@@ -409,8 +434,21 @@ mod tests {
         );
         assert_eq!(options.request_timeout(), Some(Duration::from_secs(30)));
         assert_eq!(options.shutdown_grace(), Duration::from_secs(30));
+        #[cfg(feature = "experimental-vtab")]
+        assert!(!options.experimental_vtab_writes());
         assert_eq!(options.worker_limit(2).unwrap(), 8);
         assert_eq!(options.worker_limit(64).unwrap(), 256);
+    }
+
+    #[cfg(feature = "experimental-vtab")]
+    #[test]
+    fn experimental_vtab_writes_are_an_explicit_reversible_opt_in() {
+        let enabled = EngineOptions::default().with_experimental_vtab_writes(true);
+        assert!(enabled.experimental_vtab_writes());
+
+        let disabled = enabled.with_experimental_vtab_writes(false);
+        assert!(!disabled.experimental_vtab_writes());
+        assert_eq!(disabled, EngineOptions::default());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,6 +144,15 @@ struct Args {
         default_value_t = DEFAULT_SHUTDOWN_GRACE_MS
     )]
     shutdown_grace_ms: u64,
+
+    /// Route registered autocommit writes through the experimental virtual-table facade.
+    #[cfg(feature = "experimental-vtab")]
+    #[arg(
+        long,
+        env = "BRISKDB_EXPERIMENTAL_VTAB_WRITES",
+        default_value_t = false
+    )]
+    experimental_vtab_writes: bool,
 }
 
 impl Args {
@@ -166,6 +175,8 @@ impl Args {
                 .with_prepared_statement_limits(prepared_statement_limits)
                 .with_request_timeout(request_timeout)?
                 .with_shutdown_grace(Duration::from_millis(self.shutdown_grace_ms))?;
+        #[cfg(feature = "experimental-vtab")]
+        let options = options.with_experimental_vtab_writes(self.experimental_vtab_writes);
         let config = Config {
             listen: self.listen,
             postgres_listen: self.postgres_listen.into_option(),
@@ -228,6 +239,8 @@ mod tests {
         );
         assert_eq!(args.request_timeout_ms, DEFAULT_REQUEST_TIMEOUT_MS);
         assert_eq!(args.shutdown_grace_ms, DEFAULT_SHUTDOWN_GRACE_MS);
+        #[cfg(feature = "experimental-vtab")]
+        assert!(!args.experimental_vtab_writes);
     }
 
     #[test]
@@ -339,6 +352,29 @@ mod tests {
             Some(Duration::from_millis(2_500))
         );
         assert_eq!(options.shutdown_grace(), Duration::from_millis(4_000));
+        #[cfg(feature = "experimental-vtab")]
+        assert!(!options.experimental_vtab_writes());
+    }
+
+    #[cfg(feature = "experimental-vtab")]
+    #[test]
+    fn experimental_vtab_write_flag_is_forwarded_to_engine_options() {
+        let args = Args::try_parse_from(["briskdb", "--experimental-vtab-writes"]).unwrap();
+        assert!(args.experimental_vtab_writes);
+
+        let (_, options) = args.into_server_parts().unwrap();
+        assert!(options.experimental_vtab_writes());
+    }
+
+    #[cfg(not(feature = "experimental-vtab"))]
+    #[test]
+    fn experimental_vtab_write_flag_is_absent_without_the_cargo_feature() {
+        assert!(Args::try_parse_from(["briskdb", "--experimental-vtab-writes"]).is_err());
+        assert!(
+            Args::command()
+                .get_arguments()
+                .all(|argument| argument.get_id() != "experimental_vtab_writes")
+        );
     }
 
     #[test]
@@ -474,6 +510,11 @@ mod tests {
             .get_arguments()
             .find(|argument| argument.get_id() == "shutdown_grace_ms")
             .unwrap();
+        #[cfg(feature = "experimental-vtab")]
+        let experimental_vtab_writes = command
+            .get_arguments()
+            .find(|argument| argument.get_id() == "experimental_vtab_writes")
+            .unwrap();
 
         assert_eq!(
             postgres_listener.get_env(),
@@ -512,6 +553,37 @@ mod tests {
             shutdown.get_env(),
             Some(OsStr::new("BRISKDB_SHUTDOWN_GRACE_MS"))
         );
+        #[cfg(feature = "experimental-vtab")]
+        assert_eq!(
+            experimental_vtab_writes.get_env(),
+            Some(OsStr::new("BRISKDB_EXPERIMENTAL_VTAB_WRITES"))
+        );
+    }
+
+    #[cfg(feature = "experimental-vtab")]
+    #[test]
+    fn experimental_vtab_writes_parse_from_environment_in_an_isolated_process() {
+        const CHILD_MARKER: &str = "BRISKDB_VTAB_WRITE_ENV_TEST_CHILD";
+
+        if std::env::var_os(CHILD_MARKER).is_some() {
+            let args = Args::try_parse_from(["briskdb"]).unwrap();
+            assert!(args.experimental_vtab_writes);
+            let (_, options) = args.into_server_parts().unwrap();
+            assert!(options.experimental_vtab_writes());
+            return;
+        }
+
+        let status = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "tests::experimental_vtab_writes_parse_from_environment_in_an_isolated_process",
+            ])
+            .env(CHILD_MARKER, "1")
+            .env("BRISKDB_EXPERIMENTAL_VTAB_WRITES", "true")
+            .status()
+            .unwrap();
+
+        assert!(status.success());
     }
 
     #[test]

--- a/src/protocol/http.rs
+++ b/src/protocol/http.rs
@@ -472,6 +472,9 @@ mod tests {
         let database = Arc::new(database);
         let routing_key = "reused-http-write";
         let expected_shard = database.shard_for_key(routing_key.as_bytes());
+        // The experimental virtual-table write gate is off by default, even
+        // in an all-features build. This existing pooling assertion therefore
+        // also protects parity for the established physical-shard path.
         let options = EngineOptions::new(1, 64).unwrap();
         let engine = Engine::from_database_with_options(Arc::clone(&database), options).unwrap();
         let application = router_with_engine(engine.clone());
@@ -602,6 +605,205 @@ mod tests {
         assert_eq!(isolated.retired, 1);
     }
 
+    #[cfg(feature = "experimental-vtab")]
+    #[tokio::test]
+    async fn opted_in_vtab_http_autocommit_dml_places_each_row_on_exactly_one_shard() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut database = Database::open(temp.path(), 4).unwrap();
+        database
+            .broadcast(
+                "CREATE TABLE records (
+                    tenant_id TEXT NOT NULL,
+                    record_id INTEGER NOT NULL,
+                    payload TEXT NOT NULL,
+                    PRIMARY KEY (tenant_id, record_id)
+                 )",
+            )
+            .unwrap();
+        let logical_database = database.catalog().default_database().id();
+        database
+            .register_tables(vec![
+                TableDeclaration::sharded(
+                    logical_database,
+                    "records",
+                    ShardKeyMetadata::new("tenant_id", ShardKeyType::Text).unwrap(),
+                )
+                .unwrap(),
+            ])
+            .unwrap();
+        let tenant_keys = (0..4_u16)
+            .map(|expected_shard| {
+                (0_u64..)
+                    .map(|candidate| format!("vtab-http-{expected_shard}-{candidate}"))
+                    .find(|key| database.shard_for_key(key.as_bytes()) == expected_shard)
+                    .unwrap()
+            })
+            .collect::<Vec<_>>();
+        let database = Arc::new(database);
+        let options = EngineOptions::new(2, 16)
+            .unwrap()
+            .with_experimental_vtab_writes(true);
+        let engine = Engine::from_database_with_options(Arc::clone(&database), options).unwrap();
+        let application = router_with_engine(engine.clone());
+
+        for (shard, tenant_key) in tenant_keys.iter().enumerate() {
+            assert_eq!(
+                request_json(
+                    &application,
+                    Method::POST,
+                    "/v1/execute",
+                    Some(json!({
+                        "shard_key": tenant_key,
+                        "sql": "INSERT INTO records (tenant_id, record_id, payload) VALUES (?1, ?2, ?3)",
+                        "params": [tenant_key, 1, format!("inserted-{shard}")]
+                    })),
+                )
+                .await,
+                (
+                    StatusCode::OK,
+                    json!({"shard": shard, "rows_affected": 1})
+                )
+            );
+        }
+
+        // Inspect every physical file after INSERT, rather than accepting a
+        // successful logical read as proof of placement. Each owner has its
+        // one row and no other shard has a duplicate.
+        let observer = engine.session();
+        for (shard, tenant_key) in tenant_keys.iter().enumerate() {
+            let physical = engine
+                .inspect_shard(
+                    &observer,
+                    u16::try_from(shard).unwrap(),
+                    Statement::new("SELECT tenant_id, record_id, payload FROM records", vec![]),
+                )
+                .await
+                .unwrap();
+            assert_eq!(physical.rows().len(), 1, "physical shard {shard}");
+            assert_eq!(
+                physical.rows()[0].values(),
+                [
+                    Value::from(tenant_key.clone()),
+                    Value::from(1_i64),
+                    Value::from(format!("inserted-{shard}")),
+                ],
+                "physical shard {shard}"
+            );
+        }
+
+        for (shard, tenant_key) in tenant_keys.iter().enumerate() {
+            assert_eq!(
+                request_json(
+                    &application,
+                    Method::POST,
+                    "/v1/execute",
+                    Some(json!({
+                        "shard_key": tenant_key,
+                        "sql": "UPDATE records SET payload = ?1 WHERE tenant_id = ?2 AND record_id = ?3",
+                        "params": [format!("updated-{shard}"), tenant_key, 1]
+                    })),
+                )
+                .await,
+                (
+                    StatusCode::OK,
+                    json!({"shard": shard, "rows_affected": 1})
+                )
+            );
+        }
+        assert_eq!(
+            request_json(
+                &application,
+                Method::POST,
+                "/v1/execute",
+                Some(json!({
+                    "shard_key": tenant_keys[0],
+                    "sql": "UPDATE records SET payload = 'missing' WHERE tenant_id = ?1 AND record_id = ?2",
+                    "params": [tenant_keys[0], 99]
+                })),
+            )
+            .await,
+            (
+                StatusCode::OK,
+                json!({"shard": 0, "rows_affected": 0})
+            )
+        );
+
+        for expected_rows in [1, 0] {
+            assert_eq!(
+                request_json(
+                    &application,
+                    Method::POST,
+                    "/v1/execute",
+                    Some(json!({
+                        "shard_key": tenant_keys[2],
+                        "sql": "DELETE FROM records WHERE tenant_id = ?1 AND record_id = ?2",
+                        "params": [tenant_keys[2], 1]
+                    })),
+                )
+                .await,
+                (
+                    StatusCode::OK,
+                    json!({"shard": 2, "rows_affected": expected_rows})
+                )
+            );
+        }
+
+        for (shard, tenant_key) in tenant_keys.iter().enumerate() {
+            let physical = engine
+                .inspect_shard(
+                    &observer,
+                    u16::try_from(shard).unwrap(),
+                    Statement::new("SELECT tenant_id, record_id, payload FROM records", vec![]),
+                )
+                .await
+                .unwrap();
+            if shard == 2 {
+                assert!(physical.is_empty(), "deleted owner shard must be empty");
+            } else {
+                assert_eq!(physical.rows().len(), 1, "physical shard {shard}");
+                assert_eq!(
+                    physical.rows()[0].values(),
+                    [
+                        Value::from(tenant_key.clone()),
+                        Value::from(1_i64),
+                        Value::from(format!("updated-{shard}")),
+                    ],
+                    "physical shard {shard}"
+                );
+            }
+        }
+
+        // Opting writes into the coordinator does not replace logical reads:
+        // the existing metadata-driven scatter path still visits all shards.
+        assert_eq!(
+            request_json(
+                &application,
+                Method::POST,
+                "/v1/query",
+                Some(json!({
+                    "sql": "SELECT tenant_id, record_id, payload FROM records"
+                })),
+            )
+            .await,
+            (
+                StatusCode::OK,
+                json!({
+                    "shards": [0, 1, 2, 3],
+                    "columns": [
+                        {"name": "tenant_id", "data_type": "unknown"},
+                        {"name": "record_id", "data_type": "unknown"},
+                        {"name": "payload", "data_type": "unknown"}
+                    ],
+                    "rows": [
+                        [tenant_keys[0], 1, "updated-0"],
+                        [tenant_keys[1], 1, "updated-1"],
+                        [tenant_keys[3], 1, "updated-3"]
+                    ]
+                })
+            )
+        );
+    }
+
     #[tokio::test]
     async fn empty_catalog_http_writes_keep_unique_owners_and_raw_sqlite_isolation() {
         let temp = tempfile::tempdir().unwrap();
@@ -612,6 +814,8 @@ mod tests {
         let routing_key = "raw-http-write";
         let expected_shard = database.shard_for_key(routing_key.as_bytes());
         let options = EngineOptions::new(1, 4).unwrap();
+        #[cfg(feature = "experimental-vtab")]
+        let options = options.with_experimental_vtab_writes(true);
         let engine = Engine::from_database_with_options(database, options).unwrap();
         let application = router_with_engine(engine.clone());
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -98,6 +98,11 @@ pub async fn run_with_engine_options(config: Config, options: EngineOptions) -> 
         }
     };
 
+    #[cfg(feature = "experimental-vtab")]
+    let experimental_vtab_writes = engine.options().experimental_vtab_writes();
+    #[cfg(not(feature = "experimental-vtab"))]
+    let experimental_vtab_writes = false;
+
     info!(
         listen = %config.listen,
         postgres_listen = ?config.postgres_listen,
@@ -127,6 +132,7 @@ pub async fn run_with_engine_options(config: Config, options: EngineOptions) -> 
             .request_timeout()
             .map(|timeout| timeout.as_millis()),
         shutdown_grace_ms = engine.options().shutdown_grace().as_millis(),
+        experimental_vtab_writes,
         "BriskDB is ready"
     );
 

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -437,7 +437,12 @@ fn materialize_rows_with_scatter_budget(
     })
 }
 
-fn sqlite_parameters(params: &[Value]) -> EngineResult<Vec<SqlValue>> {
+/// Convert protocol-neutral values into lossless owned SQLite bindings.
+///
+/// Storage execution boundaries use this shared conversion so direct shard
+/// statements and the experimental coordinator reject unsupported values with
+/// identical error kinds before SQLite can coerce them.
+pub(crate) fn sqlite_parameters(params: &[Value]) -> EngineResult<Vec<SqlValue>> {
     params.iter().map(value_to_sql).collect()
 }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -7,6 +7,8 @@ mod shard;
 #[cfg(feature = "experimental-vtab")]
 #[allow(dead_code)]
 mod sharded_vtab;
+#[cfg(feature = "experimental-vtab")]
+pub(crate) use sharded_vtab::{RegistrySchemaCache, WriteCoordinator};
 
 pub(crate) mod pool;
 pub(crate) use pool::{ConnectionOwner, ConnectionPools, PooledConnection};
@@ -922,6 +924,62 @@ impl Storage {
         self.fail_closed_on_corruption(result)
     }
 
+    /// Open and validate a writable virtual-table child while polling the
+    /// coordinator's cancellation epoch before an interrupt handle exists.
+    #[cfg(feature = "experimental-vtab")]
+    pub(crate) fn open_shard_write_cancellable(
+        &self,
+        shard: u16,
+        cancellation_epoch: Arc<std::sync::atomic::AtomicU64>,
+        expected_epoch: u64,
+    ) -> EngineResult<Connection> {
+        let result = (|| {
+            self.ensure_shard_in_range(shard)?;
+            let connection = self.open_unconfigured_shard(shard)?;
+            connection
+                .busy_timeout(std::time::Duration::from_millis(25))
+                .map_err(sqlite_error::storage)?;
+            let progress_epoch = Arc::clone(&cancellation_epoch);
+            connection
+                .progress_handler(
+                    64,
+                    Some(move || progress_epoch.load(Ordering::Acquire) != expected_epoch),
+                )
+                .map_err(sqlite_error::storage)?;
+
+            let deadline = std::time::Instant::now()
+                .checked_add(CONNECTION_BUSY_TIMEOUT)
+                .unwrap_or_else(std::time::Instant::now);
+            loop {
+                if cancellation_epoch.load(Ordering::Acquire) != expected_epoch {
+                    return Err(EngineError::new(
+                        EngineErrorKind::Cancelled,
+                        "the writable shard child was cancelled while opening",
+                    ));
+                }
+                match self.validate_unconfigured_shard(&connection, shard) {
+                    Ok(()) => break,
+                    Err(error)
+                        if error.kind() == EngineErrorKind::Busy
+                            && std::time::Instant::now() < deadline =>
+                    {
+                        continue;
+                    }
+                    Err(error) => return Err(error),
+                }
+            }
+            if cancellation_epoch.load(Ordering::Acquire) != expected_epoch {
+                return Err(EngineError::new(
+                    EngineErrorKind::Cancelled,
+                    "the writable shard child was cancelled while opening",
+                ));
+            }
+            attach_storage_authorizer(&connection)?;
+            Ok(connection)
+        })();
+        self.fail_closed_on_corruption(result)
+    }
+
     #[cfg(feature = "experimental-vtab")]
     pub(crate) fn open_shard_read_only(&self, shard: u16) -> EngineResult<Connection> {
         let result = (|| {
@@ -941,6 +999,29 @@ impl Storage {
             )?;
             attach_storage_authorizer(&connection)?;
             Ok(connection)
+        })();
+        self.fail_closed_on_corruption(result)
+    }
+
+    /// Validate and inspect one read-only shard while cancellation remains
+    /// installed across the entire virtual-table registry discovery.
+    #[cfg(feature = "experimental-vtab")]
+    pub(crate) fn with_shard_read_only_controlled<T>(
+        &self,
+        shard: u16,
+        control: Arc<crate::core::OperationControl>,
+        inspect: impl FnOnce(&Connection) -> EngineResult<T>,
+    ) -> EngineResult<T> {
+        let result = (|| {
+            self.ensure_shard_in_range(shard)?;
+            let mut connection = shard::open_required_file_read_only(&self.shard_path(shard))?;
+            pool::with_read_only_connection_controlled(
+                &mut connection,
+                control,
+                self,
+                shard,
+                inspect,
+            )
         })();
         self.fail_closed_on_corruption(result)
     }
@@ -1018,6 +1099,32 @@ impl Storage {
                 self.catalog.logical().schema_generation(),
                 &expected_digest,
             )
+        })();
+        self.fail_closed_on_corruption(result)
+    }
+
+    #[cfg(feature = "experimental-vtab")]
+    fn validate_unconfigured_shard_read_only(
+        &self,
+        connection: &Connection,
+        shard: u16,
+    ) -> EngineResult<()> {
+        let result = (|| {
+            self.ensure_shard_in_range(shard)?;
+            shard::validate_open_read_only_connection(
+                connection,
+                &self.shard_path(shard),
+                shard,
+                self.catalog.logical().schema_generation(),
+                &self.shard_layout,
+            )?;
+            let expected_digest = self.schema_coordination.committed_schema_digest()?;
+            shard::verify_schema_digest(
+                connection,
+                self.catalog.logical().schema_generation(),
+                &expected_digest,
+            )?;
+            attach_storage_authorizer(connection)
         })();
         self.fail_closed_on_corruption(result)
     }

--- a/src/storage/pool.rs
+++ b/src/storage/pool.rs
@@ -934,6 +934,41 @@ fn configure_connection_controlled(
     shard: u16,
     #[cfg(test)] barrier: Option<ControlledBarrier>,
 ) -> EngineResult<()> {
+    run_connection_validation_controlled(connection, control, |connection, _control| {
+        #[cfg(test)]
+        if let Some(barrier) = barrier {
+            barrier.wait(_control);
+        }
+
+        // Do not call the ordinary configuration wrapper here: its fixed
+        // busy timeout would replace the cancellable handler before these
+        // pragmas can encounter a SQLite lock.
+        storage.validate_unconfigured_shard(connection, shard)
+    })
+}
+
+/// Validate and inspect a dedicated read-only coordinator-bootstrap handle
+/// while request cancellation owns its busy handler, progress hook, and
+/// interrupt handle for the entire registry-discovery operation.
+#[cfg(feature = "experimental-vtab")]
+pub(super) fn with_read_only_connection_controlled<T>(
+    connection: &mut Connection,
+    control: Arc<OperationControl>,
+    storage: &Storage,
+    shard: u16,
+    inspect: impl FnOnce(&Connection) -> EngineResult<T>,
+) -> EngineResult<T> {
+    run_connection_validation_controlled(connection, control, |connection, _control| {
+        storage.validate_unconfigured_shard_read_only(connection, shard)?;
+        inspect(connection)
+    })
+}
+
+fn run_connection_validation_controlled<T>(
+    connection: &mut Connection,
+    control: Arc<OperationControl>,
+    validate: impl FnOnce(&mut Connection, &OperationControl) -> EngineResult<T>,
+) -> EngineResult<T> {
     let _busy_operation = BusyOperationGuard::install(Arc::clone(&control));
     connection
         .busy_handler(Some(cancellable_busy_handler))
@@ -954,15 +989,7 @@ fn configure_connection_controlled(
         return Err(reason.error());
     }
 
-    #[cfg(test)]
-    if let Some(barrier) = barrier {
-        barrier.wait(&control);
-    }
-
-    // Do not call the ordinary configuration wrapper here: its fixed busy
-    // timeout would replace the cancellable handler before these pragmas can
-    // encounter a SQLite lock.
-    let result = storage.validate_unconfigured_shard(connection, shard);
+    let result = validate(connection, &control);
     let progress_cleanup = connection
         .progress_handler(0, None::<fn() -> bool>)
         .map_err(sqlite_error::storage);
@@ -973,14 +1000,14 @@ fn configure_connection_controlled(
     match (result, progress_cleanup, busy_cleanup, reason) {
         (Err(_), _, _, Some(reason)) => Err(reason.error()),
         (Err(error), _, _, None) => Err(error),
-        (Ok(()), _, _, Some(reason)) => Err(reason.error()),
-        (Ok(()), Err(error), _, None) => {
+        (Ok(_), _, _, Some(reason)) => Err(reason.error()),
+        (Ok(_), Err(error), _, None) => {
             Err(error.context("failed to remove the SQLite request progress hook after setup"))
         }
-        (Ok(()), Ok(()), Err(error), None) => {
+        (Ok(_), Ok(()), Err(error), None) => {
             Err(error.context("failed to restore the SQLite busy timeout after setup"))
         }
-        (Ok(()), Ok(()), Ok(()), None) => Ok(()),
+        (Ok(value), Ok(()), Ok(()), None) => Ok(value),
     }
 }
 

--- a/src/storage/shard.rs
+++ b/src/storage/shard.rs
@@ -273,14 +273,38 @@ pub(super) fn open_existing_read_only(
     schema_generation: u64,
     layout: &ShardLayout,
 ) -> EngineResult<Connection> {
-    validate_existing_file(path)?;
-    let connection = open_existing_read_only_connection(path)?;
+    let connection = open_required_file_read_only(path)?;
     configure_busy_timeout(&connection)?;
+    validate_open_read_only_connection(&connection, path, shard_id, schema_generation, layout)?;
+    Ok(connection)
+}
+
+/// Open a required shard through an OS-level read-only handle while leaving
+/// validation to the caller. The controlled virtual-table bootstrap path uses
+/// this split so it can install cancellation hooks before validation touches
+/// SQLite schema state that may be locked by another process.
+#[cfg(feature = "experimental-vtab")]
+pub(super) fn open_required_file_read_only(path: &Path) -> EngineResult<Connection> {
+    validate_existing_file(path)?;
+    open_existing_read_only_connection(path)
+}
+
+/// Validate an already-open read-only shard without replacing its busy handler
+/// or progress hook.
+#[cfg(feature = "experimental-vtab")]
+pub(super) fn validate_open_read_only_connection(
+    connection: &Connection,
+    path: &Path,
+    shard_id: u16,
+    schema_generation: u64,
+    layout: &ShardLayout,
+) -> EngineResult<()> {
+    configure_cell_size_check(connection)?;
     validate_shard_id(shard_id)?;
     let expected_user_version = expected_user_version(schema_generation)?;
-    require_read_only(&connection)?;
-    validate_exact_shard(&connection, path, shard_id, expected_user_version, layout)?;
-    Ok(connection)
+    require_read_only(connection)?;
+    validate_exact_shard(connection, path, shard_id, expected_user_version, layout)?;
+    Ok(())
 }
 
 /// Open the required path with strict filesystem and SQLite no-create/no-follow
@@ -2284,7 +2308,6 @@ fn open_existing_read_only_connection(path: &Path) -> EngineResult<Connection> {
         sqlite_error::storage(error)
             .context(format!("failed to open read-only shard {}", path.display()))
     })?;
-    configure_cell_size_check(&connection)?;
     Ok(connection)
 }
 

--- a/src/storage/sharded_vtab.rs
+++ b/src/storage/sharded_vtab.rs
@@ -32,7 +32,8 @@ use crate::{
     core::generated_id::{GeneratedIdClassification, classify_generated_id},
     core::{
         AllocationOwnerMap, CanonicalShardKeyRef, EngineError, EngineErrorKind, EngineResult,
-        GeneratedIdPolicy, ShardKeyType, TableMetadata, TablePlacement, canonical_shard_key_bytes,
+        GeneratedIdPolicy, OperationControl, ShardKeyType, TableMetadata, TablePlacement,
+        canonical_shard_key_bytes,
     },
     sqlite_error,
 };
@@ -53,6 +54,102 @@ mod write;
 
 #[allow(unused_imports)]
 pub(crate) use write::{CoordinatorWriteResult, WriteCoordinator};
+
+/// Engine-local cache of immutable physical table descriptors for one schema
+/// generation. Each coordinator still owns independent transaction and
+/// cancellation state; only the validated registry blueprint is shared.
+#[derive(Debug, Default)]
+pub(crate) struct RegistrySchemaCache {
+    inner: Mutex<Option<Arc<RegistrySchema>>>,
+    #[cfg(test)]
+    child_busy_gate: Mutex<Option<TestChildScanGate>>,
+    #[cfg(test)]
+    commit_gate: Mutex<Option<TestChildScanGate>>,
+    #[cfg(test)]
+    cancellation_observer: Mutex<Option<Arc<std::sync::atomic::AtomicBool>>>,
+}
+
+impl RegistrySchemaCache {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn requires_bootstrap(&self, schema_generation: u64) -> bool {
+        self.current(schema_generation).is_none()
+    }
+
+    fn current(&self, schema_generation: u64) -> Option<Arc<RegistrySchema>> {
+        self.inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .as_ref()
+            .filter(|schema| schema.schema_generation == schema_generation)
+            .cloned()
+    }
+
+    fn publish(&self, schema: Arc<RegistrySchema>) {
+        *self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(schema);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn install_child_busy_gate(&self) -> TestChildScanControl {
+        let (gate, control) = TestChildScanGate::channel();
+        *self
+            .child_busy_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(gate);
+        control
+    }
+
+    #[cfg(test)]
+    pub(crate) fn install_commit_gate(&self) -> TestChildScanControl {
+        let (gate, control) = TestChildScanGate::channel();
+        *self
+            .commit_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(gate);
+        control
+    }
+
+    #[cfg(test)]
+    pub(crate) fn install_cancellation_observer(&self) -> Arc<std::sync::atomic::AtomicBool> {
+        let observer = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        *self
+            .cancellation_observer
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Arc::clone(&observer));
+        observer
+    }
+
+    #[cfg(test)]
+    fn take_write_test_controls(
+        &self,
+    ) -> (
+        Option<TestChildScanGate>,
+        Option<TestChildScanGate>,
+        Option<Arc<std::sync::atomic::AtomicBool>>,
+    ) {
+        let child_busy = self
+            .child_busy_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        let commit = self
+            .commit_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        let cancellation = self
+            .cancellation_observer
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        (child_busy, commit, cancellation)
+    }
+}
 
 /// A separate SQLite coordinator whose logical tables are backed by BriskDB
 /// shard files. The coordinator never attaches those files to its own schema.
@@ -372,7 +469,7 @@ fn register_module(connection: &Connection, registry: Arc<Registry>) -> SqliteRe
 struct Registry {
     storage: Storage,
     schema_generation: u64,
-    tables: BTreeMap<u64, Arc<TableSpec>>,
+    tables: Arc<BTreeMap<u64, Arc<TableSpec>>>,
     mode: CoordinatorMode,
     write_state: Option<Arc<write::WriteState>>,
     limits: CursorLimits,
@@ -385,6 +482,14 @@ struct Registry {
     child_scan_gate: Mutex<Option<TestChildScanGate>>,
     #[cfg(test)]
     child_scan_complete_gate: Mutex<Option<TestChildScanGate>>,
+    #[cfg(test)]
+    write_child_busy_gate: Mutex<Option<TestChildScanGate>>,
+}
+
+#[derive(Debug)]
+struct RegistrySchema {
+    schema_generation: u64,
+    tables: Arc<BTreeMap<u64, Arc<TableSpec>>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -414,6 +519,8 @@ impl Registry {
             storage,
             CursorLimits::default(),
             CoordinatorMode::ReadOnly,
+            None,
+            None,
         )
     }
 
@@ -421,31 +528,198 @@ impl Registry {
         storage: Storage,
         limits: CursorLimits,
     ) -> EngineResult<Arc<Self>> {
-        Self::build_admitted_with_limits_and_mode(storage, limits, CoordinatorMode::ReadOnly)
+        Self::build_admitted_with_limits_and_mode(
+            storage,
+            limits,
+            CoordinatorMode::ReadOnly,
+            None,
+            None,
+        )
     }
 
     fn build_writable(storage: Storage, limits: CursorLimits) -> EngineResult<Arc<Self>> {
-        Self::build_admitted_with_limits_and_mode(storage, limits, CoordinatorMode::Writable)
+        Self::build_admitted_with_limits_and_mode(
+            storage,
+            limits,
+            CoordinatorMode::Writable,
+            None,
+            None,
+        )
+    }
+
+    fn build_writable_admitted(
+        storage: Storage,
+        limits: CursorLimits,
+        operation: SchemaOperationGuard,
+        control: Option<Arc<OperationControl>>,
+    ) -> EngineResult<Arc<Self>> {
+        Self::build_admitted_with_limits_and_mode(
+            storage,
+            limits,
+            CoordinatorMode::Writable,
+            Some(operation),
+            control,
+        )
+    }
+
+    fn build_writable_cached(
+        storage: Storage,
+        limits: CursorLimits,
+        operation: SchemaOperationGuard,
+        control: Arc<OperationControl>,
+        cache: &RegistrySchemaCache,
+    ) -> EngineResult<Arc<Self>> {
+        Self::validate_limits(limits)?;
+        let schema_generation = storage.current_schema_generation();
+        let schema = match cache.current(schema_generation) {
+            Some(schema) => schema,
+            None => {
+                let schema = Arc::new(Self::discover_schema(
+                    &storage,
+                    schema_generation,
+                    Some(control),
+                )?);
+                cache.publish(Arc::clone(&schema));
+                schema
+            }
+        };
+        Self::from_schema(
+            storage,
+            limits,
+            CoordinatorMode::Writable,
+            Some(operation),
+            schema,
+        )
     }
 
     fn build_admitted_with_limits_and_mode(
         storage: Storage,
         limits: CursorLimits,
         mode: CoordinatorMode,
+        admitted_operation: Option<SchemaOperationGuard>,
+        bootstrap_control: Option<Arc<OperationControl>>,
     ) -> EngineResult<Arc<Self>> {
+        Self::validate_limits(limits)?;
+        let schema_generation = storage.current_schema_generation();
+        let schema = Arc::new(Self::discover_schema(
+            &storage,
+            schema_generation,
+            bootstrap_control,
+        )?);
+        Self::from_schema(storage, limits, mode, admitted_operation, schema)
+    }
+
+    fn validate_limits(limits: CursorLimits) -> EngineResult<()> {
         if limits.rows == 0 || limits.bytes == 0 {
             return Err(EngineError::new(
                 EngineErrorKind::InvalidArgument,
                 "brisk_shard result limits must be non-zero",
             ));
         }
-        let schema_generation = storage.current_schema_generation();
-        let shard = storage.open_shard_read_only(0)?;
-        shard
-            .pragma_update(None, "query_only", "ON")
-            .map_err(sqlite_error::storage)?;
+        Ok(())
+    }
 
+    fn discover_schema(
+        storage: &Storage,
+        schema_generation: u64,
+        bootstrap_control: Option<Arc<OperationControl>>,
+    ) -> EngineResult<RegistrySchema> {
         let allocation_owners = storage.allocation_owner_map().cloned().map(Arc::new);
+        let tables = match bootstrap_control {
+            Some(control) => storage.with_shard_read_only_controlled(0, control, |shard| {
+                shard
+                    .pragma_update(None, "query_only", "ON")
+                    .map_err(sqlite_error::storage)?;
+                Self::discover_tables(storage, shard, allocation_owners.as_ref())
+            })?,
+            None => {
+                let shard = storage.open_shard_read_only(0)?;
+                shard
+                    .pragma_update(None, "query_only", "ON")
+                    .map_err(sqlite_error::storage)?;
+                Self::discover_tables(storage, &shard, allocation_owners.as_ref())?
+            }
+        };
+        Ok(RegistrySchema {
+            schema_generation,
+            tables: Arc::new(tables),
+        })
+    }
+
+    fn from_schema(
+        storage: Storage,
+        limits: CursorLimits,
+        mode: CoordinatorMode,
+        admitted_operation: Option<SchemaOperationGuard>,
+        schema: Arc<RegistrySchema>,
+    ) -> EngineResult<Arc<Self>> {
+        if schema.schema_generation != storage.current_schema_generation() {
+            return Err(EngineError::new(
+                EngineErrorKind::Busy,
+                "cached brisk_shard registry belongs to a stale schema generation",
+            ));
+        }
+        let write_state = matches!(mode, CoordinatorMode::Writable).then(|| {
+            Arc::new(
+                admitted_operation
+                    .map_or_else(write::WriteState::new, write::WriteState::new_admitted),
+            )
+        });
+        Ok(Arc::new(Self {
+            storage,
+            schema_generation: schema.schema_generation,
+            tables: Arc::clone(&schema.tables),
+            mode,
+            write_state,
+            limits,
+            cancellation_epoch: Arc::new(AtomicU64::new(0)),
+            active_child_scans: Arc::new(Mutex::new(0)),
+            lifecycle: Arc::new(LifecycleCounters::default()),
+            #[cfg(test)]
+            opened_shards: Mutex::new(Vec::new()),
+            #[cfg(test)]
+            child_scan_gate: Mutex::new(None),
+            #[cfg(test)]
+            child_scan_complete_gate: Mutex::new(None),
+            #[cfg(test)]
+            write_child_busy_gate: Mutex::new(None),
+        }))
+    }
+
+    fn wait_after_child_busy_for_test(&self) -> EngineResult<()> {
+        #[cfg(test)]
+        {
+            let gate = self
+                .write_child_busy_gate
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .take();
+            if gate.is_some_and(|gate| !gate.wait_for_release()) {
+                return Err(EngineError::new(
+                    EngineErrorKind::Internal,
+                    "writable child-busy test gate timed out or disconnected",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn install_write_test_controls(&self, cache: &RegistrySchemaCache) {
+        let (child_busy, commit, cancellation) = cache.take_write_test_controls();
+        *self
+            .write_child_busy_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = child_busy;
+        self.write_state()
+            .install_test_controls(commit, cancellation);
+    }
+
+    fn discover_tables(
+        storage: &Storage,
+        shard: &Connection,
+        allocation_owners: Option<&Arc<AllocationOwnerMap>>,
+    ) -> EngineResult<BTreeMap<u64, Arc<TableSpec>>> {
         let mut tables = BTreeMap::new();
         for table in storage.logical_catalog().tables() {
             #[allow(unreachable_patterns)]
@@ -466,33 +740,14 @@ impl Registry {
                 }
             };
             let spec = TableSpec::from_physical_table(
-                &shard,
+                shard,
                 table,
-                allocation_owners.clone(),
+                allocation_owners.cloned(),
                 targets.into_boxed_slice(),
             )?;
             tables.insert(table.id().get(), Arc::new(spec));
         }
-
-        let write_state =
-            matches!(mode, CoordinatorMode::Writable).then(|| Arc::new(write::WriteState::new()));
-        Ok(Arc::new(Self {
-            storage,
-            schema_generation,
-            tables,
-            mode,
-            write_state,
-            limits,
-            cancellation_epoch: Arc::new(AtomicU64::new(0)),
-            active_child_scans: Arc::new(Mutex::new(0)),
-            lifecycle: Arc::new(LifecycleCounters::default()),
-            #[cfg(test)]
-            opened_shards: Mutex::new(Vec::new()),
-            #[cfg(test)]
-            child_scan_gate: Mutex::new(None),
-            #[cfg(test)]
-            child_scan_complete_gate: Mutex::new(None),
-        }))
+        Ok(tables)
     }
 
     fn table(&self, id: u64) -> Option<Arc<TableSpec>> {
@@ -503,6 +758,12 @@ impl Registry {
         self.write_state
             .as_ref()
             .expect("writable coordinator registry has shared write state")
+    }
+
+    fn has_retained_schema_admission(&self) -> bool {
+        self.write_state
+            .as_ref()
+            .is_some_and(|state| state.has_retained_schema_admission())
     }
 
     fn equality_scan(
@@ -908,6 +1169,7 @@ impl Drop for TrackedChildConnection {
     }
 }
 
+#[derive(Debug)]
 struct TableSpec {
     id: u64,
     name: String,
@@ -1836,17 +2098,22 @@ impl BriskShardCursor {
                 )));
             }
         }
-        let operation = self
-            .registry
-            .storage
-            .enter_schema_operation()
-            .map_err(vtab_error)?;
+        let operation = if self.registry.has_retained_schema_admission() {
+            None
+        } else {
+            Some(
+                self.registry
+                    .storage
+                    .enter_schema_operation()
+                    .map_err(vtab_error)?,
+            )
+        };
         if self.registry.storage.current_schema_generation() != self.registry.schema_generation {
             return Err(module_error(
                 "brisk_shard coordinator schema is stale; reopen the coordinator",
             ));
         }
-        self.operation = Some(operation);
+        self.operation = operation;
         self.scan_epoch = self.registry.cancellation_epoch.load(Ordering::Acquire);
         if self.registry.cancelled(self.scan_epoch) {
             return Err(vtab_error(cancelled_error()));
@@ -2138,7 +2405,8 @@ fn limit_error(resource: &str, limit: usize) -> EngineError {
 const TEST_SYNC_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[cfg(test)]
-struct TestChildScanGate {
+#[derive(Debug)]
+pub(crate) struct TestChildScanGate {
     started: mpsc::SyncSender<()>,
     release: mpsc::Receiver<()>,
 }
@@ -2166,20 +2434,20 @@ impl TestChildScanGate {
 }
 
 #[cfg(test)]
-struct TestChildScanControl {
+pub(crate) struct TestChildScanControl {
     started: mpsc::Receiver<()>,
     release: TestRelease,
 }
 
 #[cfg(test)]
 impl TestChildScanControl {
-    fn wait_until_started(&self) {
+    pub(crate) fn wait_until_started(&self) {
         self.started
             .recv_timeout(TEST_SYNC_TIMEOUT)
             .expect("child scan did not reach its test gate before the timeout");
     }
 
-    fn release(&mut self) {
+    pub(crate) fn release(&mut self) {
         self.release.signal();
     }
 }
@@ -4416,6 +4684,124 @@ mod tests {
             "written"
         );
         assert_eq!(fixture.storage.schema_gate_snapshot().active_operations, 0);
+    }
+
+    #[test]
+    fn writable_admitted_coordinator_does_not_reenter_schema_admission() {
+        let fixture = Fixture::new();
+        let operation = fixture.storage.enter_schema_operation().unwrap();
+        let migration = fixture.storage.begin_schema_migration().unwrap();
+        assert_eq!(fixture.storage.schema_gate_snapshot().active_operations, 1);
+
+        // Opening and executing after the migration starts proves bootstrap,
+        // write-state callbacks, and the UPDATE cursor all reuse the admission
+        // that the Engine acquired before the migration closed the gate.
+        let mut coordinator =
+            WriteCoordinator::open_admitted(fixture.storage.clone(), operation).unwrap();
+        let updated = coordinator
+            .execute_dml(
+                "UPDATE events SET payload = 'admitted'
+                 WHERE tenant_id = ?1 AND event_id = 1",
+                [fixture.keys[0]],
+            )
+            .unwrap();
+        assert_eq!(updated.affected_rows(), 1);
+        assert_eq!(fixture.storage.schema_gate_snapshot().active_operations, 1);
+
+        drop(coordinator);
+        assert_eq!(fixture.storage.schema_gate_snapshot().active_operations, 0);
+        migration.publish_ready().unwrap();
+        assert_eq!(
+            fixture
+                .storage
+                .open_shard(0)
+                .unwrap()
+                .query_row(
+                    "SELECT payload FROM events WHERE tenant_id = ?1 AND event_id = 1",
+                    [fixture.keys[0]],
+                    |row| row.get::<_, String>(0),
+                )
+                .unwrap(),
+            "admitted"
+        );
+    }
+
+    #[test]
+    fn writable_coordinator_binds_protocol_neutral_values_without_coercion() {
+        let fixture = Fixture::new();
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+        let parameters = [
+            Value::Int64(fixture.keys[0]),
+            Value::Int64(2),
+            Value::Text("bound text".to_owned()),
+            Value::Float64(3.5),
+            Value::Binary(vec![0, 255]),
+            Value::Null,
+            Value::Text("beta".to_owned()),
+        ];
+
+        let result = coordinator
+            .execute_dml_values(
+                "INSERT INTO events
+                 (tenant_id, event_id, payload, amount, raw, optional, category)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                &parameters,
+            )
+            .unwrap();
+
+        assert_eq!(result.affected_rows(), 1);
+        assert_eq!(result.explicit_key(), Some(&Value::Int64(fixture.keys[0])));
+        let connection = fixture.storage.open_shard(0).unwrap();
+        let persisted = connection
+            .query_row(
+                "SELECT payload, amount, raw, optional
+                 FROM events WHERE tenant_id = ?1 AND event_id = 2",
+                [fixture.keys[0]],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, f64>(1)?,
+                        row.get::<_, Vec<u8>>(2)?,
+                        row.get::<_, Option<String>>(3)?,
+                    ))
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            persisted,
+            ("bound text".to_owned(), 3.5, vec![0, 255], None)
+        );
+    }
+
+    #[test]
+    fn writable_protocol_value_rejection_precedes_transaction_and_allows_reuse() {
+        let fixture = Fixture::new();
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+        let too_large = u64::try_from(i64::MAX).unwrap() + 1;
+
+        let error = coordinator
+            .execute_dml_values(
+                "INSERT INTO events
+                 (tenant_id, event_id, payload, amount, raw, optional, category)
+                 VALUES (?1, 2, 'rejected', 1.0, x'00', NULL, 'beta')",
+                &[Value::UInt64(too_large)],
+            )
+            .unwrap_err();
+
+        assert_eq!(error.kind(), EngineErrorKind::NumericOutOfRange);
+        assert!(!coordinator.in_transaction());
+        assert_eq!(fixture.physical_row_count(), 2);
+
+        let result = coordinator
+            .execute_dml_values(
+                "INSERT INTO events
+                 (tenant_id, event_id, payload, amount, raw, optional, category)
+                 VALUES (?1, 2, 'accepted', 1.0, x'00', NULL, 'beta')",
+                &[Value::Int64(fixture.keys[0])],
+            )
+            .unwrap();
+        assert_eq!(result.affected_rows(), 1);
+        assert_eq!(fixture.physical_row_count(), 3);
     }
 
     #[test]

--- a/src/storage/sharded_vtab/write.rs
+++ b/src/storage/sharded_vtab/write.rs
@@ -2,7 +2,7 @@
 
 use std::{
     sync::{
-        Arc, Mutex, MutexGuard,
+        Arc, Mutex, MutexGuard, TryLockError,
         atomic::{AtomicBool, Ordering},
     },
     time::{Duration, Instant},
@@ -15,14 +15,14 @@ use rusqlite::{
 
 use super::{
     ALLOCATION_OVERHEAD_BYTES, CoordinatorCancellation, CursorLimits, ROW_ACCOUNTING_BYTES,
-    RawCell, Registry, TableSpec, VALUE_ACCOUNTING_BYTES, allocation_error,
+    RawCell, Registry, RegistrySchemaCache, TableSpec, VALUE_ACCOUNTING_BYTES, allocation_error,
     attach_writable_coordinator_authorizer, bootstrap_coordinator_schema, cancelled_error,
     limit_error, locator, module_v2,
 };
 #[cfg(test)]
 use super::{TestChildScanControl, TestChildScanGate};
 use crate::{
-    core::{EngineError, EngineErrorKind, EngineResult, Value},
+    core::{EngineError, EngineErrorKind, EngineResult, OperationControl, Value},
     sqlite_error,
     storage::{CONNECTION_BUSY_TIMEOUT, SchemaOperationGuard, Storage},
 };
@@ -33,6 +33,21 @@ const CANCELLABLE_BUSY_SLICE: Duration = Duration::from_millis(25);
 pub(crate) struct CoordinatorWriteResult {
     pub(crate) affected_rows: usize,
     pub(crate) explicit_key: Option<Value>,
+}
+
+impl CoordinatorWriteResult {
+    /// Return the direct physical rows changed by this statement.
+    pub(crate) const fn affected_rows(&self) -> usize {
+        self.affected_rows
+    }
+
+    /// Return the caller-supplied key reported for a successful INSERT.
+    ///
+    /// UPDATE and DELETE do not produce a key. Generated keys remain outside
+    /// the current explicit-key coordinator contract.
+    pub(crate) const fn explicit_key(&self) -> Option<&Value> {
+        self.explicit_key.as_ref()
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -74,11 +89,99 @@ pub(crate) struct WriteCoordinator {
     statement_arm_gate: Mutex<Option<TestChildScanGate>>,
 }
 
+enum CoordinatorAdmission {
+    Standalone(SchemaOperationGuard),
+    Retained {
+        operation: SchemaOperationGuard,
+        controlled: Option<(Arc<OperationControl>, Arc<RegistrySchemaCache>)>,
+    },
+}
+
 impl WriteCoordinator {
     pub(crate) fn open(storage: Storage) -> EngineResult<Self> {
         let bootstrap_operation = storage.enter_schema_operation()?;
+        Self::open_with_admission(
+            storage,
+            CoordinatorAdmission::Standalone(bootstrap_operation),
+        )
+    }
+
+    /// Open an ephemeral coordinator under schema admission already owned by
+    /// the Engine operation.
+    ///
+    /// The supplied guard is retained through bootstrap, statement execution,
+    /// child cleanup, and coordinator drop. Neither writable callbacks nor
+    /// cursors try to re-enter schema admission while a migration is waiting
+    /// for this already-admitted operation to drain.
+    pub(crate) fn open_admitted(
+        storage: Storage,
+        operation: SchemaOperationGuard,
+    ) -> EngineResult<Self> {
+        Self::open_with_admission(
+            storage,
+            CoordinatorAdmission::Retained {
+                operation,
+                controlled: None,
+            },
+        )
+    }
+
+    /// Open an Engine-admitted coordinator with cancellation installed before
+    /// registry discovery can wait on shard-0 schema state.
+    pub(crate) fn open_admitted_controlled(
+        storage: Storage,
+        operation: SchemaOperationGuard,
+        control: Arc<OperationControl>,
+        registry_cache: Arc<RegistrySchemaCache>,
+    ) -> EngineResult<Self> {
+        Self::open_with_admission(
+            storage,
+            CoordinatorAdmission::Retained {
+                operation,
+                controlled: Some((control, registry_cache)),
+            },
+        )
+    }
+
+    fn open_with_admission(
+        storage: Storage,
+        admission: CoordinatorAdmission,
+    ) -> EngineResult<Self> {
         let connection = Connection::open_in_memory().map_err(sqlite_error::storage)?;
-        let registry = Registry::build_writable(storage, CursorLimits::default())?;
+        let (registry, bootstrap_operation, test_registry_cache) = match admission {
+            CoordinatorAdmission::Standalone(operation) => (
+                Registry::build_writable(storage, CursorLimits::default())?,
+                Some(operation),
+                None,
+            ),
+            CoordinatorAdmission::Retained {
+                operation,
+                controlled: Some((control, registry_cache)),
+            } => (
+                Registry::build_writable_cached(
+                    storage,
+                    CursorLimits::default(),
+                    operation,
+                    control,
+                    &registry_cache,
+                )?,
+                None,
+                Some(registry_cache),
+            ),
+            CoordinatorAdmission::Retained {
+                operation,
+                controlled: None,
+            } => (
+                Registry::build_writable_admitted(
+                    storage,
+                    CursorLimits::default(),
+                    operation,
+                    None,
+                )?,
+                None,
+                None,
+            ),
+        };
         module_v2::register_module(&connection, Arc::clone(&registry))
             .map_err(sqlite_error::storage)?;
         let bootstrap_epoch = registry.cancellation_epoch.load(Ordering::Acquire);
@@ -110,6 +213,13 @@ impl WriteCoordinator {
             ));
         }
         drop(bootstrap_operation);
+
+        #[cfg(test)]
+        if let Some(cache) = test_registry_cache {
+            registry.install_write_test_controls(&cache);
+        }
+        #[cfg(not(test))]
+        let _ = test_registry_cache;
 
         let cancellation = CoordinatorCancellation {
             epoch: Arc::clone(&registry.cancellation_epoch),
@@ -165,6 +275,21 @@ impl WriteCoordinator {
         let result = self.reconcile_statement(execution);
         drop(statement_arm);
         result
+    }
+
+    /// Execute DML using protocol-neutral values from the Engine boundary.
+    ///
+    /// Conversion happens before the coordinator arms a statement, so a value
+    /// without a lossless SQLite representation cannot begin or disturb a
+    /// physical transaction. The generic [`Self::execute_dml`] entry point is
+    /// retained for storage-local callers and focused callback tests.
+    pub(crate) fn execute_dml_values(
+        &mut self,
+        sql: &str,
+        parameters: &[Value],
+    ) -> EngineResult<CoordinatorWriteResult> {
+        let parameters = crate::sql::sqlite_parameters(parameters)?;
+        self.execute_dml(sql, rusqlite::params_from_iter(parameters))
     }
 
     pub(crate) fn begin(&mut self) -> EngineResult<()> {
@@ -504,9 +629,11 @@ fn transaction_identifier(name: &str) -> EngineResult<String> {
 
 pub(super) struct WriteState {
     inner: Mutex<WriteTransactionState>,
+    retained_schema_operation: Option<SchemaOperationGuard>,
     armed_statement_epoch: Mutex<Option<u64>>,
     active_interrupt: Mutex<Option<Arc<InterruptHandle>>>,
     commit_linearization: Mutex<()>,
+    nonblocking_cancel_requested: AtomicBool,
     #[cfg(test)]
     fail_next_commit: AtomicBool,
     #[cfg(test)]
@@ -515,15 +642,29 @@ pub(super) struct WriteState {
     fail_next_commit_corruption: AtomicBool,
     #[cfg(test)]
     fail_next_savepoint_operation: Mutex<Option<(SavepointOperation, EngineErrorKind)>>,
+    #[cfg(test)]
+    commit_gate: Mutex<Option<TestChildScanGate>>,
+    #[cfg(test)]
+    cancellation_observer: Mutex<Option<Arc<AtomicBool>>>,
 }
 
 impl WriteState {
     pub(super) fn new() -> Self {
+        Self::new_with_admission(None)
+    }
+
+    pub(super) fn new_admitted(operation: SchemaOperationGuard) -> Self {
+        Self::new_with_admission(Some(operation))
+    }
+
+    fn new_with_admission(retained_schema_operation: Option<SchemaOperationGuard>) -> Self {
         Self {
             inner: Mutex::new(WriteTransactionState::Idle),
+            retained_schema_operation,
             armed_statement_epoch: Mutex::new(None),
             active_interrupt: Mutex::new(None),
             commit_linearization: Mutex::new(()),
+            nonblocking_cancel_requested: AtomicBool::new(false),
             #[cfg(test)]
             fail_next_commit: AtomicBool::new(false),
             #[cfg(test)]
@@ -532,7 +673,61 @@ impl WriteState {
             fail_next_commit_corruption: AtomicBool::new(false),
             #[cfg(test)]
             fail_next_savepoint_operation: Mutex::new(None),
+            #[cfg(test)]
+            commit_gate: Mutex::new(None),
+            #[cfg(test)]
+            cancellation_observer: Mutex::new(None),
         }
+    }
+
+    #[cfg(test)]
+    pub(super) fn install_test_controls(
+        &self,
+        commit_gate: Option<TestChildScanGate>,
+        cancellation_observer: Option<Arc<AtomicBool>>,
+    ) {
+        *self
+            .commit_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = commit_gate;
+        *self
+            .cancellation_observer
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = cancellation_observer;
+    }
+
+    fn wait_before_commit_for_test(&self) -> EngineResult<()> {
+        #[cfg(test)]
+        {
+            let gate = self
+                .commit_gate
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .take();
+            if gate.is_some_and(|gate| !gate.wait_for_release()) {
+                return Err(EngineError::new(
+                    EngineErrorKind::Internal,
+                    "writable commit test gate timed out or disconnected",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn observe_nonblocking_cancellation_for_test(&self) {
+        if let Some(observer) = self
+            .cancellation_observer
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .as_ref()
+        {
+            observer.store(true, Ordering::Release);
+        }
+    }
+
+    pub(super) const fn has_retained_schema_admission(&self) -> bool {
+        self.retained_schema_operation.is_some()
     }
 
     fn lock(&self) -> MutexGuard<'_, WriteTransactionState> {
@@ -546,6 +741,9 @@ impl WriteState {
             .armed_statement_epoch
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if self.nonblocking_cancel_requested.load(Ordering::Acquire) {
+            return Err(cancelled_error());
+        }
         if armed.is_some() {
             return Err(EngineError::new(
                 EngineErrorKind::Internal,
@@ -590,6 +788,14 @@ impl WriteState {
         self.commit_linearization
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn try_lock_commit_linearization(&self) -> Option<MutexGuard<'_, ()>> {
+        match self.commit_linearization.try_lock() {
+            Ok(guard) => Some(guard),
+            Err(TryLockError::Poisoned(error)) => Some(error.into_inner()),
+            Err(TryLockError::WouldBlock) => None,
+        }
     }
 
     pub(super) fn interrupt_child(&self) {
@@ -790,6 +996,9 @@ impl WriteState {
                         EngineErrorKind::StorageUnavailable,
                         "injected writable child commit failure",
                     ))
+                } else if let Err(error) = self.wait_before_commit_for_test() {
+                    let _ = transaction.rollback();
+                    Err(error)
                 } else {
                     transaction.commit().map(FinalizedWrite::Committed)
                 }
@@ -982,7 +1191,11 @@ impl WriteState {
         registry: &Registry,
     ) -> EngineResult<&'a mut WriteTransaction> {
         if matches!(state, WriteTransactionState::Idle) {
-            let operation = registry.storage.enter_schema_operation()?;
+            let operation = if self.has_retained_schema_admission() {
+                None
+            } else {
+                Some(registry.storage.enter_schema_operation()?)
+            };
             if registry.storage.current_schema_generation() != registry.schema_generation {
                 return Err(EngineError::new(
                     EngineErrorKind::Busy,
@@ -1067,6 +1280,41 @@ impl WriteState {
     }
 }
 
+impl CoordinatorCancellation {
+    /// Request cancellation without waiting behind durable child finalization.
+    ///
+    /// The commit-linearization mutex remains the ordering point. Acquiring it
+    /// means cancellation won before finalization, so advancing the epoch and
+    /// interrupting SQLite force the child transaction to roll back. If the
+    /// mutex is already held, finalization won; waiting for its potentially
+    /// slow `COMMIT` would block an async runtime thread and interrupting it
+    /// could make the durable outcome ambiguous.
+    pub(crate) fn cancel_write_nonblocking(&self) {
+        let Some(write_state) = &self.write_state else {
+            debug_assert!(
+                false,
+                "write cancellation requires writable coordinator state"
+            );
+            return;
+        };
+        #[cfg(test)]
+        write_state.observe_nonblocking_cancellation_for_test();
+        let Some(_commit) = write_state.try_lock_commit_linearization() else {
+            return;
+        };
+
+        // Publish the one-shot request before advancing the reusable epoch.
+        // Otherwise a statement starting in this narrow window could capture
+        // the new epoch and mistake a pre-start cancellation for fresh state.
+        write_state
+            .nonblocking_cancel_requested
+            .store(true, Ordering::Release);
+        self.epoch.fetch_add(1, Ordering::AcqRel);
+        write_state.interrupt_child();
+        self.interrupt.interrupt();
+    }
+}
+
 struct StatementEpochArm {
     state: Arc<WriteState>,
     epoch: u64,
@@ -1103,7 +1351,7 @@ enum WriteTransactionState {
 }
 
 struct WriteTransaction {
-    _operation: SchemaOperationGuard,
+    _operation: Option<SchemaOperationGuard>,
     epoch: u64,
     child: Option<WriteChild>,
     savepoints: Vec<SavepointMark>,
@@ -1119,7 +1367,7 @@ struct SavepointMark {
 }
 
 impl WriteTransaction {
-    fn new(operation: SchemaOperationGuard, epoch: u64) -> Self {
+    fn new(operation: Option<SchemaOperationGuard>, epoch: u64) -> Self {
         Self {
             _operation: operation,
             epoch,
@@ -1200,7 +1448,11 @@ impl WriteTransaction {
             ));
         }
         if self.child.is_none() {
-            let connection = registry.storage.open_shard(shard)?;
+            let connection = registry.storage.open_shard_write_cancellable(
+                shard,
+                Arc::clone(&registry.cancellation_epoch),
+                self.epoch,
+            )?;
             connection
                 .busy_timeout(CANCELLABLE_BUSY_SLICE)
                 .map_err(sqlite_error::storage)?;
@@ -1230,6 +1482,7 @@ impl WriteTransaction {
                         let error = sqlite_error::statement(error);
                         if error.kind() == EngineErrorKind::Busy && Instant::now() < begin_deadline
                         {
+                            registry.wait_after_child_busy_for_test()?;
                             continue;
                         }
                         break Err(error);
@@ -1750,7 +2003,30 @@ pub(super) fn map_callback(result: EngineResult<()>) -> SqliteResult<()> {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        sync::{atomic::AtomicU64, mpsc},
+        thread,
+    };
+
     use super::*;
+
+    fn write_cancellation_fixture() -> (
+        Connection,
+        CoordinatorCancellation,
+        Arc<WriteState>,
+        Arc<AtomicU64>,
+    ) {
+        let connection = Connection::open_in_memory().unwrap();
+        let epoch = Arc::new(AtomicU64::new(0));
+        let write_state = Arc::new(WriteState::new());
+        let cancellation = CoordinatorCancellation {
+            epoch: Arc::clone(&epoch),
+            active_child_scans: Arc::new(Mutex::new(0)),
+            interrupt: Arc::new(connection.get_interrupt_handle()),
+            write_state: Some(Arc::clone(&write_state)),
+        };
+        (connection, cancellation, write_state, epoch)
+    }
 
     #[test]
     fn transaction_identifier_is_bounded_and_injection_safe() {
@@ -1773,8 +2049,58 @@ mod tests {
             affected_rows: 1,
             explicit_key: Some(Value::Int64(7)),
         };
-        assert_eq!(result.affected_rows, 1);
-        assert_eq!(result.explicit_key, Some(Value::Int64(7)));
+        assert_eq!(result.affected_rows(), 1);
+        assert_eq!(result.explicit_key(), Some(&Value::Int64(7)));
         assert_eq!(super::super::MODULE_NAME, "brisk_shard");
+    }
+
+    #[test]
+    fn nonblocking_write_cancellation_wins_before_child_finalization() {
+        let (connection, cancellation, write_state, epoch) = write_cancellation_fixture();
+
+        cancellation.cancel_write_nonblocking();
+
+        assert_eq!(epoch.load(Ordering::Acquire), 1);
+        let arm_error = match write_state.arm_statement(epoch.load(Ordering::Acquire)) {
+            Ok(_) => panic!("a pre-start cancellation was lost at statement arm"),
+            Err(error) => error,
+        };
+        assert_eq!(arm_error.kind(), EngineErrorKind::Cancelled);
+        let _commit = write_state.lock_commit_linearization();
+        assert_eq!(
+            connection.query_row("SELECT 1", [], |row| row.get::<_, i64>(0)),
+            Ok(1)
+        );
+    }
+
+    #[test]
+    fn nonblocking_write_cancellation_does_not_wait_after_finalization_wins() {
+        let (_connection, cancellation, write_state, epoch) = write_cancellation_fixture();
+        let (locked_tx, locked_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let finalizer_state = Arc::clone(&write_state);
+        let finalizer = thread::spawn(move || {
+            let _commit = finalizer_state.lock_commit_linearization();
+            locked_tx.send(()).unwrap();
+            let _ = release_rx.recv();
+        });
+        locked_rx.recv().unwrap();
+
+        let (returned_tx, returned_rx) = mpsc::channel();
+        let canceller = thread::spawn(move || {
+            cancellation.cancel_write_nonblocking();
+            returned_tx.send(()).unwrap();
+        });
+        let returned_before_release = returned_rx.recv_timeout(Duration::from_secs(1)).is_ok();
+
+        release_tx.send(()).unwrap();
+        finalizer.join().unwrap();
+        canceller.join().unwrap();
+
+        assert!(
+            returned_before_release,
+            "write cancellation waited behind child finalization"
+        );
+        assert_eq!(epoch.load(Ordering::Acquire), 0);
     }
 }

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -991,6 +991,8 @@ fn engine_options_are_public_validated_and_have_stable_defaults() {
         defaults.shutdown_grace(),
         Duration::from_millis(core::DEFAULT_SHUTDOWN_GRACE_MS)
     );
+    #[cfg(feature = "experimental-vtab")]
+    assert!(!defaults.experimental_vtab_writes());
 
     let minimum = core::EngineOptions::new(1, 1).unwrap();
     assert_eq!(minimum.connections_per_shard(), 1);
@@ -1069,6 +1071,18 @@ fn engine_options_are_public_validated_and_have_stable_defaults() {
     assert_eq!(configured.prepared_statement_limits(), prepared_limits);
     assert_eq!(configured.request_timeout(), None);
     assert_eq!(configured.shutdown_grace(), Duration::from_millis(250));
+}
+
+#[cfg(feature = "experimental-vtab")]
+#[test]
+fn experimental_vtab_write_option_is_public_and_opt_in() {
+    let constructed = core::EngineOptions::new(2, 7).unwrap();
+    assert!(!constructed.experimental_vtab_writes());
+
+    let enabled = constructed.with_experimental_vtab_writes(true);
+    assert!(enabled.experimental_vtab_writes());
+    assert_eq!(enabled.connections_per_shard(), 2);
+    assert_eq!(enabled.queue_capacity_per_shard(), 7);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #136.

## What changed

- Added the feature-gated, default-off `experimental_vtab_writes` Engine option, CLI flag, environment variable, and startup status field.
- Routed catalog-authoritative explicit-key `INSERT`, `UPDATE`, and `DELETE` through a fresh storage-owned writable coordinator while preserving the protocol-neutral Engine and HTTP contracts.
- Added schema-generation descriptor caching, bounded shard/worker admission, cancellation/deadline/shutdown integration, deterministic commit linearization, and independent per-shard write progress.
- Kept empty catalogs, gate-off builds, logical reads, and unsupported native/generated-ID writes on their established behavior.
- Documented the exact experimental autocommit-only boundary.

## Why

The writable virtual-table facade existed only as a storage-internal capability. Applications using `Engine::execute` or `POST /v1/execute` could not opt into it, so concurrent writes continued through the legacy direct-shard path and the facade had no supported entry point.

## Impact

When BriskDB is compiled with `experimental-vtab` and explicitly enabled at runtime, supported registered-table autocommit DML now executes through the sharded facade. Default behavior and feature-off builds are unchanged. Reads, explicit transactions, generated IDs, `RETURNING`, Global writes, and cross-shard transactions remain out of scope.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --all-targets`
- `cargo test --all-targets --all-features`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --all-features`
- Rust 1.85.0: locked default/all-feature checks, all-target tests, and all-feature doc tests

All checks passed. The all-feature library suite completed with 772 passed and 2 intentionally ignored tests; the default library suite completed with 683 passed and 1 intentionally ignored test.
