### PR TITLE
Publish multi-architecture alpha binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,148 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+            platform: linux-x86_64
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            platform: linux-aarch64
+          - runner: macos-15-intel
+            target: x86_64-apple-darwin
+            platform: macos-x86_64
+          - runner: macos-15
+            target: aarch64-apple-darwin
+            platform: macos-aarch64
+    steps:
+      - name: Check out tagged source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install stable Rust
+        run: rustup toolchain install stable --profile minimal --target "${{ matrix.target }}"
+
+      - name: Select stable Rust
+        run: rustup default stable
+
+      - name: Verify release version
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(cargo metadata --locked --no-deps --format-version 1 | python3 -c 'import json,sys; print(next(p["version"] for p in json.load(sys.stdin)["packages"] if p["name"] == "briskdb"))')"
+          if [[ "$GITHUB_REF_TYPE" == "tag" && "$GITHUB_REF_NAME" != "v$version" ]]; then
+            echo "tag $GITHUB_REF_NAME does not match package version $version" >&2
+            exit 1
+          fi
+          echo "VERSION=$version" >> "$GITHUB_ENV"
+
+      - name: Build locked release binaries
+        run: cargo build --release --locked --bins --target "${{ matrix.target }}"
+
+      - name: Smoke-test native server
+        shell: bash
+        run: |
+          set -euo pipefail
+          binary="target/${{ matrix.target }}/release/briskdb"
+          "$binary" --version | grep -F "briskdb $VERSION"
+          data_dir="$(mktemp -d)"
+          "$binary" \
+            --listen 127.0.0.1:17654 \
+            --postgres-listen disabled \
+            --data-dir "$data_dir/database" \
+            --shards 2 &
+          server_pid=$!
+          cleanup() {
+            kill -TERM "$server_pid" 2>/dev/null || true
+            wait "$server_pid" 2>/dev/null || true
+            rm -rf "$data_dir"
+          }
+          trap cleanup EXIT
+          for attempt in {1..30}; do
+            if curl --fail --silent --show-error http://127.0.0.1:17654/admin >/dev/null; then
+              kill -TERM "$server_pid"
+              wait "$server_pid"
+              trap - EXIT
+              rm -rf "$data_dir"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "server did not become ready" >&2
+          exit 1
+
+      - name: Package release archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          archive="briskdb-v${VERSION}-${{ matrix.platform }}"
+          mkdir -p "dist/$archive"
+          cp "target/${{ matrix.target }}/release/briskdb" "dist/$archive/"
+          cp "target/${{ matrix.target }}/release/briskdb-import" "dist/$archive/"
+          cp README.md RELEASE_NOTES.md LICENSE ROADMAP.md CONTRIBUTING.md "dist/$archive/"
+          cp -R docs "dist/$archive/docs"
+          tar -C dist -czf "dist/$archive.tar.gz" "$archive"
+          tar -tzf "dist/$archive.tar.gz" | grep -F "$archive/docs/OFFLINE_BACKUP.md"
+
+      - name: Upload release archive
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: briskdb-${{ matrix.platform }}
+          path: dist/*.tar.gz
+          if-no-files-found: error
+          retention-days: 7
+
+  release:
+    name: Publish GitHub prerelease
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Check out tagged source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Download release archives
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          path: dist
+          pattern: briskdb-*
+          merge-multiple: true
+
+      - name: Create checksums
+        working-directory: dist
+        run: sha256sum *.tar.gz > SHA256SUMS
+
+      - name: Publish prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" dist/* \
+            --verify-tag \
+            --prerelease \
+            --title "BriskDB $GITHUB_REF_NAME" \
+            --notes-file RELEASE_NOTES.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "briskdb"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "briskdb"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 edition = "2024"
 rust-version = "1.85"
 default-run = "briskdb"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # BriskDB
 
 [![CI](https://github.com/schapman1974/briskdb/actions/workflows/ci.yml/badge.svg)](https://github.com/schapman1974/briskdb/actions/workflows/ci.yml)
+[![Release](https://github.com/schapman1974/briskdb/actions/workflows/release.yml/badge.svg)](https://github.com/schapman1974/briskdb/actions/workflows/release.yml)
 
 BriskDB is an experimental Rust server that spreads keyed workloads across
 multiple SQLite databases. It takes the central sharding model proven in
@@ -79,6 +80,13 @@ operating-system, Rust, and filesystem boundaries.
 
 BriskDB supports Rust 1.85 and newer stable releases. CI tests the declared
 minimum supported Rust version (MSRV) and the latest stable toolchain.
+
+Prebuilt alpha archives are published on the [GitHub releases
+page](https://github.com/schapman1974/briskdb/releases). Each release contains
+native server and import binaries for Ubuntu 24.04 and macOS on x86-64 and
+ARM64, plus release notes, the license, and SHA-256 checksums. Only Ubuntu 24.04
+x86-64 receives the full required test suite; the other archives are preview
+artifacts built and startup-smoke-tested on native GitHub-hosted runners.
 
 ## Current foundation
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,56 @@
+# BriskDB 0.1.0-alpha.1
+
+This is the first BriskDB alpha release. It is intended for local evaluation
+and development, not production deployment.
+
+## Included binaries
+
+Each archive contains `briskdb`, `briskdb-import`, this file, `README.md`, the
+MIT license, and the repository documentation. Native archives are provided
+for:
+
+- Ubuntu 24.04 x86-64;
+- Ubuntu 24.04 ARM64;
+- macOS Intel x86-64; and
+- macOS Apple Silicon ARM64.
+
+Ubuntu 24.04 x86-64 is the only full-suite CI-supported platform. The other
+archives are preview builds that are compiled and startup-smoke-tested on native
+GitHub-hosted runners. Verify downloads against `SHA256SUMS`.
+
+## What is available
+
+- A protocol-neutral asynchronous engine over multiple bundled SQLite files.
+- Deterministic keyed routing, bounded scatter reads, connection pools,
+  cancellation, deadlines, result budgets, and graceful shutdown.
+- An HTTP SQL interface and embedded read-only admin browser on loopback.
+- Versioned manifest migrations, generated-key policies, prepared statements,
+  standard SQLite import, and a tested stopped-server backup/restore procedure.
+- A disabled-by-default PostgreSQL endpoint for protocol startup and session
+  handling only.
+
+## Critical alpha boundaries
+
+- HTTP has no authentication, authorization, or TLS and is restricted to
+  loopback. Do not expose it to a network.
+- PostgreSQL cannot execute SQL yet. It is disabled by default and, when
+  explicitly enabled on loopback, supports only startup/session handling.
+- General cross-shard transactions are unsupported. Global ordering,
+  pagination, and aggregation pushdown are incomplete, and BriskDB does not
+  claim full SQL compatibility.
+- Backups require a stopped server and a complete data-directory copy. Online
+  backup/restore, resharding, and online rebalance are unsupported.
+- There is no production metrics or observability suite.
+
+## Storage compatibility
+
+There is no stable pre-1.0 on-disk compatibility promise. This release writes
+manifest version 12 and accepts the exact documented legacy version-1 shape and
+manifest versions 2 through 11 for automatic, ordered forward migration.
+Unknown, malformed, partially migrated, or newer layouts fail closed.
+
+Before opening existing data, stop the old process and make a complete backup
+as described in `docs/OFFLINE_BACKUP.md`. Startup may migrate the data.
+In-place downgrade is unsupported; rollback requires restoring the complete
+pre-upgrade backup. This first published release has no on-disk format change
+relative to the source revision from which it was cut.

--- a/docs/SUPPORTED_PLATFORMS.md
+++ b/docs/SUPPORTED_PLATFORMS.md
@@ -63,9 +63,21 @@ until it has repeatable automated coverage. See the
 
 Maintainers also develop and run the full suite on `aarch64-apple-darwin`.
 macOS is useful for development and benchmark comparisons, but it is
-best-effort until it has a required CI job. Linux ARM64, Intel macOS, Windows,
-the musl target, 32-bit targets, big-endian targets, mobile platforms, and
-WebAssembly are not currently tested or supported.
+best-effort until it has a required full-suite CI job.
+
+Every tagged alpha release also builds and startup-smoke-tests native archives
+on these GitHub-hosted runners:
+
+- Ubuntu 24.04 x86-64 (`x86_64-unknown-linux-gnu`);
+- Ubuntu 24.04 ARM64 (`aarch64-unknown-linux-gnu`);
+- macOS Intel x86-64 (`x86_64-apple-darwin`); and
+- macOS Apple Silicon ARM64 (`aarch64-apple-darwin`).
+
+Those release artifacts are previews outside Ubuntu 24.04 x86-64. Their native
+jobs verify the locked release build, CLI version, HTTP startup, admin endpoint,
+and clean termination, but do not run the full storage and integration suite.
+Windows, the musl target, 32-bit targets, big-endian targets, mobile platforms,
+and WebAssembly are not currently tested or supported.
 
 Reports from unlisted targets are welcome. A target moves into the supported
 tier only after repeatable CI coverage exists for its compile, test, and

--- a/tests/release_packaging.rs
+++ b/tests/release_packaging.rs
@@ -1,0 +1,43 @@
+#[test]
+fn alpha_release_contract_covers_every_native_archive_and_safety_boundary() {
+    assert_eq!(env!("CARGO_PKG_VERSION"), "0.1.0-alpha.1");
+
+    let workflow = include_str!("../.github/workflows/release.yml");
+    for required in [
+        "ubuntu-24.04",
+        "ubuntu-24.04-arm",
+        "macos-15-intel",
+        "macos-15",
+        "x86_64-unknown-linux-gnu",
+        "aarch64-unknown-linux-gnu",
+        "x86_64-apple-darwin",
+        "aarch64-apple-darwin",
+        "cargo build --release --locked --bins",
+        "Smoke-test native server",
+        "docs/OFFLINE_BACKUP.md",
+        "SHA256SUMS",
+        "--prerelease",
+    ] {
+        assert!(
+            workflow.contains(required),
+            "release workflow is missing: {required}"
+        );
+    }
+
+    let notes = include_str!("../RELEASE_NOTES.md");
+    for required in [
+        "no authentication, authorization, or TLS",
+        "PostgreSQL cannot execute SQL yet",
+        "General cross-shard transactions are unsupported",
+        "complete data-directory copy",
+        "There is no stable pre-1.0 on-disk compatibility promise",
+        "manifest version 12",
+        "In-place downgrade is unsupported",
+        "no on-disk format change",
+    ] {
+        assert!(
+            notes.contains(required),
+            "release notes are missing critical boundary: {required}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- version the first prerelease as `0.1.0-alpha.1` and add normative release notes
- add native GitHub release builds for Linux and macOS on x86-64 and ARM64
- smoke-test each native server before packaging both binaries and documentation
- publish tagged builds as a prerelease with SHA-256 checksums
- document that non-Ubuntu-x86-64 artifacts remain preview tier
- add an executable release contract covering the target matrix and critical alpha boundaries

## Validation
- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features`
- `cargo test --locked --doc --all-features`
- native `aarch64-apple-darwin` release build, version check, HTTP/admin startup, and clean SIGTERM shutdown
- release workflow YAML parse

Closes #150