### PR TITLE
Implement durable hilo_v1 block leasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ minimum supported Rust version (MSRV) and the latest stable toolchain.
   into the raw HTTP execute/query path, while an empty catalog alone retains
   the legacy pass-through behavior
 - A transactionally versioned `manifest.sqlite` with durable 4,096-bucket
-  routing plus logical-database and authoritative table-placement metadata
+  routing, logical-database and authoritative table-placement metadata, and
+  optional per-table durable `hilo_v1` ID block leasing
 - A supported offline SQLite importer with complete per-table placement plans,
   one physical owner for every Sharded row, explicit-only Global replication,
   exact-value verification, and atomic no-replace publication
@@ -113,7 +114,8 @@ minimum supported Rust version (MSRV) and the latest stable toolchain.
   recreated after initialization
 - Routed writes and catalog-aware logical query execution, with a separately
   compiled and runtime-enabled virtual-table coordinator for explicit-key
-  autocommit writes to registered Sharded tables
+  autocommit writes to registered Sharded tables and internal preflighted
+  generated-key seams for `native_range_v1` and `hilo_v1`
 - A crash-resumable, journaled schema-migration endpoint for every shard
 - A checksummed manifest, generation-bound shard-schema fingerprints, and
   fail-closed `Verifying`/`Ready`/`Migrating`/`Degraded` storage states
@@ -561,6 +563,25 @@ keep their original hash route. An internal coordinator seam can allocate and
 capture one preflighted omitted-key row on an eligible active shard, but no
 public Engine or HTTP SQL path can invoke it yet. SQL declarations, omitted-key
 Engine planning, and response rendering remain issue #130.
+
+Version 11 adds optional `hilo_v1`, a manifest-leased global sequence for one
+registered Sharded table. The generated column must be the table's exact
+visible `Int64` shard key and physically `INTEGER PRIMARY KEY` without
+`AUTOINCREMENT` on every shard. One immediate manifest transaction reserves a
+fixed block of 4,096 sequences before any target-shard write lock; an in-memory
+allocator then consumes that committed block and hash-routes each encoded ID
+across the ordinary persisted bucket map. The value interval is
+`0x2000_0000_0000_0001..=0x3fff_ffff_ffff_ffff`, disjoint from
+`native_range_v1`. A monotonic fence and random 32-byte process incarnation
+identify each committed lease without clocks or expiry. Committed ranges are
+never reclaimed: restart, crash, rollback, cancellation, and constraint
+failure may burn an ID or unused range tail, so gaps are expected and numeric
+order is allocation order, not commit order. The allocator promises uniqueness
+and non-reuse, not gapless IDs or global commit ordering. Explicit inserts may
+still use negative and positive pre-marker legacy IDs, which hash-route normally;
+the complete hi/lo namespace is allocator-owned and rejected when supplied by
+the caller. This release exposes generation through the lower coordinator seam;
+public DDL/omitted-key SQL and wire-result integration remain issue #130.
 
 Registration marks schema admission `Pending` before its manifest commit. If
 that commit reports an ambiguous cleanup or I/O failure, close the registering

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,7 +30,7 @@ server ---------> protocol::http
 | Module | Responsibility | Must not own |
 | --- | --- | --- |
 | `core` | Protocol-neutral `Engine`, `Session`, statements, immutable bound portals, values, results, errors, read-only catalog views and initialization declarations, generated-ID policy and codec types, synchronous bound-value-aware plans, prepared lifecycle, explicit-shard read-only inspection, logical Sharded read target selection and scatter/gather, and sharded routing policy; stable key routing; bounded per-session and per-shard admission; routed execution and journaled schema migration | JSON/HTTP types, listeners, or Axum handlers |
-| `storage` | Versioned routing and authoritative logical manifest, persisted generated-ID policy/activation and stable active/retired allocation-owner slots, recoverable one-time table provisioning, shard layout, migration journals and recovery, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
+| `storage` | Versioned routing and authoritative logical manifest, persisted generated-ID policy/activation, stable active/retired allocation-owner slots, durable per-table hi/lo block leases, recoverable one-time table provisioning, shard layout, migration journals and recovery, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
 | `import` | Offline source-schema preflight, explicit placement and generated-ID plan validation, exact-value row routing into private staging, independent verification, durable receipt creation, and atomic publication | Network handlers, live/incremental migration, generated-ID inference, implicit Global placement, or protocol-specific behavior |
 | `sql` | Dialect-explicit SQL syntax parsing, recursive common-subset validation, protocol-neutral statement/batch classification, source-preserving placeholder normalization, explicit strict/compatibility translation, catalog-aware typed shard-key inference, and narrow crate-private DML-shape inspection behind BriskDB-owned boundaries; exact source retention; SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, key hashing or shard selection, mutable session state, physical write-routing policy, filesystem layout, protocol responses, protocol-buffer ownership, or protocol-specific support policy |
 | `protocol::http` | Existing HTTP request extraction, shared JSON/BriskDB value and RFC 9457 problem-detail encoding, and the embedded admin shell/assets, temporary browser sessions, metadata-driven logical discovery, exact logical counts, and bounded shard-major page handlers | BLAKE3 routing, shard files, direct SQLite access, or rusqlite calls |
@@ -477,6 +477,19 @@ AUTOINCREMENT` storage and installs disjoint owner-local `sqlite_sequence`
 floors on every shard before catalog authority is published. Omitted-key
 dialect parsing and DDL rewriting remain later work.
 
+Version 11 adds the `briskdb_hilo_leases` allocation head and manifest digest
+version 4. An active `hilo_v1` table has exactly one row with fixed block size
+4,096, the first sequence not yet leased, a monotonic fence token, and the most
+recent committed range plus its random 32-byte process-incarnation owner. One
+`BEGIN IMMEDIATE` manifest transaction advances that row and reseals the
+semantic root before an ID can reach a shard writer. The process-local cache
+then consumes the committed block without another central write. It never
+restores a range after exit or returns an issued ID after rollback,
+cancellation, constraint failure, or an ambiguous commit. No timestamp, lease
+expiry, or wall clock participates. The v10-to-v11 migration creates an empty
+lease table, raises the downgrade fence, and changes no policy, shard, or
+application row.
+
 Each manifest version retains an intentionally incompatible
 `briskdb_metadata` definition and row as a downgrade fence. The v3-to-v4
 migration remains manifest-atomic. The v4-to-v5 step first validates the v4
@@ -500,6 +513,8 @@ The v9-to-v10 step remains manifest-only: it preserves every policy but marks it
 inactive, marks existing owner rows active, creates empty provisioning tables,
 raises the fence, and installs checksum version 3. A migrated native policy must
 therefore be explicitly reprovisioned before it may generate a new key.
+The v10-to-v11 step is likewise manifest-only: it creates the empty durable
+hi/lo allocation table, raises the fence, and installs checksum version 4.
 There is no automatic downgrade; an older binary requires a backup from before
 the newer format.
 
@@ -525,14 +540,15 @@ lock through independently durable per-shard work and `Ready` publication. A
 lagging opener re-reads `Ready` and strictly validates instead of provisioning
 from a stale `Creating` observation. Only a locked, durable `Creating` state
 permits missing canonical shard files to be created and WAL to be enabled. The
-validated v10 manifest may also contain one active table-provisioning record.
+validated v11 manifest may also contain one active table-provisioning record.
 Startup then keeps admission `Pending`, revalidates the complete declarations
 and committed schema digest, and resumes the ascending `next_shard` prefix. A
 shard-local sequence seed commits before its separate manifest acknowledgement;
 if process loss lands between those boundaries, startup repeats that same seed
 idempotently rather than skipping it. Only after all shards are durable does one
-manifest transaction activate native policies, clear the transient journal,
-reseal digest version 3, and publish the replacement catalog. A conflict never
+manifest transaction activate generated policies, create the initial hi/lo
+allocation row where required, clear the transient journal, reseal digest
+version 4, and publish the replacement catalog. A conflict never
 causes BriskDB to infer a new request from partial shard state.
 
 The final strict shard opens and catalog reconciliation complete before the
@@ -680,6 +696,10 @@ AUTOINCREMENT` storage on every physical shard. Import defaults every table to
 legacy key domain. Every pre-v9 manifest upgrade selects `None`; v9-to-v10
 preserves any native policy but marks it inactive. An old `AUTOINCREMENT` clause
 or marker-looking imported value therefore cannot silently enable generation.
+`HiloV1` has the same Sharded/visible-`Int64` catalog constraint but requires
+exact `INTEGER PRIMARY KEY` storage without `AUTOINCREMENT`. Its policy also
+remains inactive until empty-table provisioning has validated every shard and
+atomically installed an initial manifest allocation head.
 
 The version-1 native value is a positive signed 64-bit integer with bit 62 set,
 an immutable 10-bit allocation-owner slot in bits 61 through 52, and a 52-bit
@@ -725,6 +745,49 @@ publication activates policy and clears the journal. Every later shard
 admission rejects missing, duplicate, malformed, out-of-owner, or row-lagging
 allocator state. Omitted-key SQL translation belongs to issue #130.
 
+The version-1 hi/lo value sets bit 61 and stores one global per-table sequence
+in bits 60 through 0:
+
+```text
+0 | 0 | 1 | global table sequence (61 bits)
+63  62  61               60..0
+```
+
+Sequence zero is reserved. Valid hi/lo IDs are therefore
+`0x2000_0000_0000_0001..=0x3fff_ffff_ffff_ffff`, disjoint from the native
+range beginning at bit 62. Each complete encoded `Int64` value is routed
+through the frozen canonical hash and persisted virtual-bucket map; it does
+not embed or pin a physical shard. Negative and positive pre-marker values
+remain explicit legacy IDs with that same hash route. For a `hilo_v1` table,
+every caller-supplied value at or above the hi/lo marker is reserved to
+allocator namespaces and is rejected before mutation.
+
+The manifest owns one durable global sequence head per active hi/lo table. A
+lease transaction reserves up to 4,096 consecutive values, increments a
+monotonic fence, records the random 32-byte incarnation of the requesting
+process, reseals the semantic root, and commits before the allocator can expose
+the first value. Independent BriskDB processes that reach this narrow allocator
+path serialize only that refill transaction through SQLite and receive
+non-overlapping ranges. The fence distinguishes successive durable reservations;
+it is not an expiry time and does not revoke earlier IDs. There are no clocks,
+heartbeats, or reclaim decisions. This cross-process uniqueness property does
+not by itself broaden the rest of BriskDB's single-process-per-root deployment
+boundary. Independently started processes, including processes after `exec`,
+are the tested allocator model. Continuing to use an inherited live handle or
+lease cache after `fork()` is unsupported.
+
+Committed leases are irrevocable. The process cache advances before the target
+shard insert, never returns an ID after rollback, cancellation, constraint
+failure, or an ignored insertion, and never reloads its unused tail after
+restart. A manifest commit whose outcome cannot safely be acknowledged also
+returns no lease, so a block that may have committed is burned. Gaps and
+abandoned tails are expected. Numeric order reflects allocation order only;
+transactions may commit in another order. `hilo_v1` promises uniqueness and
+non-reuse, not a gapless sequence or global commit ordering. Allocation happens
+before a target shard is selected or write-locked. Consequently, an explicit
+transaction that has already pinned a physical child rejects later hi/lo
+generation rather than trying to lease and move to another shard.
+
 The `experimental-vtab` feature adds separate read-only and narrowly writable
 SQLite coordinators that statically register `brisk_shard`. They prove a
 no-fork logical table boundary while leaving the manifest and physical schemas
@@ -734,7 +797,8 @@ dynamically loads an extension. Trusted metadata supplies each declared
 schema. An exact, storage-class-compatible `Int64`, `Text`, or `Binary`
 shard-key equality can open only its owner and bind the equality on that
 physical child; `native_range_v1` IDs use the stable active/retired owner map
-while legacy integers retain ordinary hash routing. `NULL` is empty and a type
+while `hilo_v1` and policy-accepted legacy integers use ordinary hash routing.
+`NULL` is empty and a type
 mismatch falls back to a full scan so SQLite can retain its comparison semantics.
 Unconstrained scans visit shards in ascending order with `UNION ALL` duplicate
 semantics. Remaining filters, aggregation, ordering, limits, and feature-local
@@ -760,7 +824,12 @@ capacity under the pinned child lock, omits the physical ID column, captures
 `INSERT ... RETURNING id` on that same handle, validates the owner and sequence,
 and publishes a protocol-neutral `GeneratedKey` only after successful
 reconciliation. Generic NULL inserts and a second generated callback remain
-rejected. Engine/HTTP omitted-key planning, Global writes, multi-shard
+rejected. The same one-shot seam accepts `hilo_v1`: it leases and irrevocably
+consumes an ID before any target-shard lock, hashes the encoded value to its
+owner, inserts it explicitly with `RETURNING`, and verifies the returned key.
+Because that allocation may select any shard, a transaction that already
+pinned a child rejects a later hi/lo insert. Engine/HTTP omitted-key planning,
+Global writes, multi-shard
 transactions, caller-authored `RETURNING`, defaults, generated columns, and
 triggers remain later work.
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -218,6 +218,88 @@ an experimental complement and optimization foundation. It must not replace
 the Engine/protocol query path at this stage. Streaming child cursors and pooled
 read handles are the clearest measured follow-up opportunities.
 
+## Hi/lo versus native generated-write workload
+
+Issue #129 adds a separate ignored release harness for the two internal
+generated-ID seams. It is a four-shard, one-row autocommit comparison, not a
+wire-protocol benchmark. Each fresh fixture registers these exact empty table
+shapes on every shard:
+
+```sql
+CREATE TABLE benchmark_generated_native (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    payload TEXT NOT NULL
+) STRICT;
+
+CREATE TABLE benchmark_generated_hilo (
+    id INTEGER PRIMARY KEY,
+    payload TEXT NOT NULL
+) STRICT;
+```
+
+The matrix is frozen at exactly 2, 4, 8, and 10 concurrent writers. Each writer
+owns one pre-opened writable coordinator on its own OS thread. A barrier releases
+all writers together, after coordinator construction, and each performs 10,000
+single-row inserts. The native workload uses its automatic active-owner
+selection. The hi/lo workload consumes a globally leased ID and hash-routes the
+complete encoded value. Five samples are taken per policy and writer count;
+which policy runs first alternates by sample. The report uses the median by
+total writes per second. A fresh fixture is used for each writer count, and
+both physical table counts must equal the exact expected cumulative writes
+before that comparison is reported.
+
+Timing includes generated-ID consumption, route selection, virtual-table
+callback and reconciliation, physical SQLite WAL work, `synchronous=FULL`, and
+all 10,000 autocommit inserts per worker. For `hilo_v1`, it therefore includes
+one immediate manifest reservation and semantic-root refresh per 4,096-value
+block. It excludes database and table creation, registration/provisioning,
+coordinator opening, and thread creation. Timing starts immediately before the
+parent joins the start barrier, so it includes the final worker rendezvous and
+barrier release.
+The two policies intentionally retain their production allocation semantics:
+native generation advances shard-local `sqlite_sequence`, whereas hi/lo makes
+one central durable write per block and hash-distributes its encoded IDs.
+
+Run the correctness smoke test first, then the optimized matrix on a quiet local
+filesystem:
+
+```bash
+cargo test --locked --features experimental-vtab --lib \
+  storage::sharded_vtab::benchmarks::generated_write_benchmark_smoke_covers_the_frozen_writer_matrix_and_both_policies \
+  -- --exact
+
+cargo test --release --locked --features experimental-vtab --lib \
+  storage::sharded_vtab::benchmarks::release_benchmark_matrix_reports_issue_129_generated_write_comparison \
+  -- --ignored --exact --nocapture --test-threads=1
+```
+
+The tab-separated output schema is:
+
+```text
+record  policy  shards  writers  writes_per_worker  samples  median_total_writes  median_elapsed_ms  median_writes_per_sec
+comparison_record  shards  writers  hilo_over_native
+```
+
+The issue #129 matrix was measured on 2026-08-12 from branch
+`agent/129-hilo-v1`, based on `e8a1a05`, with the exact release command above.
+The host was an Apple M1 Pro with 10 cores and 16 GiB RAM, macOS 26.2/Darwin
+25.2.0, Rust 1.94.1 (`aarch64-apple-darwin`), and Cargo 1.94.1. The repository
+and temporary fixtures were on the internal solid-state APFS data volume. The
+machine was on AC power with a charged battery; samples used the operating
+system's normal warm cache and no cache flush. The complete test took 757.34
+seconds and all post-run physical row counts matched.
+
+| Writers | `native_range_v1` writes/s | `hilo_v1` writes/s | Hi/lo ÷ native |
+| ---: | ---: | ---: | ---: |
+| 2 | 1,911.16 | 2,059.28 | 1.078× |
+| 4 | 2,566.69 | 3,021.51 | 1.177× |
+| 8 | 3,683.81 | 3,782.75 | 1.027× |
+| 10 | 3,490.22 | 3,614.71 | 1.036× |
+
+On this host, hi/lo remained ahead at every tested concurrency, with the
+largest measured gain at four writers. These values are one-host engineering
+measurements, not capacity guarantees or CI thresholds.
+
 The decision record must report measurements for both paths, including startup
 where relevant, and explain whether the virtual-table boundary advances,
 remains experimental, or is rejected. The feature remains off the authoritative

--- a/docs/SHARDED_VIRTUAL_TABLE.md
+++ b/docs/SHARDED_VIRTUAL_TABLE.md
@@ -70,17 +70,36 @@ routed through its persisted allocation owner at planning, pool admission,
 coordinator execution, and returned-shard reporting. Marker-clear and negative
 legacy IDs retain the exact ordinary Int64 hash route. A reserved sequence
 floor or an owner absent from the active map is rejected before mutation.
+For `hilo_v1`, negative and positive values below
+`0x2000_0000_0000_0000` remain explicit legacy IDs and use that ordinary hash
+route. Every value at or above the marker belongs to a generated-ID namespace
+and a caller-authored INSERT is rejected; only the allocator may introduce a
+hi/lo ID.
 
 The coordinator also has a narrow generated-insert seam for issue #130's
-planner: a caller that has already proven one omitted-key row and selected one
-eligible shard can arm exactly one callback. The child uses
-`INSERT ... RETURNING id`, checks `sqlite_sequence` and decoded ownership on the
-same pinned handle, and retains the generated key only after successful
-reconciliation. `Engine::execute_write` has the protocol-neutral result shape
-needed to carry that data, but every currently accepted Engine statement returns
-`generated_key: None`: Engine and HTTP SQL planning still reject omitted shard
-keys. Dialect translation, Engine invocation, and public response rendering
-belong to #130.
+planner. A caller that has already proven one omitted-key row can arm exactly
+one callback. For `native_range_v1`, the caller may select an eligible shard;
+the child uses `INSERT ... RETURNING id`, checks `sqlite_sequence` and decoded
+ownership on the same pinned handle, and retains the generated key only after
+successful reconciliation. For `hilo_v1`, the coordinator first irrevocably
+consumes an ID from a durable manifest-leased block, hashes that encoded value
+to its target shard, inserts it explicitly with `RETURNING`, and verifies the
+returned value. Leasing occurs before any target-shard write lock. A transaction
+that already pinned a child therefore rejects later hi/lo generation instead
+of moving to another shard. `Engine::execute_write` has the protocol-neutral
+result shape needed to carry that data, but every currently accepted Engine
+statement returns `generated_key: None`: Engine and HTTP SQL planning still
+reject omitted shard keys. Dialect translation, Engine invocation, and public
+response rendering belong to #130.
+
+Each hi/lo manifest write reserves 4,096 global per-table sequence values and
+records a monotonic fence plus a random 32-byte process incarnation. There is no
+clock, expiry, or lease reclamation. The fence identifies one committed block;
+it does not invalidate IDs from an older block. A restart or crash abandons the
+unconsumed tail, and an ID consumed before a rollback, cancellation, ignored
+insert, or constraint failure is never returned. Gaps are therefore normal.
+Numeric ID order is allocation order, not transaction commit order, and the
+contract does not promise a gapless sequence or global commit ordering.
 
 The integration opens an ephemeral coordinator for one statement. It does not
 retain a coordinator in `Session`, and it does not add `BEGIN`, `COMMIT`,
@@ -108,7 +127,9 @@ class mismatch is not a routing proof: it conservatively visits every normal
 target and leaves SQLite to apply its affinity and comparison rules. With
 `native_range_v1`, a valid encoded native integer maps its immutable owner slot
 through the catalog's allocation-owner map. An integer classified as legacy
-under that policy uses the ordinary canonical Int64 hash route instead. No ID
+under that policy uses the ordinary canonical Int64 hash route instead. Under
+`hilo_v1`, valid hi/lo IDs and accepted pre-marker legacy IDs both use that
+canonical hash route; reserved or incompatible namespaces fail closed. No ID
 allocation occurs on this read path.
 
 Normal SQLite evaluates remaining filtering, aggregation, ordering, limits, and

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -115,20 +115,33 @@ handles; it does not use `ATTACH`, runtime extension loading, a SQLite fork, or
 a storage-format change. The writable wrapper accepts explicit-key Sharded
 INSERT and exactly routed UPDATE/DELETE, pins one physical transaction, and
 rejects cross-shard or Global writes. An internal preflighted seam also permits
-one `native_range_v1` NULL callback for a single omitted-key row on an already
-selected shard; it captures the generated ID with child `RETURNING` on the same
-handle. Generic generated/missing-key SQL remains rejected until #130 supplies
-AST intent and protocol rendering. Schema operations, attachments, unsafe
+one generated NULL callback for a single omitted-key row. `native_range_v1`
+allocates on an already selected shard and captures the ID with child
+`RETURNING` on the same handle. `hilo_v1` durably leases before taking a child
+write lock, consumes one global per-table ID, hash-routes it, inserts it
+explicitly, and verifies the returned value. A transaction that already pinned
+a shard rejects later hi/lo generation. Generic generated/missing-key SQL
+remains rejected until #130 supplies AST intent and protocol rendering. Schema
+operations, attachments, unsafe
 PRAGMAs, extension loading, defaults, generated columns, triggers, and
 caller-authored `RETURNING` remain rejected. This surface is internal and
 cannot be reached by the query app or protocol adapters.
+
+The lower `hilo_v1` seam reserves fixed 4,096-value blocks in the manifest and
+serves them from a fenced process-local cache. A monotonic fence and random
+32-byte process incarnation identify the committed reservation; no clock or
+expiry is involved. Committed ranges are never reclaimed. Restart, crash,
+rollback, cancellation, an ignored insert, or a constraint failure can burn IDs
+and leave gaps. The guarantee is uniqueness and non-reuse, not gaplessness or
+global commit ordering; numeric order records allocation order only.
 
 Within that feature gate only, a usable equality on the exact cataloged shard
 key requests one virtual-table argument without `omit`. Exact SQLite `INTEGER`,
 UTF-8 `TEXT`, and `BLOB` values can route matching `Int64`, `Text`, and `Binary`
 keys to one child, where the value is bound against the indexed physical key.
-A valid `native_range_v1` value uses its allocation owner; a legacy integer
-under that policy uses normal hash routing. `NULL` is empty, while a non-null
+A valid `native_range_v1` value uses its allocation owner. Valid `hilo_v1` IDs
+and policy-accepted legacy integers use normal hash routing; caller-authored
+hi/lo-namespace inserts are rejected. `NULL` is empty, while a non-null
 type mismatch conservatively scans all placement targets. Unconstrained scans
 visit shards in ascending order and preserve duplicates as `UNION ALL`.
 SQLite applies remaining filters, aggregation, ordering, limits, and

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -11,25 +11,25 @@ permitted; later migration opens never create a missing replacement, use
 SQLite's no-follow mode, and revalidate the freshly opened layout identity
 inside the same manifest transaction before changing journal state.
 
-## Current format: version 10
+## Current format: version 11
 
 SQLite header fields identify the file and its format:
 
 | Header field | Value | Meaning |
 | --- | --- | --- |
 | `PRAGMA application_id` | `0x42524442` (`BRDB`) | Permanent BriskDB manifest-family marker |
-| `PRAGMA user_version` | `10` | Authoritative manifest schema version |
+| `PRAGMA user_version` | `11` | Authoritative manifest schema version |
 
 The application ID prevents an accidental foreign SQLite file from being
 adopted as a manifest. It is not authentication or tamper protection: a process
 that can write the data directory can forge it and the unkeyed checksums
 described below.
 
-Version 10 has fifteen strict manifest tables. It retains the v9 routing,
+Version 11 has sixteen strict manifest tables. It retains the v10 routing,
 authoritative logical catalog, physical layout, application-schema migration,
-and integrity tables; replaces the downgrade fence; separates generated-ID
-policy from activation; makes allocation-owner lifecycle explicit; and adds a
-recoverable native table-provisioning journal without changing a shard file.
+integrity, generated-ID activation, allocation-owner lifecycle, and recoverable
+table-provisioning tables; replaces the downgrade fence; adds optional durable
+`hilo_v1` block leasing; and changes no shard-file format.
 
 ```sql
 CREATE TABLE briskdb_manifest (
@@ -39,7 +39,7 @@ CREATE TABLE briskdb_manifest (
 
 CREATE TABLE briskdb_metadata (
     requires_manifest_version INTEGER NOT NULL
-        CHECK (requires_manifest_version >= 10)
+        CHECK (requires_manifest_version >= 11)
 ) STRICT;
 
 CREATE TABLE briskdb_routing (
@@ -183,6 +183,52 @@ CREATE TABLE briskdb_allocation_owners (
 CREATE UNIQUE INDEX briskdb_one_active_owner_per_shard
 ON briskdb_allocation_owners (physical_shard_id)
 WHERE owner_state = 1;
+
+CREATE TABLE briskdb_hilo_leases (
+    table_id INTEGER PRIMARY KEY CHECK (table_id > 0),
+    block_size INTEGER NOT NULL CHECK (block_size = 4096),
+    next_sequence INTEGER NOT NULL
+        CHECK (next_sequence BETWEEN 1 AND 2305843009213693952),
+    fence_token INTEGER NOT NULL CHECK (fence_token >= 0),
+    last_owner_id BLOB
+        CHECK (
+            last_owner_id IS NULL
+            OR (typeof(last_owner_id) = 'blob' AND length(last_owner_id) = 32)
+        ),
+    last_first_sequence INTEGER
+        CHECK (
+            last_first_sequence IS NULL
+            OR last_first_sequence BETWEEN 1 AND 2305843009213693951
+        ),
+    last_last_sequence INTEGER
+        CHECK (
+            last_last_sequence IS NULL
+            OR last_last_sequence BETWEEN 1 AND 2305843009213693951
+        ),
+    FOREIGN KEY (table_id)
+        REFERENCES briskdb_generated_ids (table_id)
+        ON DELETE RESTRICT,
+    CHECK (
+        (
+            fence_token = 0
+            AND next_sequence = 1
+            AND last_owner_id IS NULL
+            AND last_first_sequence IS NULL
+            AND last_last_sequence IS NULL
+        )
+        OR
+        (
+            fence_token > 0
+            AND last_owner_id IS NOT NULL
+            AND last_first_sequence IS NOT NULL
+            AND last_last_sequence IS NOT NULL
+            AND last_first_sequence <= last_last_sequence
+            AND last_last_sequence < next_sequence
+            AND last_last_sequence = next_sequence - 1
+            AND last_last_sequence - last_first_sequence + 1 BETWEEN 1 AND block_size
+        )
+    )
+) STRICT;
 
 CREATE TABLE briskdb_table_provisioning (
     singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
@@ -336,30 +382,30 @@ CREATE TABLE briskdb_integrity (
 ```
 
 The manifest, metadata, routing, schema-catalog, shard-layout, and integrity
-tables each contain exactly one row. The v10 downgrade-fence row is exactly
-`10`. `briskdb_table_provisioning` contains either zero or one row, and its
+tables each contain exactly one row. The v11 downgrade-fence row is exactly
+`11`. `briskdb_table_provisioning` contains either zero or one row, and its
 declaration rows exist only while that parent row exists.
 The two integrity-version columns deliberately accept any positive integer so
 a future digest encoding can remain structurally readable long enough for an
-older binary to reject it as `FailedPrecondition`; v10 writers emit manifest
-digest version `3` and schema digest version `1`.
+older binary to reject it as `FailedPrecondition`; v11 writers emit manifest
+digest version `4` and schema digest version `1`.
 Zero or negative versions are malformed and are `DataCorruption`.
 `briskdb_manifest.shard_count` is immutable and is the initial routing modulus;
 it is also the live physical-shard count. Physical IDs are exactly
 `0..shard_count - 1`. Filenames remain derived by trusted code as
 `shards/{shard_id:04}.sqlite` and are never read from catalog-controlled paths.
-Version 10 supports only the `active` physical-shard lifecycle state. Adding
+Version 11 supports only the `active` physical-shard lifecycle state. Adding
 provisioning, draining, or retirement states to the routing catalog requires a
 later format and state-machine change. The separate shard-layout state governs
 only startup identity reconciliation.
 
 ### Logical catalog
 
-Every fresh or upgraded v10 manifest contains logical database ID `1` named
+Every fresh or upgraded v11 manifest contains logical database ID `1` named
 `default`. A fresh or pre-v6 upgrade begins at application-schema
 generation `0`; each completed journal row advances it by exactly one, through
 a maximum of `2,147,483,647`. The schema-catalog singleton also contains
-identifier encoding version `1` and default database ID `1`. Version 10 permits
+identifier encoding version `1` and default database ID `1`. Version 11 permits
 at most 64 logical databases and 4,096 table rows. Database and table IDs are
 positive; table names are unique within their owning database, and every table
 references an existing database.
@@ -412,31 +458,33 @@ row can never grant allocation authority by inference. The stable codes are:
 | --- | --- | --- | --- | --- |
 | `0` | `GeneratedIdPolicy::None` | null | null | `0` (`Inactive`) only |
 | `1` | `GeneratedIdPolicy::NativeRangeV1` | The table's canonical Int64 shard-key column | `1` | `0` (`Inactive`) or `1` (`Active`) |
+| `2` | `GeneratedIdPolicy::HiloV1` | The table's canonical Int64 shard-key column | `1` | `0` (`Inactive`) or `1` (`Active`) |
 
-Policy and activation are orthogonal. An inactive native row preserves its ID
-classification and owner-routing domain, but it grants no omitted-key
+Policy and activation are orthogonal. An inactive generated-policy row preserves
+its ID classification and routing domain, but it grants no omitted-key
 allocation authority. Generated inserts fail closed until provisioning has
 made every shard durable and atomically changed that row to active. A `None`
 policy can never be active.
 
 The SQL shape permits a positive future policy or encoding so an older binary
 can distinguish an unsupported format from malformed storage. The reader first
-verifies the version-3 semantic root, so an unsealed change remains
+verifies the version-4 semantic root, so an unsealed change remains
 `DataCorruption`; with a valid root, it returns `FailedPrecondition` as soon as
 a structurally admitted positive policy or encoding is newer than it supports.
 It does not apply current-version relational semantics to that future format.
 For supported policy and encoding
 codes, zero or negative encodings, null native fields, a noncanonical column,
 missing or extra policy rows, and relational disagreement are `DataCorruption`.
-Current cross-table validation accepts `native_range_v1` only for a `Sharded`
-table whose generated column exactly equals its visible `Int64` shard key.
-Activation additionally requires that physical column to be exactly `INTEGER
-PRIMARY KEY AUTOINCREMENT` on every shard. `Global`, `Catalog`, Text, Binary, or
-a different generated column fail closed. An inactive migrated policy remains
-readable and explicitly routable without claiming that a legacy physical
-schema is an allocator; a plain non-AUTOINCREMENT integer primary key therefore
-cannot be activated. An exact provisioning retry compares the complete policy
-and activation outcome as part of idempotency.
+Current cross-table validation accepts `native_range_v1` and `hilo_v1` only for
+a `Sharded` table whose generated column exactly equals its visible `Int64`
+shard key. Native activation requires that physical column to be exactly
+`INTEGER PRIMARY KEY AUTOINCREMENT` on every shard. Hi/lo activation requires
+exactly `INTEGER PRIMARY KEY` without `AUTOINCREMENT`. Both shapes require one
+visible primary-key column with no default. `Global`, `Catalog`, Text, Binary,
+or a different generated column fail closed. An inactive migrated policy
+remains readable and explicitly routable without claiming that a legacy
+physical schema is an allocator. An exact provisioning retry compares the
+complete policy and activation outcome as part of idempotency.
 
 `briskdb_allocation_owners.owner_state = 1` means `Active`; `2` means
 `Retired`. Every physical shard has exactly one active allocation owner, which
@@ -451,10 +499,10 @@ shard. SQLite never lowers an `AUTOINCREMENT` high-water mark, even after the
 row which established it is deleted, so a lower replacement could otherwise
 continue allocating values in a retired owner's encoded range.
 
-Fresh version 10 storage seeds active `owner_slot = physical_shard_id`, so the
+Fresh version 11 storage seeds active `owner_slot = physical_shard_id`, so the
 initial slots are the contiguous range `0..shard_count - 1`. A slot is an
 immutable ID namespace, not a value that may be recomputed from a later shard
-count or bucket map. Version 10 has no public owner-map mutation operation, but
+count or bucket map. Version 11 has no public owner-map mutation operation, but
 its format preserves the state required by a later resharding workflow: retire
 the old slot without deleting it and explicitly add a never-used replacement
 whose slot is greater than every prior owner of that physical shard.
@@ -500,6 +548,64 @@ retry-sensitive; putting its counter in one central file would recreate one
 serialized writer. The no-fork design instead lets unmodified SQLite allocate
 inside disjoint shard-local ranges after those ranges are explicitly installed.
 
+Hi/lo encoding version 1 uses bit 61 as its format marker and the lower 61 bits
+as one global per-table sequence:
+
+```text
+bit       63  62  61  60........................................0
+meaning    0   0   1          global sequence (61)
+mask               0x2000_0000_0000_0000
+```
+
+Sequence zero is reserved, so valid IDs are
+`0x2000_0000_0000_0001..=0x3fff_ffff_ffff_ffff`. The interval is positive and
+disjoint from `native_range_v1`, whose marker begins at bit 62. Under
+`HiloV1`, negative and positive values below the hi/lo marker classify as
+explicit legacy IDs and retain the canonical Int64 hash route. Valid hi/lo IDs
+also hash-route as their complete encoded Int64 value through routing
+generation 1 and the persisted virtual-bucket map. Every explicit INSERT value
+at or above the hi/lo marker is allocator-owned and rejected; that rule also
+prevents a native-range encoding from being introduced into a hi/lo table.
+Sequence-zero and incompatible generated namespaces fail closed on reads and
+existing-row mutations rather than being treated as legacy.
+
+`briskdb_hilo_leases` contains exactly one row for every active `hilo_v1`
+policy and no row for an inactive hi/lo, native, or `None` policy. Activation
+inserts the initial state `block_size = 4096`, `next_sequence = 1`, and
+`fence_token = 0`, with all last-lease columns null. A lease transaction uses
+`BEGIN IMMEDIATE`, validates the complete current manifest, and reserves
+`first = next_sequence` through
+`last = min(first + 4095, 2^61 - 1)`. It advances `next_sequence` to
+`last + 1`, increments the positive fence, records the requester's random
+32-byte process-incarnation ID and exact range, refreshes semantic digest
+version 4, validates the result, and commits before returning the block. The
+terminal `next_sequence = 2^61` is a valid exhausted head; another reservation
+returns `LimitExceeded`. Fence overflow also returns `LimitExceeded`.
+
+The fence identifies a successive committed reservation; it is not a lock
+file, timestamp, expiry, or revocation of IDs issued under an older fence. No
+wall or monotonic clock is stored or consulted. Independent processes contend
+on SQLite's manifest transaction and therefore cannot commit overlapping
+ranges. Process-local handles for the same canonical root share one cache per
+table and write the manifest once per block, not once per row. This narrow
+cross-process allocator property does not change the wider deployment boundary
+for simultaneously serving one data root from multiple BriskDB processes.
+Here, independent processes means processes that initialize BriskDB after their
+own start (including an `exec` boundary). A child must not inherit and continue
+using a live BriskDB handle or cached lease across `fork()`; inherited handles
+are outside the supported process model.
+
+Every committed block is irrevocable. The allocator consumes an ID before
+taking the target-shard write lock and never returns it to the cache after a
+rollback, cancellation, ignored insert, constraint failure, or child commit
+failure. Process exit abandons the unused tail; startup never recovers it. If a
+manifest commit reports an error after it may have become durable, BriskDB
+returns no lease and a later reservation advances from the durable head, so the
+ambiguous block is burned rather than reused. Gaps are expected. Numeric order
+represents allocation order only and may differ from commit order. The policy
+guarantees uniqueness and non-reuse across processes and shards, not a gapless
+sequence or global transaction ordering.
+
 The loaded `Catalog` remains read-only to observers. Version 8 added the one-time
 `Database::register_tables` mutation boundary for an empty table catalog. The
 caller supplies the complete declaration set for the storage-default logical
@@ -520,15 +626,15 @@ unsupported. Registration assigns table IDs after sorting by logical database
 and canonical table name. A declaration set containing only `None` policies
 commits every table and policy row, refreshes the manifest root atomically, and
 publishes the replacement catalog only after revalidation. A set containing a
-native policy instead uses the provisioning journal below; it does not publish
-allocator authority in the transaction that records intent.
+native or hi/lo policy instead uses the provisioning journal below; it does not
+publish allocator authority in the transaction that records intent.
 
 Registration is initialization-only and requires exclusive live ownership of
 the data root. An exact complete repeat is a read-only idempotent success;
 empty, partial, different, duplicate, nonempty, or physically mismatched
 declarations fail without replacing the catalog. Once populated, the catalog
 cannot be edited in place. The one exception is an exact declaration repeat for
-a v9 catalog migrated with an inactive native policy: v10 may provision that
+a v9 catalog migrated with an inactive native policy: v11 may provision that
 unchanged policy if all declared physical tables are still empty, but it may
 not alter a declaration or catalog ID. A later journaled schema migration must preserve the
 exact registered physical table set on every shard and retain every sharded
@@ -550,10 +656,10 @@ live, a reopen that observes a committed replacement fails `FailedPrecondition`
 rather than publishing conflicting catalog snapshots. A new registration must
 not be attempted through the pending handle.
 
-### Native table-provisioning journal
+### Generated table-provisioning journal
 
 `briskdb_table_provisioning` is a transient, checksummed recovery record for
-the cross-file work required to activate native allocation. It has either no
+the cross-file work required to activate generated-ID allocation. It has either no
 row or singleton row `1`. `digest_version = 1` identifies a deterministic
 32-byte `provisioning_id` over the complete normalized declaration set, the
 requested shard count, and the committed schema digest. The recorded
@@ -590,16 +696,17 @@ The protocol is deliberately one-way and prefix based:
 1. Under the exclusive in-process schema gate, validate the complete empty
    physical table set and committed schema digest. In one manifest transaction,
    write the provisioning singleton and all declarations, reseal digest version
-   3, and commit before changing any shard.
-2. Starting at `next_shard`, seed every native table's active-owner
-   `sqlite_sequence` floor in one shard-local transaction. Only after that shard
-   commits may a separate manifest transaction advance `next_shard` by exactly
-   one and reseal the root.
+   4, and commit before changing any shard.
+2. Starting at `next_shard`, validate every generated table's exact physical
+   shape and seed every native table's active-owner `sqlite_sequence` floor in
+   one shard-local transaction. Hi/lo needs no shard-local allocator state.
+   Only after that shard commits may a separate manifest transaction advance
+   `next_shard` by exactly one and reseal the root.
 3. Once `next_shard = shard_count`, one final manifest transaction assigns or
-   verifies the authoritative catalog, changes every requested native policy to
-   `activation_state = 1`, deletes both provisioning tables' rows, reseals the
-   root, and commits. Only that complete catalog snapshot may be published to
-   callers.
+   verifies the authoritative catalog, changes every requested generated policy
+   to `activation_state = 1`, inserts the initial lease row for every hi/lo
+   table, deletes both provisioning tables' rows, reseals the root, and commits.
+   Only that complete catalog snapshot may be published to callers.
 
 A process loss after journal publication leaves ordinary admission closed on
 the next open while startup resumes the exact recorded request. A loss after a
@@ -611,8 +718,8 @@ acknowledged or replayed shard, resumes in ascending order, and publishes
 digests, owner ranges, or nonempty tables fail closed; BriskDB never infers a
 different request from partial shard state.
 
-Fresh v10 initialization leaves `briskdb_tables`, `briskdb_generated_ids`, and
-both provisioning tables empty. The v7-to-v8 migration
+Fresh v11 initialization leaves `briskdb_tables`, `briskdb_generated_ids`,
+`briskdb_hilo_leases`, and both provisioning tables empty. The v7-to-v8 migration
 also clears all v7 table rows because those rows were advisory and were never
 proved against the physical schema; silently promoting them would create false
 routing authority. The upgrade preserves logical databases, routing, schema
@@ -657,7 +764,7 @@ additional `Applying` row may exist, and it must target
 `schema_generation + 1`. Its stored source generation, shard count, SQL text,
 digest, state, and progress are validated on every manifest open. Any journal
 history requires the physical layout to be `Ready`; `Creating` and `Adopting`
-manifests have an empty journal. Fresh v10 initialization and pre-v6 upgrades
+manifests have an empty journal. Fresh v11 initialization and pre-v6 upgrades
 begin with an empty journal at generation 0.
 
 The retained journal proves which exact batches BriskDB coordinated; it does
@@ -699,8 +806,8 @@ restart as repair after any reported `DataCorruption`; whole-shard corruption
 drills and failure handling remain issue #68. Those storage failures retain
 their own error kinds and do not themselves justify rebaselining data.
 
-Manifest digest version 3 is a full 32-byte, unkeyed BLAKE3 digest. The stream
-begins with `briskdb.manifest.semantic-root.v3` plus its terminating NUL. It
+Manifest digest version 4 is a full 32-byte, unkeyed BLAKE3 digest. The stream
+begins with `briskdb.manifest.semantic-root.v4` plus its terminating NUL. It
 then encodes the length-prefixed name `application_id` and its tagged integer,
 followed by the length-prefixed name `user_version` and its tagged integer.
 These tables and columns follow in fixed order:
@@ -717,6 +824,7 @@ These tables and columns follow in fixed order:
 | `briskdb_schema_catalog` | `singleton`, `identifier_encoding_version`, `schema_generation`, `default_database_id` |
 | `briskdb_tables` | `table_id`, `database_id`, `table_name`, `placement`, `shard_key_column`, `shard_key_type` |
 | `briskdb_generated_ids` | `table_id`, `policy`, `generated_column`, `encoding_version`, `activation_state` |
+| `briskdb_hilo_leases` | `table_id`, `block_size`, `next_sequence`, `fence_token`, `last_owner_id`, `last_first_sequence`, `last_last_sequence` |
 | `briskdb_table_provisioning` | `singleton`, `provisioning_id`, `digest_version`, `schema_digest_version`, `committed_schema_digest`, `shard_count`, `declaration_count`, `next_shard` |
 | `briskdb_table_provisioning_declarations` | `provisioning_singleton`, `ordinal`, `database_id`, `table_name`, `placement`, `shard_key_column`, `shard_key_type`, `generated_policy`, `generated_column`, `generated_encoding_version` |
 | `briskdb_shard_layout` | `singleton`, `layout_id`, `shard_application_id`, `shard_metadata_version`, `layout_state` |
@@ -736,23 +844,28 @@ self-reference; its version, database state, and schema digest fields are
 covered. Frozen SQL definitions, STRICT flags, indexes, and foreign keys are
 validated separately rather than encoded as semantic rows.
 
-Every BriskDB-owned v10 manifest mutation recalculates the root after its row
+Every BriskDB-owned v11 manifest mutation recalculates the root after its row
 changes and before the same transaction commits. Progress acknowledgement,
 migration publication/finalization, provisioning intent/progress/finalization,
-layout publication, owner/activation state changes, and catalog changes
+layout publication, owner/activation state changes, catalog changes, and each
+hi/lo block reservation
 therefore cannot commit with a stale root through supported code. Hashing
 semantic values instead of the raw SQLite file makes the root stable across WAL
 checkpoints, page relocation, and `VACUUM`; it deliberately does not cover
 SQLite page bytes, rollback journals, WAL, or shared memory.
 
-Digest version 2 remains frozen solely to verify and migrate version-9
-manifests. It uses the `briskdb.manifest.semantic-root.v2` domain and the same
+Digest version 3 remains frozen solely to verify and migrate version-10
+manifests. It uses the `briskdb.manifest.semantic-root.v3` domain and the same
+encoding, covers activation, owner lifecycle, and both provisioning tables, but
+omits `briskdb_hilo_leases`. Digest version 2 remains frozen solely to verify
+and migrate version-9 manifests. It uses the
+`briskdb.manifest.semantic-root.v2` domain and the same
 encoding, covers generated-ID policy and the owner-to-shard mapping, but omits
 activation, owner lifecycle, and both provisioning tables. Digest version 1
 remains frozen for version-7 and version-8 manifests. It uses the
 `briskdb.manifest.semantic-root.v1` domain and the same encoding, but omits the
-two version-9 tables. A v10 manifest must store version 3; storing an older
-digest in an otherwise v10 shape is corruption, and an unsupported future
+two version-9 tables. A v11 manifest must store version 4; storing an older
+digest in an otherwise v11 shape is corruption, and an unsupported future
 positive digest version is a failed precondition.
 
 The frozen four-shard v8/version-1 fixture with layout ID
@@ -887,7 +1000,7 @@ The routing singleton contains exactly these generation-1 values:
 | `key_encoding_version` | `1` | Canonical bytes defined below for raw, explicit, and typed inferred routing keys |
 | `bucket_algorithm_version` | `1` | Compatibility-preserving range algorithm below |
 | `virtual_bucket_count` | `4096` | Fixed virtual bucket space `0..4095` |
-| `map_generation` | `1` | Initial committed bucket map and the only generation version 10 can interpret |
+| `map_generation` | `1` | Initial committed bucket map and the only generation version 11 can interpret |
 
 Every bucket ID exists exactly once and references an active physical shard.
 Every physical shard owns at least one bucket. The generation-1 map partitions
@@ -929,7 +1042,7 @@ vectors freeze the exact key bytes, BLAKE3 prefix, little-endian hash integer,
 bucket ID, and persisted physical shard.
 
 `map_generation` is separate from manifest `user_version` and from
-`schema_generation`. Version 10 accepts only routing generation 1 and validates
+`schema_generation`. Version 11 accepts only routing generation 1 and validates
 its exact deterministic assignment; no public map-mutation operation exists
 yet. A future format that can commit a changed map must bump `user_version` and
 its downgrade fence as well as `map_generation`. That requirement makes this
@@ -940,12 +1053,30 @@ At each open, BriskDB validates the exact objects, columns, strict flags, frozen
 schema SQL, singleton rows, logical identifiers and limits, metadata codes,
 supported algorithm values, contiguous physical and bucket IDs, active
 lifecycle states, assignments, coverage, and foreign keys. A recognized
-version-10 manifest that violates any invariant is `DataCorruption` and is
+version-11 manifest that violates any invariant is `DataCorruption` and is
 rejected before shard connections are opened. The same locked transaction
 returns routing and logical rows as one coherent shared snapshot. Request
 routing performs no manifest query and cannot fall back to modulo after a failed
 validation; only successful migration finalization publishes a newer logical
 schema generation into the snapshot.
+
+## Previous version 10
+
+Version 10 has fifteen strict tables. It has activation state, explicit owner
+lifecycle, and both provisioning tables, but no `briskdb_hilo_leases` table and
+no supported `hilo_v1` policy. Its downgrade fence requires 10 and it stores
+semantic manifest digest version 3.
+
+The atomic v10-to-v11 transaction creates the empty hi/lo lease table, replaces
+the downgrade fence with 11, changes the integrity row to manifest digest
+version 4, stamps `user_version = 11`, and reseals the version-4 root. It
+preserves routing, placement, every existing `None` or native generated-ID
+policy and activation, owner lifecycle, provisioning state, schema generation
+and history, layout and integrity state, schema fingerprints, shard files, and
+application rows. The migration never opens or mutates a shard. Because no v10
+policy can already be hi/lo, the new lease table is necessarily empty. A
+version-10 reader rejects the version-11 header and downgrade fence before it
+could ignore durable global allocation state.
 
 ## Previous version 9
 
@@ -1122,7 +1253,7 @@ CREATE TABLE briskdb_metadata (
 
 The fence contains exactly `2`. A current opener validates this complete format
 before applying the numbered v2-to-v3, v3-to-v4, v4-to-v5, v5-to-v6,
-v6-to-v7, v7-to-v8, v8-to-v9, and v9-to-v10 transactions.
+v6-to-v7, v7-to-v8, v8-to-v9, v9-to-v10, and v10-to-v11 transactions.
 
 ## Legacy version 1
 
@@ -1179,11 +1310,12 @@ returning:
    authoritative-catalog downgrade fence; v8-to-v9 installs explicit
    generated-ID policies, allocation-owner slots, and semantic digest version
    2; and v9-to-v10 installs activation/lifecycle state, the provisioning
-   journal, and semantic digest version 3. Older formats therefore cannot be
+   journal, and semantic digest version 3. The v10-to-v11 step adds durable
+   hi/lo allocation heads and semantic digest version 4. Older formats therefore cannot be
    mistaken for checksummed, authoritative-catalog, allocator-authority, or
    recoverable provisioning data.
 6. Fresh initialization is allowed only beside an otherwise empty physical
-   layout and commits v10 physical state `Creating`, integrity state
+   layout and commits v11 physical state `Creating`, integrity state
    `Verifying`, generation 0, and empty application-schema and provisioning
    journals. An existing
    v1/v2/v3 manifest first advances through v4; the v4-to-v5 transaction commits
@@ -1192,9 +1324,10 @@ returning:
    the unsealed integrity row, and v7-to-v8 establishes an empty authoritative
    table catalog. The v8-to-v9 step adds the empty generated-policy catalog and
    immutable owner map; v9-to-v10 adds inactive activation fields, active owner
-   states, and empty provisioning tables.
+   states, and empty provisioning tables; v10-to-v11 adds the empty hi/lo lease
+   table.
 7. If the validated integrity state is `Degraded`, fail startup without
-   changing it. Otherwise, if a validated v10 manifest contains one `Applying`
+   changing it. Otherwise, if a validated v11 manifest contains one `Applying`
    migration, require state `Migrating`, validate every shard against the
    trusted source/target fingerprint for its exact journal-prefix position,
    and resume it in ascending order. The final transaction publishes the
@@ -1256,6 +1389,9 @@ The v9-to-v10 step also changes no shard: it preserves every policy but marks
 it inactive, marks existing owners active, creates empty provisioning tables,
 and moves the checksum to version 3. Any later native activation is a distinct
 recoverable provisioning operation, not part of the format migration.
+The v10-to-v11 step likewise changes no shard: it creates an empty hi/lo lease
+table and moves the checksum to version 4. Existing policies, activation,
+owner state, provisioning progress, schema, and application rows are unchanged.
 
 A new application-schema migration follows a separate durable protocol:
 
@@ -1325,11 +1461,13 @@ later storage-hardening certification.
 
 ## Compatibility and operations
 
-- Version 1 upgrades through versions 2, 3, 4, 5, 6, 7, 8, 9, and 10; later versions
+- Version 1 upgrades through versions 2, 3, 4, 5, 6, 7, 8, 9, 10, and 11; later versions
   begin at the next numbered transaction. Opening is therefore potentially
   mutating. An active v6 journal is completed before its v7 transaction.
 - There is no automatic downgrade. Older readers are fenced by the incompatible
-  metadata schema and authoritative header. In particular, a version-9 reader
+  metadata schema and authoritative header. In particular, a version-10 reader
+  rejects `user_version = 11` before it can ignore durable hi/lo allocation
+  heads; a version-9 reader
   rejects `user_version = 10` before it can ignore policy activation, owner
   lifecycle, or table provisioning; a version-8 reader
   rejects `user_version = 9` before it can ignore generated-ID policy and owner
@@ -1386,7 +1524,7 @@ header value, format version, digest input, routing metadata, schema
 fingerprint, journal record, or recovery step. Listener settings are not
 persisted. Because engine open and its existing recovery precede listener
 binding, a later bind failure does not undo a migration or recovery transaction
-that already committed; a subsequent startup revalidates the same version-10
+that already committed; a subsequent startup revalidates the same version-11
 layout normally.
 
 Issue #29's pinned `pgwire` dependency and issue #30's production startup,
@@ -1427,12 +1565,16 @@ root. A formal backup/restore workflow is not implemented. Recovery to an older
 binary requires a backup from before the unsupported format. Separate server
 processes against one data
 directory are unsupported even though SQLite and the manifest use file locks;
-the in-process coordination is intentionally not a distributed lock.
+the in-process coordination is intentionally not a distributed lock. The
+`hilo_v1` reservation transaction is deliberately stronger at its narrow
+boundary: competing processes obtain non-overlapping fenced blocks. That
+allocator guarantee is tested independently and does not certify concurrent
+multi-server operation for the rest of the root.
 
 ## Verification contract
 
-Tests cover fresh creation and every v1/v2/v3/v4/v5/v6/v7/v8/v9 upgrade path to
-v10, every
+Tests cover fresh creation and every v1/v2/v3/v4/v5/v6/v7/v8/v9/v10 upgrade path to
+v11, every
 manifest layout and integrity state, the exact shard header and metadata row,
 dynamic schema generations, retained migration history, checksum golden
 vectors, and no-op ready reopen. Failure
@@ -1448,12 +1590,17 @@ matching and conflicting shard counts and layout transitions.
 
 Catalog tests continue to cover default logical metadata, every placement and
 shard-key type code, every generated-ID policy, activation, and encoding
-boundary, legacy/native classification, active and retired allocation-owner
+boundary, legacy/native/hi-lo classification, active and retired allocation-owner
 coverage, identifier and relational corruption, row limits, v7 advisory-row
 clearing, v8 explicit `None` migration, v9 inactive-policy migration, atomic
 registration and commit ambiguity, provisioning-prefix replay at every commit
 boundary, exact idempotency, empty-schema and key/constraint validation,
 immutable public lookups, stale-handle exclusion, and migration enforcement.
+Hi/lo tests cover one manifest write per block, restart, process abort before
+and after durable reservation, rollback, cancellation, constraint failure,
+exhaustion, fence overflow, clock-independent schema, manifest contention, and
+competing process incarnations. They assert uniqueness across shards and
+processes, burned abandoned tails, and non-reuse.
 Routing tests
 freeze golden hash/bucket/shard vectors,
 cover every algorithm state for every supported shard count, prove the final

--- a/src/core/catalog.rs
+++ b/src/core/catalog.rs
@@ -135,6 +135,7 @@ pub enum ShardKeyType {
 ///     match policy {
 ///         GeneratedIdPolicy::None => "none",
 ///         GeneratedIdPolicy::NativeRangeV1 { .. } => "native_range_v1",
+///         GeneratedIdPolicy::HiloV1 { .. } => "hilo_v1",
 ///     }
 /// }
 /// ```
@@ -143,6 +144,14 @@ pub enum ShardKeyType {
 /// use briskdb::core::GeneratedIdPolicy;
 ///
 /// let _ = GeneratedIdPolicy::NativeRangeV1 {
+///     column: "id".to_owned(),
+/// };
+/// ```
+///
+/// ```compile_fail
+/// use briskdb::core::GeneratedIdPolicy;
+///
+/// let _ = GeneratedIdPolicy::HiloV1 {
 ///     column: "id".to_owned(),
 /// };
 /// ```
@@ -163,6 +172,17 @@ pub enum GeneratedIdPolicy {
         /// Canonical generated column name.
         column: String,
     },
+    /// BriskDB leases durable blocks from one manifest-owned, per-table
+    /// sequence and hash-routes each generated ID to its physical shard.
+    ///
+    /// Construction is intentionally restricted to
+    /// [`GeneratedIdPolicy::hilo_v1`] so the stored column name always
+    /// satisfies the canonical catalog-identifier contract.
+    #[non_exhaustive]
+    HiloV1 {
+        /// Canonical generated column name.
+        column: String,
+    },
 }
 
 impl GeneratedIdPolicy {
@@ -178,11 +198,23 @@ impl GeneratedIdPolicy {
         Self::NativeRangeV1 { column }
     }
 
+    /// Construct the first durable manifest-backed hi/lo policy.
+    pub fn hilo_v1(column: impl Into<String>) -> EngineResult<Self> {
+        let column = column.into();
+        ensure_catalog_identifier(&column)?;
+        Ok(Self::HiloV1 { column })
+    }
+
+    pub(crate) fn hilo_v1_from_validated(column: String) -> Self {
+        debug_assert!(validate_catalog_identifier(&column));
+        Self::HiloV1 { column }
+    }
+
     /// Return the generated column, or `None` when generation is disabled.
     pub fn column(&self) -> Option<&str> {
         match self {
             Self::None => None,
-            Self::NativeRangeV1 { column } => Some(column),
+            Self::NativeRangeV1 { column } | Self::HiloV1 { column } => Some(column),
         }
     }
 
@@ -190,7 +222,7 @@ impl GeneratedIdPolicy {
     pub const fn encoding_version(&self) -> Option<u32> {
         match self {
             Self::None => None,
-            Self::NativeRangeV1 { .. } => Some(1),
+            Self::NativeRangeV1 { .. } | Self::HiloV1 { .. } => Some(1),
         }
     }
 }
@@ -410,23 +442,32 @@ fn ensure_generated_id_policy_compatible(
         return Ok(());
     }
 
+    let policy_name = match policy {
+        GeneratedIdPolicy::None => "none",
+        GeneratedIdPolicy::NativeRangeV1 { .. } => "native_range_v1",
+        GeneratedIdPolicy::HiloV1 { .. } => "hilo_v1",
+    };
     let diagnostic = match (placement, policy) {
-        (TablePlacement::Sharded(shard_key), GeneratedIdPolicy::NativeRangeV1 { column: _ })
-            if shard_key.key_type() != ShardKeyType::Int64 =>
-        {
+        (
+            TablePlacement::Sharded(shard_key),
+            GeneratedIdPolicy::NativeRangeV1 { .. } | GeneratedIdPolicy::HiloV1 { .. },
+        ) if shard_key.key_type() != ShardKeyType::Int64 => {
             format!(
-                "native_range_v1 generated IDs require an Int64 shard key, but table shard key {} has a different type",
+                "{policy_name} generated IDs require an Int64 shard key, but table shard key {} has a different type",
                 shard_key.column()
             )
         }
-        (TablePlacement::Sharded(shard_key), GeneratedIdPolicy::NativeRangeV1 { column }) => {
+        (
+            TablePlacement::Sharded(shard_key),
+            GeneratedIdPolicy::NativeRangeV1 { column } | GeneratedIdPolicy::HiloV1 { column },
+        ) => {
             format!(
-                "native_range_v1 generated column {column} must be the table shard key {}",
+                "{policy_name} generated column {column} must be the table shard key {}",
                 shard_key.column()
             )
         }
-        (_, GeneratedIdPolicy::NativeRangeV1 { .. }) => {
-            "native_range_v1 generated IDs require Sharded table placement".to_owned()
+        (_, GeneratedIdPolicy::NativeRangeV1 { .. } | GeneratedIdPolicy::HiloV1 { .. }) => {
+            format!("{policy_name} generated IDs require Sharded table placement")
         }
         (_, GeneratedIdPolicy::None) => {
             "the None generated-ID policy is unexpectedly incompatible".to_owned()
@@ -444,12 +485,14 @@ fn generated_id_policy_is_compatible(
 ) -> bool {
     match policy {
         GeneratedIdPolicy::None => true,
-        GeneratedIdPolicy::NativeRangeV1 { column } => matches!(
-            placement,
-            TablePlacement::Sharded(shard_key)
-                if shard_key.key_type() == ShardKeyType::Int64
-                    && shard_key.column() == column
-        ),
+        GeneratedIdPolicy::NativeRangeV1 { column } | GeneratedIdPolicy::HiloV1 { column } => {
+            matches!(
+                placement,
+                TablePlacement::Sharded(shard_key)
+                    if shard_key.key_type() == ShardKeyType::Int64
+                        && shard_key.column() == column
+            )
+        }
     }
 }
 
@@ -654,6 +697,7 @@ pub(crate) struct CatalogSnapshot {
     logical: Catalog,
     allocation_owners: Option<AllocationOwnerMap>,
     active_native_id_table_ids: Box<[TableId]>,
+    active_hilo_id_table_ids: Box<[TableId]>,
 }
 
 impl CatalogSnapshot {
@@ -664,6 +708,7 @@ impl CatalogSnapshot {
             logical,
             allocation_owners: None,
             active_native_id_table_ids: Box::new([]),
+            active_hilo_id_table_ids: Box::new([]),
         }
     }
 
@@ -682,6 +727,7 @@ impl CatalogSnapshot {
             logical,
             allocation_owners: Some(allocation_owners),
             active_native_id_table_ids: Box::new([]),
+            active_hilo_id_table_ids: Box::new([]),
         }
     }
 
@@ -716,8 +762,33 @@ impl CatalogSnapshot {
         &self.active_native_id_table_ids
     }
 
+    /// Attach the sorted manifest-validated set of active hi/lo tables.
+    pub(crate) fn with_active_hilo_id_table_ids(mut self, table_ids: Box<[TableId]>) -> Self {
+        debug_assert!(table_ids.windows(2).all(|ids| ids[0] < ids[1]));
+        debug_assert!(table_ids.iter().all(|id| {
+            self.logical.table_by_id(*id).is_some_and(|table| {
+                matches!(
+                    table.generated_id_policy(),
+                    GeneratedIdPolicy::HiloV1 { .. }
+                )
+            })
+        }));
+        self.active_hilo_id_table_ids = table_ids;
+        self
+    }
+
+    pub(crate) fn active_hilo_id_table_ids(&self) -> &[TableId] {
+        &self.active_hilo_id_table_ids
+    }
+
     pub(crate) fn native_id_policy_is_active(&self, table_id: TableId) -> bool {
         self.active_native_id_table_ids
+            .binary_search(&table_id)
+            .is_ok()
+    }
+
+    pub(crate) fn hilo_id_policy_is_active(&self, table_id: TableId) -> bool {
+        self.active_hilo_id_table_ids
             .binary_search(&table_id)
             .is_ok()
     }
@@ -922,6 +993,26 @@ mod tests {
                 EngineErrorKind::InvalidArgument
             );
         }
+
+        let hilo = GeneratedIdPolicy::hilo_v1("id").unwrap();
+        assert_eq!(hilo.column(), Some("id"));
+        assert_eq!(hilo.encoding_version(), Some(1));
+        assert_eq!(
+            GeneratedIdPolicy::hilo_v1("Invalid").unwrap_err().kind(),
+            EngineErrorKind::InvalidArgument
+        );
+        let hilo = TableDeclaration::sharded(
+            database,
+            "hilo_events",
+            ShardKeyMetadata::new("id", ShardKeyType::Int64).unwrap(),
+        )
+        .unwrap()
+        .with_generated_id_policy(hilo)
+        .unwrap();
+        assert!(matches!(
+            hilo.generated_id_policy(),
+            GeneratedIdPolicy::HiloV1 { .. }
+        ));
     }
 
     #[test]
@@ -958,6 +1049,30 @@ mod tests {
                 .with_generated_id_policy(GeneratedIdPolicy::native_range_v1("id").unwrap())
                 .unwrap_err();
             assert_eq!(error.kind(), EngineErrorKind::InvalidArgument);
+        }
+
+        for declaration in [
+            TableDeclaration::sharded(
+                database,
+                "events",
+                ShardKeyMetadata::new("tenant_id", ShardKeyType::Int64).unwrap(),
+            )
+            .unwrap(),
+            TableDeclaration::sharded(
+                database,
+                "events",
+                ShardKeyMetadata::new("id", ShardKeyType::Text).unwrap(),
+            )
+            .unwrap(),
+            TableDeclaration::global(database, "events").unwrap(),
+        ] {
+            assert_eq!(
+                declaration
+                    .with_generated_id_policy(GeneratedIdPolicy::hilo_v1("id").unwrap())
+                    .unwrap_err()
+                    .kind(),
+                EngineErrorKind::InvalidArgument
+            );
         }
 
         let disabled = TableDeclaration::global(database, "events")

--- a/src/core/generated_id.rs
+++ b/src/core/generated_id.rs
@@ -16,6 +16,14 @@ pub(crate) const MAX_ALLOCATION_OWNER_SLOT: u16 = (1_u16 << NATIVE_RANGE_V1_OWNE
 pub(crate) const MAX_NATIVE_RANGE_V1_LOCAL_SEQUENCE: u64 =
     (1_u64 << NATIVE_RANGE_V1_LOCAL_SEQUENCE_BITS) - 1;
 
+/// `hilo_v1` owns the positive signed interval whose two highest usable bits
+/// are `01`. Values at or above this marker are never legacy IDs under a
+/// `hilo_v1` policy; the native interval is therefore an incompatible stored
+/// namespace rather than something a hi/lo table may hash-route.
+pub(crate) const HILO_V1_FORMAT_MARKER: u64 = 0x2000_0000_0000_0000;
+pub(crate) const HILO_V1_SEQUENCE_BITS: u32 = 61;
+pub(crate) const MAX_HILO_V1_SEQUENCE: u64 = (1_u64 << HILO_V1_SEQUENCE_BITS) - 1;
+
 const NATIVE_RANGE_V1_OWNER_MASK: u64 =
     ((1_u64 << NATIVE_RANGE_V1_OWNER_BITS) - 1) << NATIVE_RANGE_V1_OWNER_SHIFT;
 
@@ -242,6 +250,48 @@ pub(crate) struct NativeRangeV1Id {
     local_sequence: u64,
 }
 
+/// Decoded sequence of one manifest-leased `hilo_v1` ID.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) struct HiloV1Id {
+    sequence: u64,
+}
+
+impl HiloV1Id {
+    pub(crate) fn new(sequence: u64) -> EngineResult<Self> {
+        if sequence == 0 {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "hilo_v1 sequence zero is reserved",
+            ));
+        }
+        if sequence > MAX_HILO_V1_SEQUENCE {
+            return Err(EngineError::new(
+                EngineErrorKind::NumericOutOfRange,
+                format!("hilo_v1 sequence {sequence} exceeds {MAX_HILO_V1_SEQUENCE}"),
+            ));
+        }
+        Ok(Self { sequence })
+    }
+
+    pub(crate) const fn sequence(self) -> u64 {
+        self.sequence
+    }
+
+    pub(crate) fn encode(self) -> i64 {
+        i64::try_from(HILO_V1_FORMAT_MARKER | self.sequence)
+            .expect("hilo_v1 reserves the signed high bit")
+    }
+
+    pub(crate) fn decode(encoded: i64) -> EngineResult<Self> {
+        decode_hilo_v1(encoded)?.ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::NumericOutOfRange,
+                "value does not contain the hilo_v1 format marker",
+            )
+        })
+    }
+}
+
 impl NativeRangeV1Id {
     pub(crate) fn new(owner: AllocationOwnerSlot, local_sequence: u64) -> EngineResult<Self> {
         if local_sequence == 0 {
@@ -298,14 +348,19 @@ pub(crate) enum GeneratedIdClassification {
     Legacy(i64),
     /// A valid value allocated from one native owner range.
     NativeRangeV1(NativeRangeV1Id),
+    /// A valid value allocated from the manifest-backed hi/lo sequence.
+    HiloV1(HiloV1Id),
 }
 
 /// Classify one value without inferring generation policy from its bits.
 ///
 /// A table whose policy is `None` treats every signed 64-bit value as legacy,
-/// including values that resemble a native marker. A native-range table keeps
-/// negative and pre-marker values on the legacy routing path, allowing an
-/// explicitly validated transition without changing existing keys.
+/// including values that resemble a generated marker. A native-range table
+/// keeps negative and pre-native-marker values on the legacy routing path,
+/// allowing an explicitly validated transition without changing existing
+/// keys. A hi/lo table keeps only negative and pre-hi/lo-marker values on that
+/// path; its empty-only registration contract reserves every larger value for
+/// generated formats.
 pub(crate) fn classify_generated_id(
     policy: &GeneratedIdPolicy,
     encoded: i64,
@@ -316,6 +371,12 @@ pub(crate) fn classify_generated_id(
             decoded.map_or(
                 GeneratedIdClassification::Legacy(encoded),
                 GeneratedIdClassification::NativeRangeV1,
+            )
+        }),
+        GeneratedIdPolicy::HiloV1 { .. } => decode_hilo_v1(encoded).map(|decoded| {
+            decoded.map_or(
+                GeneratedIdClassification::Legacy(encoded),
+                GeneratedIdClassification::HiloV1,
             )
         }),
     }
@@ -341,6 +402,16 @@ pub(crate) fn classify_caller_generated_id(
                     )
                 })
         }
+        GeneratedIdPolicy::HiloV1 { .. } => {
+            decode_hilo_v1_with_reserved_error(encoded, EngineErrorKind::InvalidArgument).map(
+                |decoded| {
+                    decoded.map_or(
+                        GeneratedIdClassification::Legacy(encoded),
+                        GeneratedIdClassification::HiloV1,
+                    )
+                },
+            )
+        }
     }
 }
 
@@ -364,6 +435,25 @@ pub(crate) fn native_range_v1_first_id(owner: AllocationOwnerSlot) -> i64 {
 pub(crate) fn native_range_v1_sequence_ceiling(owner: AllocationOwnerSlot) -> i64 {
     NativeRangeV1Id::new(owner, MAX_NATIVE_RANGE_V1_LOCAL_SEQUENCE)
         .expect("the codec's maximum local sequence is valid")
+        .encode()
+}
+
+/// Reserved sequence-zero boundary immediately below the first hi/lo ID.
+pub(crate) fn hilo_v1_sequence_floor() -> i64 {
+    i64::try_from(HILO_V1_FORMAT_MARKER).expect("hilo_v1 reserves the signed high bit")
+}
+
+/// First value produced by the global per-table hi/lo sequence.
+pub(crate) fn hilo_v1_first_id() -> i64 {
+    HiloV1Id::new(1)
+        .expect("hilo_v1 sequence one is valid")
+        .encode()
+}
+
+/// Last value available to the global per-table hi/lo sequence.
+pub(crate) fn hilo_v1_sequence_ceiling() -> i64 {
+    HiloV1Id::new(MAX_HILO_V1_SEQUENCE)
+        .expect("the codec's maximum hi/lo sequence is valid")
         .encode()
 }
 
@@ -402,12 +492,47 @@ fn decode_native_range_v1_with_reserved_error(
     }))
 }
 
+fn decode_hilo_v1(encoded: i64) -> EngineResult<Option<HiloV1Id>> {
+    decode_hilo_v1_with_reserved_error(encoded, EngineErrorKind::DataCorruption)
+}
+
+fn decode_hilo_v1_with_reserved_error(
+    encoded: i64,
+    reserved_error_kind: EngineErrorKind,
+) -> EngineResult<Option<HiloV1Id>> {
+    if encoded < 0 {
+        return Ok(None);
+    }
+    let bits = u64::try_from(encoded).expect("non-negative i64 fits u64");
+    if bits < HILO_V1_FORMAT_MARKER {
+        return Ok(None);
+    }
+    if bits > (HILO_V1_FORMAT_MARKER | MAX_HILO_V1_SEQUENCE) {
+        return Err(EngineError::new(
+            reserved_error_kind,
+            "hilo_v1 row ID uses an incompatible generated-ID namespace",
+        ));
+    }
+    let sequence = bits & MAX_HILO_V1_SEQUENCE;
+    if sequence == 0 {
+        return Err(EngineError::new(
+            reserved_error_kind,
+            "hilo_v1 row ID contains the reserved sequence zero",
+        ));
+    }
+    Ok(Some(HiloV1Id { sequence }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     fn native_policy() -> GeneratedIdPolicy {
         GeneratedIdPolicy::native_range_v1("id").unwrap()
+    }
+
+    fn hilo_policy() -> GeneratedIdPolicy {
+        GeneratedIdPolicy::hilo_v1("id").unwrap()
     }
 
     #[test]
@@ -444,6 +569,85 @@ mod tests {
             assert_eq!(id.encode(), expected);
             assert_eq!(id.owner(), owner);
             assert_eq!(id.local_sequence(), local_sequence);
+        }
+    }
+
+    #[test]
+    fn hilo_global_sequence_round_trips_at_both_boundaries() {
+        for (sequence, expected) in [
+            (1, 0x2000_0000_0000_0001_i64),
+            (MAX_HILO_V1_SEQUENCE, 0x3fff_ffff_ffff_ffff),
+        ] {
+            let id = HiloV1Id::new(sequence).unwrap();
+            assert_eq!(id.sequence(), sequence);
+            assert_eq!(id.encode(), expected);
+            assert_eq!(HiloV1Id::decode(expected).unwrap(), id);
+            assert_eq!(
+                classify_generated_id(&hilo_policy(), expected).unwrap(),
+                GeneratedIdClassification::HiloV1(id)
+            );
+        }
+        assert_eq!(hilo_v1_sequence_floor(), 0x2000_0000_0000_0000);
+        assert_eq!(hilo_v1_first_id(), 0x2000_0000_0000_0001);
+        assert_eq!(hilo_v1_sequence_ceiling(), 0x3fff_ffff_ffff_ffff);
+        assert!(hilo_v1_sequence_ceiling() < NATIVE_RANGE_V1_FORMAT_MARKER as i64);
+    }
+
+    #[test]
+    fn hilo_zero_overflow_and_later_namespaces_fail_closed() {
+        assert_eq!(
+            HiloV1Id::new(0).unwrap_err().kind(),
+            EngineErrorKind::InvalidArgument
+        );
+        assert_eq!(
+            HiloV1Id::new(MAX_HILO_V1_SEQUENCE + 1).unwrap_err().kind(),
+            EngineErrorKind::NumericOutOfRange
+        );
+
+        let floor = hilo_v1_sequence_floor();
+        assert_eq!(
+            classify_generated_id(&hilo_policy(), floor)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::DataCorruption
+        );
+        assert_eq!(
+            classify_caller_generated_id(&hilo_policy(), floor)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::InvalidArgument
+        );
+
+        for value in [NATIVE_RANGE_V1_FORMAT_MARKER as i64, i64::MAX] {
+            let stored = classify_generated_id(&hilo_policy(), value).unwrap_err();
+            assert_eq!(stored.kind(), EngineErrorKind::DataCorruption);
+            assert!(stored.diagnostic().contains("incompatible"));
+
+            let caller = classify_caller_generated_id(&hilo_policy(), value).unwrap_err();
+            assert_eq!(caller.kind(), EngineErrorKind::InvalidArgument);
+            assert!(caller.diagnostic().contains("incompatible"));
+            assert_eq!(
+                HiloV1Id::decode(value).unwrap_err().kind(),
+                EngineErrorKind::DataCorruption
+            );
+        }
+    }
+
+    #[test]
+    fn hilo_policy_preserves_only_negative_and_pre_marker_legacy_ids() {
+        for value in [i64::MIN, -1, 0, 1, (HILO_V1_FORMAT_MARKER - 1) as i64] {
+            assert_eq!(
+                classify_generated_id(&hilo_policy(), value).unwrap(),
+                GeneratedIdClassification::Legacy(value)
+            );
+            assert_eq!(
+                classify_caller_generated_id(&hilo_policy(), value).unwrap(),
+                GeneratedIdClassification::Legacy(value)
+            );
+            assert_eq!(
+                HiloV1Id::decode(value).unwrap_err().kind(),
+                EngineErrorKind::NumericOutOfRange
+            );
         }
     }
 
@@ -509,6 +713,9 @@ mod tests {
             -1,
             0,
             1,
+            HILO_V1_FORMAT_MARKER as i64,
+            0x2000_0000_0000_0001,
+            0x3fff_ffff_ffff_ffff,
             NATIVE_RANGE_V1_FORMAT_MARKER as i64,
             0x4000_0000_0000_0001,
             i64::MAX,
@@ -547,6 +754,7 @@ mod tests {
         assert_owned::<AllocationOwnerState>();
         assert_owned::<AllocationOwnerMap>();
         assert_owned::<NativeRangeV1Id>();
+        assert_owned::<HiloV1Id>();
         assert_owned::<GeneratedIdClassification>();
     }
 

--- a/src/core/planner.rs
+++ b/src/core/planner.rs
@@ -10,7 +10,9 @@ use crate::sql::{
 use super::{
     AllocationOwnerMap, Catalog, EngineError, EngineErrorKind, EngineResult, GeneratedIdPolicy,
     LogicalDatabaseId, TableMetadata, TablePlacement, Value,
-    generated_id::{GeneratedIdClassification, classify_caller_generated_id},
+    generated_id::{
+        GeneratedIdClassification, HILO_V1_FORMAT_MARKER, classify_caller_generated_id,
+    },
 };
 
 /// Borrowed typed shard key encoded identically by every routing entry point.
@@ -267,6 +269,12 @@ where
         .table_id()
         .and_then(|table| catalog.table_by_id(table))
         .filter(|table| table.database_id() == database);
+    let shard_key_column = sharded_key_column(catalog, database, &inference)?;
+    let dml = shard_key_column
+        .map(|column| routed_dml_shape(normalized, statement_index, column))
+        .transpose()?
+        .flatten();
+    reject_hilo_allocator_namespace_insert(dml, inferred_table, inference.values())?;
 
     let mut unique_routes = HashMap::<&ShardKeyValue, PlannedRoute>::new();
     let mut inferred_routes = Vec::with_capacity(inference.values().len());
@@ -306,11 +314,6 @@ where
         }
     });
 
-    let shard_key_column = sharded_key_column(catalog, database, &inference)?;
-    let dml = shard_key_column
-        .map(|column| routed_dml_shape(normalized, statement_index, column))
-        .transpose()?
-        .flatten();
     reject_retired_owner_insert(dml, inferred_table, allocation_owners, inference.values())?;
     let inferred_shards = inferred_shards(&inferred_routes);
 
@@ -352,6 +355,36 @@ where
         explicit_route,
         assigned_shard,
     })
+}
+
+fn reject_hilo_allocator_namespace_insert(
+    dml: Option<RoutedDml>,
+    table: Option<&TableMetadata>,
+    values: &[ShardKeyValue],
+) -> EngineResult<()> {
+    if dml != Some(RoutedDml::Insert)
+        || !table.is_some_and(|table| {
+            matches!(
+                table.generated_id_policy(),
+                GeneratedIdPolicy::HiloV1 { .. }
+            )
+        })
+    {
+        return Ok(());
+    }
+
+    let first_reserved =
+        i64::try_from(HILO_V1_FORMAT_MARKER).expect("hilo_v1 reserves the signed high bit");
+    if values
+        .iter()
+        .any(|value| matches!(value, ShardKeyValue::Int64(value) if *value >= first_reserved))
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "hilo_v1 generated-ID values are allocator-owned and cannot be supplied by an explicit INSERT",
+        ));
+    }
+    Ok(())
 }
 
 fn reject_retired_owner_insert(
@@ -541,18 +574,25 @@ where
     let Some(table) = table else {
         return Ok(shard_for_key(canonical_key));
     };
-    let (GeneratedIdPolicy::NativeRangeV1 { .. }, ShardKeyValue::Int64(value)) =
-        (table.generated_id_policy(), value)
-    else {
+    let ShardKeyValue::Int64(value) = value else {
         return Ok(shard_for_key(canonical_key));
     };
+    if !matches!(
+        table.generated_id_policy(),
+        GeneratedIdPolicy::NativeRangeV1 { .. } | GeneratedIdPolicy::HiloV1 { .. }
+    ) {
+        return Ok(shard_for_key(canonical_key));
+    }
 
     let classification = classify_caller_generated_id(table.generated_id_policy(), *value)?;
-    let GeneratedIdClassification::NativeRangeV1(native) = classification else {
-        // Negative and pre-marker values deliberately retain the frozen legacy
-        // hash route so imported identifiers never move when native allocation
-        // is enabled explicitly for future rows.
-        return Ok(shard_for_key(canonical_key));
+    let native = match classification {
+        GeneratedIdClassification::Legacy(_) | GeneratedIdClassification::HiloV1(_) => {
+            // Native tables keep their pre-native-marker legacy route. Hi/lo
+            // tables hash both their global sequence values and the explicitly
+            // supported negative/pre-hi/lo legacy interval.
+            return Ok(shard_for_key(canonical_key));
+        }
+        GeneratedIdClassification::NativeRangeV1(native) => native,
     };
     let owners = allocation_owners.ok_or_else(|| {
         EngineError::new(
@@ -687,6 +727,30 @@ mod tests {
                     ShardKeyType::Int64,
                 )),
                 GeneratedIdPolicy::native_range_v1("id").unwrap(),
+            )]
+            .into_boxed_slice(),
+        )
+    }
+
+    fn hilo_catalog() -> Catalog {
+        Catalog::from_validated_parts(
+            1,
+            7,
+            DEFAULT_DATABASE,
+            vec![LogicalDatabaseMetadata::from_validated(
+                DEFAULT_DATABASE,
+                "default".to_owned(),
+            )]
+            .into_boxed_slice(),
+            vec![TableMetadata::from_validated_with_generated_id_policy(
+                EVENTS_TABLE,
+                DEFAULT_DATABASE,
+                "hilo_events".to_owned(),
+                TablePlacement::Sharded(ShardKeyMetadata::from_validated(
+                    "id".to_owned(),
+                    ShardKeyType::Int64,
+                )),
+                GeneratedIdPolicy::hilo_v1("id").unwrap(),
             )]
             .into_boxed_slice(),
         )
@@ -1332,6 +1396,178 @@ mod tests {
             )
             .unwrap();
             assert_eq!(plan.inferred_routes()[0].shard(), expected, "{value}");
+        }
+    }
+
+    #[test]
+    fn hilo_ids_and_pre_marker_legacy_values_use_the_frozen_hash_route() {
+        let catalog = hilo_catalog();
+        let routing = routing_catalog(4);
+        let generated = [
+            crate::core::generated_id::HiloV1Id::new(1)
+                .unwrap()
+                .encode(),
+            crate::core::generated_id::HiloV1Id::new(41)
+                .unwrap()
+                .encode(),
+            crate::core::generated_id::HiloV1Id::new(
+                crate::core::generated_id::MAX_HILO_V1_SEQUENCE,
+            )
+            .unwrap()
+            .encode(),
+        ];
+        let legacy = [
+            i64::MIN,
+            -1,
+            0,
+            1,
+            (crate::core::generated_id::HILO_V1_FORMAT_MARKER - 1) as i64,
+        ];
+
+        for value in generated.into_iter().chain(legacy) {
+            for source in [
+                "SELECT * FROM hilo_events WHERE id = ?1",
+                "DELETE FROM hilo_events WHERE id = ?1",
+            ] {
+                let normalized = normalize(SqlDialect::Sqlite, source);
+                let expected = routing.shard_for_key(value.to_string().as_bytes());
+                let explicit = value.to_string();
+                let plan = plan_bound_statement(
+                    BoundStatementPlanInput::new(
+                        &catalog,
+                        database_id(DEFAULT_DATABASE),
+                        &normalized,
+                        0,
+                        &[Value::Int64(value)],
+                        Some(explicit.as_bytes()),
+                    ),
+                    RoutingProvenance::new(1, 1, 1, 1),
+                    |key| routing.shard_for_key(key),
+                )
+                .unwrap();
+                assert_eq!(plan.inferred_routes()[0].shard(), expected, "{value}");
+                assert_eq!(plan.explicit_route().unwrap().shard(), expected, "{value}");
+                assert_eq!(plan.assigned_shard(), Some(expected), "{value}");
+            }
+        }
+    }
+
+    #[test]
+    fn hilo_explicit_insert_rejects_the_entire_allocator_namespace_before_routing() {
+        let catalog = hilo_catalog();
+        let normalized = normalize(
+            SqlDialect::Sqlite,
+            "INSERT INTO hilo_events (id) VALUES (?1)",
+        );
+        for value in [
+            crate::core::generated_id::hilo_v1_sequence_floor(),
+            crate::core::generated_id::hilo_v1_first_id(),
+            0x3000_0000_0000_0041,
+            crate::core::generated_id::hilo_v1_sequence_ceiling(),
+            crate::core::generated_id::NATIVE_RANGE_V1_FORMAT_MARKER as i64,
+            0x5000_0000_0000_0041,
+            i64::MAX,
+        ] {
+            let error = plan_bound_statement(
+                BoundStatementPlanInput::new(
+                    &catalog,
+                    database_id(DEFAULT_DATABASE),
+                    &normalized,
+                    0,
+                    &[Value::Int64(value)],
+                    None,
+                ),
+                RoutingProvenance::new(1, 1, 1, 1),
+                |_| panic!("allocator-owned INSERT must fail before routing"),
+            )
+            .unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+            assert!(error.diagnostic().contains("allocator-owned"));
+        }
+
+        let multirow = normalize(
+            SqlDialect::Sqlite,
+            "INSERT INTO hilo_events (id) VALUES (?1), (?2)",
+        );
+        let error = plan_bound_statement(
+            BoundStatementPlanInput::new(
+                &catalog,
+                database_id(DEFAULT_DATABASE),
+                &multirow,
+                0,
+                &[
+                    Value::Int64(41),
+                    Value::Int64(crate::core::generated_id::hilo_v1_first_id()),
+                ],
+                None,
+            ),
+            RoutingProvenance::new(1, 1, 1, 1),
+            |_| panic!("a mixed multi-row INSERT must fail before routing"),
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert!(error.diagnostic().contains("allocator-owned"));
+    }
+
+    #[test]
+    fn hilo_explicit_insert_still_accepts_pre_marker_legacy_values() {
+        let catalog = hilo_catalog();
+        let routing = routing_catalog(4);
+        let normalized = normalize(
+            SqlDialect::Sqlite,
+            "INSERT INTO hilo_events (id) VALUES (?1)",
+        );
+        for value in [
+            i64::MIN,
+            -1,
+            0,
+            1,
+            (crate::core::generated_id::HILO_V1_FORMAT_MARKER - 1) as i64,
+        ] {
+            let expected = routing.shard_for_key(value.to_string().as_bytes());
+            let plan = plan_bound_statement(
+                BoundStatementPlanInput::new(
+                    &catalog,
+                    database_id(DEFAULT_DATABASE),
+                    &normalized,
+                    0,
+                    &[Value::Int64(value)],
+                    None,
+                ),
+                RoutingProvenance::new(1, 1, 1, 1),
+                |key| routing.shard_for_key(key),
+            )
+            .unwrap();
+            assert_eq!(plan.assigned_shard(), Some(expected), "{value}");
+        }
+    }
+
+    #[test]
+    fn hilo_reads_fail_closed_on_reserved_or_incompatible_namespaces() {
+        let catalog = hilo_catalog();
+        let normalized = normalize(
+            SqlDialect::Sqlite,
+            "SELECT * FROM hilo_events WHERE id = ?1",
+        );
+        for value in [
+            crate::core::generated_id::hilo_v1_sequence_floor(),
+            crate::core::generated_id::NATIVE_RANGE_V1_FORMAT_MARKER as i64,
+            i64::MAX,
+        ] {
+            let error = plan_bound_statement(
+                BoundStatementPlanInput::new(
+                    &catalog,
+                    database_id(DEFAULT_DATABASE),
+                    &normalized,
+                    0,
+                    &[Value::Int64(value)],
+                    None,
+                ),
+                RoutingProvenance::new(1, 1, 1, 1),
+                |_| 0,
+            )
+            .unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::InvalidArgument, "{value}");
         }
     }
 

--- a/src/storage/hilo.rs
+++ b/src/storage/hilo.rs
@@ -1,0 +1,267 @@
+//! Process-local consumption of manifest-leased `hilo_v1` ranges.
+//!
+//! The manifest is the only durable allocator. This cache never restores a
+//! range after process exit and never returns an issued value to a range, so
+//! rollback, cancellation, constraint failures, and crashes can create gaps
+//! but cannot cause reuse.
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use crate::core::{
+    EngineError, EngineErrorKind, EngineResult, TableId,
+    generated_id::{HiloV1Id, MAX_HILO_V1_SEQUENCE},
+};
+
+/// One range durably committed by the manifest allocator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct DurableHiloLease {
+    table_id: TableId,
+    owner_id: [u8; 32],
+    fence: u64,
+    first_sequence: u64,
+    last_sequence: u64,
+}
+
+impl DurableHiloLease {
+    pub(super) const fn new(
+        table_id: TableId,
+        owner_id: [u8; 32],
+        fence: u64,
+        first_sequence: u64,
+        last_sequence: u64,
+    ) -> Self {
+        Self {
+            table_id,
+            owner_id,
+            fence,
+            first_sequence,
+            last_sequence,
+        }
+    }
+}
+
+/// One irrevocably consumed ID and the durable fence that authorized it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct HiloAllocation {
+    id: i64,
+    table_id: TableId,
+    owner_id: [u8; 32],
+    fence: u64,
+}
+
+impl HiloAllocation {
+    pub(super) const fn id(self) -> i64 {
+        self.id
+    }
+
+    pub(super) const fn table_id(self) -> TableId {
+        self.table_id
+    }
+
+    pub(super) const fn owner_id(self) -> [u8; 32] {
+        self.owner_id
+    }
+
+    pub(super) const fn fence(self) -> u64 {
+        self.fence
+    }
+}
+
+#[derive(Debug)]
+struct CachedRange {
+    owner_id: [u8; 32],
+    fence: u64,
+    next_sequence: u64,
+    last_sequence: u64,
+}
+
+#[derive(Debug, Default)]
+struct TableAllocator {
+    range: Mutex<Option<CachedRange>>,
+}
+
+/// Shared by every `Storage` handle for one canonical root in this process.
+#[derive(Debug)]
+pub(super) struct HiloAllocator {
+    owner_id: [u8; 32],
+    tables: Mutex<HashMap<TableId, Arc<TableAllocator>>>,
+}
+
+impl HiloAllocator {
+    pub(super) fn new() -> EngineResult<Self> {
+        let mut owner_id = [0_u8; 32];
+        getrandom::fill(&mut owner_id).map_err(|error| {
+            EngineError::from_source(
+                EngineErrorKind::StorageUnavailable,
+                "failed to create the hilo_v1 process-incarnation identity",
+                error,
+            )
+        })?;
+        Ok(Self {
+            owner_id,
+            tables: Mutex::new(HashMap::new()),
+        })
+    }
+
+    pub(super) const fn owner_id(&self) -> [u8; 32] {
+        self.owner_id
+    }
+
+    /// Irrevocably consume one sequence, refilling through `reserve` only
+    /// after the previous range is empty.
+    pub(super) fn allocate<F>(&self, table_id: TableId, reserve: F) -> EngineResult<HiloAllocation>
+    where
+        F: FnOnce([u8; 32]) -> EngineResult<DurableHiloLease>,
+    {
+        let table = {
+            let mut tables = self.tables.lock().map_err(|error| {
+                EngineError::new(
+                    EngineErrorKind::Internal,
+                    format!("hilo_v1 allocator registry is poisoned: {error}"),
+                )
+            })?;
+            Arc::clone(
+                tables
+                    .entry(table_id)
+                    .or_insert_with(|| Arc::new(TableAllocator::default())),
+            )
+        };
+        let mut range = table.range.lock().map_err(|error| {
+            EngineError::new(
+                EngineErrorKind::Internal,
+                format!("hilo_v1 table allocator is poisoned: {error}"),
+            )
+        })?;
+        if range
+            .as_ref()
+            .is_none_or(|current| current.next_sequence > current.last_sequence)
+        {
+            let lease = reserve(self.owner_id)?;
+            validate_lease(table_id, self.owner_id, lease)?;
+            *range = Some(CachedRange {
+                owner_id: lease.owner_id,
+                fence: lease.fence,
+                next_sequence: lease.first_sequence,
+                last_sequence: lease.last_sequence,
+            });
+        }
+        let current = range.as_mut().expect("a validated lease was installed");
+        let sequence = current.next_sequence;
+        current.next_sequence = sequence
+            .checked_add(1)
+            .expect("a validated hilo_v1 sequence has a successor sentinel");
+        Ok(HiloAllocation {
+            id: HiloV1Id::new(sequence)?.encode(),
+            table_id,
+            owner_id: current.owner_id,
+            fence: current.fence,
+        })
+    }
+}
+
+fn validate_lease(
+    table_id: TableId,
+    owner_id: [u8; 32],
+    lease: DurableHiloLease,
+) -> EngineResult<()> {
+    if lease.table_id != table_id
+        || lease.owner_id != owner_id
+        || lease.fence == 0
+        || lease.first_sequence == 0
+        || lease.first_sequence > lease.last_sequence
+        || lease.last_sequence > MAX_HILO_V1_SEQUENCE
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "manifest returned an invalid hilo_v1 lease",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    #[test]
+    fn one_durable_lease_serves_every_value_once() {
+        let allocator = HiloAllocator::new().unwrap();
+        let table = TableId::new(7).unwrap();
+        let calls = AtomicUsize::new(0);
+        let mut ids = Vec::new();
+        for _ in 0..4 {
+            ids.push(
+                allocator
+                    .allocate(table, |owner| {
+                        calls.fetch_add(1, Ordering::Relaxed);
+                        Ok(DurableHiloLease::new(table, owner, 1, 9, 12))
+                    })
+                    .unwrap()
+                    .id(),
+            );
+        }
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            ids,
+            (9..=12)
+                .map(|sequence| HiloV1Id::new(sequence).unwrap().encode())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn exhausted_cache_refills_and_never_reuses_a_value() {
+        let allocator = HiloAllocator::new().unwrap();
+        let table = TableId::new(1).unwrap();
+        let calls = AtomicUsize::new(0);
+        let mut ids = Vec::new();
+        for _ in 0..3 {
+            ids.push(
+                allocator
+                    .allocate(table, |owner| {
+                        let call = calls.fetch_add(1, Ordering::Relaxed);
+                        let first = 1 + u64::try_from(call).unwrap() * 2;
+                        Ok(DurableHiloLease::new(
+                            table,
+                            owner,
+                            u64::try_from(call + 1).unwrap(),
+                            first,
+                            first + 1,
+                        ))
+                    })
+                    .unwrap()
+                    .id(),
+            );
+        }
+        assert_eq!(calls.load(Ordering::Relaxed), 2);
+        assert_eq!(ids.len(), 3);
+        ids.sort_unstable();
+        ids.dedup();
+        assert_eq!(ids.len(), 3);
+    }
+
+    #[test]
+    fn malformed_or_cross_table_lease_is_rejected_without_installation() {
+        let allocator = HiloAllocator::new().unwrap();
+        let table = TableId::new(1).unwrap();
+        let other = TableId::new(2).unwrap();
+        let error = allocator
+            .allocate(table, |owner| {
+                Ok(DurableHiloLease::new(other, owner, 1, 1, 4))
+            })
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+
+        let allocation = allocator
+            .allocate(table, |owner| {
+                Ok(DurableHiloLease::new(table, owner, 2, 5, 8))
+            })
+            .unwrap();
+        assert_eq!(allocation.id(), HiloV1Id::new(5).unwrap().encode());
+    }
+}

--- a/src/storage/manifest.rs
+++ b/src/storage/manifest.rs
@@ -21,7 +21,10 @@ use crate::{
     sqlite_error,
 };
 
-use super::shard::{SHARD_APPLICATION_ID, SHARD_METADATA_VERSION, ShardLayout, ShardLayoutState};
+use super::{
+    hilo::DurableHiloLease,
+    shard::{SHARD_APPLICATION_ID, SHARD_METADATA_VERSION, ShardLayout, ShardLayoutState},
+};
 
 /// `BRDB` encoded as SQLite's 32-bit application identifier.
 pub(super) const MANIFEST_APPLICATION_ID: i64 = 0x4252_4442;
@@ -35,7 +38,8 @@ const V7_SCHEMA_VERSION: u32 = 7;
 const V8_SCHEMA_VERSION: u32 = 8;
 const V9_SCHEMA_VERSION: u32 = 9;
 const V10_SCHEMA_VERSION: u32 = 10;
-pub(super) const CURRENT_SCHEMA_VERSION: u32 = V10_SCHEMA_VERSION;
+const V11_SCHEMA_VERSION: u32 = 11;
+pub(super) const CURRENT_SCHEMA_VERSION: u32 = V11_SCHEMA_VERSION;
 const MAX_TABLE_SQL_BYTES: i64 = 4_096;
 
 pub(super) const MAX_SCHEMA_MIGRATION_SQL_BYTES: usize = 65_536;
@@ -47,10 +51,12 @@ const TABLE_PROVISIONING_DIGEST_VERSION: u32 = 1;
 const V1_MANIFEST_DIGEST_VERSION: u32 = 1;
 const V2_MANIFEST_DIGEST_VERSION: u32 = 2;
 const V3_MANIFEST_DIGEST_VERSION: u32 = 3;
+const V4_MANIFEST_DIGEST_VERSION: u32 = 4;
 pub(super) const SCHEMA_DIGEST_VERSION: u32 = 1;
 const V1_MANIFEST_DIGEST_DOMAIN: &[u8] = b"briskdb.manifest.semantic-root.v1\0";
 const V2_MANIFEST_DIGEST_DOMAIN: &[u8] = b"briskdb.manifest.semantic-root.v2\0";
 const V3_MANIFEST_DIGEST_DOMAIN: &[u8] = b"briskdb.manifest.semantic-root.v3\0";
+const V4_MANIFEST_DIGEST_DOMAIN: &[u8] = b"briskdb.manifest.semantic-root.v4\0";
 const TABLE_PROVISIONING_DIGEST_DOMAIN: &[u8] = b"briskdb.table-provisioning.v1\0";
 
 const DATABASE_STATE_VERIFYING: i64 = 1;
@@ -67,9 +73,14 @@ const TEXT_SHARD_KEY_TYPE: i64 = 2;
 const BINARY_SHARD_KEY_TYPE: i64 = 3;
 const GENERATED_ID_POLICY_NONE: i64 = 0;
 const GENERATED_ID_POLICY_NATIVE_RANGE_V1: i64 = 1;
+const GENERATED_ID_POLICY_HILO_V1: i64 = 2;
 const GENERATED_ID_INACTIVE: i64 = 0;
 const GENERATED_ID_ACTIVE: i64 = 1;
 const NATIVE_RANGE_V1_ENCODING_VERSION: u32 = 1;
+const HILO_V1_ENCODING_VERSION: u32 = 1;
+pub(super) const HILO_V1_BLOCK_SIZE: u64 = 4_096;
+const MAX_HILO_V1_SEQUENCE: u64 = (1_u64 << 61) - 1;
+const HILO_V1_EXHAUSTED_HEAD: u64 = MAX_HILO_V1_SEQUENCE + 1;
 const MAX_ALLOCATION_OWNER_SLOT: i64 = 1_023;
 const ALLOCATION_OWNER_ACTIVE: i64 = 1;
 const ALLOCATION_OWNER_RETIRED: i64 = 2;
@@ -89,6 +100,13 @@ pub(super) fn fail_next_table_registration_post_commit_for_test() {
 #[cfg(test)]
 fn abort_table_registration_at_test_boundary(boundary: &str) {
     if std::env::var("BRISKDB_TABLE_REGISTRATION_ABORT_POINT").as_deref() == Ok(boundary) {
+        std::process::abort();
+    }
+}
+
+#[cfg(test)]
+fn abort_hilo_lease_at_test_boundary(boundary: &str) {
+    if std::env::var("BRISKDB_HILO_LEASE_ABORT_POINT").as_deref() == Ok(boundary) {
         std::process::abort();
     }
 }
@@ -136,6 +154,10 @@ const V9_DOWNGRADE_FENCE_SQL: &str = "CREATE TABLE briskdb_metadata (
 const V10_DOWNGRADE_FENCE_SQL: &str = "CREATE TABLE briskdb_metadata (
     requires_manifest_version INTEGER NOT NULL
         CHECK (requires_manifest_version >= 10)
+) STRICT";
+const V11_DOWNGRADE_FENCE_SQL: &str = "CREATE TABLE briskdb_metadata (
+    requires_manifest_version INTEGER NOT NULL
+        CHECK (requires_manifest_version >= 11)
 ) STRICT";
 const V3_ROUTING_TABLE_SQL: &str = "CREATE TABLE briskdb_routing (
     singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
@@ -398,6 +420,51 @@ const V10_TABLE_PROVISIONING_DECLARATIONS_SQL: &str =
             generated_policy > 0
             AND generated_column IS NOT NULL
             AND generated_encoding_version IS NOT NULL
+        )
+    )
+) STRICT";
+const V11_HILO_LEASES_TABLE_SQL: &str = "CREATE TABLE briskdb_hilo_leases (
+    table_id INTEGER PRIMARY KEY CHECK (table_id > 0),
+    block_size INTEGER NOT NULL CHECK (block_size = 4096),
+    next_sequence INTEGER NOT NULL
+        CHECK (next_sequence BETWEEN 1 AND 2305843009213693952),
+    fence_token INTEGER NOT NULL CHECK (fence_token >= 0),
+    last_owner_id BLOB
+        CHECK (
+            last_owner_id IS NULL
+            OR (typeof(last_owner_id) = 'blob' AND length(last_owner_id) = 32)
+        ),
+    last_first_sequence INTEGER
+        CHECK (
+            last_first_sequence IS NULL
+            OR last_first_sequence BETWEEN 1 AND 2305843009213693951
+        ),
+    last_last_sequence INTEGER
+        CHECK (
+            last_last_sequence IS NULL
+            OR last_last_sequence BETWEEN 1 AND 2305843009213693951
+        ),
+    FOREIGN KEY (table_id)
+        REFERENCES briskdb_generated_ids (table_id)
+        ON DELETE RESTRICT,
+    CHECK (
+        (
+            fence_token = 0
+            AND next_sequence = 1
+            AND last_owner_id IS NULL
+            AND last_first_sequence IS NULL
+            AND last_last_sequence IS NULL
+        )
+        OR
+        (
+            fence_token > 0
+            AND last_owner_id IS NOT NULL
+            AND last_first_sequence IS NOT NULL
+            AND last_last_sequence IS NOT NULL
+            AND last_first_sequence <= last_last_sequence
+            AND last_last_sequence < next_sequence
+            AND last_last_sequence = next_sequence - 1
+            AND last_last_sequence - last_first_sequence + 1 BETWEEN 1 AND block_size
         )
     )
 ) STRICT";
@@ -674,6 +741,7 @@ struct ManifestSnapshot {
     integrity: Option<ManifestIntegrity>,
     allocation_owners: Option<AllocationOwnerMap>,
     active_native_id_table_ids: Box<[TableId]>,
+    active_hilo_id_table_ids: Box<[TableId]>,
     active_table_provisioning: Option<NativeTableProvisioning>,
 }
 
@@ -684,6 +752,7 @@ pub(super) struct LoadedManifest {
     active_migration: Option<SchemaMigration>,
     integrity: ManifestIntegrity,
     active_native_id_table_ids: Box<[TableId]>,
+    active_hilo_id_table_ids: Box<[TableId]>,
     active_table_provisioning: Option<NativeTableProvisioning>,
 }
 
@@ -742,6 +811,7 @@ impl LoadedManifest {
         Option<SchemaMigration>,
         ManifestIntegrity,
         Box<[TableId]>,
+        Box<[TableId]>,
         Option<NativeTableProvisioning>,
     ) {
         (
@@ -750,6 +820,7 @@ impl LoadedManifest {
             self.active_migration,
             self.integrity,
             self.active_native_id_table_ids,
+            self.active_hilo_id_table_ids,
             self.active_table_provisioning,
         )
     }
@@ -819,6 +890,13 @@ const MIGRATIONS: &[Migration] = &[
         apply: migrate_v9_to_v10,
         validate: validate_v10,
     },
+    Migration {
+        from: V10_SCHEMA_VERSION,
+        to: V11_SCHEMA_VERSION,
+        name: "durable_hilo_v1_block_leases",
+        apply: migrate_v10_to_v11,
+        validate: validate_v11,
+    },
 ];
 
 #[derive(Clone, Copy)]
@@ -832,8 +910,8 @@ struct MigrationPlan<'a> {
 const CURRENT_PLAN: MigrationPlan<'static> = MigrationPlan {
     current_version: CURRENT_SCHEMA_VERSION,
     migrations: MIGRATIONS,
-    initialize_current: create_v10_schema,
-    initialize_interrupted_legacy: migrate_interrupted_legacy_to_v10,
+    initialize_current: create_v11_schema,
+    initialize_interrupted_legacy: migrate_interrupted_legacy_to_v11,
 };
 
 // Startup uses this frozen plan only to finish an already-active v6 journal
@@ -904,6 +982,7 @@ pub(super) fn load_or_create_manifest_with_fresh_layout(
         &mut |_| Ok(()),
     )?;
     let active_native_id_table_ids = std::mem::take(&mut snapshot.active_native_id_table_ids);
+    let active_hilo_id_table_ids = std::mem::take(&mut snapshot.active_hilo_id_table_ids);
     let catalog = catalog_snapshot_from_parts(
         snapshot.routing_catalog.take(),
         snapshot.logical_catalog.take(),
@@ -927,6 +1006,7 @@ pub(super) fn load_or_create_manifest_with_fresh_layout(
         active_migration: snapshot.active_migration,
         integrity,
         active_native_id_table_ids,
+        active_hilo_id_table_ids,
         active_table_provisioning: snapshot.active_table_provisioning,
     })
 }
@@ -1665,6 +1745,170 @@ fn current_manifest_snapshot(
     }
 }
 
+/// Reserve one durable global `hilo_v1` block before any target-shard write
+/// lock is acquired. A commit failure is deliberately not reconciled into a
+/// returned lease: if SQLite committed despite the error, that block remains
+/// burned and the next reservation advances beyond it.
+pub(super) fn reserve_hilo_v1_block(
+    connection: &mut Connection,
+    requested_shards: u16,
+    table_id: TableId,
+    owner_id: [u8; 32],
+) -> EngineResult<DurableHiloLease> {
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    let snapshot = current_manifest_snapshot(&transaction, requested_shards)?;
+    ensure_table_registration_ready(&snapshot)?;
+    if snapshot.active_table_provisioning.is_some() {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "hilo_v1 block reservation cannot run during table provisioning",
+        ));
+    }
+    let catalog = snapshot.logical_catalog.as_ref().ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::Internal,
+            "hilo_v1 reservation validation omitted the logical catalog",
+        )
+    })?;
+    let table = catalog.table_by_id(table_id).ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            format!("hilo_v1 reservation refers to unknown table {table_id}"),
+        )
+    })?;
+    if !matches!(
+        table.generated_id_policy(),
+        GeneratedIdPolicy::HiloV1 { .. }
+    ) || snapshot
+        .active_hilo_id_table_ids
+        .binary_search(&table_id)
+        .is_err()
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!("hilo_v1 generation is not active for table {table_id}"),
+        ));
+    }
+    let stored_table_id = i64::try_from(table_id.get()).map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::NumericOutOfRange,
+            "hilo_v1 table ID does not fit in SQLite",
+            error,
+        )
+    })?;
+    let (stored_block_size, stored_next, stored_fence) = transaction
+        .query_row(
+            "SELECT block_size, next_sequence, fence_token
+             FROM briskdb_hilo_leases
+             WHERE table_id = ?1",
+            [stored_table_id],
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, i64>(2)?,
+                ))
+            },
+        )
+        .map_err(|error| manifest_read_error(error, "failed to read hilo_v1 allocation head"))?;
+    if stored_block_size != i64::try_from(HILO_V1_BLOCK_SIZE).expect("block size fits i64") {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "hilo_v1 allocation head has an unsupported block size",
+        ));
+    }
+    let first_sequence = u64::try_from(stored_next).map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::DataCorruption,
+            "hilo_v1 allocation head is outside its numeric range",
+            error,
+        )
+    })?;
+    if first_sequence > MAX_HILO_V1_SEQUENCE {
+        return Err(EngineError::new(
+            EngineErrorKind::LimitExceeded,
+            format!("hilo_v1 table {table_id} exhausted its global sequence"),
+        ));
+    }
+    let fence_token = u64::try_from(stored_fence).map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::DataCorruption,
+            "hilo_v1 fence token is outside its numeric range",
+            error,
+        )
+    })?;
+    let next_fence = fence_token
+        .checked_add(1)
+        .filter(|value| *value <= i64::MAX as u64)
+        .ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::LimitExceeded,
+                format!("hilo_v1 table {table_id} exhausted its fence tokens"),
+            )
+        })?;
+    let last_sequence = first_sequence
+        .saturating_add(HILO_V1_BLOCK_SIZE - 1)
+        .min(MAX_HILO_V1_SEQUENCE);
+    let next_sequence = last_sequence
+        .checked_add(1)
+        .expect("the maximum hilo_v1 sequence has a representable sentinel");
+    let changed = transaction
+        .execute(
+            "UPDATE briskdb_hilo_leases
+             SET next_sequence = ?1,
+                 fence_token = ?2,
+                 last_owner_id = ?3,
+                 last_first_sequence = ?4,
+                 last_last_sequence = ?5
+             WHERE table_id = ?6
+               AND next_sequence = ?7
+               AND fence_token = ?8",
+            rusqlite::params![
+                i64::try_from(next_sequence).expect("hi/lo sentinel fits SQLite"),
+                i64::try_from(next_fence).expect("bounded hi/lo fence fits SQLite"),
+                owner_id.as_slice(),
+                i64::try_from(first_sequence).expect("hi/lo sequence fits SQLite"),
+                i64::try_from(last_sequence).expect("hi/lo sequence fits SQLite"),
+                stored_table_id,
+                stored_next,
+                stored_fence,
+            ],
+        )
+        .map_err(sqlite_error::storage)?;
+    if changed != 1 {
+        return Err(EngineError::new(
+            EngineErrorKind::Busy,
+            "hilo_v1 allocation head changed concurrently",
+        ));
+    }
+    refresh_manifest_digest(&transaction)?;
+    let verified = current_manifest_snapshot(&transaction, requested_shards)?;
+    if verified
+        .active_hilo_id_table_ids
+        .binary_search(&table_id)
+        .is_err()
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::Internal,
+            "hilo_v1 block reservation lost its active policy",
+        ));
+    }
+    #[cfg(test)]
+    abort_hilo_lease_at_test_boundary("before-commit");
+    transaction.commit().map_err(sqlite_error::storage)?;
+    #[cfg(test)]
+    abort_hilo_lease_at_test_boundary("after-commit");
+    Ok(DurableHiloLease::new(
+        table_id,
+        owner_id,
+        next_fence,
+        first_sequence,
+        last_sequence,
+    ))
+}
+
 /// Classify an exact native table-provisioning request without changing it.
 #[cfg(test)]
 pub(super) fn classify_native_table_provisioning(
@@ -1768,6 +2012,16 @@ where
 
     let provisioning_id =
         table_provisioning_id(&declarations, requested_shards, committed_schema_digest);
+    let initial_next_shard = if declarations.iter().any(|declaration| {
+        matches!(
+            declaration.generated_id_policy(),
+            GeneratedIdPolicy::NativeRangeV1 { .. }
+        )
+    }) {
+        0
+    } else {
+        requested_shards
+    };
     transaction
         .execute(
             "INSERT INTO briskdb_table_provisioning (
@@ -1779,7 +2033,7 @@ where
                 shard_count,
                 declaration_count,
                 next_shard
-             ) VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, 0)",
+             ) VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7)",
             rusqlite::params![
                 provisioning_id.as_slice(),
                 TABLE_PROVISIONING_DIGEST_VERSION,
@@ -1787,6 +2041,7 @@ where
                 committed_schema_digest.as_slice(),
                 requested_shards,
                 i64::try_from(declarations.len()).expect("bounded declaration count fits SQLite"),
+                initial_next_shard,
             ],
         )
         .map_err(sqlite_error::storage)?;
@@ -2069,7 +2324,8 @@ pub(super) fn inspect_with_v9_plan_for_test(
 fn downgrade_v10_manifest_to_v9_for_test(connection: &Connection) -> EngineResult<()> {
     connection
         .execute_batch(
-            "DROP TABLE briskdb_table_provisioning_declarations;
+            "DROP TABLE IF EXISTS briskdb_hilo_leases;
+             DROP TABLE briskdb_table_provisioning_declarations;
              DROP TABLE briskdb_table_provisioning;
              DROP INDEX briskdb_one_active_owner_per_shard;
              ALTER TABLE briskdb_generated_ids RENAME TO briskdb_generated_ids_v10;
@@ -2120,6 +2376,38 @@ fn downgrade_v10_manifest_to_v9_for_test(connection: &Connection) -> EngineResul
             [V2_MANIFEST_DIGEST_VERSION],
         )
         .map_err(sqlite_error::storage)?;
+    Ok(())
+}
+
+#[cfg(test)]
+fn downgrade_v11_manifest_to_v10_for_test(
+    connection: &Connection,
+    shard_count: u16,
+) -> EngineResult<()> {
+    connection
+        .execute_batch(
+            "DROP TABLE briskdb_hilo_leases;
+             DROP TABLE briskdb_metadata;",
+        )
+        .map_err(sqlite_error::storage)?;
+    connection
+        .execute_batch(V10_DOWNGRADE_FENCE_SQL)
+        .map_err(sqlite_error::storage)?;
+    connection
+        .execute(
+            "INSERT INTO briskdb_metadata (requires_manifest_version) VALUES (?1)",
+            [V10_SCHEMA_VERSION],
+        )
+        .map_err(sqlite_error::storage)?;
+    connection
+        .execute(
+            "UPDATE briskdb_integrity SET manifest_digest_version = ?1 WHERE singleton = 1",
+            [V3_MANIFEST_DIGEST_VERSION],
+        )
+        .map_err(sqlite_error::storage)?;
+    set_identity(connection, V10_SCHEMA_VERSION)?;
+    refresh_manifest_digest(connection)?;
+    validate_v10(connection, shard_count, &schema_objects(connection)?)?;
     Ok(())
 }
 
@@ -2180,11 +2468,33 @@ where
             .execute(
                 "UPDATE briskdb_generated_ids
                  SET activation_state = ?1
-                 WHERE policy = ?2",
-                rusqlite::params![GENERATED_ID_ACTIVE, GENERATED_ID_POLICY_NATIVE_RANGE_V1,],
+                 WHERE policy IN (?2, ?3)",
+                rusqlite::params![
+                    GENERATED_ID_ACTIVE,
+                    GENERATED_ID_POLICY_NATIVE_RANGE_V1,
+                    GENERATED_ID_POLICY_HILO_V1,
+                ],
             )
             .map_err(sqlite_error::storage)?;
     }
+    transaction
+        .execute(
+            "INSERT INTO briskdb_hilo_leases (
+                table_id, block_size, next_sequence, fence_token,
+                last_owner_id, last_first_sequence, last_last_sequence
+             )
+             SELECT table_id, ?1, 1, 0, NULL, NULL, NULL
+             FROM briskdb_generated_ids
+             WHERE policy = ?2 AND activation_state = ?3
+             ORDER BY table_id
+             ON CONFLICT(table_id) DO NOTHING",
+            rusqlite::params![
+                i64::try_from(HILO_V1_BLOCK_SIZE).expect("hi/lo block size fits SQLite"),
+                GENERATED_ID_POLICY_HILO_V1,
+                GENERATED_ID_ACTIVE,
+            ],
+        )
+        .map_err(sqlite_error::storage)?;
     transaction
         .execute("DELETE FROM briskdb_table_provisioning_declarations", [])
         .map_err(sqlite_error::storage)?;
@@ -2238,7 +2548,7 @@ fn native_table_provisioning_complete(
     if !declarations_match_catalog_owned(declarations, catalog) {
         return false;
     }
-    let expected = catalog
+    let expected_native = catalog
         .tables()
         .iter()
         .filter(|table| {
@@ -2249,7 +2559,19 @@ fn native_table_provisioning_complete(
         })
         .map(TableMetadata::id)
         .collect::<Vec<_>>();
-    expected.as_slice() == snapshot.active_native_id_table_ids.as_ref()
+    let expected_hilo = catalog
+        .tables()
+        .iter()
+        .filter(|table| {
+            matches!(
+                table.generated_id_policy(),
+                GeneratedIdPolicy::HiloV1 { .. }
+            )
+        })
+        .map(TableMetadata::id)
+        .collect::<Vec<_>>();
+    expected_native.as_slice() == snapshot.active_native_id_table_ids.as_ref()
+        && expected_hilo.as_slice() == snapshot.active_hilo_id_table_ids.as_ref()
 }
 
 fn ensure_same_native_table_provisioning_request(
@@ -2514,10 +2836,8 @@ fn insert_authoritative_table_catalog(
         let (policy, generated_column, encoding_version) =
             encoded_generated_id_policy(declaration.generated_id_policy());
         let activation_state = if activate_native
-            && matches!(
-                declaration.generated_id_policy(),
-                GeneratedIdPolicy::NativeRangeV1 { .. }
-            ) {
+            && !matches!(declaration.generated_id_policy(), GeneratedIdPolicy::None)
+        {
             GENERATED_ID_ACTIVE
         } else {
             GENERATED_ID_INACTIVE
@@ -2567,7 +2887,9 @@ fn catalog_snapshot_from_manifest(snapshot: ManifestSnapshot) -> EngineResult<Ca
         snapshot.logical_catalog,
         snapshot.allocation_owners,
     )?;
-    Ok(catalog.with_active_native_id_table_ids(snapshot.active_native_id_table_ids))
+    Ok(catalog
+        .with_active_native_id_table_ids(snapshot.active_native_id_table_ids)
+        .with_active_hilo_id_table_ids(snapshot.active_hilo_id_table_ids))
 }
 
 fn catalog_snapshot_from_parts(
@@ -2661,15 +2983,13 @@ fn normalize_table_provisioning_declarations(
             "table provisioning contains a duplicate logical table",
         ));
     }
-    if !declarations.iter().any(|declaration| {
-        matches!(
-            declaration.generated_id_policy(),
-            GeneratedIdPolicy::NativeRangeV1 { .. }
-        )
-    }) {
+    if !declarations
+        .iter()
+        .any(|declaration| !matches!(declaration.generated_id_policy(), GeneratedIdPolicy::None))
+    {
         return Err(EngineError::new(
             EngineErrorKind::InvalidArgument,
-            "table provisioning requires a native generated-ID declaration",
+            "table provisioning requires a generated-ID declaration",
         ));
     }
     Ok(declarations.into_boxed_slice())
@@ -2737,6 +3057,11 @@ fn encoded_generated_id_policy(policy: &GeneratedIdPolicy) -> (i64, Option<&str>
             GENERATED_ID_POLICY_NATIVE_RANGE_V1,
             Some(column),
             Some(i64::from(NATIVE_RANGE_V1_ENCODING_VERSION)),
+        ),
+        GeneratedIdPolicy::HiloV1 { column } => (
+            GENERATED_ID_POLICY_HILO_V1,
+            Some(column),
+            Some(i64::from(HILO_V1_ENCODING_VERSION)),
         ),
     }
 }
@@ -3177,6 +3502,11 @@ fn create_v10_schema(transaction: &Transaction<'_>, shard_count: u16) -> EngineR
     migrate_v9_to_v10(transaction, shard_count)
 }
 
+fn create_v11_schema(transaction: &Transaction<'_>, shard_count: u16) -> EngineResult<()> {
+    create_v10_schema(transaction, shard_count)?;
+    migrate_v10_to_v11(transaction, shard_count)
+}
+
 fn migrate_interrupted_legacy_to_v6(
     transaction: &Transaction<'_>,
     shard_count: u16,
@@ -3221,6 +3551,8 @@ fn migrate_interrupted_legacy_to_v9(
     create_v9_schema(transaction, shard_count)
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
 fn migrate_interrupted_legacy_to_v10(
     transaction: &Transaction<'_>,
     shard_count: u16,
@@ -3229,6 +3561,16 @@ fn migrate_interrupted_legacy_to_v10(
         .execute_batch("DROP TABLE briskdb_metadata;")
         .map_err(sqlite_error::storage)?;
     create_v10_schema(transaction, shard_count)
+}
+
+fn migrate_interrupted_legacy_to_v11(
+    transaction: &Transaction<'_>,
+    shard_count: u16,
+) -> EngineResult<()> {
+    transaction
+        .execute_batch("DROP TABLE briskdb_metadata;")
+        .map_err(sqlite_error::storage)?;
+    create_v11_schema(transaction, shard_count)
 }
 
 #[cfg(test)]
@@ -3653,6 +3995,33 @@ fn migrate_v9_to_v10(transaction: &Transaction<'_>, _shard_count: u16) -> Engine
     Ok(())
 }
 
+fn migrate_v10_to_v11(transaction: &Transaction<'_>, _shard_count: u16) -> EngineResult<()> {
+    transaction
+        .execute_batch(V11_HILO_LEASES_TABLE_SQL)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch("DROP TABLE briskdb_metadata;")
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch(V11_DOWNGRADE_FENCE_SQL)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "INSERT INTO briskdb_metadata (requires_manifest_version) VALUES (?1)",
+            [V11_SCHEMA_VERSION],
+        )
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "UPDATE briskdb_integrity
+             SET manifest_digest_version = ?1
+             WHERE singleton = 1",
+            [V4_MANIFEST_DIGEST_VERSION],
+        )
+        .map_err(sqlite_error::storage)?;
+    Ok(())
+}
+
 fn add_v5_schema(transaction: &Transaction<'_>, state: ShardLayoutState) -> EngineResult<()> {
     transaction
         .execute_batch("DROP TABLE briskdb_metadata;")
@@ -3977,6 +4346,18 @@ fn v10_objects() -> Vec<SchemaObject> {
     objects
 }
 
+fn v11_objects() -> Vec<SchemaObject> {
+    let mut objects = v10_objects();
+    objects.push(SchemaObject {
+        object_type: "table".to_owned(),
+        name: "briskdb_hilo_leases".to_owned(),
+    });
+    objects.sort_by(|left, right| {
+        (&left.object_type, &left.name).cmp(&(&right.object_type, &right.name))
+    });
+    objects
+}
+
 fn schema_objects(connection: &Connection) -> EngineResult<Vec<SchemaObject>> {
     let mut statement = connection
         .prepare(
@@ -4101,6 +4482,10 @@ fn validate_table(
         "briskdb_table_provisioning_declarations" => {
             "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden
              FROM pragma_table_xinfo('briskdb_table_provisioning_declarations') LIMIT ?1"
+        }
+        "briskdb_hilo_leases" => {
+            "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden
+             FROM pragma_table_xinfo('briskdb_hilo_leases') LIMIT ?1"
         }
         _ => {
             return Err(EngineError::new(
@@ -4293,6 +4678,7 @@ fn validate_v2(
         integrity: None,
         allocation_owners: None,
         active_native_id_table_ids: Box::new([]),
+        active_hilo_id_table_ids: Box::new([]),
         active_table_provisioning: None,
     })
 }
@@ -4325,6 +4711,7 @@ fn validate_v3(
         integrity: None,
         allocation_owners: None,
         active_native_id_table_ids: Box::new([]),
+        active_hilo_id_table_ids: Box::new([]),
         active_table_provisioning: None,
     })
 }
@@ -4644,6 +5031,48 @@ fn validate_v10(
     snapshot.active_native_id_table_ids = validate_active_native_id_tables(connection)?;
     snapshot.active_table_provisioning = validate_table_provisioning(
         connection,
+        V10_SCHEMA_VERSION,
+        snapshot.shard_count,
+        snapshot.logical_catalog.as_ref(),
+        snapshot.active_migration.as_ref(),
+        snapshot.integrity,
+    )?;
+    Ok(snapshot)
+}
+
+fn validate_v11(
+    connection: &Connection,
+    requested_shards: u16,
+    objects: &[SchemaObject],
+) -> EngineResult<ManifestSnapshot> {
+    let mut snapshot = validate_integrity_manifest_with_definition(
+        connection,
+        requested_shards,
+        objects,
+        IntegrityManifestDefinition {
+            version: V11_SCHEMA_VERSION,
+            downgrade_fence_sql: V11_DOWNGRADE_FENCE_SQL,
+            expected_objects: &v11_objects(),
+            expected_manifest_digest_version: V4_MANIFEST_DIGEST_VERSION,
+            generated_ids: true,
+        },
+    )?;
+    snapshot.allocation_owners = Some(validate_allocation_owners(
+        connection,
+        snapshot.shard_count,
+    )?);
+    snapshot.active_native_id_table_ids =
+        validate_active_generated_id_tables(connection, GENERATED_ID_POLICY_NATIVE_RANGE_V1)?;
+    snapshot.active_hilo_id_table_ids =
+        validate_active_generated_id_tables(connection, GENERATED_ID_POLICY_HILO_V1)?;
+    validate_hilo_v1_leases(
+        connection,
+        snapshot.logical_catalog.as_ref(),
+        &snapshot.active_hilo_id_table_ids,
+    )?;
+    snapshot.active_table_provisioning = validate_table_provisioning(
+        connection,
+        V11_SCHEMA_VERSION,
         snapshot.shard_count,
         snapshot.logical_catalog.as_ref(),
         snapshot.active_migration.as_ref(),
@@ -4842,7 +5271,7 @@ fn validate_manifest_semantic_root(
             "manifest checksum version must be positive",
         ));
     }
-    if *version > i64::from(V3_MANIFEST_DIGEST_VERSION) {
+    if *version > i64::from(V4_MANIFEST_DIGEST_VERSION) {
         return Err(EngineError::new(
             EngineErrorKind::FailedPrecondition,
             "manifest checksum version is newer than this BriskDB build supports",
@@ -5027,6 +5456,19 @@ const V3_TABLE_PROVISIONING_DECLARATIONS_DIGEST_QUERY: ManifestDigestQuery = Man
     ],
     sql: "SELECT provisioning_singleton, ordinal, database_id, table_name, placement, shard_key_column, shard_key_type, generated_policy, generated_column, generated_encoding_version FROM briskdb_table_provisioning_declarations ORDER BY provisioning_singleton, ordinal",
 };
+const V4_HILO_LEASES_DIGEST_QUERY: ManifestDigestQuery = ManifestDigestQuery {
+    table: "briskdb_hilo_leases",
+    columns: &[
+        "table_id",
+        "block_size",
+        "next_sequence",
+        "fence_token",
+        "last_owner_id",
+        "last_first_sequence",
+        "last_last_sequence",
+    ],
+    sql: "SELECT table_id, block_size, next_sequence, fence_token, last_owner_id, last_first_sequence, last_last_sequence FROM briskdb_hilo_leases ORDER BY table_id",
+};
 
 fn manifest_semantic_digest_for_version(
     connection: &Connection,
@@ -5064,6 +5506,22 @@ fn manifest_semantic_digest_for_version(
                 }
             }
             (V3_MANIFEST_DIGEST_DOMAIN, queries)
+        }
+        V4_MANIFEST_DIGEST_VERSION => {
+            let mut queries = Vec::with_capacity(V1_MANIFEST_DIGEST_QUERIES.len() + 5);
+            for query in V1_MANIFEST_DIGEST_QUERIES {
+                queries.push(query);
+                if query.table == "briskdb_physical_shards" {
+                    queries.push(&V3_ALLOCATION_OWNERS_DIGEST_QUERY);
+                }
+                if query.table == "briskdb_tables" {
+                    queries.push(&V3_GENERATED_IDS_DIGEST_QUERY);
+                    queries.push(&V4_HILO_LEASES_DIGEST_QUERY);
+                    queries.push(&V3_TABLE_PROVISIONING_DIGEST_QUERY);
+                    queries.push(&V3_TABLE_PROVISIONING_DECLARATIONS_DIGEST_QUERY);
+                }
+            }
+            (V4_MANIFEST_DIGEST_DOMAIN, queries)
         }
         0 => {
             return Err(EngineError::new(
@@ -5199,7 +5657,11 @@ fn refresh_manifest_digest_if_checksummed(connection: &Connection) -> EngineResu
     if application_id == MANIFEST_APPLICATION_ID
         && matches!(
             u32::try_from(version),
-            Ok(V7_SCHEMA_VERSION | V8_SCHEMA_VERSION | V9_SCHEMA_VERSION | V10_SCHEMA_VERSION)
+            Ok(V7_SCHEMA_VERSION
+                | V8_SCHEMA_VERSION
+                | V9_SCHEMA_VERSION
+                | V10_SCHEMA_VERSION
+                | V11_SCHEMA_VERSION)
         )
     {
         let _ = refresh_manifest_digest(connection)?;
@@ -5263,7 +5725,7 @@ fn validate_manifest_integrity(
             "manifest checksum version must be positive",
         ));
     }
-    if *manifest_version > i64::from(V3_MANIFEST_DIGEST_VERSION) {
+    if *manifest_version > i64::from(V4_MANIFEST_DIGEST_VERSION) {
         return Err(EngineError::new(
             EngineErrorKind::FailedPrecondition,
             "manifest checksum version is newer than this BriskDB build supports",
@@ -5472,7 +5934,12 @@ fn validate_catalog_manifest(
         validate_schema_catalog_configuration(connection, definition.generation_policy)?;
     let databases =
         validate_logical_databases(connection, catalog_configuration.default_database_id)?;
-    let tables = validate_table_metadata(connection, &databases, definition.generated_ids)?;
+    let tables = validate_table_metadata(
+        connection,
+        &databases,
+        definition.generated_ids,
+        definition.version,
+    )?;
     validate_foreign_keys(connection)?;
 
     Ok(ManifestSnapshot {
@@ -5490,6 +5957,7 @@ fn validate_catalog_manifest(
         integrity: None,
         allocation_owners: None,
         active_native_id_table_ids: Box::new([]),
+        active_hilo_id_table_ids: Box::new([]),
         active_table_provisioning: None,
     })
 }
@@ -5700,6 +6168,13 @@ fn validate_allocation_owners(
 }
 
 fn validate_active_native_id_tables(connection: &Connection) -> EngineResult<Box<[TableId]>> {
+    validate_active_generated_id_tables(connection, GENERATED_ID_POLICY_NATIVE_RANGE_V1)
+}
+
+fn validate_active_generated_id_tables(
+    connection: &Connection,
+    selected_policy: i64,
+) -> EngineResult<Box<[TableId]>> {
     let rows = connection
         .prepare(
             "SELECT table_id, policy, activation_state
@@ -5732,12 +6207,19 @@ fn validate_active_native_id_tables(connection: &Connection) -> EngineResult<Box
         match (policy, state) {
             (GENERATED_ID_POLICY_NONE, GENERATED_ID_INACTIVE) => {}
             (GENERATED_ID_POLICY_NATIVE_RANGE_V1, GENERATED_ID_INACTIVE) => {}
-            (GENERATED_ID_POLICY_NATIVE_RANGE_V1, GENERATED_ID_ACTIVE) => {
+            (GENERATED_ID_POLICY_HILO_V1, GENERATED_ID_INACTIVE) => {}
+            (
+                GENERATED_ID_POLICY_NATIVE_RANGE_V1 | GENERATED_ID_POLICY_HILO_V1,
+                GENERATED_ID_ACTIVE,
+            ) => {
+                if policy != selected_policy {
+                    continue;
+                }
                 active.push(TableId::from_validated(positive_catalog_id(
                     table_id, "table",
                 )?));
             }
-            (_, GENERATED_ID_ACTIVE) if policy > GENERATED_ID_POLICY_NATIVE_RANGE_V1 => {
+            (_, GENERATED_ID_ACTIVE) if policy > GENERATED_ID_POLICY_HILO_V1 => {
                 return Err(EngineError::new(
                     EngineErrorKind::FailedPrecondition,
                     format!("table {table_id} activates a newer generated-ID policy"),
@@ -5754,8 +6236,105 @@ fn validate_active_native_id_tables(connection: &Connection) -> EngineResult<Box
     Ok(active.into_boxed_slice())
 }
 
+fn validate_hilo_v1_leases(
+    connection: &Connection,
+    catalog: Option<&Catalog>,
+    active_hilo_tables: &[TableId],
+) -> EngineResult<()> {
+    validate_table(
+        connection,
+        "briskdb_hilo_leases",
+        &[
+            TableColumn::expected(0, "table_id", "INTEGER", false, 1),
+            TableColumn::expected(1, "block_size", "INTEGER", true, 0),
+            TableColumn::expected(2, "next_sequence", "INTEGER", true, 0),
+            TableColumn::expected(3, "fence_token", "INTEGER", true, 0),
+            TableColumn::expected(4, "last_owner_id", "BLOB", false, 0),
+            TableColumn::expected(5, "last_first_sequence", "INTEGER", false, 0),
+            TableColumn::expected(6, "last_last_sequence", "INTEGER", false, 0),
+        ],
+        true,
+    )?;
+    validate_table_sql(connection, "briskdb_hilo_leases", V11_HILO_LEASES_TABLE_SQL)?;
+    let rows = connection
+        .prepare(
+            "SELECT table_id, block_size, next_sequence, fence_token,
+                    last_owner_id, last_first_sequence, last_last_sequence
+             FROM briskdb_hilo_leases
+             ORDER BY table_id
+             LIMIT 4097",
+        )
+        .and_then(|mut statement| {
+            statement
+                .query_map([], |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, i64>(2)?,
+                        row.get::<_, i64>(3)?,
+                        row.get::<_, Option<Vec<u8>>>(4)?,
+                        row.get::<_, Option<i64>>(5)?,
+                        row.get::<_, Option<i64>>(6)?,
+                    ))
+                })?
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .map_err(|error| manifest_read_error(error, "failed to read hi/lo lease metadata"))?;
+    if rows.len() > MAX_TABLES || rows.len() != active_hilo_tables.len() {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "hi/lo lease metadata must contain exactly one row per active hilo_v1 table",
+        ));
+    }
+    let catalog = catalog.ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::Internal,
+            "hi/lo lease validation omitted the logical catalog",
+        )
+    })?;
+    for (row, expected_id) in rows.into_iter().zip(active_hilo_tables) {
+        let (stored_id, block_size, next, fence, owner, first, last) = row;
+        let id = TableId::from_validated(positive_catalog_id(stored_id, "table")?);
+        if id != *expected_id
+            || block_size != i64::try_from(HILO_V1_BLOCK_SIZE).expect("block size fits i64")
+            || !(1..=i64::try_from(HILO_V1_EXHAUSTED_HEAD).expect("hi/lo head fits i64"))
+                .contains(&next)
+            || fence < 0
+            || catalog.table_by_id(id).is_none_or(|table| {
+                !matches!(
+                    table.generated_id_policy(),
+                    GeneratedIdPolicy::HiloV1 { .. }
+                )
+            })
+        {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "hi/lo lease metadata conflicts with its active table policy",
+            ));
+        }
+        let initial =
+            fence == 0 && next == 1 && owner.is_none() && first.is_none() && last.is_none();
+        let leased = fence > 0
+            && owner.as_ref().is_some_and(|value| value.len() == 32)
+            && first.is_some_and(|value| value >= 1)
+            && last.is_some_and(|value| value >= first.unwrap_or_default())
+            && last == next.checked_sub(1)
+            && last.zip(first).is_some_and(|(last, first)| {
+                last - first < i64::try_from(HILO_V1_BLOCK_SIZE).unwrap()
+            });
+        if !initial && !leased {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "hi/lo lease metadata has an incoherent durable block",
+            ));
+        }
+    }
+    Ok(())
+}
+
 fn validate_table_provisioning(
     connection: &Connection,
+    manifest_version: u32,
     expected_shard_count: u16,
     catalog: Option<&Catalog>,
     active_migration: Option<&SchemaMigration>,
@@ -5919,7 +6498,8 @@ fn validate_table_provisioning(
             error,
         )
     })?;
-    let declarations = read_table_provisioning_declarations(connection, declaration_count)?;
+    let declarations =
+        read_table_provisioning_declarations(connection, manifest_version, declaration_count)?;
     if table_provisioning_id(&declarations, shard_count, committed_schema_digest) != provisioning_id
     {
         return Err(EngineError::new(
@@ -5927,15 +6507,25 @@ fn validate_table_provisioning(
             "table-provisioning identifier does not match its declarations",
         ));
     }
-    if !declarations.iter().any(|declaration| {
+    if !declarations
+        .iter()
+        .any(|declaration| !matches!(declaration.generated_id_policy(), GeneratedIdPolicy::None))
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "table provisioning does not contain a generated-ID policy",
+        ));
+    }
+    let has_native = declarations.iter().any(|declaration| {
         matches!(
             declaration.generated_id_policy(),
             GeneratedIdPolicy::NativeRangeV1 { .. }
         )
-    }) {
+    });
+    if !has_native && next_shard != shard_count {
         return Err(EngineError::new(
             EngineErrorKind::DataCorruption,
-            "table provisioning does not contain a native generated-ID policy",
+            "hi/lo-only table provisioning must not claim pending shard-local work",
         ));
     }
     if let Some(catalog) = catalog {
@@ -5958,6 +6548,7 @@ fn validate_table_provisioning(
 
 fn read_table_provisioning_declarations(
     connection: &Connection,
+    manifest_version: u32,
     expected_count: usize,
 ) -> EngineResult<Box<[TableDeclaration]>> {
     let limit = i64::try_from(MAX_TABLES + 1).expect("table journal limit fits SQLite");
@@ -6046,6 +6637,7 @@ fn read_table_provisioning_declarations(
         let policy = decode_generated_id_policy(
             1,
             &placement,
+            manifest_version,
             Some(generated_policy),
             generated_column,
             generated_version,
@@ -6482,6 +7074,7 @@ fn validate_table_metadata(
     connection: &Connection,
     databases: &[LogicalDatabaseMetadata],
     generated_ids: bool,
+    manifest_version: u32,
 ) -> EngineResult<Box<[TableMetadata]>> {
     let sql = if generated_ids {
         "SELECT tables.table_id,
@@ -6602,6 +7195,7 @@ fn validate_table_metadata(
         let generated_id_policy = decode_generated_id_policy(
             table_id,
             &placement,
+            manifest_version,
             generated_policy,
             generated_column,
             generated_encoding_version,
@@ -6621,6 +7215,7 @@ fn validate_table_metadata(
 fn decode_generated_id_policy(
     table_id: u64,
     placement: &TablePlacement,
+    manifest_version: u32,
     policy: Option<i64>,
     column: Option<String>,
     encoding_version: Option<i64>,
@@ -6654,12 +7249,43 @@ fn decode_generated_id_policy(
             }
             Ok(GeneratedIdPolicy::native_range_v1_from_validated(column))
         }
-        (Some(policy), _, _) if policy > GENERATED_ID_POLICY_NATIVE_RANGE_V1 => {
+        (Some(GENERATED_ID_POLICY_HILO_V1), _, _) if manifest_version < V11_SCHEMA_VERSION => {
             Err(EngineError::new(
                 EngineErrorKind::FailedPrecondition,
                 format!("table {table_id} uses a newer generated-ID policy"),
             ))
         }
+        (Some(GENERATED_ID_POLICY_HILO_V1), Some(column), Some(version)) => {
+            if !validate_catalog_identifier(&column) {
+                return Err(EngineError::new(
+                    EngineErrorKind::DataCorruption,
+                    format!("table {table_id} has an invalid generated-ID column"),
+                ));
+            }
+            if version <= 0 {
+                return Err(EngineError::new(
+                    EngineErrorKind::DataCorruption,
+                    format!("table {table_id} has an invalid generated-ID encoding version"),
+                ));
+            }
+            if version > i64::from(HILO_V1_ENCODING_VERSION) {
+                return Err(EngineError::new(
+                    EngineErrorKind::FailedPrecondition,
+                    format!("table {table_id} uses a newer generated-ID encoding version"),
+                ));
+            }
+            let TablePlacement::Sharded(shard_key) = placement else {
+                return Err(inconsistent_generated_id_policy(table_id));
+            };
+            if shard_key.key_type() != ShardKeyType::Int64 || shard_key.column() != column {
+                return Err(inconsistent_generated_id_policy(table_id));
+            }
+            Ok(GeneratedIdPolicy::hilo_v1_from_validated(column))
+        }
+        (Some(policy), _, _) if policy > GENERATED_ID_POLICY_HILO_V1 => Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!("table {table_id} uses a newer generated-ID policy"),
+        )),
         (Some(policy), _, _) if policy < GENERATED_ID_POLICY_NONE => Err(EngineError::new(
             EngineErrorKind::DataCorruption,
             format!("table {table_id} has an invalid generated-ID policy code"),
@@ -7064,6 +7690,13 @@ mod tests {
         initialize_interrupted_legacy: migrate_interrupted_legacy_to_v8,
     };
 
+    const V10_PLAN: MigrationPlan<'static> = MigrationPlan {
+        current_version: V10_SCHEMA_VERSION,
+        migrations: MIGRATIONS,
+        initialize_current: create_v10_schema,
+        initialize_interrupted_legacy: migrate_interrupted_legacy_to_v10,
+    };
+
     fn create_legacy_manifest(connection: &Connection, shards: u16, version: u32) {
         create_empty_legacy_manifest(connection);
         connection
@@ -7124,6 +7757,68 @@ mod tests {
             mark_shard_layout_ready(connection, shards, &creating).unwrap();
         }
         seal_verified_schema(connection, shards, [0x5a; 32]).unwrap();
+    }
+
+    fn create_ready_v10_manifest(connection: &mut Connection, shards: u16) {
+        let transaction = connection.transaction().unwrap();
+        create_v10_schema(&transaction, shards).unwrap();
+        transaction
+            .execute(
+                "UPDATE briskdb_shard_layout SET layout_state = ?1 WHERE singleton = 1",
+                [ShardLayoutState::Ready.code()],
+            )
+            .unwrap();
+        transaction
+            .execute(
+                "UPDATE briskdb_integrity
+                 SET database_state = ?1,
+                     committed_schema_digest = ?2,
+                     target_schema_digest = NULL
+                 WHERE singleton = 1",
+                rusqlite::params![DATABASE_STATE_READY, [0x5a_u8; 32].as_slice()],
+            )
+            .unwrap();
+        set_identity(&transaction, V10_SCHEMA_VERSION).unwrap();
+        refresh_manifest_digest(&transaction).unwrap();
+        validate_v10(&transaction, shards, &schema_objects(&transaction).unwrap()).unwrap();
+        transaction.commit().unwrap();
+    }
+
+    fn activate_hilo_table(connection: &mut Connection, shards: u16) -> TableId {
+        let database = crate::core::LogicalDatabaseId::new(1).unwrap();
+        let declarations = vec![
+            TableDeclaration::sharded(
+                database,
+                "events",
+                ShardKeyMetadata::new("id", ShardKeyType::Int64).unwrap(),
+            )
+            .unwrap()
+            .with_generated_id_policy(GeneratedIdPolicy::hilo_v1("id").unwrap())
+            .unwrap(),
+        ];
+        let active = match begin_native_table_provisioning(
+            connection,
+            shards,
+            declarations,
+            [0x5a; 32],
+            || {},
+        )
+        .unwrap()
+        {
+            NativeTableProvisioningClassification::Active(active) => active,
+            other => panic!("unexpected hi/lo provisioning classification: {other:?}"),
+        };
+        assert_eq!(active.next_shard(), shards);
+        let catalog =
+            finalize_native_table_provisioning(connection, shards, &active, || {}).unwrap();
+        let table = catalog
+            .logical()
+            .table("default", "events")
+            .unwrap()
+            .unwrap();
+        assert_eq!(catalog.active_hilo_id_table_ids(), [table.id()]);
+        assert!(catalog.active_native_id_table_ids().is_empty());
+        table.id()
     }
 
     fn create_ready_v7_manifest(connection: &mut Connection, shards: u16) {
@@ -7439,7 +8134,7 @@ mod tests {
             identity(connection),
             (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
         );
-        assert_eq!(schema_objects(connection).unwrap(), v10_objects());
+        assert_eq!(schema_objects(connection).unwrap(), v11_objects());
         assert_eq!(
             connection
                 .query_row(
@@ -7506,7 +8201,7 @@ mod tests {
                     |row| row.get::<_, i64>(0),
                 )
                 .unwrap(),
-            i64::from(V3_MANIFEST_DIGEST_VERSION)
+            i64::from(V4_MANIFEST_DIGEST_VERSION)
         );
         let (layout_id, application_id, metadata_version, state) = shard_layout_row(connection);
         assert_eq!(layout_id.len(), 16);
@@ -7623,6 +8318,7 @@ mod tests {
                 (7, 8),
                 (8, 9),
                 (9, 10),
+                (10, 11),
             ]
         );
         assert_generation_one_catalog(&connection, 4);
@@ -7649,6 +8345,439 @@ mod tests {
             .pragma_query_value(None, "data_version", |row| row.get(0))
             .unwrap();
         assert_eq!(before, after, "a current-version reopen must not write");
+    }
+
+    #[test]
+    fn v10_to_v11_is_atomic_retryable_and_fences_v10_readers() {
+        for failing_phase in [
+            MigrationPhase::AfterSchemaChange,
+            MigrationPhase::AfterVersionStamp,
+        ] {
+            for inject_panic in [false, true] {
+                let mut connection = Connection::open_in_memory().unwrap();
+                create_ready_v10_manifest(&mut connection, 4);
+                let objects_before = schema_objects(&connection).unwrap();
+                let root_before = stored_manifest_digest(&connection);
+
+                let attempt = catch_unwind(AssertUnwindSafe(|| {
+                    load_or_create_with_hook(&mut connection, 4, |point| {
+                        if point.from == V10_SCHEMA_VERSION && point.phase == failing_phase {
+                            if inject_panic {
+                                panic!("injected v10 to v11 migration panic");
+                            }
+                            return Err(EngineError::new(
+                                EngineErrorKind::Internal,
+                                "injected v10 to v11 migration failure",
+                            ));
+                        }
+                        Ok(())
+                    })
+                }));
+                if inject_panic {
+                    assert!(attempt.is_err());
+                } else {
+                    assert_eq!(
+                        attempt.unwrap().unwrap_err().kind(),
+                        EngineErrorKind::Internal
+                    );
+                }
+                assert_eq!(identity(&connection).1, i64::from(V10_SCHEMA_VERSION));
+                assert_eq!(schema_objects(&connection).unwrap(), objects_before);
+                assert_eq!(stored_manifest_digest(&connection), root_before);
+                assert_eq!(manifest_semantic_digest(&connection).unwrap(), root_before);
+                assert_eq!(quick_check(&connection), "ok");
+
+                load_or_create_manifest(&mut connection, 4).unwrap();
+                assert_eq!(identity(&connection).1, i64::from(V11_SCHEMA_VERSION));
+                assert_eq!(schema_objects(&connection).unwrap(), v11_objects());
+                assert_eq!(
+                    connection
+                        .query_row(
+                            "SELECT manifest_digest_version FROM briskdb_integrity",
+                            [],
+                            |row| row.get::<_, i64>(0),
+                        )
+                        .unwrap(),
+                    i64::from(V4_MANIFEST_DIGEST_VERSION)
+                );
+                assert_eq!(
+                    connection
+                        .query_row("SELECT COUNT(*) FROM briskdb_hilo_leases", [], |row| {
+                            row.get::<_, i64>(0)
+                        })
+                        .unwrap(),
+                    0
+                );
+                let identity_before = identity(&connection);
+                let root_before = stored_manifest_digest(&connection);
+                assert_eq!(
+                    inspect_with_plan(&connection, 4, V10_PLAN)
+                        .unwrap_err()
+                        .kind(),
+                    EngineErrorKind::FailedPrecondition
+                );
+                assert_eq!(identity(&connection), identity_before);
+                assert_eq!(stored_manifest_digest(&connection), root_before);
+            }
+        }
+    }
+
+    #[test]
+    fn hilo_activation_atomically_installs_one_global_lease_head() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        create_ready_current_manifest(&mut connection, 4);
+        let table_id = activate_hilo_table(&mut connection, 4);
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT table_id, block_size, next_sequence, fence_token,
+                            last_owner_id, last_first_sequence, last_last_sequence
+                     FROM briskdb_hilo_leases",
+                    [],
+                    |row| {
+                        Ok((
+                            row.get::<_, i64>(0)?,
+                            row.get::<_, i64>(1)?,
+                            row.get::<_, i64>(2)?,
+                            row.get::<_, i64>(3)?,
+                            row.get::<_, Option<Vec<u8>>>(4)?,
+                            row.get::<_, Option<i64>>(5)?,
+                            row.get::<_, Option<i64>>(6)?,
+                        ))
+                    },
+                )
+                .unwrap(),
+            (
+                i64::try_from(table_id.get()).unwrap(),
+                i64::try_from(HILO_V1_BLOCK_SIZE).unwrap(),
+                1,
+                0,
+                None,
+                None,
+                None,
+            )
+        );
+        assert_eq!(
+            manifest_semantic_digest(&connection).unwrap(),
+            stored_manifest_digest(&connection)
+        );
+    }
+
+    #[test]
+    fn hilo_lease_state_is_clock_independent_and_has_no_expiry_fields() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        create_ready_current_manifest(&mut connection, 4);
+        let table_id = activate_hilo_table(&mut connection, 4);
+
+        let columns = connection
+            .prepare("SELECT name FROM pragma_table_xinfo('briskdb_hilo_leases') ORDER BY cid")
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(0))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(
+            columns,
+            [
+                "table_id",
+                "block_size",
+                "next_sequence",
+                "fence_token",
+                "last_owner_id",
+                "last_first_sequence",
+                "last_last_sequence",
+            ]
+        );
+        assert!(columns.iter().all(|column| {
+            let column = column.to_ascii_lowercase();
+            !column.contains("time")
+                && !column.contains("clock")
+                && !column.contains("expire")
+                && !column.contains("ttl")
+        }));
+
+        let first = reserve_hilo_v1_block(&mut connection, 4, table_id, [0x71; 32]).unwrap();
+        thread::sleep(Duration::from_millis(2));
+        let second = reserve_hilo_v1_block(&mut connection, 4, table_id, [0x71; 32]).unwrap();
+        assert_eq!(
+            first,
+            DurableHiloLease::new(table_id, [0x71; 32], 1, 1, 4096)
+        );
+        assert_eq!(
+            second,
+            DurableHiloLease::new(table_id, [0x71; 32], 2, 4097, 8192)
+        );
+    }
+
+    #[test]
+    fn hilo_reservations_are_durable_fenced_and_part_of_the_semantic_root() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        create_ready_current_manifest(&mut connection, 4);
+        let table_id = activate_hilo_table(&mut connection, 4);
+        let initial_root = stored_manifest_digest(&connection);
+        let first_owner = [0x11; 32];
+        let second_owner = [0x22; 32];
+
+        let first = reserve_hilo_v1_block(&mut connection, 4, table_id, first_owner).unwrap();
+        assert_eq!(
+            first,
+            DurableHiloLease::new(table_id, first_owner, 1, 1, HILO_V1_BLOCK_SIZE)
+        );
+        let first_root = stored_manifest_digest(&connection);
+        assert_ne!(first_root, initial_root);
+        let second = reserve_hilo_v1_block(&mut connection, 4, table_id, second_owner).unwrap();
+        assert_eq!(
+            second,
+            DurableHiloLease::new(
+                table_id,
+                second_owner,
+                2,
+                HILO_V1_BLOCK_SIZE + 1,
+                HILO_V1_BLOCK_SIZE * 2,
+            )
+        );
+        assert_ne!(stored_manifest_digest(&connection), first_root);
+        assert_eq!(
+            manifest_semantic_digest(&connection).unwrap(),
+            stored_manifest_digest(&connection)
+        );
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT next_sequence, fence_token, last_owner_id,
+                            last_first_sequence, last_last_sequence
+                     FROM briskdb_hilo_leases WHERE table_id = ?1",
+                    [i64::try_from(table_id.get()).unwrap()],
+                    |row| {
+                        Ok((
+                            row.get::<_, i64>(0)?,
+                            row.get::<_, i64>(1)?,
+                            row.get::<_, Vec<u8>>(2)?,
+                            row.get::<_, i64>(3)?,
+                            row.get::<_, i64>(4)?,
+                        ))
+                    },
+                )
+                .unwrap(),
+            (8193, 2, second_owner.to_vec(), 4097, 8192)
+        );
+    }
+
+    #[test]
+    fn hilo_reservation_returns_a_partial_final_block_then_reports_both_limits() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        create_ready_current_manifest(&mut connection, 4);
+        let table_id = activate_hilo_table(&mut connection, 4);
+        let owner = [0x33; 32];
+        let final_first = MAX_HILO_V1_SEQUENCE - 2;
+        let previous_first = final_first - HILO_V1_BLOCK_SIZE;
+        connection
+            .execute(
+                "UPDATE briskdb_hilo_leases
+                 SET next_sequence = ?1, fence_token = 1, last_owner_id = ?2,
+                     last_first_sequence = ?3, last_last_sequence = ?4
+                 WHERE table_id = ?5",
+                rusqlite::params![
+                    i64::try_from(final_first).unwrap(),
+                    [0x22_u8; 32].as_slice(),
+                    i64::try_from(previous_first).unwrap(),
+                    i64::try_from(final_first - 1).unwrap(),
+                    i64::try_from(table_id.get()).unwrap(),
+                ],
+            )
+            .unwrap();
+        refresh_manifest_digest(&connection).unwrap();
+        assert_eq!(
+            reserve_hilo_v1_block(&mut connection, 4, table_id, owner).unwrap(),
+            DurableHiloLease::new(table_id, owner, 2, final_first, MAX_HILO_V1_SEQUENCE)
+        );
+        assert_eq!(
+            reserve_hilo_v1_block(&mut connection, 4, table_id, owner)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::LimitExceeded
+        );
+
+        connection
+            .execute(
+                "UPDATE briskdb_hilo_leases
+                 SET next_sequence = 8193, fence_token = ?1, last_owner_id = ?2,
+                     last_first_sequence = 4097, last_last_sequence = 8192
+                 WHERE table_id = ?3",
+                rusqlite::params![
+                    i64::MAX,
+                    owner.as_slice(),
+                    i64::try_from(table_id.get()).unwrap()
+                ],
+            )
+            .unwrap();
+        refresh_manifest_digest(&connection).unwrap();
+        assert_eq!(
+            reserve_hilo_v1_block(&mut connection, 4, table_id, owner)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::LimitExceeded
+        );
+    }
+
+    #[test]
+    fn hilo_lease_tampering_and_resealed_cardinality_loss_are_detected() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        create_ready_current_manifest(&mut connection, 4);
+        let table_id = activate_hilo_table(&mut connection, 4);
+        reserve_hilo_v1_block(&mut connection, 4, table_id, [0x44; 32]).unwrap();
+        connection
+            .execute(
+                "UPDATE briskdb_hilo_leases SET last_owner_id = ?1 WHERE table_id = ?2",
+                rusqlite::params![
+                    [0x45_u8; 32].as_slice(),
+                    i64::try_from(table_id.get()).unwrap()
+                ],
+            )
+            .unwrap();
+        assert_eq!(
+            current_manifest_snapshot(&connection, 4)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::DataCorruption
+        );
+        refresh_manifest_digest(&connection).unwrap();
+        connection
+            .execute(
+                "DELETE FROM briskdb_hilo_leases WHERE table_id = ?1",
+                [i64::try_from(table_id.get()).unwrap()],
+            )
+            .unwrap();
+        refresh_manifest_digest(&connection).unwrap();
+        assert_eq!(
+            current_manifest_snapshot(&connection, 4)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::DataCorruption
+        );
+    }
+
+    #[test]
+    fn independent_connections_serialize_hilo_reservations_without_overlap() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("manifest.sqlite");
+        let mut setup = Connection::open(&path).unwrap();
+        setup.busy_timeout(Duration::from_secs(5)).unwrap();
+        create_ready_current_manifest(&mut setup, 4);
+        let table_id = activate_hilo_table(&mut setup, 4);
+        drop(setup);
+
+        let barrier = Arc::new(Barrier::new(3));
+        let mut workers = Vec::new();
+        for owner in [[0x51_u8; 32], [0x52_u8; 32]] {
+            let path = path.clone();
+            let barrier = Arc::clone(&barrier);
+            workers.push(thread::spawn(move || {
+                let mut connection = Connection::open(path).unwrap();
+                connection.busy_timeout(Duration::from_secs(5)).unwrap();
+                barrier.wait();
+                reserve_hilo_v1_block(&mut connection, 4, table_id, owner).unwrap()
+            }));
+        }
+        barrier.wait();
+        let leases = workers
+            .into_iter()
+            .map(|worker| worker.join().unwrap())
+            .collect::<Vec<_>>();
+        let owner_51_first = DurableHiloLease::new(table_id, [0x51; 32], 1, 1, 4096);
+        let owner_51_second = DurableHiloLease::new(table_id, [0x51; 32], 2, 4097, 8192);
+        let owner_52_first = DurableHiloLease::new(table_id, [0x52; 32], 1, 1, 4096);
+        let owner_52_second = DurableHiloLease::new(table_id, [0x52; 32], 2, 4097, 8192);
+        assert!(
+            (leases.contains(&owner_51_first) && leases.contains(&owner_52_second))
+                || (leases.contains(&owner_52_first) && leases.contains(&owner_51_second))
+        );
+        let mut observer = Connection::open(&path).unwrap();
+        let third = reserve_hilo_v1_block(&mut observer, 4, table_id, [0x53; 32]).unwrap();
+        assert_eq!(
+            third,
+            DurableHiloLease::new(table_id, [0x53; 32], 3, 8193, 12288)
+        );
+    }
+
+    #[test]
+    fn manifest_write_lock_contention_is_busy_and_retryable() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("manifest.sqlite");
+        let mut setup = Connection::open(&path).unwrap();
+        create_ready_current_manifest(&mut setup, 4);
+        let table_id = activate_hilo_table(&mut setup, 4);
+        drop(setup);
+
+        let mut holder = Connection::open(&path).unwrap();
+        let held = holder
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .unwrap();
+        let mut contender = Connection::open(&path).unwrap();
+        contender.busy_timeout(Duration::ZERO).unwrap();
+        assert_eq!(
+            reserve_hilo_v1_block(&mut contender, 4, table_id, [0x61; 32])
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::Busy
+        );
+        held.rollback().unwrap();
+        let lease = reserve_hilo_v1_block(&mut contender, 4, table_id, [0x61; 32]).unwrap();
+        assert_eq!(
+            lease,
+            DurableHiloLease::new(table_id, [0x61; 32], 1, 1, 4096)
+        );
+    }
+
+    #[test]
+    fn active_provisioning_journal_survives_degradation_and_reopen() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("manifest.sqlite");
+        let mut connection = Connection::open(&path).unwrap();
+        create_ready_current_manifest(&mut connection, 4);
+        let database = crate::core::LogicalDatabaseId::new(1).unwrap();
+        let declarations = vec![
+            TableDeclaration::sharded(
+                database,
+                "events",
+                ShardKeyMetadata::new("id", ShardKeyType::Int64).unwrap(),
+            )
+            .unwrap()
+            .with_generated_id_policy(GeneratedIdPolicy::hilo_v1("id").unwrap())
+            .unwrap(),
+        ];
+        let active = match begin_native_table_provisioning(
+            &mut connection,
+            4,
+            declarations,
+            [0x5a; 32],
+            || {},
+        )
+        .unwrap()
+        {
+            NativeTableProvisioningClassification::Active(active) => active,
+            other => panic!("unexpected provisioning classification: {other:?}"),
+        };
+        let layout = current_manifest_snapshot(&connection, 4)
+            .unwrap()
+            .shard_layout
+            .unwrap();
+        mark_degraded(&mut connection, 4, &layout).unwrap();
+        assert_eq!(
+            current_integrity(&connection, 4).unwrap().state(),
+            DatabaseIntegrityState::Degraded
+        );
+        drop(connection);
+
+        let mut reopened = Connection::open(&path).unwrap();
+        let loaded = load_or_create_manifest(&mut reopened, 4).unwrap();
+        let (_, _, _, integrity, _, _, provisioning) = loaded.into_parts_with_recovery();
+        assert_eq!(integrity.state(), DatabaseIntegrityState::Degraded);
+        assert_eq!(provisioning, Some(active));
+        assert_eq!(
+            manifest_semantic_digest(&reopened).unwrap(),
+            stored_manifest_digest(&reopened)
+        );
     }
 
     #[test]
@@ -7806,9 +8935,9 @@ mod tests {
 
         assert_eq!(
             identity(&connection),
-            (MANIFEST_APPLICATION_ID, i64::from(V10_SCHEMA_VERSION))
+            (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
         );
-        assert_eq!(schema_objects(&connection).unwrap(), v10_objects());
+        assert_eq!(schema_objects(&connection).unwrap(), v11_objects());
         assert_eq!(table_metadata_rows(&connection), tables_before);
         assert_eq!(logical_databases(&connection), databases_before);
         assert_eq!(routing_configuration(&connection), routing_before);
@@ -7851,7 +8980,7 @@ mod tests {
                     |row| row.get::<_, i64>(0),
                 )
                 .unwrap(),
-            i64::from(V3_MANIFEST_DIGEST_VERSION)
+            i64::from(V4_MANIFEST_DIGEST_VERSION)
         );
         assert_eq!(
             manifest_semantic_digest(&connection).unwrap(),
@@ -7913,7 +9042,8 @@ mod tests {
             .unwrap();
         connection
             .execute_batch(
-                "DROP TABLE briskdb_table_provisioning_declarations;
+                "DROP TABLE briskdb_hilo_leases;
+                 DROP TABLE briskdb_table_provisioning_declarations;
                  DROP TABLE briskdb_table_provisioning;
                  DROP INDEX briskdb_one_active_owner_per_shard;
                  ALTER TABLE briskdb_generated_ids RENAME TO briskdb_generated_ids_v10;
@@ -7974,7 +9104,7 @@ mod tests {
             &GeneratedIdPolicy::native_range_v1("id").unwrap()
         );
         assert!(loaded.catalog.active_native_id_table_ids().is_empty());
-        assert_eq!(identity(&connection).1, i64::from(V10_SCHEMA_VERSION));
+        assert_eq!(identity(&connection).1, i64::from(CURRENT_SCHEMA_VERSION));
     }
 
     #[test]
@@ -8381,9 +9511,9 @@ mod tests {
                 );
                 assert_eq!(
                     identity(&connection),
-                    (MANIFEST_APPLICATION_ID, i64::from(V10_SCHEMA_VERSION))
+                    (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
                 );
-                assert_eq!(schema_objects(&connection).unwrap(), v10_objects());
+                assert_eq!(schema_objects(&connection).unwrap(), v11_objects());
                 assert_eq!(
                     manifest_semantic_digest(&connection).unwrap(),
                     stored_manifest_digest(&connection)
@@ -8702,6 +9832,7 @@ mod tests {
             active,
             NativeTableProvisioningClassification::Active(_)
         ));
+        downgrade_v11_manifest_to_v10_for_test(&connection, 4).unwrap();
 
         let digest = manifest_semantic_digest(&connection).unwrap();
         assert_eq!(
@@ -8716,10 +9847,38 @@ mod tests {
     }
 
     #[test]
+    fn manifest_semantic_digest_v4_has_a_frozen_hilo_lease_vector() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        create_ready_current_manifest(&mut connection, 4);
+        connection
+            .execute(
+                "UPDATE briskdb_shard_layout
+                 SET layout_id = x'000102030405060708090a0b0c0d0e0f'
+                 WHERE singleton = 1",
+                [],
+            )
+            .unwrap();
+        refresh_manifest_digest(&connection).unwrap();
+        let table_id = activate_hilo_table(&mut connection, 4);
+        reserve_hilo_v1_block(&mut connection, 4, table_id, [0x6b; 32]).unwrap();
+
+        let digest = manifest_semantic_digest(&connection).unwrap();
+        assert_eq!(
+            digest,
+            [
+                0x5e, 0x6d, 0x41, 0xf6, 0x02, 0xcf, 0xaf, 0x77, 0x41, 0x4a, 0x90, 0x59, 0x5a, 0x7e,
+                0xa0, 0x37, 0x8e, 0x4e, 0x83, 0x07, 0x07, 0x06, 0xd6, 0x86, 0xed, 0x1f, 0x2b, 0xa7,
+                0xed, 0x67, 0x5d, 0xe6,
+            ]
+        );
+        assert_eq!(stored_manifest_digest(&connection), digest);
+    }
+
+    #[test]
     fn semantic_root_covers_every_authoritative_manifest_table_and_integrity_state() {
         let mutations = [
             "UPDATE briskdb_manifest SET singleton = 2 WHERE singleton = 1",
-            "UPDATE briskdb_metadata SET requires_manifest_version = 11",
+            "UPDATE briskdb_metadata SET requires_manifest_version = 12",
             "UPDATE briskdb_routing SET hash_version = 2 WHERE singleton = 1",
             "UPDATE briskdb_physical_shards SET lifecycle_state = 'retired' WHERE shard_id = 0",
             "UPDATE briskdb_allocation_owners SET owner_slot = 100 WHERE owner_slot = 0",
@@ -8728,6 +9887,7 @@ mod tests {
             "UPDATE briskdb_schema_catalog SET identifier_encoding_version = 2 WHERE singleton = 1",
             "INSERT INTO briskdb_tables VALUES (1, 1, 'widgets', 2, NULL, NULL)",
             "INSERT INTO briskdb_generated_ids VALUES (1, 0, NULL, NULL, 0)",
+            "INSERT INTO briskdb_hilo_leases VALUES (1, 4096, 1, 0, NULL, NULL, NULL)",
             "UPDATE briskdb_shard_layout SET layout_id = randomblob(16) WHERE singleton = 1",
             "INSERT INTO briskdb_schema_migrations VALUES (1, 0, randomblob(32), 1, 'SELECT 1', 4, 2, 4)",
             "INSERT INTO briskdb_table_provisioning VALUES (1, zeroblob(32), 1, 1, zeroblob(32), 4, 1, 0)",
@@ -8773,7 +9933,7 @@ mod tests {
         for (mutation, expected_diagnostic) in [
             (
                 "UPDATE briskdb_generated_ids
-                 SET policy = 2, generated_column = 'tenant_id', encoding_version = 1
+                 SET policy = 3, generated_column = 'tenant_id', encoding_version = 1
                  WHERE table_id = 3",
                 "table 3 uses a newer generated-ID policy",
             ),
@@ -8884,7 +10044,7 @@ mod tests {
     #[test]
     fn integrity_versions_lengths_and_forged_state_invariants_fail_closed() {
         for (version_column, unsupported_version) in
-            [("manifest_digest_version", 4), ("schema_digest_version", 2)]
+            [("manifest_digest_version", 5), ("schema_digest_version", 2)]
         {
             let mut unsupported = Connection::open_in_memory().unwrap();
             create_ready_current_manifest(&mut unsupported, 4);
@@ -9112,7 +10272,7 @@ mod tests {
             identity(&connection),
             (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
         );
-        assert_eq!(schema_objects(&connection).unwrap(), v10_objects());
+        assert_eq!(schema_objects(&connection).unwrap(), v11_objects());
         assert_eq!(
             shard_layout_row(&connection).3,
             ShardLayoutState::Adopting.code()
@@ -9136,7 +10296,7 @@ mod tests {
             identity(&connection),
             (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
         );
-        assert_eq!(schema_objects(&connection).unwrap(), v10_objects());
+        assert_eq!(schema_objects(&connection).unwrap(), v11_objects());
         assert_eq!(layout.state(), ShardLayoutState::Ready);
         assert_eq!(shard_layout_row(&connection), layout_before);
         assert_eq!(catalog.logical().schema_generation(), 0);
@@ -9228,7 +10388,7 @@ mod tests {
                 identity(&connection),
                 (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
             );
-            assert_eq!(schema_objects(&connection).unwrap(), v10_objects());
+            assert_eq!(schema_objects(&connection).unwrap(), v11_objects());
         }
 
         let mut connection = Connection::open_in_memory().unwrap();

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,5 +1,6 @@
 //! SQLite file layout, versioned manifest management, and connection configuration.
 
+mod hilo;
 mod manifest;
 mod migration;
 mod schema_gate;
@@ -60,6 +61,7 @@ struct RootSchemaCoordination {
     gate: schema_gate::SchemaGate,
     catalogs: Mutex<Vec<Weak<CatalogSnapshot>>>,
     schema_digests: Mutex<RuntimeSchemaDigests>,
+    hilo_allocator: hilo::HiloAllocator,
 }
 
 struct CatalogReplacementGuard<'a> {
@@ -95,12 +97,13 @@ struct RuntimeSchemaDigests {
 }
 
 impl RootSchemaCoordination {
-    fn new() -> Self {
-        Self {
+    fn new() -> EngineResult<Self> {
+        Ok(Self {
             gate: schema_gate::SchemaGate::new(),
             catalogs: Mutex::new(Vec::new()),
             schema_digests: Mutex::new(RuntimeSchemaDigests::default()),
-        }
+            hilo_allocator: hilo::HiloAllocator::new()?,
+        })
     }
 
     fn mark_degraded(&self) {
@@ -315,6 +318,7 @@ fn immutable_catalog_metadata_matches(left: &CatalogSnapshot, right: &CatalogSna
     left.routing() == right.routing()
         && left.allocation_owners() == right.allocation_owners()
         && left.active_native_id_table_ids() == right.active_native_id_table_ids()
+        && left.active_hilo_id_table_ids() == right.active_hilo_id_table_ids()
         && left_logical.identifier_encoding_version() == right_logical.identifier_encoding_version()
         && left_logical.default_database().id() == right_logical.default_database().id()
         && left_logical.logical_databases() == right_logical.logical_databases()
@@ -336,7 +340,7 @@ fn root_schema_coordination(root: &Path) -> EngineResult<Arc<RootSchemaCoordinat
     if let Some(coordination) = registry.get(root).and_then(Weak::upgrade) {
         return Ok(coordination);
     }
-    let coordination = Arc::new(RootSchemaCoordination::new());
+    let coordination = Arc::new(RootSchemaCoordination::new()?);
     registry.insert(root.to_path_buf(), Arc::downgrade(&coordination));
     Ok(coordination)
 }
@@ -500,9 +504,11 @@ impl Storage {
             active_migration,
             mut integrity,
             active_native_id_table_ids,
+            active_hilo_id_table_ids,
             active_table_provisioning,
         ) = loaded.into_parts_with_recovery();
         let catalog = catalog.with_active_native_id_table_ids(active_native_id_table_ids);
+        let catalog = catalog.with_active_hilo_id_table_ids(active_hilo_id_table_ids);
         let catalog = schema_coordination.register_catalog(catalog)?;
         schema_coordination.publish_schema_digests(
             integrity.committed_schema_digest(),
@@ -694,6 +700,40 @@ impl Storage {
         self.catalog.native_id_policy_is_active(table_id)
     }
 
+    #[cfg(any(feature = "experimental-vtab", test))]
+    pub(crate) fn generated_id_policy_is_active(&self, table_id: TableId) -> bool {
+        self.catalog.native_id_policy_is_active(table_id)
+            || self.catalog.hilo_id_policy_is_active(table_id)
+    }
+
+    #[cfg(any(feature = "experimental-vtab", test))]
+    pub(crate) fn allocate_hilo_v1(&self, table_id: TableId) -> EngineResult<hilo::HiloAllocation> {
+        if !self.catalog.hilo_id_policy_is_active(table_id) {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!("hilo_v1 generation is not active for table {table_id}"),
+            ));
+        }
+        self.schema_coordination
+            .hilo_allocator
+            .allocate(table_id, |owner_id| {
+                let mut manifest_connection =
+                    open_existing_manifest(&self.root.join("manifest.sqlite"))?;
+                configure_manifest_connection(&manifest_connection)?;
+                manifest::reserve_hilo_v1_block(
+                    &mut manifest_connection,
+                    self.shard_count(),
+                    table_id,
+                    owner_id,
+                )
+            })
+    }
+
+    #[cfg(any(feature = "experimental-vtab", test))]
+    pub(crate) fn hilo_owner_id(&self) -> [u8; 32] {
+        self.schema_coordination.hilo_allocator.owner_id()
+    }
+
     pub(crate) fn register_tables(
         &mut self,
         declarations: Vec<TableDeclaration>,
@@ -712,26 +752,30 @@ impl Storage {
                 "the authoritative table catalog is already registered",
             ));
         }
-        let has_native_policy = declarations.iter().any(|declaration| {
-            matches!(
-                declaration.generated_id_policy(),
-                GeneratedIdPolicy::NativeRangeV1 { .. }
-            )
+        let has_generated_policy = declarations.iter().any(|declaration| {
+            !matches!(declaration.generated_id_policy(), GeneratedIdPolicy::None)
         });
-        let every_native_policy_is_active = !has_native_policy
-            || declarations.iter().all(|declaration| {
-                !matches!(
-                    declaration.generated_id_policy(),
-                    GeneratedIdPolicy::NativeRangeV1 { .. }
-                ) || self
-                    .catalog
-                    .logical()
-                    .table("default", declaration.name())
-                    .ok()
-                    .flatten()
-                    .is_some_and(|table| self.catalog.native_id_policy_is_active(table.id()))
-            });
-        if !catalog_is_empty && every_native_policy_is_active {
+        let every_generated_policy_is_active = !has_generated_policy
+            || declarations
+                .iter()
+                .all(|declaration| match declaration.generated_id_policy() {
+                    GeneratedIdPolicy::None => true,
+                    GeneratedIdPolicy::NativeRangeV1 { .. } => self
+                        .catalog
+                        .logical()
+                        .table("default", declaration.name())
+                        .ok()
+                        .flatten()
+                        .is_some_and(|table| self.catalog.native_id_policy_is_active(table.id())),
+                    GeneratedIdPolicy::HiloV1 { .. } => self
+                        .catalog
+                        .logical()
+                        .table("default", declaration.name())
+                        .ok()
+                        .flatten()
+                        .is_some_and(|table| self.catalog.hilo_id_policy_is_active(table.id())),
+                });
+        if !catalog_is_empty && every_generated_policy_is_active {
             let _operation = self.enter_schema_operation()?;
             return Ok(());
         }
@@ -746,7 +790,7 @@ impl Storage {
             let manifest_path = self.root.join("manifest.sqlite");
             let mut manifest_connection = open_existing_manifest(&manifest_path)?;
             configure_manifest_connection(&manifest_connection)?;
-            let replacement = if has_native_policy {
+            let replacement = if has_generated_policy {
                 let committed_schema_digest = self.schema_coordination.committed_schema_digest()?;
                 let classification = manifest::begin_native_table_provisioning(
                     &mut manifest_connection,
@@ -883,7 +927,7 @@ impl Storage {
                 GeneratedIdPolicy::NativeRangeV1 { column } => {
                     Some((declaration.name(), column.as_str()))
                 }
-                GeneratedIdPolicy::None => None,
+                GeneratedIdPolicy::None | GeneratedIdPolicy::HiloV1 { .. } => None,
             })
             .collect::<Vec<_>>();
         if native_tables.is_empty() {
@@ -1345,10 +1389,11 @@ impl Storage {
         // enforcing compatibility policy. Otherwise a policy error on an early
         // shard could mask later corruption and prevent terminal degradation.
         for (shard_id, connection) in verified_connections.iter().enumerate() {
-            shard::validate_registered_table_schema_with_active_native_ids(
+            shard::validate_registered_table_schema_with_active_generated_ids(
                 connection,
                 self.catalog.logical(),
                 self.catalog.active_native_id_table_ids(),
+                self.catalog.active_hilo_id_table_ids(),
             )?;
             self.validate_native_range_v1_state(
                 connection,
@@ -1666,6 +1711,17 @@ fn validate_empty_table_declaration(
                 EngineErrorKind::FailedPrecondition,
                 format!(
                     "generated column {column} on table {} must be exactly INTEGER PRIMARY KEY AUTOINCREMENT on physical shard {shard_id}",
+                    declaration.name()
+                ),
+            ));
+        }
+    }
+    if let GeneratedIdPolicy::HiloV1 { column } = declaration.generated_id_policy() {
+        if !shard::hilo_generated_column_is_exact(connection, declaration.name(), column)? {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "generated column {column} on table {} must be exactly INTEGER PRIMARY KEY without AUTOINCREMENT on physical shard {shard_id}",
                     declaration.name()
                 ),
             ));
@@ -2524,6 +2580,7 @@ mod tests {
             manifest
                 .execute_batch(
                     "BEGIN IMMEDIATE;
+                     DROP TABLE briskdb_hilo_leases;
                      DROP TABLE briskdb_table_provisioning_declarations;
                      DROP TABLE briskdb_table_provisioning;
                      DROP TABLE briskdb_generated_ids;
@@ -2626,6 +2683,7 @@ mod tests {
             .unwrap()
             .execute_batch(
                 "BEGIN IMMEDIATE;
+                 DROP TABLE briskdb_hilo_leases;
                  DROP TABLE briskdb_table_provisioning_declarations;
                  DROP TABLE briskdb_table_provisioning;
                  DROP TABLE briskdb_generated_ids;
@@ -2722,6 +2780,7 @@ mod tests {
             .unwrap()
             .execute_batch(
                 "BEGIN IMMEDIATE;
+                 DROP TABLE briskdb_hilo_leases;
                  DROP TABLE briskdb_table_provisioning_declarations;
                  DROP TABLE briskdb_table_provisioning;
                  DROP TABLE briskdb_generated_ids;
@@ -3569,6 +3628,42 @@ mod tests {
             native_events_declaration(storage.logical_catalog().default_database().id());
         storage.register_tables(vec![declaration]).unwrap();
         storage
+    }
+
+    fn create_registered_hilo_storage(root: &Path, shard_count: u16) -> Storage {
+        let mut storage = Storage::open(root, shard_count).unwrap();
+        let mut migration = storage.begin_schema_migration().unwrap();
+        migration.wait_for_quiescence_blocking();
+        storage
+            .apply_schema_migration(
+                "CREATE TABLE events (
+                     id INTEGER PRIMARY KEY,
+                     payload BLOB
+                 ) STRICT;",
+                &mut migration,
+                None,
+            )
+            .unwrap();
+        migration.publish_ready().unwrap();
+        let declaration = TableDeclaration::sharded(
+            storage.logical_catalog().default_database().id(),
+            "events",
+            crate::core::ShardKeyMetadata::new("id", ShardKeyType::Int64).unwrap(),
+        )
+        .unwrap()
+        .with_generated_id_policy(crate::core::GeneratedIdPolicy::hilo_v1("id").unwrap())
+        .unwrap();
+        storage.register_tables(vec![declaration]).unwrap();
+        storage
+    }
+
+    fn hilo_events_table_id(storage: &Storage) -> TableId {
+        storage
+            .logical_catalog()
+            .table("default", "events")
+            .unwrap()
+            .unwrap()
+            .id()
     }
 
     #[test]
@@ -4995,6 +5090,175 @@ mod tests {
             reopened.register_tables(declarations).unwrap();
             assert_eq!(reopened.catalog().tables().len(), 2);
         }
+    }
+
+    #[test]
+    fn hilo_lease_process_child() {
+        let Ok(root) = std::env::var("BRISKDB_HILO_PROCESS_ROOT") else {
+            return;
+        };
+        let storage = Storage::open(root, 2).unwrap();
+        let table_id = hilo_events_table_id(&storage);
+        if let Ok(ready) = std::env::var("BRISKDB_HILO_PROCESS_READY") {
+            fs::write(&ready, b"ready").unwrap();
+            let go = PathBuf::from(std::env::var("BRISKDB_HILO_PROCESS_GO").unwrap());
+            let deadline = Instant::now() + std::time::Duration::from_secs(10);
+            while !go.exists() && Instant::now() < deadline {
+                thread::sleep(std::time::Duration::from_millis(5));
+            }
+            assert!(go.exists(), "parent did not release hilo_v1 child");
+        }
+        let allocation = storage.allocate_hilo_v1(table_id).unwrap();
+        if let Ok(output) = std::env::var("BRISKDB_HILO_PROCESS_OUTPUT") {
+            fs::write(output, allocation.id().to_string()).unwrap();
+        }
+    }
+
+    #[test]
+    fn hilo_restart_burns_the_unconsumed_tail_of_the_committed_block() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = create_registered_hilo_storage(temp.path(), 2);
+        let table_id = hilo_events_table_id(&storage);
+        let first = storage.allocate_hilo_v1(table_id).unwrap().id();
+        assert_eq!(
+            crate::core::generated_id::HiloV1Id::decode(first)
+                .unwrap()
+                .sequence(),
+            1
+        );
+        drop(storage);
+
+        let reopened = Storage::open(temp.path(), 2).unwrap();
+        let next = reopened.allocate_hilo_v1(table_id).unwrap().id();
+        assert_eq!(
+            crate::core::generated_id::HiloV1Id::decode(next)
+                .unwrap()
+                .sequence(),
+            manifest::HILO_V1_BLOCK_SIZE + 1
+        );
+    }
+
+    #[test]
+    fn hilo_allocator_reserves_manifest_state_once_per_block() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = create_registered_hilo_storage(temp.path(), 4);
+        let table_id = hilo_events_table_id(&storage);
+
+        for expected_sequence in 1..=manifest::HILO_V1_BLOCK_SIZE + 1 {
+            let allocation = storage.allocate_hilo_v1(table_id).unwrap();
+            assert_eq!(
+                crate::core::generated_id::HiloV1Id::decode(allocation.id())
+                    .unwrap()
+                    .sequence(),
+                expected_sequence
+            );
+        }
+
+        let connection = Connection::open(temp.path().join("manifest.sqlite")).unwrap();
+        let (next_sequence, fence_token) = connection
+            .query_row(
+                "SELECT next_sequence, fence_token
+                 FROM briskdb_hilo_leases
+                 WHERE table_id = ?1",
+                [i64::try_from(table_id.get()).unwrap()],
+                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            next_sequence,
+            i64::try_from(manifest::HILO_V1_BLOCK_SIZE * 2 + 1).unwrap()
+        );
+        assert_eq!(fence_token, 2);
+    }
+
+    #[test]
+    fn real_process_abort_before_or_after_hilo_lease_commit_never_reuses_a_block() {
+        for (boundary, expected_sequence) in [
+            ("before-commit", 1),
+            ("after-commit", manifest::HILO_V1_BLOCK_SIZE + 1),
+        ] {
+            let temp = tempfile::tempdir().unwrap();
+            drop(create_registered_hilo_storage(temp.path(), 2));
+            let status = Command::new(std::env::current_exe().unwrap())
+                .arg("--exact")
+                .arg("storage::tests::hilo_lease_process_child")
+                .arg("--nocapture")
+                .env("BRISKDB_HILO_PROCESS_ROOT", temp.path())
+                .env("BRISKDB_HILO_LEASE_ABORT_POINT", boundary)
+                .status()
+                .unwrap();
+            assert!(!status.success(), "child did not abort at {boundary}");
+
+            let storage = Storage::open(temp.path(), 2).unwrap();
+            let allocation = storage
+                .allocate_hilo_v1(hilo_events_table_id(&storage))
+                .unwrap();
+            assert_eq!(
+                crate::core::generated_id::HiloV1Id::decode(allocation.id())
+                    .unwrap()
+                    .sequence(),
+                expected_sequence,
+                "{boundary}"
+            );
+        }
+    }
+
+    #[test]
+    fn competing_processes_receive_disjoint_hilo_blocks() {
+        let temp = tempfile::tempdir().unwrap();
+        drop(create_registered_hilo_storage(temp.path(), 2));
+        let go = temp.path().join("go");
+        let mut children = Vec::new();
+        let mut ready_paths = Vec::new();
+        let mut output_paths = Vec::new();
+        for index in 0..2 {
+            let ready = temp.path().join(format!("ready-{index}"));
+            let output = temp.path().join(format!("allocation-{index}"));
+            let child = Command::new(std::env::current_exe().unwrap())
+                .arg("--exact")
+                .arg("storage::tests::hilo_lease_process_child")
+                .arg("--nocapture")
+                .env("BRISKDB_HILO_PROCESS_ROOT", temp.path())
+                .env("BRISKDB_HILO_PROCESS_READY", &ready)
+                .env("BRISKDB_HILO_PROCESS_GO", &go)
+                .env("BRISKDB_HILO_PROCESS_OUTPUT", &output)
+                .spawn()
+                .unwrap();
+            children.push(child);
+            ready_paths.push(ready);
+            output_paths.push(output);
+        }
+        let deadline = Instant::now() + std::time::Duration::from_secs(10);
+        while ready_paths.iter().any(|path| !path.exists()) && Instant::now() < deadline {
+            thread::sleep(std::time::Duration::from_millis(5));
+        }
+        assert!(ready_paths.iter().all(|path| path.exists()));
+        fs::write(&go, b"go").unwrap();
+        for mut child in children {
+            assert!(child.wait().unwrap().success());
+        }
+        let mut sequences = output_paths
+            .iter()
+            .map(|path| {
+                let id = fs::read_to_string(path).unwrap().parse::<i64>().unwrap();
+                crate::core::generated_id::HiloV1Id::decode(id)
+                    .unwrap()
+                    .sequence()
+            })
+            .collect::<Vec<_>>();
+        sequences.sort_unstable();
+        assert_eq!(sequences, [1, manifest::HILO_V1_BLOCK_SIZE + 1]);
+
+        let storage = Storage::open(temp.path(), 2).unwrap();
+        let next = storage
+            .allocate_hilo_v1(hilo_events_table_id(&storage))
+            .unwrap();
+        assert_eq!(
+            crate::core::generated_id::HiloV1Id::decode(next.id())
+                .unwrap()
+                .sequence(),
+            manifest::HILO_V1_BLOCK_SIZE * 2 + 1
+        );
     }
 
     #[test]

--- a/src/storage/pool.rs
+++ b/src/storage/pool.rs
@@ -940,6 +940,15 @@ fn configure_connection_controlled(
             barrier.wait(_control);
         }
 
+        // A cancellation that released a blocked setup hook must win before
+        // strict storage validation starts. Otherwise SQLite's interrupted
+        // schema reads can be classified as corruption and unnecessarily
+        // degrade a healthy root before the outer controlled wrapper replaces
+        // the error with the accepted cancellation reason.
+        if let Some(reason) = _control.reason() {
+            return Err(reason.error());
+        }
+
         // Do not call the ordinary configuration wrapper here: its fixed
         // busy timeout would replace the cancellable handler before these
         // pragmas can encounter a SQLite lock.

--- a/src/storage/shard.rs
+++ b/src/storage/shard.rs
@@ -675,7 +675,10 @@ pub(super) fn preflight_schema_migration_on_connection_with_digest_and_catalog_s
         sql,
         Some((
             catalog.logical(),
-            Some(catalog.active_native_id_table_ids()),
+            Some((
+                catalog.active_native_id_table_ids(),
+                catalog.active_hilo_id_table_ids(),
+            )),
         )),
     )
 }
@@ -689,7 +692,7 @@ fn preflight_schema_migration_on_connection_with_digest_inner(
     target_generation: u64,
     layout: &ShardLayout,
     sql: &str,
-    catalog: Option<(&Catalog, Option<&[TableId]>)>,
+    catalog: Option<SchemaCatalogValidation<'_>>,
 ) -> EngineResult<(SchemaMigrationShardState, SchemaDigest)> {
     if catalog.is_some_and(|(catalog, _)| !catalog.tables().is_empty()) {
         crate::sql::validate_authoritative_schema_migration(sql)?;
@@ -767,6 +770,9 @@ fn preflight_schema_migration_on_connection_with_digest_inner(
     Ok((state, target_digest))
 }
 
+type ActiveGeneratedIdTableIds<'a> = (&'a [TableId], &'a [TableId]);
+type SchemaCatalogValidation<'a> = (&'a Catalog, Option<ActiveGeneratedIdTableIds<'a>>);
+
 /// Verify that one physical shard still implements the complete authoritative
 /// logical table catalog after a tentative schema migration.
 ///
@@ -784,18 +790,23 @@ pub(super) fn validate_registered_table_schema(
     validate_registered_table_schema_inner(connection, catalog, None)
 }
 
-pub(super) fn validate_registered_table_schema_with_active_native_ids(
+pub(super) fn validate_registered_table_schema_with_active_generated_ids(
     connection: &Connection,
     catalog: &Catalog,
     active_native_id_table_ids: &[TableId],
+    active_hilo_id_table_ids: &[TableId],
 ) -> EngineResult<()> {
-    validate_registered_table_schema_inner(connection, catalog, Some(active_native_id_table_ids))
+    validate_registered_table_schema_inner(
+        connection,
+        catalog,
+        Some((active_native_id_table_ids, active_hilo_id_table_ids)),
+    )
 }
 
 fn validate_registered_table_schema_inner(
     connection: &Connection,
     catalog: &Catalog,
-    active_native_id_table_ids: Option<&[TableId]>,
+    active_generated_id_table_ids: Option<(&[TableId], &[TableId])>,
 ) -> EngineResult<()> {
     if catalog.tables().is_empty() {
         return Ok(());
@@ -963,17 +974,34 @@ fn validate_registered_table_schema_inner(
                 "has an incompatible SQLite declared type",
             ));
         }
-        let native_policy_is_active =
-            active_native_id_table_ids.is_none_or(|ids| ids.binary_search(&table.id()).is_ok());
-        if native_policy_is_active {
-            if let GeneratedIdPolicy::NativeRangeV1 { column } = table.generated_id_policy() {
-                if !native_generated_column_is_exact(connection, table.name(), column)? {
+        let generated_policy_is_active = match table.generated_id_policy() {
+            GeneratedIdPolicy::NativeRangeV1 { .. } => active_generated_id_table_ids
+                .is_none_or(|(ids, _)| ids.binary_search(&table.id()).is_ok()),
+            GeneratedIdPolicy::HiloV1 { .. } => active_generated_id_table_ids
+                .is_none_or(|(_, ids)| ids.binary_search(&table.id()).is_ok()),
+            GeneratedIdPolicy::None => false,
+        };
+        if generated_policy_is_active {
+            match table.generated_id_policy() {
+                GeneratedIdPolicy::NativeRangeV1 { column }
+                    if !native_generated_column_is_exact(connection, table.name(), column)? =>
+                {
                     return Err(registered_shard_key_error(
                         table.name(),
                         column,
                         "must remain exactly INTEGER PRIMARY KEY AUTOINCREMENT",
                     ));
                 }
+                GeneratedIdPolicy::HiloV1 { column }
+                    if !hilo_generated_column_is_exact(connection, table.name(), column)? =>
+                {
+                    return Err(registered_shard_key_error(
+                        table.name(),
+                        column,
+                        "must remain exactly INTEGER PRIMARY KEY without AUTOINCREMENT",
+                    ));
+                }
+                _ => {}
             }
         }
         if matches!(shard_key.key_type(), ShardKeyType::Text)
@@ -1631,6 +1659,12 @@ fn generated_id_routing_domains_match(
     matches!(
         (child, parent),
         (GeneratedIdPolicy::None, GeneratedIdPolicy::None)
+            | (GeneratedIdPolicy::None, GeneratedIdPolicy::HiloV1 { .. })
+            | (GeneratedIdPolicy::HiloV1 { .. }, GeneratedIdPolicy::None)
+            | (
+                GeneratedIdPolicy::HiloV1 { .. },
+                GeneratedIdPolicy::HiloV1 { .. }
+            )
             | (
                 GeneratedIdPolicy::NativeRangeV1 { .. },
                 GeneratedIdPolicy::NativeRangeV1 { .. }
@@ -1853,6 +1887,33 @@ pub(super) fn native_generated_column_is_exact(
             .is_some_and(|declared_type| declared_type.to_bytes().eq_ignore_ascii_case(b"INTEGER"))
         && primary_key
         && auto_increment)
+}
+
+pub(super) fn hilo_generated_column_is_exact(
+    connection: &Connection,
+    table: &str,
+    column: &str,
+) -> EngineResult<bool> {
+    let (declared_type, _, _, primary_key, auto_increment) = connection
+        .column_metadata(Some("main"), table, column)
+        .map_err(sqlite_error::storage)?;
+    let exact_shape = connection
+        .query_row(
+            "SELECT COUNT(*) = 1
+                    AND COALESCE(MAX(dflt_value IS NULL), 0) = 1
+                    AND COALESCE(MAX(pk), 0) = 1
+                    AND COALESCE(MAX(hidden), 1) = 0
+             FROM pragma_table_xinfo(?1)
+             WHERE name = ?2 COLLATE BINARY",
+            (table, column),
+            |row| row.get::<_, bool>(0),
+        )
+        .map_err(sqlite_error::storage)?;
+    Ok(exact_shape
+        && declared_type
+            .is_some_and(|declared_type| declared_type.to_bytes().eq_ignore_ascii_case(b"INTEGER"))
+        && primary_key
+        && !auto_increment)
 }
 
 fn registered_shard_key_is_non_null(
@@ -4047,6 +4108,83 @@ mod tests {
         let error = validate_registered_table_schema(&unsafe_catalog_parent, &catalog).unwrap_err();
         assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
         assert!(error.diagnostic().contains("catalog-only table"));
+    }
+
+    #[test]
+    fn hilo_and_plain_int64_shard_keys_share_a_foreign_key_routing_domain() {
+        let connection = Connection::open_in_memory().unwrap();
+        connection
+            .pragma_update(None, "foreign_keys", "ON")
+            .unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE hilo_parents (
+                     id INTEGER PRIMARY KEY,
+                     payload TEXT NOT NULL
+                 ) STRICT;
+                 CREATE TABLE plain_children (
+                     parent_id INTEGER PRIMARY KEY
+                         REFERENCES hilo_parents(id),
+                     payload TEXT NOT NULL
+                 ) STRICT;",
+            )
+            .unwrap();
+        let database = crate::core::LogicalDatabaseId::new(1).unwrap();
+        let parent = TableDeclaration::sharded(
+            database,
+            "hilo_parents",
+            ShardKeyMetadata::new("id", ShardKeyType::Int64).unwrap(),
+        )
+        .unwrap()
+        .with_generated_id_policy(GeneratedIdPolicy::hilo_v1("id").unwrap())
+        .unwrap();
+        let child = TableDeclaration::sharded(
+            database,
+            "plain_children",
+            ShardKeyMetadata::new("parent_id", ShardKeyType::Int64).unwrap(),
+        )
+        .unwrap();
+        let declarations = [parent.clone(), child.clone()];
+
+        validate_declared_table_constraints(&connection, &parent, &declarations).unwrap();
+        validate_declared_table_constraints(&connection, &child, &declarations).unwrap();
+
+        let generated = crate::core::generated_id::HiloV1Id::new(1)
+            .unwrap()
+            .encode();
+        connection
+            .execute(
+                "INSERT INTO hilo_parents (id, payload) VALUES (?1, 'parent')",
+                [generated],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO plain_children (parent_id, payload) VALUES (?1, 'child')",
+                [generated],
+            )
+            .unwrap();
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT COUNT(*)
+                     FROM plain_children AS child
+                     JOIN hilo_parents AS parent ON parent.id = child.parent_id",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            1
+        );
+
+        assert!(generated_id_routing_domains_match(
+            &GeneratedIdPolicy::None,
+            parent.generated_id_policy()
+        ));
+        assert!(!generated_id_routing_domains_match(
+            &GeneratedIdPolicy::native_range_v1("parent_id").unwrap(),
+            parent.generated_id_policy()
+        ));
     }
 
     #[test]

--- a/src/storage/sharded_vtab.rs
+++ b/src/storage/sharded_vtab.rs
@@ -29,7 +29,9 @@ use rusqlite::{
 
 use super::{SchemaOperationGuard, SqliteAffinity, Storage, quote_identifier, sqlite_affinity};
 use crate::{
-    core::generated_id::{GeneratedIdClassification, classify_generated_id},
+    core::generated_id::{
+        GeneratedIdClassification, classify_caller_generated_id, classify_generated_id,
+    },
     core::{
         AllocationOwnerMap, CanonicalShardKeyRef, EngineError, EngineErrorKind, EngineResult,
         GeneratedIdPolicy, OperationControl, ShardKeyType, TableMetadata, TablePlacement,
@@ -764,7 +766,7 @@ impl Registry {
             let spec = TableSpec::from_physical_table(
                 shard,
                 table,
-                storage.native_id_policy_is_active(table.id()),
+                storage.generated_id_policy_is_active(table.id()),
                 allocation_owners.cloned(),
                 targets.into_boxed_slice(),
             )?;
@@ -854,6 +856,9 @@ impl Registry {
                             .physical_shard(id.owner())
                             .map_or(EqualityTargets::Empty, EqualityTargets::One));
                     }
+                    GeneratedIdClassification::HiloV1(id) => Some(self.storage.shard_for_key(
+                        &canonical_shard_key_bytes(CanonicalShardKeyRef::Int64(id.encode())),
+                    )),
                 }
             }
             (ShardKeyType::Text, ValueRef::Text(value)) => {
@@ -892,7 +897,7 @@ impl Registry {
                 ));
             }
             (ShardKeyType::Int64, ValueRef::Integer(value)) => {
-                match classify_generated_id(&spec.generated_id_policy, value)? {
+                match classify_caller_generated_id(&spec.generated_id_policy, value)? {
                     GeneratedIdClassification::Legacy(value) => self.storage.shard_for_key(
                         &canonical_shard_key_bytes(CanonicalShardKeyRef::Int64(value)),
                     ),
@@ -918,6 +923,9 @@ impl Registry {
                                 ),
                             )
                         })?,
+                    GeneratedIdClassification::HiloV1(id) => self.storage.shard_for_key(
+                        &canonical_shard_key_bytes(CanonicalShardKeyRef::Int64(id.encode())),
+                    ),
                 }
             }
             (ShardKeyType::Text, ValueRef::Text(value)) => {
@@ -970,15 +978,32 @@ impl Registry {
         Ok(target)
     }
 
-    /// Resolve an explicit INSERT target while preventing new rows from being
-    /// introduced into a retired native-ID namespace. Historical IDs remain
-    /// routable through `write_target` for delete/update lookup semantics.
-    fn insert_target(&self, spec: &TableSpec, value: ValueRef<'_>) -> EngineResult<u16> {
+    /// Resolve a caller-supplied key for INSERT or a key-changing UPDATE while
+    /// preventing new rows from being introduced into allocator-owned or
+    /// retired namespaces. Historical IDs remain routable through
+    /// `write_target` for lookup and unchanged-key mutation semantics.
+    fn caller_new_key_target(&self, spec: &TableSpec, value: ValueRef<'_>) -> EngineResult<u16> {
+        if let (GeneratedIdPolicy::HiloV1 { .. }, ValueRef::Integer(value)) =
+            (&spec.generated_id_policy, value)
+        {
+            if matches!(
+                classify_caller_generated_id(&spec.generated_id_policy, value)?,
+                GeneratedIdClassification::HiloV1(_)
+            ) {
+                return Err(EngineError::new(
+                    EngineErrorKind::FailedPrecondition,
+                    format!(
+                        "hilo_v1 ID for {} is allocator-owned and cannot be supplied explicitly",
+                        spec.name
+                    ),
+                ));
+            }
+        }
         if let (GeneratedIdPolicy::NativeRangeV1 { .. }, ValueRef::Integer(value)) =
             (&spec.generated_id_policy, value)
         {
             if let GeneratedIdClassification::NativeRangeV1(id) =
-                classify_generated_id(&spec.generated_id_policy, value)?
+                classify_caller_generated_id(&spec.generated_id_policy, value)?
             {
                 if let Some(owners) = spec.allocation_owners.as_ref() {
                     if owners.physical_shard(id.owner()).is_some()
@@ -1238,7 +1263,7 @@ struct TableSpec {
     targets: Box<[u16]>,
     shard_key: Option<ShardKeySpec>,
     generated_id_policy: GeneratedIdPolicy,
-    native_id_policy_active: bool,
+    generated_id_policy_active: bool,
     allocation_owners: Option<Arc<AllocationOwnerMap>>,
     generated_shard_cursor: AtomicU64,
 }
@@ -1293,7 +1318,7 @@ impl TableSpec {
     fn from_physical_table(
         connection: &Connection,
         table: &TableMetadata,
-        native_id_policy_active: bool,
+        generated_id_policy_active: bool,
         allocation_owners: Option<Arc<AllocationOwnerMap>>,
         targets: Box<[u16]>,
     ) -> EngineResult<Self> {
@@ -1573,7 +1598,7 @@ impl TableSpec {
             targets,
             shard_key,
             generated_id_policy: table.generated_id_policy().clone(),
-            native_id_policy_active,
+            generated_id_policy_active,
             allocation_owners,
             generated_shard_cursor: AtomicU64::new(0),
         })
@@ -1729,6 +1754,84 @@ impl TableSpec {
             )
         };
         Ok((insert, parameters, generated_column.to_owned()))
+    }
+
+    fn hilo_insert_sql_and_values(
+        &self,
+        values: &[ValueRef<'_>],
+        conflict: ConflictMode,
+        generated_id: i64,
+    ) -> EngineResult<(String, Vec<RawCell>, String)> {
+        self.ensure_writable()?;
+        if values.len() != self.column_count {
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                format!(
+                    "brisk_shard received an invalid hilo_v1 INSERT shape for {}",
+                    self.name
+                ),
+            ));
+        }
+        let GeneratedIdPolicy::HiloV1 {
+            column: generated_column,
+        } = &self.generated_id_policy
+        else {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!("registered table {} does not use hilo_v1", self.name),
+            ));
+        };
+        let generated_index = self
+            .columns
+            .iter()
+            .position(|column| column.name == *generated_column)
+            .ok_or_else(|| {
+                EngineError::new(
+                    EngineErrorKind::DataCorruption,
+                    format!(
+                        "registered generated column {}.{} is absent from the physical schema",
+                        self.name, generated_column
+                    ),
+                )
+            })?;
+        if !matches!(values[generated_index], ValueRef::Null) {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "hilo_v1 INSERT for {} unexpectedly supplied an explicit {} value",
+                    self.name, generated_column
+                ),
+            ));
+        }
+
+        let columns = self
+            .columns
+            .iter()
+            .map(|column| quote_identifier(&column.name))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let mut parameters = Vec::with_capacity(self.column_count);
+        for (index, value) in values.iter().enumerate() {
+            parameters.push(if index == generated_index {
+                RawCell::Integer(generated_id)
+            } else {
+                RawCell::try_copy_from(*value)?
+            });
+        }
+        let placeholders = (1..=parameters.len())
+            .map(|position| format!("?{position}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        Ok((
+            format!(
+                "INSERT{} INTO main.{} ({columns}) VALUES ({placeholders}) RETURNING {}",
+                write_conflict_clause(conflict),
+                quote_identifier(&self.name),
+                quote_identifier(generated_column),
+            ),
+            parameters,
+            generated_column.to_owned(),
+        ))
     }
 
     fn delete_sql(&self) -> EngineResult<String> {
@@ -2882,6 +2985,71 @@ mod tests {
         text_keys: Vec<String>,
         blob_keys: Vec<Vec<u8>>,
         native_ids: Vec<i64>,
+    }
+
+    struct HiloFixture {
+        _temp: tempfile::TempDir,
+        storage: Storage,
+        table_id: u64,
+    }
+
+    impl HiloFixture {
+        fn new(shard_count: u16) -> Self {
+            let temp = tempfile::tempdir().unwrap();
+            let mut storage = Storage::open(temp.path(), shard_count).unwrap();
+            let mut migration = storage.begin_schema_migration().unwrap();
+            migration.wait_for_quiescence_blocking();
+            storage
+                .apply_schema_migration(
+                    "CREATE TABLE hilo_events (
+                         id INTEGER PRIMARY KEY,
+                         payload TEXT NOT NULL CHECK (payload <> 'reject')
+                     ) STRICT;",
+                    &mut migration,
+                    None,
+                )
+                .unwrap();
+            migration.publish_ready().unwrap();
+            let database_id = storage.logical_catalog().default_database().id();
+            storage
+                .register_tables(vec![
+                    TableDeclaration::sharded(
+                        database_id,
+                        "hilo_events",
+                        ShardKeyMetadata::new("id", ShardKeyType::Int64).unwrap(),
+                    )
+                    .unwrap()
+                    .with_generated_id_policy(GeneratedIdPolicy::hilo_v1("id").unwrap())
+                    .unwrap(),
+                ])
+                .unwrap();
+            let table_id = storage
+                .logical_catalog()
+                .table("default", "hilo_events")
+                .unwrap()
+                .unwrap()
+                .id()
+                .get();
+            Self {
+                _temp: temp,
+                storage,
+                table_id,
+            }
+        }
+
+        fn row_count(&self) -> i64 {
+            (0..self.storage.shard_count())
+                .map(|shard| {
+                    self.storage
+                        .open_shard(shard)
+                        .unwrap()
+                        .query_row("SELECT COUNT(*) FROM hilo_events", [], |row| {
+                            row.get::<_, i64>(0)
+                        })
+                        .unwrap()
+                })
+                .sum()
+        }
     }
 
     struct ScaleFixture {
@@ -4461,7 +4629,10 @@ mod tests {
             Ok(_) => panic!("shadow coordinator schema must be rejected"),
             Err(error) => error,
         };
-        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert!(matches!(
+            error.kind(),
+            EngineErrorKind::InvalidQuery | EngineErrorKind::FailedPrecondition
+        ));
         let connection = Connection::open(&path).unwrap();
         let objects = connection
             .prepare(
@@ -6024,6 +6195,361 @@ mod tests {
             assert_eq!(owners.physical_shard(decoded.owner()), Some(expected_shard));
             assert!(owners.owner_is_active(decoded.owner()));
         }
+    }
+
+    #[test]
+    fn writable_hilo_generation_leases_once_and_hash_routes_each_id() {
+        let fixture = HiloFixture::new(4);
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+        let mut generated = Vec::new();
+        for index in 0..10 {
+            let result = coordinator
+                .execute_generated_dml_auto(
+                    "INSERT INTO hilo_events (payload) VALUES (?1)",
+                    [format!("hilo-{index}")],
+                    fixture.table_id,
+                )
+                .unwrap();
+            let id = match &result.generated_key().unwrap().value {
+                Value::Int64(id) => *id,
+                value => panic!("unexpected generated value: {value:?}"),
+            };
+            assert_eq!(
+                result.shard(),
+                Some(
+                    fixture
+                        .storage
+                        .shard_for_key(&canonical_shard_key_bytes(CanonicalShardKeyRef::Int64(id)))
+                )
+            );
+            assert_eq!(
+                crate::core::generated_id::HiloV1Id::decode(id)
+                    .unwrap()
+                    .sequence(),
+                u64::try_from(index + 1).unwrap()
+            );
+            generated.push(id);
+        }
+        generated.sort_unstable();
+        generated.dedup();
+        assert_eq!(generated.len(), 10);
+        assert_eq!(fixture.row_count(), 10);
+
+        let manifest = Connection::open(fixture.storage.root.join("manifest.sqlite")).unwrap();
+        let (next, fence): (i64, i64) = manifest
+            .query_row(
+                "SELECT next_sequence, fence_token FROM briskdb_hilo_leases WHERE table_id = ?1",
+                [i64::try_from(fixture.table_id).unwrap()],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(next, 4_097);
+        assert_eq!(fence, 1);
+    }
+
+    #[test]
+    fn hilo_generated_write_process_child() {
+        let Ok(root) = std::env::var("BRISKDB_HILO_WRITE_PROCESS_ROOT") else {
+            return;
+        };
+        let storage = Storage::open(root, 4).unwrap();
+        let table_id = storage
+            .logical_catalog()
+            .table("default", "hilo_events")
+            .unwrap()
+            .unwrap()
+            .id()
+            .get();
+        let ready =
+            std::path::PathBuf::from(std::env::var("BRISKDB_HILO_WRITE_PROCESS_READY").unwrap());
+        let go = std::path::PathBuf::from(std::env::var("BRISKDB_HILO_WRITE_PROCESS_GO").unwrap());
+        std::fs::write(&ready, b"ready").unwrap();
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !go.exists() && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(5));
+        }
+        assert!(go.exists(), "parent did not release hilo_v1 write child");
+
+        let mut coordinator = WriteCoordinator::open(storage).unwrap();
+        let payload = format!("process-{}", std::process::id());
+        let result = coordinator
+            .execute_generated_dml_auto(
+                "INSERT INTO hilo_events (payload) VALUES (?1)",
+                [payload],
+                table_id,
+            )
+            .unwrap();
+        let id = match &result.generated_key().unwrap().value {
+            Value::Int64(value) => *value,
+            value => panic!("unexpected generated value: {value:?}"),
+        };
+        std::fs::write(
+            std::env::var("BRISKDB_HILO_WRITE_PROCESS_OUTPUT").unwrap(),
+            format!("{id},{}", result.shard().unwrap()),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn competing_processes_insert_unique_hilo_ids_on_their_hash_routed_shards() {
+        let fixture = HiloFixture::new(4);
+        let go = fixture._temp.path().join("hilo-write-go");
+        let mut children = Vec::new();
+        let mut ready_paths = Vec::new();
+        let mut output_paths = Vec::new();
+        for index in 0..3 {
+            let ready = fixture
+                ._temp
+                .path()
+                .join(format!("hilo-write-ready-{index}"));
+            let output = fixture
+                ._temp
+                .path()
+                .join(format!("hilo-write-output-{index}"));
+            let child = std::process::Command::new(std::env::current_exe().unwrap())
+                .arg("--exact")
+                .arg("storage::sharded_vtab::tests::hilo_generated_write_process_child")
+                .arg("--nocapture")
+                .env("BRISKDB_HILO_WRITE_PROCESS_ROOT", fixture._temp.path())
+                .env("BRISKDB_HILO_WRITE_PROCESS_READY", &ready)
+                .env("BRISKDB_HILO_WRITE_PROCESS_GO", &go)
+                .env("BRISKDB_HILO_WRITE_PROCESS_OUTPUT", &output)
+                .spawn()
+                .unwrap();
+            children.push(child);
+            ready_paths.push(ready);
+            output_paths.push(output);
+        }
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while ready_paths.iter().any(|path| !path.exists()) && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(5));
+        }
+        assert!(ready_paths.iter().all(|path| path.exists()));
+        std::fs::write(&go, b"go").unwrap();
+        for mut child in children {
+            assert!(child.wait().unwrap().success());
+        }
+
+        let allocations = output_paths
+            .iter()
+            .map(|path| {
+                let output = std::fs::read_to_string(path).unwrap();
+                let (id, shard) = output.split_once(',').unwrap();
+                (id.parse::<i64>().unwrap(), shard.parse::<u16>().unwrap())
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            allocations
+                .iter()
+                .map(|(id, _)| *id)
+                .collect::<BTreeSet<_>>()
+                .len(),
+            allocations.len()
+        );
+        for (id, shard) in allocations {
+            assert_eq!(
+                shard,
+                fixture
+                    .storage
+                    .shard_for_key(&canonical_shard_key_bytes(CanonicalShardKeyRef::Int64(id)))
+            );
+            for candidate in 0..4 {
+                assert_eq!(
+                    fixture
+                        .storage
+                        .open_shard(candidate)
+                        .unwrap()
+                        .query_row(
+                            "SELECT COUNT(*) FROM hilo_events WHERE id = ?1",
+                            [id],
+                            |row| row.get::<_, i64>(0),
+                        )
+                        .unwrap(),
+                    i64::from(candidate == shard)
+                );
+            }
+        }
+        assert_eq!(fixture.row_count(), 3);
+    }
+
+    #[test]
+    fn writable_hilo_constraint_rollback_and_ignore_burn_ids_without_reuse() {
+        let fixture = HiloFixture::new(2);
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+        let first = coordinator
+            .execute_generated_dml_auto(
+                "INSERT INTO hilo_events (payload) VALUES ('first')",
+                [],
+                fixture.table_id,
+            )
+            .unwrap();
+        let first = match &first.generated_key().unwrap().value {
+            Value::Int64(value) => *value,
+            value => panic!("unexpected generated value: {value:?}"),
+        };
+
+        let ignored = coordinator
+            .execute_generated_dml_auto(
+                "INSERT OR IGNORE INTO hilo_events (payload) VALUES ('reject')",
+                [],
+                fixture.table_id,
+            )
+            .unwrap();
+        assert_eq!(ignored.affected_rows(), 0);
+        assert_eq!(ignored.generated_key(), None);
+
+        let error = coordinator
+            .execute_generated_dml_auto(
+                "INSERT INTO hilo_events (payload) VALUES ('reject')",
+                [],
+                fixture.table_id,
+            )
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::CheckViolation);
+
+        let next = coordinator
+            .execute_generated_dml_auto(
+                "INSERT INTO hilo_events (payload) VALUES ('next')",
+                [],
+                fixture.table_id,
+            )
+            .unwrap();
+        let next = match &next.generated_key().unwrap().value {
+            Value::Int64(value) => *value,
+            value => panic!("unexpected generated value: {value:?}"),
+        };
+        let first_sequence = crate::core::generated_id::HiloV1Id::decode(first)
+            .unwrap()
+            .sequence();
+        let next_sequence = crate::core::generated_id::HiloV1Id::decode(next)
+            .unwrap()
+            .sequence();
+        assert_eq!(next_sequence, first_sequence + 3);
+        assert_eq!(fixture.row_count(), 2);
+    }
+
+    #[test]
+    fn writable_hilo_cancellation_after_allocation_burns_the_id_without_reuse() {
+        let fixture = HiloFixture::new(2);
+        let coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+        let cancellation = coordinator.cancellation_handle();
+        let mut gate = coordinator.install_generated_target_gate_for_test();
+        let table_id = fixture.table_id;
+        let worker = thread::spawn(move || {
+            let mut coordinator = coordinator;
+            let result = coordinator.execute_generated_dml_auto(
+                "INSERT INTO hilo_events (payload) VALUES ('cancelled')",
+                [],
+                table_id,
+            );
+            (coordinator, result)
+        });
+
+        gate.wait_until_started();
+        cancellation.cancel();
+        gate.release();
+
+        let (mut coordinator, result) = worker.join().unwrap();
+        assert_eq!(result.unwrap_err().kind(), EngineErrorKind::Cancelled);
+        assert_eq!(fixture.row_count(), 0);
+
+        let after = coordinator
+            .execute_generated_dml_auto(
+                "INSERT INTO hilo_events (payload) VALUES ('after-cancel')",
+                [],
+                fixture.table_id,
+            )
+            .unwrap();
+        let generated = match &after.generated_key().unwrap().value {
+            Value::Int64(value) => *value,
+            value => panic!("unexpected generated value: {value:?}"),
+        };
+        assert_eq!(
+            crate::core::generated_id::HiloV1Id::decode(generated)
+                .unwrap()
+                .sequence(),
+            2
+        );
+        assert_eq!(fixture.row_count(), 1);
+    }
+
+    #[test]
+    fn writable_hilo_rejects_multirow_and_explicit_allocator_ids_without_mutation() {
+        let fixture = HiloFixture::new(2);
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+        let error = coordinator
+            .execute_generated_dml_auto(
+                "INSERT INTO hilo_events (payload) VALUES ('one'), ('two')",
+                [],
+                fixture.table_id,
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error.kind(),
+            EngineErrorKind::InvalidQuery | EngineErrorKind::Unsupported
+        ));
+        assert_eq!(fixture.row_count(), 0);
+        drop(coordinator);
+
+        let explicit = crate::core::generated_id::HiloV1Id::new(99)
+            .unwrap()
+            .encode();
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+        let error = coordinator
+            .execute_dml(
+                "INSERT INTO hilo_events VALUES (?1, 'explicit')",
+                [explicit],
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error.kind(),
+            EngineErrorKind::InvalidQuery | EngineErrorKind::FailedPrecondition
+        ));
+        assert_eq!(fixture.row_count(), 0);
+    }
+
+    #[test]
+    fn writable_hilo_rejects_caller_namespaces_without_degrading_storage() {
+        let fixture = HiloFixture::new(2);
+        let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+        coordinator
+            .execute_dml("INSERT INTO hilo_events VALUES (1, 'legacy')", [])
+            .unwrap();
+        drop(coordinator);
+
+        for malformed in [
+            crate::core::generated_id::HiloV1Id::new(99)
+                .unwrap()
+                .encode(),
+            crate::core::generated_id::HILO_V1_FORMAT_MARKER as i64,
+            crate::core::generated_id::NATIVE_RANGE_V1_FORMAT_MARKER as i64,
+            i64::MAX,
+        ] {
+            let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+            let error = coordinator
+                .execute_dml(
+                    "INSERT INTO hilo_events VALUES (?1, 'malformed')",
+                    [malformed],
+                )
+                .unwrap_err();
+            assert_ne!(error.kind(), EngineErrorKind::DataCorruption);
+            drop(coordinator);
+
+            let mut coordinator = WriteCoordinator::open(fixture.storage.clone()).unwrap();
+            let error = coordinator
+                .execute_dml("UPDATE hilo_events SET id = ?1 WHERE id = 1", [malformed])
+                .unwrap_err();
+            assert_ne!(error.kind(), EngineErrorKind::DataCorruption);
+        }
+
+        assert_eq!(fixture.row_count(), 1);
+        let reopened = Storage::open(&fixture.storage.root, 2).unwrap();
+        assert!(
+            reopened.generated_id_policy_is_active(
+                crate::core::TableId::new(fixture.table_id).unwrap()
+            )
+        );
     }
 
     #[test]

--- a/src/storage/sharded_vtab/benchmarks.rs
+++ b/src/storage/sharded_vtab/benchmarks.rs
@@ -7,19 +7,28 @@
 //!   storage::sharded_vtab::benchmarks::release_benchmark_matrix_reports_issue_126_comparison \
 //!   -- --ignored --exact --nocapture --test-threads=1
 //! ```
+//!
+//! Compare the two generated-ID allocators at 2, 4, 8, and 10 writers with:
+//!
+//! ```text
+//! cargo test --release --locked --features experimental-vtab --lib \
+//!   storage::sharded_vtab::benchmarks::release_benchmark_matrix_reports_issue_129_generated_write_comparison \
+//!   -- --ignored --exact --nocapture --test-threads=1
+//! ```
 
 use std::{
     fs,
     hint::black_box,
     path::Path,
-    sync::Arc,
+    sync::{Arc, Barrier},
+    thread,
     time::{Duration, Instant},
 };
 
 use rusqlite::params;
 use tokio::runtime::{Builder, Runtime};
 
-use super::{MAX_CURSOR_BYTES, MAX_CURSOR_ROWS, ReadCoordinator, Storage};
+use super::{MAX_CURSOR_BYTES, MAX_CURSOR_ROWS, ReadCoordinator, Storage, WriteCoordinator};
 use crate::core::{
     Database, Engine, EngineOptions, GeneratedIdPolicy, ResultLimits, Session, ShardKeyMetadata,
     ShardKeyType, Statement, TableDeclaration, Value, generated_id::NativeRangeV1Id,
@@ -35,6 +44,9 @@ const WARMUP_OPERATIONS: usize = 3;
 const MIN_SAMPLE_DURATION: Duration = Duration::from_millis(250);
 const TARGET_SAMPLE_DURATION: Duration = Duration::from_millis(500);
 const MAX_CALIBRATED_ITERATIONS: usize = 1_000_000;
+const GENERATED_WRITE_SHARDS: u16 = 4;
+const GENERATED_WRITER_MATRIX: [usize; 4] = [2, 4, 8, 10];
+const GENERATED_WRITES_PER_WORKER: usize = 10_000;
 
 const CREATE_BENCHMARK_TABLES: &str = "
     CREATE TABLE benchmark_hash (
@@ -44,10 +56,27 @@ const CREATE_BENCHMARK_TABLES: &str = "
         PRIMARY KEY (tenant_id, row_no)
     ) STRICT;
     CREATE TABLE benchmark_native (
-        id INTEGER PRIMARY KEY NOT NULL,
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
         payload TEXT NOT NULL
     ) STRICT;
 ";
+
+const CREATE_GENERATED_WRITE_TABLES: &str = "
+    CREATE TABLE benchmark_generated_native (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        payload TEXT NOT NULL
+    ) STRICT;
+    CREATE TABLE benchmark_generated_hilo (
+        id INTEGER PRIMARY KEY,
+        payload TEXT NOT NULL
+    ) STRICT;
+";
+const NATIVE_GENERATED_INSERT_SQL: &str =
+    "INSERT INTO benchmark_generated_native (id, payload) VALUES (NULL, ?1)";
+const HILO_GENERATED_INSERT_SQL: &str =
+    "INSERT INTO benchmark_generated_hilo (id, payload) VALUES (NULL, ?1)";
+const NATIVE_GENERATED_COUNT_SQL: &str = "SELECT COUNT(*) FROM benchmark_generated_native";
+const HILO_GENERATED_COUNT_SQL: &str = "SELECT COUNT(*) FROM benchmark_generated_hilo";
 
 const HASH_POINT_SQL: &str = "
     SELECT tenant_id, row_no, payload
@@ -315,6 +344,192 @@ impl BenchmarkFixture {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GeneratedWritePolicy {
+    NativeRangeV1,
+    HiloV1,
+}
+
+impl GeneratedWritePolicy {
+    const fn name(self) -> &'static str {
+        match self {
+            Self::NativeRangeV1 => "native_range_v1",
+            Self::HiloV1 => "hilo_v1",
+        }
+    }
+
+    const fn insert_sql(self) -> &'static str {
+        match self {
+            Self::NativeRangeV1 => NATIVE_GENERATED_INSERT_SQL,
+            Self::HiloV1 => HILO_GENERATED_INSERT_SQL,
+        }
+    }
+
+    const fn count_sql(self) -> &'static str {
+        match self {
+            Self::NativeRangeV1 => NATIVE_GENERATED_COUNT_SQL,
+            Self::HiloV1 => HILO_GENERATED_COUNT_SQL,
+        }
+    }
+}
+
+struct GeneratedWriteBenchmarkFixture {
+    storage: Storage,
+    native_table_id: u64,
+    hilo_table_id: u64,
+    _temp: tempfile::TempDir,
+}
+
+impl GeneratedWriteBenchmarkFixture {
+    fn new() -> Self {
+        let temp = tempfile::tempdir().expect("create issue #129 benchmark directory");
+        let mut database = Database::open(temp.path(), GENERATED_WRITE_SHARDS)
+            .expect("open issue #129 benchmark database");
+        database
+            .broadcast(CREATE_GENERATED_WRITE_TABLES)
+            .expect("create issue #129 generated-ID tables on every shard");
+        let logical_database = database.catalog().default_database().id();
+        database
+            .register_tables(vec![
+                TableDeclaration::sharded(
+                    logical_database,
+                    "benchmark_generated_native",
+                    ShardKeyMetadata::new("id", ShardKeyType::Int64)
+                        .expect("declare benchmark native shard key"),
+                )
+                .expect("declare benchmark native table")
+                .with_generated_id_policy(
+                    GeneratedIdPolicy::native_range_v1("id")
+                        .expect("declare benchmark native generated-ID policy"),
+                )
+                .expect("apply benchmark native generated-ID policy"),
+                TableDeclaration::sharded(
+                    logical_database,
+                    "benchmark_generated_hilo",
+                    ShardKeyMetadata::new("id", ShardKeyType::Int64)
+                        .expect("declare benchmark hilo shard key"),
+                )
+                .expect("declare benchmark hilo table")
+                .with_generated_id_policy(
+                    GeneratedIdPolicy::hilo_v1("id")
+                        .expect("declare benchmark hilo generated-ID policy"),
+                )
+                .expect("apply benchmark hilo generated-ID policy"),
+            ])
+            .expect("register issue #129 benchmark catalog");
+        let native_table_id = database
+            .catalog()
+            .table("default", "benchmark_generated_native")
+            .expect("look up benchmark native table")
+            .expect("benchmark native table is registered")
+            .id()
+            .get();
+        let hilo_table_id = database
+            .catalog()
+            .table("default", "benchmark_generated_hilo")
+            .expect("look up benchmark hilo table")
+            .expect("benchmark hilo table is registered")
+            .id()
+            .get();
+        let storage = Storage::open(temp.path(), GENERATED_WRITE_SHARDS)
+            .expect("open issue #129 benchmark storage");
+        Self {
+            storage,
+            native_table_id,
+            hilo_table_id,
+            _temp: temp,
+        }
+    }
+
+    const fn table_id(&self, policy: GeneratedWritePolicy) -> u64 {
+        match policy {
+            GeneratedWritePolicy::NativeRangeV1 => self.native_table_id,
+            GeneratedWritePolicy::HiloV1 => self.hilo_table_id,
+        }
+    }
+
+    fn measure_concurrent_writes(
+        &self,
+        policy: GeneratedWritePolicy,
+        writers: usize,
+        writes_per_worker: usize,
+    ) -> Sample {
+        assert!(writers > 0);
+        assert!(writes_per_worker > 0);
+        let coordinators = (0..writers)
+            .map(|_| {
+                WriteCoordinator::open(self.storage.clone())
+                    .expect("open generated-write benchmark coordinator")
+            })
+            .collect::<Vec<_>>();
+        let barrier = Arc::new(Barrier::new(writers + 1));
+        let table_id = self.table_id(policy);
+        let sql = policy.insert_sql();
+
+        let (elapsed, affected_rows) = thread::scope(|scope| {
+            let handles = coordinators
+                .into_iter()
+                .enumerate()
+                .map(|(worker, mut coordinator)| {
+                    let barrier = Arc::clone(&barrier);
+                    scope.spawn(move || {
+                        let payload = format!("issue-129-{}-worker-{worker}", policy.name());
+                        barrier.wait();
+                        let mut affected_rows = 0_usize;
+                        for _ in 0..writes_per_worker {
+                            let result = coordinator
+                                .execute_generated_dml_auto(
+                                    sql,
+                                    params![payload.as_str()],
+                                    table_id,
+                                )
+                                .expect("execute generated-write benchmark insert");
+                            assert_eq!(result.affected_rows(), 1);
+                            assert!(result.generated_key().is_some());
+                            affected_rows = affected_rows
+                                .checked_add(result.affected_rows())
+                                .expect("benchmark affected-row count fits usize");
+                        }
+                        affected_rows
+                    })
+                })
+                .collect::<Vec<_>>();
+            let started = Instant::now();
+            barrier.wait();
+            let affected_rows = handles
+                .into_iter()
+                .map(|handle| {
+                    handle
+                        .join()
+                        .expect("generated-write benchmark worker panicked")
+                })
+                .sum::<usize>();
+            (started.elapsed(), affected_rows)
+        });
+        let expected = writers
+            .checked_mul(writes_per_worker)
+            .expect("benchmark operation count fits usize");
+        assert_eq!(affected_rows, expected);
+        Sample {
+            iterations: affected_rows,
+            elapsed,
+        }
+    }
+
+    fn physical_row_count(&self, policy: GeneratedWritePolicy) -> usize {
+        let total = (0..GENERATED_WRITE_SHARDS)
+            .map(|shard| {
+                self.storage
+                    .open_shard(shard)
+                    .expect("open generated-write benchmark shard for counting")
+                    .query_row(policy.count_sql(), [], |row| row.get::<_, i64>(0))
+                    .expect("count generated-write benchmark rows")
+            })
+            .sum::<i64>();
+        usize::try_from(total).expect("generated-write benchmark count is non-negative")
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct FixtureDiskBytes {
     manifest_database: u64,
     manifest_wal: u64,
@@ -540,6 +755,20 @@ impl SampleSummary {
             operations_per_second * logical_rows_per_operation as f64,
         );
     }
+
+    fn report_generated_writes(self, policy: GeneratedWritePolicy, writers: usize) {
+        println!(
+            "issue129_generated_write\t{}\t{}\t{}\t{}\t{}\t{}\t{:.3}\t{:.2}",
+            policy.name(),
+            GENERATED_WRITE_SHARDS,
+            writers,
+            GENERATED_WRITES_PER_WORKER,
+            self.sample_count,
+            self.median.iterations,
+            self.median.elapsed.as_secs_f64() * 1_000.0,
+            self.operations_per_second(),
+        );
+    }
 }
 
 fn measure_once(operation: &mut impl FnMut() -> usize, iterations: usize) -> Sample {
@@ -657,6 +886,88 @@ fn fixture_disk_bytes_counts_database_and_wal_files_but_not_shm() {
         }
     );
     assert_eq!(measured.total(), 97);
+}
+
+#[test]
+fn generated_write_benchmark_smoke_covers_the_frozen_writer_matrix_and_both_policies() {
+    assert_eq!(GENERATED_WRITER_MATRIX, [2, 4, 8, 10]);
+    assert_eq!(GENERATED_WRITE_SHARDS, 4);
+
+    let fixture = GeneratedWriteBenchmarkFixture::new();
+    for policy in [
+        GeneratedWritePolicy::NativeRangeV1,
+        GeneratedWritePolicy::HiloV1,
+    ] {
+        let sample = fixture.measure_concurrent_writes(policy, 2, 2);
+        assert_eq!(sample.iterations, 4);
+        assert_eq!(fixture.physical_row_count(policy), 4);
+    }
+}
+
+#[test]
+#[ignore = "manual release-mode issue #129 generated-ID benchmark"]
+fn release_benchmark_matrix_reports_issue_129_generated_write_comparison() {
+    if cfg!(debug_assertions) {
+        panic!("run this ignored benchmark with cargo test --release");
+    }
+    println!(
+        "record\tpolicy\tshards\twriters\twrites_per_worker\tsamples\tmedian_total_writes\tmedian_elapsed_ms\tmedian_writes_per_sec"
+    );
+    println!("comparison_record\tshards\twriters\thilo_over_native");
+
+    for writers in GENERATED_WRITER_MATRIX {
+        let fixture = GeneratedWriteBenchmarkFixture::new();
+        let mut native_samples = Vec::with_capacity(SAMPLE_COUNT);
+        let mut hilo_samples = Vec::with_capacity(SAMPLE_COUNT);
+        for sample in 0..SAMPLE_COUNT {
+            if sample % 2 == 0 {
+                native_samples.push(fixture.measure_concurrent_writes(
+                    GeneratedWritePolicy::NativeRangeV1,
+                    writers,
+                    GENERATED_WRITES_PER_WORKER,
+                ));
+                hilo_samples.push(fixture.measure_concurrent_writes(
+                    GeneratedWritePolicy::HiloV1,
+                    writers,
+                    GENERATED_WRITES_PER_WORKER,
+                ));
+            } else {
+                hilo_samples.push(fixture.measure_concurrent_writes(
+                    GeneratedWritePolicy::HiloV1,
+                    writers,
+                    GENERATED_WRITES_PER_WORKER,
+                ));
+                native_samples.push(fixture.measure_concurrent_writes(
+                    GeneratedWritePolicy::NativeRangeV1,
+                    writers,
+                    GENERATED_WRITES_PER_WORKER,
+                ));
+            }
+        }
+        let expected_rows = writers
+            .checked_mul(GENERATED_WRITES_PER_WORKER)
+            .and_then(|rows| rows.checked_mul(SAMPLE_COUNT))
+            .expect("benchmark row count fits usize");
+        assert_eq!(
+            fixture.physical_row_count(GeneratedWritePolicy::NativeRangeV1),
+            expected_rows
+        );
+        assert_eq!(
+            fixture.physical_row_count(GeneratedWritePolicy::HiloV1),
+            expected_rows
+        );
+
+        let native = SampleSummary::from_samples(native_samples);
+        let hilo = SampleSummary::from_samples(hilo_samples);
+        native.report_generated_writes(GeneratedWritePolicy::NativeRangeV1, writers);
+        hilo.report_generated_writes(GeneratedWritePolicy::HiloV1, writers);
+        println!(
+            "issue129_generated_comparison\t{}\t{}\t{:.3}",
+            GENERATED_WRITE_SHARDS,
+            writers,
+            hilo.operations_per_second() / native.operations_per_second(),
+        );
+    }
 }
 
 #[test]

--- a/src/storage/sharded_vtab/write.rs
+++ b/src/storage/sharded_vtab/write.rs
@@ -23,15 +23,15 @@ use super::{
 use super::{TestChildScanControl, TestChildScanGate};
 use crate::{
     core::{
-        EngineError, EngineErrorKind, EngineResult, GeneratedIdPolicy, GeneratedKey,
-        OperationControl, Value,
+        CanonicalShardKeyRef, EngineError, EngineErrorKind, EngineResult, GeneratedIdPolicy,
+        GeneratedKey, OperationControl, TableId, Value, canonical_shard_key_bytes,
         generated_id::{
             AllocationOwnerSlot, GeneratedIdClassification, classify_generated_id,
             native_range_v1_sequence_ceiling, native_range_v1_sequence_floor,
         },
     },
     sqlite_error,
-    storage::{CONNECTION_BUSY_TIMEOUT, SchemaOperationGuard, Storage},
+    storage::{CONNECTION_BUSY_TIMEOUT, SchemaOperationGuard, Storage, hilo::HiloAllocation},
 };
 
 const CANCELLABLE_BUSY_SLICE: Duration = Duration::from_millis(25);
@@ -1046,6 +1046,7 @@ impl WriteState {
         registry: &Registry,
         spec: &TableSpec,
         shard_key: ValueRef<'_>,
+        child_is_pinned: bool,
     ) -> EngineResult<Option<GeneratedInsertTargets>> {
         let mut generated = self
             .generated_insert
@@ -1079,9 +1080,46 @@ impl WriteState {
             ));
         }
         intent.consumed = true;
-        let targets = match intent.request.expected_shard {
-            Some(shard) => GeneratedInsertTargets::Exact(shard),
-            None => GeneratedInsertTargets::Auto(registry.generated_insert_targets(spec)?),
+        let targets = match &spec.generated_id_policy {
+            GeneratedIdPolicy::NativeRangeV1 { .. } => match intent.request.expected_shard {
+                Some(shard) => GeneratedInsertTargets::NativeExact(shard),
+                None => {
+                    GeneratedInsertTargets::NativeAuto(registry.generated_insert_targets(spec)?)
+                }
+            },
+            GeneratedIdPolicy::HiloV1 { .. } => {
+                if child_is_pinned {
+                    return Err(EngineError::new(
+                        EngineErrorKind::FailedPrecondition,
+                        "hilo_v1 cannot refill or select a new shard after a transaction has pinned a physical writer",
+                    ));
+                }
+                let table_id = TableId::new(spec.id)?;
+                let allocation = registry.storage.allocate_hilo_v1(table_id)?;
+                let shard = registry.storage.shard_for_key(&canonical_shard_key_bytes(
+                    CanonicalShardKeyRef::Int64(allocation.id()),
+                ));
+                if intent
+                    .request
+                    .expected_shard
+                    .is_some_and(|expected| expected != shard)
+                {
+                    return Err(EngineError::new(
+                        EngineErrorKind::FailedPrecondition,
+                        format!(
+                            "hilo_v1 allocated ID {} to shard {shard}, which does not match the preflighted target",
+                            allocation.id()
+                        ),
+                    ));
+                }
+                GeneratedInsertTargets::Hilo { shard, allocation }
+            }
+            GeneratedIdPolicy::None => {
+                return Err(EngineError::new(
+                    EngineErrorKind::FailedPrecondition,
+                    format!("registered table {} has no generated-ID policy", spec.name),
+                ));
+            }
         };
         registry.wait_after_generated_target_selection_for_test()?;
         Ok(Some(targets))
@@ -1417,7 +1455,12 @@ impl WriteState {
     ) -> EngineResult<i64> {
         self.with_active(registry, |transaction| {
             let shard_key = spec.write_shard_key(values)?;
-            let generated_shard = self.generated_insert_target(registry, spec, shard_key)?;
+            let generated_shard = self.generated_insert_target(
+                registry,
+                spec,
+                shard_key,
+                transaction.child.is_some(),
+            )?;
             transaction.insert(
                 registry,
                 spec,
@@ -1668,20 +1711,25 @@ struct GeneratedInsertRequest {
 
 #[derive(Debug)]
 enum GeneratedInsertTargets {
-    Exact(u16),
-    Auto(Box<[u16]>),
+    NativeExact(u16),
+    NativeAuto(Box<[u16]>),
+    Hilo {
+        shard: u16,
+        allocation: HiloAllocation,
+    },
 }
 
 impl GeneratedInsertTargets {
     fn candidates(&self) -> &[u16] {
         match self {
-            Self::Exact(shard) => std::slice::from_ref(shard),
-            Self::Auto(shards) => shards,
+            Self::NativeExact(shard) => std::slice::from_ref(shard),
+            Self::NativeAuto(shards) => shards,
+            Self::Hilo { .. } => &[],
         }
     }
 
     const fn permits_capacity_fallback(&self) -> bool {
-        matches!(self, Self::Auto(_))
+        matches!(self, Self::NativeAuto(_))
     }
 }
 
@@ -1747,29 +1795,31 @@ impl Registry {
             )
         })?;
         spec.ensure_writable()?;
-        if !spec.native_id_policy_active {
+        if !spec.generated_id_policy_active {
             return Err(EngineError::new(
                 EngineErrorKind::FailedPrecondition,
                 format!(
-                    "native generated INSERT for {} is unavailable until its allocation policy is activated",
+                    "generated INSERT for {} is unavailable until its allocation policy is activated",
                     spec.name
                 ),
             ));
         }
-        let GeneratedIdPolicy::NativeRangeV1 { column } = &spec.generated_id_policy else {
-            return Err(EngineError::new(
-                EngineErrorKind::FailedPrecondition,
-                format!(
-                    "registered table {} does not use native_range_v1 generation",
-                    spec.name
-                ),
-            ));
+        let column = match &spec.generated_id_policy {
+            GeneratedIdPolicy::NativeRangeV1 { column } | GeneratedIdPolicy::HiloV1 { column } => {
+                column
+            }
+            GeneratedIdPolicy::None => {
+                return Err(EngineError::new(
+                    EngineErrorKind::FailedPrecondition,
+                    format!("registered table {} has no generated-ID policy", spec.name),
+                ));
+            }
         };
         let shard_key = spec.shard_key.as_ref().ok_or_else(|| {
             EngineError::new(
                 EngineErrorKind::DataCorruption,
                 format!(
-                    "registered native-ID table {} has no shard-key descriptor",
+                    "registered generated-ID table {} has no shard-key descriptor",
                     spec.name
                 ),
             )
@@ -1778,7 +1828,7 @@ impl Registry {
             EngineError::new(
                 EngineErrorKind::DataCorruption,
                 format!(
-                    "registered native-ID table {} has an invalid key index",
+                    "registered generated-ID table {} has an invalid key index",
                     spec.name
                 ),
             )
@@ -1793,10 +1843,24 @@ impl Registry {
             return Err(EngineError::new(
                 EngineErrorKind::DataCorruption,
                 format!(
-                    "registered native-ID policy for {} does not match its Int64 shard key",
+                    "registered generated-ID policy for {} does not match its Int64 shard key",
                     spec.name
                 ),
             ));
+        }
+        if let Some(expected_shard) = request.expected_shard {
+            if !spec.targets.contains(&expected_shard) {
+                return Err(EngineError::new(
+                    EngineErrorKind::FailedPrecondition,
+                    format!(
+                        "generated INSERT target shard {expected_shard} is not eligible for {}",
+                        spec.name
+                    ),
+                ));
+            }
+        }
+        if matches!(spec.generated_id_policy, GeneratedIdPolicy::HiloV1 { .. }) {
+            return Ok(());
         }
         let owners = spec.allocation_owners.as_ref().ok_or_else(|| {
             EngineError::new(
@@ -1808,15 +1872,6 @@ impl Registry {
             )
         })?;
         if let Some(expected_shard) = request.expected_shard {
-            if !spec.targets.contains(&expected_shard) {
-                return Err(EngineError::new(
-                    EngineErrorKind::FailedPrecondition,
-                    format!(
-                        "native generated INSERT target shard {expected_shard} is not eligible for {}",
-                        spec.name
-                    ),
-                ));
-            }
             if owners.owner_for_physical_shard(expected_shard).is_none() {
                 return Err(EngineError::new(
                     EngineErrorKind::FailedPrecondition,
@@ -2276,7 +2331,7 @@ impl WriteTransaction {
                 active_interrupt,
             );
         }
-        let shard = registry.insert_target(spec, shard_key)?;
+        let shard = registry.caller_new_key_target(spec, shard_key)?;
         let sql = spec.insert_sql(conflict)?;
         let parameters = values
             .iter()
@@ -2323,6 +2378,20 @@ impl WriteTransaction {
         targets: GeneratedInsertTargets,
         active_interrupt: &Mutex<Option<Arc<InterruptHandle>>>,
     ) -> EngineResult<i64> {
+        let targets = match targets {
+            GeneratedInsertTargets::Hilo { shard, allocation } => {
+                return self.insert_hilo_generated(
+                    registry,
+                    spec,
+                    values,
+                    conflict,
+                    shard,
+                    allocation,
+                    active_interrupt,
+                );
+            }
+            targets => targets,
+        };
         let owners = spec.allocation_owners.as_ref().ok_or_else(|| {
             EngineError::new(
                 EngineErrorKind::DataCorruption,
@@ -2451,6 +2520,16 @@ impl WriteTransaction {
                     ),
                 ));
             }
+            GeneratedIdClassification::HiloV1(_) => {
+                self.poison("SQLite allocated a hilo ID through the native allocator");
+                return Err(EngineError::new(
+                    EngineErrorKind::DataCorruption,
+                    format!(
+                        "SQLite allocated a hilo ID for native generated table {}",
+                        spec.name
+                    ),
+                ));
+            }
         };
         if decoded.owner() != owner || owners.physical_shard(decoded.owner()) != Some(shard) {
             self.poison("SQLite allocated a generated ID outside its shard owner range");
@@ -2466,6 +2545,110 @@ impl WriteTransaction {
             return Err(EngineError::new(
                 EngineErrorKind::Internal,
                 "brisk_shard physical generated INSERT did not change exactly one row",
+            ));
+        }
+        self.record_physical_changes(changed)?;
+        self.record_write_shard(shard)?;
+        self.generated_key = Some(GeneratedKey::new(generated_column, Value::Int64(generated)));
+        self.ensure_healthy(registry)?;
+        Ok(generated)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn insert_hilo_generated(
+        &mut self,
+        registry: &Registry,
+        spec: &TableSpec,
+        values: &[ValueRef<'_>],
+        conflict: ConflictMode,
+        shard: u16,
+        allocation: HiloAllocation,
+        active_interrupt: &Mutex<Option<Arc<InterruptHandle>>>,
+    ) -> EngineResult<i64> {
+        if allocation.table_id().get() != spec.id
+            || allocation.owner_id() != registry.storage.hilo_owner_id()
+            || allocation.fence() == 0
+        {
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                "hilo_v1 INSERT received an invalid in-process lease credential",
+            ));
+        }
+        let generated = allocation.id();
+        if !matches!(
+            classify_generated_id(&spec.generated_id_policy, generated)?,
+            GeneratedIdClassification::HiloV1(_)
+        ) {
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                "hilo_v1 allocator returned an ID outside its policy namespace",
+            ));
+        }
+        let routed = registry.write_target(spec, ValueRef::Integer(generated))?;
+        if routed != shard {
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                format!(
+                    "hilo_v1 allocated ID {generated} routes to shard {routed}, not prepared shard {shard}"
+                ),
+            ));
+        }
+        let (sql, parameters, generated_column) =
+            spec.hilo_insert_sql_and_values(values, conflict, generated)?;
+        let insertion = (|| {
+            let child = self.pin(registry, shard, active_interrupt)?;
+            let mut statement = child
+                .connection
+                .prepare(&sql)
+                .map_err(sqlite_error::statement)?;
+            let mut rows = statement
+                .query(rusqlite::params_from_iter(&parameters))
+                .map_err(sqlite_error::statement)?;
+            let returned = match rows.next().map_err(sqlite_error::statement)? {
+                Some(row) => row.get::<_, i64>(0).map_err(sqlite_error::statement)?,
+                None => return Ok(None),
+            };
+            if rows.next().map_err(sqlite_error::statement)?.is_some() {
+                return Err(EngineError::new(
+                    EngineErrorKind::Internal,
+                    "hilo_v1 INSERT returned more than one generated key",
+                ));
+            }
+            drop(rows);
+            drop(statement);
+            if returned != generated {
+                return Err(EngineError::new(
+                    EngineErrorKind::DataCorruption,
+                    format!(
+                        "hilo_v1 INSERT returned ID {returned}, expected allocated ID {generated}"
+                    ),
+                ));
+            }
+            let changed = usize::try_from(child.connection.changes()).map_err(|error| {
+                EngineError::from_source(
+                    EngineErrorKind::LimitExceeded,
+                    "SQLite hilo_v1 INSERT change count does not fit usize",
+                    error,
+                )
+            })?;
+            Ok(Some(changed))
+        })();
+        let changed = match insertion {
+            Ok(Some(changed)) => changed,
+            Ok(None) => {
+                self.ensure_healthy(registry)?;
+                return Ok(0);
+            }
+            Err(error) => {
+                self.poison_if_uncertain(&error);
+                return Err(error);
+            }
+        };
+        if changed != 1 {
+            self.poison("physical hilo_v1 INSERT did not report exactly one changed row");
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                "brisk_shard physical hilo_v1 INSERT did not change exactly one row",
             ));
         }
         self.record_physical_changes(changed)?;
@@ -2554,7 +2737,7 @@ impl WriteTransaction {
         let new_shard = if no_change.get(shard_key_index).copied().unwrap_or(false) {
             decoded.shard
         } else {
-            registry.write_target(spec, spec.write_shard_key(values)?)?
+            registry.caller_new_key_target(spec, spec.write_shard_key(values)?)?
         };
         if decoded.shard != new_shard {
             self.poison("a shard-key update attempted to move a row to another file");


### PR DESCRIPTION
Closes #129

## Summary

- add versioned hilo_v1 generated-ID policy, encoding, hash routing, and allocator-owned namespace checks
- migrate the manifest to v11 with strict per-table 4,096-ID lease heads, monotonic fences, semantic digest v4, and atomic activation
- consume committed ranges from a process-local cache before shard write locking; burn rollback, cancellation, crash, and restart tails
- integrate internal generated INSERT execution, multi-process uniqueness checks, contention and exhaustion coverage, and colocated foreign-key routing
- document gap and non-commit-order semantics plus the current internal SQL integration boundary

## Verification

- cargo fmt --all --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-targets --all-features
- cargo test --locked --doc --all-features
- cargo +1.85.0 test --locked --all-targets --all-features
- cargo +1.85.0 test --locked --doc --all-features
- optimized 2/4/8/10-writer release benchmark matrix

## Benchmark

On the documented Apple M1 Pro host, median hilo_v1/native throughput ratios were 1.078x, 1.177x, 1.027x, and 1.036x at 2, 4, 8, and 10 writers. All physical row-count checks matched.