### PR TITLE
Use Node 24 artifact actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
           tar -tzf "dist/$archive.tar.gz" | grep -F "$archive/docs/OFFLINE_BACKUP.md"
 
       - name: Upload release archive
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: briskdb-${{ matrix.platform }}
           path: dist/*.tar.gz
@@ -127,7 +127,7 @@ jobs:
           persist-credentials: false
 
       - name: Download release archives
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist
           pattern: briskdb-*


### PR DESCRIPTION
## Summary
- update the pinned official artifact uploader to v7.0.1
- update the pinned official artifact downloader to v8.0.1
- remove the Node 20 deprecation warning observed in the four-platform release rehearsal

## Validation
- release workflow YAML parse
- `cargo test --locked --test release_packaging`
- four-platform rehearsal succeeded with the prior action pins; this PR will be rehearsed again after merge before tagging
