### PR TITLE
Restrict unauthenticated HTTP to loopback

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,9 @@ cargo run --bin briskdb-import -- \
 See the [import contract](docs/SQLITE_IMPORT.md) for schema support,
 verification, cancellation, and publication behavior.
 
-The HTTP listener defaults to `127.0.0.1:7654`. The separate PostgreSQL TCP
+The unauthenticated HTTP listener defaults to `127.0.0.1:7654` and currently
+requires an IPv4 or IPv6 loopback address. A non-loopback value is rejected
+before the engine opens or either listener binds. The separate PostgreSQL TCP
 listener defaults to `127.0.0.1:5433`. Set either an explicit socket address or
 the exact value `disabled` with `--postgres-listen`; the corresponding
 environment variable is `BRISKDB_POSTGRES_LISTEN`. Command-line input takes
@@ -202,9 +204,8 @@ precedence over the environment, which takes precedence over the default. The
 HTTP address, data directory, and shard count can also be supplied with
 `BRISKDB_LISTEN`, `BRISKDB_DATA_DIR`, and `BRISKDB_SHARDS`.
 
-An enabled PostgreSQL address must be IPv4 or IPv6 loopback in the current
-phase. A non-loopback value is rejected before the engine opens or either
-listener binds.
+An enabled PostgreSQL address must also be IPv4 or IPv6 loopback in the current
+phase.
 
 ```bash
 # Keep the existing HTTP service and do not bind the PostgreSQL port.
@@ -227,9 +228,10 @@ The explorer is read-only: select a logical table, see its exact logical row
 total, then move through live shard-major pages of at most 200 rows. Sharded
 tables visit every owning file; Global tables visit canonical shard 0 once.
 Browser sessions are held only in process memory, expire after eight hours,
-and disappear on restart. The fixed credentials are a development convenience;
-keep this experimental HTTP service on a trusted network. Existing `/health`
-and `/v1/*` behavior is unchanged. See the
+and disappear on restart. The fixed credentials are a development convenience,
+not a security boundary; the server therefore refuses non-loopback HTTP
+addresses until authentication and TLS are implemented. Existing `/health` and
+`/v1/*` behavior is unchanged. See the
 [admin browser contract](docs/ADMIN_BROWSER.md) for the route, table-filtering,
 pagination, and session boundaries.
 
@@ -345,7 +347,8 @@ instead. An example point response is:
 ## Deliberate boundaries
 
 This is an initial scaffold, not a production database yet. The current API
-accepts SQL and should only be exposed on a trusted network. The HTTP adapter
+accepts SQL without authentication, so server startup restricts HTTP to an IPv4
+or IPv6 loopback address. The HTTP adapter
 creates an ephemeral session for each data request, so session state and
 transactions cannot span HTTP requests. Each shard has its own bounded pool, so
 routed work queued for one shard does not consume another shard's capacity.

--- a/docs/ADMIN_BROWSER.md
+++ b/docs/ADMIN_BROWSER.md
@@ -17,9 +17,10 @@ The first implementation has one exact built-in credential pair:
 
 This is a temporary development convenience, not the user/role, password
 rotation, or transport-encryption work described by roadmap issues #56 and #64.
-Anyone who can reach the HTTP listener knows these credentials. Keep the current
-HTTP service on a trusted network and do not treat this login as a production
-identity boundary. The existing `/health` and `/v1/*` endpoints retain their
+Anyone who can reach the HTTP listener knows these credentials. Server startup
+therefore restricts the current unauthenticated HTTP service to an IPv4 or IPv6
+loopback address. Do not treat this login as a production identity boundary.
+The existing `/health` and `/v1/*` endpoints retain their
 previous behavior and are not made authenticated by issue #106.
 
 A successful login creates an opaque session from 32 operating-system-random

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ impl FromStr for ListenerSetting {
 #[derive(Debug, Parser)]
 #[command(version, about)]
 struct Args {
-    /// Address on which the HTTP server listens.
+    /// Loopback address on which the unauthenticated HTTP server listens.
     #[arg(long, env = "BRISKDB_LISTEN", default_value = "127.0.0.1:7654")]
     listen: SocketAddr,
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -72,7 +72,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
 /// [`run`] remains the compatibility entry point and delegates here with
 /// [`EngineOptions::default`].
 pub async fn run_with_engine_options(config: Config, options: EngineOptions) -> anyhow::Result<()> {
-    validate_postgres_listener(&config)?;
+    validate_listener_addresses(&config)?;
     let engine = Engine::open_with_options(&config.data_dir, config.shards, options).await?;
     let listeners = match BoundListeners::bind(&config).await {
         Ok(listeners) => listeners,
@@ -139,7 +139,13 @@ pub async fn run_with_engine_options(config: Config, options: EngineOptions) -> 
     serve_listeners_with_shutdown(listeners, engine, signal).await
 }
 
-fn validate_postgres_listener(config: &Config) -> anyhow::Result<()> {
+fn validate_listener_addresses(config: &Config) -> anyhow::Result<()> {
+    if !config.listen.ip().is_loopback() {
+        anyhow::bail!(
+            "unauthenticated HTTP startup requires a loopback listen address; received {}",
+            config.listen
+        );
+    }
     if let Some(address) = config
         .postgres_listen
         .filter(|address| !address.ip().is_loopback())
@@ -780,6 +786,41 @@ mod tests {
             "PostgreSQL wire startup currently requires a loopback listen address; received 0.0.0.0:0"
         );
         assert!(!data_dir.exists());
+    }
+
+    #[tokio::test]
+    async fn non_loopback_http_activation_fails_before_database_or_listener_startup() {
+        let temp = tempfile::tempdir().unwrap();
+        let data_dir = temp.path().join("database");
+        let error = run(Config {
+            listen: "0.0.0.0:0".parse().unwrap(),
+            postgres_listen: Some("127.0.0.1:0".parse().unwrap()),
+            data_dir: data_dir.clone(),
+            shards: 2,
+        })
+        .await
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "unauthenticated HTTP startup requires a loopback listen address; received 0.0.0.0:0"
+        );
+        assert!(!data_dir.exists());
+    }
+
+    #[test]
+    fn listener_validation_accepts_ipv4_and_ipv6_loopback_addresses() {
+        for listen in ["127.0.0.1:7654", "[::1]:7654"] {
+            for postgres_listen in [None, Some("127.0.0.1:5433"), Some("[::1]:5433")] {
+                validate_listener_addresses(&Config {
+                    listen: listen.parse().unwrap(),
+                    postgres_listen: postgres_listen.map(|address| address.parse().unwrap()),
+                    data_dir: PathBuf::from("unused"),
+                    shards: 2,
+                })
+                .unwrap();
+            }
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- reject non-loopback HTTP listen addresses before opening storage or binding listeners
- retain IPv4 and IPv6 loopback support for HTTP and PostgreSQL
- clarify the unauthenticated loopback-only boundary in CLI help and documentation

## Why

The alpha HTTP SQL and admin surfaces do not yet have authentication or TLS. Restricting startup to loopback provides a fail-closed release boundary until the broader security roadmap lands.

## Tests

- cargo fmt --all --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-targets --all-features
- cargo test --locked --doc --all-features

Closes #142