### PR TITLE
Implement native_range_v1 shard-local AUTOINCREMENT

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,11 +154,12 @@ BRISKDB_EXPERIMENTAL_VTAB_WRITES=true \
   cargo run --features experimental-vtab -- --data-dir ./briskdb-data --shards 4
 ```
 
-This opt-in changes only validated `Engine::execute` autocommit DML for a
-populated catalog, including the `/v1/execute` adapter. `/v1/query` and the
-admin browser continue to use the established metadata-driven scatter/gather
-readers. `BEGIN`, `COMMIT`, `ROLLBACK`, and transactions spanning HTTP requests
-are not enabled by this flag.
+This opt-in changes only validated `Engine::execute` and
+`Engine::execute_write` autocommit DML for a populated catalog, including the
+`/v1/execute` adapter. `/v1/query` and the admin browser continue to use the
+established metadata-driven scatter/gather readers. `BEGIN`, `COMMIT`,
+`ROLLBACK`, and transactions spanning HTTP requests are not enabled by this
+flag.
 
 To initialize a new data directory from an existing standard SQLite file, use
 the separate offline importer. The destination must not already exist, and the
@@ -474,8 +475,8 @@ unsafe or malformed foreign keys, virtual tables, and any change that breaks
 declared placement, Text collation, or one-owner uniqueness.
 
 The initial shard count is immutable, so resharding will require an explicit
-migration workflow. Opening upgrades exact version-1 through version-8
-manifests to version 9 through ordered, resumable steps.
+migration workflow. Opening upgrades exact version-1 through version-9
+manifests to version 10 through ordered, resumable steps.
 Version 3 introduced the versioned, generation-stamped 4,096-bucket routing
 map. Version 4 adds schema generation 0 and immutable logical metadata with
 default database ID 1 named `default`; identifier encoding version 1 accepts
@@ -537,9 +538,29 @@ immutable allocation-owner slot for every physical shard. The v8-to-v9
 migration preserves routing, placement, schema history, shard files, and rows;
 it assigns existing tables policy `None`, seeds `owner_slot = physical_shard_id`,
 raises the downgrade fence, and moves the semantic manifest checksum to version
-2 so both new catalogs are covered. This version defines and validates the
-`native_range_v1` ID format, but does not yet rewrite inserts or seed physical
-`sqlite_sequence` state.
+2 so both new catalogs are covered. This version defines the persisted
+`native_range_v1` ID format but does not activate allocation.
+
+Version 10 adds generated-policy activation, active/retired allocation-owner
+lifecycle, and a checksummed table-provisioning journal. The v9-to-v10 upgrade
+preserves every policy but marks it inactive, retains each prior owner as the
+active owner of its shard, raises the downgrade fence, and advances the
+semantic manifest checksum to version 3. Every later owner successor for a
+physical shard must have a greater slot than all of that shard's retired
+owners, preserving SQLite's non-decreasing `AUTOINCREMENT` high-water mark.
+Explicit activation requires the shard key to be exactly `INTEGER PRIMARY KEY
+AUTOINCREMENT` on every shard.
+Registration first commits the complete provisioning request, then installs
+each owner's reserved `sqlite_sequence` floor while all tables are empty, and
+publishes authority only after every floor is durable. Startup replays the
+journal's exact durable prefix idempotently. Reopen and shard admission validate
+the sequence range, owner-local rows, and high-water mark before use. Encoded
+explicit IDs route through active or retired persisted owners; new explicit IDs
+are rejected for retired owners, while marker-clear and negative legacy IDs
+keep their original hash route. An internal coordinator seam can allocate and
+capture one preflighted omitted-key row on an eligible active shard, but no
+public Engine or HTTP SQL path can invoke it yet. SQL declarations, omitted-key
+Engine planning, and response rendering remain issue #130.
 
 Registration marks schema admission `Pending` before its manifest commit. If
 that commit reports an ambiguous cleanup or I/O failure, close the registering

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,8 +30,8 @@ server ---------> protocol::http
 | Module | Responsibility | Must not own |
 | --- | --- | --- |
 | `core` | Protocol-neutral `Engine`, `Session`, statements, immutable bound portals, values, results, errors, read-only catalog views and initialization declarations, generated-ID policy and codec types, synchronous bound-value-aware plans, prepared lifecycle, explicit-shard read-only inspection, logical Sharded read target selection and scatter/gather, and sharded routing policy; stable key routing; bounded per-session and per-shard admission; routed execution and journaled schema migration | JSON/HTTP types, listeners, or Axum handlers |
-| `storage` | Versioned routing and authoritative logical manifest, persisted generated-ID policies and immutable allocation-owner slots, one-time table registration, shard layout, migration journal and recovery, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
-| `import` | Offline source-schema preflight, explicit placement-plan validation, exact-value row routing into private staging, explicit no-generation catalog declarations, independent verification, durable receipt creation, and atomic publication | Network handlers, live/incremental migration, generated-ID inference, implicit Global placement, or protocol-specific behavior |
+| `storage` | Versioned routing and authoritative logical manifest, persisted generated-ID policy/activation and stable active/retired allocation-owner slots, recoverable one-time table provisioning, shard layout, migration journals and recovery, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
+| `import` | Offline source-schema preflight, explicit placement and generated-ID plan validation, exact-value row routing into private staging, independent verification, durable receipt creation, and atomic publication | Network handlers, live/incremental migration, generated-ID inference, implicit Global placement, or protocol-specific behavior |
 | `sql` | Dialect-explicit SQL syntax parsing, recursive common-subset validation, protocol-neutral statement/batch classification, source-preserving placeholder normalization, explicit strict/compatibility translation, catalog-aware typed shard-key inference, and narrow crate-private DML-shape inspection behind BriskDB-owned boundaries; exact source retention; SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, key hashing or shard selection, mutable session state, physical write-routing policy, filesystem layout, protocol responses, protocol-buffer ownership, or protocol-specific support policy |
 | `protocol::http` | Existing HTTP request extraction, shared JSON/BriskDB value and RFC 9457 problem-detail encoding, and the embedded admin shell/assets, temporary browser sessions, metadata-driven logical discovery, exact logical counts, and bounded shard-major page handlers | BLAKE3 routing, shard files, direct SQLite access, or rusqlite calls |
 | `protocol::postgres` | BriskDB-owned bounded protocol-3.0 framing, finite parameter validation, selected identity/status, per-connection core-session ownership, query-deferral responses, and private compile/query-parser seam around the exactly pinned `pgwire` library | Listener binding, direct SQLite access, routing, unbounded authoritative prepared state, or public dependency-owned types |
@@ -458,14 +458,24 @@ v7-to-v8 transaction clears all legacy advisory table rows, reseals the
 manifest, and preserves routing, logical databases, migration history, shard
 schema, and application data.
 
-Version 9 adds the authoritative `briskdb_generated_ids` catalog and immutable
+Version 9 adds the authoritative `briskdb_generated_ids` catalog and stable
 `briskdb_allocation_owners` map. The v8-to-v9 transaction assigns every existing
 table explicit policy `None`, seeds each physical shard's same-numbered owner
 slot, raises the downgrade fence, and changes the semantic manifest checksum to
 version 2 so both new tables are covered. It preserves routing, placement,
 schema history, shard files, and application rows. Version 9 freezes and
-validates the `native_range_v1` ID encoding; insert rewriting and physical
-`sqlite_sequence` seeding remain later work.
+validates the `native_range_v1` ID encoding.
+
+Version 10 separates a generated-ID policy from its activation state, gives
+allocation owners explicit `Active` and `Retired` lifecycle, and adds the
+transient `briskdb_table_provisioning` journal plus its complete declaration
+rows. Exactly one active owner allocates on each physical shard; retired owners
+remain mapped so historical native IDs continue to route, but cannot receive a
+new insert. Manifest digest version 3 covers both lifecycle fields and both
+provisioning tables. Native policy activation proves exact `INTEGER PRIMARY KEY
+AUTOINCREMENT` storage and installs disjoint owner-local `sqlite_sequence`
+floors on every shard before catalog authority is published. Omitted-key
+dialect parsing and DDL rewriting remain later work.
 
 Each manifest version retains an intentionally incompatible
 `briskdb_metadata` definition and row as a downgrade fence. The v3-to-v4
@@ -486,6 +496,10 @@ checksum that v6 never stored. The v7-to-v8 step is likewise manifest-only and
 clears advisory table rows before installing the authoritative-catalog fence.
 The v8-to-v9 step is also manifest-only: it adds explicit generated-ID policies
 and stable owner slots, installs checksum version 2, and changes no shard file.
+The v9-to-v10 step remains manifest-only: it preserves every policy but marks it
+inactive, marks existing owner rows active, creates empty provisioning tables,
+raises the fence, and installs checksum version 3. A migrated native policy must
+therefore be explicitly reprovisioned before it may generate a new key.
 There is no automatic downgrade; an older binary requires a backup from before
 the newer format.
 
@@ -511,10 +525,20 @@ lock through independently durable per-shard work and `Ready` publication. A
 lagging opener re-reads `Ready` and strictly validates instead of provisioning
 from a stale `Creating` observation. Only a locked, durable `Creating` state
 permits missing canonical shard files to be created and WAL to be enabled. The
-final strict shard opens and catalog reconciliation complete before the startup
-guard publishes `Ready`; ordinary work is never served against a persisted
-mixed-generation prefix. A first v7 open treats the consensus across all strict
-generation-bound shard-schema fingerprints as its trust-on-first-upgrade
+validated v10 manifest may also contain one active table-provisioning record.
+Startup then keeps admission `Pending`, revalidates the complete declarations
+and committed schema digest, and resumes the ascending `next_shard` prefix. A
+shard-local sequence seed commits before its separate manifest acknowledgement;
+if process loss lands between those boundaries, startup repeats that same seed
+idempotently rather than skipping it. Only after all shards are durable does one
+manifest transaction activate native policies, clear the transient journal,
+reseal digest version 3, and publish the replacement catalog. A conflict never
+causes BriskDB to infer a new request from partial shard state.
+
+The final strict shard opens and catalog reconciliation complete before the
+startup guard publishes `Ready`; ordinary work is never served against a
+persisted mixed-generation prefix. A first v7 open treats the consensus across
+all strict generation-bound shard-schema fingerprints as its trust-on-first-upgrade
 baseline. Later opens require that existing trusted fingerprint. A durable
 `Degraded` state is terminal; recovery replaces the complete manifest and
 shard set from one known-good consistent copy rather than rebaselining it.
@@ -554,17 +578,29 @@ relationships, triggers, and virtual tables are rejected.
 Every primary or unique key on a sharded
 table must contain the shard-key column with `BINARY` collation, which keeps
 that constraint's complete equality domain on one owner. The coordinator
-validates physical state before opening an immediate manifest transaction,
-assigns deterministic table IDs, reseals the semantic root, revalidates, and
-atomically publishes the replacement snapshot. An exact repeat is idempotent;
-any other replacement is rejected.
+validates physical state and assigns deterministic table IDs. A declaration set
+whose policies are all `None` is committed, resealed, revalidated, and published
+in one manifest transaction. A declaration set containing `NativeRangeV1`
+first commits a versioned provisioning identity, the complete declarations,
+the committed schema fingerprint, and `next_shard = 0`. It then seeds each
+shard's active-owner allocator floor and separately advances that durable
+prefix. A final manifest transaction publishes the catalog, changes native
+activation to `Active`, clears the provisioning rows, and reseals the semantic
+root. No live snapshot can observe a native policy as active before every shard
+is durable. An exact repeat is idempotent; any other replacement is rejected.
+A v9 catalog migrated with an inactive native policy may submit its exact
+declarations to this same journal while its physical tables remain empty; that
+path activates the preserved policy without changing a catalog row or ID.
 
-The registration guard changes admission to `Pending` before manifest commit.
-If SQLite reports an ambiguous commit cleanup or I/O failure, the registering
-handle deliberately keeps its old catalog and cannot serve ordinary work. The
-operator must close that stale handle and reopen the canonical root so startup
-can determine whether the old or complete new catalog committed; a live stale
-handle prevents a conflicting durable catalog from being published in-process.
+The registration guard changes admission to `Pending` before any manifest
+commit that can leave durable registration or provisioning state. If SQLite
+reports an ambiguous commit cleanup or I/O failure, the registering handle
+deliberately keeps its old catalog and cannot serve ordinary work. The operator
+must close that stale handle and reopen the canonical root so startup can
+distinguish no request, an exact resumable shard prefix, and the complete new
+catalog; a live stale handle prevents a conflicting durable catalog from being
+published in-process. Startup never serves work while a provisioning journal
+exists.
 
 Once registered, table placement is authoritative. A `Sharded` row has exactly
 one owner selected by its canonical key; only `Global` data is intentionally
@@ -635,11 +671,15 @@ Generated IDs are authoritative catalog policy, never a conclusion drawn from
 mutable shard DDL. `GeneratedIdPolicy::None` means BriskDB classifies every
 stored signed integer as a legacy value and claims no generation authority for
 it; that includes caller-supplied and previously imported SQLite-generated
-values. `NativeRangeV1` is valid only when its
-named column is the same physically non-null Int64 key that owns a `Sharded`
-table. Import and every legacy manifest upgrade select `None` explicitly, so an
-old `AUTOINCREMENT` clause or a marker-looking imported value cannot silently
-enable BriskDB generation.
+values. `NativeRangeV1` is valid only when its named column is the same `Int64`
+key that owns a `Sharded` table. Policy and activation are separate: an inactive
+native policy retains classification and explicit-key routing but cannot
+generate a key; activation additionally requires exact `INTEGER PRIMARY KEY
+AUTOINCREMENT` storage on every physical shard. Import defaults every table to
+`None` but may opt in through an explicit plan after proving that schema and the
+legacy key domain. Every pre-v9 manifest upgrade selects `None`; v9-to-v10
+preserves any native policy but marks it inactive. An old `AUTOINCREMENT` clause
+or marker-looking imported value therefore cannot silently enable generation.
 
 The version-1 native value is a positive signed 64-bit integer with bit 62 set,
 an immutable 10-bit allocation-owner slot in bits 61 through 52, and a 52-bit
@@ -651,9 +691,16 @@ owner-local sequence in bits 51 through 0:
 ```
 
 Owner slots are stable identities rather than a live shard-count ordinal. The
-manifest initially assigns each physical shard its same-numbered slot, but a
-future shard-map change must retain every allocated slot rather than
-renumbering IDs. Local sequence zero is reserved; valid native sequences are
+manifest initially assigns each physical shard its same-numbered active slot.
+Every physical shard has exactly one active owner allowed to allocate; a
+retired owner retains its physical mapping for historical native reads and
+existing-row mutation, while new inserts naming it fail closed. A future
+shard-map change must retain every allocated slot rather than renumbering or
+reusing IDs, and each shard's replacement owner must be strictly greater than
+all owners previously retired on that shard. This monotonic succession matches
+SQLite's `AUTOINCREMENT` rule: its committed high-water mark survives row
+deletion and cannot safely move into a lower owner's range. Local sequence zero
+is reserved; valid native sequences are
 `1..=2^52-1`, slots are `0..=1023`, and the greatest encoding is `i64::MAX`.
 Policy-aware classification treats values without the marker, including
 negative imported values, as legacy. A marker with reserved local sequence zero
@@ -666,12 +713,17 @@ rowid alias, and SQLite's special insert path chooses an omitted or NULL rowid
 without evaluating a column `DEFAULT`. Moving allocation into a side-effecting
 UDF would also put durable allocator state behind connection-local registration
 and retry-sensitive schema evaluation, while a single shared allocator would
-serialize the writers sharding is meant to separate. The later native allocator
+serialize the writers sharding is meant to separate. The native allocator
 therefore reserves one disjoint range per owner and lets unmodified SQLite
-advance its own shard-local `AUTOINCREMENT` state. This issue persists and
-validates the policy, codec, and owner slots only; physical
-`sqlite_sequence` validation and seeding belong to issue #128, and omitted-key
-SQL translation belongs to issue #130.
+advance its own shard-local `AUTOINCREMENT` state. Empty-table policy activation
+first journals the exact declarations and trusted schema digest, then seeds one
+shard and durably acknowledges its prefix at a time. Retries are idempotent and
+never lower an existing same-owner high-water mark. A crash after a shard commit
+but before acknowledgement repeats that shard; a crash at any other boundary
+resumes the exact identity, never a guessed request. Only final manifest
+publication activates policy and clears the journal. Every later shard
+admission rejects missing, duplicate, malformed, out-of-owner, or row-lagging
+allocator state. Omitted-key SQL translation belongs to issue #130.
 
 The `experimental-vtab` feature adds separate read-only and narrowly writable
 SQLite coordinators that statically register `brisk_shard`. They prove a
@@ -681,9 +733,9 @@ OS-level SQLite read-only handles, never attaches a shard, and never
 dynamically loads an extension. Trusted metadata supplies each declared
 schema. An exact, storage-class-compatible `Int64`, `Text`, or `Binary`
 shard-key equality can open only its owner and bind the equality on that
-physical child; `native_range_v1` IDs use the immutable owner map while legacy
-integers retain ordinary hash routing. `NULL` is empty and a type mismatch
-falls back to a full scan so SQLite can retain its comparison semantics.
+physical child; `native_range_v1` IDs use the stable active/retired owner map
+while legacy integers retain ordinary hash routing. `NULL` is empty and a type
+mismatch falls back to a full scan so SQLite can retain its comparison semantics.
 Unconstrained scans visit shards in ascending order with `UNION ALL` duplicate
 semantics. Remaining filters, aggregation, ordering, limits, and feature-local
 joins execute in the stock SQLite coordinator without pushdown. That read
@@ -695,15 +747,22 @@ in the
 [experimental sharded virtual-table facade](SHARDED_VIRTUAL_TABLE.md).
 
 The writable coordinator accepts explicit-key INSERT and exactly routed
-UPDATE/DELETE only. Its first operation pins one `BEGIN IMMEDIATE` child shard;
+UPDATE/DELETE. Its first operation pins one `BEGIN IMMEDIATE` child shard;
 reads used to locate UPDATE/DELETE rows reuse that child, and a second-shard
 attempt aborts the whole transaction. A hidden versioned locator carries the
 physical rowid or complete `WITHOUT ROWID` key without changing shard files.
 The wrapper reconciles stock-SQLite transaction and savepoint callbacks, then
 performs the fallible child commit before acknowledging success. Physical
 constraints and conservatively admitted co-located foreign keys remain
-authoritative. Missing/generated keys, Global writes, multi-shard transactions,
-`RETURNING`, defaults, generated columns, and triggers remain later work.
+authoritative. A narrow preflighted `native_range_v1` seam can arm one
+single-row omitted-key insert for an already admitted shard. It checks range
+capacity under the pinned child lock, omits the physical ID column, captures
+`INSERT ... RETURNING id` on that same handle, validates the owner and sequence,
+and publishes a protocol-neutral `GeneratedKey` only after successful
+reconciliation. Generic NULL inserts and a second generated callback remain
+rejected. Engine/HTTP omitted-key planning, Global writes, multi-shard
+transactions, caller-authored `RETURNING`, defaults, generated columns, and
+triggers remain later work.
 
 Engine integration has two independent opt-ins. The binary must be compiled
 with `experimental-vtab`, and `EngineOptions::with_experimental_vtab_writes(true)`
@@ -726,12 +785,12 @@ handle and reserve only their target shard, so an occupied shard 0 cannot stall
 writers whose metadata is already warm. A published schema-generation mismatch
 invalidates the cache and forces controlled rediscovery before another write.
 
-This integration is intentionally autocommit-only. Each `Engine::execute` or
-HTTP `/v1/execute` request owns one statement and drops its coordinator after
-that statement reconciles. `Session` still has no transaction state, HTTP still
-creates a fresh Session per request, and `BEGIN`, `COMMIT`, `ROLLBACK`,
-read-your-writes, and transaction shard pinning are deferred to the later
-session-transaction work.
+This integration is intentionally autocommit-only. Each `Engine::execute`,
+`Engine::execute_write`, or HTTP `/v1/execute` request owns one statement and
+drops its coordinator after that statement reconciles. `Session` still has no
+transaction state, HTTP still creates a fresh Session per request, and `BEGIN`,
+`COMMIT`, `ROLLBACK`, read-your-writes, and transaction shard pinning are
+deferred to the later session-transaction work.
 
 ## Session and asynchronous engine boundary
 

--- a/docs/REQUEST_CONTROLS.md
+++ b/docs/REQUEST_CONTROLS.md
@@ -8,12 +8,16 @@ deferred to issue #31.
 
 ## Per-request context
 
-The existing `Engine::execute`, `query`, `broadcast`, and `status` methods, the
-crate-private explicit-shard inspection operation, plus `prepare_statement`,
-`bind_statement`, `describe_prepared`, `execute_portal`, and their logical read
-counterparts use a default `RequestContext`. `broadcast` now means a journaled
-application-schema migration. Frontends that have their own cancellation or
-deadline source can call the corresponding `*_with_context` method:
+The existing `Engine::execute`, `execute_write`, `query`, `broadcast`, and
+`status` methods, the crate-private explicit-shard inspection operation, plus
+`prepare_statement`, `bind_statement`, `describe_prepared`, `execute_portal`,
+and their logical read counterparts use a default `RequestContext`. `broadcast`
+now means a journaled application-schema migration. Frontends that have their
+own cancellation or deadline source can call the corresponding
+`*_with_context` method. `execute` and `execute_with_context` deliberately
+project the complete `WriteResult` down to an affected-row count; callers that
+need the generated-key result shape use `execute_write` or
+`execute_write_with_context`:
 
 ```rust
 use std::time::Duration;

--- a/docs/SHARDED_VIRTUAL_TABLE.md
+++ b/docs/SHARDED_VIRTUAL_TABLE.md
@@ -49,14 +49,14 @@ enable it with `EngineOptions::with_experimental_vtab_writes(true)`; the server
 maps `--experimental-vtab-writes` and
 `BRISKDB_EXPERIMENTAL_VTAB_WRITES=true` to that same option.
 
-With both gates enabled, `Engine::execute` and HTTP `/v1/execute` dispatch a
-write through the coordinator only after the authoritative catalog, common SQL
-frontend, bound values, caller route, and single-owner write policy
-have accepted one Sharded target. The returned `shard` remains the planner's
-assigned owner. `rows_affected` comes from the reconciled physical child, and a
-successful response is produced only after the autocommit child transaction
-commits under BriskDB's configured SQLite WAL and synchronous policy. The
-endpoint's request and response shapes do not change.
+With both gates enabled, `Engine::execute`, `Engine::execute_write`, and HTTP
+`/v1/execute` dispatch a write through the coordinator only after the
+authoritative catalog, common SQL frontend, bound values, caller route, and
+single-owner write policy have accepted one Sharded target. The returned
+`shard` remains the planner's assigned owner. `rows_affected` comes from the
+reconciled physical child, and a successful response is produced only after the
+autocommit child transaction commits under BriskDB's configured SQLite WAL and
+synchronous policy. The endpoint's request and response shapes do not change.
 
 The Engine caches the validated physical table descriptors for the current
 schema generation. One serialized cold bootstrap discovers them through a
@@ -65,11 +65,22 @@ opens reuse those immutable descriptors and reserve only the DML target shard,
 preserving independent-shard writer progress. Schema-generation publication
 invalidates the cache and makes the next write rediscover descriptors.
 
-This Engine bridge currently rejects a target table that declares
-`native_range_v1`, including writes that supply an explicit ID. Issue #128 owns
-making Engine planning, returned-shard reporting, and per-shard admission use
-the encoded allocation owner consistently. The storage-internal coordinator's
-native-ID behavior is not exposed through Engine before that work lands.
+For a target table declaring `native_range_v1`, an explicit valid native ID is
+routed through its persisted allocation owner at planning, pool admission,
+coordinator execution, and returned-shard reporting. Marker-clear and negative
+legacy IDs retain the exact ordinary Int64 hash route. A reserved sequence
+floor or an owner absent from the active map is rejected before mutation.
+
+The coordinator also has a narrow generated-insert seam for issue #130's
+planner: a caller that has already proven one omitted-key row and selected one
+eligible shard can arm exactly one callback. The child uses
+`INSERT ... RETURNING id`, checks `sqlite_sequence` and decoded ownership on the
+same pinned handle, and retains the generated key only after successful
+reconciliation. `Engine::execute_write` has the protocol-neutral result shape
+needed to carry that data, but every currently accepted Engine statement returns
+`generated_key: None`: Engine and HTTP SQL planning still reject omitted shard
+keys. Dialect translation, Engine invocation, and public response rendering
+belong to #130.
 
 The integration opens an ephemeral coordinator for one statement. It does not
 retain a coordinator in `Session`, and it does not add `BEGIN`, `COMMIT`,
@@ -201,17 +212,18 @@ This is why several alternatives are excluded:
 
 ## Current non-goals
 
-The writable coordinator provides explicit-key DML on one pinned Sharded child,
-and the opt-in Engine/HTTP integration exposes only one-statement autocommit
-writes. It does not provide missing/generated keys, replicated Global writes,
-multi-shard or session transactions, `RETURNING`, physical defaults, generated
-columns, physical triggers, client-created virtual-table indexes or triggers,
-`ALTER TABLE`, aggregate/order/limit/join pushdown, parallel shard scans, or a
-public virtual-table query API. The physical-default restriction is
-intentional: SQLite's `xUpdate` arguments do not distinguish an omitted column
-from explicit `NULL`. Generated keys and omitted-key SQL integration remain
-owned by issues #128 through #130, and the broader rollout gate remains owned
-by #131.
+The writable coordinator provides explicit-key DML and the preflighted
+single-row native allocation seam on one pinned Sharded child. The opt-in
+Engine/HTTP integration currently exposes only explicit-key one-statement
+autocommit writes. It does not provide general missing-key SQL, replicated
+Global writes, multi-shard or session transactions, caller-authored
+`RETURNING`, physical defaults, generated columns, physical triggers,
+client-created virtual-table indexes or triggers, `ALTER TABLE`,
+aggregate/order/limit/join pushdown, parallel shard scans, or a public
+virtual-table query API. The physical-default restriction is intentional:
+SQLite's `xUpdate` arguments do not distinguish an omitted column from explicit
+`NULL`, so only an AST-preflighted intent may enable allocation. Omitted-key SQL
+integration remains owned by #130, and the broader rollout gate by #131.
 
 The established protocol planner stays authoritative. The writable coordinator
 is kept behind both `experimental-vtab` and the runtime option and cannot be

--- a/docs/SQLITE_IMPORT.md
+++ b/docs/SQLITE_IMPORT.md
@@ -1,6 +1,6 @@
 # Standard SQLite import
 
-Status: implemented by roadmap issue #115
+Status: implemented by roadmap issues #115 and #128
 
 `briskdb-import` converts one ordinary SQLite database into a new BriskDB data
 directory. It is an offline initialization command, not a server endpoint and
@@ -63,6 +63,41 @@ two independent unique domains have no common column, preserving those
 constraints requires explicit Global placement or a separate schema redesign;
 the importer does not weaken uniqueness silently.
 
+### Explicit native generated IDs
+
+Generated-ID authority is disabled by default. A table opts into shard-local
+`native_range_v1` allocation only through its own plan entry:
+
+```json
+{
+  "name": "orders",
+  "placement": "sharded",
+  "shard_key": {
+    "strategy": "column",
+    "column": "id",
+    "key_type": "int64"
+  },
+  "generated_id": {
+    "policy": "native_range_v1",
+    "column": "id"
+  }
+}
+```
+
+Preflight requires that generated column to be the exact Sharded `Int64` key
+and that its source definition is exactly `INTEGER PRIMARY KEY AUTOINCREMENT`.
+Global tables, another generated column, another key type, plain `INTEGER
+PRIMARY KEY`, and `WITHOUT ROWID` tables fail before staging is created.
+
+Existing negative and pre-marker integer IDs remain legacy values and retain
+their ordinary hash routing. An opted-in source must not contain any positive
+ID with native format bit 62 set (`id >= 0x4000000000000000`); accepting one
+would make an imported legacy value indistinguishable from an owner-encoded
+native ID, so preflight rejects the source instead of guessing. Its source
+`sqlite_sequence` high-water mark must also be below that marker, even when the
+corresponding high ID was deleted: resetting such a history to an owner floor
+could otherwise reuse a numeric ID that had already committed.
+
 ## Foreign-key normalization
 
 The importer does not yet retain and prove the catalog's conservative
@@ -105,23 +140,32 @@ staging. The source file identity is retained and rechecked so a path
 replacement cannot silently change which database is imported. Cancellation
 interrupts SQLite work during this preflight. Tables and supported indexes are
 then created identically on every target shard and the complete authoritative
-catalog is registered while all tables are empty. Every imported table is
-registered with the explicit `GeneratedIdPolicy::None` policy. The importer
-never infers generated-ID authority from `INTEGER PRIMARY KEY`,
-`AUTOINCREMENT`, a `DEFAULT` expression, or `sqlite_sequence`.
+catalog is registered while all tables are empty. An omitted `generated_id`
+field registers the explicit `GeneratedIdPolicy::None` policy; only the
+validated plan field above registers `NativeRangeV1`. The importer never
+infers generated-ID authority from `INTEGER PRIMARY KEY`, `AUTOINCREMENT`, a
+`DEFAULT` expression, source rows, or `sqlite_sequence`.
 
 Rows retain their SQLite storage classes. Sharded rows use separate physical
 connections and visit one selected shard; the implementation does not use
 `ATTACH`, does not compute `hash % shard_count`, and does not describe multiple
 SQLite commits as one transaction. Global rows visit every shard only by their
 declaration. Generated columns are recomputed from copied ordinary columns.
-The source `sqlite_sequence` high-water mark is installed on every physical
-copy as source-schema state; it is not generated-ID catalog metadata and does
-not opt the table into `native_range_v1`. Existing integer keys, including
-values copied from an `AUTOINCREMENT` table, remain explicit legacy values and
-route through the ordinary Int64 shard-key encoding. Enabling a generated-ID
-policy for imported data requires a future explicit conversion that proves the
-key domain and seeds every allocator; import never guesses.
+For an ordinary table, the source `sqlite_sequence` high-water mark is
+installed on every physical copy as source-schema state; it is not generated-ID
+catalog metadata and cannot opt a table into `native_range_v1`. For an
+explicitly opted-in table, each empty physical copy instead receives the floor
+belonging to that shard's persisted allocation-owner slot. The floor has the
+native marker and owner bits with local sequence zero, which is reserved and
+never stored as a row ID; the shard-local SQLite allocator advances it to local
+sequence one. Imported legacy rows cannot overwrite that higher floor, and
+sequence verification uses the persisted owner map rather than assuming owner
+equals physical shard number.
+
+Thus existing integer keys copied from an `AUTOINCREMENT` table still remain
+explicit legacy values and route through the ordinary Int64 shard-key encoding
+even when the table explicitly enables subsequent native allocations. Import
+never relabels an existing key or infers policy from the source high-water mark.
 Preserved implicit `rowid` values remain shard-local physical locators after
 import; they are neither globally unique logical identities nor authoritative
 shard keys. Declared primary and unique constraints retain global meaning
@@ -137,6 +181,9 @@ source-schema digests, persisted routing versions and map generation, per-shard
 counts, and every explicit foreign-key omission. Receipt format version 2 also
 records each table's lowercase BLAKE3 logical-contents digest and its exact
 source `sqlite_sequence` high-water mark, or `null` when no sequence row exists.
+For an opted-in native table this report field deliberately remains the source
+value; the normalized plan digest records the opt-in, while physical
+verification separately proves every per-owner target floor.
 The logical digest covers the verified row multiset, including SQLite storage
 classes, generated values, and preserved implicit rowids; it is independent of
 row order and physical SQLite page layout.

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -114,10 +114,14 @@ stock SQLite and opens validated physical children through OS-level SQLite
 handles; it does not use `ATTACH`, runtime extension loading, a SQLite fork, or
 a storage-format change. The writable wrapper accepts explicit-key Sharded
 INSERT and exactly routed UPDATE/DELETE, pins one physical transaction, and
-rejects cross-shard or Global writes. Schema operations, attachments, unsafe
-PRAGMAs, extension loading, generated/missing keys, defaults, generated
-columns, triggers, and `RETURNING` remain rejected. This surface is internal
-and cannot be reached by the query app or protocol adapters.
+rejects cross-shard or Global writes. An internal preflighted seam also permits
+one `native_range_v1` NULL callback for a single omitted-key row on an already
+selected shard; it captures the generated ID with child `RETURNING` on the same
+handle. Generic generated/missing-key SQL remains rejected until #130 supplies
+AST intent and protocol rendering. Schema operations, attachments, unsafe
+PRAGMAs, extension loading, defaults, generated columns, triggers, and
+caller-authored `RETURNING` remain rejected. This surface is internal and
+cannot be reached by the query app or protocol adapters.
 
 Within that feature gate only, a usable equality on the exact cataloged shard
 key requests one virtual-table argument without `omit`. Exact SQLite `INTEGER`,
@@ -796,7 +800,7 @@ engine used by PostgreSQL and HTTP.
 | Identifier quoting | Backticks by default | Opt-in compatibility translation emits safely escaped double-quoted SQLite identifiers; case and collation equivalence are not claimed |
 | Type system | Static signed/unsigned column types | Opt-in Rust translation maps a finite signed integer, Boolean, 64-bit float, text, and binary declaration set; unsigned declarations are rejected, and translation performs no value or result adaptation. Independently, BriskDB retains `UInt64` values without narrowing, while current SQLite binding rejects values above `i64::MAX` until a storage mapping exists |
 | Boolean | Commonly `TINYINT(1)` | Opt-in translation maps exactly `TINYINT(1)` to `BOOLEAN` and Boolean literals to `1`/`0`; wire/result metadata remains planned |
-| `AUTO_INCREMENT` | Table column attribute | Unsupported until generated-key semantics are designed |
+| `AUTO_INCREMENT` | Table column attribute | Native shard-range allocation exists below the SQL layer; dialect recognition and omitted-key planning remain #130 |
 | `UNSIGNED`, display widths | MySQL column attributes | Rejected by compatibility translation, except that exactly `TINYINT(1)` is the documented Boolean declaration |
 | `DATETIME`, `TIMESTAMP` | Distinct MySQL temporal behavior | No implicit compatibility; canonical timestamp encoding must be defined first |
 | `JSON` | Native MySQL JSON type | Planned JSON validation stored using the canonical BriskDB representation |

--- a/docs/SQL_PLANNING.md
+++ b/docs/SQL_PLANNING.md
@@ -60,6 +60,14 @@ normal successful result for a statement that is not sharded and for a read
 that still needs later scatter or empty-result planning. Every accepted write
 to a cataloged sharded table has `Some(shard)`.
 
+For an `Int64` key on a table with `native_range_v1`, inferred marker-set IDs
+resolve through the persisted allocation-owner map instead of the routing hash.
+Negative and marker-clear values retain the frozen legacy hash route. When an
+explicit session route is byte-for-byte the inferred integer's canonical
+decimal encoding, it reuses that owner-aware assignment; other explicit routes
+must still select the same physical shard. Reserved sequence floors and owners
+absent from the active map fail during planning, before pool admission.
+
 The [prepared execution lifecycle](SQL_PREPARED_STATEMENTS.md) consumes this
 result only after values are bound. Bind validates then discards one plan;
 execution creates another under its current schema guard. Compatibility

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -11,24 +11,25 @@ permitted; later migration opens never create a missing replacement, use
 SQLite's no-follow mode, and revalidate the freshly opened layout identity
 inside the same manifest transaction before changing journal state.
 
-## Current format: version 9
+## Current format: version 10
 
 SQLite header fields identify the file and its format:
 
 | Header field | Value | Meaning |
 | --- | --- | --- |
 | `PRAGMA application_id` | `0x42524442` (`BRDB`) | Permanent BriskDB manifest-family marker |
-| `PRAGMA user_version` | `9` | Authoritative manifest schema version |
+| `PRAGMA user_version` | `10` | Authoritative manifest schema version |
 
 The application ID prevents an accidental foreign SQLite file from being
 adopted as a manifest. It is not authentication or tamper protection: a process
 that can write the data directory can forge it and the unkeyed checksums
 described below.
 
-Version 9 has thirteen strict manifest tables. It retains the v8 routing,
+Version 10 has fifteen strict manifest tables. It retains the v9 routing,
 authoritative logical catalog, physical layout, application-schema migration,
-and integrity tables; replaces the downgrade fence; and adds generated-ID
-policy and immutable allocation-owner metadata without changing a shard file.
+and integrity tables; replaces the downgrade fence; separates generated-ID
+policy from activation; makes allocation-owner lifecycle explicit; and adds a
+recoverable native table-provisioning journal without changing a shard file.
 
 ```sql
 CREATE TABLE briskdb_manifest (
@@ -38,7 +39,7 @@ CREATE TABLE briskdb_manifest (
 
 CREATE TABLE briskdb_metadata (
     requires_manifest_version INTEGER NOT NULL
-        CHECK (requires_manifest_version >= 9)
+        CHECK (requires_manifest_version >= 10)
 ) STRICT;
 
 CREATE TABLE briskdb_routing (
@@ -149,6 +150,7 @@ CREATE TABLE briskdb_generated_ids (
         ),
     encoding_version INTEGER
         CHECK (encoding_version IS NULL OR encoding_version > 0),
+    activation_state INTEGER NOT NULL CHECK (activation_state IN (0, 1)),
     FOREIGN KEY (table_id)
         REFERENCES briskdb_tables (table_id)
         ON DELETE RESTRICT,
@@ -157,6 +159,7 @@ CREATE TABLE briskdb_generated_ids (
             policy = 0
             AND generated_column IS NULL
             AND encoding_version IS NULL
+            AND activation_state = 0
         )
         OR
         (
@@ -169,11 +172,98 @@ CREATE TABLE briskdb_generated_ids (
 
 CREATE TABLE briskdb_allocation_owners (
     owner_slot INTEGER PRIMARY KEY CHECK (owner_slot BETWEEN 0 AND 1023),
-    physical_shard_id INTEGER NOT NULL UNIQUE
+    physical_shard_id INTEGER NOT NULL
         CHECK (physical_shard_id BETWEEN 0 AND 63),
+    owner_state INTEGER NOT NULL CHECK (owner_state IN (1, 2)),
     FOREIGN KEY (physical_shard_id)
         REFERENCES briskdb_physical_shards (shard_id)
         ON DELETE RESTRICT
+) STRICT;
+
+CREATE UNIQUE INDEX briskdb_one_active_owner_per_shard
+ON briskdb_allocation_owners (physical_shard_id)
+WHERE owner_state = 1;
+
+CREATE TABLE briskdb_table_provisioning (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    provisioning_id BLOB NOT NULL
+        CHECK (typeof(provisioning_id) = 'blob' AND length(provisioning_id) = 32),
+    digest_version INTEGER NOT NULL CHECK (digest_version = 1),
+    schema_digest_version INTEGER NOT NULL CHECK (schema_digest_version = 1),
+    committed_schema_digest BLOB NOT NULL
+        CHECK (typeof(committed_schema_digest) = 'blob' AND length(committed_schema_digest) = 32),
+    shard_count INTEGER NOT NULL CHECK (shard_count BETWEEN 2 AND 64),
+    declaration_count INTEGER NOT NULL CHECK (declaration_count BETWEEN 1 AND 4096),
+    next_shard INTEGER NOT NULL CHECK (next_shard BETWEEN 0 AND shard_count)
+) STRICT;
+
+CREATE TABLE briskdb_table_provisioning_declarations (
+    provisioning_singleton INTEGER NOT NULL CHECK (provisioning_singleton = 1),
+    ordinal INTEGER NOT NULL CHECK (ordinal BETWEEN 0 AND 4095),
+    database_id INTEGER NOT NULL CHECK (database_id > 0),
+    table_name TEXT NOT NULL COLLATE BINARY
+        CHECK (
+            length(table_name) BETWEEN 1 AND 63
+            AND instr(table_name, char(0)) = 0
+            AND table_name NOT GLOB '*[^a-z0-9_]*'
+            AND substr(table_name, 1, 1) GLOB '[a-z_]'
+            AND table_name <> 'briskdb'
+            AND table_name NOT GLOB 'briskdb_*'
+            AND table_name NOT GLOB 'sqlite_*'
+        ),
+    placement INTEGER NOT NULL CHECK (placement IN (1, 2, 3)),
+    shard_key_column TEXT COLLATE BINARY
+        CHECK (
+            shard_key_column IS NULL OR (
+                length(shard_key_column) BETWEEN 1 AND 63
+                AND instr(shard_key_column, char(0)) = 0
+                AND shard_key_column NOT GLOB '*[^a-z0-9_]*'
+                AND substr(shard_key_column, 1, 1) GLOB '[a-z_]'
+                AND shard_key_column <> 'briskdb'
+                AND shard_key_column NOT GLOB 'briskdb_*'
+                AND shard_key_column NOT GLOB 'sqlite_*'
+            )
+        ),
+    shard_key_type INTEGER
+        CHECK (shard_key_type IS NULL OR shard_key_type IN (1, 2, 3)),
+    generated_policy INTEGER NOT NULL CHECK (generated_policy >= 0),
+    generated_column TEXT COLLATE BINARY,
+    generated_encoding_version INTEGER
+        CHECK (generated_encoding_version IS NULL OR generated_encoding_version > 0),
+    PRIMARY KEY (provisioning_singleton, ordinal),
+    UNIQUE (provisioning_singleton, database_id, table_name),
+    FOREIGN KEY (provisioning_singleton)
+        REFERENCES briskdb_table_provisioning (singleton)
+        ON DELETE CASCADE,
+    FOREIGN KEY (database_id)
+        REFERENCES briskdb_logical_databases (database_id)
+        ON DELETE RESTRICT,
+    CHECK (
+        (
+            placement = 1
+            AND shard_key_column IS NOT NULL
+            AND shard_key_type IS NOT NULL
+        )
+        OR
+        (
+            placement IN (2, 3)
+            AND shard_key_column IS NULL
+            AND shard_key_type IS NULL
+        )
+    ),
+    CHECK (
+        (
+            generated_policy = 0
+            AND generated_column IS NULL
+            AND generated_encoding_version IS NULL
+        )
+        OR
+        (
+            generated_policy > 0
+            AND generated_column IS NOT NULL
+            AND generated_encoding_version IS NOT NULL
+        )
+    )
 ) STRICT;
 
 CREATE TABLE briskdb_shard_layout (
@@ -246,28 +336,30 @@ CREATE TABLE briskdb_integrity (
 ```
 
 The manifest, metadata, routing, schema-catalog, shard-layout, and integrity
-tables each contain exactly one row. The v9 downgrade-fence row is exactly `9`.
+tables each contain exactly one row. The v10 downgrade-fence row is exactly
+`10`. `briskdb_table_provisioning` contains either zero or one row, and its
+declaration rows exist only while that parent row exists.
 The two integrity-version columns deliberately accept any positive integer so
 a future digest encoding can remain structurally readable long enough for an
-older binary to reject it as `FailedPrecondition`; v9 writers emit manifest
-digest version `2` and schema digest version `1`.
+older binary to reject it as `FailedPrecondition`; v10 writers emit manifest
+digest version `3` and schema digest version `1`.
 Zero or negative versions are malformed and are `DataCorruption`.
 `briskdb_manifest.shard_count` is immutable and is the initial routing modulus;
 it is also the live physical-shard count. Physical IDs are exactly
 `0..shard_count - 1`. Filenames remain derived by trusted code as
 `shards/{shard_id:04}.sqlite` and are never read from catalog-controlled paths.
-Version 9 supports only the `active` physical-shard lifecycle state. Adding
+Version 10 supports only the `active` physical-shard lifecycle state. Adding
 provisioning, draining, or retirement states to the routing catalog requires a
 later format and state-machine change. The separate shard-layout state governs
 only startup identity reconciliation.
 
 ### Logical catalog
 
-Every fresh or upgraded v9 manifest contains logical database ID `1` named
+Every fresh or upgraded v10 manifest contains logical database ID `1` named
 `default`. A fresh or pre-v6 upgrade begins at application-schema
 generation `0`; each completed journal row advances it by exactly one, through
 a maximum of `2,147,483,647`. The schema-catalog singleton also contains
-identifier encoding version `1` and default database ID `1`. Version 9 permits
+identifier encoding version `1` and default database ID `1`. Version 10 permits
 at most 64 logical databases and 4,096 table rows. Database and table IDs are
 positive; table names are unique within their owning database, and every table
 references an existing database.
@@ -316,14 +408,20 @@ the ordinary shard-key and unique-locality rules.
 SQLite DDL so a mutable `AUTOINCREMENT` clause, `DEFAULT`, or `sqlite_sequence`
 row can never grant allocation authority by inference. The stable codes are:
 
-| `policy` | Rust policy | `generated_column` | `encoding_version` |
-| --- | --- | --- | --- |
-| `0` | `GeneratedIdPolicy::None` | null | null |
-| `1` | `GeneratedIdPolicy::NativeRangeV1` | The table's canonical Int64 shard-key column | `1` |
+| `policy` | Rust policy | `generated_column` | `encoding_version` | Allowed `activation_state` |
+| --- | --- | --- | --- | --- |
+| `0` | `GeneratedIdPolicy::None` | null | null | `0` (`Inactive`) only |
+| `1` | `GeneratedIdPolicy::NativeRangeV1` | The table's canonical Int64 shard-key column | `1` | `0` (`Inactive`) or `1` (`Active`) |
+
+Policy and activation are orthogonal. An inactive native row preserves its ID
+classification and owner-routing domain, but it grants no omitted-key
+allocation authority. Generated inserts fail closed until provisioning has
+made every shard durable and atomically changed that row to active. A `None`
+policy can never be active.
 
 The SQL shape permits a positive future policy or encoding so an older binary
 can distinguish an unsupported format from malformed storage. The reader first
-verifies the version-2 semantic root, so an unsealed change remains
+verifies the version-3 semantic root, so an unsealed change remains
 `DataCorruption`; with a valid root, it returns `FailedPrecondition` as soon as
 a structurally admitted positive policy or encoding is newer than it supports.
 It does not apply current-version relational semantics to that future format.
@@ -331,21 +429,39 @@ For supported policy and encoding
 codes, zero or negative encodings, null native fields, a noncanonical column,
 missing or extra policy rows, and relational disagreement are `DataCorruption`.
 Current cross-table validation accepts `native_range_v1` only for a `Sharded`
-table whose generated column exactly equals its visible, physically non-null
-`Int64` shard key. `Global`, `Catalog`, Text, Binary, and a different generated
-column fail closed. Registration persists the policy in the same manifest
-transaction as its table row; an exact retry compares it as part of
-idempotency.
+table whose generated column exactly equals its visible `Int64` shard key.
+Activation additionally requires that physical column to be exactly `INTEGER
+PRIMARY KEY AUTOINCREMENT` on every shard. `Global`, `Catalog`, Text, Binary, or
+a different generated column fail closed. An inactive migrated policy remains
+readable and explicitly routable without claiming that a legacy physical
+schema is an allocator; a plain non-AUTOINCREMENT integer primary key therefore
+cannot be activated. An exact provisioning retry compares the complete policy
+and activation outcome as part of idempotency.
 
-`briskdb_allocation_owners` contains exactly one row for every active physical
-shard and maps each physical shard to one unique slot. Version 9 seeds
-`owner_slot = physical_shard_id`, so current slots are the contiguous range
-`0..shard_count - 1`. The slot is an immutable ID namespace, not a value that
-may be recomputed from a later shard count or bucket map. Version 9 exposes no
-owner-map mutation. A future resharding format must preserve every allocated
-slot and explicitly add any new owner; reassigning a used slot would make old
-IDs ambiguous. Missing, duplicate, out-of-range, noncontiguous initial, or
-foreign-shard mappings are corruption.
+`briskdb_allocation_owners.owner_state = 1` means `Active`; `2` means
+`Retired`. Every physical shard has exactly one active allocation owner, which
+is the only slot that may allocate a new native ID there. A retired owner keeps
+its immutable mapping to the same physical shard so historical native IDs
+continue to route for reads and mutation of existing rows; a new insert that
+names a retired owner is rejected. Several historical retired owners may map to
+one shard, while the partial unique index enforces exactly one live allocator
+after manifest validation. Owner succession is strictly increasing per physical
+shard: its active slot must be greater than every retired slot mapped to that
+shard. SQLite never lowers an `AUTOINCREMENT` high-water mark, even after the
+row which established it is deleted, so a lower replacement could otherwise
+continue allocating values in a retired owner's encoded range.
+
+Fresh version 10 storage seeds active `owner_slot = physical_shard_id`, so the
+initial slots are the contiguous range `0..shard_count - 1`. A slot is an
+immutable ID namespace, not a value that may be recomputed from a later shard
+count or bucket map. Version 10 has no public owner-map mutation operation, but
+its format preserves the state required by a later resharding workflow: retire
+the old slot without deleting it and explicitly add a never-used replacement
+whose slot is greater than every prior owner of that physical shard.
+Reactivating, remapping, deleting, reassigning a used slot, or installing a
+non-increasing successor would make old IDs ambiguous or violate SQLite's
+persisted high-water mark. Missing active coverage, two active owners for one
+shard, out-of-range slots, or mappings to foreign shards are corruption.
 
 Native range encoding version 1 uses these signed 64-bit fields:
 
@@ -366,9 +482,17 @@ marker-set values decode to their owner and local sequence. Under `None`, every
 signed integer—including a marker-looking imported value—is legacy. The strict
 native decoder rejects rather than classifies negative and marker-clear values.
 
-Version 9 only defines the policy and stable namespace; it does not rewrite an
-insert or seed physical `sqlite_sequence`. That work belongs to issue #128.
-Exact `INTEGER PRIMARY KEY` cannot be replaced by a schema `DEFAULT` function:
+Activation seeds one `sqlite_sequence` row per native table and physical shard
+to that shard's reserved owner floor before manifest publication. A retry may
+raise a marker-clear legacy high-water mark to the floor and preserves an
+existing same-owner native high-water mark; it never lowers one. Missing,
+duplicate, non-integer, below-floor, above-ceiling, foreign-owner, or
+row-lagging sequence state after activation is corruption. The exact ceiling is
+a valid exhausted state, and allocation rejects it before SQLite can cross into
+the next owner's range.
+
+This does not yet rewrite a logical omitted-key insert. Exact `INTEGER PRIMARY
+KEY` cannot be replaced by a schema `DEFAULT` function:
 it is a rowid alias, and SQLite chooses an omitted or NULL rowid through its
 special insert path instead of evaluating a column default. A side-effecting
 allocation UDF would also make schema evaluation connection-local and
@@ -392,16 +516,21 @@ Foreign keys are accepted only when authoritative placement proves local
 enforcement: matching co-sharded keys in the same generated-ID routing domain,
 Sharded-to-Global, or Global-to-Global. Missing, Catalog, cross-placement, or
 SQLite-unenforceable relationships, triggers, and virtual tables are
-unsupported. Registration assigns table IDs
-after sorting by logical database and canonical table name, commits each table
-and its explicit generated-ID policy row, refreshes the manifest root
-atomically, and publishes the replacement catalog only after revalidation.
+unsupported. Registration assigns table IDs after sorting by logical database
+and canonical table name. A declaration set containing only `None` policies
+commits every table and policy row, refreshes the manifest root atomically, and
+publishes the replacement catalog only after revalidation. A set containing a
+native policy instead uses the provisioning journal below; it does not publish
+allocator authority in the transaction that records intent.
 
 Registration is initialization-only and requires exclusive live ownership of
 the data root. An exact complete repeat is a read-only idempotent success;
 empty, partial, different, duplicate, nonempty, or physically mismatched
 declarations fail without replacing the catalog. Once populated, the catalog
-cannot be edited in place. A later journaled schema migration must preserve the
+cannot be edited in place. The one exception is an exact declaration repeat for
+a v9 catalog migrated with an inactive native policy: v10 may provision that
+unchanged policy if all declared physical tables are still empty, but it may
+not alter a declaration or catalog ID. A later journaled schema migration must preserve the
 exact registered physical table set on every shard and retain every sharded
 key's visible, physically non-null column, compatible affinity, Text collation,
 and one-owner unique keys. Foreign-key changes must retain the same conservative
@@ -411,17 +540,79 @@ DML, `CREATE TABLE ... AS SELECT`, `DROP TABLE`, and `CREATE TRIGGER`. A
 violation is rejected before journal or shard publication.
 
 The registration guard changes in-process schema admission to `Pending` before
-attempting manifest commit. If SQLite reports an ambiguous commit cleanup or
-I/O failure, the registering handle deliberately retains its old catalog and
+attempting a manifest commit that could durably change registration or
+provisioning state. If SQLite reports an ambiguous commit cleanup or I/O
+failure, the registering handle deliberately retains its old catalog and
 ordinary work remains closed. Close that stale handle and reopen the canonical
-data root; startup then validates whether the old catalog or complete new
-catalog became durable. While the stale handle is live, a reopen that observes
-the committed replacement fails `FailedPrecondition` rather than publishing
-conflicting catalog snapshots. A new registration must not be attempted through
-the pending handle.
+data root; startup then validates whether no request, a recoverable provisioning
+prefix, or the complete new catalog became durable. While the stale handle is
+live, a reopen that observes a committed replacement fails `FailedPrecondition`
+rather than publishing conflicting catalog snapshots. A new registration must
+not be attempted through the pending handle.
 
-Fresh v9 initialization leaves `briskdb_tables` and `briskdb_generated_ids`
-empty. The v7-to-v8 migration
+### Native table-provisioning journal
+
+`briskdb_table_provisioning` is a transient, checksummed recovery record for
+the cross-file work required to activate native allocation. It has either no
+row or singleton row `1`. `digest_version = 1` identifies a deterministic
+32-byte `provisioning_id` over the complete normalized declaration set, the
+requested shard count, and the committed schema digest. The recorded
+`schema_digest_version`, digest bytes, shard count, declaration count, and
+identity must all match the current trusted manifest and declarations.
+
+Provisioning digest version 1 freezes this exact BLAKE3 byte stream:
+
+1. ASCII domain bytes `briskdb.table-provisioning.v1\0`;
+2. little-endian `u32` digest version, little-endian `u16` shard count, the 32
+   committed-schema-digest bytes, and little-endian `u64` declaration count;
+3. for each declaration in normalized `(database_id, table_name)` order:
+   little-endian `u64` database ID; the table name as little-endian `u64`
+   byte length followed by its bytes; little-endian `i64` placement; optional
+   shard column as tag byte `0` or tag `1` plus the same length-prefixed text;
+   optional shard-key type as tag byte `0` or tag `1` plus little-endian `i64`;
+   little-endian `i64` generated policy; optional generated column with that
+   same tagged-text encoding; and optional generated encoding version with
+   that same tagged-`i64` encoding.
+
+Changing this stream requires a new provisioning digest version; an active
+journal must remain reproducible byte-for-byte across upgrades and restart.
+
+`briskdb_table_provisioning_declarations` stores that complete canonical
+declaration set in ascending `ordinal` order. It repeats placement, shard-key,
+and generated-policy metadata rather than depending on an uncommitted catalog.
+Ordinals must be contiguous from zero, names must be unique in their logical
+database, the row count must equal `declaration_count`, and the parent foreign
+key deletes all rows when finalization removes the singleton. An active
+application-schema migration and active table provisioning are mutually
+exclusive.
+The protocol is deliberately one-way and prefix based:
+
+1. Under the exclusive in-process schema gate, validate the complete empty
+   physical table set and committed schema digest. In one manifest transaction,
+   write the provisioning singleton and all declarations, reseal digest version
+   3, and commit before changing any shard.
+2. Starting at `next_shard`, seed every native table's active-owner
+   `sqlite_sequence` floor in one shard-local transaction. Only after that shard
+   commits may a separate manifest transaction advance `next_shard` by exactly
+   one and reseal the root.
+3. Once `next_shard = shard_count`, one final manifest transaction assigns or
+   verifies the authoritative catalog, changes every requested native policy to
+   `activation_state = 1`, deletes both provisioning tables' rows, reseals the
+   root, and commits. Only that complete catalog snapshot may be published to
+   callers.
+
+A process loss after journal publication leaves ordinary admission closed on
+the next open while startup resumes the exact recorded request. A loss after a
+shard commit but before its prefix acknowledgement safely repeats that shard:
+seeding is idempotent, preserves a same-owner high-water mark, and never lowers
+the sequence. Startup revalidates the declarations as empty, verifies each
+acknowledged or replayed shard, resumes in ascending order, and publishes
+`Ready` only after atomic finalization. Conflicting declarations, schema
+digests, owner ranges, or nonempty tables fail closed; BriskDB never infers a
+different request from partial shard state.
+
+Fresh v10 initialization leaves `briskdb_tables`, `briskdb_generated_ids`, and
+both provisioning tables empty. The v7-to-v8 migration
 also clears all v7 table rows because those rows were advisory and were never
 proved against the physical schema; silently promoting them would create false
 routing authority. The upgrade preserves logical databases, routing, schema
@@ -466,7 +657,7 @@ additional `Applying` row may exist, and it must target
 `schema_generation + 1`. Its stored source generation, shard count, SQL text,
 digest, state, and progress are validated on every manifest open. Any journal
 history requires the physical layout to be `Ready`; `Creating` and `Adopting`
-manifests have an empty journal. Fresh v9 initialization and pre-v6 upgrades
+manifests have an empty journal. Fresh v10 initialization and pre-v6 upgrades
 begin with an empty journal at generation 0.
 
 The retained journal proves which exact batches BriskDB coordinated; it does
@@ -487,13 +678,13 @@ are distinct from the v5 physical-layout states:
 | Code | State | Required checksum and journal shape | Admission contract |
 | --- | --- | --- | --- |
 | `1` | `Verifying` | No active migration and no target fingerprint; the committed fingerprint may be absent during first bootstrap | Startup must verify one shard-schema consensus and seal it before serving work |
-| `2` | `Ready` | One committed fingerprint, no target fingerprint, no active migration, physical layout `Ready` | Ordinary operations may run |
-| `3` | `Migrating` | Committed source and target fingerprints plus exactly one `Applying` journal row, physical layout `Ready` | Only the migration coordinator may advance the validated prefix |
+| `2` | `Ready` | One committed fingerprint, no target fingerprint, no active schema migration, physical layout `Ready`; may contain one active table-provisioning prefix | Ordinary operations may run only when no provisioning record exists; otherwise registration or startup recovery owns the gate |
+| `3` | `Migrating` | Committed source and target fingerprints plus exactly one `Applying` schema-migration row, no table provisioning, physical layout `Ready` | Only the migration coordinator may advance the validated prefix |
 | `4` | `Degraded` | Preserves whatever trusted committed/target fingerprints and active journal existed when validation failed | Terminal fail-closed state; startup and all new work return non-retryable `DataCorruption` until the complete database is restored from a known-good copy |
 
-`Pending` is an in-process admission state used after durable migration progress
-or a durability-ambiguous manifest commit, including first catalog
-registration; it is not a fifth manifest state. A state transition, its
+`Pending` is an in-process admission state used after durable schema-migration
+or table-provisioning progress, and after a durability-ambiguous manifest
+commit, including first catalog registration; it is not a fifth manifest state. A state transition, its
 checksum fields, the corresponding journal/catalog mutation, and the refreshed
 semantic root commit in one `manifest.sqlite` transaction. A failed validation
 marks the canonical
@@ -508,8 +699,8 @@ restart as repair after any reported `DataCorruption`; whole-shard corruption
 drills and failure handling remain issue #68. Those storage failures retain
 their own error kinds and do not themselves justify rebaselining data.
 
-Manifest digest version 2 is a full 32-byte, unkeyed BLAKE3 digest. The stream
-begins with `briskdb.manifest.semantic-root.v2` plus its terminating NUL. It
+Manifest digest version 3 is a full 32-byte, unkeyed BLAKE3 digest. The stream
+begins with `briskdb.manifest.semantic-root.v3` plus its terminating NUL. It
 then encodes the length-prefixed name `application_id` and its tagged integer,
 followed by the length-prefixed name `user_version` and its tagged integer.
 These tables and columns follow in fixed order:
@@ -520,12 +711,14 @@ These tables and columns follow in fixed order:
 | `briskdb_metadata` | `requires_manifest_version` |
 | `briskdb_routing` | `singleton`, `hash_version`, `key_encoding_version`, `bucket_algorithm_version`, `virtual_bucket_count`, `map_generation` |
 | `briskdb_physical_shards` | `shard_id`, `lifecycle_state` |
-| `briskdb_allocation_owners` | `owner_slot`, `physical_shard_id` |
+| `briskdb_allocation_owners` | `owner_slot`, `physical_shard_id`, `owner_state` |
 | `briskdb_virtual_buckets` | `bucket_id`, `physical_shard_id` |
 | `briskdb_logical_databases` | `database_id`, `database_name` |
 | `briskdb_schema_catalog` | `singleton`, `identifier_encoding_version`, `schema_generation`, `default_database_id` |
 | `briskdb_tables` | `table_id`, `database_id`, `table_name`, `placement`, `shard_key_column`, `shard_key_type` |
-| `briskdb_generated_ids` | `table_id`, `policy`, `generated_column`, `encoding_version` |
+| `briskdb_generated_ids` | `table_id`, `policy`, `generated_column`, `encoding_version`, `activation_state` |
+| `briskdb_table_provisioning` | `singleton`, `provisioning_id`, `digest_version`, `schema_digest_version`, `committed_schema_digest`, `shard_count`, `declaration_count`, `next_shard` |
+| `briskdb_table_provisioning_declarations` | `provisioning_singleton`, `ordinal`, `database_id`, `table_name`, `placement`, `shard_key_column`, `shard_key_type`, `generated_policy`, `generated_column`, `generated_encoding_version` |
 | `briskdb_shard_layout` | `singleton`, `layout_id`, `shard_application_id`, `shard_metadata_version`, `layout_state` |
 | `briskdb_schema_migrations` | `target_generation`, `source_generation`, `migration_id`, `digest_version`, `sql_text`, `shard_count`, `migration_state`, `next_shard` |
 | `briskdb_integrity` | `singleton`, `manifest_digest_version`, `schema_digest_version`, `database_state`, `committed_schema_digest`, `target_schema_digest` |
@@ -543,20 +736,24 @@ self-reference; its version, database state, and schema digest fields are
 covered. Frozen SQL definitions, STRICT flags, indexes, and foreign keys are
 validated separately rather than encoded as semantic rows.
 
-Every BriskDB-owned v9 manifest mutation recalculates the root after its row
+Every BriskDB-owned v10 manifest mutation recalculates the root after its row
 changes and before the same transaction commits. Progress acknowledgement,
-migration publication/finalization, layout publication, state changes, and
-catalog changes therefore cannot commit with a stale root through supported
-code. Hashing semantic values instead of the raw SQLite file makes the root
-stable across WAL checkpoints, page relocation, and `VACUUM`; it deliberately
-does not cover SQLite page bytes, rollback journals, WAL, or shared memory.
+migration publication/finalization, provisioning intent/progress/finalization,
+layout publication, owner/activation state changes, and catalog changes
+therefore cannot commit with a stale root through supported code. Hashing
+semantic values instead of the raw SQLite file makes the root stable across WAL
+checkpoints, page relocation, and `VACUUM`; it deliberately does not cover
+SQLite page bytes, rollback journals, WAL, or shared memory.
 
-Digest version 1 remains frozen solely to verify and migrate version-7 and
-version-8 manifests. It uses the
+Digest version 2 remains frozen solely to verify and migrate version-9
+manifests. It uses the `briskdb.manifest.semantic-root.v2` domain and the same
+encoding, covers generated-ID policy and the owner-to-shard mapping, but omits
+activation, owner lifecycle, and both provisioning tables. Digest version 1
+remains frozen for version-7 and version-8 manifests. It uses the
 `briskdb.manifest.semantic-root.v1` domain and the same encoding, but omits the
-two version-9 tables. A v9 manifest must store version 2; storing version 1 in
-an otherwise v9 shape is corruption, and an unsupported future positive digest
-version is a failed precondition.
+two version-9 tables. A v10 manifest must store version 3; storing an older
+digest in an otherwise v10 shape is corruption, and an unsupported future
+positive digest version is a failed precondition.
 
 The frozen four-shard v8/version-1 fixture with layout ID
 `000102030405060708090a0b0c0d0e0f`, committed schema fingerprint `5a` repeated
@@ -690,7 +887,7 @@ The routing singleton contains exactly these generation-1 values:
 | `key_encoding_version` | `1` | Canonical bytes defined below for raw, explicit, and typed inferred routing keys |
 | `bucket_algorithm_version` | `1` | Compatibility-preserving range algorithm below |
 | `virtual_bucket_count` | `4096` | Fixed virtual bucket space `0..4095` |
-| `map_generation` | `1` | Initial committed bucket map and the only generation version 9 can interpret |
+| `map_generation` | `1` | Initial committed bucket map and the only generation version 10 can interpret |
 
 Every bucket ID exists exactly once and references an active physical shard.
 Every physical shard owns at least one bucket. The generation-1 map partitions
@@ -732,7 +929,7 @@ vectors freeze the exact key bytes, BLAKE3 prefix, little-endian hash integer,
 bucket ID, and persisted physical shard.
 
 `map_generation` is separate from manifest `user_version` and from
-`schema_generation`. Version 9 accepts only routing generation 1 and validates
+`schema_generation`. Version 10 accepts only routing generation 1 and validates
 its exact deterministic assignment; no public map-mutation operation exists
 yet. A future format that can commit a changed map must bump `user_version` and
 its downgrade fence as well as `map_generation`. That requirement makes this
@@ -743,12 +940,38 @@ At each open, BriskDB validates the exact objects, columns, strict flags, frozen
 schema SQL, singleton rows, logical identifiers and limits, metadata codes,
 supported algorithm values, contiguous physical and bucket IDs, active
 lifecycle states, assignments, coverage, and foreign keys. A recognized
-version-9 manifest that violates any invariant is `DataCorruption` and is
+version-10 manifest that violates any invariant is `DataCorruption` and is
 rejected before shard connections are opened. The same locked transaction
 returns routing and logical rows as one coherent shared snapshot. Request
 routing performs no manifest query and cannot fall back to modulo after a failed
 validation; only successful migration finalization publishes a newer logical
 schema generation into the snapshot.
+
+## Previous version 9
+
+Version 9 has thirteen strict tables. Its generated-ID table has policy,
+generated-column, and encoding fields but no independent `activation_state`.
+Its owner table maps each physical shard to one unique slot but has no
+`owner_state`. It has neither table-provisioning table, requires downgrade fence
+9, and stores semantic manifest digest version 2.
+
+The atomic v9-to-v10 transaction rebuilds every generated-ID row with
+`activation_state = 0`, preserving its exact policy metadata without treating
+prior cross-file state as proven active. It rebuilds every owner row as active,
+adds the partial one-active-owner-per-shard index, creates both empty
+provisioning tables, replaces the downgrade fence with 10, changes the integrity
+row to manifest digest version 3, stamps `user_version = 10`, and reseals the
+version-3 root. Routing, placement, schema generation and history, layout and
+integrity state, schema fingerprints, shard files, and application rows are
+preserved. The transaction never opens or mutates a shard.
+
+A migrated native policy remains usable for policy-aware classification and
+explicit key routing, but generated allocation remains disabled until the exact
+declaration set is safely reprovisioned through the v10 journal. This avoids
+asserting that an old manifest transaction proved all shard-local allocator
+floors durable. A version-9 reader rejects the version-10 header and downgrade
+fence before it could ignore activation, retired-owner routing, or an active
+provisioning journal.
 
 ## Previous version 8
 
@@ -899,7 +1122,7 @@ CREATE TABLE briskdb_metadata (
 
 The fence contains exactly `2`. A current opener validates this complete format
 before applying the numbered v2-to-v3, v3-to-v4, v4-to-v5, v5-to-v6,
-v6-to-v7, v7-to-v8, and v8-to-v9 transactions.
+v6-to-v7, v7-to-v8, v8-to-v9, and v9-to-v10 transactions.
 
 ## Legacy version 1
 
@@ -953,21 +1176,25 @@ returning:
    root, validate the complete destination, and commit one numbered step at a
    time. The v6-to-v7 transaction adds an integrity row in `Verifying`; the
    v7-to-v8 transaction clears advisory table rows and installs the
-   authoritative-catalog downgrade fence; and v8-to-v9 installs explicit
+   authoritative-catalog downgrade fence; v8-to-v9 installs explicit
    generated-ID policies, allocation-owner slots, and semantic digest version
-   2. Older formats therefore cannot be mistaken for checksummed,
-   authoritative-catalog, or allocator-authority data.
+   2; and v9-to-v10 installs activation/lifecycle state, the provisioning
+   journal, and semantic digest version 3. Older formats therefore cannot be
+   mistaken for checksummed, authoritative-catalog, allocator-authority, or
+   recoverable provisioning data.
 6. Fresh initialization is allowed only beside an otherwise empty physical
-   layout and commits v9 physical state `Creating`, integrity state
-   `Verifying`, generation 0, and an empty migration journal. An existing
+   layout and commits v10 physical state `Creating`, integrity state
+   `Verifying`, generation 0, and empty application-schema and provisioning
+   journals. An existing
    v1/v2/v3 manifest first advances through v4; the v4-to-v5 transaction commits
    a random 16-byte layout ID and physical state `Adopting` before any shard
    file changes. The v5-to-v6 step creates the journal, v6-to-v7 establishes
    the unsealed integrity row, and v7-to-v8 establishes an empty authoritative
    table catalog. The v8-to-v9 step adds the empty generated-policy catalog and
-   immutable owner map.
+   immutable owner map; v9-to-v10 adds inactive activation fields, active owner
+   states, and empty provisioning tables.
 7. If the validated integrity state is `Degraded`, fail startup without
-   changing it. Otherwise, if a validated v9 manifest contains one `Applying`
+   changing it. Otherwise, if a validated v10 manifest contains one `Applying`
    migration, require state `Migrating`, validate every shard against the
    trusted source/target fingerprint for its exact journal-prefix position,
    and resume it in ascending order. The final transaction publishes the
@@ -981,19 +1208,25 @@ returning:
    accepts only the exact current format. Re-scan for unexpected canonical
    shard filenames, strictly revalidate every expected file, publish `Ready`
    only after full validation, and commit.
-9. Open every shard once more with read-write, no-create, no-follow flags;
+9. If the manifest contains an active table-provisioning journal, keep startup
+   admission `Pending`, verify its exact identity and complete empty declaration
+   set, and resume from `next_shard`. Re-seed the first unacknowledged shard
+   idempotently, acknowledge only committed shards, then atomically activate the
+   native policies, clear the transient journal, and publish the complete
+   catalog only after every shard is durable.
+10. Open every shard once more with read-write, no-create, no-follow flags;
    enable cell-size checking; and validate identity, generation, WAL, the
    metadata-table integrity check, and the generation-bound application-schema
    fingerprint. `Verifying` requires one consensus across all shards. `Ready`
    requires the existing trusted fingerprint.
-10. In one manifest transaction, seal a first consensus as the committed
+11. In one manifest transaction, seal a first consensus as the committed
     fingerprint, transition `Verifying` to `Ready`, and refresh the root.
     Reconcile the catalog generation with other live handles for the canonical
     root, publish the startup gate `Ready`, and only then return `Storage`,
     `Database`, or `Engine`.
 
 SQLite transactional DDL keeps each numbered manifest step atomic within
-`manifest.sqlite`. A version-1 upgrade commits versions 2 through 9; a
+`manifest.sqlite`. A version-1 upgrade commits versions 2 through 10; a
 version-2 upgrade begins at 3, and so on. The v3-to-v4 step
 still creates the
 logical catalog, inserts database ID 1 named `default` plus the
@@ -1019,6 +1252,10 @@ consensus verification. The v7-to-v8 step changes no shard and clears advisory
 physical DDL. The v8-to-v9 step likewise changes no shard: it records every
 existing authoritative table as `None`, seeds owner slots from immutable
 physical shard IDs, and changes the manifest checksum domain.
+The v9-to-v10 step also changes no shard: it preserves every policy but marks
+it inactive, marks existing owners active, creates empty provisioning tables,
+and moves the checksum to version 3. Any later native activation is a distinct
+recoverable provisioning operation, not part of the format migration.
 
 A new application-schema migration follows a separate durable protocol:
 
@@ -1088,11 +1325,13 @@ later storage-hardening certification.
 
 ## Compatibility and operations
 
-- Version 1 upgrades through versions 2, 3, 4, 5, 6, 7, 8, and 9; later versions
+- Version 1 upgrades through versions 2, 3, 4, 5, 6, 7, 8, 9, and 10; later versions
   begin at the next numbered transaction. Opening is therefore potentially
   mutating. An active v6 journal is completed before its v7 transaction.
 - There is no automatic downgrade. Older readers are fenced by the incompatible
-  metadata schema and authoritative header. In particular, a version-8 reader
+  metadata schema and authoritative header. In particular, a version-9 reader
+  rejects `user_version = 10` before it can ignore policy activation, owner
+  lifecycle, or table provisioning; a version-8 reader
   rejects `user_version = 9` before it can ignore generated-ID policy and owner
   mappings, a version-7 reader
   rejects `user_version = 8` before it can treat authoritative table rows as
@@ -1147,7 +1386,7 @@ header value, format version, digest input, routing metadata, schema
 fingerprint, journal record, or recovery step. Listener settings are not
 persisted. Because engine open and its existing recovery precede listener
 binding, a later bind failure does not undo a migration or recovery transaction
-that already committed; a subsequent startup revalidates the same version-9
+that already committed; a subsequent startup revalidates the same version-10
 layout normally.
 
 Issue #29's pinned `pgwire` dependency and issue #30's production startup,
@@ -1192,8 +1431,8 @@ the in-process coordination is intentionally not a distributed lock.
 
 ## Verification contract
 
-Tests cover fresh creation and every v1/v2/v3/v4/v5/v6/v7/v8 upgrade path to
-v9, every
+Tests cover fresh creation and every v1/v2/v3/v4/v5/v6/v7/v8/v9 upgrade path to
+v10, every
 manifest layout and integrity state, the exact shard header and metadata row,
 dynamic schema generations, retained migration history, checksum golden
 vectors, and no-op ready reopen. Failure
@@ -1208,12 +1447,14 @@ being published before full strict revalidation. Concurrent openers exercise
 matching and conflicting shard counts and layout transitions.
 
 Catalog tests continue to cover default logical metadata, every placement and
-shard-key type code, every generated-ID policy and encoding boundary,
-legacy/native classification, immutable allocation-owner coverage, identifier
-and relational corruption, row limits, v7 advisory-row clearing, v8 explicit
-`None` migration, atomic registration and commit ambiguity, exact idempotency,
-empty-schema and key/constraint validation, immutable public lookups,
-stale-handle exclusion, and migration enforcement. Routing tests
+shard-key type code, every generated-ID policy, activation, and encoding
+boundary, legacy/native classification, active and retired allocation-owner
+coverage, identifier and relational corruption, row limits, v7 advisory-row
+clearing, v8 explicit `None` migration, v9 inactive-policy migration, atomic
+registration and commit ambiguity, provisioning-prefix replay at every commit
+boundary, exact idempotency, empty-schema and key/constraint validation,
+immutable public lookups, stale-handle exclusion, and migration enforcement.
+Routing tests
 freeze golden hash/bucket/shard vectors,
 cover every algorithm state for every supported shard count, prove the final
 map lookup with a synthetic reassignment, and exercise parallel and reopen

--- a/src/core/catalog.rs
+++ b/src/core/catalog.rs
@@ -653,6 +653,7 @@ pub(crate) struct CatalogSnapshot {
     routing: RoutingCatalog,
     logical: Catalog,
     allocation_owners: Option<AllocationOwnerMap>,
+    active_native_id_table_ids: Box<[TableId]>,
 }
 
 impl CatalogSnapshot {
@@ -662,6 +663,7 @@ impl CatalogSnapshot {
             routing,
             logical,
             allocation_owners: None,
+            active_native_id_table_ids: Box::new([]),
         }
     }
 
@@ -679,7 +681,23 @@ impl CatalogSnapshot {
             routing,
             logical,
             allocation_owners: Some(allocation_owners),
+            active_native_id_table_ids: Box::new([]),
         }
+    }
+
+    /// Attach the sorted manifest-validated set of allocator-active tables.
+    pub(crate) fn with_active_native_id_table_ids(mut self, table_ids: Box<[TableId]>) -> Self {
+        debug_assert!(table_ids.windows(2).all(|ids| ids[0] < ids[1]));
+        debug_assert!(table_ids.iter().all(|id| {
+            self.logical.table_by_id(*id).is_some_and(|table| {
+                matches!(
+                    table.generated_id_policy(),
+                    GeneratedIdPolicy::NativeRangeV1 { .. }
+                )
+            })
+        }));
+        self.active_native_id_table_ids = table_ids;
+        self
     }
 
     pub(crate) const fn routing(&self) -> &RoutingCatalog {
@@ -692,6 +710,16 @@ impl CatalogSnapshot {
 
     pub(crate) const fn allocation_owners(&self) -> Option<&AllocationOwnerMap> {
         self.allocation_owners.as_ref()
+    }
+
+    pub(crate) fn active_native_id_table_ids(&self) -> &[TableId] {
+        &self.active_native_id_table_ids
+    }
+
+    pub(crate) fn native_id_policy_is_active(&self, table_id: TableId) -> bool {
+        self.active_native_id_table_ids
+            .binary_search(&table_id)
+            .is_ok()
     }
 }
 

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -380,7 +380,8 @@ impl Engine {
                 statement_index,
                 parameters,
                 explicit_routing_key,
-            ),
+            )
+            .with_allocation_owners(self.inner.database.storage.allocation_owner_map()),
             super::planner::RoutingProvenance::new(
                 hash_version,
                 key_encoding_version,
@@ -1034,12 +1035,32 @@ impl Engine {
     }
 
     /// Execute a routed statement and return its selected shard.
+    ///
+    /// This compatibility method returns only the affected-row count. Use
+    /// [`Engine::execute_write`] when generated-key result data is needed.
     pub async fn execute(
         &self,
         session: &Session,
         statement: Statement,
     ) -> EngineResult<Routed<usize>> {
-        self.execute_with_context(session, statement, RequestContext::new())
+        self.execute_write(session, statement)
+            .await
+            .map(write_rows_affected)
+    }
+
+    /// Execute a routed statement with the result shape used for generated keys.
+    ///
+    /// The current public SQL planner rejects an omitted generated shard key,
+    /// so every statement accepted through this public planned path returns a
+    /// [`super::WriteResult`] whose `generated_key` is `None`. Roadmap issue
+    /// #130 will connect the lower-level same-connection allocator result to
+    /// this boundary.
+    pub async fn execute_write(
+        &self,
+        session: &Session,
+        statement: Statement,
+    ) -> EngineResult<Routed<super::WriteResult>> {
+        self.execute_write_with_context(session, statement, RequestContext::new())
             .await
     }
 
@@ -1062,15 +1083,36 @@ impl Engine {
             ExecuteOwnerPolicy::ReuseValidatedCatalogWrite,
         )
         .await
+        .map(write_rows_affected)
     }
 
     /// Execute a routed statement with explicit request controls.
+    ///
+    /// This compatibility method returns only the affected-row count. Use
+    /// [`Engine::execute_write_with_context`] to retain the complete write
+    /// result shape.
     pub async fn execute_with_context(
         &self,
         session: &Session,
         statement: Statement,
         context: RequestContext,
     ) -> EngineResult<Routed<usize>> {
+        self.execute_write_with_context(session, statement, context)
+            .await
+            .map(write_rows_affected)
+    }
+
+    /// Execute a routed statement with explicit request controls and the result
+    /// shape used for same-connection generated-key capture.
+    ///
+    /// Omitted generated-key Engine planning remains roadmap issue #130, so
+    /// currently accepted Engine statements return `generated_key: None`.
+    pub async fn execute_write_with_context(
+        &self,
+        session: &Session,
+        statement: Statement,
+        context: RequestContext,
+    ) -> EngineResult<Routed<super::WriteResult>> {
         self.execute_with_context_and_owner(
             session,
             statement,
@@ -1080,13 +1122,143 @@ impl Engine {
         .await
     }
 
+    /// Execute one preflighted native-ID INSERT on a caller-admitted shard.
+    ///
+    /// This crate-private seam deliberately does not parse an omitted-key SQL
+    /// form or choose a shard. Roadmap issue #130 owns that public planning;
+    /// its planner can call this method only after proving a single-row INSERT
+    /// and selecting an eligible physical owner.
+    #[cfg(feature = "experimental-vtab")]
+    #[allow(dead_code)] // Connected to public omitted-key planning by issue #130.
+    pub(crate) async fn execute_generated_write(
+        &self,
+        session: &Session,
+        statement: Statement,
+        table: super::TableId,
+        target_shard: u16,
+    ) -> EngineResult<Routed<super::WriteResult>> {
+        self.execute_generated_write_with_context(
+            session,
+            statement,
+            table,
+            target_shard,
+            RequestContext::new(),
+        )
+        .await
+    }
+
+    /// Execute a preflighted native-ID INSERT with request controls.
+    #[cfg(feature = "experimental-vtab")]
+    #[allow(dead_code)] // Connected to public omitted-key planning by issue #130.
+    pub(crate) async fn execute_generated_write_with_context(
+        &self,
+        session: &Session,
+        statement: Statement,
+        table: super::TableId,
+        target_shard: u16,
+        context: RequestContext,
+    ) -> EngineResult<Routed<super::WriteResult>> {
+        let mut operation = self.operation(context)?;
+        let schema_operation = match self.inner.database.storage.enter_schema_operation() {
+            Ok(guard) => guard,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let guard = match operation.wait_pending(self.ready_session(session)).await {
+            Ok(guard) => guard,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        if !self.inner.options.experimental_vtab_writes() {
+            return operation.finish(Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "experimental virtual-table writes are disabled",
+            )));
+        }
+        if target_shard >= self.shard_count() {
+            return operation.finish(Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                format!(
+                    "native generated INSERT target shard {target_shard} is outside shard count {}",
+                    self.shard_count()
+                ),
+            )));
+        }
+        let Some(table_metadata) = self.catalog().table_by_id(table) else {
+            return operation.finish(Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                format!("native generated INSERT refers to unknown table identity {table}"),
+            )));
+        };
+        if !matches!(
+            table_metadata.generated_id_policy(),
+            super::GeneratedIdPolicy::NativeRangeV1 { .. }
+        ) {
+            return operation.finish(Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "registered table {} does not use native_range_v1 generation",
+                    table_metadata.name()
+                ),
+            )));
+        }
+        if !self
+            .inner
+            .database
+            .storage
+            .native_id_policy_is_active(table)
+        {
+            return operation.finish(Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "native_range_v1 generation is not active for registered table {}",
+                    table_metadata.name()
+                ),
+            )));
+        }
+        let Some(allocation_owners) = self.inner.database.storage.allocation_owner_map() else {
+            return operation.finish(Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "native generated INSERT has no allocation-owner map",
+            )));
+        };
+        if allocation_owners
+            .owner_for_physical_shard(target_shard)
+            .is_none()
+        {
+            return operation.finish(Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "native generated INSERT target shard {target_shard} has no active allocation owner"
+                ),
+            )));
+        }
+
+        let (sql, params) = statement.into_parts();
+        let value = self
+            .run_coordinator_write(
+                &mut operation,
+                target_shard,
+                ConnectionOwner::new(session.id().get()),
+                schema_operation,
+                guard,
+                sql,
+                params,
+                Some(table),
+            )
+            .await;
+        let value = operation.finish_started(value)?;
+        Ok(Routed {
+            shard: target_shard,
+            value,
+        })
+    }
+
     async fn execute_with_context_and_owner(
         &self,
         session: &Session,
         statement: Statement,
         context: RequestContext,
         owner_policy: ExecuteOwnerPolicy,
-    ) -> EngineResult<Routed<usize>> {
+    ) -> EngineResult<Routed<super::WriteResult>> {
         let mut operation = self.operation(context)?;
         let schema_operation = match self.inner.database.storage.enter_schema_operation() {
             Ok(guard) => guard,
@@ -1111,16 +1283,6 @@ impl Engine {
             Err(error) => return operation.finish(Err(error)),
         };
         let catalog_authoritative = plan.is_some();
-        #[cfg(feature = "experimental-vtab")]
-        if catalog_authoritative
-            && self.inner.options.experimental_vtab_writes()
-            && plan.as_ref().is_some_and(|plan| plan.native_range_v1)
-        {
-            return operation.finish(Err(EngineError::new(
-                EngineErrorKind::Unsupported,
-                "experimental virtual-table Engine writes do not yet support native_range_v1 tables",
-            )));
-        }
         let owner = match (owner_policy, plan.is_some()) {
             (ExecuteOwnerPolicy::ReuseValidatedCatalogWrite, true) => {
                 ConnectionOwner::stateless_catalog_write()
@@ -1148,6 +1310,7 @@ impl Engine {
                     guard,
                     sql,
                     params,
+                    None,
                 )
                 .await;
             let value = operation.finish_started(value)?;
@@ -1173,6 +1336,7 @@ impl Engine {
             )
             .await;
         let value = operation.finish_started(value)?;
+        let value = super::WriteResult::without_generated_key(value);
         Ok(Routed { shard, value })
     }
 
@@ -1193,7 +1357,8 @@ impl Engine {
         session: OwnedMutexGuard<SessionInner>,
         sql: String,
         params: Vec<Value>,
-    ) -> EngineResult<usize> {
+        generated_table: Option<super::TableId>,
+    ) -> EngineResult<super::WriteResult> {
         // A cold registry cache briefly owns an unpooled read-only shard-0
         // handle; the physical DML child later owns the target-shard handle.
         // Serialize that one-time discovery, reserve every real handle through
@@ -1286,9 +1451,28 @@ impl Engine {
                 worker_control
                     .arm(Arc::new(move || cancellation.cancel_write_nonblocking()))
                     .map_err(CancellationReason::error)?;
-                coordinator
-                    .execute_dml_values(&sql, &params)
-                    .map(|result| result.affected_rows())
+                let result = match generated_table {
+                    Some(table) => coordinator.execute_generated_dml_values(
+                        &sql,
+                        &params,
+                        table.get(),
+                        shard,
+                    )?,
+                    None => coordinator.execute_dml_values(&sql, &params)?,
+                };
+                if result.shard().is_some_and(|actual| actual != shard) {
+                    return Err(EngineError::new(
+                        EngineErrorKind::Internal,
+                        format!(
+                            "writable coordinator mutated shard {}, but Engine admitted shard {shard}",
+                            result.shard().expect("checked as present")
+                        ),
+                    ));
+                }
+                Ok(super::WriteResult {
+                    rows_affected: result.affected_rows(),
+                    generated_key: result.generated_key().cloned(),
+                })
             })();
             drop(registry_bootstrap_gate);
             if result
@@ -2348,6 +2532,13 @@ fn pending_cancellation_reason(
     }
 }
 
+fn write_rows_affected(result: Routed<super::WriteResult>) -> Routed<usize> {
+    Routed {
+        shard: result.shard,
+        value: result.value.rows_affected,
+    }
+}
+
 fn required_routing_key(session: &SessionInner) -> EngineResult<&str> {
     session.routing_key().ok_or_else(|| {
         EngineError::new(
@@ -2436,6 +2627,52 @@ mod tests {
             .unwrap();
         let engine = Engine::from_database_with_options(Arc::new(database), options).unwrap();
         (temp, engine)
+    }
+
+    #[cfg(feature = "experimental-vtab")]
+    fn engine_with_native_events(shards: u16) -> (tempfile::TempDir, Engine, crate::core::TableId) {
+        let temp = tempfile::tempdir().unwrap();
+        let mut database = Database::open(temp.path(), shards).unwrap();
+        database
+            .broadcast(
+                "CREATE TABLE native_events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    payload TEXT NOT NULL
+                 );
+                 CREATE TABLE ordinary_events (
+                    id INTEGER PRIMARY KEY,
+                    payload TEXT NOT NULL
+                 )",
+            )
+            .unwrap();
+        let logical_database = database.catalog().default_database().id();
+        database
+            .register_tables(vec![
+                TableDeclaration::sharded(
+                    logical_database,
+                    "native_events",
+                    ShardKeyMetadata::new("id", ShardKeyType::Int64).unwrap(),
+                )
+                .unwrap()
+                .with_generated_id_policy(GeneratedIdPolicy::native_range_v1("id").unwrap())
+                .unwrap(),
+                TableDeclaration::sharded(
+                    logical_database,
+                    "ordinary_events",
+                    ShardKeyMetadata::new("id", ShardKeyType::Int64).unwrap(),
+                )
+                .unwrap(),
+            ])
+            .unwrap();
+        let table = database
+            .catalog()
+            .table("default", "native_events")
+            .unwrap()
+            .unwrap()
+            .id();
+        let options = EngineOptions::default().with_experimental_vtab_writes(true);
+        let engine = Engine::from_database_with_options(Arc::new(database), options).unwrap();
+        (temp, engine, table)
     }
 
     fn engine_with_prepared_catalog(
@@ -7453,15 +7690,15 @@ mod tests {
 
     #[cfg(feature = "experimental-vtab")]
     #[tokio::test]
-    async fn experimental_vtab_engine_rejects_native_range_targets_before_coordinator_open() {
+    async fn experimental_vtab_engine_routes_explicit_native_ids_to_their_owner() {
         let temp = tempfile::tempdir().unwrap();
         let mut database = Database::open(temp.path(), 4).unwrap();
         database
             .broadcast(
                 "CREATE TABLE native_events (
-                     id INTEGER PRIMARY KEY NOT NULL,
+                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                      payload TEXT NOT NULL
-                 ) STRICT",
+                 )",
             )
             .unwrap();
         let logical_database = database.catalog().default_database().id();
@@ -7514,31 +7751,49 @@ mod tests {
         let engine = Engine::from_database_with_options(Arc::new(database), options).unwrap();
         let session = engine.session();
 
-        // A valid explicit native ID would otherwise make the planner reserve
-        // and report its hash-selected shard while the coordinator writes to
-        // its encoded allocation owner. The reserved floor is more severe:
-        // the coordinator classifies it as corruption. Both must stop at the
-        // same client-facing Engine preflight while storage is still healthy.
-        for value in [native_id, reserved_floor] {
-            session.set_routing_key(value.to_string()).await.unwrap();
-            let error = engine
-                .execute(
-                    &session,
-                    Statement::new(
-                        "INSERT INTO native_events (id, payload) VALUES (?1, 'rejected')",
-                        vec![Value::Int64(value)],
-                    ),
-                )
-                .await
-                .unwrap_err();
-            assert_eq!(error.kind(), EngineErrorKind::Unsupported);
-            assert!(error.diagnostic().contains("native_range_v1"));
-            assert_eq!(session.state().await, SessionState::Ready);
-            assert_eq!(
-                engine.inner.database.storage.schema_gate_snapshot().state,
-                crate::storage::SchemaGateState::Ready
-            );
-        }
+        // The planner, pool admission, coordinator callback, and reported
+        // shard must all use the persisted allocation owner rather than the
+        // ordinary hash route for the decimal routing-context bytes.
+        session
+            .set_routing_key(native_id.to_string())
+            .await
+            .unwrap();
+        let inserted = engine
+            .execute_write(
+                &session,
+                Statement::new(
+                    "INSERT INTO native_events (id, payload) VALUES (?1, 'owner-routed')",
+                    vec![Value::Int64(native_id)],
+                ),
+            )
+            .await
+            .unwrap();
+        assert_eq!(inserted.shard, owner_shard);
+        assert_eq!(inserted.value.rows_affected, 1);
+        assert_eq!(inserted.value.generated_key, None);
+
+        // A sequence floor has native marker bits but is not a valid row ID.
+        // Reject it as caller input without degrading authoritative storage.
+        session
+            .set_routing_key(reserved_floor.to_string())
+            .await
+            .unwrap();
+        let error = engine
+            .execute(
+                &session,
+                Statement::new(
+                    "INSERT INTO native_events (id, payload) VALUES (?1, 'reserved')",
+                    vec![Value::Int64(reserved_floor)],
+                ),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::InvalidArgument);
+        assert_eq!(session.state().await, SessionState::Ready);
+        assert_eq!(
+            engine.inner.database.storage.schema_gate_snapshot().state,
+            crate::storage::SchemaGateState::Ready
+        );
 
         for shard in 0..engine.shard_count() {
             assert_eq!(
@@ -7552,14 +7807,289 @@ mod tests {
                         row.get::<_, i64>(0)
                     })
                     .unwrap(),
+                if shard == owner_shard { 1 } else { 0 },
+                "shard {shard}"
+            );
+        }
+    }
+
+    #[cfg(feature = "experimental-vtab")]
+    #[tokio::test]
+    async fn experimental_vtab_engine_generated_write_returns_the_routed_physical_key() {
+        let (temp, engine, table) = engine_with_native_events(2);
+        let session = engine.session();
+
+        // Issue #130 will select this target from public omitted-key SQL. This
+        // lower seam accepts only that already-admitted decision and does not
+        // require a session routing-key surrogate.
+        let inserted = engine
+            .execute_generated_write(
+                &session,
+                Statement::new(
+                    "INSERT INTO native_events (payload) VALUES (?1)",
+                    vec![Value::from("engine-generated")],
+                ),
+                table,
+                1,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(inserted.shard, 1);
+        assert_eq!(inserted.value.rows_affected, 1);
+        let generated = inserted.value.generated_key.unwrap();
+        assert_eq!(generated.column, "id");
+        let Value::Int64(generated_id) = generated.value else {
+            panic!("native_range_v1 must return an Int64 generated key");
+        };
+        let decoded = crate::core::generated_id::NativeRangeV1Id::decode(generated_id).unwrap();
+        assert_eq!(
+            engine
+                .inner
+                .database
+                .storage
+                .allocation_owner_map()
+                .unwrap()
+                .physical_shard(decoded.owner()),
+            Some(1)
+        );
+        assert_eq!(
+            rusqlite::Connection::open(temp.path().join("shards/0001.sqlite"))
+                .unwrap()
+                .query_row(
+                    "SELECT payload FROM native_events WHERE id = ?1",
+                    [generated_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .unwrap(),
+            "engine-generated"
+        );
+        assert_eq!(
+            rusqlite::Connection::open(temp.path().join("shards/0000.sqlite"))
+                .unwrap()
+                .query_row("SELECT COUNT(*) FROM native_events", [], |row| {
+                    row.get::<_, i64>(0)
+                })
+                .unwrap(),
+            0
+        );
+    }
+
+    #[cfg(feature = "experimental-vtab")]
+    #[tokio::test]
+    async fn experimental_vtab_generated_known_commit_wins_a_late_engine_cancellation() {
+        let (temp, engine, table) = engine_with_native_events(2);
+        let session = Arc::new(engine.session());
+        let token = CancellationToken::new();
+        let context = RequestContext::new().with_cancellation_token(token.clone());
+        let commit_gate = engine.inner.registry_schema_cache.install_commit_gate();
+        let cancellation_observer = engine
+            .inner
+            .registry_schema_cache
+            .install_cancellation_observer();
+
+        let write_engine = engine.clone();
+        let write_session = Arc::clone(&session);
+        let write = tokio::spawn(async move {
+            write_engine
+                .execute_generated_write_with_context(
+                    &write_session,
+                    Statement::new(
+                        "INSERT INTO native_events (payload) VALUES (?1)",
+                        vec![Value::from("committed-after-cancellation")],
+                    ),
+                    table,
+                    1,
+                    context,
+                )
+                .await
+        });
+        let mut commit_gate = timeout(
+            Duration::from_secs(2),
+            tokio::task::spawn_blocking(move || {
+                commit_gate.wait_until_started();
+                commit_gate
+            }),
+        )
+        .await
+        .expect("the generated child finalizer must claim the commit decision")
+        .unwrap();
+
+        assert!(token.cancel());
+        timeout(Duration::from_secs(2), async {
+            while !cancellation_observer.load(Ordering::Acquire) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("late cancellation must reach the generated commit linearization point");
+        commit_gate.release();
+
+        let inserted = timeout(Duration::from_secs(2), write)
+            .await
+            .expect("the known generated commit must finish after cancellation")
+            .unwrap()
+            .unwrap();
+        assert_eq!(inserted.shard, 1);
+        assert_eq!(inserted.value.rows_affected, 1);
+        let generated = inserted.value.generated_key.unwrap();
+        assert_eq!(generated.column, "id");
+        let Value::Int64(generated_id) = generated.value else {
+            panic!("native_range_v1 must return an Int64 generated key");
+        };
+        let decoded = crate::core::generated_id::NativeRangeV1Id::decode(generated_id).unwrap();
+        assert_eq!(
+            engine
+                .inner
+                .database
+                .storage
+                .allocation_owner_map()
+                .unwrap()
+                .physical_shard(decoded.owner()),
+            Some(1)
+        );
+        assert_eq!(
+            rusqlite::Connection::open(temp.path().join("shards/0001.sqlite"))
+                .unwrap()
+                .query_row(
+                    "SELECT payload FROM native_events WHERE id = ?1",
+                    [generated_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .unwrap(),
+            "committed-after-cancellation"
+        );
+        assert_eq!(session.state().await, SessionState::Ready);
+        assert_eq!(
+            engine.inner.database.storage.schema_gate_snapshot().state,
+            crate::storage::SchemaGateState::Ready
+        );
+        for shard in 0..engine.shard_count() {
+            wait_for_pool_occupancy(&engine, shard, 0, 0).await;
+        }
+        assert_eq!(engine.active_operations_for_test(), 0);
+    }
+
+    #[cfg(feature = "experimental-vtab")]
+    #[tokio::test]
+    async fn experimental_vtab_engine_generated_write_rejects_multirow_without_mutation() {
+        let (temp, engine, table) = engine_with_native_events(2);
+        let session = engine.session();
+
+        let error = engine
+            .execute_generated_write(
+                &session,
+                Statement::new(
+                    "INSERT INTO native_events (payload) VALUES ('first'), ('second')",
+                    vec![],
+                ),
+                table,
+                0,
+            )
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.kind(), EngineErrorKind::InvalidQuery);
+        assert!(
+            error
+                .diagnostic()
+                .contains("multi-row native generated INSERT")
+        );
+        assert_eq!(session.state().await, SessionState::Ready);
+        for shard in 0..engine.shard_count() {
+            assert_eq!(
+                rusqlite::Connection::open(temp.path().join(format!("shards/{shard:04}.sqlite")))
+                    .unwrap()
+                    .query_row("SELECT COUNT(*) FROM native_events", [], |row| {
+                        row.get::<_, i64>(0)
+                    })
+                    .unwrap(),
                 0,
                 "shard {shard}"
             );
         }
-        let pools = engine.pool_snapshot_for_test().unwrap();
-        assert!(pools.shards.iter().all(|shard| {
-            shard.active == 0 && shard.queued == 0 && shard.opened == 0 && shard.checkouts == 0
-        }));
+        assert_eq!(engine.active_operations_for_test(), 0);
+    }
+
+    #[cfg(feature = "experimental-vtab")]
+    #[tokio::test]
+    async fn experimental_vtab_engine_generated_write_validates_admission_before_mutation() {
+        let (temp, engine, native_table) = engine_with_native_events(2);
+        let session = engine.session();
+        let ordinary_table = engine
+            .catalog()
+            .table("default", "ordinary_events")
+            .unwrap()
+            .unwrap()
+            .id();
+
+        let cases = [
+            (native_table, 2, EngineErrorKind::InvalidArgument),
+            (ordinary_table, 0, EngineErrorKind::FailedPrecondition),
+            (
+                crate::core::TableId::new(u64::MAX).unwrap(),
+                0,
+                EngineErrorKind::InvalidArgument,
+            ),
+        ];
+        for (table, shard, expected) in cases {
+            let error = engine
+                .execute_generated_write(
+                    &session,
+                    Statement::new(
+                        "INSERT INTO native_events (payload) VALUES ('must-not-run')",
+                        vec![],
+                    ),
+                    table,
+                    shard,
+                )
+                .await
+                .unwrap_err();
+            assert_eq!(error.kind(), expected);
+            assert_eq!(session.state().await, SessionState::Ready);
+        }
+
+        let cancellation = CancellationToken::new();
+        assert!(cancellation.cancel());
+        let error = engine
+            .execute_generated_write_with_context(
+                &session,
+                Statement::new(
+                    "INSERT INTO native_events (payload) VALUES ('cancelled')",
+                    vec![],
+                ),
+                native_table,
+                0,
+                RequestContext::new().with_cancellation_token(cancellation),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Cancelled);
+
+        for shard in 0..engine.shard_count() {
+            let connection =
+                rusqlite::Connection::open(temp.path().join(format!("shards/{shard:04}.sqlite")))
+                    .unwrap();
+            assert_eq!(
+                connection
+                    .query_row("SELECT COUNT(*) FROM native_events", [], |row| {
+                        row.get::<_, i64>(0)
+                    })
+                    .unwrap(),
+                0,
+                "shard {shard}"
+            );
+            assert_eq!(
+                connection
+                    .query_row("SELECT COUNT(*) FROM ordinary_events", [], |row| {
+                        row.get::<_, i64>(0)
+                    })
+                    .unwrap(),
+                0,
+                "shard {shard}"
+            );
+        }
+        assert_eq!(engine.active_operations_for_test(), 0);
     }
 
     #[cfg(feature = "experimental-vtab")]

--- a/src/core/generated_id.rs
+++ b/src/core/generated_id.rs
@@ -46,6 +46,16 @@ impl AllocationOwnerSlot {
     }
 }
 
+/// Durable lifecycle state for one native-range allocation namespace.
+///
+/// Retired owners remain routable so committed historical IDs can still be
+/// read, but they are never selected for a new SQLite allocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum AllocationOwnerState {
+    Active,
+    Retired,
+}
+
 /// Immutable, bidirectional assignment of generated-ID owner slots to
 /// physical SQLite shards.
 ///
@@ -55,7 +65,7 @@ impl AllocationOwnerSlot {
 /// the same immutable runtime snapshot.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct AllocationOwnerMap {
-    by_owner: Box<[(AllocationOwnerSlot, u16)]>,
+    by_owner: Box<[(AllocationOwnerSlot, u16, AllocationOwnerState)]>,
     by_physical_shard: Box<[AllocationOwnerSlot]>,
 }
 
@@ -66,27 +76,53 @@ impl AllocationOwnerMap {
         physical_shard_count: u16,
         pairs: Box<[(u16, u16)]>,
     ) -> EngineResult<Self> {
+        Self::try_from_assignments(
+            physical_shard_count,
+            pairs
+                .into_vec()
+                .into_iter()
+                .map(|(owner, physical_shard)| {
+                    (owner, physical_shard, AllocationOwnerState::Active)
+                })
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        )
+    }
+
+    /// Validate active and historical owner assignments for the current
+    /// physical shard set and normalize them into owner-slot order.
+    ///
+    /// Every physical shard has exactly one active allocator. Any number of
+    /// retired owners may retain a route to that shard, and every owner slot
+    /// appears at most once across both lifecycle states. The active owner for
+    /// a shard must be greater than all of its retired owners so SQLite's
+    /// non-decreasing `AUTOINCREMENT` high-water mark remains in the active
+    /// owner's encoded range.
+    pub(crate) fn try_from_assignments(
+        physical_shard_count: u16,
+        assignments: Box<[(u16, u16, AllocationOwnerState)]>,
+    ) -> EngineResult<Self> {
         if physical_shard_count == 0 {
             return Err(EngineError::new(
                 EngineErrorKind::InvalidArgument,
                 "an allocation-owner map requires at least one physical shard",
             ));
         }
-        if pairs.len() != usize::from(physical_shard_count) {
+        if assignments.len() < usize::from(physical_shard_count) {
             return Err(EngineError::new(
                 EngineErrorKind::InvalidArgument,
-                "an allocation-owner map must contain exactly one entry per physical shard",
+                "an allocation-owner map must contain an active entry for every physical shard",
             ));
         }
 
-        let mut by_owner = pairs
+        let mut by_owner = assignments
             .into_vec()
             .into_iter()
-            .map(|(owner, physical_shard)| {
-                AllocationOwnerSlot::new(owner).map(|owner| (owner, physical_shard))
+            .map(|(owner, physical_shard, state)| {
+                AllocationOwnerSlot::new(owner).map(|owner| (owner, physical_shard, state))
             })
             .collect::<EngineResult<Vec<_>>>()?;
-        by_owner.sort_unstable_by_key(|(owner, _)| *owner);
+        by_owner.sort_unstable_by_key(|(owner, _, _)| *owner);
         if by_owner
             .windows(2)
             .any(|entries| entries[0].0 == entries[1].0)
@@ -98,8 +134,8 @@ impl AllocationOwnerMap {
         }
 
         let mut by_physical_shard = vec![None; usize::from(physical_shard_count)];
-        for &(owner, physical_shard) in &by_owner {
-            let Some(entry) = by_physical_shard.get_mut(usize::from(physical_shard)) else {
+        for &(owner, physical_shard, state) in &by_owner {
+            let Some(active_owner) = by_physical_shard.get_mut(usize::from(physical_shard)) else {
                 return Err(EngineError::new(
                     EngineErrorKind::InvalidArgument,
                     format!(
@@ -108,11 +144,11 @@ impl AllocationOwnerMap {
                     ),
                 ));
             };
-            if entry.replace(owner).is_some() {
+            if state == AllocationOwnerState::Active && active_owner.replace(owner).is_some() {
                 return Err(EngineError::new(
                     EngineErrorKind::InvalidArgument,
                     format!(
-                        "physical shard {physical_shard} cannot have more than one allocation owner"
+                        "physical shard {physical_shard} cannot have more than one active allocation owner"
                     ),
                 ));
             }
@@ -129,6 +165,22 @@ impl AllocationOwnerMap {
                 })
             })
             .collect::<EngineResult<Vec<_>>>()?;
+        for &(retired_owner, physical_shard, state) in &by_owner {
+            if state != AllocationOwnerState::Retired {
+                continue;
+            }
+            let active_owner = by_physical_shard[usize::from(physical_shard)];
+            if active_owner <= retired_owner {
+                return Err(EngineError::new(
+                    EngineErrorKind::InvalidArgument,
+                    format!(
+                        "active allocation owner {} for physical shard {physical_shard} must be greater than retired owner {}",
+                        active_owner.get(),
+                        retired_owner.get()
+                    ),
+                ));
+            }
+        }
 
         Ok(Self {
             by_owner: by_owner.into_boxed_slice(),
@@ -138,9 +190,20 @@ impl AllocationOwnerMap {
 
     pub(crate) fn physical_shard(&self, owner: AllocationOwnerSlot) -> Option<u16> {
         self.by_owner
-            .binary_search_by_key(&owner, |(candidate, _)| *candidate)
+            .binary_search_by_key(&owner, |(candidate, _, _)| *candidate)
             .ok()
             .map(|index| self.by_owner[index].1)
+    }
+
+    pub(crate) fn owner_state(&self, owner: AllocationOwnerSlot) -> Option<AllocationOwnerState> {
+        self.by_owner
+            .binary_search_by_key(&owner, |(candidate, _, _)| *candidate)
+            .ok()
+            .map(|index| self.by_owner[index].2)
+    }
+
+    pub(crate) fn owner_is_active(&self, owner: AllocationOwnerSlot) -> bool {
+        self.owner_state(owner) == Some(AllocationOwnerState::Active)
     }
 
     pub(crate) fn owner_for_physical_shard(
@@ -160,7 +223,15 @@ impl AllocationOwnerMap {
     pub(crate) fn pairs(&self) -> impl ExactSizeIterator<Item = (u16, u16)> + '_ {
         self.by_owner
             .iter()
-            .map(|(owner, physical_shard)| (owner.get(), *physical_shard))
+            .map(|(owner, physical_shard, _)| (owner.get(), *physical_shard))
+    }
+
+    pub(crate) fn assignments(
+        &self,
+    ) -> impl ExactSizeIterator<Item = (u16, u16, AllocationOwnerState)> + '_ {
+        self.by_owner
+            .iter()
+            .map(|(owner, physical_shard, state)| (owner.get(), *physical_shard, *state))
     }
 }
 
@@ -250,6 +321,29 @@ pub(crate) fn classify_generated_id(
     }
 }
 
+/// Classify a caller-supplied value without treating malformed input as
+/// corruption of already-committed storage.
+///
+/// In particular, the owner-local sequence-zero sentinel is valid only in
+/// `sqlite_sequence`; callers cannot insert it as a row ID.
+pub(crate) fn classify_caller_generated_id(
+    policy: &GeneratedIdPolicy,
+    encoded: i64,
+) -> EngineResult<GeneratedIdClassification> {
+    match policy {
+        GeneratedIdPolicy::None => Ok(GeneratedIdClassification::Legacy(encoded)),
+        GeneratedIdPolicy::NativeRangeV1 { .. } => {
+            decode_native_range_v1_with_reserved_error(encoded, EngineErrorKind::InvalidArgument)
+                .map(|decoded| {
+                    decoded.map_or(
+                        GeneratedIdClassification::Legacy(encoded),
+                        GeneratedIdClassification::NativeRangeV1,
+                    )
+                })
+        }
+    }
+}
+
 /// SQLite `sqlite_sequence` floor for an empty owner-local table.
 ///
 /// This sentinel contains the v1 marker and owner but local sequence zero, so
@@ -259,11 +353,32 @@ pub(crate) fn native_range_v1_sequence_floor(owner: AllocationOwnerSlot) -> i64 
     i64::try_from(sequence_floor_bits(owner)).expect("native_range_v1 reserves the signed high bit")
 }
 
+/// First row ID SQLite allocates after an owner-local sequence floor.
+pub(crate) fn native_range_v1_first_id(owner: AllocationOwnerSlot) -> i64 {
+    native_range_v1_sequence_floor(owner)
+        .checked_add(1)
+        .expect("every native-range owner has a non-empty signed ID interval")
+}
+
+/// Last row ID that belongs to an owner-local allocation range.
+pub(crate) fn native_range_v1_sequence_ceiling(owner: AllocationOwnerSlot) -> i64 {
+    NativeRangeV1Id::new(owner, MAX_NATIVE_RANGE_V1_LOCAL_SEQUENCE)
+        .expect("the codec's maximum local sequence is valid")
+        .encode()
+}
+
 fn sequence_floor_bits(owner: AllocationOwnerSlot) -> u64 {
     NATIVE_RANGE_V1_FORMAT_MARKER | (u64::from(owner.get()) << NATIVE_RANGE_V1_OWNER_SHIFT)
 }
 
 fn decode_native_range_v1(encoded: i64) -> EngineResult<Option<NativeRangeV1Id>> {
+    decode_native_range_v1_with_reserved_error(encoded, EngineErrorKind::DataCorruption)
+}
+
+fn decode_native_range_v1_with_reserved_error(
+    encoded: i64,
+    reserved_error_kind: EngineErrorKind,
+) -> EngineResult<Option<NativeRangeV1Id>> {
     if encoded < 0 {
         return Ok(None);
     }
@@ -275,7 +390,7 @@ fn decode_native_range_v1(encoded: i64) -> EngineResult<Option<NativeRangeV1Id>>
     let local_sequence = bits & MAX_NATIVE_RANGE_V1_LOCAL_SEQUENCE;
     if local_sequence == 0 {
         return Err(EngineError::new(
-            EngineErrorKind::DataCorruption,
+            reserved_error_kind,
             "native_range_v1 row ID contains the reserved local sequence zero",
         ));
     }
@@ -344,9 +459,25 @@ mod tests {
                 EngineErrorKind::DataCorruption
             );
             assert_eq!(
-                floor.checked_add(1).unwrap(),
+                native_range_v1_first_id(owner),
                 NativeRangeV1Id::new(owner, 1).unwrap().encode()
             );
+            assert_eq!(
+                native_range_v1_sequence_ceiling(owner),
+                NativeRangeV1Id::new(owner, MAX_NATIVE_RANGE_V1_LOCAL_SEQUENCE)
+                    .unwrap()
+                    .encode()
+            );
+        }
+    }
+
+    #[test]
+    fn caller_classification_rejects_reserved_floors_as_input_not_corruption() {
+        for owner in [0, 1, 63, MAX_ALLOCATION_OWNER_SLOT] {
+            let floor = native_range_v1_sequence_floor(AllocationOwnerSlot::new(owner).unwrap());
+            let error = classify_caller_generated_id(&native_policy(), floor).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::InvalidArgument);
+            assert!(error.diagnostic().contains("sequence zero"));
         }
     }
 
@@ -413,6 +544,7 @@ mod tests {
     fn codec_types_are_owned_send_and_sync() {
         fn assert_owned<T: Clone + Send + Sync + 'static>() {}
         assert_owned::<AllocationOwnerSlot>();
+        assert_owned::<AllocationOwnerState>();
         assert_owned::<AllocationOwnerMap>();
         assert_owned::<NativeRangeV1Id>();
         assert_owned::<GeneratedIdClassification>();
@@ -441,6 +573,105 @@ mod tests {
             None
         );
         assert_eq!(map.owner_for_physical_shard(4), None);
+    }
+
+    #[test]
+    fn retired_owners_keep_historical_routes_but_cannot_allocate() {
+        let map = AllocationOwnerMap::try_from_assignments(
+            2,
+            vec![
+                (7, 0, AllocationOwnerState::Retired),
+                (8, 0, AllocationOwnerState::Active),
+                (11, 1, AllocationOwnerState::Active),
+            ]
+            .into_boxed_slice(),
+        )
+        .unwrap();
+
+        let retired = AllocationOwnerSlot::new(7).unwrap();
+        let replacement = AllocationOwnerSlot::new(8).unwrap();
+        assert_eq!(map.physical_shard(retired), Some(0));
+        assert_eq!(
+            map.owner_state(retired),
+            Some(AllocationOwnerState::Retired)
+        );
+        assert!(!map.owner_is_active(retired));
+        assert_eq!(map.owner_for_physical_shard(0), Some(replacement));
+        assert!(map.owner_is_active(replacement));
+        assert_eq!(
+            map.assignments().collect::<Vec<_>>(),
+            [
+                (7, 0, AllocationOwnerState::Retired),
+                (8, 0, AllocationOwnerState::Active),
+                (11, 1, AllocationOwnerState::Active),
+            ]
+        );
+    }
+
+    #[test]
+    fn replacement_owner_must_advance_past_every_retired_owner_on_its_shard() {
+        let error = AllocationOwnerMap::try_from_assignments(
+            2,
+            vec![
+                (9, 0, AllocationOwnerState::Retired),
+                (8, 0, AllocationOwnerState::Active),
+                (0, 1, AllocationOwnerState::Active),
+            ]
+            .into_boxed_slice(),
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::InvalidArgument);
+        assert_eq!(
+            error.diagnostic(),
+            "active allocation owner 8 for physical shard 0 must be greater than retired owner 9"
+        );
+
+        // Succession is monotonic per physical shard, not a global ordering
+        // between otherwise independent shard allocators.
+        let valid = AllocationOwnerMap::try_from_assignments(
+            2,
+            vec![
+                (7, 0, AllocationOwnerState::Retired),
+                (9, 0, AllocationOwnerState::Retired),
+                (10, 0, AllocationOwnerState::Active),
+                (1, 1, AllocationOwnerState::Active),
+            ]
+            .into_boxed_slice(),
+        )
+        .unwrap();
+        assert_eq!(
+            valid.owner_for_physical_shard(0),
+            Some(AllocationOwnerSlot::new(10).unwrap())
+        );
+        assert_eq!(
+            valid.owner_for_physical_shard(1),
+            Some(AllocationOwnerSlot::new(1).unwrap())
+        );
+    }
+
+    #[test]
+    fn owner_lifecycle_requires_one_active_allocator_per_shard() {
+        for assignments in [
+            vec![
+                (0, 0, AllocationOwnerState::Retired),
+                (1, 1, AllocationOwnerState::Active),
+            ],
+            vec![
+                (0, 0, AllocationOwnerState::Active),
+                (1, 0, AllocationOwnerState::Active),
+                (2, 1, AllocationOwnerState::Active),
+            ],
+            vec![
+                (0, 0, AllocationOwnerState::Active),
+                (0, 1, AllocationOwnerState::Retired),
+                (2, 1, AllocationOwnerState::Active),
+            ],
+        ] {
+            assert!(
+                AllocationOwnerMap::try_from_assignments(2, assignments.into_boxed_slice())
+                    .is_err()
+            );
+        }
     }
 
     #[test]

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -58,7 +58,8 @@ pub(crate) use routing::{
 pub(crate) use scatter::merge_scatter_results;
 pub use session::{Session, SessionId, SessionState};
 pub use types::{
-    Column, DataType, Decimal, ParseDecimalError, ResultSet, ResultSetShapeError, Row, Value,
+    Column, DataType, Decimal, GeneratedKey, ParseDecimalError, ResultSet, ResultSetShapeError,
+    Row, Value, WriteResult,
 };
 pub(crate) use worker::BlockingPool;
 
@@ -78,8 +79,6 @@ pub(crate) enum RawDataOperation {
 pub(crate) struct RawDataPlan {
     pub(crate) shard: u16,
     pub(crate) sqlite_sql: String,
-    #[cfg(feature = "experimental-vtab")]
-    pub(crate) native_range_v1: bool,
 }
 
 #[derive(Debug)]
@@ -187,7 +186,8 @@ impl Database {
                 0,
                 params,
                 Some(shard_key.as_bytes()),
-            ),
+            )
+            .with_allocation_owners(self.storage.allocation_owner_map()),
             planner::RoutingProvenance::new(
                 hash_version,
                 key_encoding_version,
@@ -197,23 +197,9 @@ impl Database {
             |key| self.shard_for_key(key),
         )?;
         let shard = raw_data_execution_shard(&plan, catalog, operation)?;
-        #[cfg(feature = "experimental-vtab")]
-        let native_range_v1 = plan
-            .inference()
-            .table_id()
-            .and_then(|table| catalog.table_by_id(table))
-            .is_some_and(|table| {
-                matches!(
-                    table.generated_id_policy(),
-                    GeneratedIdPolicy::NativeRangeV1 { .. }
-                )
-            });
-
         Ok(Some(RawDataPlan {
             shard,
             sqlite_sql: translated.sqlite_sql().to_owned(),
-            #[cfg(feature = "experimental-vtab")]
-            native_range_v1,
         }))
     }
 

--- a/src/core/planner.rs
+++ b/src/core/planner.rs
@@ -8,7 +8,9 @@ use crate::sql::{
 };
 
 use super::{
-    Catalog, EngineError, EngineErrorKind, EngineResult, LogicalDatabaseId, TablePlacement, Value,
+    AllocationOwnerMap, Catalog, EngineError, EngineErrorKind, EngineResult, GeneratedIdPolicy,
+    LogicalDatabaseId, TableMetadata, TablePlacement, Value,
+    generated_id::{GeneratedIdClassification, classify_caller_generated_id},
 };
 
 /// Borrowed typed shard key encoded identically by every routing entry point.
@@ -178,6 +180,7 @@ pub(super) struct BoundStatementPlanInput<'a> {
     statement_index: usize,
     parameters: &'a [Value],
     explicit_routing_key: Option<&'a [u8]>,
+    allocation_owners: Option<&'a AllocationOwnerMap>,
 }
 
 impl<'a> BoundStatementPlanInput<'a> {
@@ -196,7 +199,16 @@ impl<'a> BoundStatementPlanInput<'a> {
             statement_index,
             parameters,
             explicit_routing_key,
+            allocation_owners: None,
         }
+    }
+
+    pub(super) const fn with_allocation_owners(
+        mut self,
+        allocation_owners: Option<&'a AllocationOwnerMap>,
+    ) -> Self {
+        self.allocation_owners = allocation_owners;
+        self
     }
 }
 
@@ -239,6 +251,7 @@ where
         statement_index,
         parameters,
         explicit_routing_key,
+        allocation_owners,
     } = input;
     let classification = classify_normalized_statements(normalized)?;
     let behavior = classification.behavior(statement_index).ok_or_else(|| {
@@ -250,6 +263,10 @@ where
     let schema_generation = catalog.schema_generation();
     let inference = infer_shard_keys(catalog, database, normalized, statement_index, parameters)?;
     validate_inference_shape(&inference)?;
+    let inferred_table = inference
+        .table_id()
+        .and_then(|table| catalog.table_by_id(table))
+        .filter(|table| table.database_id() == database);
 
     let mut unique_routes = HashMap::<&ShardKeyValue, PlannedRoute>::new();
     let mut inferred_routes = Vec::with_capacity(inference.values().len());
@@ -260,7 +277,13 @@ where
         }
         let key_bytes = canonical_key_bytes(value);
         let route = PlannedRoute {
-            shard: shard_for_key(&key_bytes),
+            shard: route_inferred_value(
+                inferred_table,
+                allocation_owners,
+                value,
+                &key_bytes,
+                &mut shard_for_key,
+            )?,
             key_bytes,
         };
         unique_routes.insert(value, route.clone());
@@ -268,9 +291,19 @@ where
     }
     drop(unique_routes);
 
-    let explicit_route = explicit_routing_key.map(|key| PlannedRoute {
-        shard: shard_for_key(key),
-        key_bytes: Arc::from(key),
+    let explicit_route = explicit_routing_key.map(|key| {
+        // A protocol routing key that is byte-for-byte the canonical inferred
+        // key must resolve through the same table policy. In particular, a
+        // native-range integer is owner-routed rather than re-hashed merely
+        // because it arrived through session context as decimal text.
+        let shard = inferred_routes
+            .iter()
+            .find(|route| route.key_bytes() == key)
+            .map_or_else(|| shard_for_key(key), PlannedRoute::shard);
+        PlannedRoute {
+            shard,
+            key_bytes: Arc::from(key),
+        }
     });
 
     let shard_key_column = sharded_key_column(catalog, database, &inference)?;
@@ -278,6 +311,7 @@ where
         .map(|column| routed_dml_shape(normalized, statement_index, column))
         .transpose()?
         .flatten();
+    reject_retired_owner_insert(dml, inferred_table, allocation_owners, inference.values())?;
     let inferred_shards = inferred_shards(&inferred_routes);
 
     if matches!(
@@ -318,6 +352,51 @@ where
         explicit_route,
         assigned_shard,
     })
+}
+
+fn reject_retired_owner_insert(
+    dml: Option<RoutedDml>,
+    table: Option<&TableMetadata>,
+    allocation_owners: Option<&AllocationOwnerMap>,
+    values: &[ShardKeyValue],
+) -> EngineResult<()> {
+    if dml != Some(RoutedDml::Insert) {
+        return Ok(());
+    }
+    let Some(table) = table else {
+        return Ok(());
+    };
+    let GeneratedIdPolicy::NativeRangeV1 { .. } = table.generated_id_policy() else {
+        return Ok(());
+    };
+    let owners = allocation_owners.ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "native_range_v1 table metadata is missing its allocation-owner map",
+        )
+    })?;
+    for value in values {
+        let ShardKeyValue::Int64(value) = value else {
+            continue;
+        };
+        let GeneratedIdClassification::NativeRangeV1(native) =
+            classify_caller_generated_id(table.generated_id_policy(), *value)?
+        else {
+            continue;
+        };
+        if owners.physical_shard(native.owner()).is_some()
+            && !owners.owner_is_active(native.owner())
+        {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "native_range_v1 owner {} is retired and cannot accept new IDs",
+                    native.owner().get()
+                ),
+            ));
+        }
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -449,6 +528,49 @@ fn planning_invariant() -> EngineError {
     )
 }
 
+fn route_inferred_value<F>(
+    table: Option<&TableMetadata>,
+    allocation_owners: Option<&AllocationOwnerMap>,
+    value: &ShardKeyValue,
+    canonical_key: &[u8],
+    shard_for_key: &mut F,
+) -> EngineResult<u16>
+where
+    F: FnMut(&[u8]) -> u16,
+{
+    let Some(table) = table else {
+        return Ok(shard_for_key(canonical_key));
+    };
+    let (GeneratedIdPolicy::NativeRangeV1 { .. }, ShardKeyValue::Int64(value)) =
+        (table.generated_id_policy(), value)
+    else {
+        return Ok(shard_for_key(canonical_key));
+    };
+
+    let classification = classify_caller_generated_id(table.generated_id_policy(), *value)?;
+    let GeneratedIdClassification::NativeRangeV1(native) = classification else {
+        // Negative and pre-marker values deliberately retain the frozen legacy
+        // hash route so imported identifiers never move when native allocation
+        // is enabled explicitly for future rows.
+        return Ok(shard_for_key(canonical_key));
+    };
+    let owners = allocation_owners.ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "native_range_v1 table metadata is missing its allocation-owner map",
+        )
+    })?;
+    owners.physical_shard(native.owner()).ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!(
+                "native_range_v1 owner {} is not assigned to an active physical shard",
+                native.owner().get()
+            ),
+        )
+    })
+}
+
 fn canonical_key_bytes(value: &ShardKeyValue) -> Arc<[u8]> {
     let canonical = match value {
         ShardKeyValue::Int64(value) => {
@@ -544,6 +666,41 @@ mod tests {
             ]
             .into_boxed_slice(),
         )
+    }
+
+    fn native_range_catalog() -> Catalog {
+        Catalog::from_validated_parts(
+            1,
+            7,
+            DEFAULT_DATABASE,
+            vec![LogicalDatabaseMetadata::from_validated(
+                DEFAULT_DATABASE,
+                "default".to_owned(),
+            )]
+            .into_boxed_slice(),
+            vec![TableMetadata::from_validated_with_generated_id_policy(
+                EVENTS_TABLE,
+                DEFAULT_DATABASE,
+                "native_events".to_owned(),
+                TablePlacement::Sharded(ShardKeyMetadata::from_validated(
+                    "id".to_owned(),
+                    ShardKeyType::Int64,
+                )),
+                GeneratedIdPolicy::native_range_v1("id").unwrap(),
+            )]
+            .into_boxed_slice(),
+        )
+    }
+
+    fn owner_map(shard_count: u16) -> AllocationOwnerMap {
+        AllocationOwnerMap::try_from_pairs(
+            shard_count,
+            (0..shard_count)
+                .map(|shard| (shard, shard))
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        )
+        .unwrap()
     }
 
     fn register_engine_catalog_fixture(database: &mut Database) {
@@ -1113,6 +1270,184 @@ mod tests {
             let diagnostic = error.to_string();
             assert!(!diagnostic.contains("different-shard-context"));
             assert!(!diagnostic.contains("private"));
+        }
+    }
+
+    #[test]
+    fn native_ids_route_by_persisted_owner_and_canonical_explicit_context() {
+        let catalog = native_range_catalog();
+        let owners = owner_map(4);
+        let owner = owners.owner_for_physical_shard(2).unwrap();
+        let value = crate::core::generated_id::NativeRangeV1Id::new(owner, 41)
+            .unwrap()
+            .encode();
+        let normalized = normalize(
+            SqlDialect::Sqlite,
+            "INSERT INTO native_events (id) VALUES (?1)",
+        );
+        let explicit = value.to_string();
+        let plan = plan_bound_statement(
+            BoundStatementPlanInput::new(
+                &catalog,
+                database_id(DEFAULT_DATABASE),
+                &normalized,
+                0,
+                &[Value::Int64(value)],
+                Some(explicit.as_bytes()),
+            )
+            .with_allocation_owners(Some(&owners)),
+            RoutingProvenance::new(1, 1, 1, 1),
+            |_| 3,
+        )
+        .unwrap();
+
+        assert_eq!(plan.inferred_routes()[0].shard(), 2);
+        assert_eq!(plan.explicit_route().unwrap().shard(), 2);
+        assert_eq!(plan.assigned_shard(), Some(2));
+    }
+
+    #[test]
+    fn native_policy_preserves_legacy_hash_routes_exactly() {
+        let catalog = native_range_catalog();
+        let owners = owner_map(4);
+        let routing = routing_catalog(4);
+        for value in [-19_i64, 0, 42, 0x3fff_ffff_ffff_ffff] {
+            let normalized = normalize(
+                SqlDialect::Sqlite,
+                "SELECT * FROM native_events WHERE id = ?1",
+            );
+            let expected = routing.shard_for_key(value.to_string().as_bytes());
+            let plan = plan_bound_statement(
+                BoundStatementPlanInput::new(
+                    &catalog,
+                    database_id(DEFAULT_DATABASE),
+                    &normalized,
+                    0,
+                    &[Value::Int64(value)],
+                    None,
+                )
+                .with_allocation_owners(Some(&owners)),
+                RoutingProvenance::new(1, 1, 1, 1),
+                |key| routing.shard_for_key(key),
+            )
+            .unwrap();
+            assert_eq!(plan.inferred_routes()[0].shard(), expected, "{value}");
+        }
+    }
+
+    #[test]
+    fn retired_native_owner_routes_reads_but_rejects_new_explicit_ids() {
+        let catalog = native_range_catalog();
+        let owners = AllocationOwnerMap::try_from_assignments(
+            2,
+            vec![
+                (
+                    0,
+                    0,
+                    crate::core::generated_id::AllocationOwnerState::Retired,
+                ),
+                (
+                    2,
+                    0,
+                    crate::core::generated_id::AllocationOwnerState::Active,
+                ),
+                (
+                    1,
+                    1,
+                    crate::core::generated_id::AllocationOwnerState::Active,
+                ),
+            ]
+            .into_boxed_slice(),
+        )
+        .unwrap();
+        let retired_id = crate::core::generated_id::NativeRangeV1Id::new(
+            crate::core::generated_id::AllocationOwnerSlot::new(0).unwrap(),
+            41,
+        )
+        .unwrap()
+        .encode();
+
+        for source in [
+            "SELECT * FROM native_events WHERE id = ?1",
+            "DELETE FROM native_events WHERE id = ?1",
+        ] {
+            let normalized = normalize(SqlDialect::Sqlite, source);
+            let plan = plan_bound_statement(
+                BoundStatementPlanInput::new(
+                    &catalog,
+                    database_id(DEFAULT_DATABASE),
+                    &normalized,
+                    0,
+                    &[Value::Int64(retired_id)],
+                    None,
+                )
+                .with_allocation_owners(Some(&owners)),
+                RoutingProvenance::new(1, 1, 1, 1),
+                |_| 1,
+            )
+            .unwrap();
+            assert_eq!(plan.assigned_shard(), Some(0), "{source}");
+        }
+
+        let insert = normalize(
+            SqlDialect::Sqlite,
+            "INSERT INTO native_events (id) VALUES (?1)",
+        );
+        let error = plan_bound_statement(
+            BoundStatementPlanInput::new(
+                &catalog,
+                database_id(DEFAULT_DATABASE),
+                &insert,
+                0,
+                &[Value::Int64(retired_id)],
+                None,
+            )
+            .with_allocation_owners(Some(&owners)),
+            RoutingProvenance::new(1, 1, 1, 1),
+            |_| 1,
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert!(error.diagnostic().contains("retired"));
+    }
+
+    #[test]
+    fn reserved_or_unassigned_native_owners_fail_before_execution() {
+        let catalog = native_range_catalog();
+        let owners = owner_map(4);
+        let normalized = normalize(
+            SqlDialect::Sqlite,
+            "INSERT INTO native_events (id) VALUES (?1)",
+        );
+        let reserved = crate::core::generated_id::native_range_v1_sequence_floor(
+            owners.owner_for_physical_shard(1).unwrap(),
+        );
+        let unassigned = crate::core::generated_id::NativeRangeV1Id::new(
+            crate::core::generated_id::AllocationOwnerSlot::new(9).unwrap(),
+            1,
+        )
+        .unwrap()
+        .encode();
+
+        for (value, kind) in [
+            (reserved, EngineErrorKind::InvalidArgument),
+            (unassigned, EngineErrorKind::FailedPrecondition),
+        ] {
+            let error = plan_bound_statement(
+                BoundStatementPlanInput::new(
+                    &catalog,
+                    database_id(DEFAULT_DATABASE),
+                    &normalized,
+                    0,
+                    &[Value::Int64(value)],
+                    None,
+                )
+                .with_allocation_owners(Some(&owners)),
+                RoutingProvenance::new(1, 1, 1, 1),
+                |_| 0,
+            )
+            .unwrap_err();
+            assert_eq!(error.kind(), kind, "{value}: {error}");
         }
     }
 

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -138,6 +138,69 @@ impl From<Decimal> for Value {
     }
 }
 
+/// One generated column value captured by the write that produced it.
+///
+/// Adapters must render the typed [`Value`] directly from this result instead
+/// of consulting connection-local SQLite state after a pooled handle has been
+/// released. Native-range IDs are represented as [`Value::Int64`]. Values
+/// produced by the Engine always use the canonical logical catalog column.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct GeneratedKey {
+    /// Canonical logical column name from the table catalog.
+    pub column: String,
+    /// Generated value captured on the same physical SQLite connection.
+    pub value: Value,
+}
+
+impl GeneratedKey {
+    /// Construct a generated-key value.
+    ///
+    /// This protocol-neutral container does not validate `column`; Engine
+    /// results provide the stronger canonical-catalog-name guarantee described
+    /// on [`GeneratedKey`].
+    pub fn new(column: impl Into<String>, value: Value) -> Self {
+        Self {
+            column: column.into(),
+            value,
+        }
+    }
+}
+
+/// Protocol-neutral outcome of one logical write.
+///
+/// The native-range allocation contract accepts at most one automatically
+/// generated row per statement, so `generated_key` is singular. Statements
+/// with explicit keys, updates, and deletes return `None`. The current public
+/// Engine SQL planner also returns `None` because omitted generated-key
+/// planning remains roadmap issue #130.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct WriteResult {
+    /// Rows durably affected by the reconciled physical operation.
+    pub rows_affected: usize,
+    /// Generated key captured before the owning SQLite handle was released.
+    pub generated_key: Option<GeneratedKey>,
+}
+
+impl WriteResult {
+    /// Construct a write result that did not allocate a key.
+    pub const fn without_generated_key(rows_affected: usize) -> Self {
+        Self {
+            rows_affected,
+            generated_key: None,
+        }
+    }
+
+    /// Construct a write result containing one generated key.
+    pub fn with_generated_key(rows_affected: usize, generated_key: GeneratedKey) -> Self {
+        Self {
+            rows_affected,
+            generated_key: Some(generated_key),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Decimal {
     representation: String,
@@ -394,6 +457,20 @@ mod tests {
         assert_eq!(Value::from(true).as_str(), None);
         assert_eq!(Value::from(vec![1_u8, 2]).as_bytes(), Some(&[1, 2][..]));
         assert_eq!(Value::Null.as_bytes(), None);
+    }
+
+    #[test]
+    fn write_results_carry_generated_keys_without_connection_state() {
+        let ordinary = WriteResult::without_generated_key(2);
+        assert_eq!(ordinary.rows_affected, 2);
+        assert_eq!(ordinary.generated_key, None);
+
+        let generated = WriteResult::with_generated_key(
+            1,
+            GeneratedKey::new("id", Value::Int64(0x4000_0000_0000_0001)),
+        );
+        assert_eq!(generated.rows_affected, 1);
+        assert_eq!(generated.generated_key.unwrap().column, "id");
     }
 
     #[test]

--- a/src/import/copy.rs
+++ b/src/import/copy.rs
@@ -10,7 +10,8 @@ use rusqlite::{
 use crate::{
     core::{
         CancellationToken, CanonicalShardKeyRef, EngineError, EngineErrorKind, EngineResult,
-        ShardKeyType, TablePlacement, canonical_shard_key_bytes,
+        GeneratedIdPolicy, ShardKeyType, TablePlacement, canonical_shard_key_bytes,
+        generated_id::{AllocationOwnerMap, AllocationOwnerSlot, native_range_v1_sequence_floor},
     },
     sqlite_error,
     storage::Storage,
@@ -80,7 +81,12 @@ fn copy_and_verify_on_connections(
     begin_target_transactions(targets)?;
     let copied = (|| {
         let expectations = copy_tables(source, storage, targets, cancellation)?;
-        restore_sequences(source.sequences(), targets, cancellation)?;
+        restore_sequences(
+            source,
+            storage.allocation_owner_map(),
+            targets,
+            cancellation,
+        )?;
         commit_target_transactions(targets, cancellation, fault)?;
         Ok(expectations)
     })();
@@ -94,7 +100,12 @@ fn copy_and_verify_on_connections(
 
     ensure_not_cancelled(cancellation)?;
     let reports = verify_tables(source, storage, targets, &expectations, cancellation)?;
-    verify_sequences(source.sequences(), targets, cancellation)?;
+    verify_sequences(
+        source,
+        storage.allocation_owner_map(),
+        targets,
+        cancellation,
+    )?;
     for (shard, connection) in targets.iter().enumerate() {
         ensure_not_cancelled(cancellation)?;
         verify_quick_check(connection, shard)?;
@@ -216,7 +227,7 @@ fn validate_committed_placement(storage: &Storage, table: &SourceTable) -> Engin
             ),
         )
     })?;
-    let matches = match (table.placement(), committed.placement()) {
+    let placement_matches = match (table.placement(), committed.placement()) {
         (SqliteImportPlacement::Global, TablePlacement::Global) => table.shard_key().is_none(),
         (SqliteImportPlacement::Sharded { .. }, TablePlacement::Sharded(committed_key)) => {
             table.shard_key().is_some_and(|source_key| {
@@ -226,7 +237,7 @@ fn validate_committed_placement(storage: &Storage, table: &SourceTable) -> Engin
         }
         _ => false,
     };
-    if matches {
+    if placement_matches && table.generated_id_policy() == committed.generated_id_policy() {
         Ok(())
     } else {
         Err(EngineError::new(
@@ -509,15 +520,17 @@ fn canonical_key_for_import<'a>(
 }
 
 fn restore_sequences(
-    sequences: &[SourceSequence],
+    source: &SourceSnapshot,
+    allocation_owners: Option<&AllocationOwnerMap>,
     targets: &[Connection],
     cancellation: &CancellationToken,
 ) -> EngineResult<()> {
+    let native_tables = native_range_v1_tables(source);
     for (shard, connection) in targets.iter().enumerate() {
         ensure_not_cancelled(cancellation)?;
         let exists = sqlite_sequence_exists(connection)?;
         if !exists {
-            if sequences.is_empty() {
+            if source.sequences().is_empty() && native_tables.is_empty() {
                 continue;
             }
             return Err(EngineError::new(
@@ -527,10 +540,26 @@ fn restore_sequences(
                 ),
             ));
         }
-        connection
-            .execute("DELETE FROM main.sqlite_sequence", [])
+        let sequence_names = connection
+            .prepare("SELECT name FROM main.sqlite_sequence ORDER BY rowid")
+            .and_then(|mut statement| {
+                statement
+                    .query_map([], |row| row.get::<_, String>(0))?
+                    .collect::<Result<Vec<_>, _>>()
+            })
             .map_err(sqlite_error::storage)?;
-        for sequence in sequences {
+        for name in sequence_names {
+            if !native_tables.iter().any(|table| table == &name) {
+                connection
+                    .execute("DELETE FROM main.sqlite_sequence WHERE name = ?1", [&name])
+                    .map_err(sqlite_error::storage)?;
+            }
+        }
+        for sequence in source
+            .sequences()
+            .iter()
+            .filter(|sequence| !native_tables.iter().any(|table| table == sequence.table()))
+        {
             ensure_not_cancelled(cancellation)?;
             connection
                 .execute(
@@ -543,8 +572,96 @@ fn restore_sequences(
                     ))
                 })?;
         }
+        if !native_tables.is_empty() {
+            let owner = import_allocation_owner(allocation_owners, shard)?;
+            let floor = native_range_v1_sequence_floor(owner);
+            for table in &native_tables {
+                ensure_not_cancelled(cancellation)?;
+                validate_imported_native_sequence_floor(connection, table, floor, shard)?;
+            }
+        }
     }
     Ok(())
+}
+
+fn validate_imported_native_sequence_floor(
+    connection: &Connection,
+    table: &str,
+    floor: i64,
+    shard: usize,
+) -> EngineResult<()> {
+    let rows = connection
+        .query_row(
+            "SELECT count(*) FROM main.sqlite_sequence WHERE name = ?1",
+            [table],
+            |row| row.get::<_, i64>(0),
+        )
+        .map_err(sqlite_error::storage)?;
+    if rows != 1 {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!(
+                "native_range_v1 import table {table} has {rows} sqlite_sequence rows on physical shard {shard}; expected exactly one provisioned owner floor"
+            ),
+        ));
+    }
+    let observed = connection
+        .query_row(
+            "SELECT seq FROM main.sqlite_sequence WHERE name = ?1",
+            [table],
+            |row| row.get::<_, i64>(0),
+        )
+        .map_err(|error| {
+            sqlite_error::storage(error).context(format!(
+                "native_range_v1 import table {table} has a malformed sqlite_sequence value on physical shard {shard}"
+            ))
+        })?;
+    if observed != floor {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!(
+                "native_range_v1 import table {table} has sqlite_sequence {observed} on physical shard {shard}; expected provisioned owner floor {floor}"
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn import_allocation_owner(
+    allocation_owners: Option<&AllocationOwnerMap>,
+    shard: usize,
+) -> EngineResult<AllocationOwnerSlot> {
+    let shard = u16::try_from(shard).map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::LimitExceeded,
+            "SQLite import shard index exceeds its supported representation",
+            error,
+        )
+    })?;
+    allocation_owners
+        .and_then(|owners| owners.owner_for_physical_shard(shard))
+        .ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!(
+                    "native_range_v1 SQLite import is missing an allocation owner for physical shard {shard}"
+                ),
+            )
+        })
+}
+
+fn native_range_v1_tables(source: &SourceSnapshot) -> Vec<String> {
+    source
+        .tables()
+        .iter()
+        .filter(|table| {
+            matches!(
+                table.generated_id_policy(),
+                GeneratedIdPolicy::NativeRangeV1 { .. }
+            )
+        })
+        .map(|table| table.name().to_owned())
+        .collect()
 }
 
 fn verify_tables(
@@ -691,17 +808,28 @@ fn scan_target_table(
 }
 
 fn verify_sequences(
-    source: &[SourceSequence],
+    source: &SourceSnapshot,
+    allocation_owners: Option<&AllocationOwnerMap>,
     targets: &[Connection],
     cancellation: &CancellationToken,
 ) -> EngineResult<()> {
-    let mut expected = source
+    let native_tables = native_range_v1_tables(source);
+    let mut ordinary_expected = source
+        .sequences()
         .iter()
+        .filter(|sequence| !native_tables.iter().any(|table| table == sequence.table()))
         .map(|sequence| (sequence.table().to_owned(), sequence.seq()))
         .collect::<Vec<_>>();
-    expected.sort();
+    ordinary_expected.sort();
     for (shard, connection) in targets.iter().enumerate() {
         ensure_not_cancelled(cancellation)?;
+        let mut expected = ordinary_expected.clone();
+        if !native_tables.is_empty() {
+            let floor =
+                native_range_v1_sequence_floor(import_allocation_owner(allocation_owners, shard)?);
+            expected.extend(native_tables.iter().map(|table| (table.clone(), floor)));
+        }
+        expected.sort();
         if !sqlite_sequence_exists(connection)? {
             if expected.is_empty() {
                 continue;
@@ -960,6 +1088,88 @@ fn row_count_overflow() -> EngineError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn sequence_restore_keeps_native_owner_floors_instead_of_source_high_water() {
+        let source_file = tempfile::NamedTempFile::new().unwrap();
+        let source_connection = Connection::open(source_file.path()).unwrap();
+        source_connection
+            .execute_batch(
+                "CREATE TABLE native_ids(
+                     id INTEGER PRIMARY KEY AUTOINCREMENT,
+                     value TEXT NOT NULL
+                 );
+                 CREATE TABLE legacy_ids(
+                     id INTEGER PRIMARY KEY AUTOINCREMENT,
+                     value TEXT NOT NULL
+                 );
+                 INSERT INTO native_ids(id, value) VALUES (17, 'legacy-native-table');
+                 INSERT INTO legacy_ids(id, value) VALUES (23, 'legacy-table');",
+            )
+            .unwrap();
+        drop(source_connection);
+        let plan = super::super::SqliteImportPlan::new(vec![
+            super::super::SqliteTableImportPlan::sharded_by_primary_key("native_ids")
+                .with_native_range_v1("id")
+                .unwrap(),
+            super::super::SqliteTableImportPlan::sharded_by_primary_key("legacy_ids"),
+        ]);
+        let source = SourceSnapshot::open(source_file.path(), &plan).unwrap();
+        let owners =
+            AllocationOwnerMap::try_from_pairs(2, vec![(7, 0), (3, 1)].into_boxed_slice()).unwrap();
+        let targets = (0..2)
+            .map(|shard| {
+                let connection = Connection::open_in_memory().unwrap();
+                connection
+                    .execute_batch(
+                        "CREATE TABLE native_ids(
+                             id INTEGER PRIMARY KEY AUTOINCREMENT,
+                             value TEXT NOT NULL
+                         );
+                         CREATE TABLE legacy_ids(
+                             id INTEGER PRIMARY KEY AUTOINCREMENT,
+                             value TEXT NOT NULL
+                         );",
+                    )
+                    .unwrap();
+                let owner = owners.owner_for_physical_shard(shard).unwrap();
+                connection
+                    .execute(
+                        "INSERT INTO sqlite_sequence(name, seq) VALUES ('native_ids', ?1)",
+                        [native_range_v1_sequence_floor(owner)],
+                    )
+                    .unwrap();
+                connection
+            })
+            .collect::<Vec<_>>();
+
+        restore_sequences(&source, Some(&owners), &targets, &CancellationToken::new()).unwrap();
+        verify_sequences(&source, Some(&owners), &targets, &CancellationToken::new()).unwrap();
+        for (shard, connection) in targets.iter().enumerate() {
+            let native: i64 = connection
+                .query_row(
+                    "SELECT seq FROM sqlite_sequence WHERE name = 'native_ids'",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            let owner = owners
+                .owner_for_physical_shard(u16::try_from(shard).unwrap())
+                .unwrap();
+            assert_eq!(native, native_range_v1_sequence_floor(owner));
+            assert_ne!(native, 17);
+            assert_eq!(
+                connection
+                    .query_row(
+                        "SELECT seq FROM sqlite_sequence WHERE name = 'legacy_ids'",
+                        [],
+                        |row| row.get::<_, i64>(0)
+                    )
+                    .unwrap(),
+                23
+            );
+        }
+    }
 
     #[test]
     fn multiset_digest_is_order_independent_and_multiplicity_sensitive() {

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -14,7 +14,9 @@ use std::{
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error as _};
 
 use crate::{
-    core::{CancellationToken, Database, EngineError, EngineErrorKind, EngineResult},
+    core::{
+        CancellationToken, Database, EngineError, EngineErrorKind, EngineResult, GeneratedIdPolicy,
+    },
     storage::{MAX_SCHEMA_MIGRATION_SQL_BYTES, Storage},
 };
 
@@ -88,12 +90,54 @@ pub enum SqliteForeignKeyPolicy {
     Omit,
 }
 
+/// Explicit generated-ID policy for one imported SQLite table.
+///
+/// Existing import plans omit this field and retain the historical behavior:
+/// every imported key is caller-owned and routed by the legacy hash codec.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "policy", rename_all = "snake_case", deny_unknown_fields)]
+#[non_exhaustive]
+pub enum SqliteGeneratedIdPlan {
+    /// Do not enable BriskDB-generated IDs for this table.
+    #[default]
+    None,
+    /// Seed one SQLite `AUTOINCREMENT` range per physical shard after
+    /// validating the named column as the table's signed-integer shard key.
+    #[non_exhaustive]
+    NativeRangeV1 {
+        /// Exact canonical lowercase generated column name.
+        column: String,
+    },
+}
+
+impl SqliteGeneratedIdPlan {
+    /// Construct an explicitly enabled native shard-range policy.
+    pub fn native_range_v1(column: impl Into<String>) -> EngineResult<Self> {
+        let column = column.into();
+        GeneratedIdPolicy::native_range_v1(column.clone())?;
+        Ok(Self::NativeRangeV1 { column })
+    }
+
+    /// Return the generated column, or `None` when generation is disabled.
+    pub fn column(&self) -> Option<&str> {
+        match self {
+            Self::None => None,
+            Self::NativeRangeV1 { column } => Some(column),
+        }
+    }
+}
+
+const fn generated_id_plan_is_none(policy: &SqliteGeneratedIdPlan) -> bool {
+    matches!(policy, SqliteGeneratedIdPlan::None)
+}
+
 /// Complete explicit import declaration for one source table.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SqliteTableImportPlan {
     name: String,
     placement: SqliteImportPlacement,
     foreign_keys: SqliteForeignKeyPolicy,
+    generated_id: SqliteGeneratedIdPlan,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -112,6 +156,8 @@ struct SqliteTableImportPlanWire {
     shard_key: Option<SqliteShardKeyPlan>,
     #[serde(default)]
     foreign_keys: SqliteForeignKeyPolicy,
+    #[serde(default)]
+    generated_id: SqliteGeneratedIdPlan,
 }
 
 #[derive(Serialize)]
@@ -122,6 +168,8 @@ struct SqliteTableImportPlanRef<'a> {
     shard_key: Option<&'a SqliteShardKeyPlan>,
     #[serde(skip_serializing_if = "foreign_key_policy_is_reject")]
     foreign_keys: SqliteForeignKeyPolicy,
+    #[serde(skip_serializing_if = "generated_id_plan_is_none")]
+    generated_id: &'a SqliteGeneratedIdPlan,
 }
 
 const fn foreign_key_policy_is_reject(policy: &SqliteForeignKeyPolicy) -> bool {
@@ -149,6 +197,7 @@ impl<'de> Deserialize<'de> for SqliteTableImportPlan {
             name: wire.name,
             placement,
             foreign_keys: wire.foreign_keys,
+            generated_id: wire.generated_id,
         })
     }
 }
@@ -169,6 +218,7 @@ impl Serialize for SqliteTableImportPlan {
             placement,
             shard_key,
             foreign_keys: self.foreign_keys,
+            generated_id: &self.generated_id,
         }
         .serialize(serializer)
     }
@@ -190,6 +240,7 @@ impl SqliteTableImportPlan {
                 },
             },
             foreign_keys: SqliteForeignKeyPolicy::Reject,
+            generated_id: SqliteGeneratedIdPlan::None,
         }
     }
 
@@ -201,6 +252,7 @@ impl SqliteTableImportPlan {
                 shard_key: SqliteShardKeyPlan::PrimaryKey,
             },
             foreign_keys: SqliteForeignKeyPolicy::Reject,
+            generated_id: SqliteGeneratedIdPlan::None,
         }
     }
 
@@ -210,6 +262,7 @@ impl SqliteTableImportPlan {
             name: name.into(),
             placement: SqliteImportPlacement::Global,
             foreign_keys: SqliteForeignKeyPolicy::Reject,
+            generated_id: SqliteGeneratedIdPlan::None,
         }
     }
 
@@ -218,6 +271,16 @@ impl SqliteTableImportPlan {
     pub fn with_foreign_key_policy(mut self, policy: SqliteForeignKeyPolicy) -> Self {
         self.foreign_keys = policy;
         self
+    }
+
+    /// Enable the native shard-local SQLite allocator for one generated key.
+    ///
+    /// Source-schema preflight still proves that this exact column is the
+    /// Sharded `Int64` key and is declared `INTEGER PRIMARY KEY
+    /// AUTOINCREMENT`; merely selecting the policy cannot weaken those checks.
+    pub fn with_native_range_v1(mut self, column: impl Into<String>) -> EngineResult<Self> {
+        self.generated_id = SqliteGeneratedIdPlan::native_range_v1(column)?;
+        Ok(self)
     }
 
     /// Return the exact declared source table name.
@@ -233,6 +296,11 @@ impl SqliteTableImportPlan {
     /// Return the source foreign-key policy.
     pub const fn foreign_key_policy(&self) -> SqliteForeignKeyPolicy {
         self.foreign_keys
+    }
+
+    /// Return the explicitly selected generated-ID import policy.
+    pub const fn generated_id_plan(&self) -> &SqliteGeneratedIdPlan {
+        &self.generated_id
     }
 }
 
@@ -636,6 +704,29 @@ mod tests {
             &SqliteImportPlacement::Sharded {
                 shard_key: SqliteShardKeyPlan::PrimaryKey
             }
+        );
+        assert_eq!(table.generated_id_plan(), &SqliteGeneratedIdPlan::None);
+        assert_eq!(
+            serde_json::to_string(&table).unwrap(),
+            r#"{"name":"events","placement":"sharded","shard_key":{"strategy":"primary_key"}}"#
+        );
+
+        let native: SqliteTableImportPlan = serde_json::from_str(
+            r#"{"name":"events","placement":"sharded","generated_id":{"policy":"native_range_v1","column":"id"}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            native.generated_id_plan(),
+            &SqliteGeneratedIdPlan::NativeRangeV1 {
+                column: "id".to_owned()
+            }
+        );
+        assert_eq!(
+            SqliteTableImportPlan::sharded_by_primary_key("events")
+                .with_native_range_v1("Bad-Id")
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::InvalidArgument
         );
 
         assert!(

--- a/src/import/schema.rs
+++ b/src/import/schema.rs
@@ -12,13 +12,14 @@ use same_file::Handle;
 
 use super::{
     MAX_SQLITE_IMPORT_ROW_BYTES, OmittedForeignKey, SQLITE_IMPORT_PLAN_VERSION,
-    SqliteForeignKeyPolicy, SqliteImportKeyType, SqliteImportPlacement, SqliteImportPlan,
-    SqliteShardKeyPlan, SqliteTableImportPlan,
+    SqliteForeignKeyPolicy, SqliteGeneratedIdPlan, SqliteImportKeyType, SqliteImportPlacement,
+    SqliteImportPlan, SqliteShardKeyPlan, SqliteTableImportPlan,
 };
 use crate::{
     core::{
         CancellationToken, EngineError, EngineErrorKind, EngineResult, GeneratedIdPolicy,
         LogicalDatabaseId, MAX_TABLES, ShardKeyMetadata, ShardKeyType, TableDeclaration,
+        generated_id::NATIVE_RANGE_V1_FORMAT_MARKER,
     },
     sqlite_error,
 };
@@ -45,6 +46,7 @@ pub(super) struct SourceTable {
     placement: SqliteImportPlacement,
     columns: Vec<SourceColumn>,
     shard_key: Option<SourceShardKey>,
+    generated_id_policy: GeneratedIdPolicy,
     rowid_projection: Option<String>,
     without_rowid: bool,
     strict: bool,
@@ -229,6 +231,12 @@ impl SourceSnapshot {
                     Some(resolve_shard_key(&connection, &raw, &columns, shard_key)?)
                 }
             };
+            let generated_id_policy = resolve_generated_id_policy(
+                &connection,
+                &raw,
+                shard_key.as_ref(),
+                table_plan.generated_id_plan(),
+            )?;
 
             tables.push(SourceTable {
                 name: raw.name,
@@ -238,6 +246,7 @@ impl SourceSnapshot {
                 placement: table_plan.placement().clone(),
                 columns,
                 shard_key,
+                generated_id_policy,
                 rowid_projection,
                 without_rowid: raw.without_rowid,
                 strict: raw.strict,
@@ -341,7 +350,7 @@ impl SourceSnapshot {
                     ),
                     None => TableDeclaration::global(database_id, table.name()),
                 }?;
-                declaration.with_generated_id_policy(GeneratedIdPolicy::None)
+                declaration.with_generated_id_policy(table.generated_id_policy().clone())
             })
             .collect()
     }
@@ -374,6 +383,10 @@ impl SourceTable {
 
     pub(super) const fn shard_key(&self) -> Option<&SourceShardKey> {
         self.shard_key.as_ref()
+    }
+
+    pub(super) const fn generated_id_policy(&self) -> &GeneratedIdPolicy {
+        &self.generated_id_policy
     }
 
     /// Unshadowed SQLite magic name used to preserve an implicit rowid.
@@ -869,6 +882,79 @@ fn resolve_shard_key(
         column: column.name.clone(),
         key_type,
     })
+}
+
+fn resolve_generated_id_policy(
+    connection: &Connection,
+    table: &RawTable,
+    shard_key: Option<&SourceShardKey>,
+    plan: &SqliteGeneratedIdPlan,
+) -> EngineResult<GeneratedIdPolicy> {
+    let SqliteGeneratedIdPlan::NativeRangeV1 { column } = plan else {
+        return Ok(GeneratedIdPolicy::None);
+    };
+    let policy = GeneratedIdPolicy::native_range_v1(column.clone())?;
+    let key = shard_key.ok_or_else(|| {
+        precondition(format!(
+            "source table {} cannot enable native_range_v1 unless it is Sharded",
+            table.name
+        ))
+    })?;
+    if key.column() != column || key.key_type() != SqliteImportKeyType::Int64 {
+        return Err(precondition(format!(
+            "native_range_v1 column {}.{} must be the table's Sharded Int64 key",
+            table.name, column
+        )));
+    }
+
+    let (declared_type, _, _, primary_key, auto_increment) = connection
+        .column_metadata(Some("main"), table.name.as_str(), column.as_str())
+        .map_err(sqlite_error::storage)?;
+    let exact_integer =
+        declared_type.is_some_and(|declared| declared.to_bytes().eq_ignore_ascii_case(b"INTEGER"));
+    if !exact_integer || !primary_key || !auto_increment || table.without_rowid {
+        return Err(precondition(format!(
+            "native_range_v1 column {}.{} must be exactly INTEGER PRIMARY KEY AUTOINCREMENT",
+            table.name, column
+        )));
+    }
+
+    let marker = i64::try_from(NATIVE_RANGE_V1_FORMAT_MARKER)
+        .expect("native_range_v1 marker fits in a signed SQLite INTEGER");
+    let marked_id_exists = connection
+        .query_row(
+            &format!(
+                "SELECT EXISTS(SELECT 1 FROM {} WHERE {} >= ?1)",
+                quote_identifier(&table.name),
+                quote_identifier(column)
+            ),
+            [marker],
+            |row| row.get::<_, bool>(0),
+        )
+        .map_err(sqlite_error::storage)?;
+    if marked_id_exists {
+        return Err(precondition(format!(
+            "source table {} contains an ID in the reserved native_range_v1 namespace; imported IDs must remain legacy-routed",
+            table.name
+        )));
+    }
+    let marked_sequence_exists = connection
+        .query_row(
+            "SELECT EXISTS(
+                 SELECT 1 FROM main.sqlite_sequence
+                 WHERE name = ?1 AND typeof(seq) = 'integer' AND seq >= ?2
+             )",
+            (table.name.as_str(), marker),
+            |row| row.get::<_, bool>(0),
+        )
+        .map_err(sqlite_error::storage)?;
+    if marked_sequence_exists {
+        return Err(precondition(format!(
+            "source table {} has a sqlite_sequence high-water mark in the reserved native_range_v1 namespace; resetting it could reuse a previously committed ID",
+            table.name
+        )));
+    }
+    Ok(policy)
 }
 
 fn resolve_rowid_projection(
@@ -1865,6 +1951,10 @@ mod tests {
         SqliteTableImportPlan::sharded_by_primary_key(name)
     }
 
+    fn native_primary(name: &str, column: &str) -> SqliteTableImportPlan {
+        sharded_primary(name).with_native_range_v1(column).unwrap()
+    }
+
     #[test]
     fn inventories_exact_schema_counts_indexes_sequences_and_generated_columns() {
         let source = create_source(
@@ -1913,6 +2003,119 @@ mod tests {
                     .get::<_, i64>(0))
                 .unwrap(),
             1
+        );
+        assert_eq!(table.generated_id_policy(), &GeneratedIdPolicy::None);
+    }
+
+    #[test]
+    fn native_range_import_is_explicit_and_reaches_the_table_declaration() {
+        let source = create_source(
+            "CREATE TABLE records(
+                 id INTEGER PRIMARY KEY AUTOINCREMENT,
+                 value TEXT NOT NULL
+             );
+             INSERT INTO records(id, value) VALUES (-7, 'negative'), (11, 'legacy');",
+        );
+        let snapshot = SourceSnapshot::open(
+            source.path(),
+            &SqliteImportPlan::new(vec![native_primary("records", "id")]),
+        )
+        .unwrap();
+        assert_eq!(
+            snapshot.tables()[0].generated_id_policy(),
+            &GeneratedIdPolicy::native_range_v1("id").unwrap()
+        );
+        let declarations = snapshot
+            .table_declarations(LogicalDatabaseId::new(1).unwrap())
+            .unwrap();
+        assert_eq!(
+            declarations[0].generated_id_policy(),
+            &GeneratedIdPolicy::native_range_v1("id").unwrap()
+        );
+    }
+
+    #[test]
+    fn native_range_import_requires_the_exact_autoincrement_shard_key() {
+        let no_autoincrement =
+            create_source("CREATE TABLE records(id INTEGER PRIMARY KEY, value TEXT NOT NULL);");
+        let error = SourceSnapshot::open(
+            no_autoincrement.path(),
+            &SqliteImportPlan::new(vec![native_primary("records", "id")]),
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert!(
+            error
+                .diagnostic()
+                .contains("exactly INTEGER PRIMARY KEY AUTOINCREMENT"),
+            "{error}"
+        );
+
+        let wrong_column = create_source(
+            "CREATE TABLE records(
+                 id INTEGER PRIMARY KEY AUTOINCREMENT,
+                 other INTEGER NOT NULL
+             );",
+        );
+        let error = SourceSnapshot::open(
+            wrong_column.path(),
+            &SqliteImportPlan::new(vec![native_primary("records", "other")]),
+        )
+        .unwrap_err();
+        assert!(error.diagnostic().contains("Sharded Int64 key"), "{error}");
+
+        let global = create_source(
+            "CREATE TABLE records(id INTEGER PRIMARY KEY AUTOINCREMENT, value TEXT);",
+        );
+        let error = SourceSnapshot::open(
+            global.path(),
+            &SqliteImportPlan::new(vec![
+                SqliteTableImportPlan::global("records")
+                    .with_native_range_v1("id")
+                    .unwrap(),
+            ]),
+        )
+        .unwrap_err();
+        assert!(
+            error.diagnostic().contains("unless it is Sharded"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn native_range_import_rejects_source_ids_in_the_marked_namespace() {
+        let marked = i64::try_from(NATIVE_RANGE_V1_FORMAT_MARKER).unwrap() + 1;
+        let source = create_source(&format!(
+            "CREATE TABLE records(id INTEGER PRIMARY KEY AUTOINCREMENT, value TEXT NOT NULL);
+             INSERT INTO records(id, value) VALUES ({marked}, 'already-marked');"
+        ));
+        let error = SourceSnapshot::open(
+            source.path(),
+            &SqliteImportPlan::new(vec![native_primary("records", "id")]),
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert!(
+            error
+                .diagnostic()
+                .contains("reserved native_range_v1 namespace"),
+            "{error}"
+        );
+
+        let deleted = create_source(&format!(
+            "CREATE TABLE records(id INTEGER PRIMARY KEY AUTOINCREMENT, value TEXT NOT NULL);
+             INSERT INTO records(id, value) VALUES ({marked}, 'committed-then-deleted');
+             DELETE FROM records;"
+        ));
+        let error = SourceSnapshot::open(
+            deleted.path(),
+            &SqliteImportPlan::new(vec![native_primary("records", "id")]),
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert!(
+            error.diagnostic().contains("resetting it could reuse"),
+            "{error}"
         );
     }
 

--- a/src/storage/manifest.rs
+++ b/src/storage/manifest.rs
@@ -5,6 +5,9 @@ use rusqlite::{Connection, Transaction, TransactionBehavior, types::ValueRef};
 #[cfg(test)]
 use std::cell::Cell;
 
+#[cfg(all(test, feature = "experimental-vtab"))]
+use crate::core::generated_id::AllocationOwnerSlot;
+use crate::core::generated_id::AllocationOwnerState;
 use crate::{
     core::{
         AllocationOwnerMap, BUCKET_ALGORITHM_VERSION, Catalog, CatalogSnapshot,
@@ -12,7 +15,7 @@ use crate::{
         EngineResult, GeneratedIdPolicy, HASH_VERSION, IDENTIFIER_ENCODING_VERSION,
         INITIAL_MAP_GENERATION, KEY_ENCODING_VERSION, LogicalDatabaseMetadata,
         MAX_LOGICAL_DATABASES, MAX_TABLES, RoutingCatalog, ShardKeyMetadata, ShardKeyType,
-        TableDeclaration, TableMetadata, TablePlacement, VIRTUAL_BUCKET_COUNT,
+        TableDeclaration, TableId, TableMetadata, TablePlacement, VIRTUAL_BUCKET_COUNT,
         initial_physical_shard, validate_catalog_identifier,
     },
     sqlite_error,
@@ -31,7 +34,8 @@ const V6_SCHEMA_VERSION: u32 = 6;
 const V7_SCHEMA_VERSION: u32 = 7;
 const V8_SCHEMA_VERSION: u32 = 8;
 const V9_SCHEMA_VERSION: u32 = 9;
-pub(super) const CURRENT_SCHEMA_VERSION: u32 = V9_SCHEMA_VERSION;
+const V10_SCHEMA_VERSION: u32 = 10;
+pub(super) const CURRENT_SCHEMA_VERSION: u32 = V10_SCHEMA_VERSION;
 const MAX_TABLE_SQL_BYTES: i64 = 4_096;
 
 pub(super) const MAX_SCHEMA_MIGRATION_SQL_BYTES: usize = 65_536;
@@ -39,11 +43,15 @@ pub(super) const MAX_SCHEMA_GENERATION: u64 = i32::MAX as u64;
 const SCHEMA_MIGRATION_DIGEST_VERSION: u32 = 1;
 const SCHEMA_MIGRATION_APPLYING: i64 = 1;
 const SCHEMA_MIGRATION_COMPLETE: i64 = 2;
+const TABLE_PROVISIONING_DIGEST_VERSION: u32 = 1;
 const V1_MANIFEST_DIGEST_VERSION: u32 = 1;
 const V2_MANIFEST_DIGEST_VERSION: u32 = 2;
+const V3_MANIFEST_DIGEST_VERSION: u32 = 3;
 pub(super) const SCHEMA_DIGEST_VERSION: u32 = 1;
 const V1_MANIFEST_DIGEST_DOMAIN: &[u8] = b"briskdb.manifest.semantic-root.v1\0";
 const V2_MANIFEST_DIGEST_DOMAIN: &[u8] = b"briskdb.manifest.semantic-root.v2\0";
+const V3_MANIFEST_DIGEST_DOMAIN: &[u8] = b"briskdb.manifest.semantic-root.v3\0";
+const TABLE_PROVISIONING_DIGEST_DOMAIN: &[u8] = b"briskdb.table-provisioning.v1\0";
 
 const DATABASE_STATE_VERIFYING: i64 = 1;
 const DATABASE_STATE_READY: i64 = 2;
@@ -59,8 +67,12 @@ const TEXT_SHARD_KEY_TYPE: i64 = 2;
 const BINARY_SHARD_KEY_TYPE: i64 = 3;
 const GENERATED_ID_POLICY_NONE: i64 = 0;
 const GENERATED_ID_POLICY_NATIVE_RANGE_V1: i64 = 1;
+const GENERATED_ID_INACTIVE: i64 = 0;
+const GENERATED_ID_ACTIVE: i64 = 1;
 const NATIVE_RANGE_V1_ENCODING_VERSION: u32 = 1;
 const MAX_ALLOCATION_OWNER_SLOT: i64 = 1_023;
+const ALLOCATION_OWNER_ACTIVE: i64 = 1;
+const ALLOCATION_OWNER_RETIRED: i64 = 2;
 
 const ACTIVE_LIFECYCLE_STATE: &str = "active";
 
@@ -120,6 +132,10 @@ const V8_DOWNGRADE_FENCE_SQL: &str = "CREATE TABLE briskdb_metadata (
 const V9_DOWNGRADE_FENCE_SQL: &str = "CREATE TABLE briskdb_metadata (
     requires_manifest_version INTEGER NOT NULL
         CHECK (requires_manifest_version >= 9)
+) STRICT";
+const V10_DOWNGRADE_FENCE_SQL: &str = "CREATE TABLE briskdb_metadata (
+    requires_manifest_version INTEGER NOT NULL
+        CHECK (requires_manifest_version >= 10)
 ) STRICT";
 const V3_ROUTING_TABLE_SQL: &str = "CREATE TABLE briskdb_routing (
     singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
@@ -248,6 +264,42 @@ const V9_GENERATED_IDS_TABLE_SQL: &str = "CREATE TABLE briskdb_generated_ids (
         )
     )
 ) STRICT";
+const V10_GENERATED_IDS_TABLE_SQL: &str = "CREATE TABLE briskdb_generated_ids (
+    table_id INTEGER PRIMARY KEY CHECK (table_id > 0),
+    policy INTEGER NOT NULL CHECK (policy >= 0),
+    generated_column TEXT COLLATE BINARY
+        CHECK (
+            generated_column IS NULL OR (
+                length(generated_column) BETWEEN 1 AND 63
+                AND instr(generated_column, char(0)) = 0
+                AND generated_column NOT GLOB '*[^a-z0-9_]*'
+                AND substr(generated_column, 1, 1) GLOB '[a-z_]'
+                AND generated_column <> 'briskdb'
+                AND generated_column NOT GLOB 'briskdb_*'
+                AND generated_column NOT GLOB 'sqlite_*'
+            )
+        ),
+    encoding_version INTEGER
+        CHECK (encoding_version IS NULL OR encoding_version > 0),
+    activation_state INTEGER NOT NULL CHECK (activation_state IN (0, 1)),
+    FOREIGN KEY (table_id)
+        REFERENCES briskdb_tables (table_id)
+        ON DELETE RESTRICT,
+    CHECK (
+        (
+            policy = 0
+            AND generated_column IS NULL
+            AND encoding_version IS NULL
+            AND activation_state = 0
+        )
+        OR
+        (
+            policy > 0
+            AND generated_column IS NOT NULL
+            AND encoding_version IS NOT NULL
+        )
+    )
+) STRICT";
 const V9_ALLOCATION_OWNERS_TABLE_SQL: &str = "CREATE TABLE briskdb_allocation_owners (
     owner_slot INTEGER PRIMARY KEY CHECK (owner_slot BETWEEN 0 AND 1023),
     physical_shard_id INTEGER NOT NULL UNIQUE
@@ -255,6 +307,99 @@ const V9_ALLOCATION_OWNERS_TABLE_SQL: &str = "CREATE TABLE briskdb_allocation_ow
     FOREIGN KEY (physical_shard_id)
         REFERENCES briskdb_physical_shards (shard_id)
         ON DELETE RESTRICT
+) STRICT";
+const V10_ALLOCATION_OWNERS_TABLE_SQL: &str = "CREATE TABLE briskdb_allocation_owners (
+    owner_slot INTEGER PRIMARY KEY CHECK (owner_slot BETWEEN 0 AND 1023),
+    physical_shard_id INTEGER NOT NULL
+        CHECK (physical_shard_id BETWEEN 0 AND 63),
+    owner_state INTEGER NOT NULL CHECK (owner_state IN (1, 2)),
+    FOREIGN KEY (physical_shard_id)
+        REFERENCES briskdb_physical_shards (shard_id)
+        ON DELETE RESTRICT
+) STRICT";
+const V10_ACTIVE_OWNER_INDEX_SQL: &str = "CREATE UNIQUE INDEX briskdb_one_active_owner_per_shard
+ON briskdb_allocation_owners (physical_shard_id)
+WHERE owner_state = 1";
+const V10_TABLE_PROVISIONING_SQL: &str = "CREATE TABLE briskdb_table_provisioning (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    provisioning_id BLOB NOT NULL
+        CHECK (typeof(provisioning_id) = 'blob' AND length(provisioning_id) = 32),
+    digest_version INTEGER NOT NULL CHECK (digest_version = 1),
+    schema_digest_version INTEGER NOT NULL CHECK (schema_digest_version = 1),
+    committed_schema_digest BLOB NOT NULL
+        CHECK (typeof(committed_schema_digest) = 'blob' AND length(committed_schema_digest) = 32),
+    shard_count INTEGER NOT NULL CHECK (shard_count BETWEEN 2 AND 64),
+    declaration_count INTEGER NOT NULL CHECK (declaration_count BETWEEN 1 AND 4096),
+    next_shard INTEGER NOT NULL CHECK (next_shard BETWEEN 0 AND shard_count)
+) STRICT";
+const V10_TABLE_PROVISIONING_DECLARATIONS_SQL: &str =
+    "CREATE TABLE briskdb_table_provisioning_declarations (
+    provisioning_singleton INTEGER NOT NULL CHECK (provisioning_singleton = 1),
+    ordinal INTEGER NOT NULL CHECK (ordinal BETWEEN 0 AND 4095),
+    database_id INTEGER NOT NULL CHECK (database_id > 0),
+    table_name TEXT NOT NULL COLLATE BINARY
+        CHECK (
+            length(table_name) BETWEEN 1 AND 63
+            AND instr(table_name, char(0)) = 0
+            AND table_name NOT GLOB '*[^a-z0-9_]*'
+            AND substr(table_name, 1, 1) GLOB '[a-z_]'
+            AND table_name <> 'briskdb'
+            AND table_name NOT GLOB 'briskdb_*'
+            AND table_name NOT GLOB 'sqlite_*'
+        ),
+    placement INTEGER NOT NULL CHECK (placement IN (1, 2, 3)),
+    shard_key_column TEXT COLLATE BINARY
+        CHECK (
+            shard_key_column IS NULL OR (
+                length(shard_key_column) BETWEEN 1 AND 63
+                AND instr(shard_key_column, char(0)) = 0
+                AND shard_key_column NOT GLOB '*[^a-z0-9_]*'
+                AND substr(shard_key_column, 1, 1) GLOB '[a-z_]'
+                AND shard_key_column <> 'briskdb'
+                AND shard_key_column NOT GLOB 'briskdb_*'
+                AND shard_key_column NOT GLOB 'sqlite_*'
+            )
+        ),
+    shard_key_type INTEGER
+        CHECK (shard_key_type IS NULL OR shard_key_type IN (1, 2, 3)),
+    generated_policy INTEGER NOT NULL CHECK (generated_policy >= 0),
+    generated_column TEXT COLLATE BINARY,
+    generated_encoding_version INTEGER
+        CHECK (generated_encoding_version IS NULL OR generated_encoding_version > 0),
+    PRIMARY KEY (provisioning_singleton, ordinal),
+    UNIQUE (provisioning_singleton, database_id, table_name),
+    FOREIGN KEY (provisioning_singleton)
+        REFERENCES briskdb_table_provisioning (singleton)
+        ON DELETE CASCADE,
+    FOREIGN KEY (database_id)
+        REFERENCES briskdb_logical_databases (database_id)
+        ON DELETE RESTRICT,
+    CHECK (
+        (
+            placement = 1
+            AND shard_key_column IS NOT NULL
+            AND shard_key_type IS NOT NULL
+        )
+        OR
+        (
+            placement IN (2, 3)
+            AND shard_key_column IS NULL
+            AND shard_key_type IS NULL
+        )
+    ),
+    CHECK (
+        (
+            generated_policy = 0
+            AND generated_column IS NULL
+            AND generated_encoding_version IS NULL
+        )
+        OR
+        (
+            generated_policy > 0
+            AND generated_column IS NOT NULL
+            AND generated_encoding_version IS NOT NULL
+        )
+    )
 ) STRICT";
 const V5_SHARD_LAYOUT_TABLE_SQL: &str = "CREATE TABLE briskdb_shard_layout (
     singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
@@ -465,6 +610,51 @@ pub(super) enum SchemaMigrationClassification {
     Complete(SchemaMigration),
 }
 
+/// One fully validated, checksummed table-provisioning journal.
+///
+/// The durable prefix means every shard below `next_shard` has committed the
+/// exact native-range sequence seed for every declaration in this journal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct NativeTableProvisioning {
+    provisioning_id: [u8; 32],
+    committed_schema_digest: [u8; 32],
+    shard_count: u16,
+    declarations: Box<[TableDeclaration]>,
+    next_shard: u16,
+}
+
+impl NativeTableProvisioning {
+    #[cfg(test)]
+    pub(super) const fn provisioning_id(&self) -> [u8; 32] {
+        self.provisioning_id
+    }
+
+    #[cfg(test)]
+    pub(super) const fn committed_schema_digest(&self) -> [u8; 32] {
+        self.committed_schema_digest
+    }
+
+    pub(super) const fn shard_count(&self) -> u16 {
+        self.shard_count
+    }
+
+    pub(super) fn declarations(&self) -> &[TableDeclaration] {
+        &self.declarations
+    }
+
+    pub(super) const fn next_shard(&self) -> u16 {
+        self.next_shard
+    }
+}
+
+/// Exact classification of a requested table-provisioning operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum NativeTableProvisioningClassification {
+    Absent,
+    Active(NativeTableProvisioning),
+    Complete,
+}
+
 #[derive(Clone, Copy)]
 struct Migration {
     from: u32,
@@ -483,6 +673,8 @@ struct ManifestSnapshot {
     active_migration: Option<SchemaMigration>,
     integrity: Option<ManifestIntegrity>,
     allocation_owners: Option<AllocationOwnerMap>,
+    active_native_id_table_ids: Box<[TableId]>,
+    active_table_provisioning: Option<NativeTableProvisioning>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -491,6 +683,8 @@ pub(super) struct LoadedManifest {
     shard_layout: ShardLayout,
     active_migration: Option<SchemaMigration>,
     integrity: ManifestIntegrity,
+    active_native_id_table_ids: Box<[TableId]>,
+    active_table_provisioning: Option<NativeTableProvisioning>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -517,6 +711,12 @@ impl LoadedManifest {
         self.active_migration.as_ref()
     }
 
+    #[cfg(test)]
+    pub(super) fn active_table_provisioning(&self) -> Option<&NativeTableProvisioning> {
+        self.active_table_provisioning.as_ref()
+    }
+
+    #[cfg(test)]
     pub(super) fn into_parts_with_migration(
         self,
     ) -> (
@@ -530,6 +730,27 @@ impl LoadedManifest {
             self.shard_layout,
             self.active_migration,
             self.integrity,
+        )
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub(super) fn into_parts_with_recovery(
+        self,
+    ) -> (
+        CatalogSnapshot,
+        ShardLayout,
+        Option<SchemaMigration>,
+        ManifestIntegrity,
+        Box<[TableId]>,
+        Option<NativeTableProvisioning>,
+    ) {
+        (
+            self.catalog,
+            self.shard_layout,
+            self.active_migration,
+            self.integrity,
+            self.active_native_id_table_ids,
+            self.active_table_provisioning,
         )
     }
 }
@@ -591,6 +812,13 @@ const MIGRATIONS: &[Migration] = &[
         apply: migrate_v8_to_v9,
         validate: validate_v9,
     },
+    Migration {
+        from: V9_SCHEMA_VERSION,
+        to: V10_SCHEMA_VERSION,
+        name: "native_id_activation_and_table_provisioning",
+        apply: migrate_v9_to_v10,
+        validate: validate_v10,
+    },
 ];
 
 #[derive(Clone, Copy)]
@@ -604,8 +832,8 @@ struct MigrationPlan<'a> {
 const CURRENT_PLAN: MigrationPlan<'static> = MigrationPlan {
     current_version: CURRENT_SCHEMA_VERSION,
     migrations: MIGRATIONS,
-    initialize_current: create_v9_schema,
-    initialize_interrupted_legacy: migrate_interrupted_legacy_to_v9,
+    initialize_current: create_v10_schema,
+    initialize_interrupted_legacy: migrate_interrupted_legacy_to_v10,
 };
 
 // Startup uses this frozen plan only to finish an already-active v6 journal
@@ -675,6 +903,7 @@ pub(super) fn load_or_create_manifest_with_fresh_layout(
         fresh_layout_allowed,
         &mut |_| Ok(()),
     )?;
+    let active_native_id_table_ids = std::mem::take(&mut snapshot.active_native_id_table_ids);
     let catalog = catalog_snapshot_from_parts(
         snapshot.routing_catalog.take(),
         snapshot.logical_catalog.take(),
@@ -697,6 +926,8 @@ pub(super) fn load_or_create_manifest_with_fresh_layout(
         shard_layout,
         active_migration: snapshot.active_migration,
         integrity,
+        active_native_id_table_ids,
+        active_table_provisioning: snapshot.active_table_provisioning,
     })
 }
 
@@ -1434,6 +1665,628 @@ fn current_manifest_snapshot(
     }
 }
 
+/// Classify an exact native table-provisioning request without changing it.
+#[cfg(test)]
+pub(super) fn classify_native_table_provisioning(
+    connection: &mut Connection,
+    requested_shards: u16,
+    declarations: Vec<TableDeclaration>,
+    committed_schema_digest: [u8; 32],
+) -> EngineResult<NativeTableProvisioningClassification> {
+    let declarations = normalize_table_provisioning_declarations(declarations)?;
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    let snapshot = current_manifest_snapshot(&transaction, requested_shards)?;
+    let result = classify_native_table_provisioning_snapshot(
+        &snapshot,
+        &declarations,
+        committed_schema_digest,
+    )?;
+    transaction.commit().map_err(sqlite_error::storage)?;
+    Ok(result)
+}
+
+/// Durably publish a pending native table-provisioning journal before any
+/// shard-local sequence is seeded.
+pub(super) fn begin_native_table_provisioning<F>(
+    connection: &mut Connection,
+    requested_shards: u16,
+    declarations: Vec<TableDeclaration>,
+    committed_schema_digest: [u8; 32],
+    on_commit_attempted: F,
+) -> EngineResult<NativeTableProvisioningClassification>
+where
+    F: FnOnce(),
+{
+    let mut on_commit_attempted = Some(on_commit_attempted);
+    let declarations = normalize_table_provisioning_declarations(declarations)?;
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    let snapshot = current_manifest_snapshot(&transaction, requested_shards)?;
+    match classify_native_table_provisioning_snapshot(
+        &snapshot,
+        &declarations,
+        committed_schema_digest,
+    )? {
+        NativeTableProvisioningClassification::Active(active) => {
+            on_commit_attempted
+                .take()
+                .expect("table-provisioning commit callback is one-shot")();
+            transaction.commit().map_err(sqlite_error::storage)?;
+            return Ok(NativeTableProvisioningClassification::Active(active));
+        }
+        NativeTableProvisioningClassification::Complete => {
+            transaction.commit().map_err(sqlite_error::storage)?;
+            return Ok(NativeTableProvisioningClassification::Complete);
+        }
+        NativeTableProvisioningClassification::Absent => {}
+    }
+    ensure_table_registration_ready(&snapshot)?;
+    if snapshot.active_migration.is_some() {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "table provisioning cannot run during an application-schema migration",
+        ));
+    }
+    let integrity = snapshot.integrity.ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "table provisioning requires checksummed integrity metadata",
+        )
+    })?;
+    if integrity.committed_schema_digest() != Some(committed_schema_digest) {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "table provisioning schema digest does not match the committed schema",
+        ));
+    }
+    let catalog = snapshot.logical_catalog.as_ref().ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::Internal,
+            "table provisioning validation omitted the logical catalog",
+        )
+    })?;
+    for declaration in declarations.iter() {
+        if catalog.database_by_id(declaration.database_id()).is_none() {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                format!(
+                    "table {} references an unknown logical database",
+                    declaration.name()
+                ),
+            ));
+        }
+    }
+    if !catalog.tables().is_empty() && !declarations_match_catalog_owned(&declarations, catalog) {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "the authoritative table catalog is already registered with different declarations",
+        ));
+    }
+
+    let provisioning_id =
+        table_provisioning_id(&declarations, requested_shards, committed_schema_digest);
+    transaction
+        .execute(
+            "INSERT INTO briskdb_table_provisioning (
+                singleton,
+                provisioning_id,
+                digest_version,
+                schema_digest_version,
+                committed_schema_digest,
+                shard_count,
+                declaration_count,
+                next_shard
+             ) VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, 0)",
+            rusqlite::params![
+                provisioning_id.as_slice(),
+                TABLE_PROVISIONING_DIGEST_VERSION,
+                SCHEMA_DIGEST_VERSION,
+                committed_schema_digest.as_slice(),
+                requested_shards,
+                i64::try_from(declarations.len()).expect("bounded declaration count fits SQLite"),
+            ],
+        )
+        .map_err(sqlite_error::storage)?;
+    {
+        let mut insert = transaction
+            .prepare(
+                "INSERT INTO briskdb_table_provisioning_declarations (
+                    provisioning_singleton,
+                    ordinal,
+                    database_id,
+                    table_name,
+                    placement,
+                    shard_key_column,
+                    shard_key_type,
+                    generated_policy,
+                    generated_column,
+                    generated_encoding_version
+                 ) VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            )
+            .map_err(sqlite_error::storage)?;
+        for (ordinal, declaration) in declarations.iter().enumerate() {
+            let (placement, shard_column, shard_type) =
+                encoded_table_placement(declaration.placement());
+            let (policy, generated_column, encoding_version) =
+                encoded_generated_id_policy(declaration.generated_id_policy());
+            insert
+                .execute(rusqlite::params![
+                    i64::try_from(ordinal).expect("bounded ordinal fits SQLite"),
+                    i64::try_from(declaration.database_id().get()).map_err(|error| {
+                        EngineError::from_source(
+                            EngineErrorKind::NumericOutOfRange,
+                            "table-provisioning database ID does not fit in SQLite",
+                            error,
+                        )
+                    })?,
+                    declaration.name(),
+                    placement,
+                    shard_column,
+                    shard_type,
+                    policy,
+                    generated_column,
+                    encoding_version,
+                ])
+                .map_err(sqlite_error::storage)?;
+        }
+    }
+    refresh_manifest_digest(&transaction)?;
+    let current = current_manifest_snapshot(&transaction, requested_shards)?;
+    let active = current.active_table_provisioning.ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::Internal,
+            "table provisioning did not publish its journal",
+        )
+    })?;
+    ensure_same_native_table_provisioning_request(&active, &declarations, committed_schema_digest)?;
+    on_commit_attempted
+        .take()
+        .expect("table-provisioning commit callback is one-shot")();
+    transaction.commit().map_err(sqlite_error::storage)?;
+    Ok(NativeTableProvisioningClassification::Active(active))
+}
+
+/// Advance the durable seeded-shard prefix by exactly one shard.
+pub(super) fn advance_native_table_provisioning(
+    connection: &mut Connection,
+    requested_shards: u16,
+    expected: &NativeTableProvisioning,
+    next_shard: u16,
+) -> EngineResult<NativeTableProvisioning> {
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    let snapshot = current_manifest_snapshot(&transaction, requested_shards)?;
+    let active = snapshot.active_table_provisioning.ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "table provisioning is no longer active",
+        )
+    })?;
+    ensure_same_native_table_provisioning(&active, expected)?;
+    if next_shard == active.next_shard {
+        transaction.commit().map_err(sqlite_error::storage)?;
+        return Ok(active);
+    }
+    if next_shard != active.next_shard.saturating_add(1) || next_shard > active.shard_count {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            "table-provisioning progress must advance by exactly one shard",
+        ));
+    }
+    let changed = transaction
+        .execute(
+            "UPDATE briskdb_table_provisioning
+             SET next_shard = ?1
+             WHERE singleton = 1
+               AND provisioning_id = ?2
+               AND next_shard = ?3",
+            rusqlite::params![
+                next_shard,
+                active.provisioning_id.as_slice(),
+                active.next_shard,
+            ],
+        )
+        .map_err(sqlite_error::storage)?;
+    if changed != 1 {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "table-provisioning progress changed concurrently",
+        ));
+    }
+    refresh_manifest_digest(&transaction)?;
+    let advanced = current_manifest_snapshot(&transaction, requested_shards)?
+        .active_table_provisioning
+        .ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::Internal,
+                "table-provisioning progress update lost its journal",
+            )
+        })?;
+    ensure_same_native_table_provisioning(&advanced, expected)?;
+    if advanced.next_shard != next_shard {
+        return Err(EngineError::new(
+            EngineErrorKind::Internal,
+            "table-provisioning progress did not persist",
+        ));
+    }
+    transaction.commit().map_err(sqlite_error::storage)?;
+    Ok(advanced)
+}
+
+#[cfg(all(test, feature = "experimental-vtab"))]
+pub(super) fn replace_allocation_owner_for_test(
+    connection: &mut Connection,
+    requested_shards: u16,
+    retired_owner: u16,
+    replacement_owner: u16,
+    physical_shard: u16,
+) -> EngineResult<()> {
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    let snapshot = current_manifest_snapshot(&transaction, requested_shards)?;
+    ensure_table_registration_ready(&snapshot)?;
+    if snapshot.active_migration.is_some() || snapshot.active_table_provisioning.is_some() {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "allocation-owner test transition requires no active recovery journal",
+        ));
+    }
+    let retired_owner = AllocationOwnerSlot::new(retired_owner)?;
+    let replacement_owner = AllocationOwnerSlot::new(replacement_owner)?;
+    let current_owners = snapshot.allocation_owners.as_ref().ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::Internal,
+            "allocation-owner test transition requires a current owner map",
+        )
+    })?;
+    if current_owners.owner_for_physical_shard(physical_shard) != Some(retired_owner) {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            "allocation-owner test transition did not identify one active owner",
+        ));
+    }
+    let proposed = current_owners
+        .assignments()
+        .map(|(owner, shard, state)| {
+            if owner == retired_owner.get() {
+                (owner, shard, AllocationOwnerState::Retired)
+            } else {
+                (owner, shard, state)
+            }
+        })
+        .chain(std::iter::once((
+            replacement_owner.get(),
+            physical_shard,
+            AllocationOwnerState::Active,
+        )))
+        .collect::<Vec<_>>()
+        .into_boxed_slice();
+    AllocationOwnerMap::try_from_assignments(requested_shards, proposed)?;
+
+    let changed = transaction
+        .execute(
+            "UPDATE briskdb_allocation_owners
+             SET owner_state = ?1
+             WHERE owner_slot = ?2
+               AND physical_shard_id = ?3
+               AND owner_state = ?4",
+            rusqlite::params![
+                ALLOCATION_OWNER_RETIRED,
+                retired_owner.get(),
+                physical_shard,
+                ALLOCATION_OWNER_ACTIVE,
+            ],
+        )
+        .map_err(sqlite_error::storage)?;
+    if changed != 1 {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            "allocation-owner test transition did not identify one active owner",
+        ));
+    }
+    transaction
+        .execute(
+            "INSERT INTO briskdb_allocation_owners (
+                owner_slot, physical_shard_id, owner_state
+             ) VALUES (?1, ?2, ?3)",
+            rusqlite::params![
+                replacement_owner.get(),
+                physical_shard,
+                ALLOCATION_OWNER_ACTIVE,
+            ],
+        )
+        .map_err(sqlite_error::storage)?;
+    refresh_manifest_digest(&transaction)?;
+    let verified = current_manifest_snapshot(&transaction, requested_shards)?;
+    let owners = verified.allocation_owners.ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::Internal,
+            "allocation-owner transition validation omitted its owner map",
+        )
+    })?;
+    if owners.physical_shard(retired_owner) != Some(physical_shard)
+        || owners.owner_is_active(retired_owner)
+        || owners.owner_for_physical_shard(physical_shard) != Some(replacement_owner)
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::Internal,
+            "allocation-owner transition did not preserve historical and active routing",
+        ));
+    }
+    transaction.commit().map_err(sqlite_error::storage)
+}
+
+#[cfg(test)]
+pub(super) fn install_v9_native_catalog_for_test(
+    connection: &mut Connection,
+    requested_shards: u16,
+    declarations: &[TableDeclaration],
+) -> EngineResult<()> {
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    let snapshot = current_manifest_snapshot(&transaction, requested_shards)?;
+    ensure_table_registration_ready(&snapshot)?;
+    if snapshot
+        .logical_catalog
+        .as_ref()
+        .is_none_or(|catalog| !catalog.tables().is_empty())
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "v9 compatibility fixture requires an empty authoritative catalog",
+        ));
+    }
+    insert_authoritative_table_catalog(&transaction, declarations, false)?;
+    downgrade_v10_manifest_to_v9_for_test(&transaction)?;
+    set_identity(&transaction, V9_SCHEMA_VERSION)?;
+    refresh_manifest_digest(&transaction)?;
+    let objects = schema_objects(&transaction)?;
+    validate_v9(&transaction, requested_shards, &objects)?;
+    transaction.commit().map_err(sqlite_error::storage)
+}
+
+#[cfg(test)]
+pub(super) fn inspect_with_v9_plan_for_test(
+    connection: &Connection,
+    requested_shards: u16,
+) -> EngineResult<()> {
+    const V9_PLAN: MigrationPlan<'static> = MigrationPlan {
+        current_version: V9_SCHEMA_VERSION,
+        migrations: MIGRATIONS,
+        initialize_current: create_v9_schema,
+        initialize_interrupted_legacy: migrate_interrupted_legacy_to_v9,
+    };
+    inspect_with_plan(connection, requested_shards, V9_PLAN).map(|_| ())
+}
+
+#[cfg(test)]
+fn downgrade_v10_manifest_to_v9_for_test(connection: &Connection) -> EngineResult<()> {
+    connection
+        .execute_batch(
+            "DROP TABLE briskdb_table_provisioning_declarations;
+             DROP TABLE briskdb_table_provisioning;
+             DROP INDEX briskdb_one_active_owner_per_shard;
+             ALTER TABLE briskdb_generated_ids RENAME TO briskdb_generated_ids_v10;
+             ALTER TABLE briskdb_allocation_owners RENAME TO briskdb_allocation_owners_v10;",
+        )
+        .map_err(sqlite_error::storage)?;
+    connection
+        .execute_batch(V9_GENERATED_IDS_TABLE_SQL)
+        .map_err(sqlite_error::storage)?;
+    connection
+        .execute(
+            "INSERT INTO briskdb_generated_ids
+             SELECT table_id, policy, generated_column, encoding_version
+             FROM briskdb_generated_ids_v10",
+            [],
+        )
+        .map_err(sqlite_error::storage)?;
+    connection
+        .execute_batch(V9_ALLOCATION_OWNERS_TABLE_SQL)
+        .map_err(sqlite_error::storage)?;
+    connection
+        .execute(
+            "INSERT INTO briskdb_allocation_owners
+             SELECT owner_slot, physical_shard_id
+             FROM briskdb_allocation_owners_v10",
+            [],
+        )
+        .map_err(sqlite_error::storage)?;
+    connection
+        .execute_batch(
+            "DROP TABLE briskdb_generated_ids_v10;
+             DROP TABLE briskdb_allocation_owners_v10;
+             DROP TABLE briskdb_metadata;",
+        )
+        .map_err(sqlite_error::storage)?;
+    connection
+        .execute_batch(V9_DOWNGRADE_FENCE_SQL)
+        .map_err(sqlite_error::storage)?;
+    connection
+        .execute(
+            "INSERT INTO briskdb_metadata VALUES (?1)",
+            [V9_SCHEMA_VERSION],
+        )
+        .map_err(sqlite_error::storage)?;
+    connection
+        .execute(
+            "UPDATE briskdb_integrity SET manifest_digest_version = ?1",
+            [V2_MANIFEST_DIGEST_VERSION],
+        )
+        .map_err(sqlite_error::storage)?;
+    Ok(())
+}
+
+/// Atomically publish the authoritative catalog and activate native policies
+/// after every shard-local sequence seed is durable.
+pub(super) fn finalize_native_table_provisioning<F>(
+    connection: &mut Connection,
+    requested_shards: u16,
+    expected: &NativeTableProvisioning,
+    on_commit_attempted: F,
+) -> EngineResult<CatalogSnapshot>
+where
+    F: FnOnce(),
+{
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    let snapshot = current_manifest_snapshot(&transaction, requested_shards)?;
+    let Some(active) = snapshot.active_table_provisioning else {
+        let declarations = expected.declarations.to_vec();
+        let classification = classify_native_table_provisioning_snapshot(
+            &snapshot,
+            &declarations,
+            expected.committed_schema_digest,
+        )?;
+        if classification == NativeTableProvisioningClassification::Complete {
+            let catalog = catalog_snapshot_from_manifest(snapshot)?;
+            transaction.commit().map_err(sqlite_error::storage)?;
+            return Ok(catalog);
+        }
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "table provisioning is no longer active",
+        ));
+    };
+    ensure_same_native_table_provisioning(&active, expected)?;
+    if active.next_shard != active.shard_count {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "table provisioning cannot finish before every shard is durable",
+        ));
+    }
+    let catalog = snapshot.logical_catalog.as_ref().ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::Internal,
+            "table provisioning finalization omitted the logical catalog",
+        )
+    })?;
+    if catalog.tables().is_empty() {
+        insert_authoritative_table_catalog(&transaction, &active.declarations, true)?;
+    } else if !declarations_match_catalog_owned(&active.declarations, catalog) {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "table provisioning finalization found a conflicting catalog",
+        ));
+    } else {
+        transaction
+            .execute(
+                "UPDATE briskdb_generated_ids
+                 SET activation_state = ?1
+                 WHERE policy = ?2",
+                rusqlite::params![GENERATED_ID_ACTIVE, GENERATED_ID_POLICY_NATIVE_RANGE_V1,],
+            )
+            .map_err(sqlite_error::storage)?;
+    }
+    transaction
+        .execute("DELETE FROM briskdb_table_provisioning_declarations", [])
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute("DELETE FROM briskdb_table_provisioning", [])
+        .map_err(sqlite_error::storage)?;
+    refresh_manifest_digest(&transaction)?;
+    let finalized = current_manifest_snapshot(&transaction, requested_shards)?;
+    if finalized.active_table_provisioning.is_some()
+        || !native_table_provisioning_complete(&finalized, &active.declarations)
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::Internal,
+            "table-provisioning finalization did not publish the active catalog",
+        ));
+    }
+    let catalog = catalog_snapshot_from_manifest(finalized)?;
+    on_commit_attempted();
+    transaction.commit().map_err(sqlite_error::storage)?;
+    Ok(catalog)
+}
+
+fn classify_native_table_provisioning_snapshot(
+    snapshot: &ManifestSnapshot,
+    declarations: &[TableDeclaration],
+    committed_schema_digest: [u8; 32],
+) -> EngineResult<NativeTableProvisioningClassification> {
+    if let Some(active) = snapshot.active_table_provisioning.as_ref() {
+        ensure_same_native_table_provisioning_request(
+            active,
+            declarations,
+            committed_schema_digest,
+        )?;
+        return Ok(NativeTableProvisioningClassification::Active(
+            active.clone(),
+        ));
+    }
+    if native_table_provisioning_complete(snapshot, declarations) {
+        return Ok(NativeTableProvisioningClassification::Complete);
+    }
+    Ok(NativeTableProvisioningClassification::Absent)
+}
+
+fn native_table_provisioning_complete(
+    snapshot: &ManifestSnapshot,
+    declarations: &[TableDeclaration],
+) -> bool {
+    let Some(catalog) = snapshot.logical_catalog.as_ref() else {
+        return false;
+    };
+    if !declarations_match_catalog_owned(declarations, catalog) {
+        return false;
+    }
+    let expected = catalog
+        .tables()
+        .iter()
+        .filter(|table| {
+            matches!(
+                table.generated_id_policy(),
+                GeneratedIdPolicy::NativeRangeV1 { .. }
+            )
+        })
+        .map(TableMetadata::id)
+        .collect::<Vec<_>>();
+    expected.as_slice() == snapshot.active_native_id_table_ids.as_ref()
+}
+
+fn ensure_same_native_table_provisioning_request(
+    active: &NativeTableProvisioning,
+    declarations: &[TableDeclaration],
+    committed_schema_digest: [u8; 32],
+) -> EngineResult<()> {
+    if active.declarations.as_ref() != declarations
+        || active.committed_schema_digest != committed_schema_digest
+        || active.provisioning_id
+            != table_provisioning_id(declarations, active.shard_count, committed_schema_digest)
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "a different table-provisioning operation is already active",
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_same_native_table_provisioning(
+    observed: &NativeTableProvisioning,
+    expected: &NativeTableProvisioning,
+) -> EngineResult<()> {
+    if observed.provisioning_id != expected.provisioning_id
+        || observed.committed_schema_digest != expected.committed_schema_digest
+        || observed.shard_count != expected.shard_count
+        || observed.declarations != expected.declarations
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "table-provisioning identity changed while it was being applied",
+        ));
+    }
+    Ok(())
+}
+
 /// Atomically install the complete authoritative table catalog.
 ///
 /// Physical-table and emptiness validation belongs to the storage coordinator,
@@ -1484,6 +2337,12 @@ where
         .transaction_with_behavior(TransactionBehavior::Immediate)
         .map_err(sqlite_error::storage)?;
     let current = current_manifest_snapshot(&transaction, requested_shards)?;
+    if current.active_table_provisioning.is_some() {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "table registration cannot run during native table provisioning",
+        ));
+    }
     ensure_table_registration_ready(&current)?;
     let current_catalog = current.logical_catalog.as_ref().ok_or_else(|| {
         EngineError::new(
@@ -1555,9 +2414,16 @@ where
                         table_id,
                         policy,
                         generated_column,
-                        encoding_version
-                     ) VALUES (?1, ?2, ?3, ?4)",
-                    rusqlite::params![table_id, policy, generated_column, encoding_version,],
+                        encoding_version,
+                        activation_state
+                     ) VALUES (?1, ?2, ?3, ?4, ?5)",
+                    rusqlite::params![
+                        table_id,
+                        policy,
+                        generated_column,
+                        encoding_version,
+                        GENERATED_ID_INACTIVE,
+                    ],
                 )
                 .map_err(sqlite_error::storage)?;
         }
@@ -1593,6 +2459,82 @@ where
     Ok(replacement)
 }
 
+fn insert_authoritative_table_catalog(
+    transaction: &Transaction<'_>,
+    declarations: &[TableDeclaration],
+    activate_native: bool,
+) -> EngineResult<()> {
+    let mut insert_table = transaction
+        .prepare(
+            "INSERT INTO briskdb_tables (
+                table_id,
+                database_id,
+                table_name,
+                placement,
+                shard_key_column,
+                shard_key_type
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        )
+        .map_err(sqlite_error::storage)?;
+    let mut insert_policy = transaction
+        .prepare(
+            "INSERT INTO briskdb_generated_ids (
+                table_id,
+                policy,
+                generated_column,
+                encoding_version,
+                activation_state
+             ) VALUES (?1, ?2, ?3, ?4, ?5)",
+        )
+        .map_err(sqlite_error::storage)?;
+    for (index, declaration) in declarations.iter().enumerate() {
+        let table_id = i64::try_from(index + 1).expect("bounded table ID fits in SQLite");
+        let database_id = i64::try_from(declaration.database_id().get()).map_err(|error| {
+            EngineError::from_source(
+                EngineErrorKind::NumericOutOfRange,
+                format!(
+                    "logical database ID for table {} does not fit in SQLite",
+                    declaration.name()
+                ),
+                error,
+            )
+        })?;
+        let (placement, shard_key_column, shard_key_type) =
+            encoded_table_placement(declaration.placement());
+        insert_table
+            .execute(rusqlite::params![
+                table_id,
+                database_id,
+                declaration.name(),
+                placement,
+                shard_key_column,
+                shard_key_type,
+            ])
+            .map_err(sqlite_error::storage)?;
+        let (policy, generated_column, encoding_version) =
+            encoded_generated_id_policy(declaration.generated_id_policy());
+        let activation_state = if activate_native
+            && matches!(
+                declaration.generated_id_policy(),
+                GeneratedIdPolicy::NativeRangeV1 { .. }
+            ) {
+            GENERATED_ID_ACTIVE
+        } else {
+            GENERATED_ID_INACTIVE
+        };
+        insert_policy
+            .execute(rusqlite::params![
+                table_id,
+                policy,
+                generated_column,
+                encoding_version,
+                activation_state,
+            ])
+            .map_err(sqlite_error::storage)?;
+    }
+    Ok(())
+}
+
 fn ensure_table_registration_ready(snapshot: &ManifestSnapshot) -> EngineResult<()> {
     if snapshot.active_migration.is_some() {
         return Err(EngineError::new(
@@ -1620,11 +2562,12 @@ fn ensure_table_registration_ready(snapshot: &ManifestSnapshot) -> EngineResult<
 }
 
 fn catalog_snapshot_from_manifest(snapshot: ManifestSnapshot) -> EngineResult<CatalogSnapshot> {
-    catalog_snapshot_from_parts(
+    let catalog = catalog_snapshot_from_parts(
         snapshot.routing_catalog,
         snapshot.logical_catalog,
         snapshot.allocation_owners,
-    )
+    )?;
+    Ok(catalog.with_active_native_id_table_ids(snapshot.active_native_id_table_ids))
 }
 
 fn catalog_snapshot_from_parts(
@@ -1672,6 +2615,119 @@ fn declarations_match_catalog(
                     && generated_id_policy == table.generated_id_policy()
             },
         )
+}
+
+fn declarations_match_catalog_owned(declarations: &[TableDeclaration], catalog: &Catalog) -> bool {
+    declarations.len() == catalog.tables().len()
+        && declarations
+            .iter()
+            .zip(catalog.tables())
+            .all(|(declaration, table)| {
+                declaration.database_id() == table.database_id()
+                    && declaration.name() == table.name()
+                    && declaration.placement() == table.placement()
+                    && declaration.generated_id_policy() == table.generated_id_policy()
+            })
+}
+
+fn is_sorted_unique_declarations(declarations: &[TableDeclaration]) -> bool {
+    declarations.windows(2).all(|rows| {
+        (rows[0].database_id(), rows[0].name()) < (rows[1].database_id(), rows[1].name())
+    })
+}
+
+fn normalize_table_provisioning_declarations(
+    declarations: Vec<TableDeclaration>,
+) -> EngineResult<Box<[TableDeclaration]>> {
+    if declarations.is_empty() {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            "table provisioning requires at least one declaration",
+        ));
+    }
+    if declarations.len() > MAX_TABLES {
+        return Err(EngineError::new(
+            EngineErrorKind::LimitExceeded,
+            format!("table provisioning exceeds its {MAX_TABLES}-table limit"),
+        ));
+    }
+    let mut declarations = declarations;
+    declarations.sort_by(|left, right| {
+        (left.database_id(), left.name()).cmp(&(right.database_id(), right.name()))
+    });
+    if !is_sorted_unique_declarations(&declarations) {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            "table provisioning contains a duplicate logical table",
+        ));
+    }
+    if !declarations.iter().any(|declaration| {
+        matches!(
+            declaration.generated_id_policy(),
+            GeneratedIdPolicy::NativeRangeV1 { .. }
+        )
+    }) {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            "table provisioning requires a native generated-ID declaration",
+        ));
+    }
+    Ok(declarations.into_boxed_slice())
+}
+
+fn table_provisioning_id(
+    declarations: &[TableDeclaration],
+    shard_count: u16,
+    committed_schema_digest: [u8; 32],
+) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(TABLE_PROVISIONING_DIGEST_DOMAIN);
+    hasher.update(&TABLE_PROVISIONING_DIGEST_VERSION.to_le_bytes());
+    hasher.update(&shard_count.to_le_bytes());
+    hasher.update(&committed_schema_digest);
+    hasher.update(
+        &u64::try_from(declarations.len())
+            .expect("bounded declaration count fits u64")
+            .to_le_bytes(),
+    );
+    for declaration in declarations {
+        hasher.update(&declaration.database_id().get().to_le_bytes());
+        hash_manifest_name(&mut hasher, declaration.name().as_bytes());
+        let (placement, column, key_type) = encoded_table_placement(declaration.placement());
+        hasher.update(&placement.to_le_bytes());
+        hash_optional_provisioning_text(&mut hasher, column);
+        hash_optional_provisioning_integer(&mut hasher, key_type);
+        let (policy, generated_column, encoding_version) =
+            encoded_generated_id_policy(declaration.generated_id_policy());
+        hasher.update(&policy.to_le_bytes());
+        hash_optional_provisioning_text(&mut hasher, generated_column);
+        hash_optional_provisioning_integer(&mut hasher, encoding_version);
+    }
+    *hasher.finalize().as_bytes()
+}
+
+fn hash_optional_provisioning_text(hasher: &mut blake3::Hasher, value: Option<&str>) {
+    match value {
+        None => {
+            hasher.update(&[0]);
+        }
+        Some(value) => {
+            hasher.update(&[1]);
+            hash_manifest_name(hasher, value.as_bytes());
+        }
+    }
+}
+
+fn hash_optional_provisioning_integer(hasher: &mut blake3::Hasher, value: Option<i64>) {
+    match value {
+        None => {
+            hasher.update(&[0]);
+        }
+        Some(value) => {
+            hasher.update(&[1]);
+            hasher.update(&value.to_le_bytes());
+        }
+    }
 }
 
 fn encoded_generated_id_policy(policy: &GeneratedIdPolicy) -> (i64, Option<&str>, Option<i64>) {
@@ -2116,6 +3172,11 @@ fn create_v9_schema(transaction: &Transaction<'_>, shard_count: u16) -> EngineRe
     migrate_v8_to_v9(transaction, shard_count)
 }
 
+fn create_v10_schema(transaction: &Transaction<'_>, shard_count: u16) -> EngineResult<()> {
+    create_v9_schema(transaction, shard_count)?;
+    migrate_v9_to_v10(transaction, shard_count)
+}
+
 fn migrate_interrupted_legacy_to_v6(
     transaction: &Transaction<'_>,
     shard_count: u16,
@@ -2149,6 +3210,7 @@ fn migrate_interrupted_legacy_to_v8(
     create_v8_schema(transaction, shard_count)
 }
 
+#[cfg(test)]
 fn migrate_interrupted_legacy_to_v9(
     transaction: &Transaction<'_>,
     shard_count: u16,
@@ -2157,6 +3219,16 @@ fn migrate_interrupted_legacy_to_v9(
         .execute_batch("DROP TABLE briskdb_metadata;")
         .map_err(sqlite_error::storage)?;
     create_v9_schema(transaction, shard_count)
+}
+
+fn migrate_interrupted_legacy_to_v10(
+    transaction: &Transaction<'_>,
+    shard_count: u16,
+) -> EngineResult<()> {
+    transaction
+        .execute_batch("DROP TABLE briskdb_metadata;")
+        .map_err(sqlite_error::storage)?;
+    create_v10_schema(transaction, shard_count)
 }
 
 #[cfg(test)]
@@ -2496,6 +3568,91 @@ fn migrate_v8_to_v9(transaction: &Transaction<'_>, _shard_count: u16) -> EngineR
     Ok(())
 }
 
+fn migrate_v9_to_v10(transaction: &Transaction<'_>, _shard_count: u16) -> EngineResult<()> {
+    transaction
+        .execute_batch(
+            "ALTER TABLE briskdb_allocation_owners RENAME TO briskdb_allocation_owners_v9;",
+        )
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch(V10_ALLOCATION_OWNERS_TABLE_SQL)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "INSERT INTO briskdb_allocation_owners (
+                owner_slot, physical_shard_id, owner_state
+             )
+             SELECT owner_slot, physical_shard_id, ?1
+             FROM briskdb_allocation_owners_v9
+             ORDER BY owner_slot",
+            [ALLOCATION_OWNER_ACTIVE],
+        )
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch("DROP TABLE briskdb_allocation_owners_v9;")
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch(V10_ACTIVE_OWNER_INDEX_SQL)
+        .map_err(sqlite_error::storage)?;
+
+    transaction
+        .execute_batch("ALTER TABLE briskdb_generated_ids RENAME TO briskdb_generated_ids_v9;")
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch(V10_GENERATED_IDS_TABLE_SQL)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "INSERT INTO briskdb_generated_ids (
+                table_id,
+                policy,
+                generated_column,
+                encoding_version,
+                activation_state
+             )
+             SELECT table_id,
+                    policy,
+                    generated_column,
+                    encoding_version,
+                    ?1
+             FROM briskdb_generated_ids_v9
+             ORDER BY table_id",
+            [GENERATED_ID_INACTIVE],
+        )
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch("DROP TABLE briskdb_generated_ids_v9;")
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch(V10_TABLE_PROVISIONING_SQL)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch(V10_TABLE_PROVISIONING_DECLARATIONS_SQL)
+        .map_err(sqlite_error::storage)?;
+
+    transaction
+        .execute_batch("DROP TABLE briskdb_metadata;")
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch(V10_DOWNGRADE_FENCE_SQL)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "INSERT INTO briskdb_metadata (requires_manifest_version) VALUES (?1)",
+            [V10_SCHEMA_VERSION],
+        )
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "UPDATE briskdb_integrity
+             SET manifest_digest_version = ?1
+             WHERE singleton = 1",
+            [V3_MANIFEST_DIGEST_VERSION],
+        )
+        .map_err(sqlite_error::storage)?;
+    Ok(())
+}
+
 fn add_v5_schema(transaction: &Transaction<'_>, state: ShardLayoutState) -> EngineResult<()> {
     transaction
         .execute_batch("DROP TABLE briskdb_metadata;")
@@ -2799,6 +3956,27 @@ fn v9_objects() -> Vec<SchemaObject> {
     objects
 }
 
+fn v10_objects() -> Vec<SchemaObject> {
+    let mut objects = v9_objects();
+    objects.push(SchemaObject {
+        object_type: "index".to_owned(),
+        name: "briskdb_one_active_owner_per_shard".to_owned(),
+    });
+    for name in [
+        "briskdb_table_provisioning",
+        "briskdb_table_provisioning_declarations",
+    ] {
+        objects.push(SchemaObject {
+            object_type: "table".to_owned(),
+            name: name.to_owned(),
+        });
+    }
+    objects.sort_by(|left, right| {
+        (&left.object_type, &left.name).cmp(&(&right.object_type, &right.name))
+    });
+    objects
+}
+
 fn schema_objects(connection: &Connection) -> EngineResult<Vec<SchemaObject>> {
     let mut statement = connection
         .prepare(
@@ -2915,6 +4093,14 @@ fn validate_table(
         "briskdb_allocation_owners" => {
             "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden
              FROM pragma_table_xinfo('briskdb_allocation_owners') LIMIT ?1"
+        }
+        "briskdb_table_provisioning" => {
+            "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden
+             FROM pragma_table_xinfo('briskdb_table_provisioning') LIMIT ?1"
+        }
+        "briskdb_table_provisioning_declarations" => {
+            "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden
+             FROM pragma_table_xinfo('briskdb_table_provisioning_declarations') LIMIT ?1"
         }
         _ => {
             return Err(EngineError::new(
@@ -3106,6 +4292,8 @@ fn validate_v2(
         active_migration: None,
         integrity: None,
         allocation_owners: None,
+        active_native_id_table_ids: Box::new([]),
+        active_table_provisioning: None,
     })
 }
 
@@ -3136,6 +4324,8 @@ fn validate_v3(
         active_migration: None,
         integrity: None,
         allocation_owners: None,
+        active_native_id_table_ids: Box::new([]),
+        active_table_provisioning: None,
     })
 }
 
@@ -3430,6 +4620,38 @@ fn validate_v9(
     Ok(snapshot)
 }
 
+fn validate_v10(
+    connection: &Connection,
+    requested_shards: u16,
+    objects: &[SchemaObject],
+) -> EngineResult<ManifestSnapshot> {
+    let mut snapshot = validate_integrity_manifest_with_definition(
+        connection,
+        requested_shards,
+        objects,
+        IntegrityManifestDefinition {
+            version: V10_SCHEMA_VERSION,
+            downgrade_fence_sql: V10_DOWNGRADE_FENCE_SQL,
+            expected_objects: &v10_objects(),
+            expected_manifest_digest_version: V3_MANIFEST_DIGEST_VERSION,
+            generated_ids: true,
+        },
+    )?;
+    snapshot.allocation_owners = Some(validate_allocation_owners(
+        connection,
+        snapshot.shard_count,
+    )?);
+    snapshot.active_native_id_table_ids = validate_active_native_id_tables(connection)?;
+    snapshot.active_table_provisioning = validate_table_provisioning(
+        connection,
+        snapshot.shard_count,
+        snapshot.logical_catalog.as_ref(),
+        snapshot.active_migration.as_ref(),
+        snapshot.integrity,
+    )?;
+    Ok(snapshot)
+}
+
 fn validate_integrity_manifest(
     connection: &Connection,
     requested_shards: u16,
@@ -3458,6 +4680,14 @@ struct IntegrityManifestDefinition<'a> {
     expected_objects: &'a [SchemaObject],
     expected_manifest_digest_version: u32,
     generated_ids: bool,
+}
+
+fn generated_ids_table_sql(version: u32) -> &'static str {
+    if version >= V10_SCHEMA_VERSION {
+        V10_GENERATED_IDS_TABLE_SQL
+    } else {
+        V9_GENERATED_IDS_TABLE_SQL
+    }
 }
 
 fn validate_integrity_manifest_with_definition(
@@ -3612,7 +4842,7 @@ fn validate_manifest_semantic_root(
             "manifest checksum version must be positive",
         ));
     }
-    if *version > i64::from(V2_MANIFEST_DIGEST_VERSION) {
+    if *version > i64::from(V3_MANIFEST_DIGEST_VERSION) {
         return Err(EngineError::new(
             EngineErrorKind::FailedPrecondition,
             "manifest checksum version is newer than this BriskDB build supports",
@@ -3751,6 +4981,52 @@ const V2_GENERATED_IDS_DIGEST_QUERY: ManifestDigestQuery = ManifestDigestQuery {
     columns: &["table_id", "policy", "generated_column", "encoding_version"],
     sql: "SELECT table_id, policy, generated_column, encoding_version FROM briskdb_generated_ids ORDER BY table_id",
 };
+const V3_GENERATED_IDS_DIGEST_QUERY: ManifestDigestQuery = ManifestDigestQuery {
+    table: "briskdb_generated_ids",
+    columns: &[
+        "table_id",
+        "policy",
+        "generated_column",
+        "encoding_version",
+        "activation_state",
+    ],
+    sql: "SELECT table_id, policy, generated_column, encoding_version, activation_state FROM briskdb_generated_ids ORDER BY table_id",
+};
+const V3_ALLOCATION_OWNERS_DIGEST_QUERY: ManifestDigestQuery = ManifestDigestQuery {
+    table: "briskdb_allocation_owners",
+    columns: &["owner_slot", "physical_shard_id", "owner_state"],
+    sql: "SELECT owner_slot, physical_shard_id, owner_state FROM briskdb_allocation_owners ORDER BY owner_slot",
+};
+const V3_TABLE_PROVISIONING_DIGEST_QUERY: ManifestDigestQuery = ManifestDigestQuery {
+    table: "briskdb_table_provisioning",
+    columns: &[
+        "singleton",
+        "provisioning_id",
+        "digest_version",
+        "schema_digest_version",
+        "committed_schema_digest",
+        "shard_count",
+        "declaration_count",
+        "next_shard",
+    ],
+    sql: "SELECT singleton, provisioning_id, digest_version, schema_digest_version, committed_schema_digest, shard_count, declaration_count, next_shard FROM briskdb_table_provisioning ORDER BY singleton",
+};
+const V3_TABLE_PROVISIONING_DECLARATIONS_DIGEST_QUERY: ManifestDigestQuery = ManifestDigestQuery {
+    table: "briskdb_table_provisioning_declarations",
+    columns: &[
+        "provisioning_singleton",
+        "ordinal",
+        "database_id",
+        "table_name",
+        "placement",
+        "shard_key_column",
+        "shard_key_type",
+        "generated_policy",
+        "generated_column",
+        "generated_encoding_version",
+    ],
+    sql: "SELECT provisioning_singleton, ordinal, database_id, table_name, placement, shard_key_column, shard_key_type, generated_policy, generated_column, generated_encoding_version FROM briskdb_table_provisioning_declarations ORDER BY provisioning_singleton, ordinal",
+};
 
 fn manifest_semantic_digest_for_version(
     connection: &Connection,
@@ -3773,6 +5049,21 @@ fn manifest_semantic_digest_for_version(
                 }
             }
             (V2_MANIFEST_DIGEST_DOMAIN, queries)
+        }
+        V3_MANIFEST_DIGEST_VERSION => {
+            let mut queries = Vec::with_capacity(V1_MANIFEST_DIGEST_QUERIES.len() + 4);
+            for query in V1_MANIFEST_DIGEST_QUERIES {
+                queries.push(query);
+                if query.table == "briskdb_physical_shards" {
+                    queries.push(&V3_ALLOCATION_OWNERS_DIGEST_QUERY);
+                }
+                if query.table == "briskdb_tables" {
+                    queries.push(&V3_GENERATED_IDS_DIGEST_QUERY);
+                    queries.push(&V3_TABLE_PROVISIONING_DIGEST_QUERY);
+                    queries.push(&V3_TABLE_PROVISIONING_DECLARATIONS_DIGEST_QUERY);
+                }
+            }
+            (V3_MANIFEST_DIGEST_DOMAIN, queries)
         }
         0 => {
             return Err(EngineError::new(
@@ -3908,7 +5199,7 @@ fn refresh_manifest_digest_if_checksummed(connection: &Connection) -> EngineResu
     if application_id == MANIFEST_APPLICATION_ID
         && matches!(
             u32::try_from(version),
-            Ok(V7_SCHEMA_VERSION | V8_SCHEMA_VERSION | V9_SCHEMA_VERSION)
+            Ok(V7_SCHEMA_VERSION | V8_SCHEMA_VERSION | V9_SCHEMA_VERSION | V10_SCHEMA_VERSION)
         )
     {
         let _ = refresh_manifest_digest(connection)?;
@@ -3972,7 +5263,7 @@ fn validate_manifest_integrity(
             "manifest checksum version must be positive",
         ));
     }
-    if *manifest_version > i64::from(V2_MANIFEST_DIGEST_VERSION) {
+    if *manifest_version > i64::from(V3_MANIFEST_DIGEST_VERSION) {
         return Err(EngineError::new(
             EngineErrorKind::FailedPrecondition,
             "manifest checksum version is newer than this BriskDB build supports",
@@ -4154,21 +5445,26 @@ fn validate_catalog_manifest(
     )?;
     validate_table_sql(connection, "briskdb_tables", V4_TABLES_TABLE_SQL)?;
     if definition.generated_ids {
-        validate_table(
-            connection,
-            "briskdb_generated_ids",
-            &[
-                TableColumn::expected(0, "table_id", "INTEGER", false, 1),
-                TableColumn::expected(1, "policy", "INTEGER", true, 0),
-                TableColumn::expected(2, "generated_column", "TEXT", false, 0),
-                TableColumn::expected(3, "encoding_version", "INTEGER", false, 0),
-            ],
-            true,
-        )?;
+        let mut columns = vec![
+            TableColumn::expected(0, "table_id", "INTEGER", false, 1),
+            TableColumn::expected(1, "policy", "INTEGER", true, 0),
+            TableColumn::expected(2, "generated_column", "TEXT", false, 0),
+            TableColumn::expected(3, "encoding_version", "INTEGER", false, 0),
+        ];
+        if definition.version >= V10_SCHEMA_VERSION {
+            columns.push(TableColumn::expected(
+                4,
+                "activation_state",
+                "INTEGER",
+                true,
+                0,
+            ));
+        }
+        validate_table(connection, "briskdb_generated_ids", &columns, true)?;
         validate_table_sql(
             connection,
             "briskdb_generated_ids",
-            V9_GENERATED_IDS_TABLE_SQL,
+            generated_ids_table_sql(definition.version),
         )?;
     }
 
@@ -4193,6 +5489,8 @@ fn validate_catalog_manifest(
         active_migration: None,
         integrity: None,
         allocation_owners: None,
+        active_native_id_table_ids: Box::new([]),
+        active_table_provisioning: None,
     })
 }
 
@@ -4270,43 +5568,85 @@ fn validate_allocation_owners(
     connection: &Connection,
     shard_count: u16,
 ) -> EngineResult<AllocationOwnerMap> {
+    let current = read_identity(connection)?.1 >= i64::from(V10_SCHEMA_VERSION);
     validate_table(
         connection,
         "briskdb_allocation_owners",
-        &[
-            TableColumn::expected(0, "owner_slot", "INTEGER", false, 1),
-            TableColumn::expected(1, "physical_shard_id", "INTEGER", true, 0),
-        ],
+        &if current {
+            vec![
+                TableColumn::expected(0, "owner_slot", "INTEGER", false, 1),
+                TableColumn::expected(1, "physical_shard_id", "INTEGER", true, 0),
+                TableColumn::expected(2, "owner_state", "INTEGER", true, 0),
+            ]
+        } else {
+            vec![
+                TableColumn::expected(0, "owner_slot", "INTEGER", false, 1),
+                TableColumn::expected(1, "physical_shard_id", "INTEGER", true, 0),
+            ]
+        },
         true,
     )?;
     validate_table_sql(
         connection,
         "briskdb_allocation_owners",
-        V9_ALLOCATION_OWNERS_TABLE_SQL,
+        if current {
+            V10_ALLOCATION_OWNERS_TABLE_SQL
+        } else {
+            V9_ALLOCATION_OWNERS_TABLE_SQL
+        },
     )?;
 
+    if current {
+        let sql: String = connection
+            .query_row(
+                "SELECT sql FROM sqlite_schema
+                 WHERE type = 'index' AND name = 'briskdb_one_active_owner_per_shard'",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(|error| manifest_read_error(error, "failed to inspect active-owner index"))?;
+        if normalize_schema_sql(&sql) != normalize_schema_sql(V10_ACTIVE_OWNER_INDEX_SQL) {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "allocation-owner active index has an incompatible definition",
+            ));
+        }
+    }
+
+    let sql = if current {
+        "SELECT owner_slot, physical_shard_id, owner_state
+         FROM briskdb_allocation_owners
+         ORDER BY owner_slot
+         LIMIT 1025"
+    } else {
+        "SELECT owner_slot, physical_shard_id, 1 AS owner_state
+         FROM briskdb_allocation_owners
+         ORDER BY owner_slot
+         LIMIT 1025"
+    };
     let rows = connection
-        .prepare(
-            "SELECT owner_slot, physical_shard_id
-             FROM briskdb_allocation_owners
-             ORDER BY owner_slot
-             LIMIT 1025",
-        )
+        .prepare(sql)
         .and_then(|mut statement| {
             statement
-                .query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)))?
+                .query_map([], |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, i64>(2)?,
+                    ))
+                })?
                 .collect::<Result<Vec<_>, _>>()
         })
         .map_err(|error| manifest_read_error(error, "failed to read allocation-owner metadata"))?;
-    if rows.len() != usize::from(shard_count) {
+    if rows.len() < usize::from(shard_count) || rows.len() > 1_024 {
         return Err(EngineError::new(
             EngineErrorKind::DataCorruption,
-            "allocation-owner metadata must contain exactly one row per physical shard",
+            "allocation-owner metadata has an invalid number of historical owners",
         ));
     }
 
     let mut owners = Vec::with_capacity(rows.len());
-    for (expected, (owner_slot, physical_shard_id)) in (0..shard_count).zip(rows) {
+    for (ordinal, (owner_slot, physical_shard_id, owner_state)) in rows.into_iter().enumerate() {
         if !(0..=MAX_ALLOCATION_OWNER_SLOT).contains(&owner_slot) {
             return Err(EngineError::new(
                 EngineErrorKind::DataCorruption,
@@ -4327,23 +5667,405 @@ fn validate_allocation_owners(
                 error,
             )
         })?;
-        // Version 9 establishes the immutable initial mapping. A future shard
-        // lifecycle version may append owners, but v9 never infers or remaps.
-        if owner_slot != expected || physical_shard_id != expected {
+        if !current
+            && (owner_slot != u16::try_from(ordinal).expect("bounded owner ordinal fits u16")
+                || physical_shard_id != owner_slot)
+        {
             return Err(EngineError::new(
                 EngineErrorKind::DataCorruption,
                 "allocation-owner metadata does not match the immutable v9 owner mapping",
             ));
         }
-        owners.push((owner_slot, physical_shard_id));
+        let state = match owner_state {
+            ALLOCATION_OWNER_ACTIVE => AllocationOwnerState::Active,
+            ALLOCATION_OWNER_RETIRED => AllocationOwnerState::Retired,
+            _ => {
+                return Err(EngineError::new(
+                    EngineErrorKind::DataCorruption,
+                    "allocation-owner metadata has an unsupported lifecycle state",
+                ));
+            }
+        };
+        owners.push((owner_slot, physical_shard_id, state));
     }
-    AllocationOwnerMap::try_from_pairs(shard_count, owners.into_boxed_slice()).map_err(|error| {
+    AllocationOwnerMap::try_from_assignments(shard_count, owners.into_boxed_slice()).map_err(
+        |error| {
+            EngineError::from_source(
+                EngineErrorKind::DataCorruption,
+                "allocation-owner metadata does not define one active allocator with monotonic succession per shard",
+                error,
+            )
+        },
+    )
+}
+
+fn validate_active_native_id_tables(connection: &Connection) -> EngineResult<Box<[TableId]>> {
+    let rows = connection
+        .prepare(
+            "SELECT table_id, policy, activation_state
+             FROM briskdb_generated_ids
+             ORDER BY table_id
+             LIMIT 4097",
+        )
+        .and_then(|mut statement| {
+            statement
+                .query_map([], |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, i64>(2)?,
+                    ))
+                })?
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .map_err(|error| {
+            manifest_read_error(error, "failed to read generated-ID activation metadata")
+        })?;
+    if rows.len() > MAX_TABLES {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "generated-ID activation metadata exceeds the table limit",
+        ));
+    }
+    let mut active = Vec::new();
+    for (table_id, policy, state) in rows {
+        match (policy, state) {
+            (GENERATED_ID_POLICY_NONE, GENERATED_ID_INACTIVE) => {}
+            (GENERATED_ID_POLICY_NATIVE_RANGE_V1, GENERATED_ID_INACTIVE) => {}
+            (GENERATED_ID_POLICY_NATIVE_RANGE_V1, GENERATED_ID_ACTIVE) => {
+                active.push(TableId::from_validated(positive_catalog_id(
+                    table_id, "table",
+                )?));
+            }
+            (_, GENERATED_ID_ACTIVE) if policy > GENERATED_ID_POLICY_NATIVE_RANGE_V1 => {
+                return Err(EngineError::new(
+                    EngineErrorKind::FailedPrecondition,
+                    format!("table {table_id} activates a newer generated-ID policy"),
+                ));
+            }
+            _ => {
+                return Err(EngineError::new(
+                    EngineErrorKind::DataCorruption,
+                    format!("table {table_id} has inconsistent generated-ID activation metadata"),
+                ));
+            }
+        }
+    }
+    Ok(active.into_boxed_slice())
+}
+
+fn validate_table_provisioning(
+    connection: &Connection,
+    expected_shard_count: u16,
+    catalog: Option<&Catalog>,
+    active_migration: Option<&SchemaMigration>,
+    integrity: Option<ManifestIntegrity>,
+) -> EngineResult<Option<NativeTableProvisioning>> {
+    validate_table(
+        connection,
+        "briskdb_table_provisioning",
+        &[
+            TableColumn::expected(0, "singleton", "INTEGER", false, 1),
+            TableColumn::expected(1, "provisioning_id", "BLOB", true, 0),
+            TableColumn::expected(2, "digest_version", "INTEGER", true, 0),
+            TableColumn::expected(3, "schema_digest_version", "INTEGER", true, 0),
+            TableColumn::expected(4, "committed_schema_digest", "BLOB", true, 0),
+            TableColumn::expected(5, "shard_count", "INTEGER", true, 0),
+            TableColumn::expected(6, "declaration_count", "INTEGER", true, 0),
+            TableColumn::expected(7, "next_shard", "INTEGER", true, 0),
+        ],
+        true,
+    )?;
+    validate_table_sql(
+        connection,
+        "briskdb_table_provisioning",
+        V10_TABLE_PROVISIONING_SQL,
+    )?;
+    validate_table(
+        connection,
+        "briskdb_table_provisioning_declarations",
+        &[
+            TableColumn::expected(0, "provisioning_singleton", "INTEGER", true, 1),
+            TableColumn::expected(1, "ordinal", "INTEGER", true, 2),
+            TableColumn::expected(2, "database_id", "INTEGER", true, 0),
+            TableColumn::expected(3, "table_name", "TEXT", true, 0),
+            TableColumn::expected(4, "placement", "INTEGER", true, 0),
+            TableColumn::expected(5, "shard_key_column", "TEXT", false, 0),
+            TableColumn::expected(6, "shard_key_type", "INTEGER", false, 0),
+            TableColumn::expected(7, "generated_policy", "INTEGER", true, 0),
+            TableColumn::expected(8, "generated_column", "TEXT", false, 0),
+            TableColumn::expected(9, "generated_encoding_version", "INTEGER", false, 0),
+        ],
+        true,
+    )?;
+    validate_table_sql(
+        connection,
+        "briskdb_table_provisioning_declarations",
+        V10_TABLE_PROVISIONING_DECLARATIONS_SQL,
+    )?;
+
+    let singleton_rows = connection
+        .prepare(
+            "SELECT singleton,
+                    provisioning_id,
+                    digest_version,
+                    schema_digest_version,
+                    committed_schema_digest,
+                    shard_count,
+                    declaration_count,
+                    next_shard
+             FROM briskdb_table_provisioning
+             ORDER BY singleton
+             LIMIT 3",
+        )
+        .and_then(|mut statement| {
+            statement
+                .query_map([], |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, Vec<u8>>(1)?,
+                        row.get::<_, i64>(2)?,
+                        row.get::<_, i64>(3)?,
+                        row.get::<_, Vec<u8>>(4)?,
+                        row.get::<_, i64>(5)?,
+                        row.get::<_, i64>(6)?,
+                        row.get::<_, i64>(7)?,
+                    ))
+                })?
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .map_err(|error| manifest_read_error(error, "failed to read table-provisioning journal"))?;
+    if singleton_rows.is_empty() {
+        let declaration_exists = connection
+            .query_row(
+                "SELECT EXISTS(
+                    SELECT 1 FROM briskdb_table_provisioning_declarations
+                 )",
+                [],
+                |row| row.get::<_, bool>(0),
+            )
+            .map_err(|error| {
+                manifest_read_error(error, "failed to inspect table-provisioning declarations")
+            })?;
+        if declaration_exists {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "table-provisioning declarations exist without their journal",
+            ));
+        }
+        return Ok(None);
+    }
+    if singleton_rows.len() != 1 || singleton_rows[0].0 != 1 {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "table provisioning must contain exactly its singleton journal",
+        ));
+    }
+    if active_migration.is_some() {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "table provisioning cannot overlap an application-schema migration",
+        ));
+    }
+    let (_, id, digest_version, schema_version, committed, shards, count, next) =
+        &singleton_rows[0];
+    if *digest_version != i64::from(TABLE_PROVISIONING_DIGEST_VERSION)
+        || *schema_version != i64::from(SCHEMA_DIGEST_VERSION)
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "table-provisioning journal has unsupported digest metadata",
+        ));
+    }
+    let provisioning_id = digest_from_blob(id, "table-provisioning identifier")?;
+    let committed_schema_digest = digest_from_blob(committed, "table-provisioning schema digest")?;
+    let integrity_state = integrity.map(ManifestIntegrity::state);
+    if integrity.and_then(ManifestIntegrity::committed_schema_digest)
+        != Some(committed_schema_digest)
+        || !matches!(
+            integrity_state,
+            Some(DatabaseIntegrityState::Ready | DatabaseIntegrityState::Degraded)
+        )
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "table provisioning does not match a valid committed schema",
+        ));
+    }
+    let shard_count = u16::try_from(*shards).map_err(|error| {
         EngineError::from_source(
             EngineErrorKind::DataCorruption,
-            "allocation-owner metadata is not a complete one-to-one mapping",
+            "table-provisioning shard count is outside the supported range",
             error,
         )
-    })
+    })?;
+    let next_shard = u16::try_from(*next).map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::DataCorruption,
+            "table-provisioning progress is outside the supported range",
+            error,
+        )
+    })?;
+    if shard_count != expected_shard_count || next_shard > shard_count {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "table provisioning has inconsistent shard progress",
+        ));
+    }
+    let declaration_count = usize::try_from(*count).map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::DataCorruption,
+            "table-provisioning declaration count is outside the supported range",
+            error,
+        )
+    })?;
+    let declarations = read_table_provisioning_declarations(connection, declaration_count)?;
+    if table_provisioning_id(&declarations, shard_count, committed_schema_digest) != provisioning_id
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "table-provisioning identifier does not match its declarations",
+        ));
+    }
+    if !declarations.iter().any(|declaration| {
+        matches!(
+            declaration.generated_id_policy(),
+            GeneratedIdPolicy::NativeRangeV1 { .. }
+        )
+    }) {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "table provisioning does not contain a native generated-ID policy",
+        ));
+    }
+    if let Some(catalog) = catalog {
+        if !catalog.tables().is_empty() && !declarations_match_catalog_owned(&declarations, catalog)
+        {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "table provisioning declarations conflict with the authoritative catalog",
+            ));
+        }
+    }
+    Ok(Some(NativeTableProvisioning {
+        provisioning_id,
+        committed_schema_digest,
+        shard_count,
+        declarations,
+        next_shard,
+    }))
+}
+
+fn read_table_provisioning_declarations(
+    connection: &Connection,
+    expected_count: usize,
+) -> EngineResult<Box<[TableDeclaration]>> {
+    let limit = i64::try_from(MAX_TABLES + 1).expect("table journal limit fits SQLite");
+    let rows = connection
+        .prepare(
+            "SELECT ordinal,
+                    database_id,
+                    table_name,
+                    placement,
+                    shard_key_column,
+                    shard_key_type,
+                    generated_policy,
+                    generated_column,
+                    generated_encoding_version
+             FROM briskdb_table_provisioning_declarations
+             ORDER BY ordinal
+             LIMIT ?1",
+        )
+        .and_then(|mut statement| {
+            statement
+                .query_map([limit], |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, String>(2)?,
+                        row.get::<_, i64>(3)?,
+                        row.get::<_, Option<String>>(4)?,
+                        row.get::<_, Option<i64>>(5)?,
+                        row.get::<_, i64>(6)?,
+                        row.get::<_, Option<String>>(7)?,
+                        row.get::<_, Option<i64>>(8)?,
+                    ))
+                })?
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .map_err(|error| {
+            manifest_read_error(error, "failed to read table-provisioning declarations")
+        })?;
+    if rows.len() != expected_count || rows.is_empty() || rows.len() > MAX_TABLES {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "table-provisioning declaration count is inconsistent",
+        ));
+    }
+    let mut declarations = Vec::with_capacity(rows.len());
+    for (
+        expected_ordinal,
+        (
+            ordinal,
+            database_id,
+            name,
+            placement_code,
+            shard_column,
+            shard_type,
+            generated_policy,
+            generated_column,
+            generated_version,
+        ),
+    ) in rows.into_iter().enumerate()
+    {
+        if ordinal != i64::try_from(expected_ordinal).expect("bounded ordinal fits SQLite") {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "table-provisioning declaration ordinals are not contiguous",
+            ));
+        }
+        let database_id = crate::core::LogicalDatabaseId::new(positive_catalog_id(
+            database_id,
+            "logical database",
+        )?)
+        .map_err(|error| error.context("invalid table-provisioning database ID"))?;
+        let placement = match (placement_code, shard_column, shard_type) {
+            (SHARDED_PLACEMENT, Some(column), Some(key_type)) => TablePlacement::Sharded(
+                ShardKeyMetadata::new(column, decode_shard_key_type(key_type, 1)?)
+                    .map_err(|error| error.context("invalid table-provisioning shard key"))?,
+            ),
+            (GLOBAL_PLACEMENT, None, None) => TablePlacement::Global,
+            (CATALOG_PLACEMENT, None, None) => TablePlacement::Catalog,
+            _ => {
+                return Err(EngineError::new(
+                    EngineErrorKind::DataCorruption,
+                    "table-provisioning declaration has inconsistent placement",
+                ));
+            }
+        };
+        let policy = decode_generated_id_policy(
+            1,
+            &placement,
+            Some(generated_policy),
+            generated_column,
+            generated_version,
+        )?;
+        let declaration = match placement {
+            TablePlacement::Sharded(key) => TableDeclaration::sharded(database_id, name, key),
+            TablePlacement::Global => TableDeclaration::global(database_id, name),
+            TablePlacement::Catalog => TableDeclaration::catalog(database_id, name),
+        }
+        .and_then(|declaration| declaration.with_generated_id_policy(policy))
+        .map_err(|error| error.context("invalid table-provisioning declaration"))?;
+        declarations.push(declaration);
+    }
+    if !is_sorted_unique_declarations(&declarations) {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "table-provisioning declarations are not in canonical order",
+        ));
+    }
+    Ok(declarations.into_boxed_slice())
 }
 
 fn validate_schema_catalog_configuration(
@@ -5328,6 +7050,8 @@ mod tests {
 
     use rusqlite::OptionalExtension;
 
+    use crate::core::generated_id::AllocationOwnerSlot;
+
     use super::*;
 
     type StoredTableMetadataRow = (i64, i64, String, i64, Option<String>, Option<i64>);
@@ -5664,20 +7388,48 @@ mod tests {
             )
             .unwrap();
         if has_generated_ids {
-            connection
-                .execute(
-                    "INSERT INTO briskdb_generated_ids (
-                        table_id,
-                        policy,
-                        generated_column,
-                        encoding_version
-                     )
-                     SELECT table_id, ?1, NULL, NULL
-                     FROM briskdb_tables
-                     ORDER BY table_id",
-                    [GENERATED_ID_POLICY_NONE],
+            let has_activation = connection
+                .query_row(
+                    "SELECT EXISTS(
+                        SELECT 1 FROM pragma_table_xinfo('briskdb_generated_ids')
+                        WHERE name = 'activation_state'
+                     )",
+                    [],
+                    |row| row.get::<_, bool>(0),
                 )
                 .unwrap();
+            if has_activation {
+                connection
+                    .execute(
+                        "INSERT INTO briskdb_generated_ids (
+                            table_id,
+                            policy,
+                            generated_column,
+                            encoding_version,
+                            activation_state
+                         )
+                         SELECT table_id, ?1, NULL, NULL, ?2
+                         FROM briskdb_tables
+                         ORDER BY table_id",
+                        rusqlite::params![GENERATED_ID_POLICY_NONE, GENERATED_ID_INACTIVE],
+                    )
+                    .unwrap();
+            } else {
+                connection
+                    .execute(
+                        "INSERT INTO briskdb_generated_ids (
+                            table_id,
+                            policy,
+                            generated_column,
+                            encoding_version
+                         )
+                         SELECT table_id, ?1, NULL, NULL
+                         FROM briskdb_tables
+                         ORDER BY table_id",
+                        [GENERATED_ID_POLICY_NONE],
+                    )
+                    .unwrap();
+            }
         }
         refresh_manifest_digest_if_checksummed(connection).unwrap();
     }
@@ -5687,7 +7439,7 @@ mod tests {
             identity(connection),
             (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
         );
-        assert_eq!(schema_objects(connection).unwrap(), v9_objects());
+        assert_eq!(schema_objects(connection).unwrap(), v10_objects());
         assert_eq!(
             connection
                 .query_row(
@@ -5754,7 +7506,7 @@ mod tests {
                     |row| row.get::<_, i64>(0),
                 )
                 .unwrap(),
-            i64::from(V2_MANIFEST_DIGEST_VERSION)
+            i64::from(V3_MANIFEST_DIGEST_VERSION)
         );
         let (layout_id, application_id, metadata_version, state) = shard_layout_row(connection);
         assert_eq!(layout_id.len(), 16);
@@ -5862,7 +7614,16 @@ mod tests {
         );
         assert_eq!(
             resumed_steps,
-            [(2, 3), (3, 4), (4, 5), (5, 6), (6, 7), (7, 8), (8, 9),]
+            [
+                (2, 3),
+                (3, 4),
+                (4, 5),
+                (5, 6),
+                (6, 7),
+                (7, 8),
+                (8, 9),
+                (9, 10),
+            ]
         );
         assert_generation_one_catalog(&connection, 4);
         assert_eq!(quick_check(&connection), "ok");
@@ -6018,7 +7779,7 @@ mod tests {
     }
 
     #[test]
-    fn v8_to_v9_persists_explicit_none_policies_and_owner_slots() {
+    fn v8_to_current_persists_explicit_none_policies_and_owner_slots() {
         let mut connection = Connection::open_in_memory().unwrap();
         create_ready_v8_manifest(&mut connection, 4);
         insert_valid_table_catalog(&connection);
@@ -6045,9 +7806,9 @@ mod tests {
 
         assert_eq!(
             identity(&connection),
-            (MANIFEST_APPLICATION_ID, i64::from(V9_SCHEMA_VERSION))
+            (MANIFEST_APPLICATION_ID, i64::from(V10_SCHEMA_VERSION))
         );
-        assert_eq!(schema_objects(&connection).unwrap(), v9_objects());
+        assert_eq!(schema_objects(&connection).unwrap(), v10_objects());
         assert_eq!(table_metadata_rows(&connection), tables_before);
         assert_eq!(logical_databases(&connection), databases_before);
         assert_eq!(routing_configuration(&connection), routing_before);
@@ -6090,7 +7851,7 @@ mod tests {
                     |row| row.get::<_, i64>(0),
                 )
                 .unwrap(),
-            i64::from(V2_MANIFEST_DIGEST_VERSION)
+            i64::from(V3_MANIFEST_DIGEST_VERSION)
         );
         assert_eq!(
             manifest_semantic_digest(&connection).unwrap(),
@@ -6107,6 +7868,300 @@ mod tests {
         );
         assert_eq!(identity(&connection), identity_before);
         assert_eq!(stored_manifest_digest(&connection), root_before);
+    }
+
+    #[test]
+    fn v9_native_policy_migrates_inactive_without_losing_catalog_metadata() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        create_ready_current_manifest(&mut connection, 4);
+        let database = crate::core::LogicalDatabaseId::new(1).unwrap();
+        let declarations = vec![
+            TableDeclaration::sharded(
+                database,
+                "events",
+                ShardKeyMetadata::new("id", ShardKeyType::Int64).unwrap(),
+            )
+            .unwrap()
+            .with_generated_id_policy(GeneratedIdPolicy::native_range_v1("id").unwrap())
+            .unwrap(),
+        ];
+        let ready_digest = [0x5a; 32];
+        let active = match begin_native_table_provisioning(
+            &mut connection,
+            4,
+            declarations.clone(),
+            ready_digest,
+            || {},
+        )
+        .unwrap()
+        {
+            NativeTableProvisioningClassification::Active(active) => active,
+            other => panic!("unexpected provisioning classification: {other:?}"),
+        };
+        let mut progress = active;
+        for next in 1..=4 {
+            progress =
+                advance_native_table_provisioning(&mut connection, 4, &progress, next).unwrap();
+        }
+        finalize_native_table_provisioning(&mut connection, 4, &progress, || {}).unwrap();
+
+        connection
+            .execute(
+                "UPDATE briskdb_generated_ids SET activation_state = 0 WHERE table_id = 1",
+                [],
+            )
+            .unwrap();
+        connection
+            .execute_batch(
+                "DROP TABLE briskdb_table_provisioning_declarations;
+                 DROP TABLE briskdb_table_provisioning;
+                 DROP INDEX briskdb_one_active_owner_per_shard;
+                 ALTER TABLE briskdb_generated_ids RENAME TO briskdb_generated_ids_v10;
+                 ALTER TABLE briskdb_allocation_owners RENAME TO briskdb_allocation_owners_v10;",
+            )
+            .unwrap();
+        connection
+            .execute_batch(V9_GENERATED_IDS_TABLE_SQL)
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO briskdb_generated_ids
+                 SELECT table_id, policy, generated_column, encoding_version
+                 FROM briskdb_generated_ids_v10",
+                [],
+            )
+            .unwrap();
+        connection
+            .execute_batch(V9_ALLOCATION_OWNERS_TABLE_SQL)
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO briskdb_allocation_owners
+                 SELECT owner_slot, physical_shard_id
+                 FROM briskdb_allocation_owners_v10",
+                [],
+            )
+            .unwrap();
+        connection
+            .execute_batch(
+                "DROP TABLE briskdb_generated_ids_v10;
+                 DROP TABLE briskdb_allocation_owners_v10;
+                 DROP TABLE briskdb_metadata;",
+            )
+            .unwrap();
+        connection.execute_batch(V9_DOWNGRADE_FENCE_SQL).unwrap();
+        connection
+            .execute("INSERT INTO briskdb_metadata VALUES (9)", [])
+            .unwrap();
+        connection
+            .execute(
+                "UPDATE briskdb_integrity SET manifest_digest_version = 2",
+                [],
+            )
+            .unwrap();
+        set_identity(&connection, V9_SCHEMA_VERSION).unwrap();
+        refresh_manifest_digest(&connection).unwrap();
+
+        let loaded = load_or_create_manifest(&mut connection, 4).unwrap();
+        let table = loaded
+            .catalog
+            .logical()
+            .table("default", "events")
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            table.generated_id_policy(),
+            &GeneratedIdPolicy::native_range_v1("id").unwrap()
+        );
+        assert!(loaded.catalog.active_native_id_table_ids().is_empty());
+        assert_eq!(identity(&connection).1, i64::from(V10_SCHEMA_VERSION));
+    }
+
+    #[test]
+    fn table_provisioning_journal_is_exact_monotonic_and_atomic() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        create_ready_current_manifest(&mut connection, 4);
+        let database = crate::core::LogicalDatabaseId::new(1).unwrap();
+        let declarations = vec![
+            TableDeclaration::global(database, "countries").unwrap(),
+            TableDeclaration::sharded(
+                database,
+                "events",
+                ShardKeyMetadata::new("id", ShardKeyType::Int64).unwrap(),
+            )
+            .unwrap()
+            .with_generated_id_policy(GeneratedIdPolicy::native_range_v1("id").unwrap())
+            .unwrap(),
+        ];
+        let schema_digest = [0x5a; 32];
+
+        let active = match begin_native_table_provisioning(
+            &mut connection,
+            4,
+            declarations.clone(),
+            schema_digest,
+            || {},
+        )
+        .unwrap()
+        {
+            NativeTableProvisioningClassification::Active(active) => active,
+            other => panic!("unexpected provisioning classification: {other:?}"),
+        };
+        assert_eq!(active.next_shard(), 0);
+        assert_eq!(active.declarations(), declarations.as_slice());
+        assert_eq!(active.committed_schema_digest(), schema_digest);
+        assert_eq!(
+            active.provisioning_id(),
+            [
+                0x2a, 0x5e, 0xc9, 0x09, 0x53, 0x3f, 0xa2, 0x27, 0x8e, 0xaa, 0x36, 0xee, 0xf0, 0x1a,
+                0x24, 0xba, 0xc5, 0xe9, 0xf2, 0x25, 0x54, 0x9c, 0xf6, 0xf4, 0xa8, 0x9b, 0x3d, 0xfa,
+                0xe7, 0x57, 0xda, 0x2c,
+            ]
+        );
+        assert_eq!(
+            begin_native_table_provisioning(
+                &mut connection,
+                4,
+                declarations.clone(),
+                schema_digest,
+                || {},
+            )
+            .unwrap(),
+            NativeTableProvisioningClassification::Active(active.clone())
+        );
+        let conflict = vec![
+            TableDeclaration::sharded(
+                database,
+                "other_events",
+                ShardKeyMetadata::new("id", ShardKeyType::Int64).unwrap(),
+            )
+            .unwrap()
+            .with_generated_id_policy(GeneratedIdPolicy::native_range_v1("id").unwrap())
+            .unwrap(),
+        ];
+        assert_eq!(
+            begin_native_table_provisioning(&mut connection, 4, conflict, schema_digest, || {})
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+        assert_eq!(
+            advance_native_table_provisioning(&mut connection, 4, &active, 2)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::InvalidArgument
+        );
+        assert_eq!(
+            finalize_native_table_provisioning(&mut connection, 4, &active, || {})
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+
+        let mut progress = active;
+        for next in 1..=4 {
+            progress =
+                advance_native_table_provisioning(&mut connection, 4, &progress, next).unwrap();
+            assert_eq!(progress.next_shard(), next);
+        }
+        let mut commit_attempted = false;
+        let catalog = finalize_native_table_provisioning(&mut connection, 4, &progress, || {
+            commit_attempted = true;
+        })
+        .unwrap();
+        assert!(commit_attempted);
+        assert_eq!(catalog.logical().tables().len(), 2);
+        assert_eq!(catalog.active_native_id_table_ids().len(), 1);
+        assert!(
+            load_or_create_manifest(&mut connection, 4)
+                .unwrap()
+                .active_table_provisioning()
+                .is_none()
+        );
+        assert_eq!(
+            classify_native_table_provisioning(
+                &mut connection,
+                4,
+                declarations.clone(),
+                schema_digest,
+            )
+            .unwrap(),
+            NativeTableProvisioningClassification::Complete
+        );
+        assert_eq!(
+            finalize_native_table_provisioning(&mut connection, 4, &progress, || {}).unwrap(),
+            catalog
+        );
+    }
+
+    #[test]
+    fn retired_owners_route_history_while_replacement_owners_allocate() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        create_ready_current_manifest(&mut connection, 4);
+        connection
+            .execute(
+                "UPDATE briskdb_allocation_owners
+                 SET owner_state = ?1
+                 WHERE owner_slot = 0",
+                [ALLOCATION_OWNER_RETIRED],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO briskdb_allocation_owners (
+                    owner_slot, physical_shard_id, owner_state
+                 ) VALUES (100, 0, ?1)",
+                [ALLOCATION_OWNER_ACTIVE],
+            )
+            .unwrap();
+        refresh_manifest_digest(&connection).unwrap();
+        let catalog = load_or_create_catalog(&mut connection, 4).unwrap();
+        let owners = catalog.allocation_owners().unwrap();
+        assert_eq!(
+            owners.physical_shard(AllocationOwnerSlot::from_validated(0)),
+            Some(0)
+        );
+        assert_eq!(
+            owners.owner_for_physical_shard(0),
+            Some(AllocationOwnerSlot::from_validated(100))
+        );
+        assert_eq!(
+            owners
+                .assignments()
+                .filter(|(_, shard, _)| *shard == 0)
+                .collect::<Vec<_>>(),
+            [
+                (0, 0, AllocationOwnerState::Retired),
+                (100, 0, AllocationOwnerState::Active),
+            ]
+        );
+    }
+
+    #[cfg(feature = "experimental-vtab")]
+    #[test]
+    fn allocation_owner_lifecycle_rejects_a_lower_successor_atomically() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        create_ready_current_manifest(&mut connection, 4);
+        replace_allocation_owner_for_test(&mut connection, 4, 0, 100, 0).unwrap();
+        let root_before = stored_manifest_digest(&connection);
+        let owners_before = allocation_owner_rows(&connection);
+
+        let error = replace_allocation_owner_for_test(&mut connection, 4, 100, 50, 0).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::InvalidArgument);
+        assert!(error.diagnostic().contains("must be greater"));
+
+        assert_eq!(stored_manifest_digest(&connection), root_before);
+        assert_eq!(allocation_owner_rows(&connection), owners_before);
+        let owners = load_or_create_catalog(&mut connection, 4)
+            .unwrap()
+            .allocation_owners()
+            .unwrap()
+            .clone();
+        assert_eq!(
+            owners.owner_for_physical_shard(0),
+            Some(AllocationOwnerSlot::from_validated(100))
+        );
+        assert!(owners.owner_is_active(AllocationOwnerSlot::from_validated(100)));
     }
 
     #[test]
@@ -6169,6 +8224,170 @@ mod tests {
                     [(0, 0), (1, 1), (2, 2), (3, 3)]
                 );
                 assert_eq!(generated_id_rows(&connection).len(), tables_before.len());
+            }
+        }
+    }
+
+    #[test]
+    fn v9_to_v10_failures_and_panics_roll_back_exactly_and_retry() {
+        for failing_phase in [
+            MigrationPhase::AfterSchemaChange,
+            MigrationPhase::AfterVersionStamp,
+        ] {
+            for inject_panic in [false, true] {
+                let mut connection = Connection::open_in_memory().unwrap();
+                create_ready_current_manifest(&mut connection, 4);
+                let database = crate::core::LogicalDatabaseId::new(1).unwrap();
+                let declarations = vec![
+                    TableDeclaration::sharded(
+                        database,
+                        "events",
+                        ShardKeyMetadata::new("id", ShardKeyType::Int64).unwrap(),
+                    )
+                    .unwrap()
+                    .with_generated_id_policy(GeneratedIdPolicy::native_range_v1("id").unwrap())
+                    .unwrap(),
+                ];
+                install_v9_native_catalog_for_test(&mut connection, 4, &declarations).unwrap();
+
+                let root_before = stored_manifest_digest(&connection);
+                let databases_before = logical_databases(&connection);
+                let tables_before = table_metadata_rows(&connection);
+                let generated_ids_before = generated_id_rows(&connection);
+                let owners_before = allocation_owner_rows(&connection);
+                let objects_before = schema_objects(&connection).unwrap();
+                let fence_before = connection
+                    .query_row(
+                        "SELECT requires_manifest_version FROM briskdb_metadata",
+                        [],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .unwrap();
+                let digest_version_before = connection
+                    .query_row(
+                        "SELECT manifest_digest_version
+                         FROM briskdb_integrity
+                         WHERE singleton = 1",
+                        [],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .unwrap();
+
+                let attempt = catch_unwind(AssertUnwindSafe(|| {
+                    load_or_create_with_hook(&mut connection, 4, |point| {
+                        if point.from == V9_SCHEMA_VERSION && point.phase == failing_phase {
+                            if inject_panic {
+                                panic!("injected v9 to v10 migration panic");
+                            }
+                            return Err(EngineError::new(
+                                EngineErrorKind::Internal,
+                                "injected v9 to v10 migration failure",
+                            ));
+                        }
+                        Ok(())
+                    })
+                }));
+                if inject_panic {
+                    assert!(attempt.is_err());
+                } else {
+                    assert_eq!(
+                        attempt.unwrap().unwrap_err().kind(),
+                        EngineErrorKind::Internal
+                    );
+                }
+
+                assert_eq!(
+                    identity(&connection),
+                    (MANIFEST_APPLICATION_ID, i64::from(V9_SCHEMA_VERSION))
+                );
+                assert_eq!(schema_objects(&connection).unwrap(), objects_before);
+                assert_eq!(logical_databases(&connection), databases_before);
+                assert_eq!(table_metadata_rows(&connection), tables_before);
+                assert_eq!(generated_id_rows(&connection), generated_ids_before);
+                assert_eq!(allocation_owner_rows(&connection), owners_before);
+                assert_eq!(stored_manifest_digest(&connection), root_before);
+                assert_eq!(manifest_semantic_digest(&connection).unwrap(), root_before);
+                assert_eq!(quick_check(&connection), "ok");
+                assert_eq!(
+                    connection
+                        .query_row(
+                            "SELECT requires_manifest_version FROM briskdb_metadata",
+                            [],
+                            |row| row.get::<_, i64>(0),
+                        )
+                        .unwrap(),
+                    fence_before
+                );
+                assert_eq!(
+                    connection
+                        .query_row(
+                            "SELECT manifest_digest_version
+                             FROM briskdb_integrity
+                             WHERE singleton = 1",
+                            [],
+                            |row| row.get::<_, i64>(0),
+                        )
+                        .unwrap(),
+                    digest_version_before
+                );
+
+                let loaded = load_or_create_catalog(&mut connection, 4).unwrap();
+                let table = loaded
+                    .logical()
+                    .table("default", "events")
+                    .unwrap()
+                    .unwrap();
+                assert_eq!(
+                    table.generated_id_policy(),
+                    &GeneratedIdPolicy::native_range_v1("id").unwrap()
+                );
+                assert!(loaded.active_native_id_table_ids().is_empty());
+                assert_eq!(generated_id_rows(&connection), generated_ids_before);
+                assert_eq!(allocation_owner_rows(&connection), owners_before);
+                assert_eq!(
+                    connection
+                        .query_row(
+                            "SELECT COUNT(*)
+                             FROM briskdb_generated_ids
+                             WHERE activation_state != ?1",
+                            [GENERATED_ID_INACTIVE],
+                            |row| row.get::<_, i64>(0),
+                        )
+                        .unwrap(),
+                    0
+                );
+                assert_eq!(
+                    connection
+                        .query_row(
+                            "SELECT COUNT(*)
+                             FROM briskdb_allocation_owners
+                             WHERE owner_state != ?1",
+                            [ALLOCATION_OWNER_ACTIVE],
+                            |row| row.get::<_, i64>(0),
+                        )
+                        .unwrap(),
+                    0
+                );
+                assert_eq!(
+                    connection
+                        .query_row(
+                            "SELECT (SELECT COUNT(*) FROM briskdb_table_provisioning) +
+                                    (SELECT COUNT(*) FROM briskdb_table_provisioning_declarations)",
+                            [],
+                            |row| row.get::<_, i64>(0),
+                        )
+                        .unwrap(),
+                    0
+                );
+                assert_eq!(
+                    identity(&connection),
+                    (MANIFEST_APPLICATION_ID, i64::from(V10_SCHEMA_VERSION))
+                );
+                assert_eq!(schema_objects(&connection).unwrap(), v10_objects());
+                assert_eq!(
+                    manifest_semantic_digest(&connection).unwrap(),
+                    stored_manifest_digest(&connection)
+                );
             }
         }
     }
@@ -6416,7 +8635,7 @@ mod tests {
     }
 
     #[test]
-    fn manifest_semantic_digest_v2_orders_catalog_rows_by_frozen_keys() {
+    fn manifest_semantic_digest_v3_orders_catalog_rows_by_frozen_keys() {
         let mut forward = Connection::open_in_memory().unwrap();
         let mut reverse = Connection::open_in_memory().unwrap();
         for connection in [&mut forward, &mut reverse] {
@@ -6439,31 +8658,68 @@ mod tests {
                  INSERT INTO briskdb_tables VALUES (21, 9, 'audit_log', 3, NULL, NULL);
                  INSERT INTO briskdb_tables VALUES (8, 1, 'countries', 2, NULL, NULL);
                  INSERT INTO briskdb_tables VALUES (3, 1, 'accounts', 1, 'tenant_id', 2);
-                 INSERT INTO briskdb_generated_ids VALUES (55, 0, NULL, NULL);
-                 INSERT INTO briskdb_generated_ids VALUES (34, 0, NULL, NULL);
-                 INSERT INTO briskdb_generated_ids VALUES (21, 0, NULL, NULL);
-                 INSERT INTO briskdb_generated_ids VALUES (8, 0, NULL, NULL);
-                 INSERT INTO briskdb_generated_ids VALUES (3, 0, NULL, NULL);",
+                 INSERT INTO briskdb_generated_ids VALUES (55, 0, NULL, NULL, 0);
+                 INSERT INTO briskdb_generated_ids VALUES (34, 0, NULL, NULL, 0);
+                 INSERT INTO briskdb_generated_ids VALUES (21, 0, NULL, NULL, 0);
+                 INSERT INTO briskdb_generated_ids VALUES (8, 0, NULL, NULL, 0);
+                 INSERT INTO briskdb_generated_ids VALUES (3, 0, NULL, NULL, 0);",
             )
             .unwrap();
 
         let digest = refresh_manifest_digest(&forward).unwrap();
         assert_eq!(digest, refresh_manifest_digest(&reverse).unwrap());
+    }
+
+    #[test]
+    fn manifest_semantic_digest_v3_has_a_frozen_golden_vector() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        create_ready_current_manifest(&mut connection, 4);
+        connection
+            .execute(
+                "UPDATE briskdb_shard_layout
+                 SET layout_id = x'000102030405060708090a0b0c0d0e0f'
+                 WHERE singleton = 1",
+                [],
+            )
+            .unwrap();
+        refresh_manifest_digest(&connection).unwrap();
+        let database = crate::core::LogicalDatabaseId::new(1).unwrap();
+        let declarations = vec![
+            TableDeclaration::global(database, "countries").unwrap(),
+            TableDeclaration::sharded(
+                database,
+                "events",
+                ShardKeyMetadata::new("id", ShardKeyType::Int64).unwrap(),
+            )
+            .unwrap()
+            .with_generated_id_policy(GeneratedIdPolicy::native_range_v1("id").unwrap())
+            .unwrap(),
+        ];
+        let active =
+            begin_native_table_provisioning(&mut connection, 4, declarations, [0x5a; 32], || {})
+                .unwrap();
+        assert!(matches!(
+            active,
+            NativeTableProvisioningClassification::Active(_)
+        ));
+
+        let digest = manifest_semantic_digest(&connection).unwrap();
         assert_eq!(
             digest,
             [
-                0xb4, 0xc6, 0xcb, 0x52, 0x95, 0xc1, 0x43, 0xf8, 0xe5, 0xf9, 0x3c, 0x96, 0xa3, 0x96,
-                0x84, 0xa7, 0xca, 0xd3, 0x72, 0x50, 0x13, 0x68, 0x7b, 0x07, 0x94, 0xd8, 0x2f, 0x58,
-                0x0f, 0x0e, 0xed, 0xf0,
+                0x14, 0xd3, 0xd7, 0x26, 0x2d, 0x98, 0x5b, 0x0a, 0x6d, 0xe3, 0x57, 0x23, 0xe8, 0xa6,
+                0x21, 0xec, 0x49, 0xf9, 0x81, 0x52, 0xc4, 0xa7, 0xa8, 0xaf, 0xcf, 0xee, 0x50, 0xb9,
+                0x98, 0x34, 0xd1, 0x5c,
             ]
         );
+        assert_eq!(stored_manifest_digest(&connection), digest);
     }
 
     #[test]
     fn semantic_root_covers_every_authoritative_manifest_table_and_integrity_state() {
         let mutations = [
             "UPDATE briskdb_manifest SET singleton = 2 WHERE singleton = 1",
-            "UPDATE briskdb_metadata SET requires_manifest_version = 10",
+            "UPDATE briskdb_metadata SET requires_manifest_version = 11",
             "UPDATE briskdb_routing SET hash_version = 2 WHERE singleton = 1",
             "UPDATE briskdb_physical_shards SET lifecycle_state = 'retired' WHERE shard_id = 0",
             "UPDATE briskdb_allocation_owners SET owner_slot = 100 WHERE owner_slot = 0",
@@ -6471,9 +8727,11 @@ mod tests {
             "UPDATE briskdb_logical_databases SET database_name = 'primary' WHERE database_id = 1",
             "UPDATE briskdb_schema_catalog SET identifier_encoding_version = 2 WHERE singleton = 1",
             "INSERT INTO briskdb_tables VALUES (1, 1, 'widgets', 2, NULL, NULL)",
-            "INSERT INTO briskdb_generated_ids VALUES (1, 0, NULL, NULL)",
+            "INSERT INTO briskdb_generated_ids VALUES (1, 0, NULL, NULL, 0)",
             "UPDATE briskdb_shard_layout SET layout_id = randomblob(16) WHERE singleton = 1",
             "INSERT INTO briskdb_schema_migrations VALUES (1, 0, randomblob(32), 1, 'SELECT 1', 4, 2, 4)",
+            "INSERT INTO briskdb_table_provisioning VALUES (1, zeroblob(32), 1, 1, zeroblob(32), 4, 1, 0)",
+            "INSERT INTO briskdb_table_provisioning_declarations VALUES (1, 0, 1, 'events', 1, 'id', 1, 1, 'id', 1)",
             "UPDATE briskdb_integrity SET database_state = 4 WHERE singleton = 1",
             "UPDATE briskdb_integrity SET committed_schema_digest = randomblob(32) WHERE singleton = 1",
         ];
@@ -6557,7 +8815,7 @@ mod tests {
     fn resealed_generated_id_relational_tampering_fails_closed() {
         for mutation in [
             "DELETE FROM briskdb_generated_ids WHERE table_id = 3",
-            "INSERT INTO briskdb_generated_ids VALUES (999, 0, NULL, NULL)",
+            "INSERT INTO briskdb_generated_ids VALUES (999, 0, NULL, NULL, 0)",
             "UPDATE briskdb_generated_ids
              SET policy = 1, generated_column = 'id', encoding_version = 1
              WHERE table_id = 8",
@@ -6595,8 +8853,14 @@ mod tests {
     fn resealed_allocation_owner_relational_tampering_fails_closed() {
         for mutation in [
             "DELETE FROM briskdb_allocation_owners WHERE owner_slot = 0",
-            "UPDATE briskdb_allocation_owners SET owner_slot = 100 WHERE owner_slot = 0",
+            "UPDATE briskdb_allocation_owners SET owner_state = 2 WHERE owner_slot = 0",
             "UPDATE briskdb_allocation_owners SET physical_shard_id = 63 WHERE owner_slot = 0",
+            "UPDATE briskdb_allocation_owners
+             SET owner_slot = 100, owner_state = 2
+             WHERE owner_slot = 0;
+             INSERT INTO briskdb_allocation_owners (
+                 owner_slot, physical_shard_id, owner_state
+             ) VALUES (50, 0, 1)",
         ] {
             let mut connection = Connection::open_in_memory().unwrap();
             create_ready_current_manifest(&mut connection, 4);
@@ -6620,7 +8884,7 @@ mod tests {
     #[test]
     fn integrity_versions_lengths_and_forged_state_invariants_fail_closed() {
         for (version_column, unsupported_version) in
-            [("manifest_digest_version", 3), ("schema_digest_version", 2)]
+            [("manifest_digest_version", 4), ("schema_digest_version", 2)]
         {
             let mut unsupported = Connection::open_in_memory().unwrap();
             create_ready_current_manifest(&mut unsupported, 4);
@@ -6848,7 +9112,7 @@ mod tests {
             identity(&connection),
             (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
         );
-        assert_eq!(schema_objects(&connection).unwrap(), v9_objects());
+        assert_eq!(schema_objects(&connection).unwrap(), v10_objects());
         assert_eq!(
             shard_layout_row(&connection).3,
             ShardLayoutState::Adopting.code()
@@ -6872,7 +9136,7 @@ mod tests {
             identity(&connection),
             (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
         );
-        assert_eq!(schema_objects(&connection).unwrap(), v9_objects());
+        assert_eq!(schema_objects(&connection).unwrap(), v10_objects());
         assert_eq!(layout.state(), ShardLayoutState::Ready);
         assert_eq!(shard_layout_row(&connection), layout_before);
         assert_eq!(catalog.logical().schema_generation(), 0);
@@ -6964,7 +9228,7 @@ mod tests {
                 identity(&connection),
                 (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
             );
-            assert_eq!(schema_objects(&connection).unwrap(), v9_objects());
+            assert_eq!(schema_objects(&connection).unwrap(), v10_objects());
         }
 
         let mut connection = Connection::open_in_memory().unwrap();
@@ -8584,7 +10848,7 @@ mod tests {
         for mutation in [
             "DELETE FROM briskdb_metadata",
             "DELETE FROM briskdb_manifest",
-            "INSERT INTO briskdb_metadata VALUES (9)",
+            "INSERT INTO briskdb_metadata VALUES (11)",
             "DELETE FROM briskdb_routing",
             "DELETE FROM briskdb_virtual_buckets WHERE bucket_id = 4095",
             "DELETE FROM briskdb_physical_shards WHERE shard_id = 3",
@@ -8805,9 +11069,10 @@ mod tests {
                         table_id,
                         policy,
                         generated_column,
-                        encoding_version
+                        encoding_version,
+                        activation_state
                      )
-                     SELECT table_id, 0, NULL, NULL
+                     SELECT table_id, 0, NULL, NULL, 0
                      FROM briskdb_tables
                      ORDER BY table_id",
                     [],

--- a/src/storage/migration.rs
+++ b/src/storage/migration.rs
@@ -1018,7 +1018,7 @@ fn preflight_one_shard(
                 layout,
             )?;
             shard::verify_schema_digest(&connection, source_generation, expected_source_digest)?;
-            shard::preflight_schema_migration_on_connection_with_digest_and_catalog(
+            shard::preflight_schema_migration_on_connection_with_digest_and_catalog_snapshot(
                 &mut connection,
                 path,
                 shard_id,
@@ -1026,7 +1026,7 @@ fn preflight_one_shard(
                 target_generation,
                 layout,
                 sql,
-                catalog.logical(),
+                catalog,
             )
         }
         Some(control) => {
@@ -1041,7 +1041,7 @@ fn preflight_one_shard(
                     layout,
                 )?;
                 shard::verify_schema_digest(connection, source_generation, expected_source_digest)?;
-                shard::preflight_schema_migration_on_connection_with_digest_and_catalog(
+                shard::preflight_schema_migration_on_connection_with_digest_and_catalog_snapshot(
                     connection,
                     path,
                     shard_id,
@@ -1049,7 +1049,7 @@ fn preflight_one_shard(
                     target_generation,
                     layout,
                     sql,
-                    catalog.logical(),
+                    catalog,
                 )
             })
         }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -25,7 +25,7 @@ use std::{
 };
 
 use rusqlite::{
-    Connection, OpenFlags,
+    Connection, OpenFlags, TransactionBehavior,
     hooks::{AuthAction, AuthContext, Authorization},
 };
 
@@ -36,15 +36,20 @@ pub(crate) use schema_gate::{SchemaGateSnapshot, SchemaGateState};
 pub(crate) use schema_gate::{SchemaMigrationGuard, SchemaOperationGuard};
 
 pub use crate::core::Database;
+#[cfg(any(feature = "experimental-vtab", test))]
+use crate::core::TableId;
 use crate::{
     core::{
-        Catalog, CatalogSnapshot, EngineError, EngineErrorKind, EngineResult, MAX_TABLES,
-        ShardKeyType, TableDeclaration, TablePlacement,
+        Catalog, CatalogSnapshot, EngineError, EngineErrorKind, EngineResult, GeneratedIdPolicy,
+        MAX_TABLES, ShardKeyType, TableDeclaration, TablePlacement,
+        generated_id::{
+            NATIVE_RANGE_V1_FORMAT_MARKER, native_range_v1_sequence_ceiling,
+            native_range_v1_sequence_floor,
+        },
     },
     sqlite_error,
 };
 
-#[cfg(feature = "experimental-vtab")]
 use crate::core::AllocationOwnerMap;
 
 pub(crate) const CONNECTION_BUSY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
@@ -309,6 +314,7 @@ fn immutable_catalog_metadata_matches(left: &CatalogSnapshot, right: &CatalogSna
     let right_logical = right.logical();
     left.routing() == right.routing()
         && left.allocation_owners() == right.allocation_owners()
+        && left.active_native_id_table_ids() == right.active_native_id_table_ids()
         && left_logical.identifier_encoding_version() == right_logical.identifier_encoding_version()
         && left_logical.default_database().id() == right_logical.default_database().id()
         && left_logical.logical_databases() == right_logical.logical_databases()
@@ -488,8 +494,15 @@ impl Storage {
                 return Err(error);
             }
         };
-        let (catalog, shard_layout, active_migration, mut integrity) =
-            loaded.into_parts_with_migration();
+        let (
+            catalog,
+            shard_layout,
+            active_migration,
+            mut integrity,
+            active_native_id_table_ids,
+            active_table_provisioning,
+        ) = loaded.into_parts_with_recovery();
+        let catalog = catalog.with_active_native_id_table_ids(active_native_id_table_ids);
         let catalog = schema_coordination.register_catalog(catalog)?;
         schema_coordination.publish_schema_digests(
             integrity.committed_schema_digest(),
@@ -507,7 +520,7 @@ impl Storage {
 
         if let Some(active_migration) = active_migration {
             startup.mark_pending_on_drop();
-            let recovery = (|| {
+            let recovery: EngineResult<()> = (|| {
                 validate_schema_migration_checksum_prefix(
                     &root.join("shards"),
                     requested_shards,
@@ -559,12 +572,53 @@ impl Storage {
             }
         };
 
-        let storage = Self {
+        let mut storage = Self {
             root,
             catalog,
             shard_layout: ready_layout,
             schema_coordination,
         };
+        if let Some(mut provisioning) = active_table_provisioning {
+            startup.mark_pending_on_drop();
+            let recovery: EngineResult<()> = (|| {
+                storage.validate_empty_table_declarations(provisioning.declarations())?;
+                while provisioning.next_shard() < provisioning.shard_count() {
+                    let shard_id = provisioning.next_shard();
+                    storage.seed_native_range_v1_sequences_on_shard(
+                        provisioning.declarations(),
+                        shard_id,
+                    )?;
+                    provisioning = manifest::advance_native_table_provisioning(
+                        &mut manifest,
+                        requested_shards,
+                        &provisioning,
+                        shard_id + 1,
+                    )?;
+                }
+                let replacement_guard = storage
+                    .schema_coordination
+                    .reserve_catalog_replacement(&storage.catalog)?;
+                let replacement = manifest::finalize_native_table_provisioning(
+                    &mut manifest,
+                    requested_shards,
+                    &provisioning,
+                    || {},
+                )?;
+                storage.catalog = replacement_guard.publish(&storage.catalog, replacement)?;
+                Ok::<(), EngineError>(())
+            })();
+            if let Err(error) = recovery {
+                if error.kind() == EngineErrorKind::DataCorruption {
+                    storage.mark_schema_degraded();
+                    let _ = manifest::mark_degraded(
+                        &mut manifest,
+                        requested_shards,
+                        &storage.shard_layout,
+                    );
+                }
+                return Err(error);
+            }
+        }
         let verification = storage.verify_current_schema_consensus(integrity);
         let observed_digest = match verification {
             Ok(digest) => digest,
@@ -631,9 +685,13 @@ impl Storage {
         self.catalog.logical()
     }
 
-    #[cfg(feature = "experimental-vtab")]
     pub(crate) fn allocation_owner_map(&self) -> Option<&AllocationOwnerMap> {
         self.catalog.allocation_owners()
+    }
+
+    #[cfg(any(feature = "experimental-vtab", test))]
+    pub(crate) fn native_id_policy_is_active(&self, table_id: TableId) -> bool {
+        self.catalog.native_id_policy_is_active(table_id)
     }
 
     pub(crate) fn register_tables(
@@ -646,16 +704,36 @@ impl Storage {
 
     fn register_tables_inner(&mut self, declarations: Vec<TableDeclaration>) -> EngineResult<()> {
         self.validate_table_declaration_request(&declarations)?;
-        if !self.catalog.logical().tables().is_empty() {
+        let catalog_is_empty = self.catalog.logical().tables().is_empty();
+        if !catalog_is_empty && !declarations_match_catalog(self.catalog.logical(), &declarations) {
             let _operation = self.enter_schema_operation()?;
-            return if declarations_match_catalog(self.catalog.logical(), &declarations) {
-                Ok(())
-            } else {
-                Err(EngineError::new(
-                    EngineErrorKind::FailedPrecondition,
-                    "the authoritative table catalog is already registered",
-                ))
-            };
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "the authoritative table catalog is already registered",
+            ));
+        }
+        let has_native_policy = declarations.iter().any(|declaration| {
+            matches!(
+                declaration.generated_id_policy(),
+                GeneratedIdPolicy::NativeRangeV1 { .. }
+            )
+        });
+        let every_native_policy_is_active = !has_native_policy
+            || declarations.iter().all(|declaration| {
+                !matches!(
+                    declaration.generated_id_policy(),
+                    GeneratedIdPolicy::NativeRangeV1 { .. }
+                ) || self
+                    .catalog
+                    .logical()
+                    .table("default", declaration.name())
+                    .ok()
+                    .flatten()
+                    .is_some_and(|table| self.catalog.native_id_policy_is_active(table.id()))
+            });
+        if !catalog_is_empty && every_native_policy_is_active {
+            let _operation = self.enter_schema_operation()?;
+            return Ok(());
         }
         let mut migration = self.schema_coordination.gate.begin_new_migration()?;
         migration.wait_for_quiescence_blocking();
@@ -668,12 +746,59 @@ impl Storage {
             let manifest_path = self.root.join("manifest.sqlite");
             let mut manifest_connection = open_existing_manifest(&manifest_path)?;
             configure_manifest_connection(&manifest_connection)?;
-            let replacement = manifest::register_table_catalog(
-                &mut manifest_connection,
-                self.shard_count(),
-                declarations,
-                || migration.mark_pending_on_drop(),
-            )?;
+            let replacement = if has_native_policy {
+                let committed_schema_digest = self.schema_coordination.committed_schema_digest()?;
+                let classification = manifest::begin_native_table_provisioning(
+                    &mut manifest_connection,
+                    self.shard_count(),
+                    declarations.clone(),
+                    committed_schema_digest,
+                    || migration.mark_pending_on_drop(),
+                )?;
+                let mut provisioning = match classification {
+                    manifest::NativeTableProvisioningClassification::Active(provisioning) => {
+                        provisioning
+                    }
+                    manifest::NativeTableProvisioningClassification::Complete => {
+                        return Err(EngineError::new(
+                            EngineErrorKind::FailedPrecondition,
+                            "table provisioning is already complete in the manifest; reopen this stale handle",
+                        ));
+                    }
+                    manifest::NativeTableProvisioningClassification::Absent => {
+                        return Err(EngineError::new(
+                            EngineErrorKind::Internal,
+                            "table provisioning did not create its durable journal",
+                        ));
+                    }
+                };
+                while provisioning.next_shard() < provisioning.shard_count() {
+                    let shard_id = provisioning.next_shard();
+                    self.seed_native_range_v1_sequences_on_shard(
+                        provisioning.declarations(),
+                        shard_id,
+                    )?;
+                    provisioning = manifest::advance_native_table_provisioning(
+                        &mut manifest_connection,
+                        self.shard_count(),
+                        &provisioning,
+                        shard_id + 1,
+                    )?;
+                }
+                manifest::finalize_native_table_provisioning(
+                    &mut manifest_connection,
+                    self.shard_count(),
+                    &provisioning,
+                    || migration.mark_pending_on_drop(),
+                )?
+            } else {
+                manifest::register_table_catalog(
+                    &mut manifest_connection,
+                    self.shard_count(),
+                    declarations,
+                    || migration.mark_pending_on_drop(),
+                )?
+            };
             let replacement = replacement_guard.publish(&self.catalog, replacement)?;
             self.catalog = replacement;
             Ok(())
@@ -727,6 +852,151 @@ impl Storage {
             }
         }
         Ok(())
+    }
+
+    /// Seed every native table's shard-local AUTOINCREMENT source before the
+    /// authoritative catalog can publish the policy.
+    ///
+    /// Each shard is committed independently, so a process exit can leave a
+    /// prefix seeded. Publication is deliberately last, and retries install at
+    /// least the same durable owner floor without lowering a valid same-owner
+    /// high-water mark left by earlier committed-and-deleted rows.
+    #[cfg(test)]
+    fn seed_native_range_v1_sequences(
+        &self,
+        declarations: &[TableDeclaration],
+    ) -> EngineResult<()> {
+        for shard_id in 0..self.shard_count() {
+            self.seed_native_range_v1_sequences_on_shard(declarations, shard_id)?;
+        }
+        Ok(())
+    }
+
+    fn seed_native_range_v1_sequences_on_shard(
+        &self,
+        declarations: &[TableDeclaration],
+        shard_id: u16,
+    ) -> EngineResult<()> {
+        let native_tables = declarations
+            .iter()
+            .filter_map(|declaration| match declaration.generated_id_policy() {
+                GeneratedIdPolicy::NativeRangeV1 { column } => {
+                    Some((declaration.name(), column.as_str()))
+                }
+                GeneratedIdPolicy::None => None,
+            })
+            .collect::<Vec<_>>();
+        if native_tables.is_empty() {
+            return Ok(());
+        }
+        let allocation_owners = self.catalog.allocation_owners().ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "native_range_v1 registration requires a durable allocation-owner map",
+            )
+        })?;
+
+        let owner = allocation_owners
+            .owner_for_physical_shard(shard_id)
+            .ok_or_else(|| {
+                EngineError::new(
+                    EngineErrorKind::DataCorruption,
+                    format!(
+                        "physical shard {shard_id} has no durable native-range allocation owner"
+                    ),
+                )
+            })?;
+        let floor = native_range_v1_sequence_floor(owner);
+        let ceiling = native_range_v1_sequence_ceiling(owner);
+        let marker = i64::try_from(NATIVE_RANGE_V1_FORMAT_MARKER)
+            .expect("the native-range marker reserves the signed high bit");
+        let mut connection = self.open_shard(shard_id)?;
+        let transaction = connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(sqlite_error::storage)?;
+        for &(table, column) in &native_tables {
+            let quoted_table = quote_identifier(table);
+            let has_rows = transaction
+                .query_row(
+                    &format!("SELECT EXISTS(SELECT 1 FROM {quoted_table} LIMIT 1)"),
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .map_err(sqlite_error::storage)?;
+            if has_rows != 0 {
+                return Err(EngineError::new(
+                    EngineErrorKind::FailedPrecondition,
+                    format!(
+                        "table {table} must remain empty on physical shard {shard_id} while native_range_v1 is provisioned"
+                    ),
+                ));
+            }
+            if !shard::native_generated_column_is_exact(&transaction, table, column)? {
+                return Err(EngineError::new(
+                    EngineErrorKind::FailedPrecondition,
+                    format!(
+                        "generated column {column} on table {table} must be exactly INTEGER PRIMARY KEY AUTOINCREMENT on physical shard {shard_id}"
+                    ),
+                ));
+            }
+            let (row_count, integer_count) = transaction
+                .query_row(
+                    "SELECT COUNT(*), COALESCE(SUM(typeof(seq) = 'integer'), 0)
+                         FROM main.sqlite_sequence
+                         WHERE name = ?1 COLLATE BINARY",
+                    [table],
+                    |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+                )
+                .map_err(sqlite_error::storage)?;
+            match (row_count, integer_count) {
+                (0, 0) => {
+                    transaction
+                        .execute(
+                            "INSERT INTO main.sqlite_sequence(name, seq) VALUES (?1, ?2)",
+                            rusqlite::params![table, floor],
+                        )
+                        .map_err(sqlite_error::storage)?;
+                }
+                (1, 1) => {
+                    let sequence = transaction
+                        .query_row(
+                            "SELECT seq FROM main.sqlite_sequence
+                                 WHERE name = ?1 COLLATE BINARY",
+                            [table],
+                            |row| row.get::<_, i64>(0),
+                        )
+                        .map_err(sqlite_error::storage)?;
+                    if sequence < marker {
+                        transaction
+                            .execute(
+                                "UPDATE main.sqlite_sequence SET seq = ?2
+                                     WHERE name = ?1 COLLATE BINARY",
+                                rusqlite::params![table, floor],
+                            )
+                            .map_err(sqlite_error::storage)?;
+                    } else if !(floor..=ceiling).contains(&sequence) {
+                        return Err(EngineError::new(
+                            EngineErrorKind::FailedPrecondition,
+                            format!(
+                                "table {table} on physical shard {shard_id} has sqlite_sequence value {sequence} in a conflicting native allocation-owner range"
+                            ),
+                        ));
+                    }
+                    // Preserve a same-owner high-water mark. Lowering it,
+                    // even while the table is empty, could reuse an ID
+                    // that was committed and later deleted.
+                }
+                _ => {
+                    return Err(EngineError::new(
+                        EngineErrorKind::FailedPrecondition,
+                        format!(
+                            "table {table} on physical shard {shard_id} must have at most one integer sqlite_sequence row before native_range_v1 registration"
+                        ),
+                    ));
+                }
+            }
+        }
+        transaction.commit().map_err(sqlite_error::storage)
     }
 
     fn validate_empty_table_declarations(
@@ -918,6 +1188,7 @@ impl Storage {
                 self.catalog.logical().schema_generation(),
                 &expected_digest,
             )?;
+            self.validate_native_range_v1_state(&connection, shard)?;
             attach_storage_authorizer(&connection)?;
             Ok(connection)
         })();
@@ -997,6 +1268,7 @@ impl Storage {
                 self.catalog.logical().schema_generation(),
                 &expected_digest,
             )?;
+            self.validate_native_range_v1_state(&connection, shard)?;
             attach_storage_authorizer(&connection)?;
             Ok(connection)
         })();
@@ -1072,8 +1344,16 @@ impl Storage {
         // Establish trusted and cross-shard digest agreement everywhere before
         // enforcing compatibility policy. Otherwise a policy error on an early
         // shard could mask later corruption and prevent terminal degradation.
-        for connection in &verified_connections {
-            shard::validate_registered_table_schema(connection, self.catalog.logical())?;
+        for (shard_id, connection) in verified_connections.iter().enumerate() {
+            shard::validate_registered_table_schema_with_active_native_ids(
+                connection,
+                self.catalog.logical(),
+                self.catalog.active_native_id_table_ids(),
+            )?;
+            self.validate_native_range_v1_state(
+                connection,
+                u16::try_from(shard_id).expect("the validated shard set fits u16"),
+            )?;
         }
         Ok(consensus)
     }
@@ -1098,7 +1378,8 @@ impl Storage {
                 connection,
                 self.catalog.logical().schema_generation(),
                 &expected_digest,
-            )
+            )?;
+            self.validate_native_range_v1_state(connection, shard)
         })();
         self.fail_closed_on_corruption(result)
     }
@@ -1124,9 +1405,33 @@ impl Storage {
                 self.catalog.logical().schema_generation(),
                 &expected_digest,
             )?;
+            self.validate_native_range_v1_state(connection, shard)?;
             attach_storage_authorizer(connection)
         })();
         self.fail_closed_on_corruption(result)
+    }
+
+    fn validate_native_range_v1_state(
+        &self,
+        connection: &Connection,
+        physical_shard: u16,
+    ) -> EngineResult<()> {
+        if self.catalog.active_native_id_table_ids().is_empty() {
+            return Ok(());
+        }
+        let allocation_owners = self.catalog.allocation_owners().ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "native_range_v1 catalog is missing its durable allocation-owner map",
+            )
+        })?;
+        shard::validate_native_range_v1_state_with_active_ids(
+            connection,
+            self.catalog.logical(),
+            allocation_owners,
+            physical_shard,
+            Some(self.catalog.active_native_id_table_ids()),
+        )
     }
 
     fn ensure_shard_in_range(&self, shard: u16) -> EngineResult<()> {
@@ -1354,6 +1659,17 @@ fn validate_empty_table_declaration(
                 declaration.name()
             ),
         ));
+    }
+    if let GeneratedIdPolicy::NativeRangeV1 { column } = declaration.generated_id_policy() {
+        if !shard::native_generated_column_is_exact(connection, declaration.name(), column)? {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "generated column {column} on table {} must be exactly INTEGER PRIMARY KEY AUTOINCREMENT on physical shard {shard_id}",
+                    declaration.name()
+                ),
+            ));
+        }
     }
     let affinity = sqlite_affinity(declared_type);
     let compatible = matches!(
@@ -2208,7 +2524,10 @@ mod tests {
             manifest
                 .execute_batch(
                     "BEGIN IMMEDIATE;
+                     DROP TABLE briskdb_table_provisioning_declarations;
+                     DROP TABLE briskdb_table_provisioning;
                      DROP TABLE briskdb_generated_ids;
+                     DROP INDEX briskdb_one_active_owner_per_shard;
                      DROP TABLE briskdb_allocation_owners;
                      DROP TABLE briskdb_integrity;
                      DROP TABLE briskdb_metadata;
@@ -2307,7 +2626,10 @@ mod tests {
             .unwrap()
             .execute_batch(
                 "BEGIN IMMEDIATE;
+                 DROP TABLE briskdb_table_provisioning_declarations;
+                 DROP TABLE briskdb_table_provisioning;
                  DROP TABLE briskdb_generated_ids;
+                 DROP INDEX briskdb_one_active_owner_per_shard;
                  DROP TABLE briskdb_allocation_owners;
                  DROP TABLE briskdb_integrity;
                  DROP TABLE briskdb_metadata;
@@ -2400,7 +2722,10 @@ mod tests {
             .unwrap()
             .execute_batch(
                 "BEGIN IMMEDIATE;
+                 DROP TABLE briskdb_table_provisioning_declarations;
+                 DROP TABLE briskdb_table_provisioning;
                  DROP TABLE briskdb_generated_ids;
+                 DROP INDEX briskdb_one_active_owner_per_shard;
                  DROP TABLE briskdb_allocation_owners;
                  DROP TABLE briskdb_integrity;
                  DROP TABLE briskdb_metadata;
@@ -3214,6 +3539,394 @@ mod tests {
             .unwrap();
     }
 
+    fn native_events_declaration(database_id: crate::core::LogicalDatabaseId) -> TableDeclaration {
+        TableDeclaration::sharded(
+            database_id,
+            "events",
+            crate::core::ShardKeyMetadata::new("id", ShardKeyType::Int64).unwrap(),
+        )
+        .unwrap()
+        .with_generated_id_policy(crate::core::GeneratedIdPolicy::native_range_v1("id").unwrap())
+        .unwrap()
+    }
+
+    fn create_registered_native_storage(root: &Path, shard_count: u16) -> Storage {
+        let mut storage = Storage::open(root, shard_count).unwrap();
+        let mut migration = storage.begin_schema_migration().unwrap();
+        migration.wait_for_quiescence_blocking();
+        storage
+            .apply_schema_migration(
+                "CREATE TABLE events (
+                     id INTEGER PRIMARY KEY AUTOINCREMENT,
+                     payload BLOB
+                 )",
+                &mut migration,
+                None,
+            )
+            .unwrap();
+        migration.publish_ready().unwrap();
+        let declaration =
+            native_events_declaration(storage.logical_catalog().default_database().id());
+        storage.register_tables(vec![declaration]).unwrap();
+        storage
+    }
+
+    #[test]
+    fn degradation_preserves_active_native_provisioning_and_startup_does_not_replay_it() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = Storage::open(temp.path(), 2).unwrap();
+        let mut migration = storage.begin_schema_migration().unwrap();
+        migration.wait_for_quiescence_blocking();
+        storage
+            .apply_schema_migration(
+                "CREATE TABLE events (
+                     id INTEGER PRIMARY KEY AUTOINCREMENT,
+                     payload BLOB
+                 )",
+                &mut migration,
+                None,
+            )
+            .unwrap();
+        migration.publish_ready().unwrap();
+
+        let declaration =
+            native_events_declaration(storage.logical_catalog().default_database().id());
+        let committed_schema_digest = storage
+            .schema_coordination
+            .committed_schema_digest()
+            .unwrap();
+        let mut manifest_connection =
+            open_existing_manifest(&temp.path().join("manifest.sqlite")).unwrap();
+        configure_manifest_connection(&manifest_connection).unwrap();
+        let active = match manifest::begin_native_table_provisioning(
+            &mut manifest_connection,
+            2,
+            vec![declaration],
+            committed_schema_digest,
+            || {},
+        )
+        .unwrap()
+        {
+            manifest::NativeTableProvisioningClassification::Active(active) => active,
+            classification => panic!("unexpected classification: {classification:?}"),
+        };
+        let provisioning_id = active.provisioning_id();
+
+        manifest::mark_degraded(&mut manifest_connection, 2, &storage.shard_layout).unwrap();
+        assert_eq!(
+            manifest::current_integrity(&manifest_connection, 2)
+                .unwrap()
+                .state(),
+            manifest::DatabaseIntegrityState::Degraded
+        );
+        assert_eq!(
+            manifest_connection
+                .query_row(
+                    "SELECT provisioning_id, next_shard
+                     FROM briskdb_table_provisioning
+                     WHERE singleton = 1",
+                    [],
+                    |row| Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, u16>(1)?)),
+                )
+                .unwrap(),
+            (provisioning_id.to_vec(), 0)
+        );
+        assert_eq!(
+            manifest_connection
+                .query_row(
+                    "SELECT COUNT(*) FROM briskdb_table_provisioning_declarations",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            1
+        );
+        drop(manifest_connection);
+        drop(storage);
+
+        for shard in 0..2 {
+            assert_eq!(
+                Connection::open(shard_file(temp.path(), shard))
+                    .unwrap()
+                    .query_row(
+                        "SELECT COUNT(*) FROM sqlite_sequence WHERE name = 'events'",
+                        [],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .unwrap(),
+                0
+            );
+        }
+
+        let reopen_error = Storage::open(temp.path(), 2).unwrap_err();
+        assert_eq!(reopen_error.kind(), EngineErrorKind::DataCorruption);
+        assert!(reopen_error.to_string().contains("persistently degraded"));
+
+        let manifest_connection =
+            open_existing_manifest(&temp.path().join("manifest.sqlite")).unwrap();
+        configure_manifest_connection(&manifest_connection).unwrap();
+        assert_eq!(
+            manifest::current_integrity(&manifest_connection, 2)
+                .unwrap()
+                .state(),
+            manifest::DatabaseIntegrityState::Degraded
+        );
+        assert_eq!(
+            manifest_connection
+                .query_row(
+                    "SELECT provisioning_id, next_shard
+                     FROM briskdb_table_provisioning
+                     WHERE singleton = 1",
+                    [],
+                    |row| Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, u16>(1)?)),
+                )
+                .unwrap(),
+            (provisioning_id.to_vec(), 0)
+        );
+        assert_eq!(
+            manifest_connection
+                .query_row(
+                    "SELECT COUNT(*) FROM briskdb_table_provisioning_declarations",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            1
+        );
+        drop(manifest_connection);
+        for shard in 0..2 {
+            assert_eq!(
+                Connection::open(shard_file(temp.path(), shard))
+                    .unwrap()
+                    .query_row(
+                        "SELECT COUNT(*) FROM sqlite_sequence WHERE name = 'events'",
+                        [],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .unwrap(),
+                0
+            );
+        }
+    }
+
+    #[test]
+    fn startup_recovers_every_native_provisioning_commit_boundary() {
+        use crate::core::generated_id::native_range_v1_sequence_floor;
+
+        // `seeded` may exceed the acknowledged prefix by one to model the
+        // crash window after a shard commit and before journal advancement.
+        for (acknowledged, seeded) in [(0_u16, 0_u16), (0, 1), (2, 3), (4, 4)] {
+            let temp = tempfile::tempdir().unwrap();
+            let storage = Storage::open(temp.path(), 4).unwrap();
+            let mut migration = storage.begin_schema_migration().unwrap();
+            migration.wait_for_quiescence_blocking();
+            storage
+                .apply_schema_migration(
+                    "CREATE TABLE events (
+                         id INTEGER PRIMARY KEY AUTOINCREMENT,
+                         payload BLOB
+                     )",
+                    &mut migration,
+                    None,
+                )
+                .unwrap();
+            migration.publish_ready().unwrap();
+            let declaration =
+                native_events_declaration(storage.logical_catalog().default_database().id());
+            let committed_schema_digest = storage
+                .schema_coordination
+                .committed_schema_digest()
+                .unwrap();
+            let mut manifest_connection =
+                open_existing_manifest(&temp.path().join("manifest.sqlite")).unwrap();
+            configure_manifest_connection(&manifest_connection).unwrap();
+            let mut provisioning = match manifest::begin_native_table_provisioning(
+                &mut manifest_connection,
+                4,
+                vec![declaration],
+                committed_schema_digest,
+                || {},
+            )
+            .unwrap()
+            {
+                manifest::NativeTableProvisioningClassification::Active(provisioning) => {
+                    provisioning
+                }
+                classification => panic!("unexpected classification: {classification:?}"),
+            };
+            for shard in 0..seeded {
+                storage
+                    .seed_native_range_v1_sequences_on_shard(provisioning.declarations(), shard)
+                    .unwrap();
+                if shard < acknowledged {
+                    provisioning = manifest::advance_native_table_provisioning(
+                        &mut manifest_connection,
+                        4,
+                        &provisioning,
+                        shard + 1,
+                    )
+                    .unwrap();
+                }
+            }
+            assert_eq!(provisioning.next_shard(), acknowledged);
+            drop(manifest_connection);
+            drop(storage);
+
+            let reopened = Storage::open(temp.path(), 4).unwrap();
+            let table = reopened
+                .logical_catalog()
+                .table("default", "events")
+                .unwrap()
+                .unwrap();
+            assert!(reopened.native_id_policy_is_active(table.id()));
+            for shard in 0..4 {
+                let owner = reopened
+                    .allocation_owner_map()
+                    .unwrap()
+                    .owner_for_physical_shard(shard)
+                    .unwrap();
+                assert_eq!(
+                    reopened
+                        .open_shard(shard)
+                        .unwrap()
+                        .query_row(
+                            "SELECT seq FROM sqlite_sequence WHERE name = 'events'",
+                            [],
+                            |row| row.get::<_, i64>(0),
+                        )
+                        .unwrap(),
+                    native_range_v1_sequence_floor(owner)
+                );
+            }
+            let mut manifest_connection =
+                open_existing_manifest(&temp.path().join("manifest.sqlite")).unwrap();
+            assert!(
+                manifest::classify_native_table_provisioning(
+                    &mut manifest_connection,
+                    4,
+                    vec![native_events_declaration(
+                        reopened.logical_catalog().default_database().id(),
+                    )],
+                    reopened
+                        .schema_coordination
+                        .committed_schema_digest()
+                        .unwrap(),
+                )
+                .unwrap()
+                    == manifest::NativeTableProvisioningClassification::Complete
+            );
+            drop(manifest_connection);
+            drop(reopened);
+
+            let second_reopen = Storage::open(temp.path(), 4).unwrap();
+            let table = second_reopen
+                .logical_catalog()
+                .table("default", "events")
+                .unwrap()
+                .unwrap();
+            assert!(second_reopen.native_id_policy_is_active(table.id()));
+        }
+    }
+
+    #[test]
+    fn finalized_native_provisioning_stays_pending_until_stale_handle_closes() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = Storage::open(temp.path(), 2).unwrap();
+        let mut schema = storage.begin_schema_migration().unwrap();
+        schema.wait_for_quiescence_blocking();
+        storage
+            .apply_schema_migration(
+                "CREATE TABLE events (
+                     id INTEGER PRIMARY KEY AUTOINCREMENT,
+                     payload BLOB
+                 )",
+                &mut schema,
+                None,
+            )
+            .unwrap();
+        schema.publish_ready().unwrap();
+
+        let declaration =
+            native_events_declaration(storage.logical_catalog().default_database().id());
+        let committed_schema_digest = storage
+            .schema_coordination
+            .committed_schema_digest()
+            .unwrap();
+        let mut registration = storage.begin_schema_migration().unwrap();
+        registration.wait_for_quiescence_blocking();
+        let mut manifest_connection =
+            open_existing_manifest(&temp.path().join("manifest.sqlite")).unwrap();
+        configure_manifest_connection(&manifest_connection).unwrap();
+        let mut provisioning = match manifest::begin_native_table_provisioning(
+            &mut manifest_connection,
+            2,
+            vec![declaration],
+            committed_schema_digest,
+            || registration.mark_pending_on_drop(),
+        )
+        .unwrap()
+        {
+            manifest::NativeTableProvisioningClassification::Active(provisioning) => provisioning,
+            classification => panic!("unexpected classification: {classification:?}"),
+        };
+        while provisioning.next_shard() < provisioning.shard_count() {
+            let shard = provisioning.next_shard();
+            storage
+                .seed_native_range_v1_sequences_on_shard(provisioning.declarations(), shard)
+                .unwrap();
+            provisioning = manifest::advance_native_table_provisioning(
+                &mut manifest_connection,
+                2,
+                &provisioning,
+                shard + 1,
+            )
+            .unwrap();
+        }
+
+        // Simulate process loss after manifest finalization but before the
+        // returned catalog can be published into the live Storage handle.
+        let durable_replacement = manifest::finalize_native_table_provisioning(
+            &mut manifest_connection,
+            2,
+            &provisioning,
+            || registration.mark_pending_on_drop(),
+        )
+        .unwrap();
+        assert_eq!(durable_replacement.active_native_id_table_ids().len(), 1);
+        drop(durable_replacement);
+        drop(manifest_connection);
+        drop(registration);
+
+        assert!(storage.logical_catalog().tables().is_empty());
+        assert_eq!(
+            storage.schema_gate_snapshot().state,
+            SchemaGateState::Pending
+        );
+        assert_eq!(
+            storage.enter_schema_operation().unwrap_err().kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+        let conflict = Storage::open(temp.path(), 2).unwrap_err();
+        assert_eq!(conflict.kind(), EngineErrorKind::FailedPrecondition);
+        assert_eq!(
+            storage.schema_gate_snapshot().state,
+            SchemaGateState::Pending
+        );
+        drop(storage);
+
+        let reopened = Storage::open(temp.path(), 2).unwrap();
+        let table = reopened
+            .logical_catalog()
+            .table("default", "events")
+            .unwrap()
+            .unwrap();
+        assert!(reopened.native_id_policy_is_active(table.id()));
+        assert_eq!(
+            reopened.schema_gate_snapshot().state,
+            SchemaGateState::Ready
+        );
+    }
+
     #[test]
     fn table_registration_is_authoritative_persistent_and_idempotent() {
         let temp = tempfile::tempdir().unwrap();
@@ -3265,7 +3978,7 @@ mod tests {
         database
             .broadcast(
                 "CREATE TABLE events (
-                     id INTEGER PRIMARY KEY,
+                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                      payload BLOB
                  )",
             )
@@ -3295,15 +4008,764 @@ mod tests {
         drop(database);
 
         let reopened = Database::open(temp.path(), 3).unwrap();
+        let reopened_table = reopened
+            .catalog()
+            .table("default", "events")
+            .unwrap()
+            .unwrap();
+        assert_eq!(reopened_table.generated_id_policy(), &policy);
+        drop(reopened);
+
+        let reopened = Storage::open(temp.path(), 3).unwrap();
+        let reopened_table = reopened
+            .logical_catalog()
+            .table("default", "events")
+            .unwrap()
+            .unwrap();
+        assert!(reopened.native_id_policy_is_active(reopened_table.id()));
+        for shard in 0..3 {
+            reopened.open_shard(shard).unwrap();
+        }
+    }
+
+    #[test]
+    fn file_backed_v9_native_policy_upgrades_inactive_without_autoincrement() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = Storage::open(temp.path(), 2).unwrap();
+        let mut migration = storage.begin_schema_migration().unwrap();
+        migration.wait_for_quiescence_blocking();
+        storage
+            .apply_schema_migration(
+                "CREATE TABLE events (
+                     id INTEGER PRIMARY KEY,
+                     payload BLOB
+                 )",
+                &mut migration,
+                None,
+            )
+            .unwrap();
+        migration.publish_ready().unwrap();
+        let declaration =
+            native_events_declaration(storage.logical_catalog().default_database().id());
+        let mut manifest_connection =
+            open_existing_manifest(&temp.path().join("manifest.sqlite")).unwrap();
+        manifest::install_v9_native_catalog_for_test(
+            &mut manifest_connection,
+            2,
+            std::slice::from_ref(&declaration),
+        )
+        .unwrap();
+        manifest::inspect_with_v9_plan_for_test(&manifest_connection, 2).unwrap();
+        drop(manifest_connection);
+        drop(storage);
+
+        let mut upgraded = Storage::open(temp.path(), 2).unwrap();
+        let table = upgraded
+            .logical_catalog()
+            .table("default", "events")
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            table.generated_id_policy(),
+            declaration.generated_id_policy()
+        );
+        assert!(!upgraded.native_id_policy_is_active(table.id()));
+        for shard in 0..2 {
+            let connection = upgraded.open_shard(shard).unwrap();
+            assert!(
+                !connection
+                    .query_row(
+                        "SELECT EXISTS(
+                         SELECT 1 FROM sqlite_schema
+                         WHERE type = 'table' AND name = 'sqlite_sequence'
+                     )",
+                        [],
+                        |row| row.get::<_, bool>(0),
+                    )
+                    .unwrap()
+            );
+        }
+
+        // Activation checks the physical shape before publishing a journal;
+        // the old v9 policy remains readable and ordinary admission remains ready.
+        let error = upgraded.register_tables(vec![declaration]).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert!(error.diagnostic().contains("AUTOINCREMENT"));
+        assert_eq!(
+            upgraded.schema_gate_snapshot().state,
+            SchemaGateState::Ready
+        );
+
+        let manifest_connection =
+            open_existing_manifest(&temp.path().join("manifest.sqlite")).unwrap();
+        let identity_before = manifest_connection
+            .pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
+            .unwrap();
+        let root_before = manifest_connection
+            .query_row(
+                "SELECT manifest_digest FROM briskdb_integrity WHERE singleton = 1",
+                [],
+                |row| row.get::<_, Vec<u8>>(0),
+            )
+            .unwrap();
+        let error = manifest::inspect_with_v9_plan_for_test(&manifest_connection, 2).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert_eq!(
+            manifest_connection
+                .pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
+                .unwrap(),
+            identity_before
+        );
+        assert_eq!(
+            manifest_connection
+                .query_row(
+                    "SELECT manifest_digest FROM briskdb_integrity WHERE singleton = 1",
+                    [],
+                    |row| row.get::<_, Vec<u8>>(0),
+                )
+                .unwrap(),
+            root_before
+        );
+        drop(manifest_connection);
+        drop(upgraded);
+
+        let reopened = Storage::open(temp.path(), 2).unwrap();
+        let table = reopened
+            .logical_catalog()
+            .table("default", "events")
+            .unwrap()
+            .unwrap();
+        assert!(!reopened.native_id_policy_is_active(table.id()));
+
+        #[cfg(feature = "experimental-vtab")]
+        {
+            let mut coordinator = WriteCoordinator::open(reopened.clone()).unwrap();
+            let error = coordinator
+                .execute_generated_dml_auto(
+                    "INSERT INTO events (payload) VALUES (x'01')",
+                    [],
+                    table.id().get(),
+                )
+                .unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+            assert_eq!(
+                reopened
+                    .open_shard(0)
+                    .unwrap()
+                    .query_row("SELECT COUNT(*) FROM events", [], |row| row
+                        .get::<_, i64>(0))
+                    .unwrap(),
+                0
+            );
+        }
+    }
+
+    #[test]
+    fn native_generated_id_policy_requires_exact_autoincrement_storage() {
+        for schema in [
+            "CREATE TABLE events (id INTEGER PRIMARY KEY, payload BLOB)",
+            "CREATE TABLE events (id INTEGER NOT NULL UNIQUE, payload BLOB)",
+            "CREATE TABLE events (
+                 id INTEGER PRIMARY KEY AUTOINCREMENT DEFAULT 7,
+                 payload BLOB
+             )",
+        ] {
+            let temp = tempfile::tempdir().unwrap();
+            let mut database = Database::open(temp.path(), 2).unwrap();
+            database.broadcast(schema).unwrap();
+            let declaration = native_events_declaration(database.catalog().default_database().id());
+
+            let error = database.register_tables(vec![declaration]).unwrap_err();
+            assert_eq!(
+                error.kind(),
+                EngineErrorKind::FailedPrecondition,
+                "{schema}"
+            );
+            assert!(
+                error
+                    .diagnostic()
+                    .contains("INTEGER PRIMARY KEY AUTOINCREMENT"),
+                "{}",
+                error.diagnostic()
+            );
+            assert!(database.catalog().tables().is_empty());
+        }
+    }
+
+    #[test]
+    fn native_sequence_provisioning_is_idempotent_for_2_4_8_and_10_shards() {
+        use crate::core::generated_id::{
+            AllocationOwnerSlot, native_range_v1_first_id, native_range_v1_sequence_floor,
+        };
+
+        for shard_count in [2, 4, 8, 10] {
+            let temp = tempfile::tempdir().unwrap();
+            let mut storage = Storage::open(temp.path(), shard_count).unwrap();
+            let mut migration = storage.begin_schema_migration().unwrap();
+            migration.wait_for_quiescence_blocking();
+            storage
+                .apply_schema_migration(
+                    "CREATE TABLE events (
+                         id INTEGER PRIMARY KEY AUTOINCREMENT,
+                         payload BLOB
+                     )",
+                    &mut migration,
+                    None,
+                )
+                .unwrap();
+            migration.publish_ready().unwrap();
+            let declaration =
+                native_events_declaration(storage.logical_catalog().default_database().id());
+
+            storage
+                .seed_native_range_v1_sequences(std::slice::from_ref(&declaration))
+                .unwrap();
+            storage
+                .seed_native_range_v1_sequences(std::slice::from_ref(&declaration))
+                .unwrap();
+            storage.register_tables(vec![declaration.clone()]).unwrap();
+            storage.register_tables(vec![declaration]).unwrap();
+
+            for shard_id in 0..shard_count {
+                let owner = AllocationOwnerSlot::new(shard_id).unwrap();
+                let connection = Connection::open(shard_file(temp.path(), shard_id)).unwrap();
+                let rows = connection
+                    .query_row(
+                        "SELECT COUNT(*), MIN(seq), MAX(seq)
+                         FROM sqlite_sequence WHERE name = 'events'",
+                        [],
+                        |row| {
+                            Ok((
+                                row.get::<_, i64>(0)?,
+                                row.get::<_, i64>(1)?,
+                                row.get::<_, i64>(2)?,
+                            ))
+                        },
+                    )
+                    .unwrap();
+                assert_eq!(
+                    rows,
+                    (
+                        1,
+                        native_range_v1_sequence_floor(owner),
+                        native_range_v1_sequence_floor(owner)
+                    ),
+                    "shard count {shard_count}, shard {shard_id}"
+                );
+                let allocated = connection
+                    .query_row(
+                        "INSERT INTO events (payload) VALUES (x'01') RETURNING id",
+                        [],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .unwrap();
+                assert_eq!(allocated, native_range_v1_first_id(owner));
+            }
+            drop(storage);
+            Storage::open(temp.path(), shard_count).unwrap();
+        }
+    }
+
+    #[test]
+    fn native_sequence_provisioning_never_lowers_a_deleted_same_owner_high_water() {
+        use crate::core::generated_id::{AllocationOwnerSlot, native_range_v1_first_id};
+
+        let temp = tempfile::tempdir().unwrap();
+        let mut storage = Storage::open(temp.path(), 2).unwrap();
+        let mut migration = storage.begin_schema_migration().unwrap();
+        migration.wait_for_quiescence_blocking();
+        storage
+            .apply_schema_migration(
+                "CREATE TABLE events (
+                     id INTEGER PRIMARY KEY AUTOINCREMENT,
+                     payload BLOB
+                 )",
+                &mut migration,
+                None,
+            )
+            .unwrap();
+        migration.publish_ready().unwrap();
+
+        let owner = AllocationOwnerSlot::new(0).unwrap();
+        let committed_high_water = native_range_v1_first_id(owner) + 24;
+        let connection = storage.open_shard(0).unwrap();
+        connection
+            .execute(
+                "INSERT INTO events (id, payload) VALUES (?1, x'01')",
+                [committed_high_water],
+            )
+            .unwrap();
+        connection
+            .execute("DELETE FROM events WHERE id = ?1", [committed_high_water])
+            .unwrap();
+        drop(connection);
+
+        let declaration =
+            native_events_declaration(storage.logical_catalog().default_database().id());
+        storage.register_tables(vec![declaration]).unwrap();
+
+        let connection = storage.open_shard(0).unwrap();
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT seq FROM sqlite_sequence WHERE name = 'events'",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            committed_high_water
+        );
+        let next = connection
+            .query_row(
+                "INSERT INTO events (payload) VALUES (x'02') RETURNING id",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap();
+        assert_eq!(next, committed_high_water + 1);
+    }
+
+    #[test]
+    fn native_sequence_provisioning_rejects_a_conflicting_owner_high_water() {
+        use crate::core::generated_id::{AllocationOwnerSlot, native_range_v1_first_id};
+
+        let temp = tempfile::tempdir().unwrap();
+        let mut storage = Storage::open(temp.path(), 2).unwrap();
+        let mut migration = storage.begin_schema_migration().unwrap();
+        migration.wait_for_quiescence_blocking();
+        storage
+            .apply_schema_migration(
+                "CREATE TABLE events (
+                     id INTEGER PRIMARY KEY AUTOINCREMENT,
+                     payload BLOB
+                 )",
+                &mut migration,
+                None,
+            )
+            .unwrap();
+        migration.publish_ready().unwrap();
+
+        let conflicting = native_range_v1_first_id(AllocationOwnerSlot::new(0).unwrap()) + 9;
+        let connection = storage.open_shard(1).unwrap();
+        connection
+            .execute(
+                "INSERT INTO events (id, payload) VALUES (?1, x'01')",
+                [conflicting],
+            )
+            .unwrap();
+        connection
+            .execute("DELETE FROM events WHERE id = ?1", [conflicting])
+            .unwrap();
+        drop(connection);
+
+        let declaration =
+            native_events_declaration(storage.logical_catalog().default_database().id());
+        let error = storage.register_tables(vec![declaration]).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert!(
+            error
+                .diagnostic()
+                .contains("conflicting native allocation-owner")
+        );
+        assert!(storage.logical_catalog().tables().is_empty());
+        assert_eq!(
+            storage.schema_gate_snapshot().state,
+            SchemaGateState::Pending
+        );
+        assert_eq!(
+            storage.enter_schema_operation().unwrap_err().kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+
+        let connection = Connection::open(shard_file(temp.path(), 1)).unwrap();
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT seq FROM sqlite_sequence WHERE name = 'events'",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            conflicting
+        );
+    }
+
+    #[test]
+    fn native_allocator_state_tampering_fails_closed() {
+        use crate::core::generated_id::{
+            AllocationOwnerSlot, native_range_v1_first_id, native_range_v1_sequence_ceiling,
+            native_range_v1_sequence_floor,
+        };
+
+        enum Tamper {
+            Missing,
+            Duplicate,
+            NonInteger,
+            BelowFloor,
+            AboveCeiling,
+            SequenceBehindRow,
+            ForeignOwnerRow,
+        }
+
+        for tamper in [
+            Tamper::Missing,
+            Tamper::Duplicate,
+            Tamper::NonInteger,
+            Tamper::BelowFloor,
+            Tamper::AboveCeiling,
+            Tamper::SequenceBehindRow,
+            Tamper::ForeignOwnerRow,
+        ] {
+            let temp = tempfile::tempdir().unwrap();
+            let storage = create_registered_native_storage(temp.path(), 2);
+            let physical_shard = if matches!(tamper, Tamper::ForeignOwnerRow) {
+                1
+            } else {
+                0
+            };
+            let owner = AllocationOwnerSlot::new(physical_shard).unwrap();
+            let floor = native_range_v1_sequence_floor(owner);
+            let ceiling = native_range_v1_sequence_ceiling(owner);
+            let connection = Connection::open(shard_file(temp.path(), physical_shard)).unwrap();
+            match tamper {
+                Tamper::Missing => {
+                    connection
+                        .execute("DELETE FROM sqlite_sequence WHERE name = 'events'", [])
+                        .unwrap();
+                }
+                Tamper::Duplicate => {
+                    connection
+                        .execute(
+                            "INSERT INTO sqlite_sequence(name, seq) VALUES ('events', ?1)",
+                            [floor],
+                        )
+                        .unwrap();
+                }
+                Tamper::NonInteger => {
+                    connection
+                        .execute(
+                            "UPDATE sqlite_sequence SET seq = 'invalid' WHERE name = 'events'",
+                            [],
+                        )
+                        .unwrap();
+                }
+                Tamper::BelowFloor => {
+                    connection
+                        .execute(
+                            "UPDATE sqlite_sequence SET seq = ?1 WHERE name = 'events'",
+                            [floor - 1],
+                        )
+                        .unwrap();
+                }
+                Tamper::AboveCeiling => {
+                    connection
+                        .execute(
+                            "UPDATE sqlite_sequence SET seq = ?1 WHERE name = 'events'",
+                            [ceiling + 1],
+                        )
+                        .unwrap();
+                }
+                Tamper::SequenceBehindRow => {
+                    connection
+                        .execute(
+                            "INSERT INTO events (id, payload) VALUES (?1, x'01')",
+                            [native_range_v1_first_id(owner) + 5],
+                        )
+                        .unwrap();
+                    connection
+                        .execute(
+                            "UPDATE sqlite_sequence SET seq = ?1 WHERE name = 'events'",
+                            [floor],
+                        )
+                        .unwrap();
+                }
+                Tamper::ForeignOwnerRow => {
+                    let foreign = native_range_v1_first_id(AllocationOwnerSlot::new(0).unwrap());
+                    connection
+                        .execute(
+                            "INSERT INTO events (id, payload) VALUES (?1, x'01')",
+                            [foreign],
+                        )
+                        .unwrap();
+                    connection
+                        .execute(
+                            "UPDATE sqlite_sequence SET seq = ?1 WHERE name = 'events'",
+                            [floor],
+                        )
+                        .unwrap();
+                }
+            }
+            drop(connection);
+
+            let error = storage.open_shard(physical_shard).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+            assert!(error.diagnostic().contains("native_range_v1"));
+        }
+    }
+
+    #[test]
+    fn native_allocator_accepts_an_exhausted_owner_at_its_exact_ceiling() {
+        use crate::core::generated_id::{AllocationOwnerSlot, native_range_v1_sequence_ceiling};
+
+        let temp = tempfile::tempdir().unwrap();
+        let storage = create_registered_native_storage(temp.path(), 2);
+        let ceiling = native_range_v1_sequence_ceiling(AllocationOwnerSlot::new(0).unwrap());
+        let connection = Connection::open(shard_file(temp.path(), 0)).unwrap();
+        connection
+            .execute(
+                "UPDATE sqlite_sequence SET seq = ?1 WHERE name = 'events'",
+                [ceiling],
+            )
+            .unwrap();
+        drop(connection);
+
+        storage.open_shard(0).unwrap();
+    }
+
+    #[cfg(feature = "experimental-vtab")]
+    #[test]
+    fn retired_owner_rows_survive_reopen_while_new_allocation_uses_replacement_owner() {
+        use crate::core::generated_id::{
+            AllocationOwnerSlot, NativeRangeV1Id, native_range_v1_first_id,
+            native_range_v1_sequence_floor,
+        };
+
+        let temp = tempfile::tempdir().unwrap();
+        let storage = create_registered_native_storage(temp.path(), 2);
+        let old_owner = storage
+            .allocation_owner_map()
+            .unwrap()
+            .owner_for_physical_shard(0)
+            .unwrap();
+        let old_id = NativeRangeV1Id::new(old_owner, 5).unwrap().encode();
+        storage
+            .open_shard(0)
+            .unwrap()
+            .execute(
+                "INSERT INTO events (id, payload) VALUES (?1, x'6f6c64')",
+                [old_id],
+            )
+            .unwrap();
+        drop(storage);
+
+        let replacement_owner = AllocationOwnerSlot::new(100).unwrap();
+        let mut manifest_connection =
+            open_existing_manifest(&temp.path().join("manifest.sqlite")).unwrap();
+        configure_manifest_connection(&manifest_connection).unwrap();
+        manifest::replace_allocation_owner_for_test(
+            &mut manifest_connection,
+            2,
+            old_owner.get(),
+            replacement_owner.get(),
+            0,
+        )
+        .unwrap();
+        drop(manifest_connection);
+        Connection::open(shard_file(temp.path(), 0))
+            .unwrap()
+            .execute(
+                "UPDATE sqlite_sequence SET seq = ?1 WHERE name = 'events'",
+                [native_range_v1_sequence_floor(replacement_owner)],
+            )
+            .unwrap();
+
+        let storage = Storage::open(temp.path(), 2).unwrap();
+        let owners = storage.allocation_owner_map().unwrap();
+        assert_eq!(owners.physical_shard(old_owner), Some(0));
+        assert!(!owners.owner_is_active(old_owner));
+        assert_eq!(owners.owner_for_physical_shard(0), Some(replacement_owner));
+        for shard in 0..2 {
+            storage.open_shard(shard).unwrap();
+        }
+
+        let reader = sharded_vtab::ReadCoordinator::open(storage.clone()).unwrap();
+        assert_eq!(
+            reader
+                .connection()
+                .query_row(
+                    "SELECT payload FROM events WHERE id = ?1",
+                    [old_id],
+                    |row| { row.get::<_, Vec<u8>>(0) }
+                )
+                .unwrap(),
+            b"old"
+        );
+        drop(reader);
+
+        let retired_candidate = NativeRangeV1Id::new(old_owner, 6).unwrap().encode();
+        let error = WriteCoordinator::open(storage.clone())
+            .unwrap()
+            .execute_dml(
+                "INSERT INTO events (id, payload) VALUES (?1, x'6e6577')",
+                [retired_candidate],
+            )
+            .unwrap_err();
+        // SQLite surfaces an xUpdate module rejection as SQLITE_ERROR; the
+        // shared planner preserves FailedPrecondition before this callback.
+        assert_eq!(error.kind(), EngineErrorKind::InvalidQuery);
+        assert!(error.diagnostic().contains("retired allocation owner"));
+
+        let table_id = storage
+            .logical_catalog()
+            .table("default", "events")
+            .unwrap()
+            .unwrap()
+            .id()
+            .get();
+        let generated = WriteCoordinator::open(storage.clone())
+            .unwrap()
+            .execute_generated_dml(
+                "INSERT INTO events (payload) VALUES (x'6e6577')",
+                [],
+                table_id,
+                0,
+            )
+            .unwrap();
+        assert_eq!(generated.shard(), Some(0));
+        assert_eq!(
+            generated.generated_key().unwrap().value,
+            crate::core::Value::Int64(native_range_v1_first_id(replacement_owner))
+        );
+
+        let deleted = WriteCoordinator::open(storage.clone())
+            .unwrap()
+            .execute_dml("DELETE FROM events WHERE id = ?1", [old_id])
+            .unwrap();
+        assert_eq!(deleted.affected_rows(), 1);
+        drop(storage);
+
+        let reopened = Storage::open(temp.path(), 2).unwrap();
         assert_eq!(
             reopened
-                .catalog()
-                .table("default", "events")
+                .open_shard(0)
                 .unwrap()
-                .unwrap()
-                .generated_id_policy(),
-            &policy
+                .query_row(
+                    "SELECT COUNT(*) FROM events WHERE id = ?1",
+                    [old_id],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            0
         );
+        assert_eq!(
+            reopened
+                .allocation_owner_map()
+                .unwrap()
+                .physical_shard(old_owner),
+            Some(0)
+        );
+    }
+
+    #[cfg(feature = "experimental-vtab")]
+    #[test]
+    fn lower_owner_replacement_is_rejected_after_a_deleted_committed_high_water() {
+        use crate::core::generated_id::{
+            AllocationOwnerSlot, NativeRangeV1Id, native_range_v1_sequence_floor,
+        };
+
+        let temp = tempfile::tempdir().unwrap();
+        let storage = create_registered_native_storage(temp.path(), 2);
+        let original_owner = storage
+            .allocation_owner_map()
+            .unwrap()
+            .owner_for_physical_shard(0)
+            .unwrap();
+        drop(storage);
+
+        let active_owner = AllocationOwnerSlot::new(100).unwrap();
+        let mut manifest_connection =
+            open_existing_manifest(&temp.path().join("manifest.sqlite")).unwrap();
+        configure_manifest_connection(&manifest_connection).unwrap();
+        manifest::replace_allocation_owner_for_test(
+            &mut manifest_connection,
+            2,
+            original_owner.get(),
+            active_owner.get(),
+            0,
+        )
+        .unwrap();
+        drop(manifest_connection);
+
+        Connection::open(shard_file(temp.path(), 0))
+            .unwrap()
+            .execute(
+                "UPDATE sqlite_sequence SET seq = ?1 WHERE name = 'events'",
+                [native_range_v1_sequence_floor(active_owner)],
+            )
+            .unwrap();
+
+        let storage = Storage::open(temp.path(), 2).unwrap();
+        let connection = storage.open_shard(0).unwrap();
+        let deleted_high_water = connection
+            .query_row(
+                "INSERT INTO events (payload) VALUES (x'01') RETURNING id",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap();
+        assert_eq!(
+            NativeRangeV1Id::decode(deleted_high_water).unwrap().owner(),
+            active_owner
+        );
+        connection
+            .execute("DELETE FROM events WHERE id = ?1", [deleted_high_water])
+            .unwrap();
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT COUNT(*) FROM events WHERE id = ?1",
+                    [deleted_high_water],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT seq FROM sqlite_sequence WHERE name = 'events'",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            deleted_high_water
+        );
+        drop(connection);
+        drop(storage);
+
+        let mut manifest_connection =
+            open_existing_manifest(&temp.path().join("manifest.sqlite")).unwrap();
+        configure_manifest_connection(&manifest_connection).unwrap();
+        let error = manifest::replace_allocation_owner_for_test(
+            &mut manifest_connection,
+            2,
+            active_owner.get(),
+            50,
+            0,
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::InvalidArgument);
+        assert!(error.diagnostic().contains("must be greater"));
+        drop(manifest_connection);
+
+        let reopened = Storage::open(temp.path(), 2).unwrap();
+        assert_eq!(
+            reopened
+                .allocation_owner_map()
+                .unwrap()
+                .owner_for_physical_shard(0),
+            Some(active_owner)
+        );
+        let connection = reopened.open_shard(0).unwrap();
+        let next = connection
+            .query_row(
+                "INSERT INTO events (payload) VALUES (x'02') RETURNING id",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap();
+        assert_eq!(next, deleted_high_water + 1);
+        assert_eq!(NativeRangeV1Id::decode(next).unwrap().owner(), active_owner);
     }
 
     #[test]
@@ -3808,9 +5270,9 @@ mod tests {
             let mut database = Database::open(temp.path(), 2).unwrap();
             database
                 .broadcast(
-                    "CREATE TABLE parents (id INTEGER PRIMARY KEY);
+                    "CREATE TABLE parents (id INTEGER PRIMARY KEY AUTOINCREMENT);
                      CREATE TABLE children (
-                         id INTEGER PRIMARY KEY REFERENCES parents(id)
+                         id INTEGER PRIMARY KEY AUTOINCREMENT REFERENCES parents(id)
                      );",
                 )
                 .unwrap();

--- a/src/storage/shard.rs
+++ b/src/storage/shard.rs
@@ -13,8 +13,13 @@ use rusqlite::{
 
 use crate::{
     core::{
-        Catalog, EngineError, EngineErrorKind, EngineResult, GeneratedIdPolicy, ShardKeyType,
-        TableDeclaration, TablePlacement,
+        AllocationOwnerMap, Catalog, CatalogSnapshot, EngineError, EngineErrorKind, EngineResult,
+        GeneratedIdPolicy, ShardKeyType, TableDeclaration, TableId, TablePlacement,
+        generated_id::{
+            AllocationOwnerSlot, MAX_ALLOCATION_OWNER_SLOT, NATIVE_RANGE_V1_FORMAT_MARKER,
+            native_range_v1_first_id, native_range_v1_sequence_ceiling,
+            native_range_v1_sequence_floor,
+        },
     },
     sqlite_error,
 };
@@ -623,6 +628,7 @@ pub(super) fn preflight_schema_migration_on_connection_with_digest(
 /// Connection-level digesting preflight that also preserves the complete
 /// authoritative table catalog. The catalog check runs inside the rollback
 /// transaction after the SQL batch, before its target digest is trusted.
+#[cfg(test)]
 #[allow(clippy::too_many_arguments)]
 pub(super) fn preflight_schema_migration_on_connection_with_digest_and_catalog(
     connection: &mut Connection,
@@ -642,7 +648,35 @@ pub(super) fn preflight_schema_migration_on_connection_with_digest_and_catalog(
         target_generation,
         layout,
         sql,
-        Some(catalog),
+        Some((catalog, None)),
+    )
+}
+
+/// Catalog-preserving preflight that also distinguishes manifest-activated
+/// native allocators from v9 policy metadata that has not been provisioned.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn preflight_schema_migration_on_connection_with_digest_and_catalog_snapshot(
+    connection: &mut Connection,
+    path: &Path,
+    shard_id: u16,
+    source_generation: u64,
+    target_generation: u64,
+    layout: &ShardLayout,
+    sql: &str,
+    catalog: &CatalogSnapshot,
+) -> EngineResult<(SchemaMigrationShardState, SchemaDigest)> {
+    preflight_schema_migration_on_connection_with_digest_inner(
+        connection,
+        path,
+        shard_id,
+        source_generation,
+        target_generation,
+        layout,
+        sql,
+        Some((
+            catalog.logical(),
+            Some(catalog.active_native_id_table_ids()),
+        )),
     )
 }
 
@@ -655,9 +689,9 @@ fn preflight_schema_migration_on_connection_with_digest_inner(
     target_generation: u64,
     layout: &ShardLayout,
     sql: &str,
-    catalog: Option<&Catalog>,
+    catalog: Option<(&Catalog, Option<&[TableId]>)>,
 ) -> EngineResult<(SchemaMigrationShardState, SchemaDigest)> {
-    if catalog.is_some_and(|catalog| !catalog.tables().is_empty()) {
+    if catalog.is_some_and(|(catalog, _)| !catalog.tables().is_empty()) {
         crate::sql::validate_authoritative_schema_migration(sql)?;
     }
     let initial = validate_schema_migration_connection(
@@ -669,8 +703,8 @@ fn preflight_schema_migration_on_connection_with_digest_inner(
         layout,
     )?;
     if initial == SchemaMigrationShardState::Target {
-        if let Some(catalog) = catalog {
-            validate_registered_table_schema(connection, catalog)?;
+        if let Some((catalog, active)) = catalog {
+            validate_registered_table_schema_inner(connection, catalog, active)?;
         }
         let digest = calculate_schema_digest(connection, target_generation)?;
         return Ok((initial, digest));
@@ -699,8 +733,8 @@ fn preflight_schema_migration_on_connection_with_digest_inner(
             target_generation,
             layout,
         )?;
-        if let Some(catalog) = catalog {
-            validate_registered_table_schema(connection, catalog)?;
+        if let Some((catalog, active)) = catalog {
+            validate_registered_table_schema_inner(connection, catalog, active)?;
         }
         let digest = calculate_schema_digest(connection, target_generation)?;
         return Ok((state, digest));
@@ -709,8 +743,8 @@ fn preflight_schema_migration_on_connection_with_digest_inner(
     let reserved_before = reserved_schema_snapshot(&transaction)?;
     execute_schema_migration_batch(&transaction, sql)?;
     ensure_reserved_schema_unchanged(&reserved_before, &transaction)?;
-    if let Some(catalog) = catalog {
-        validate_registered_table_schema(&transaction, catalog)?;
+    if let Some((catalog, active)) = catalog {
+        validate_registered_table_schema_inner(&transaction, catalog, active)?;
     }
     ensure_no_foreign_key_violations(&transaction)?;
     let target_digest = calculate_schema_digest(&transaction, target_generation)?;
@@ -742,9 +776,26 @@ fn preflight_schema_migration_on_connection_with_digest_inner(
 /// such declaration must have a physical table, and Catalog declarations must
 /// remain manifest-only. Sharded keys additionally retain the representation
 /// required by deterministic routing.
+#[cfg(test)]
 pub(super) fn validate_registered_table_schema(
     connection: &Connection,
     catalog: &Catalog,
+) -> EngineResult<()> {
+    validate_registered_table_schema_inner(connection, catalog, None)
+}
+
+pub(super) fn validate_registered_table_schema_with_active_native_ids(
+    connection: &Connection,
+    catalog: &Catalog,
+    active_native_id_table_ids: &[TableId],
+) -> EngineResult<()> {
+    validate_registered_table_schema_inner(connection, catalog, Some(active_native_id_table_ids))
+}
+
+fn validate_registered_table_schema_inner(
+    connection: &Connection,
+    catalog: &Catalog,
+    active_native_id_table_ids: Option<&[TableId]>,
 ) -> EngineResult<()> {
     if catalog.tables().is_empty() {
         return Ok(());
@@ -912,6 +963,19 @@ pub(super) fn validate_registered_table_schema(
                 "has an incompatible SQLite declared type",
             ));
         }
+        let native_policy_is_active =
+            active_native_id_table_ids.is_none_or(|ids| ids.binary_search(&table.id()).is_ok());
+        if native_policy_is_active {
+            if let GeneratedIdPolicy::NativeRangeV1 { column } = table.generated_id_policy() {
+                if !native_generated_column_is_exact(connection, table.name(), column)? {
+                    return Err(registered_shard_key_error(
+                        table.name(),
+                        column,
+                        "must remain exactly INTEGER PRIMARY KEY AUTOINCREMENT",
+                    ));
+                }
+            }
+        }
         if matches!(shard_key.key_type(), ShardKeyType::Text)
             && !shard_key_uses_binary_collation(connection, table.name(), shard_key.column())?
         {
@@ -943,6 +1007,217 @@ pub(super) fn validate_registered_table_schema(
         )?;
     }
     Ok(())
+}
+
+/// Validate the durable allocator state for every activated native-range
+/// table on one physical shard.
+///
+/// Registration seeds the reserved owner-local floor while every table is
+/// empty. Once the catalog is authoritative, a missing, duplicate, non-integer
+/// or cross-owner state is committed-storage corruption and must fail closed.
+pub(super) fn validate_native_range_v1_state_with_active_ids(
+    connection: &Connection,
+    catalog: &Catalog,
+    owners: &AllocationOwnerMap,
+    physical_shard: u16,
+    active_native_id_table_ids: Option<&[TableId]>,
+) -> EngineResult<()> {
+    let opened_snapshot = connection.is_autocommit();
+    if opened_snapshot {
+        connection
+            .execute_batch("BEGIN DEFERRED")
+            .map_err(sqlite_error::storage)?;
+    }
+    let validation = validate_native_range_v1_state_inner(
+        connection,
+        catalog,
+        owners,
+        physical_shard,
+        active_native_id_table_ids,
+    );
+    let snapshot_release = if opened_snapshot {
+        connection
+            .execute_batch("ROLLBACK")
+            .map_err(sqlite_error::storage)
+    } else {
+        Ok(())
+    };
+    match (validation, snapshot_release) {
+        (Err(error), _) => Err(error),
+        (Ok(()), Err(error)) => {
+            Err(error.context("failed to release the native-range allocator validation snapshot"))
+        }
+        (Ok(()), Ok(())) => Ok(()),
+    }
+}
+
+fn validate_native_range_v1_state_inner(
+    connection: &Connection,
+    catalog: &Catalog,
+    owners: &AllocationOwnerMap,
+    physical_shard: u16,
+    active_native_id_table_ids: Option<&[TableId]>,
+) -> EngineResult<()> {
+    let owner = owners
+        .owner_for_physical_shard(physical_shard)
+        .ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!(
+                    "physical shard {physical_shard} has no active native-range allocation owner"
+                ),
+            )
+        })?;
+    let floor = native_range_v1_sequence_floor(owner);
+    let first = native_range_v1_first_id(owner);
+    let ceiling = native_range_v1_sequence_ceiling(owner);
+
+    for table in catalog.tables() {
+        if active_native_id_table_ids.is_some_and(|ids| ids.binary_search(&table.id()).is_err()) {
+            continue;
+        }
+        let GeneratedIdPolicy::NativeRangeV1 { column } = table.generated_id_policy() else {
+            continue;
+        };
+        let (row_count, integer_count) = connection
+            .query_row(
+                "SELECT COUNT(*), COALESCE(SUM(typeof(seq) = 'integer'), 0)
+                 FROM main.sqlite_sequence
+                 WHERE name = ?1 COLLATE BINARY",
+                [table.name()],
+                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+            )
+            .map_err(|error| native_range_state_read_error(error, table.name()))?;
+        if row_count != 1 || integer_count != 1 {
+            return Err(native_range_state_error(
+                table.name(),
+                format!(
+                    "sqlite_sequence must contain exactly one integer row, found {row_count} rows and {integer_count} integer rows"
+                ),
+            ));
+        }
+        let sequence = connection
+            .query_row(
+                "SELECT seq FROM main.sqlite_sequence
+                 WHERE name = ?1 COLLATE BINARY",
+                [table.name()],
+                |row| row.get::<_, i64>(0),
+            )
+            .map_err(|error| native_range_state_read_error(error, table.name()))?;
+        if !(floor..=ceiling).contains(&sequence) {
+            return Err(native_range_state_error(
+                table.name(),
+                format!(
+                    "sqlite_sequence value {sequence} is outside owner {} range {floor}..={ceiling}",
+                    owner.get()
+                ),
+            ));
+        }
+
+        let quoted_table = quote_identifier(table.name());
+        let quoted_column = quote_identifier(column);
+        let foreign_probes =
+            foreign_native_id_probe_sql(&quoted_table, &quoted_column, owners, physical_shard)?;
+        let mut foreign_native_id = None;
+        for probe in foreign_probes {
+            foreign_native_id = connection
+                .query_row(&probe, [], |row| row.get::<_, i64>(0))
+                .optional()
+                .map_err(|error| native_range_state_read_error(error, table.name()))?;
+            if foreign_native_id.is_some() {
+                break;
+            }
+        }
+        if let Some(value) = foreign_native_id {
+            return Err(native_range_state_error(
+                table.name(),
+                format!(
+                    "row ID {value} does not belong to a native-range owner routed to physical shard {physical_shard}"
+                ),
+            ));
+        }
+
+        let maximum_native_id = connection
+            .query_row(
+                &format!(
+                    "SELECT MAX({quoted_column}) FROM {quoted_table}
+                     WHERE {quoted_column} BETWEEN ?1 AND ?2"
+                ),
+                (first, ceiling),
+                |row| row.get::<_, Option<i64>>(0),
+            )
+            .map_err(|error| native_range_state_read_error(error, table.name()))?;
+        if maximum_native_id.is_some_and(|maximum| sequence < maximum) {
+            return Err(native_range_state_error(
+                table.name(),
+                format!(
+                    "sqlite_sequence value {sequence} is below committed native row ID {}",
+                    maximum_native_id.expect("is_some_and observed a value")
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Build indexed range probes for every gap outside the owner ranges routed to
+/// one shard. Unlike a bitwise owner predicate, every probe can seek
+/// through the INTEGER PRIMARY KEY instead of scanning all native rows.
+fn foreign_native_id_probe_sql(
+    quoted_table: &str,
+    quoted_column: &str,
+    owners: &AllocationOwnerMap,
+    physical_shard: u16,
+) -> EngineResult<Box<[String]>> {
+    let mut routable = owners
+        .assignments()
+        .filter(|(_, shard, _)| *shard == physical_shard)
+        .map(|(owner, _, _)| AllocationOwnerSlot::from_validated(owner))
+        .collect::<Vec<_>>();
+    routable.sort_unstable_by_key(|owner| owner.get());
+    routable.dedup();
+    if routable.is_empty() {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!("physical shard {physical_shard} has no routable native-range owner"),
+        ));
+    }
+
+    let marker = i64::try_from(NATIVE_RANGE_V1_FORMAT_MARKER)
+        .expect("the native-range marker reserves the signed high bit");
+    let maximum_owner = AllocationOwnerSlot::new(MAX_ALLOCATION_OWNER_SLOT)
+        .expect("the native-range maximum owner is valid");
+    let maximum = native_range_v1_sequence_ceiling(maximum_owner);
+    let mut next_gap_start = Some(marker);
+    let mut gaps = Vec::with_capacity(routable.len() + 1);
+    for owner in routable {
+        let Some(gap_start) = next_gap_start else {
+            break;
+        };
+        let first = native_range_v1_first_id(owner);
+        if gap_start < first {
+            gaps.push((gap_start, first - 1));
+        }
+        next_gap_start = native_range_v1_sequence_ceiling(owner).checked_add(1);
+    }
+    if let Some(gap_start) = next_gap_start.filter(|start| *start <= maximum) {
+        gaps.push((gap_start, maximum));
+    }
+    debug_assert!(
+        !gaps.is_empty(),
+        "every owner range reserves local sequence zero"
+    );
+
+    Ok(gaps
+        .into_iter()
+        .map(|(lower, upper)| {
+            format!(
+                "SELECT {quoted_column} FROM {quoted_table} \
+                 WHERE {quoted_column} BETWEEN {lower} AND {upper} LIMIT 1"
+            )
+        })
+        .collect::<Vec<_>>()
+        .into_boxed_slice())
 }
 
 /// Validate one registration candidate against the complete authoritative
@@ -1553,6 +1828,33 @@ pub(super) fn shard_key_uses_binary_collation(
     Ok(collation.is_some_and(|name| name.to_bytes().eq_ignore_ascii_case(b"BINARY")))
 }
 
+pub(super) fn native_generated_column_is_exact(
+    connection: &Connection,
+    table: &str,
+    column: &str,
+) -> EngineResult<bool> {
+    let (declared_type, _, _, primary_key, auto_increment) = connection
+        .column_metadata(Some("main"), table, column)
+        .map_err(sqlite_error::storage)?;
+    let exact_shape = connection
+        .query_row(
+            "SELECT COUNT(*) = 1
+                    AND COALESCE(MAX(dflt_value IS NULL), 0) = 1
+                    AND COALESCE(MAX(pk), 0) = 1
+                    AND COALESCE(MAX(hidden), 1) = 0
+             FROM pragma_table_xinfo(?1)
+             WHERE name = ?2 COLLATE BINARY",
+            (table, column),
+            |row| row.get::<_, bool>(0),
+        )
+        .map_err(sqlite_error::storage)?;
+    Ok(exact_shape
+        && declared_type
+            .is_some_and(|declared_type| declared_type.to_bytes().eq_ignore_ascii_case(b"INTEGER"))
+        && primary_key
+        && auto_increment)
+}
+
 fn registered_shard_key_is_non_null(
     connection: &Connection,
     table: &str,
@@ -1602,6 +1904,37 @@ fn registered_shard_key_error(table: &str, column: &str, detail: &str) -> Engine
             "schema migration violates the authoritative table catalog: shard key {column} on table {table} {detail}"
         ),
     )
+}
+
+fn quote_identifier(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
+}
+
+fn native_range_state_error(table: &str, detail: impl std::fmt::Display) -> EngineError {
+    EngineError::new(
+        EngineErrorKind::DataCorruption,
+        format!("native_range_v1 allocator state for table {table} is invalid: {detail}"),
+    )
+}
+
+fn native_range_state_read_error(error: rusqlite::Error, table: &str) -> EngineError {
+    let classified = sqlite_error::storage(error);
+    let diagnostic =
+        format!("failed to validate native_range_v1 allocator state for table {table}");
+    if matches!(
+        classified.kind(),
+        EngineErrorKind::Busy
+            | EngineErrorKind::Cancelled
+            | EngineErrorKind::PermissionDenied
+            | EngineErrorKind::ReadOnly
+            | EngineErrorKind::StorageFull
+            | EngineErrorKind::OutOfMemory
+            | EngineErrorKind::StorageUnavailable
+    ) {
+        classified.context(diagnostic)
+    } else {
+        EngineError::from_source(EngineErrorKind::DataCorruption, diagnostic, classified)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/storage/sharded_vtab.rs
+++ b/src/storage/sharded_vtab.rs
@@ -484,6 +484,8 @@ struct Registry {
     child_scan_complete_gate: Mutex<Option<TestChildScanGate>>,
     #[cfg(test)]
     write_child_busy_gate: Mutex<Option<TestChildScanGate>>,
+    #[cfg(test)]
+    generated_target_gate: Mutex<Option<TestChildScanGate>>,
 }
 
 #[derive(Debug)]
@@ -683,6 +685,8 @@ impl Registry {
             child_scan_complete_gate: Mutex::new(None),
             #[cfg(test)]
             write_child_busy_gate: Mutex::new(None),
+            #[cfg(test)]
+            generated_target_gate: Mutex::new(None),
         }))
     }
 
@@ -698,6 +702,24 @@ impl Registry {
                 return Err(EngineError::new(
                     EngineErrorKind::Internal,
                     "writable child-busy test gate timed out or disconnected",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn wait_after_generated_target_selection_for_test(&self) -> EngineResult<()> {
+        #[cfg(test)]
+        {
+            let gate = self
+                .generated_target_gate
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .take();
+            if gate.is_some_and(|gate| !gate.wait_for_release()) {
+                return Err(EngineError::new(
+                    EngineErrorKind::Internal,
+                    "native generated target-selection test gate timed out or disconnected",
                 ));
             }
         }
@@ -742,6 +764,7 @@ impl Registry {
             let spec = TableSpec::from_physical_table(
                 shard,
                 table,
+                storage.native_id_policy_is_active(table.id()),
                 allocation_owners.cloned(),
                 targets.into_boxed_slice(),
             )?;
@@ -945,6 +968,35 @@ impl Registry {
             ));
         }
         Ok(target)
+    }
+
+    /// Resolve an explicit INSERT target while preventing new rows from being
+    /// introduced into a retired native-ID namespace. Historical IDs remain
+    /// routable through `write_target` for delete/update lookup semantics.
+    fn insert_target(&self, spec: &TableSpec, value: ValueRef<'_>) -> EngineResult<u16> {
+        if let (GeneratedIdPolicy::NativeRangeV1 { .. }, ValueRef::Integer(value)) =
+            (&spec.generated_id_policy, value)
+        {
+            if let GeneratedIdClassification::NativeRangeV1(id) =
+                classify_generated_id(&spec.generated_id_policy, value)?
+            {
+                if let Some(owners) = spec.allocation_owners.as_ref() {
+                    if owners.physical_shard(id.owner()).is_some()
+                        && !owners.owner_is_active(id.owner())
+                    {
+                        return Err(EngineError::new(
+                            EngineErrorKind::FailedPrecondition,
+                            format!(
+                                "native ID for {} uses retired allocation owner {}",
+                                spec.name,
+                                id.owner().get()
+                            ),
+                        ));
+                    }
+                }
+            }
+        }
+        self.write_target(spec, value)
     }
 
     fn cancelled(&self, scan_epoch: u64) -> bool {
@@ -1186,7 +1238,9 @@ struct TableSpec {
     targets: Box<[u16]>,
     shard_key: Option<ShardKeySpec>,
     generated_id_policy: GeneratedIdPolicy,
+    native_id_policy_active: bool,
     allocation_owners: Option<Arc<AllocationOwnerMap>>,
+    generated_shard_cursor: AtomicU64,
 }
 
 #[derive(Debug, Clone)]
@@ -1239,6 +1293,7 @@ impl TableSpec {
     fn from_physical_table(
         connection: &Connection,
         table: &TableMetadata,
+        native_id_policy_active: bool,
         allocation_owners: Option<Arc<AllocationOwnerMap>>,
         targets: Box<[u16]>,
     ) -> EngineResult<Self> {
@@ -1518,7 +1573,9 @@ impl TableSpec {
             targets,
             shard_key,
             generated_id_policy: table.generated_id_policy().clone(),
+            native_id_policy_active,
             allocation_owners,
+            generated_shard_cursor: AtomicU64::new(0),
         })
     }
 
@@ -1598,6 +1655,82 @@ impl TableSpec {
         ))
     }
 
+    fn generated_insert_sql_and_values(
+        &self,
+        values: &[ValueRef<'_>],
+        conflict: ConflictMode,
+    ) -> EngineResult<(String, Vec<RawCell>, String)> {
+        self.ensure_writable()?;
+        if values.len() != self.column_count {
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                format!(
+                    "brisk_shard received an invalid generated INSERT shape for {}",
+                    self.name
+                ),
+            ));
+        }
+        let generated_column = self.generated_id_policy.column().ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!("registered table {} has no generated-ID policy", self.name),
+            )
+        })?;
+        let generated_index = self
+            .columns
+            .iter()
+            .position(|column| column.name == generated_column)
+            .ok_or_else(|| {
+                EngineError::new(
+                    EngineErrorKind::DataCorruption,
+                    format!(
+                        "registered generated column {}.{} is absent from the physical schema",
+                        self.name, generated_column
+                    ),
+                )
+            })?;
+        if !matches!(values[generated_index], ValueRef::Null) {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "generated INSERT for {} supplied an explicit {} value",
+                    self.name, generated_column
+                ),
+            ));
+        }
+
+        let mut columns = Vec::with_capacity(self.column_count.saturating_sub(1));
+        let mut parameters = Vec::with_capacity(self.column_count.saturating_sub(1));
+        for (index, (column, value)) in self.columns.iter().zip(values).enumerate() {
+            if index == generated_index {
+                continue;
+            }
+            columns.push(quote_identifier(&column.name));
+            parameters.push(RawCell::try_copy_from(*value)?);
+        }
+        let placeholders = (1..=parameters.len())
+            .map(|position| format!("?{position}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let insert = if columns.is_empty() {
+            format!(
+                "INSERT{} INTO main.{} DEFAULT VALUES RETURNING {}",
+                write_conflict_clause(conflict),
+                quote_identifier(&self.name),
+                quote_identifier(generated_column),
+            )
+        } else {
+            format!(
+                "INSERT{} INTO main.{} ({}) VALUES ({placeholders}) RETURNING {}",
+                write_conflict_clause(conflict),
+                quote_identifier(&self.name),
+                columns.join(", "),
+                quote_identifier(generated_column),
+            )
+        };
+        Ok((insert, parameters, generated_column.to_owned()))
+    }
+
     fn delete_sql(&self) -> EngineResult<String> {
         self.ensure_writable()?;
         let locator = self.locator.as_ref().ok_or_else(|| {
@@ -1634,6 +1767,15 @@ impl TableSpec {
         for ((column, value), unchanged) in self.columns.iter().zip(values).zip(no_change) {
             if *unchanged {
                 continue;
+            }
+            if self.generated_id_policy.column() == Some(column.name.as_str()) {
+                return Err(EngineError::new(
+                    EngineErrorKind::ReadOnly,
+                    format!(
+                        "native generated identity {}.{} cannot be updated",
+                        self.name, column.name
+                    ),
+                ));
             }
             if column.generated {
                 return Err(EngineError::new(
@@ -2834,8 +2976,11 @@ mod tests {
                          payload TEXT NOT NULL
                      ) WITHOUT ROWID;
                      CREATE TABLE native_events (
-                         id INTEGER PRIMARY KEY NOT NULL,
+                         id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
                          payload TEXT NOT NULL
+                     ) STRICT;
+                     CREATE TABLE native_id_only (
+                         id INTEGER PRIMARY KEY AUTOINCREMENT
                      ) STRICT;",
                     &mut migration,
                     None,
@@ -2867,6 +3012,14 @@ mod tests {
                     TableDeclaration::sharded(
                         database_id,
                         "native_events",
+                        ShardKeyMetadata::new("id", ShardKeyType::Int64).unwrap(),
+                    )
+                    .unwrap()
+                    .with_generated_id_policy(GeneratedIdPolicy::native_range_v1("id").unwrap())
+                    .unwrap(),
+                    TableDeclaration::sharded(
+                        database_id,
+                        "native_id_only",
                         ShardKeyMetadata::new("id", ShardKeyType::Int64).unwrap(),
                     )
                     .unwrap()
@@ -2937,6 +3090,26 @@ mod tests {
                 blob_keys,
                 native_ids,
             }
+        }
+
+        fn native_table_id(&self) -> u64 {
+            self.storage
+                .logical_catalog()
+                .table("default", "native_events")
+                .unwrap()
+                .unwrap()
+                .id()
+                .get()
+        }
+
+        fn native_id_only_table_id(&self) -> u64 {
+            self.storage
+                .logical_catalog()
+                .table("default", "native_id_only")
+                .unwrap()
+                .unwrap()
+                .id()
+                .get()
         }
     }
 
@@ -5766,6 +5939,1038 @@ mod tests {
                 .unwrap(),
             "native-explicit"
         );
+    }
+
+    #[test]
+    fn writable_native_generation_captures_returning_id_on_selected_child() {
+        let fixture = TypedRoutingFixture::new(2);
+        let table_id = fixture.native_table_id();
+        let owner = fixture
+            .storage
+            .allocation_owner_map()
+            .unwrap()
+            .owner_for_physical_shard(1)
+            .unwrap();
+        let expected = NativeRangeV1Id::new(owner, 2).unwrap().encode();
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+
+        let result = coordinator
+            .execute_generated_dml(
+                "INSERT INTO native_events (payload) VALUES (?1)",
+                ["generated-on-one"],
+                table_id,
+                1,
+            )
+            .unwrap();
+
+        assert_eq!(result.affected_rows(), 1);
+        assert_eq!(result.shard(), Some(1));
+        assert_eq!(result.explicit_key(), None);
+        assert_eq!(
+            result.generated_key(),
+            Some(&crate::core::GeneratedKey::new(
+                "id",
+                Value::Int64(expected)
+            ))
+        );
+        assert_eq!(coordinator.last_insert_rowid_for_test(), expected);
+        assert_eq!(
+            fixture
+                .storage
+                .open_shard(1)
+                .unwrap()
+                .query_row(
+                    "SELECT payload FROM native_events WHERE id = ?1",
+                    [expected],
+                    |row| row.get::<_, String>(0),
+                )
+                .unwrap(),
+            "generated-on-one"
+        );
+        assert_eq!(
+            fixture
+                .storage
+                .open_shard(0)
+                .unwrap()
+                .query_row("SELECT COUNT(*) FROM native_events", [], |row| {
+                    row.get::<_, i64>(0)
+                })
+                .unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn writable_native_generation_auto_selects_round_robin_active_owners() {
+        let fixture = TypedRoutingFixture::new(2);
+        let table_id = fixture.native_table_id();
+        let owners = fixture.storage.allocation_owner_map().unwrap().clone();
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+
+        for expected_shard in 0..2 {
+            let result = coordinator
+                .execute_generated_dml_auto(
+                    "INSERT INTO native_events (payload) VALUES (?1)",
+                    [format!("auto-{expected_shard}")],
+                    table_id,
+                )
+                .unwrap();
+            assert_eq!(result.shard(), Some(expected_shard));
+            let generated = match &result.generated_key().unwrap().value {
+                Value::Int64(value) => *value,
+                value => panic!("unexpected generated value: {value:?}"),
+            };
+            let decoded = NativeRangeV1Id::decode(generated).unwrap();
+            assert_eq!(owners.physical_shard(decoded.owner()), Some(expected_shard));
+            assert!(owners.owner_is_active(decoded.owner()));
+        }
+    }
+
+    #[test]
+    fn writable_native_generation_auto_skips_exhausted_owners() {
+        let fixture = TypedRoutingFixture::new(2);
+        let owners = fixture.storage.allocation_owner_map().unwrap();
+        let exhausted_owner = owners.owner_for_physical_shard(0).unwrap();
+        let ceiling = crate::core::generated_id::native_range_v1_sequence_ceiling(exhausted_owner);
+        fixture
+            .storage
+            .open_shard(0)
+            .unwrap()
+            .execute(
+                "UPDATE sqlite_sequence SET seq = ?1 WHERE name = 'native_events'",
+                [ceiling],
+            )
+            .unwrap();
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+
+        let result = coordinator
+            .execute_generated_dml_auto(
+                "INSERT INTO native_events (payload) VALUES ('fallback')",
+                [],
+                fixture.native_table_id(),
+            )
+            .unwrap();
+        assert_eq!(result.shard(), Some(1));
+        let generated = match &result.generated_key().unwrap().value {
+            Value::Int64(value) => *value,
+            value => panic!("unexpected generated value: {value:?}"),
+        };
+        assert_eq!(
+            owners.physical_shard(NativeRangeV1Id::decode(generated).unwrap().owner()),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn writable_native_generation_auto_retries_when_selected_owner_exhausts_before_lock() {
+        let fixture = TypedRoutingFixture::new(2);
+        let owners = fixture.storage.allocation_owner_map().unwrap().clone();
+        let first_owner = owners.owner_for_physical_shard(0).unwrap();
+        let ceiling = crate::core::generated_id::native_range_v1_sequence_ceiling(first_owner);
+        fixture
+            .storage
+            .open_shard(0)
+            .unwrap()
+            .execute(
+                "UPDATE sqlite_sequence SET seq = ?1 WHERE name = 'native_events'",
+                [ceiling - 1],
+            )
+            .unwrap();
+
+        let coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+        let mut gate = coordinator.install_generated_target_gate_for_test();
+        let table_id = fixture.native_table_id();
+        let worker = thread::spawn(move || {
+            let mut coordinator = coordinator;
+            coordinator.execute_generated_dml_auto(
+                "INSERT INTO native_events (payload) VALUES ('raced-fallback')",
+                [],
+                table_id,
+            )
+        });
+
+        gate.wait_until_started();
+        let competing = fixture
+            .storage
+            .open_shard(0)
+            .unwrap()
+            .query_row(
+                "INSERT INTO native_events (payload) VALUES ('last-on-zero') RETURNING id",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap();
+        assert_eq!(competing, ceiling);
+        gate.release();
+
+        let result = worker.join().unwrap().unwrap();
+        assert_eq!(result.affected_rows(), 1);
+        assert_eq!(result.shard(), Some(1));
+        let generated = match &result.generated_key().unwrap().value {
+            Value::Int64(value) => *value,
+            value => panic!("unexpected generated value: {value:?}"),
+        };
+        assert_eq!(
+            owners.physical_shard(NativeRangeV1Id::decode(generated).unwrap().owner()),
+            Some(1)
+        );
+        assert_eq!(
+            fixture
+                .storage
+                .open_shard(0)
+                .unwrap()
+                .query_row(
+                    "SELECT COUNT(*) FROM native_events WHERE payload = 'raced-fallback'",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            fixture
+                .storage
+                .open_shard(1)
+                .unwrap()
+                .query_row(
+                    "SELECT COUNT(*) FROM native_events WHERE payload = 'raced-fallback'",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn writable_native_generation_auto_reports_all_active_owners_exhausted() {
+        let fixture = TypedRoutingFixture::new(2);
+        for shard in 0..2 {
+            let owner = fixture
+                .storage
+                .allocation_owner_map()
+                .unwrap()
+                .owner_for_physical_shard(shard)
+                .unwrap();
+            let ceiling = crate::core::generated_id::native_range_v1_sequence_ceiling(owner);
+            fixture
+                .storage
+                .open_shard(shard)
+                .unwrap()
+                .execute(
+                    "UPDATE sqlite_sequence SET seq = ?1 WHERE name = 'native_events'",
+                    [ceiling],
+                )
+                .unwrap();
+        }
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+
+        let error = coordinator
+            .execute_generated_dml_auto(
+                "INSERT INTO native_events (payload) VALUES ('all-exhausted')",
+                [],
+                fixture.native_table_id(),
+            )
+            .unwrap_err();
+
+        assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+        assert!(error.diagnostic().contains("exhausted every active"));
+        for shard in 0..2 {
+            assert_eq!(
+                fixture
+                    .storage
+                    .open_shard(shard)
+                    .unwrap()
+                    .query_row(
+                        "SELECT COUNT(*) FROM native_events WHERE payload = 'all-exhausted'",
+                        [],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .unwrap(),
+                0
+            );
+        }
+    }
+
+    #[test]
+    fn writable_native_generation_requires_an_explicit_intent() {
+        let fixture = TypedRoutingFixture::new(2);
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+
+        let error = coordinator
+            .execute_dml(
+                "INSERT INTO native_events (payload) VALUES ('not-authorized')",
+                [],
+            )
+            .unwrap_err();
+
+        assert_eq!(error.kind(), EngineErrorKind::NotNullViolation);
+        assert_eq!(
+            (0..2)
+                .map(|shard| fixture
+                    .storage
+                    .open_shard(shard)
+                    .unwrap()
+                    .query_row("SELECT COUNT(*) FROM native_events", [], |row| {
+                        row.get::<_, i64>(0)
+                    })
+                    .unwrap())
+                .sum::<i64>(),
+            2
+        );
+    }
+
+    #[test]
+    fn writable_native_generation_rejects_multiple_callbacks_and_rolls_back() {
+        let fixture = TypedRoutingFixture::new(2);
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+
+        let error = coordinator
+            .execute_generated_dml(
+                "INSERT INTO native_events (payload) VALUES ('first'), ('second')",
+                [],
+                fixture.native_table_id(),
+                0,
+            )
+            .unwrap_err();
+
+        // The virtual-table module preserves the rejection diagnostic; the
+        // outer SQLite statement classifies a module callback rejection as an
+        // invalid query.
+        assert_eq!(error.kind(), EngineErrorKind::InvalidQuery);
+        assert!(
+            error
+                .to_string()
+                .contains("multi-row native generated INSERT")
+        );
+        assert_eq!(
+            fixture
+                .storage
+                .open_shard(0)
+                .unwrap()
+                .query_row("SELECT COUNT(*) FROM native_events", [], |row| {
+                    row.get::<_, i64>(0)
+                })
+                .unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn writable_native_generation_rollback_discards_row_and_result_state() {
+        let fixture = TypedRoutingFixture::new(2);
+        let table_id = fixture.native_table_id();
+        let owner = fixture
+            .storage
+            .allocation_owner_map()
+            .unwrap()
+            .owner_for_physical_shard(0)
+            .unwrap();
+        let rolled_back_id = NativeRangeV1Id::new(owner, 2).unwrap().encode();
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+        coordinator.begin().unwrap();
+        let pending = coordinator
+            .execute_generated_dml(
+                "INSERT INTO native_events (payload) VALUES ('rolled-back')",
+                [],
+                table_id,
+                0,
+            )
+            .unwrap();
+        assert_eq!(
+            pending.generated_key().unwrap().value,
+            Value::Int64(rolled_back_id)
+        );
+        coordinator.rollback().unwrap();
+
+        let committed = coordinator
+            .execute_generated_dml(
+                "INSERT INTO native_events (payload) VALUES ('committed')",
+                [],
+                table_id,
+                0,
+            )
+            .unwrap();
+        assert_eq!(
+            committed.generated_key().unwrap().value,
+            Value::Int64(rolled_back_id)
+        );
+        let connection = fixture.storage.open_shard(0).unwrap();
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT COUNT(*) FROM native_events WHERE payload = 'rolled-back'",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT COUNT(*) FROM native_events WHERE payload = 'committed'",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn writable_native_generation_supports_id_only_default_values() {
+        let fixture = TypedRoutingFixture::new(2);
+        let owner = fixture
+            .storage
+            .allocation_owner_map()
+            .unwrap()
+            .owner_for_physical_shard(0)
+            .unwrap();
+        let expected = NativeRangeV1Id::new(owner, 1).unwrap().encode();
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+
+        let result = coordinator
+            .execute_generated_dml(
+                "INSERT INTO native_id_only DEFAULT VALUES",
+                [],
+                fixture.native_id_only_table_id(),
+                0,
+            )
+            .unwrap();
+
+        assert_eq!(result.generated_key().unwrap().column, "id");
+        assert_eq!(
+            result.generated_key().unwrap().value,
+            Value::Int64(expected)
+        );
+        assert_eq!(result.shard(), Some(0));
+    }
+
+    #[test]
+    fn writable_native_generation_constraint_failure_does_not_leak_a_key() {
+        let fixture = TypedRoutingFixture::new(2);
+        let table_id = fixture.native_table_id();
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+
+        let error = coordinator
+            .execute_generated_dml(
+                "INSERT INTO native_events (payload) VALUES (NULL)",
+                [],
+                table_id,
+                0,
+            )
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::NotNullViolation);
+
+        let successful = coordinator
+            .execute_generated_dml(
+                "INSERT INTO native_events (payload) VALUES ('after-constraint')",
+                [],
+                table_id,
+                0,
+            )
+            .unwrap();
+        assert!(successful.generated_key().is_some());
+        assert_eq!(successful.affected_rows(), 1);
+    }
+
+    #[test]
+    fn writable_native_generation_commit_failure_never_acknowledges_the_key() {
+        let fixture = TypedRoutingFixture::new(2);
+        let table_id = fixture.native_table_id();
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+        coordinator.fail_next_commit_for_test();
+
+        let error = coordinator
+            .execute_generated_dml(
+                "INSERT INTO native_events (payload) VALUES ('failed-commit')",
+                [],
+                table_id,
+                0,
+            )
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::StorageUnavailable);
+        assert_eq!(
+            fixture
+                .storage
+                .open_shard(0)
+                .unwrap()
+                .query_row(
+                    "SELECT COUNT(*) FROM native_events WHERE payload = 'failed-commit'",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            0
+        );
+
+        let recovered = WriteCoordinator::open(fixture.storage.clone())
+            .unwrap()
+            .execute_generated_dml(
+                "INSERT INTO native_events (payload) VALUES ('after-failed-commit')",
+                [],
+                table_id,
+                0,
+            )
+            .unwrap();
+        assert!(recovered.generated_key().is_some());
+    }
+
+    #[test]
+    fn writable_native_generation_or_ignore_exposes_no_key_and_rolls_back_its_sequence_attempt() {
+        let TypedRoutingFixture { _temp, storage, .. } = TypedRoutingFixture::new(2);
+        let table_id = storage
+            .logical_catalog()
+            .table("default", "native_events")
+            .unwrap()
+            .unwrap()
+            .id()
+            .get();
+        let owner = storage
+            .allocation_owner_map()
+            .unwrap()
+            .owner_for_physical_shard(0)
+            .unwrap();
+        let committed_id = NativeRangeV1Id::new(owner, 1).unwrap().encode();
+        let next_id = NativeRangeV1Id::new(owner, 2).unwrap().encode();
+        let mut coordinator = WriteCoordinator::open(storage.clone()).unwrap();
+
+        let ignored = coordinator
+            .execute_generated_dml(
+                "INSERT OR IGNORE INTO native_events (payload) VALUES (NULL)",
+                [],
+                table_id,
+                0,
+            )
+            .unwrap();
+
+        assert_eq!(ignored.affected_rows(), 0);
+        assert_eq!(ignored.shard(), None);
+        assert_eq!(ignored.generated_key(), None);
+        assert_eq!(ignored.explicit_key(), None);
+        drop(coordinator);
+
+        let sequence = storage
+            .open_shard(0)
+            .unwrap()
+            .query_row(
+                "SELECT seq FROM sqlite_sequence WHERE name = 'native_events'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap();
+        // The facade delegates non-REPLACE physical conflicts as OR ABORT and
+        // lets the outer virtual-table statement apply IGNORE. The failed
+        // child statement therefore rolls back its sequence attempt instead
+        // of committing the gap that direct SQLite OR IGNORE would retain.
+        assert_eq!(sequence, committed_id);
+        assert_eq!(
+            storage
+                .open_shard(0)
+                .unwrap()
+                .query_row(
+                    "SELECT COUNT(*) FROM native_events WHERE id = ?1",
+                    [next_id],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            0
+        );
+
+        drop(storage);
+        let reopened = Storage::open(_temp.path(), 2).unwrap();
+        assert_eq!(
+            reopened
+                .open_shard(0)
+                .unwrap()
+                .query_row(
+                    "SELECT seq FROM sqlite_sequence WHERE name = 'native_events'",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            committed_id
+        );
+        let inserted = WriteCoordinator::open(reopened.clone())
+            .unwrap()
+            .execute_generated_dml(
+                "INSERT INTO native_events (payload) VALUES ('after-ignored-gap')",
+                [],
+                table_id,
+                0,
+            )
+            .unwrap();
+        assert_eq!(
+            inserted.generated_key().unwrap().value,
+            Value::Int64(next_id)
+        );
+        assert_ne!(next_id, committed_id);
+        let connection = reopened.open_shard(0).unwrap();
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT payload FROM native_events WHERE id = ?1",
+                    [next_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .unwrap(),
+            "after-ignored-gap"
+        );
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT seq FROM sqlite_sequence WHERE name = 'native_events'",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            next_id
+        );
+    }
+
+    #[test]
+    fn writable_native_generation_preflight_mismatch_does_not_mutate() {
+        let fixture = TypedRoutingFixture::new(2);
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+
+        let outside = coordinator
+            .execute_generated_dml(
+                "INSERT INTO native_events (payload) VALUES ('outside')",
+                [],
+                fixture.native_table_id(),
+                2,
+            )
+            .unwrap_err();
+        assert_eq!(outside.kind(), EngineErrorKind::FailedPrecondition);
+
+        let explicit = coordinator
+            .execute_generated_dml(
+                "INSERT INTO native_events (id, payload) VALUES (?1, 'explicit')",
+                [fixture.native_ids[0]],
+                fixture.native_table_id(),
+                0,
+            )
+            .unwrap_err();
+        assert_eq!(explicit.kind(), EngineErrorKind::InvalidQuery);
+        assert!(
+            explicit
+                .to_string()
+                .contains("unexpectedly supplied an explicit key")
+        );
+        assert_eq!(
+            (0..2)
+                .map(|shard| fixture
+                    .storage
+                    .open_shard(shard)
+                    .unwrap()
+                    .query_row(
+                        "SELECT COUNT(*) FROM native_events WHERE payload IN ('outside', 'explicit')",
+                        [],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .unwrap())
+                .sum::<i64>(),
+            0
+        );
+    }
+
+    #[test]
+    fn writable_native_generated_identity_cannot_be_updated_even_in_place() {
+        let fixture = TypedRoutingFixture::new(2);
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+
+        let error = coordinator
+            .execute_dml(
+                "UPDATE native_events SET id = id WHERE id = ?1",
+                [fixture.native_ids[0]],
+            )
+            .unwrap_err();
+
+        assert_eq!(error.kind(), EngineErrorKind::ReadOnly);
+        assert_eq!(
+            fixture
+                .storage
+                .open_shard(0)
+                .unwrap()
+                .query_row(
+                    "SELECT COUNT(*) FROM native_events WHERE id = ?1",
+                    [fixture.native_ids[0]],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn writable_native_generation_reopens_with_the_persisted_sequence() {
+        let TypedRoutingFixture { _temp, storage, .. } = TypedRoutingFixture::new(2);
+        let table_id = storage
+            .logical_catalog()
+            .table("default", "native_events")
+            .unwrap()
+            .unwrap()
+            .id()
+            .get();
+        let owner = storage
+            .allocation_owner_map()
+            .unwrap()
+            .owner_for_physical_shard(1)
+            .unwrap();
+        let first_expected = NativeRangeV1Id::new(owner, 2).unwrap().encode();
+        let second_expected = NativeRangeV1Id::new(owner, 3).unwrap().encode();
+
+        let first = WriteCoordinator::open(storage.clone())
+            .unwrap()
+            .execute_generated_dml(
+                "INSERT INTO native_events (payload) VALUES ('before-reopen')",
+                [],
+                table_id,
+                1,
+            )
+            .unwrap();
+        assert_eq!(
+            first.generated_key().unwrap().value,
+            Value::Int64(first_expected)
+        );
+        drop(storage);
+
+        let reopened = Storage::open(_temp.path(), 2).unwrap();
+        assert_eq!(
+            reopened
+                .logical_catalog()
+                .table("default", "native_events")
+                .unwrap()
+                .unwrap()
+                .id()
+                .get(),
+            table_id
+        );
+        let second = WriteCoordinator::open(reopened.clone())
+            .unwrap()
+            .execute_generated_dml(
+                "INSERT INTO native_events (payload) VALUES ('after-reopen')",
+                [],
+                table_id,
+                1,
+            )
+            .unwrap();
+        assert_eq!(
+            second.generated_key().unwrap().value,
+            Value::Int64(second_expected)
+        );
+        assert_eq!(
+            reopened
+                .open_shard(1)
+                .unwrap()
+                .query_row(
+                    "SELECT COUNT(*) FROM native_events
+                     WHERE payload IN ('before-reopen', 'after-reopen')",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            2
+        );
+    }
+
+    #[test]
+    fn writable_native_generation_stops_at_the_owner_ceiling() {
+        let fixture = TypedRoutingFixture::new(2);
+        let owner = fixture
+            .storage
+            .allocation_owner_map()
+            .unwrap()
+            .owner_for_physical_shard(0)
+            .unwrap();
+        let ceiling = crate::core::generated_id::native_range_v1_sequence_ceiling(owner);
+        fixture
+            .storage
+            .open_shard(0)
+            .unwrap()
+            .execute(
+                "UPDATE sqlite_sequence SET seq = ?1 WHERE name = 'native_events'",
+                [ceiling],
+            )
+            .unwrap();
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+
+        let error = coordinator
+            .execute_generated_dml(
+                "INSERT INTO native_events (payload) VALUES ('outside-range')",
+                [],
+                fixture.native_table_id(),
+                0,
+            )
+            .unwrap_err();
+
+        assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+        assert_eq!(
+            fixture
+                .storage
+                .open_shard(0)
+                .unwrap()
+                .query_row(
+                    "SELECT COUNT(*) FROM native_events WHERE payload = 'outside-range'",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn writable_native_auto_generation_is_concurrent_unique_and_uses_every_wal() {
+        const ROUNDS_PER_SHARD: usize = 3;
+
+        for shard_count in [2_u16, 4, 8, 10] {
+            let fixture = TypedRoutingFixture::new(shard_count);
+            let table_id = fixture.native_table_id();
+
+            // Pin a pre-write read snapshot on every physical database. This
+            // prevents a closing writer from resetting its WAL before the
+            // assertions below can prove that each independent file received
+            // frames from this concurrent workload.
+            let mut wal_readers = Vec::with_capacity(usize::from(shard_count));
+            for shard in 0..shard_count {
+                let path = fixture
+                    ._temp
+                    .path()
+                    .join("shards")
+                    .join(format!("{shard:04}.sqlite"));
+                let reader = Connection::open(path).unwrap();
+                reader
+                    .execute_batch("PRAGMA wal_checkpoint(TRUNCATE)")
+                    .unwrap();
+                reader.execute_batch("BEGIN DEFERRED").unwrap();
+                reader
+                    .query_row("SELECT COUNT(*) FROM native_events", [], |row| {
+                        row.get::<_, i64>(0)
+                    })
+                    .unwrap();
+                wal_readers.push(reader);
+            }
+
+            let worker_count = usize::from(shard_count);
+            let inserts_per_worker = worker_count * ROUNDS_PER_SHARD;
+            let barrier = Arc::new(std::sync::Barrier::new(worker_count));
+            let mut workers = Vec::with_capacity(worker_count);
+            for worker in 0..worker_count {
+                let storage = fixture.storage.clone();
+                let barrier = Arc::clone(&barrier);
+                workers.push(thread::spawn(move || {
+                    let mut coordinator = WriteCoordinator::open(storage).unwrap();
+                    barrier.wait();
+                    (0..inserts_per_worker)
+                        .map(|insert| {
+                            let result = coordinator
+                                .execute_generated_dml_auto(
+                                    "INSERT INTO native_events (payload) VALUES (?1)",
+                                    [format!("auto-concurrent-{worker}-{insert}")],
+                                    table_id,
+                                )
+                                .unwrap();
+                            let shard = result.shard().expect("generated write selected a shard");
+                            let generated = match &result.generated_key().unwrap().value {
+                                Value::Int64(value) => *value,
+                                value => panic!("unexpected generated value: {value:?}"),
+                            };
+                            (shard, generated)
+                        })
+                        .collect::<Vec<_>>()
+                }));
+            }
+
+            let results = workers
+                .into_iter()
+                .flat_map(|worker| worker.join().unwrap())
+                .collect::<Vec<_>>();
+            let expected_total = worker_count * inserts_per_worker;
+            assert_eq!(results.len(), expected_total);
+
+            let owners = fixture.storage.allocation_owner_map().unwrap();
+            let mut unique_ids = BTreeSet::new();
+            let mut seen_shards = BTreeSet::new();
+            let mut rows_per_shard = vec![0_usize; worker_count];
+            let mut maximum_per_shard = vec![i64::MIN; worker_count];
+            for (shard, generated) in results {
+                assert!(
+                    unique_ids.insert(generated),
+                    "duplicate generated ID {generated} with {shard_count} shards"
+                );
+                seen_shards.insert(shard);
+                rows_per_shard[usize::from(shard)] += 1;
+                maximum_per_shard[usize::from(shard)] =
+                    maximum_per_shard[usize::from(shard)].max(generated);
+
+                let decoded = NativeRangeV1Id::decode(generated).unwrap();
+                assert_eq!(owners.physical_shard(decoded.owner()), Some(shard));
+                assert!(owners.owner_is_active(decoded.owner()));
+            }
+            assert_eq!(unique_ids.len(), expected_total);
+            assert_eq!(seen_shards, (0..shard_count).collect::<BTreeSet<_>>());
+
+            let expected_per_shard = worker_count * ROUNDS_PER_SHARD;
+            for shard in 0..shard_count {
+                let index = usize::from(shard);
+                assert_eq!(rows_per_shard[index], expected_per_shard);
+                let connection = fixture.storage.open_shard(shard).unwrap();
+                assert_eq!(
+                    connection
+                        .query_row(
+                            "SELECT COUNT(*) FROM native_events
+                             WHERE payload LIKE 'auto-concurrent-%'",
+                            [],
+                            |row| row.get::<_, i64>(0),
+                        )
+                        .unwrap(),
+                    i64::try_from(expected_per_shard).unwrap(),
+                    "shard count {shard_count}, shard {shard}"
+                );
+                assert_eq!(
+                    connection
+                        .query_row(
+                            "SELECT seq FROM sqlite_sequence WHERE name = 'native_events'",
+                            [],
+                            |row| row.get::<_, i64>(0),
+                        )
+                        .unwrap(),
+                    maximum_per_shard[index],
+                    "shard count {shard_count}, shard {shard}"
+                );
+                assert_eq!(
+                    connection
+                        .pragma_query_value(None, "journal_mode", |row| row.get::<_, String>(0))
+                        .unwrap(),
+                    "wal"
+                );
+                let wal = fixture
+                    ._temp
+                    .path()
+                    .join("shards")
+                    .join(format!("{shard:04}.sqlite-wal"));
+                assert!(
+                    std::fs::metadata(&wal).unwrap().len() > 32,
+                    "shard count {shard_count}, shard {shard} did not retain a WAL frame"
+                );
+            }
+            drop(wal_readers);
+        }
+    }
+
+    #[test]
+    fn writable_native_generation_is_concurrent_and_unique_across_supported_shard_counts() {
+        for shard_count in [2_u16, 4, 8, 10] {
+            let fixture = TypedRoutingFixture::new(shard_count);
+            let table_id = fixture.native_table_id();
+            let barrier = Arc::new(std::sync::Barrier::new(usize::from(shard_count)));
+            let mut workers = Vec::new();
+            for shard in 0..shard_count {
+                let storage = fixture.storage.clone();
+                let barrier = Arc::clone(&barrier);
+                workers.push(thread::spawn(move || {
+                    let mut coordinator = WriteCoordinator::open(storage).unwrap();
+                    barrier.wait();
+                    let result = coordinator
+                        .execute_generated_dml(
+                            "INSERT INTO native_events (payload) VALUES (?1)",
+                            [format!("concurrent-{shard}")],
+                            table_id,
+                            shard,
+                        )
+                        .unwrap();
+                    let generated = match &result.generated_key().unwrap().value {
+                        Value::Int64(value) => *value,
+                        value => panic!("unexpected generated value: {value:?}"),
+                    };
+                    (shard, result.shard(), generated)
+                }));
+            }
+
+            let results = workers
+                .into_iter()
+                .map(|worker| worker.join().unwrap())
+                .collect::<Vec<_>>();
+            let unique = results
+                .iter()
+                .map(|(_, _, generated)| *generated)
+                .collect::<BTreeSet<_>>();
+            assert_eq!(unique.len(), usize::from(shard_count));
+            let owners = fixture.storage.allocation_owner_map().unwrap();
+            for (expected_shard, actual_shard, generated) in results {
+                assert_eq!(actual_shard, Some(expected_shard));
+                let decoded = NativeRangeV1Id::decode(generated).unwrap();
+                assert_eq!(owners.physical_shard(decoded.owner()), Some(expected_shard));
+                assert_eq!(decoded.local_sequence(), 2);
+                let connection = fixture.storage.open_shard(expected_shard).unwrap();
+                assert_eq!(
+                    connection
+                        .pragma_query_value(None, "journal_mode", |row| row.get::<_, String>(0))
+                        .unwrap(),
+                    "wal"
+                );
+                assert_eq!(
+                    connection
+                        .query_row(
+                            "SELECT COUNT(*) FROM native_events WHERE id = ?1",
+                            [generated],
+                            |row| row.get::<_, i64>(0),
+                        )
+                        .unwrap(),
+                    1
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn writable_native_generation_cancellation_before_callback_exposes_no_key() {
+        let fixture = TypedRoutingFixture::new(2);
+        let table_id = fixture.native_table_id();
+        let coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+        let cancellation = coordinator.cancellation_handle();
+        let mut gate = coordinator.install_statement_arm_gate_for_test();
+        let worker = thread::spawn(move || {
+            let mut coordinator = coordinator;
+            let result = coordinator.execute_generated_dml(
+                "INSERT INTO native_events (payload) VALUES ('cancelled-generated')",
+                [],
+                table_id,
+                0,
+            );
+            (coordinator, result)
+        });
+
+        gate.wait_until_started();
+        cancellation.cancel();
+        gate.release();
+
+        let (mut coordinator, result) = worker.join().unwrap();
+        assert_eq!(result.unwrap_err().kind(), EngineErrorKind::Cancelled);
+        assert_eq!(
+            fixture
+                .storage
+                .open_shard(0)
+                .unwrap()
+                .query_row(
+                    "SELECT COUNT(*) FROM native_events WHERE payload = 'cancelled-generated'",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            0
+        );
+        let after = coordinator
+            .execute_generated_dml(
+                "INSERT INTO native_events (payload) VALUES ('after-cancel')",
+                [],
+                table_id,
+                0,
+            )
+            .unwrap();
+        assert!(after.generated_key().is_some());
     }
 
     #[test]

--- a/src/storage/sharded_vtab/write.rs
+++ b/src/storage/sharded_vtab/write.rs
@@ -22,17 +22,118 @@ use super::{
 #[cfg(test)]
 use super::{TestChildScanControl, TestChildScanGate};
 use crate::{
-    core::{EngineError, EngineErrorKind, EngineResult, OperationControl, Value},
+    core::{
+        EngineError, EngineErrorKind, EngineResult, GeneratedIdPolicy, GeneratedKey,
+        OperationControl, Value,
+        generated_id::{
+            AllocationOwnerSlot, GeneratedIdClassification, classify_generated_id,
+            native_range_v1_sequence_ceiling, native_range_v1_sequence_floor,
+        },
+    },
     sqlite_error,
     storage::{CONNECTION_BUSY_TIMEOUT, SchemaOperationGuard, Storage},
 };
 
 const CANCELLABLE_BUSY_SLICE: Duration = Duration::from_millis(25);
 
+fn validate_allocation_sequence_capacity(
+    connection: &Connection,
+    table: &str,
+    owner: AllocationOwnerSlot,
+) -> EngineResult<()> {
+    let sequence = read_allocation_sequence(connection, table)?;
+    let floor = native_range_v1_sequence_floor(owner);
+    let ceiling = native_range_v1_sequence_ceiling(owner);
+    if sequence < floor || sequence > ceiling {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!(
+                "native generated table {table} sequence {sequence} is outside owner {} range",
+                owner.get()
+            ),
+        ));
+    }
+    if sequence == ceiling {
+        return Err(EngineError::new(
+            EngineErrorKind::LimitExceeded,
+            format!(
+                "native generated table {table} exhausted allocation owner {}",
+                owner.get()
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn read_allocation_sequence(connection: &Connection, table: &str) -> EngineResult<i64> {
+    let mut statement = connection
+        .prepare("SELECT seq FROM main.sqlite_sequence WHERE name = ?1 COLLATE BINARY")
+        .map_err(|error| allocation_sequence_read_error(error, table))?;
+    let mut rows = statement
+        .query([table])
+        .map_err(|error| allocation_sequence_read_error(error, table))?;
+    let sequence = match rows
+        .next()
+        .map_err(|error| allocation_sequence_read_error(error, table))?
+    {
+        Some(row) => match row
+            .get_ref(0)
+            .map_err(|error| allocation_sequence_read_error(error, table))?
+        {
+            ValueRef::Integer(sequence) => sequence,
+            _ => {
+                return Err(EngineError::new(
+                    EngineErrorKind::DataCorruption,
+                    format!("native generated table {table} has a non-integer SQLite sequence"),
+                ));
+            }
+        },
+        None => {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!("native generated table {table} is missing its SQLite sequence"),
+            ));
+        }
+    };
+    if rows
+        .next()
+        .map_err(|error| allocation_sequence_read_error(error, table))?
+        .is_some()
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!("native generated table {table} has duplicate SQLite sequences"),
+        ));
+    }
+
+    Ok(sequence)
+}
+
+fn allocation_sequence_read_error(error: rusqlite::Error, table: &str) -> EngineError {
+    let classified = sqlite_error::storage(error);
+    let diagnostic = format!("failed to read native generated sequence for table {table}");
+    if matches!(
+        classified.kind(),
+        EngineErrorKind::Busy
+            | EngineErrorKind::Cancelled
+            | EngineErrorKind::PermissionDenied
+            | EngineErrorKind::ReadOnly
+            | EngineErrorKind::StorageFull
+            | EngineErrorKind::OutOfMemory
+            | EngineErrorKind::StorageUnavailable
+    ) {
+        classified.context(diagnostic)
+    } else {
+        EngineError::from_source(EngineErrorKind::DataCorruption, diagnostic, classified)
+    }
+}
+
 #[derive(Debug, PartialEq)]
 pub(crate) struct CoordinatorWriteResult {
     pub(crate) affected_rows: usize,
+    pub(crate) shard: Option<u16>,
     pub(crate) explicit_key: Option<Value>,
+    pub(crate) generated_key: Option<GeneratedKey>,
 }
 
 impl CoordinatorWriteResult {
@@ -41,12 +142,30 @@ impl CoordinatorWriteResult {
         self.affected_rows
     }
 
+    /// Return the one physical shard mutated by this statement.
+    ///
+    /// A successful no-op (for example, an ignored constraint) has no shard
+    /// result. The writable coordinator still refuses to mutate two shards in
+    /// one transaction.
+    pub(crate) const fn shard(&self) -> Option<u16> {
+        self.shard
+    }
+
     /// Return the caller-supplied key reported for a successful INSERT.
     ///
-    /// UPDATE and DELETE do not produce a key. Generated keys remain outside
-    /// the current explicit-key coordinator contract.
+    /// UPDATE and DELETE do not produce a key. Automatically allocated values
+    /// are reported separately by [`Self::generated_key`].
     pub(crate) const fn explicit_key(&self) -> Option<&Value> {
         self.explicit_key.as_ref()
+    }
+
+    /// Return the SQLite-allocated key captured by the physical INSERT.
+    ///
+    /// Caller-supplied IDs are deliberately reported only by
+    /// [`Self::explicit_key`]; adapters can therefore distinguish generation
+    /// from an explicit value without inspecting SQL text.
+    pub(crate) const fn generated_key(&self) -> Option<&GeneratedKey> {
+        self.generated_key.as_ref()
     }
 }
 
@@ -243,9 +362,66 @@ impl WriteCoordinator {
         sql: &str,
         parameters: P,
     ) -> EngineResult<CoordinatorWriteResult> {
+        self.execute_dml_inner(sql, parameters, None)
+    }
+
+    /// Execute one preflighted single-row INSERT whose native generated key
+    /// was omitted by the caller.
+    ///
+    /// This is intentionally a narrow seam for the shared SQL planner added
+    /// by issue #130: the caller must identify both the catalog table and its
+    /// already-selected physical shard. Merely supplying NULL through
+    /// [`Self::execute_dml`] never enables allocation.
+    pub(crate) fn execute_generated_dml<P: Params>(
+        &mut self,
+        sql: &str,
+        parameters: P,
+        table_id: u64,
+        expected_shard: u16,
+    ) -> EngineResult<CoordinatorWriteResult> {
+        self.execute_dml_inner(
+            sql,
+            parameters,
+            Some(GeneratedInsertRequest {
+                table_id,
+                expected_shard: Some(expected_shard),
+            }),
+        )
+    }
+
+    /// Execute one generated INSERT and let the writable registry choose an
+    /// active, non-exhausted owner using a per-table round-robin cursor.
+    pub(crate) fn execute_generated_dml_auto<P: Params>(
+        &mut self,
+        sql: &str,
+        parameters: P,
+        table_id: u64,
+    ) -> EngineResult<CoordinatorWriteResult> {
+        self.execute_dml_inner(
+            sql,
+            parameters,
+            Some(GeneratedInsertRequest {
+                table_id,
+                expected_shard: None,
+            }),
+        )
+    }
+
+    fn execute_dml_inner<P: Params>(
+        &mut self,
+        sql: &str,
+        parameters: P,
+        generated: Option<GeneratedInsertRequest>,
+    ) -> EngineResult<CoordinatorWriteResult> {
         self.ensure_usable()?;
         let epoch = self.registry.cancellation_epoch.load(Ordering::Acquire);
         let statement_arm = self.registry.write_state().arm_statement(epoch)?;
+        let generated_arm = generated
+            .map(|request| {
+                self.registry.validate_generated_insert_request(request)?;
+                self.registry.write_state().arm_generated_insert(request)
+            })
+            .transpose()?;
         self.registry.write_state().reset_statement_outcome()?;
 
         let execution = (|| {
@@ -272,7 +448,12 @@ impl WriteCoordinator {
                 .map_err(sqlite_error::statement)
         })();
 
+        let execution = match (&generated_arm, execution) {
+            (Some(arm), Ok(changed)) => arm.require_consumed().map(|()| changed),
+            (_, execution) => execution,
+        };
         let result = self.reconcile_statement(execution);
+        drop(generated_arm);
         drop(statement_arm);
         result
     }
@@ -290,6 +471,34 @@ impl WriteCoordinator {
     ) -> EngineResult<CoordinatorWriteResult> {
         let parameters = crate::sql::sqlite_parameters(parameters)?;
         self.execute_dml(sql, rusqlite::params_from_iter(parameters))
+    }
+
+    /// Protocol-neutral counterpart to [`Self::execute_generated_dml`].
+    pub(crate) fn execute_generated_dml_values(
+        &mut self,
+        sql: &str,
+        parameters: &[Value],
+        table_id: u64,
+        expected_shard: u16,
+    ) -> EngineResult<CoordinatorWriteResult> {
+        let parameters = crate::sql::sqlite_parameters(parameters)?;
+        self.execute_generated_dml(
+            sql,
+            rusqlite::params_from_iter(parameters),
+            table_id,
+            expected_shard,
+        )
+    }
+
+    /// Protocol-neutral counterpart to [`Self::execute_generated_dml_auto`].
+    pub(crate) fn execute_generated_dml_values_auto(
+        &mut self,
+        sql: &str,
+        parameters: &[Value],
+        table_id: u64,
+    ) -> EngineResult<CoordinatorWriteResult> {
+        let parameters = crate::sql::sqlite_parameters(parameters)?;
+        self.execute_generated_dml_auto(sql, rusqlite::params_from_iter(parameters), table_id)
     }
 
     pub(crate) fn begin(&mut self) -> EngineResult<()> {
@@ -413,10 +622,26 @@ impl WriteCoordinator {
     }
 
     #[cfg(test)]
+    pub(super) fn last_insert_rowid_for_test(&self) -> i64 {
+        self.connection.last_insert_rowid()
+    }
+
+    #[cfg(test)]
     pub(super) fn install_statement_arm_gate_for_test(&self) -> TestChildScanControl {
         let (gate, control) = TestChildScanGate::channel();
         *self
             .statement_arm_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(gate);
+        control
+    }
+
+    #[cfg(test)]
+    pub(super) fn install_generated_target_gate_for_test(&self) -> TestChildScanControl {
+        let (gate, control) = TestChildScanGate::channel();
+        *self
+            .registry
+            .generated_target_gate
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(gate);
         control
@@ -473,12 +698,16 @@ impl WriteCoordinator {
                 }),
                 Ok(FinalizedWrite::None) => execution.map(|_| CoordinatorWriteResult {
                     affected_rows: 0,
+                    shard: None,
                     explicit_key: None,
+                    generated_key: None,
                 }),
                 Ok(FinalizedWrite::Committed(outcome)) => {
                     execution.map(|_| CoordinatorWriteResult {
                         affected_rows: outcome.affected_rows,
+                        shard: outcome.shard,
                         explicit_key: outcome.explicit_key,
+                        generated_key: outcome.generated_key,
                     })
                 }
             };
@@ -505,7 +734,9 @@ impl WriteCoordinator {
         let outcome = self.registry.write_state().take_statement_outcome()?;
         execution.map(|_| CoordinatorWriteResult {
             affected_rows: outcome.affected_rows,
+            shard: outcome.shard,
             explicit_key: outcome.explicit_key,
+            generated_key: outcome.generated_key,
         })
     }
 
@@ -631,6 +862,7 @@ pub(super) struct WriteState {
     inner: Mutex<WriteTransactionState>,
     retained_schema_operation: Option<SchemaOperationGuard>,
     armed_statement_epoch: Mutex<Option<u64>>,
+    generated_insert: Mutex<Option<GeneratedInsertIntent>>,
     active_interrupt: Mutex<Option<Arc<InterruptHandle>>>,
     commit_linearization: Mutex<()>,
     nonblocking_cancel_requested: AtomicBool,
@@ -662,6 +894,7 @@ impl WriteState {
             inner: Mutex::new(WriteTransactionState::Idle),
             retained_schema_operation,
             armed_statement_epoch: Mutex::new(None),
+            generated_insert: Mutex::new(None),
             active_interrupt: Mutex::new(None),
             commit_linearization: Mutex::new(()),
             nonblocking_cancel_requested: AtomicBool::new(false),
@@ -781,6 +1014,92 @@ impl WriteState {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         if *armed == Some(epoch) {
             *armed = None;
+        }
+    }
+
+    fn arm_generated_insert(
+        self: &Arc<Self>,
+        request: GeneratedInsertRequest,
+    ) -> EngineResult<GeneratedInsertArm> {
+        let mut generated = self
+            .generated_insert
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if generated.is_some() {
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                "native generated INSERT intent is already armed",
+            ));
+        }
+        *generated = Some(GeneratedInsertIntent {
+            request,
+            consumed: false,
+        });
+        Ok(GeneratedInsertArm {
+            state: Arc::clone(self),
+            request,
+        })
+    }
+
+    fn generated_insert_target(
+        &self,
+        registry: &Registry,
+        spec: &TableSpec,
+        shard_key: ValueRef<'_>,
+    ) -> EngineResult<Option<GeneratedInsertTargets>> {
+        let mut generated = self
+            .generated_insert
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let Some(intent) = generated.as_mut() else {
+            return Ok(None);
+        };
+        if intent.request.table_id != spec.id {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "native generated INSERT was preflighted for a different table than {}",
+                    spec.name
+                ),
+            ));
+        }
+        if !matches!(shard_key, ValueRef::Null) {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "native generated INSERT for {} unexpectedly supplied an explicit key",
+                    spec.name
+                ),
+            ));
+        }
+        if intent.consumed {
+            return Err(EngineError::new(
+                EngineErrorKind::Unsupported,
+                "multi-row native generated INSERT is not supported until it can reserve a safe batch",
+            ));
+        }
+        intent.consumed = true;
+        let targets = match intent.request.expected_shard {
+            Some(shard) => GeneratedInsertTargets::Exact(shard),
+            None => GeneratedInsertTargets::Auto(registry.generated_insert_targets(spec)?),
+        };
+        registry.wait_after_generated_target_selection_for_test()?;
+        Ok(Some(targets))
+    }
+
+    fn reject_generated_non_insert(&self) -> EngineResult<()> {
+        if self
+            .generated_insert
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .is_some()
+        {
+            Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "native generated INSERT intent reached a non-INSERT callback",
+            ))
+        } else {
+            Ok(())
         }
     }
 
@@ -1038,7 +1357,9 @@ impl WriteState {
             WriteTransactionState::Idle => Ok(()),
             WriteTransactionState::Active(transaction) => {
                 transaction.affected_rows = 0;
+                transaction.statement_shard = None;
                 transaction.explicit_key = None;
+                transaction.generated_key = None;
                 Ok(())
             }
             WriteTransactionState::PendingCommit(_) | WriteTransactionState::PendingRollback(_) => {
@@ -1056,7 +1377,9 @@ impl WriteState {
             WriteTransactionState::Idle => Ok(WriteOutcome::default()),
             WriteTransactionState::Active(transaction) => Ok(WriteOutcome {
                 affected_rows: std::mem::take(&mut transaction.affected_rows),
+                shard: transaction.statement_shard.take(),
                 explicit_key: transaction.explicit_key.take(),
+                generated_key: transaction.generated_key.take(),
             }),
             WriteTransactionState::PendingCommit(_) | WriteTransactionState::PendingRollback(_) => {
                 Err(EngineError::new(
@@ -1093,7 +1416,16 @@ impl WriteState {
         conflict: ConflictMode,
     ) -> EngineResult<i64> {
         self.with_active(registry, |transaction| {
-            transaction.insert(registry, spec, values, conflict, &self.active_interrupt)
+            let shard_key = spec.write_shard_key(values)?;
+            let generated_shard = self.generated_insert_target(registry, spec, shard_key)?;
+            transaction.insert(
+                registry,
+                spec,
+                values,
+                conflict,
+                generated_shard,
+                &self.active_interrupt,
+            )
         })
     }
 
@@ -1103,6 +1435,7 @@ impl WriteState {
         spec: &TableSpec,
         locator: ValueRef<'_>,
     ) -> EngineResult<()> {
+        self.reject_generated_non_insert()?;
         self.with_active(registry, |transaction| {
             transaction.delete(registry, spec, locator, &self.active_interrupt)
         })
@@ -1119,6 +1452,7 @@ impl WriteState {
         no_change: &[bool],
         conflict: ConflictMode,
     ) -> EngineResult<()> {
+        self.reject_generated_non_insert()?;
         self.with_active(registry, |transaction| {
             transaction.update(
                 registry,
@@ -1326,6 +1660,236 @@ impl Drop for StatementEpochArm {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct GeneratedInsertRequest {
+    table_id: u64,
+    expected_shard: Option<u16>,
+}
+
+#[derive(Debug)]
+enum GeneratedInsertTargets {
+    Exact(u16),
+    Auto(Box<[u16]>),
+}
+
+impl GeneratedInsertTargets {
+    fn candidates(&self) -> &[u16] {
+        match self {
+            Self::Exact(shard) => std::slice::from_ref(shard),
+            Self::Auto(shards) => shards,
+        }
+    }
+
+    const fn permits_capacity_fallback(&self) -> bool {
+        matches!(self, Self::Auto(_))
+    }
+}
+
+impl Registry {
+    fn generated_insert_targets(&self, spec: &TableSpec) -> EngineResult<Box<[u16]>> {
+        if spec.targets.is_empty() {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "native generated INSERT for {} has no eligible physical shard",
+                    spec.name
+                ),
+            ));
+        }
+        let owners = spec.allocation_owners.as_ref().ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!(
+                    "registered native-ID table {} has no allocation-owner map",
+                    spec.name
+                ),
+            )
+        })?;
+        let target_count = u64::try_from(spec.targets.len()).map_err(|error| {
+            EngineError::from_source(
+                EngineErrorKind::LimitExceeded,
+                "native generated target count does not fit the selection cursor",
+                error,
+            )
+        })?;
+        let start = spec.generated_shard_cursor.fetch_add(1, Ordering::Relaxed) % target_count;
+        let start = usize::try_from(start).expect("target cursor modulo length fits usize");
+        let mut eligible = Vec::with_capacity(spec.targets.len());
+        for offset in 0..spec.targets.len() {
+            let shard = spec.targets[(start + offset) % spec.targets.len()];
+            if owners.owner_for_physical_shard(shard).is_some() {
+                eligible.push(shard);
+            }
+        }
+        if eligible.is_empty() {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "native generated INSERT for {} has no active allocation owner",
+                    spec.name
+                ),
+            ));
+        }
+        Ok(eligible.into_boxed_slice())
+    }
+
+    fn validate_generated_insert_request(
+        &self,
+        request: GeneratedInsertRequest,
+    ) -> EngineResult<()> {
+        let spec = self.tables.get(&request.table_id).ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "native generated INSERT refers to unknown table identity {}",
+                    request.table_id
+                ),
+            )
+        })?;
+        spec.ensure_writable()?;
+        if !spec.native_id_policy_active {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "native generated INSERT for {} is unavailable until its allocation policy is activated",
+                    spec.name
+                ),
+            ));
+        }
+        let GeneratedIdPolicy::NativeRangeV1 { column } = &spec.generated_id_policy else {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "registered table {} does not use native_range_v1 generation",
+                    spec.name
+                ),
+            ));
+        };
+        let shard_key = spec.shard_key.as_ref().ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!(
+                    "registered native-ID table {} has no shard-key descriptor",
+                    spec.name
+                ),
+            )
+        })?;
+        let key_index = usize::try_from(shard_key.column_index).map_err(|_| {
+            EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!(
+                    "registered native-ID table {} has an invalid key index",
+                    spec.name
+                ),
+            )
+        })?;
+        if shard_key.key_type != crate::core::ShardKeyType::Int64
+            || spec
+                .columns
+                .get(key_index)
+                .map(|column| column.name.as_str())
+                != Some(column.as_str())
+        {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!(
+                    "registered native-ID policy for {} does not match its Int64 shard key",
+                    spec.name
+                ),
+            ));
+        }
+        let owners = spec.allocation_owners.as_ref().ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!(
+                    "registered native-ID table {} has no allocation-owner map",
+                    spec.name
+                ),
+            )
+        })?;
+        if let Some(expected_shard) = request.expected_shard {
+            if !spec.targets.contains(&expected_shard) {
+                return Err(EngineError::new(
+                    EngineErrorKind::FailedPrecondition,
+                    format!(
+                        "native generated INSERT target shard {expected_shard} is not eligible for {}",
+                        spec.name
+                    ),
+                ));
+            }
+            if owners.owner_for_physical_shard(expected_shard).is_none() {
+                return Err(EngineError::new(
+                    EngineErrorKind::FailedPrecondition,
+                    format!(
+                        "native generated INSERT target shard {expected_shard} has no active allocation owner"
+                    ),
+                ));
+            }
+        } else if !spec
+            .targets
+            .iter()
+            .any(|shard| owners.owner_for_physical_shard(*shard).is_some())
+        {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "native generated INSERT for {} has no active allocation owner",
+                    spec.name
+                ),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct GeneratedInsertIntent {
+    request: GeneratedInsertRequest,
+    consumed: bool,
+}
+
+struct GeneratedInsertArm {
+    state: Arc<WriteState>,
+    request: GeneratedInsertRequest,
+}
+
+impl GeneratedInsertArm {
+    fn require_consumed(&self) -> EngineResult<()> {
+        let generated = self
+            .state
+            .generated_insert
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        match generated.as_ref() {
+            Some(intent) if intent.request == self.request && intent.consumed => Ok(()),
+            Some(intent) if intent.request == self.request => Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "native generated INSERT completed without allocating a physical row",
+            )),
+            _ => Err(EngineError::new(
+                EngineErrorKind::Internal,
+                "native generated INSERT intent changed during statement execution",
+            )),
+        }
+    }
+}
+
+impl Drop for GeneratedInsertArm {
+    fn drop(&mut self) {
+        let mut generated = self
+            .state
+            .generated_insert
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if generated
+            .as_ref()
+            .is_some_and(|intent| intent.request == self.request)
+        {
+            *generated = None;
+        }
+    }
+}
+
 impl Drop for WriteState {
     fn drop(&mut self) {
         let state = self
@@ -1357,13 +1921,17 @@ struct WriteTransaction {
     savepoints: Vec<SavepointMark>,
     poison: Option<String>,
     affected_rows: usize,
+    statement_shard: Option<u16>,
     explicit_key: Option<Value>,
+    generated_key: Option<GeneratedKey>,
 }
 
 struct SavepointMark {
     number: i32,
     affected_rows: usize,
+    statement_shard: Option<u16>,
     explicit_key: Option<Value>,
+    generated_key: Option<GeneratedKey>,
 }
 
 impl WriteTransaction {
@@ -1375,7 +1943,9 @@ impl WriteTransaction {
             savepoints: Vec::new(),
             poison: None,
             affected_rows: 0,
+            statement_shard: None,
             explicit_key: None,
+            generated_key: None,
         }
     }
 
@@ -1413,6 +1983,18 @@ impl WriteTransaction {
             ));
         };
         self.affected_rows = affected_rows;
+        Ok(())
+    }
+
+    fn record_write_shard(&mut self, shard: u16) -> EngineResult<()> {
+        if self.statement_shard.is_some_and(|current| current != shard) {
+            self.poison("one statement reported mutations on two physical shards");
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                "brisk_shard statement mutated more than one physical shard",
+            ));
+        }
+        self.statement_shard = Some(shard);
         Ok(())
     }
 
@@ -1538,6 +2120,46 @@ impl WriteTransaction {
         Ok(self.child.as_mut().expect("write child was installed"))
     }
 
+    /// Drop a capacity probe that acquired a physical writer lock but made no
+    /// change, so an auto-selected generated INSERT can try its next owner.
+    fn release_unmutated_generated_candidate(
+        &mut self,
+        active_interrupt: &Mutex<Option<Arc<InterruptHandle>>>,
+    ) -> EngineResult<()> {
+        if self.affected_rows != 0
+            || self.statement_shard.is_some()
+            || self.explicit_key.is_some()
+            || self.generated_key.is_some()
+        {
+            self.poison("generated allocation fallback followed a physical mutation");
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                "native generated allocation cannot retry after a physical mutation",
+            ));
+        }
+        let Some(child) = self.child.take() else {
+            self.poison("generated allocation fallback lost its physical child");
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                "native generated allocation retry has no physical child",
+            ));
+        };
+        let rollback = child
+            .connection
+            .execute_batch("ROLLBACK")
+            .map_err(sqlite_error::statement);
+        *active_interrupt
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+        if let Err(error) = rollback {
+            self.poison(format!(
+                "generated allocation capacity-probe rollback failed: {error}"
+            ));
+            return Err(error);
+        }
+        Ok(())
+    }
+
     fn savepoint(&mut self, number: i32) -> EngineResult<()> {
         if number < 0 {
             return Err(EngineError::new(
@@ -1571,7 +2193,9 @@ impl WriteTransaction {
         // level lets a later RELEASE of N followed by ROLLBACK TO an outer
         // level still reach the correct physical boundary.
         let affected_rows = self.affected_rows;
+        let statement_shard = self.statement_shard;
         let explicit_key = self.explicit_key.clone();
+        let generated_key = self.generated_key.clone();
         for missing in first_missing..=number {
             if let Some(child) = &self.child {
                 child
@@ -1582,7 +2206,9 @@ impl WriteTransaction {
             self.savepoints.push(SavepointMark {
                 number: missing,
                 affected_rows,
+                statement_shard,
                 explicit_key: explicit_key.clone(),
+                generated_key: generated_key.clone(),
             });
         }
         Ok(())
@@ -1622,7 +2248,9 @@ impl WriteTransaction {
                 .map_err(sqlite_error::statement)?;
         }
         self.affected_rows = self.savepoints[position].affected_rows;
+        self.statement_shard = self.savepoints[position].statement_shard;
         self.explicit_key = self.savepoints[position].explicit_key.clone();
+        self.generated_key = self.savepoints[position].generated_key.clone();
         self.savepoints.truncate(position + 1);
         Ok(())
     }
@@ -1633,11 +2261,22 @@ impl WriteTransaction {
         spec: &TableSpec,
         values: &[ValueRef<'_>],
         conflict: ConflictMode,
+        generated_targets: Option<GeneratedInsertTargets>,
         active_interrupt: &Mutex<Option<Arc<InterruptHandle>>>,
     ) -> EngineResult<i64> {
         spec.ensure_writable()?;
         let shard_key = spec.write_shard_key(values)?;
-        let shard = registry.write_target(spec, shard_key)?;
+        if let Some(targets) = generated_targets {
+            return self.insert_generated(
+                registry,
+                spec,
+                values,
+                conflict,
+                targets,
+                active_interrupt,
+            );
+        }
+        let shard = registry.insert_target(spec, shard_key)?;
         let sql = spec.insert_sql(conflict)?;
         let parameters = values
             .iter()
@@ -1665,6 +2304,7 @@ impl WriteTransaction {
             ));
         }
         self.record_physical_changes(changed)?;
+        self.record_write_shard(shard)?;
         let rowid = match &explicit_key {
             RawCell::Integer(value) => *value,
             _ => 0,
@@ -1672,6 +2312,167 @@ impl WriteTransaction {
         self.explicit_key = Some(raw_cell_to_value(explicit_key)?);
         self.ensure_healthy(registry)?;
         Ok(rowid)
+    }
+
+    fn insert_generated(
+        &mut self,
+        registry: &Registry,
+        spec: &TableSpec,
+        values: &[ValueRef<'_>],
+        conflict: ConflictMode,
+        targets: GeneratedInsertTargets,
+        active_interrupt: &Mutex<Option<Arc<InterruptHandle>>>,
+    ) -> EngineResult<i64> {
+        let owners = spec.allocation_owners.as_ref().ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!(
+                    "registered native-ID table {} has no allocation-owner map",
+                    spec.name
+                ),
+            )
+        })?;
+        let (sql, parameters, generated_column) =
+            spec.generated_insert_sql_and_values(values, conflict)?;
+
+        let pinned_shard = self.child.as_ref().map(|child| child.shard);
+        let may_fallback = targets.permits_capacity_fallback() && pinned_shard.is_none();
+        let mut selected = None;
+        let candidates = targets.candidates();
+        for &shard in candidates {
+            if pinned_shard.is_some_and(|pinned| pinned != shard) {
+                continue;
+            }
+            let owner = owners.owner_for_physical_shard(shard).ok_or_else(|| {
+                EngineError::new(
+                    EngineErrorKind::FailedPrecondition,
+                    format!(
+                        "native generated INSERT target shard {shard} has no active allocation owner"
+                    ),
+                )
+            })?;
+            let capacity = {
+                let child = self.pin(registry, shard, active_interrupt)?;
+                validate_allocation_sequence_capacity(&child.connection, &spec.name, owner)
+            };
+            match capacity {
+                Ok(()) => {
+                    selected = Some((shard, owner));
+                    break;
+                }
+                Err(error) if may_fallback && error.kind() == EngineErrorKind::LimitExceeded => {
+                    self.release_unmutated_generated_candidate(active_interrupt)?;
+                }
+                Err(error) => return Err(error),
+            }
+        }
+        let Some((shard, owner)) = selected else {
+            return Err(EngineError::new(
+                if pinned_shard.is_some() {
+                    EngineErrorKind::FailedPrecondition
+                } else {
+                    EngineErrorKind::LimitExceeded
+                },
+                if pinned_shard.is_some() {
+                    format!(
+                        "native generated INSERT for {} cannot move an existing transaction to another shard",
+                        spec.name
+                    )
+                } else {
+                    format!(
+                        "native generated table {} exhausted every active allocation owner",
+                        spec.name
+                    )
+                },
+            ));
+        };
+        let insertion = (|| {
+            let child = self.pin(registry, shard, active_interrupt)?;
+            let mut statement = child
+                .connection
+                .prepare(&sql)
+                .map_err(sqlite_error::statement)?;
+            let mut rows = statement
+                .query(rusqlite::params_from_iter(&parameters))
+                .map_err(sqlite_error::statement)?;
+            let generated = match rows.next().map_err(sqlite_error::statement)? {
+                Some(row) => row.get::<_, i64>(0).map_err(sqlite_error::statement)?,
+                // INSERT OR IGNORE can legitimately report no generated row.
+                None => return Ok(None),
+            };
+            if rows.next().map_err(sqlite_error::statement)?.is_some() {
+                return Err(EngineError::new(
+                    EngineErrorKind::Internal,
+                    "native generated INSERT returned more than one generated key",
+                ));
+            }
+            drop(rows);
+            drop(statement);
+            let sequence = read_allocation_sequence(&child.connection, &spec.name)?;
+            if sequence != generated {
+                return Err(EngineError::new(
+                    EngineErrorKind::DataCorruption,
+                    format!(
+                        "native generated table {} returned ID {generated} but SQLite recorded sequence {sequence}",
+                        spec.name
+                    ),
+                ));
+            }
+            let changed = usize::try_from(child.connection.changes()).map_err(|error| {
+                EngineError::from_source(
+                    EngineErrorKind::LimitExceeded,
+                    "SQLite generated INSERT change count does not fit usize",
+                    error,
+                )
+            })?;
+            Ok(Some((generated, changed)))
+        })();
+        let (generated, changed) = match insertion {
+            Ok(Some(result)) => result,
+            Ok(None) => {
+                self.ensure_healthy(registry)?;
+                return Ok(0);
+            }
+            Err(error) => {
+                self.poison_if_uncertain(&error);
+                return Err(error);
+            }
+        };
+
+        let decoded = match classify_generated_id(&spec.generated_id_policy, generated)? {
+            GeneratedIdClassification::NativeRangeV1(decoded) => decoded,
+            GeneratedIdClassification::Legacy(_) => {
+                self.poison("SQLite allocated a legacy value for a native generated ID");
+                return Err(EngineError::new(
+                    EngineErrorKind::DataCorruption,
+                    format!(
+                        "SQLite allocated a non-native ID for registered table {}",
+                        spec.name
+                    ),
+                ));
+            }
+        };
+        if decoded.owner() != owner || owners.physical_shard(decoded.owner()) != Some(shard) {
+            self.poison("SQLite allocated a generated ID outside its shard owner range");
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!(
+                    "SQLite allocated native ID {generated} outside shard {shard}'s owner range"
+                ),
+            ));
+        }
+        if changed != 1 {
+            self.poison("physical generated INSERT did not report exactly one changed row");
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                "brisk_shard physical generated INSERT did not change exactly one row",
+            ));
+        }
+        self.record_physical_changes(changed)?;
+        self.record_write_shard(shard)?;
+        self.generated_key = Some(GeneratedKey::new(generated_column, Value::Int64(generated)));
+        self.ensure_healthy(registry)?;
+        Ok(generated)
     }
 
     fn delete(
@@ -1706,6 +2507,9 @@ impl WriteTransaction {
         // row before its callback arrives, in which case native SQLite skips
         // the stale identity and reports no additional direct change.
         self.record_physical_changes(changed)?;
+        if changed != 0 {
+            self.record_write_shard(decoded.shard)?;
+        }
         self.ensure_healthy(registry)
     }
 
@@ -1784,6 +2588,9 @@ impl WriteTransaction {
         // away, or relocate the row. Treat its old locator as SQLite treats a
         // stale rowid: a successful zero-row no-op.
         self.record_physical_changes(changed)?;
+        if changed != 0 {
+            self.record_write_shard(decoded.shard)?;
+        }
         self.ensure_healthy(registry)
     }
 
@@ -1949,7 +2756,9 @@ impl WriteTransaction {
         }
         Ok(WriteOutcome {
             affected_rows: std::mem::take(&mut self.affected_rows),
+            shard: self.statement_shard.take(),
             explicit_key: self.explicit_key.take(),
+            generated_key: self.generated_key.take(),
         })
     }
 
@@ -1975,7 +2784,9 @@ struct WriteChild {
 #[derive(Debug, Default)]
 pub(super) struct WriteOutcome {
     pub(super) affected_rows: usize,
+    pub(super) shard: Option<u16>,
     pub(super) explicit_key: Option<Value>,
+    pub(super) generated_key: Option<GeneratedKey>,
 }
 
 pub(super) enum FinalizedWrite {
@@ -2047,11 +2858,71 @@ mod tests {
     fn coordinator_result_is_protocol_neutral() {
         let result = CoordinatorWriteResult {
             affected_rows: 1,
+            shard: Some(0),
             explicit_key: Some(Value::Int64(7)),
+            generated_key: None,
         };
         assert_eq!(result.affected_rows(), 1);
+        assert_eq!(result.shard(), Some(0));
         assert_eq!(result.explicit_key(), Some(&Value::Int64(7)));
+        assert_eq!(result.generated_key(), None);
         assert_eq!(super::super::MODULE_NAME, "brisk_shard");
+    }
+
+    #[test]
+    fn sqlite_returning_and_last_insert_rowid_match_on_the_same_connection() {
+        let connection = Connection::open_in_memory().unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE allocated (id INTEGER PRIMARY KEY AUTOINCREMENT);
+                 CREATE TABLE unrelated (id INTEGER PRIMARY KEY AUTOINCREMENT);",
+            )
+            .unwrap();
+        let owner = AllocationOwnerSlot::new(3).unwrap();
+        let floor = native_range_v1_sequence_floor(owner);
+        connection
+            .execute(
+                "INSERT INTO sqlite_sequence (name, seq) VALUES ('allocated', ?1)",
+                [floor],
+            )
+            .unwrap();
+
+        let captured = connection
+            .query_row(
+                "INSERT INTO allocated DEFAULT VALUES RETURNING id",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap();
+        assert_eq!(
+            captured,
+            crate::core::generated_id::native_range_v1_first_id(owner)
+        );
+        assert_eq!(connection.last_insert_rowid(), captured);
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT seq FROM sqlite_sequence WHERE name = 'allocated'",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            captured
+        );
+
+        // The captured RETURNING value is stable, while a later operation on
+        // the same handle demonstrates why adapters must not consult the
+        // ambient last_insert_rowid after releasing or reusing a connection.
+        connection
+            .execute("INSERT INTO unrelated DEFAULT VALUES", [])
+            .unwrap();
+        assert_ne!(connection.last_insert_rowid(), captured);
+        assert_eq!(
+            connection
+                .query_row("SELECT id FROM allocated", [], |row| row.get::<_, i64>(0))
+                .unwrap(),
+            captured
+        );
     }
 
     #[test]

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -127,6 +127,10 @@ fn assert_catalog_fixture(catalog: &core::Catalog) {
 
 #[test]
 fn legacy_and_explicit_module_paths_are_both_available() {
+    fn assert_owned_public<T: Clone + Send + Sync + 'static>() {}
+
+    assert_owned_public::<core::GeneratedKey>();
+    assert_owned_public::<core::WriteResult>();
     let _legacy_database: Option<storage::Database> = None;
     let _core_database: Option<core::Database> = None;
     let _engine: Option<core::Engine> = None;
@@ -142,6 +146,10 @@ fn legacy_and_explicit_module_paths_are_both_available() {
     let _ready = core::SessionState::Ready;
     let _closed = core::SessionState::Closed;
     let _statement = core::Statement::new("SELECT ?1", vec![core::Value::from(42_i64)]);
+    let generated_key = core::GeneratedKey::new("id", core::Value::Int64(41));
+    let write_result = core::WriteResult::with_generated_key(1, generated_key);
+    assert_eq!(write_result.rows_affected, 1);
+    assert_eq!(write_result.generated_key.unwrap().column, "id");
     let _prepared_statement_id: Option<core::PreparedStatementId> = None;
     let _portal_id: Option<core::PortalId> = None;
     let _describe_target: Option<core::DescribeTarget> = None;
@@ -189,6 +197,27 @@ fn legacy_and_explicit_module_paths_are_both_available() {
         error::mysql_error(core::EngineErrorKind::UniqueViolation).error_number,
         1062
     );
+}
+
+#[test]
+fn sqlite_import_generated_id_opt_in_is_public_owned_and_explicit() {
+    fn assert_owned_public<T: Clone + Send + Sync + 'static>() {}
+
+    assert_owned_public::<briskdb::import::SqliteGeneratedIdPlan>();
+    assert_owned_public::<briskdb::import::SqliteTableImportPlan>();
+    let ordinary = briskdb::import::SqliteTableImportPlan::sharded_by_primary_key("events");
+    assert_eq!(
+        ordinary.generated_id_plan(),
+        &briskdb::import::SqliteGeneratedIdPlan::None
+    );
+
+    let native = ordinary.with_native_range_v1("id").unwrap();
+    assert_eq!(native.generated_id_plan().column(), Some("id"));
+    assert!(matches!(
+        native.generated_id_plan(),
+        briskdb::import::SqliteGeneratedIdPlan::NativeRangeV1 { column, .. }
+            if column == "id"
+    ));
 }
 
 #[test]
@@ -1117,6 +1146,33 @@ async fn protocol_neutral_async_engine_surface_is_available() {
     assert_eq!(status.shutdown_grace(), Duration::from_millis(100));
 
     session.set_routing_key("public-controls").await.unwrap();
+    engine
+        .broadcast(
+            &session,
+            "CREATE TABLE public_write_result (id INTEGER PRIMARY KEY)".to_owned(),
+        )
+        .await
+        .unwrap();
+    let write = engine
+        .execute_write(
+            &session,
+            core::Statement::new("INSERT INTO public_write_result (id) VALUES (1)", vec![]),
+        )
+        .await
+        .unwrap();
+    assert_eq!(write.value, core::WriteResult::without_generated_key(1));
+    let controlled_write = engine
+        .execute_write_with_context(
+            &session,
+            core::Statement::new("INSERT INTO public_write_result (id) VALUES (2)", vec![]),
+            core::RequestContext::new().with_deadline(Instant::now() + Duration::from_secs(1)),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        controlled_write.value,
+        core::WriteResult::without_generated_key(1)
+    );
     let token = core::CancellationToken::new();
     let context = core::RequestContext::new()
         .with_cancellation_token(token.clone())

--- a/tests/sqlite_import.rs
+++ b/tests/sqlite_import.rs
@@ -19,6 +19,67 @@ use rusqlite::{Connection, OpenFlags, params, types::ValueRef};
 
 const SHARD_COUNT: u16 = 3;
 
+#[test]
+fn explicit_native_range_import_preserves_legacy_rows_and_owner_floors() {
+    let temporary = tempfile::tempdir().unwrap();
+    let source_path = temporary.path().join("native-source.sqlite");
+    let destination = temporary.path().join("native-imported");
+    let source = Connection::open(&source_path).unwrap();
+    source
+        .execute_batch(
+            "CREATE TABLE records(
+                 id INTEGER PRIMARY KEY AUTOINCREMENT,
+                 value TEXT NOT NULL
+             );
+             INSERT INTO records(id, value) VALUES (-9, 'negative'), (17, 'legacy');",
+        )
+        .unwrap();
+    drop(source);
+    let plan = SqliteImportPlan::new(vec![
+        SqliteTableImportPlan::sharded_by_primary_key("records")
+            .with_native_range_v1("id")
+            .unwrap(),
+    ]);
+
+    import_sqlite_database(
+        &source_path,
+        &destination,
+        &plan,
+        SqliteImportOptions::new(4).unwrap(),
+    )
+    .unwrap();
+
+    let database = Database::open(&destination, 4).unwrap();
+    let metadata = database
+        .catalog()
+        .tables()
+        .iter()
+        .find(|table| table.name() == "records")
+        .unwrap();
+    assert_eq!(
+        metadata.generated_id_policy(),
+        &GeneratedIdPolicy::native_range_v1("id").unwrap()
+    );
+    let routes = integer_routes(&database, [-9, 17]);
+    drop(database);
+
+    let shards = open_shards(&destination, 4);
+    assert_integer_owners(&shards, "records", &routes);
+    for (shard, connection) in shards.iter().enumerate() {
+        let sequence = connection
+            .query_row(
+                "SELECT seq FROM sqlite_sequence WHERE name = 'records'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap();
+        let expected_floor =
+            0x4000_0000_0000_0000_i64 + i64::try_from(shard).unwrap() * (1_i64 << 52);
+        assert_eq!(sequence, expected_floor);
+        assert_ne!(sequence, 17);
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum RawValue {
     Null,


### PR DESCRIPTION
Closes #128.

## What changed

- Added manifest v10 with explicit generated-policy activation, active/retired allocation-owner lifecycle, semantic digest v3, downgrade fencing, and a checksummed crash-resumable table-provisioning journal.
- Provisioned exact `INTEGER PRIMARY KEY AUTOINCREMENT` tables with owner-specific `sqlite_sequence` floors on every shard before atomically publishing allocator authority.
- Added owner-aware explicit routing, legacy hash compatibility, monotonic owner retirement, tamper/high-water validation, automatic active-shard selection, and same-connection `INSERT ... RETURNING` capture.
- Added protocol-neutral `GeneratedKey`/`WriteResult` results and the internal Engine seam needed by issue #130; unsupported public omitted-key and multi-row shapes remain fail-closed.
- Added an explicit `native_range_v1` SQLite import opt-in that preserves legacy rows while initializing per-shard owner floors.
- Documented manifest v10, recovery boundaries, generated-ID behavior, compatibility, and remaining SQL/frontend work.

## Safety and recovery

- Startup resumes every durable provisioning prefix and publishes the catalog only after all shard commits are acknowledged.
- Migration errors and panics roll back exactly; terminal degradation preserves, but never replays, an active provisioning journal.
- Retired owners remain readable, cannot allocate, and replacements must increase monotonically per shard so SQLite cannot cross back into a retired range.
- Sequence corruption, conflicting owners, full ranges, rollback, constraints, cancellation, restart, and committed-then-deleted high-water marks fail closed or preserve non-reuse as appropriate.

## Validation

- `cargo test --locked --all-features --all-targets` (827 passed, 2 intentionally ignored; all binaries, integrations, and benches passed)
- `cargo test --locked --all-targets` (710 passed, 1 intentionally ignored; all binaries, integrations, and benches passed before the final all-feature-only recovery regression)
- `cargo +1.85.0 test --locked --all-features --all-targets`
- `cargo +1.85.0 check --locked --all-targets --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo clippy --locked --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps --all-features`
- `cargo fmt --all -- --check`
- `git diff --check`

Concurrent automatic allocation is exercised repeatedly at 2/4/8/10 shards, with unique IDs, correct owner decoding, every shard used, and independent WAL files observed.