### PR TITLE
Define the pre-1.0 compatibility policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ offline, staged conversion of one ordinary SQLite database into an explicitly
 cataloged BriskDB layout with exactly-once Sharded row placement.
 The [manifest storage-format contract](docs/STORAGE_FORMAT.md) defines versioned
 startup migrations, downgrade behavior, and recovery boundaries.
+The [pre-1.0 compatibility policy](docs/PRE_1_COMPATIBILITY.md) defines upgrade,
+downgrade, rollback, and release-note expectations while the format is unstable.
 The [stopped-server backup contract](docs/OFFLINE_BACKUP.md) defines the
 supported alpha procedure for copying and restoring one complete data directory.
 Contributions follow the repository's [test-first completion policy](CONTRIBUTING.md).

--- a/docs/OFFLINE_BACKUP.md
+++ b/docs/OFFLINE_BACKUP.md
@@ -62,6 +62,8 @@ cargo run --locked -- --data-dir /srv/briskdb-restored --shards 4
 Restoring into a different absolute path is supported. Restoring only one
 shard, mixing recovery points, copying while the server is running, or using an
 older BriskDB binary against a newer format is unsupported.
+For release upgrades and rollback, follow the additional requirements in the
+[pre-1.0 compatibility policy](PRE_1_COMPATIBILITY.md).
 
 ## Automated evidence
 

--- a/docs/PRE_1_COMPATIBILITY.md
+++ b/docs/PRE_1_COMPATIBILITY.md
@@ -1,0 +1,67 @@
+# Pre-1.0 compatibility policy
+
+BriskDB 0.x releases are experimental. The command-line interface, HTTP
+contract, Rust API, accepted SQL subset, and on-disk format may change between
+0.x releases. A 0.x release does not promise that a newer layout can be opened
+by an older binary or that every future binary will migrate every historical
+prototype layout.
+
+This policy is narrower than the stable storage-format commitment planned for
+1.0 in issue #77.
+
+## Format and forward migration
+
+The current manifest version is recorded in [the storage-format
+contract](STORAGE_FORMAT.md). Each release that changes the format must:
+
+- use an ordered, transactional, and tested migration;
+- list the old manifest versions that the new binary accepts;
+- describe any application-visible compatibility effect in its release notes;
+- preserve fail-closed behavior for unknown, newer, malformed, or partially
+  migrated layouts; and
+- update the documented current version and its executable consistency test.
+
+A supported forward migration runs during startup before either listener binds.
+It may update `manifest.sqlite`, shard metadata, schema generations, or other
+files in the data directory. Treat startup of a newer binary as a storage
+mutation even when application rows do not change.
+
+## Required upgrade procedure
+
+Before starting a newer BriskDB release against an existing data directory:
+
+1. Stop every BriskDB process using the directory.
+2. Record the current BriskDB release and configured shard count.
+3. Create and retain a complete backup using the [stopped-server backup
+   procedure](OFFLINE_BACKUP.md).
+4. Read the target release notes and confirm that the source manifest version
+   is accepted.
+5. Start the new release and verify readiness, catalog contents, and known rows
+   before returning it to service.
+
+Skipping the backup makes rollback unsupported.
+
+## Downgrade and rollback
+
+In-place downgrade is unsupported. BriskDB persists a downgrade fence, and an
+older binary must refuse a layout that requires a newer manifest version. Do
+not bypass that refusal by editing `user_version`, manifest rows, SQLite
+headers, schema generations, or checksums.
+
+Rollback means stopping the new binary, preserving its directory separately,
+and restoring the complete pre-upgrade backup into a new empty directory. Start
+the prior binary with the recorded shard count against that restored copy. Do
+not combine the pre-upgrade manifest with post-upgrade shards or restore over
+the migrated directory.
+
+## Release-note contract
+
+Until 1.0, every release must state one of the following:
+
+- no on-disk format change; or
+- the new manifest version, accepted source versions, automatic migration
+  behavior, downgrade refusal, and any additional backup or validation steps.
+
+Release notes must also call out breaking CLI, HTTP, Rust API, and SQL-subset
+changes. Absence of a noted format change does not turn the 0.x format into a
+1.0 stability promise.

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -4,6 +4,8 @@
 never exposed through HTTP, PostgreSQL, MySQL, or the SQL execution API. The
 format is pre-1.0, but every format change must still have an ordered migration,
 failure coverage, and an explicit compatibility decision.
+The [pre-1.0 compatibility policy](PRE_1_COMPATIBILITY.md) defines the required
+operator backup, forward-upgrade, downgrade-refusal, and release-note contract.
 
 The final `manifest.sqlite` path component must be a regular file, never a
 symbolic link. Startup may create that exact file when a fresh layout is

--- a/tests/release_compatibility.rs
+++ b/tests/release_compatibility.rs
@@ -1,0 +1,43 @@
+use briskdb::core::Database;
+use rusqlite::{Connection, OpenFlags};
+
+#[test]
+fn pre_one_policy_matches_the_manifest_created_by_this_package() {
+    let package_major = env!("CARGO_PKG_VERSION")
+        .split('.')
+        .next()
+        .unwrap()
+        .parse::<u64>()
+        .unwrap();
+    assert_eq!(package_major, 0, "pre-1.0 policy applied to a 1.x package");
+
+    let directory = tempfile::tempdir().unwrap();
+    let root = directory.path().join("database");
+    drop(Database::open(&root, 2).unwrap());
+
+    let manifest = Connection::open_with_flags(
+        root.join("manifest.sqlite"),
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .unwrap();
+    let manifest_version = manifest
+        .query_row("PRAGMA user_version", [], |row| row.get::<_, u32>(0))
+        .unwrap();
+
+    let storage_contract = include_str!("../docs/STORAGE_FORMAT.md");
+    assert!(storage_contract.contains(&format!("## Current format: version {manifest_version}")));
+
+    let release_policy = include_str!("../docs/PRE_1_COMPATIBILITY.md");
+    for required_boundary in [
+        "BriskDB 0.x releases are experimental",
+        "In-place downgrade is unsupported",
+        "complete pre-upgrade backup",
+        "accepted source versions",
+        "no on-disk format change",
+    ] {
+        assert!(
+            release_policy.contains(required_boundary),
+            "pre-1.0 policy is missing required boundary: {required_boundary}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- define the 0.x storage, upgrade, downgrade, rollback, and release-note contract
- require a complete stopped-server backup before forward migration
- add an executable check tying the documented current format to a newly created manifest
- retain stable 1.0 format work in #77

## Impact

Alpha users now have an explicit one-way migration and restore-based rollback policy without a premature stable-format promise.

## Tests

- cargo fmt --all --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-targets --all-features
- cargo test --locked --doc --all-features

Closes #146