### PR TITLE
Document and test stopped-server backup and restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ offline, staged conversion of one ordinary SQLite database into an explicitly
 cataloged BriskDB layout with exactly-once Sharded row placement.
 The [manifest storage-format contract](docs/STORAGE_FORMAT.md) defines versioned
 startup migrations, downgrade behavior, and recovery boundaries.
+The [stopped-server backup contract](docs/OFFLINE_BACKUP.md) defines the
+supported alpha procedure for copying and restoring one complete data directory.
 Contributions follow the repository's [test-first completion policy](CONTRIBUTING.md).
 The [benchmark baseline](docs/BENCHMARKS.md) defines the reproducible storage
 workloads used to measure the current prototype.
@@ -661,6 +663,11 @@ asynchronous cleanup contract.
 Independent `Database` and `Engine` handles in one process that resolve to the
 same canonical data directory share schema coordination. Separate BriskDB
 server processes must not use the same data directory.
+
+The supported alpha backup is a complete data-directory copy made only after
+every BriskDB process using it has stopped. Restore into a new empty directory
+with the same release and shard count; never mix individual files or backup
+times. See the [stopped-server backup procedure](docs/OFFLINE_BACKUP.md).
 
 The `/admin` browser's fixed development login is separate from the planned
 authentication and role model. Near-term work includes that model, richer

--- a/docs/OFFLINE_BACKUP.md
+++ b/docs/OFFLINE_BACKUP.md
@@ -1,0 +1,73 @@
+# Stopped-server backup and restore
+
+BriskDB's supported alpha backup is a complete copy made while every BriskDB
+process using the data directory is stopped. This procedure preserves one
+consistent manifest, shard set, schema generation, routing map, generated-ID
+allocator state, and any SQLite sidecar files as a unit.
+
+This is not an online backup. Do not copy a live data directory, even when no
+application writes are expected. Coordinated online backup remains tracked by
+issue #67.
+
+## Backup
+
+1. Record the BriskDB version, configured shard count, and absolute data
+   directory path.
+2. Stop the BriskDB process cleanly and wait for it to exit. A service manager
+   must report the process stopped before copying begins.
+3. Verify that no other BriskDB process or embedder is using the directory.
+4. Copy the complete data directory into a new backup directory. Include
+   `manifest.sqlite`, the entire `shards` directory, the import receipt when
+   present, and every SQLite `-wal`, `-shm`, or journal sidecar that exists.
+   Do not select individual database files.
+5. Make the backup durable using the snapshot, archive, or copy tool's normal
+   completion and sync guarantees. Retain the recorded BriskDB version and
+   shard count with the backup.
+6. Restart the original server only after the copy has completed.
+
+On the supported Linux platform, one simple local-filesystem copy is:
+
+```bash
+mkdir -- /var/backups/briskdb-alpha-1
+cp -a -- /srv/briskdb-data/. /var/backups/briskdb-alpha-1/
+```
+
+The destination must be new and must not be inside the source data directory.
+Archive or snapshot tools are acceptable only when they preserve the complete
+stopped directory as one recovery point.
+
+## Restore and validate
+
+1. Stop BriskDB and preserve the failed or current data directory separately
+   for diagnosis. Never restore files over an existing layout.
+2. Create a new empty destination and copy the complete backup into it. Do not
+   combine a backup manifest with shards from another backup or time.
+3. Start the same BriskDB release with the recorded shard count and the restored
+   directory. Startup must reach `Ready` without a migration, integrity, shard
+   identity, WAL-mode, or schema-generation error.
+4. Check `/health`, inspect the expected logical catalog, and read known rows
+   from representative shard keys before returning the service to use.
+5. Keep the prior directory and backup unchanged until validation succeeds.
+   If validation fails, stop the process and investigate; do not edit manifest
+   state, SQLite headers, or checksums to force startup.
+
+Example restore copy:
+
+```bash
+mkdir -- /srv/briskdb-restored
+cp -a -- /var/backups/briskdb-alpha-1/. /srv/briskdb-restored/
+cargo run --locked -- --data-dir /srv/briskdb-restored --shards 4
+```
+
+Restoring into a different absolute path is supported. Restoring only one
+shard, mixing recovery points, copying while the server is running, or using an
+older BriskDB binary against a newer format is unsupported.
+
+## Automated evidence
+
+`tests/offline_backup.rs` creates schema and one routed row on every shard,
+performs explicit engine shutdown, copies the complete layout through a backup
+directory into a new root, reopens it, and verifies the schema generation,
+physical route, and row value for every shard. The test freezes the stopped-copy
+contract but does not claim online snapshot safety or certify a particular
+third-party backup product.

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -1791,9 +1791,10 @@ BriskDB will not sign altered manifest payload while reporting the failure.
 The current deployment boundary remains local storage and one BriskDB process
 per data directory. Independent handles inside that process share a gate,
 schema fingerprints, and live catalog coordination keyed by the canonical
-root. A formal backup/restore workflow is not implemented. Recovery to an older
-binary requires a backup from before the unsupported format. Separate server
-processes against one data
+root. The supported alpha recovery workflow is the complete stopped-directory
+copy documented in [offline backup](OFFLINE_BACKUP.md); coordinated online
+backup remains unimplemented. Recovery to an older binary requires a backup
+from before the unsupported format. Separate server processes against one data
 directory are unsupported even though SQLite and the manifest use file locks;
 the in-process coordination is intentionally not a distributed lock. The
 `hilo_v1` reservation transaction is deliberately stronger at its narrow

--- a/docs/SUPPORTED_PLATFORMS.md
+++ b/docs/SUPPORTED_PLATFORMS.md
@@ -95,10 +95,11 @@ Admin browser sessions likewise belong to one process, but are not part of that
 data-directory registry: their absolute eight-hour state is memory-only and is
 discarded on restart.
 Do not copy, move, edit, or separately open the manifest, shard, WAL, or shared
-memory files while the server is running. Backup, restore, multi-process
-access, filesystem-fault behavior, and crash-recovery guarantees will become
-supported only when their roadmap issues add the corresponding automated
-tests.
+memory files while the server is running. The stopped-server,
+complete-directory procedure in [offline backup](OFFLINE_BACKUP.md) is supported
+and tested. Live or partial copies, coordinated online backup, multi-process
+access, filesystem-fault behavior, and broader crash-recovery guarantees remain
+unsupported until their roadmap issues add corresponding automated tests.
 
 Opening a data directory can transactionally upgrade `manifest.sqlite` and can
 resume a manifest-recorded cross-file shard provisioning, adoption, or

--- a/tests/offline_backup.rs
+++ b/tests/offline_backup.rs
@@ -1,0 +1,103 @@
+use std::{fs, path::Path};
+
+use briskdb::core::{Database, Engine, Statement, Value};
+
+const SHARDS: u16 = 4;
+
+fn copy_directory(source: &Path, destination: &Path) {
+    fs::create_dir(destination).unwrap();
+    for entry in fs::read_dir(source).unwrap() {
+        let entry = entry.unwrap();
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_directory(&source_path, &destination_path);
+        } else {
+            fs::copy(&source_path, &destination_path).unwrap();
+        }
+    }
+}
+
+fn one_key_per_shard(database: &Database) -> Vec<String> {
+    let mut keys = vec![None; usize::from(SHARDS)];
+    for candidate in 0..10_000 {
+        let key = format!("backup-key-{candidate}");
+        let shard = usize::from(database.shard_for_key(key.as_bytes()));
+        keys[shard].get_or_insert(key);
+        if keys.iter().all(Option::is_some) {
+            return keys.into_iter().map(Option::unwrap).collect();
+        }
+    }
+    panic!("failed to find one routed key for every shard");
+}
+
+#[tokio::test]
+async fn stopped_server_backup_restores_schema_and_rows_from_every_shard() {
+    let directory = tempfile::tempdir().unwrap();
+    let live = directory.path().join("live");
+    let backup = directory.path().join("backup");
+    let restored = directory.path().join("restored");
+
+    let database = Database::open(&live, SHARDS).unwrap();
+    database
+        .broadcast(
+            "CREATE TABLE backup_items (
+                id TEXT PRIMARY KEY,
+                shard_number INTEGER NOT NULL
+             )",
+        )
+        .unwrap();
+    let keys = one_key_per_shard(&database);
+    drop(database);
+
+    let engine = Engine::open(&live, SHARDS).await.unwrap();
+    for (expected_shard, key) in keys.iter().enumerate() {
+        let session = engine.session();
+        session.set_routing_key(key).await.unwrap();
+        let inserted = engine
+            .execute(
+                &session,
+                Statement::new(
+                    "INSERT INTO backup_items (id, shard_number) VALUES (?1, ?2)",
+                    vec![Value::from(key.clone()), Value::from(expected_shard as i64)],
+                ),
+            )
+            .await
+            .unwrap();
+        assert_eq!(usize::from(inserted.shard), expected_shard);
+        assert_eq!(inserted.value, 1);
+    }
+    engine.shutdown().await.unwrap();
+    drop(engine);
+
+    copy_directory(&live, &backup);
+    copy_directory(&backup, &restored);
+
+    let restored_engine = Engine::open(&restored, SHARDS).await.unwrap();
+    assert_eq!(restored_engine.catalog().schema_generation(), 1);
+    for (expected_shard, key) in keys.iter().enumerate() {
+        let session = restored_engine.session();
+        session.set_routing_key(key).await.unwrap();
+        let result = restored_engine
+            .query(
+                &session,
+                Statement::new(
+                    "SELECT id, shard_number FROM backup_items WHERE id = ?1",
+                    vec![Value::from(key.clone())],
+                ),
+            )
+            .await
+            .unwrap();
+        assert_eq!(usize::from(result.shard), expected_shard);
+        assert_eq!(result.value.rows().len(), 1);
+        assert_eq!(
+            result.value.rows()[0].get(0),
+            Some(&Value::from(key.clone()))
+        );
+        assert_eq!(
+            result.value.rows()[0].get(1),
+            Some(&Value::from(expected_shard as i64))
+        );
+    }
+    restored_engine.shutdown().await.unwrap();
+}


### PR DESCRIPTION
## Summary

- define the supported alpha backup as a complete data-directory copy made after clean shutdown
- document backup, restore, validation, and rollback boundaries
- add an integration test that copies a stopped four-shard layout to a new root and verifies schema and one row from every shard
- keep coordinated online backup explicitly tracked by #67

## Impact

Operators now have a narrow, repeatable recovery procedure for the alpha without implying that live or partial copies are safe.

## Tests

- cargo fmt --all --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-targets --all-features
- cargo test --locked --doc --all-features

Closes #144