### PR TITLE
Make the alpha HTTP-first by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,31 +198,33 @@ cargo run --bin briskdb-import -- \
 See the [import contract](docs/SQLITE_IMPORT.md) for schema support,
 verification, cancellation, and publication behavior.
 
-The unauthenticated HTTP listener defaults to `127.0.0.1:7654` and currently
-requires an IPv4 or IPv6 loopback address. A non-loopback value is rejected
-before the engine opens or either listener binds. The separate PostgreSQL TCP
-listener defaults to `127.0.0.1:5433`. Set either an explicit socket address or
-the exact value `disabled` with `--postgres-listen`; the corresponding
-environment variable is `BRISKDB_POSTGRES_LISTEN`. Command-line input takes
-precedence over the environment, which takes precedence over the default. The
-HTTP address, data directory, and shard count can also be supplied with
-`BRISKDB_LISTEN`, `BRISKDB_DATA_DIR`, and `BRISKDB_SHARDS`.
+The initial alpha is HTTP-first: HTTP is the only query-capable network
+interface, and the startup/session-only PostgreSQL listener is disabled by
+default. The unauthenticated HTTP listener defaults to `127.0.0.1:7654` and
+currently requires an IPv4 or IPv6 loopback address. A non-loopback value is
+rejected before the engine opens or either listener binds. Enable the separate
+PostgreSQL TCP listener with an explicit loopback socket address, or use the
+exact value `disabled` with `--postgres-listen`; the corresponding environment
+variable is `BRISKDB_POSTGRES_LISTEN`. Command-line input takes precedence over
+the environment, which takes precedence over the default. The HTTP address,
+data directory, and shard count can also be supplied with `BRISKDB_LISTEN`,
+`BRISKDB_DATA_DIR`, and `BRISKDB_SHARDS`.
 
 An enabled PostgreSQL address must also be IPv4 or IPv6 loopback in the current
 phase.
 
 ```bash
-# Keep the existing HTTP service and do not bind the PostgreSQL port.
-cargo run -- --postgres-listen disabled
+# Explicitly enable the startup/session-only PostgreSQL endpoint.
+cargo run -- --postgres-listen 127.0.0.1:5433
 
 # The environment has the same value grammar.
-BRISKDB_POSTGRES_LISTEN=disabled cargo run
+BRISKDB_POSTGRES_LISTEN=127.0.0.1:5433 cargo run
 ```
 
-The PostgreSQL listener currently accepts only loopback addresses. It supports
-protocol 3.0 startup and session selection, then reports fixed `0A000` errors
-for SQL until issue #31 adds simple and extended query execution. It is not yet
-a query-capable PostgreSQL interface. See the
+The disabled-by-default PostgreSQL listener accepts only loopback addresses. It
+supports protocol 3.0 startup and session selection, then reports fixed
+`0A000` errors for SQL until issue #31 adds simple and extended query execution.
+It is not yet a query-capable PostgreSQL interface. See the
 [listener contract](docs/POSTGRES_LISTENER.md) and
 [adapter decision record](docs/POSTGRES_ADAPTER.md).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -103,7 +103,8 @@ address or `None`.
 The HTTP address remains `Config::listen`. The independent
 `Config::postgres_listen` is either a numeric socket address or disabled with
 `None`; the binary maps the exact `disabled` CLI/environment sentinel to that
-option. The process default enables loopback `127.0.0.1:5433`. See the
+option. The process default disables PostgreSQL; callers may explicitly enable
+loopback `127.0.0.1:5433`. See the
 [PostgreSQL listener contract](POSTGRES_LISTENER.md) for the full grammar and
 startup order.
 

--- a/docs/POSTGRES_LISTENER.md
+++ b/docs/POSTGRES_LISTENER.md
@@ -1,10 +1,11 @@
 # PostgreSQL startup and listener contract
 
-BriskDB serves PostgreSQL protocol 3.0 startup on a separately configured
-loopback TCP listener. A successful startup selects one logical database,
-creates one protocol-neutral core session, publishes BriskDB-owned parameter
-status, and keeps the socket alive until `Terminate`, EOF, server shutdown, or
-a protocol failure. SQL query execution begins in roadmap issue #31.
+BriskDB can serve PostgreSQL protocol 3.0 startup on a disabled-by-default,
+separately configured loopback TCP listener. A successful startup selects one
+logical database, creates one protocol-neutral core session, publishes
+BriskDB-owned parameter status, and keeps the socket alive until `Terminate`,
+EOF, server shutdown, or a protocol failure. SQL query execution begins in
+roadmap issue #31.
 
 ## Process configuration
 
@@ -12,8 +13,8 @@ The binary exposes one value with one grammar:
 
 | Source | Default | Enabled value | Disabled value |
 | --- | --- | --- | --- |
-| CLI | `--postgres-listen 127.0.0.1:5433` | numeric loopback `SocketAddr`, such as `127.0.0.1:6543` or `[::1]:6543` | `--postgres-listen disabled` |
-| Environment | `BRISKDB_POSTGRES_LISTEN=127.0.0.1:5433` | the same numeric loopback grammar | `BRISKDB_POSTGRES_LISTEN=disabled` |
+| CLI | `--postgres-listen disabled` | `--postgres-listen 127.0.0.1:5433`, or another numeric loopback `SocketAddr` such as `[::1]:5433` | `--postgres-listen disabled` |
+| Environment | `BRISKDB_POSTGRES_LISTEN=disabled` | `BRISKDB_POSTGRES_LISTEN=127.0.0.1:5433`, or the same numeric loopback grammar | `BRISKDB_POSTGRES_LISTEN=disabled` |
 
 An explicit command-line value wins over the environment; the environment wins
 over the default. `disabled` is the exact lowercase sentinel. Empty values,
@@ -31,9 +32,9 @@ HTTP listener remains independently configured and always enabled.
 - `Some(address)` validates, binds, and serves PostgreSQL startup;
 - `None` skips its bind, accept branch, and shutdown work.
 
-The process-only `disabled` spelling is converted to `None` before entering the
-server library. `server::run` and `server::run_with_engine_options` retain their
-existing signatures.
+The default or explicit process-only `disabled` spelling is converted to `None`
+before entering the server library. `server::run` and
+`server::run_with_engine_options` retain their existing signatures.
 
 ## Startup and failure order
 
@@ -186,7 +187,7 @@ Library selection details and upgrade constraints are normative in the
 
 Automated coverage includes:
 
-- default, explicit IPv4/IPv6, environment, CLI-over-environment, disabled, and
+- disabled-by-default, explicit IPv4/IPv6, environment, CLI-over-environment, and
   malformed configuration values;
 - loopback validation before database or listener creation;
 - dual-listener binding, bind-failure cleanup, and clean retry;

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -48,8 +48,9 @@ claiming to be a drop-in PostgreSQL or MySQL replacement.
 
 ## Current implementation
 
-Only the experimental HTTP network interface can execute SQL network requests
-today. The separately configured loopback PostgreSQL listener implements exact
+The initial alpha is HTTP-first: only the experimental HTTP network interface
+can execute SQL network requests today. The disabled-by-default, separately
+configured loopback PostgreSQL listener implements exact
 protocol-3.0 startup, logical database/user selection, BriskDB parameter
 status, and tracked session termination through a pinned `pgwire` 0.36.3
 boundary. It rejects SQL with fixed `0A000` responses until issue #31. There is

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use briskdb::{
 use clap::Parser;
 use tracing_subscriber::EnvFilter;
 
-const DEFAULT_POSTGRES_LISTEN: &str = "127.0.0.1:5433";
+const DEFAULT_POSTGRES_LISTEN: &str = "disabled";
 
 /// Command-line representation of an optional TCP listener.
 ///
@@ -212,10 +212,7 @@ mod tests {
         let args = Args::try_parse_from(["briskdb"]).unwrap();
 
         assert_eq!(args.listen, "127.0.0.1:7654".parse().unwrap());
-        assert_eq!(
-            args.postgres_listen,
-            ListenerSetting::Address(DEFAULT_POSTGRES_LISTEN.parse().unwrap())
-        );
+        assert_eq!(args.postgres_listen, ListenerSetting::Disabled);
         assert_eq!(args.data_dir, PathBuf::from("./briskdb-data"));
         assert_eq!(args.shards, 4);
         assert_eq!(args.connections_per_shard, DEFAULT_CONNECTIONS_PER_SHARD);
@@ -432,6 +429,15 @@ mod tests {
         assert_eq!(args.postgres_listen, ListenerSetting::Disabled);
 
         let (config, _) = args.into_server_parts().unwrap();
+        assert_eq!(config.postgres_listen, None);
+    }
+
+    #[test]
+    fn postgres_listener_is_disabled_in_the_default_server_config() {
+        let args = Args::try_parse_from(["briskdb"]).unwrap();
+
+        let (config, _) = args.into_server_parts().unwrap();
+
         assert_eq!(config.postgres_listen, None);
     }
 


### PR DESCRIPTION
## Summary
- disable the startup/session-only PostgreSQL listener by default
- preserve explicit IPv4 and IPv6 loopback opt-in through CLI or environment configuration
- document the HTTP-first alpha boundary consistently across user, protocol, compatibility, and architecture docs

## Testing
- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features`
- `cargo test --locked --doc --all-features`

Closes #148