### PR TITLE
Package BriskDB as a hardened systemd service

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,15 +24,19 @@ jobs:
           - runner: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             platform: linux-x86_64
+            deb_architecture: amd64
           - runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             platform: linux-aarch64
+            deb_architecture: arm64
           - runner: macos-15-intel
             target: x86_64-apple-darwin
             platform: macos-x86_64
+            deb_architecture: none
           - runner: macos-15
             target: aarch64-apple-darwin
             platform: macos-aarch64
+            deb_architecture: none
     steps:
       - name: Check out tagged source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -104,11 +108,42 @@ jobs:
           tar -C dist -czf "dist/$archive.tar.gz" "$archive"
           tar -tzf "dist/$archive.tar.gz" | grep -F "$archive/docs/OFFLINE_BACKUP.md"
 
+      - name: Build Debian package
+        if: matrix.deb_architecture != 'none'
+        shell: bash
+        run: |
+          packaging/debian/build-deb.sh \
+            "target/${{ matrix.target }}/release" \
+            "${{ matrix.deb_architecture }}" \
+            "$VERSION" \
+            dist
+
+      - name: Install and smoke-test Debian service
+        if: matrix.deb_architecture != 'none'
+        shell: bash
+        run: |
+          set -euo pipefail
+          packages=(dist/*.deb)
+          if [[ ${#packages[@]} -ne 1 || ! -f "${packages[0]}" ]]; then
+            echo "expected exactly one Debian package" >&2
+            exit 1
+          fi
+          packaging/debian/test-deb-service.sh "${packages[0]}"
+
       - name: Upload release archive
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: briskdb-${{ matrix.platform }}
           path: dist/*.tar.gz
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload Debian package
+        if: matrix.deb_architecture != 'none'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: briskdb-deb-${{ matrix.deb_architecture }}
+          path: dist/*.deb
           if-no-files-found: error
           retention-days: 7
 
@@ -135,7 +170,7 @@ jobs:
 
       - name: Create checksums
         working-directory: dist
-        run: sha256sum *.tar.gz > SHA256SUMS
+        run: sha256sum *.tar.gz *.deb > SHA256SUMS
 
       - name: Publish prerelease
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "briskdb"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "briskdb"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 edition = "2024"
 rust-version = "1.85"
 default-run = "briskdb"

--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ native server and import binaries for Ubuntu 24.04 and macOS on x86-64 and
 ARM64, plus release notes, the license, and SHA-256 checksums. Only Ubuntu 24.04
 x86-64 receives the full required test suite; the other archives are preview
 artifacts built and startup-smoke-tested on native GitHub-hosted runners.
+Linux releases also include installable `amd64` and `arm64` Debian packages.
+The [Debian service guide](docs/DEBIAN_INSTALL.md) covers systemd configuration,
+state, logging, upgrades, removal, and the planned signed APT repository.
 
 ## Current foundation
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,13 @@
-# BriskDB 0.1.0-alpha.1
+# BriskDB 0.1.0-alpha.2
 
-This is the first BriskDB alpha release. It is intended for local evaluation
+This is the second BriskDB alpha release. It is intended for local evaluation
 and development, not production deployment.
+
+This update adds native `amd64` and `arm64` Debian packages. Installing a
+package creates an unprivileged `briskdb` service account, installs a hardened
+`briskdb.service`, keeps administrator configuration in
+`/etc/default/briskdb`, stores database state in `/var/lib/briskdb`, and sends
+stdout/stderr logs to the systemd journal.
 
 ## Included binaries
 
@@ -17,6 +23,12 @@ for:
 Ubuntu 24.04 x86-64 is the only full-suite CI-supported platform. The other
 archives are preview builds that are compiled and startup-smoke-tested on native
 GitHub-hosted runners. Verify downloads against `SHA256SUMS`.
+
+The Linux release assets also contain `briskdb_0.1.0~alpha.2-1_amd64.deb` and
+`briskdb_0.1.0~alpha.2-1_arm64.deb`. Each package is installed, started through
+systemd, queried over loopback HTTP, checked through journald, reinstalled with
+a locally modified conffile, and removed while retaining configuration and
+database state on its native Ubuntu 24.04 release runner.
 
 ## What is available
 
@@ -52,5 +64,5 @@ Unknown, malformed, partially migrated, or newer layouts fail closed.
 Before opening existing data, stop the old process and make a complete backup
 as described in `docs/OFFLINE_BACKUP.md`. Startup may migrate the data.
 In-place downgrade is unsupported; rollback requires restoring the complete
-pre-upgrade backup. This first published release has no on-disk format change
-relative to the source revision from which it was cut.
+pre-upgrade backup. This release has no on-disk format change from
+`0.1.0-alpha.1`.

--- a/docs/DEBIAN_INSTALL.md
+++ b/docs/DEBIAN_INSTALL.md
@@ -1,0 +1,98 @@
+# Debian package and systemd service
+
+BriskDB publishes preview Debian packages for Ubuntu 24.04 `amd64` and `arm64`.
+They install a native systemd service with distribution-standard paths. This is
+still an alpha deployment and does not change the security or compatibility
+boundaries in the release notes.
+
+## Direct release installation
+
+Download the matching `.deb` and `SHA256SUMS` from the GitHub release. Verify
+the checksum before installation, then install the local package:
+
+```bash
+sha256sum --check SHA256SUMS --ignore-missing
+sudo apt install ./briskdb_0.1.0~alpha.2-1_amd64.deb
+```
+
+Use the `_arm64.deb` package on 64-bit ARM. `apt` resolves the package's runtime
+dependencies and enables and starts `briskdb.service` during installation.
+
+## Filesystem contract
+
+| Purpose | Path |
+| --- | --- |
+| Server | `/usr/bin/briskdb` |
+| Import utility | `/usr/bin/briskdb-import` |
+| Administrator configuration | `/etc/default/briskdb` |
+| Vendor systemd unit | `/lib/systemd/system/briskdb.service` |
+| Persistent database state | `/var/lib/briskdb` |
+| Logs | systemd journal for `briskdb.service` |
+
+The package creates a locked, unprivileged `briskdb` system account. systemd's
+`StateDirectory=briskdb` keeps `/var/lib/briskdb` owned by that account with
+mode `0750`. The service has no writable access to `/etc`, `/usr`, home
+directories, devices, kernel controls, or other application state.
+
+`/etc/default/briskdb` is a dpkg conffile: administrator edits survive upgrades
+and removals. Edit it with `sudoedit`, validate the loopback/security boundary,
+then restart:
+
+```bash
+sudoedit /etc/default/briskdb
+sudo systemctl restart briskdb
+sudo systemctl status briskdb --no-pager
+```
+
+The default database location is `/var/lib/briskdb/data`. The HTTP listener is
+`127.0.0.1:7654`, and PostgreSQL is disabled. The server rejects non-loopback
+listeners while authentication and TLS are absent.
+
+## Logging
+
+The service writes structured text to stdout/stderr; systemd sends both streams
+to journald under the `briskdb` identifier. No separate `/var/log` file or
+logrotate rule is necessary. Inspect or follow logs with:
+
+```bash
+sudo journalctl -u briskdb.service --since today
+sudo journalctl -u briskdb.service -f
+```
+
+Set `RUST_LOG` in `/etc/default/briskdb` to adjust verbosity, then restart the
+service. Journal retention, forwarding, and disk limits remain the host
+administrator's system-wide journald policy.
+
+## Upgrade, backup, and removal
+
+Before upgrading, stop BriskDB and copy the complete data directory according
+to [the offline backup procedure](OFFLINE_BACKUP.md). Package upgrades restart
+an already active service after replacing the binary. They do not replace a
+locally edited `/etc/default/briskdb`.
+
+```bash
+sudo systemctl stop briskdb
+# Complete the documented stopped-server backup here.
+sudo apt install ./briskdb_NEW_VERSION_ARCH.deb
+```
+
+Removing the package stops the service and removes the binaries and vendor unit,
+but deliberately retains `/etc/default/briskdb`, the `briskdb` account, and
+`/var/lib/briskdb`. Even purge does not delete database state. After a verified
+backup, an administrator must explicitly remove unwanted state.
+
+## Signed APT repository boundary
+
+A `.deb` attached to a GitHub release is not by itself an APT repository. APT
+also requires `Packages`, `Release`, and signed `InRelease` metadata plus a
+published archive signing key. The intended next layer is:
+
+1. retain release `.deb` files in `pool/`;
+2. generate `dists/alpha/main/binary-amd64/Packages` and the ARM64 equivalent;
+3. generate and sign the `alpha` suite metadata;
+4. deploy that static tree through GitHub Pages; and
+5. give users a `signed-by=` source entry scoped to the BriskDB keyring.
+
+Publication must not begin until the offline private signing key, recovery copy,
+expiry/rotation policy, and GitHub Actions secret access are explicitly chosen.
+Do not publish an unsigned or `trusted=yes` repository as a shortcut.

--- a/packaging/debian/briskdb.default
+++ b/packaging/debian/briskdb.default
@@ -1,0 +1,27 @@
+# BriskDB systemd service configuration.
+# After editing, run: sudo systemctl restart briskdb
+
+# The alpha HTTP endpoint has no authentication or TLS and must remain loopback.
+BRISKDB_LISTEN=127.0.0.1:7654
+
+# PostgreSQL supports startup/session handling but cannot execute SQL yet.
+BRISKDB_POSTGRES_LISTEN=disabled
+
+# Persistent package-managed state location. Back up this complete directory
+# only while the service is stopped.
+BRISKDB_DATA_DIR=/var/lib/briskdb/data
+BRISKDB_SHARDS=4
+
+# Engine resource limits.
+BRISKDB_CONNECTIONS_PER_SHARD=4
+BRISKDB_QUEUE_CAPACITY_PER_SHARD=32
+BRISKDB_MAX_RESULT_ROWS=10000
+BRISKDB_MAX_RESULT_BYTES=16777216
+BRISKDB_MAX_PREPARED_STATEMENTS_PER_SESSION=128
+BRISKDB_MAX_PORTALS_PER_SESSION=128
+BRISKDB_MAX_RETAINED_BOUND_VALUE_BYTES=16777216
+BRISKDB_REQUEST_TIMEOUT_MS=30000
+BRISKDB_SHUTDOWN_GRACE_MS=30000
+
+# Logs are written to journald. Examples: briskdb=debug, info, warn.
+RUST_LOG=briskdb=info

--- a/packaging/debian/briskdb.service
+++ b/packaging/debian/briskdb.service
@@ -2,7 +2,7 @@
 Description=BriskDB sharded SQLite server
 Documentation=https://github.com/schapman1974/briskdb
 After=local-fs.target network.target
-ConditionPathIsExecutable=/usr/bin/briskdb
+ConditionFileIsExecutable=/usr/bin/briskdb
 
 [Service]
 Type=simple

--- a/packaging/debian/briskdb.service
+++ b/packaging/debian/briskdb.service
@@ -1,0 +1,46 @@
+[Unit]
+Description=BriskDB sharded SQLite server
+Documentation=https://github.com/schapman1974/briskdb
+After=local-fs.target network.target
+ConditionPathIsExecutable=/usr/bin/briskdb
+
+[Service]
+Type=simple
+User=briskdb
+Group=briskdb
+EnvironmentFile=-/etc/default/briskdb
+WorkingDirectory=/var/lib/briskdb
+ExecStart=/usr/bin/briskdb
+Restart=on-failure
+RestartSec=2s
+TimeoutStopSec=40s
+StateDirectory=briskdb
+StateDirectoryMode=0750
+UMask=0027
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=briskdb
+
+NoNewPrivileges=true
+PrivateDevices=true
+PrivateTmp=true
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectSystem=strict
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+LockPersonality=true
+SystemCallArchitectures=native
+CapabilityBoundingSet=
+AmbientCapabilities=
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/debian/build-deb.sh
+++ b/packaging/debian/build-deb.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 4 ]]; then
+    echo "usage: $0 BINARY_DIRECTORY DEBIAN_ARCHITECTURE CARGO_VERSION OUTPUT_DIRECTORY" >&2
+    exit 2
+fi
+
+binary_directory=$1
+architecture=$2
+cargo_version=$3
+output_directory=$4
+
+case "$architecture" in
+    amd64|arm64) ;;
+    *)
+        echo "unsupported Debian architecture: $architecture" >&2
+        exit 2
+        ;;
+esac
+
+for binary in briskdb briskdb-import; do
+    if [[ ! -x "$binary_directory/$binary" ]]; then
+        echo "missing executable release binary: $binary_directory/$binary" >&2
+        exit 1
+    fi
+done
+
+debian_version=${cargo_version/-/~}-1
+package_basename="briskdb_${debian_version}_${architecture}"
+temporary_directory=$(mktemp -d)
+package_root="$temporary_directory/$package_basename"
+cleanup() {
+    rm -rf "$temporary_directory"
+}
+trap cleanup EXIT
+
+install -d \
+    "$package_root/DEBIAN" \
+    "$package_root/usr/bin" \
+    "$package_root/usr/share/doc/briskdb" \
+    "$package_root/lib/systemd/system" \
+    "$package_root/etc/default"
+
+install -m 0755 "$binary_directory/briskdb" "$package_root/usr/bin/briskdb"
+install -m 0755 "$binary_directory/briskdb-import" "$package_root/usr/bin/briskdb-import"
+install -m 0644 packaging/debian/briskdb.service "$package_root/lib/systemd/system/briskdb.service"
+install -m 0644 packaging/debian/briskdb.default "$package_root/etc/default/briskdb"
+install -m 0644 README.md RELEASE_NOTES.md LICENSE "$package_root/usr/share/doc/briskdb/"
+cp -R docs "$package_root/usr/share/doc/briskdb/docs"
+
+install -m 0755 packaging/debian/postinst "$package_root/DEBIAN/postinst"
+install -m 0755 packaging/debian/prerm "$package_root/DEBIAN/prerm"
+install -m 0755 packaging/debian/postrm "$package_root/DEBIAN/postrm"
+printf '%s\n' /etc/default/briskdb > "$package_root/DEBIAN/conffiles"
+
+installed_size=$(du -sk "$package_root" | awk '{print $1}')
+sed \
+    -e "s/@DEBIAN_VERSION@/$debian_version/g" \
+    -e "s/@ARCHITECTURE@/$architecture/g" \
+    -e "s/@INSTALLED_SIZE@/$installed_size/g" \
+    packaging/debian/control.in > "$package_root/DEBIAN/control"
+
+mkdir -p "$output_directory"
+dpkg-deb --build --root-owner-group "$package_root" "$output_directory/$package_basename.deb"

--- a/packaging/debian/build-deb.sh
+++ b/packaging/debian/build-deb.sh
@@ -1,6 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+to_debian_version() {
+    local version=$1
+    if [[ "$version" == *-* ]]; then
+        printf '%s~%s-1\n' "${version%%-*}" "${version#*-}"
+    else
+        printf '%s-1\n' "$version"
+    fi
+}
+
+if [[ $# -eq 2 && "$1" == "--print-debian-version" ]]; then
+    to_debian_version "$2"
+    exit 0
+fi
+
 if [[ $# -ne 4 ]]; then
     echo "usage: $0 BINARY_DIRECTORY DEBIAN_ARCHITECTURE CARGO_VERSION OUTPUT_DIRECTORY" >&2
     exit 2
@@ -26,7 +40,7 @@ for binary in briskdb briskdb-import; do
     fi
 done
 
-debian_version=${cargo_version/-/~}-1
+debian_version=$(to_debian_version "$cargo_version")
 package_basename="briskdb_${debian_version}_${architecture}"
 temporary_directory=$(mktemp -d)
 package_root="$temporary_directory/$package_basename"
@@ -56,9 +70,9 @@ printf '%s\n' /etc/default/briskdb > "$package_root/DEBIAN/conffiles"
 
 installed_size=$(du -sk "$package_root" | awk '{print $1}')
 sed \
-    -e "s/@DEBIAN_VERSION@/$debian_version/g" \
-    -e "s/@ARCHITECTURE@/$architecture/g" \
-    -e "s/@INSTALLED_SIZE@/$installed_size/g" \
+    -e "s|@DEBIAN_VERSION@|$debian_version|g" \
+    -e "s|@ARCHITECTURE@|$architecture|g" \
+    -e "s|@INSTALLED_SIZE@|$installed_size|g" \
     packaging/debian/control.in > "$package_root/DEBIAN/control"
 
 mkdir -p "$output_directory"

--- a/packaging/debian/control.in
+++ b/packaging/debian/control.in
@@ -1,0 +1,13 @@
+Package: briskdb
+Version: @DEBIAN_VERSION@
+Architecture: @ARCHITECTURE@
+Maintainer: BriskDB Maintainers <schapman1974@users.noreply.github.com>
+Installed-Size: @INSTALLED_SIZE@
+Depends: libc6 (>= 2.38), adduser, init-system-helpers
+Section: database
+Priority: optional
+Homepage: https://github.com/schapman1974/briskdb
+Description: experimental sharded SQLite server
+ BriskDB spreads keyed workloads across multiple bundled SQLite databases.
+ This alpha package installs the server, import utility, systemd service,
+ administrator configuration, and documentation.

--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -31,9 +31,9 @@ fi
 if [ -d /run/systemd/system ]; then
     systemctl --system daemon-reload >/dev/null || true
     if systemctl --system --quiet is-active briskdb.service; then
-        deb-systemd-invoke restart briskdb.service >/dev/null || true
+        deb-systemd-invoke restart briskdb.service >/dev/null
     else
-        deb-systemd-invoke start briskdb.service >/dev/null || true
+        deb-systemd-invoke start briskdb.service >/dev/null
     fi
 fi
 

--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -1,0 +1,40 @@
+#!/bin/sh
+set -e
+
+if ! getent group briskdb >/dev/null; then
+    addgroup --system briskdb
+fi
+
+if ! getent passwd briskdb >/dev/null; then
+    adduser --system \
+        --ingroup briskdb \
+        --home /var/lib/briskdb \
+        --no-create-home \
+        --shell /usr/sbin/nologin \
+        --gecos "BriskDB service" \
+        briskdb
+fi
+
+install -d -o briskdb -g briskdb -m 0750 /var/lib/briskdb
+
+if deb-systemd-helper debian-installed briskdb.service; then
+    deb-systemd-helper unmask briskdb.service >/dev/null || true
+    if deb-systemd-helper --quiet was-enabled briskdb.service; then
+        deb-systemd-helper enable briskdb.service >/dev/null || true
+    else
+        deb-systemd-helper update-state briskdb.service >/dev/null || true
+    fi
+else
+    deb-systemd-helper enable briskdb.service >/dev/null || true
+fi
+
+if [ -d /run/systemd/system ]; then
+    systemctl --system daemon-reload >/dev/null || true
+    if systemctl --system --quiet is-active briskdb.service; then
+        deb-systemd-invoke restart briskdb.service >/dev/null || true
+    else
+        deb-systemd-invoke start briskdb.service >/dev/null || true
+    fi
+fi
+
+exit 0

--- a/packaging/debian/postrm
+++ b/packaging/debian/postrm
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+if [ "$1" = purge ]; then
+    deb-systemd-helper purge briskdb.service >/dev/null || true
+fi
+
+if [ -d /run/systemd/system ]; then
+    systemctl --system daemon-reload >/dev/null || true
+fi
+
+# The service account and /var/lib/briskdb are deliberately retained. Database
+# removal must be an explicit administrator action after a verified backup.
+exit 0

--- a/packaging/debian/prerm
+++ b/packaging/debian/prerm
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+if [ "$1" = remove ] && [ -d /run/systemd/system ]; then
+    deb-systemd-invoke stop briskdb.service >/dev/null || true
+fi
+
+exit 0

--- a/packaging/debian/test-deb-service.sh
+++ b/packaging/debian/test-deb-service.sh
@@ -44,12 +44,12 @@ printf '\n# package smoke-test local configuration\n' | sudo tee -a "$configurat
 sudo touch "$state_directory/package-smoke-state"
 sudo env DEBIAN_FRONTEND=noninteractive dpkg -i "$package"
 grep -F '# package smoke-test local configuration' "$configuration"
-test -f "$state_directory/package-smoke-state"
+sudo test -f "$state_directory/package-smoke-state"
 wait_for_service
 
 sudo env DEBIAN_FRONTEND=noninteractive dpkg -r briskdb
 test -f "$configuration"
-test -f "$state_directory/package-smoke-state"
+sudo test -f "$state_directory/package-smoke-state"
 if systemctl is-active --quiet briskdb.service; then
     echo "briskdb.service remained active after package removal" >&2
     exit 1

--- a/packaging/debian/test-deb-service.sh
+++ b/packaging/debian/test-deb-service.sh
@@ -10,24 +10,27 @@ package=$1
 configuration=/etc/default/briskdb
 state_directory=/var/lib/briskdb
 
+wait_for_service() {
+    for attempt in {1..30}; do
+        if sudo systemctl is-active --quiet briskdb.service \
+            && curl --fail --silent --show-error http://127.0.0.1:7654/admin >/dev/null; then
+            return 0
+        fi
+        sleep 1
+    done
+
+    sudo systemctl status briskdb.service --no-pager || true
+    sudo journalctl -u briskdb.service --no-pager || true
+    return 1
+}
+
 dpkg-deb --info "$package"
 dpkg-deb --contents "$package" | grep -F ./lib/systemd/system/briskdb.service
 dpkg-deb --contents "$package" | grep -F ./etc/default/briskdb
 
 sudo env DEBIAN_FRONTEND=noninteractive dpkg -i "$package"
 sudo systemd-analyze verify /lib/systemd/system/briskdb.service
-
-for attempt in {1..30}; do
-    if curl --fail --silent --show-error http://127.0.0.1:7654/admin >/dev/null; then
-        break
-    fi
-    if [[ "$attempt" -eq 30 ]]; then
-        sudo systemctl status briskdb.service --no-pager || true
-        sudo journalctl -u briskdb.service --no-pager || true
-        exit 1
-    fi
-    sleep 1
-done
+wait_for_service
 
 sudo systemctl is-enabled --quiet briskdb.service
 sudo systemctl is-active --quiet briskdb.service
@@ -42,7 +45,7 @@ sudo touch "$state_directory/package-smoke-state"
 sudo env DEBIAN_FRONTEND=noninteractive dpkg -i "$package"
 grep -F '# package smoke-test local configuration' "$configuration"
 test -f "$state_directory/package-smoke-state"
-sudo systemctl is-active --quiet briskdb.service
+wait_for_service
 
 sudo env DEBIAN_FRONTEND=noninteractive dpkg -r briskdb
 test -f "$configuration"

--- a/packaging/debian/test-deb-service.sh
+++ b/packaging/debian/test-deb-service.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 || ! -f "$1" ]]; then
+    echo "usage: $0 PACKAGE.deb" >&2
+    exit 2
+fi
+
+package=$1
+configuration=/etc/default/briskdb
+state_directory=/var/lib/briskdb
+
+dpkg-deb --info "$package"
+dpkg-deb --contents "$package" | grep -F ./lib/systemd/system/briskdb.service
+dpkg-deb --contents "$package" | grep -F ./etc/default/briskdb
+
+sudo env DEBIAN_FRONTEND=noninteractive dpkg -i "$package"
+sudo systemd-analyze verify /lib/systemd/system/briskdb.service
+
+for attempt in {1..30}; do
+    if curl --fail --silent --show-error http://127.0.0.1:7654/admin >/dev/null; then
+        break
+    fi
+    if [[ "$attempt" -eq 30 ]]; then
+        sudo systemctl status briskdb.service --no-pager || true
+        sudo journalctl -u briskdb.service --no-pager || true
+        exit 1
+    fi
+    sleep 1
+done
+
+sudo systemctl is-enabled --quiet briskdb.service
+sudo systemctl is-active --quiet briskdb.service
+getent passwd briskdb | grep -F /usr/sbin/nologin
+test "$(stat -c '%U:%G:%a' "$state_directory")" = briskdb:briskdb:750
+test "$(stat -c '%U:%G:%a' "$configuration")" = root:root:644
+dpkg-query -W -f='${Conffiles}\n' briskdb | grep -F ' /etc/default/briskdb '
+sudo journalctl -u briskdb.service --no-pager | grep -F 'BriskDB is ready'
+
+printf '\n# package smoke-test local configuration\n' | sudo tee -a "$configuration" >/dev/null
+sudo touch "$state_directory/package-smoke-state"
+sudo env DEBIAN_FRONTEND=noninteractive dpkg -i "$package"
+grep -F '# package smoke-test local configuration' "$configuration"
+test -f "$state_directory/package-smoke-state"
+sudo systemctl is-active --quiet briskdb.service
+
+sudo env DEBIAN_FRONTEND=noninteractive dpkg -r briskdb
+test -f "$configuration"
+test -f "$state_directory/package-smoke-state"
+if systemctl is-active --quiet briskdb.service; then
+    echo "briskdb.service remained active after package removal" >&2
+    exit 1
+fi

--- a/tests/debian_packaging.rs
+++ b/tests/debian_packaging.rs
@@ -37,6 +37,23 @@ fn debian_service_uses_fhs_paths_journald_and_a_restricted_account() {
 }
 
 #[test]
+fn cargo_versions_convert_to_debian_versions_without_shell_tilde_expansion() {
+    let builder = format!(
+        "{}/packaging/debian/build-deb.sh",
+        env!("CARGO_MANIFEST_DIR")
+    );
+
+    for (cargo_version, expected) in [("0.1.0-alpha.2", "0.1.0~alpha.2-1"), ("0.1.0", "0.1.0-1")] {
+        let output = Command::new(&builder)
+            .args(["--print-debian-version", cargo_version])
+            .output()
+            .expect("package builder must run");
+        assert!(output.status.success());
+        assert_eq!(String::from_utf8(output.stdout).unwrap().trim(), expected);
+    }
+}
+
+#[test]
 fn debian_package_contract_preserves_configuration_and_database_state() {
     let builder = include_str!("../packaging/debian/build-deb.sh");
     for required in [
@@ -70,3 +87,4 @@ fn debian_package_contract_preserves_configuration_and_database_state() {
         );
     }
 }
+use std::process::Command;

--- a/tests/debian_packaging.rs
+++ b/tests/debian_packaging.rs
@@ -1,0 +1,72 @@
+#[test]
+fn debian_service_uses_fhs_paths_journald_and_a_restricted_account() {
+    let unit = include_str!("../packaging/debian/briskdb.service");
+    for required in [
+        "User=briskdb",
+        "Group=briskdb",
+        "EnvironmentFile=-/etc/default/briskdb",
+        "WorkingDirectory=/var/lib/briskdb",
+        "StateDirectory=briskdb",
+        "StateDirectoryMode=0750",
+        "ExecStart=/usr/bin/briskdb",
+        "StandardOutput=journal",
+        "StandardError=journal",
+        "ProtectSystem=strict",
+        "ProtectHome=true",
+        "NoNewPrivileges=true",
+        "RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6",
+    ] {
+        assert!(
+            unit.contains(required),
+            "systemd unit is missing: {required}"
+        );
+    }
+
+    let configuration = include_str!("../packaging/debian/briskdb.default");
+    for required in [
+        "BRISKDB_LISTEN=127.0.0.1:7654",
+        "BRISKDB_POSTGRES_LISTEN=disabled",
+        "BRISKDB_DATA_DIR=/var/lib/briskdb/data",
+        "RUST_LOG=briskdb=info",
+    ] {
+        assert!(
+            configuration.contains(required),
+            "Debian configuration is missing: {required}"
+        );
+    }
+}
+
+#[test]
+fn debian_package_contract_preserves_configuration_and_database_state() {
+    let builder = include_str!("../packaging/debian/build-deb.sh");
+    for required in [
+        "/usr/bin/briskdb",
+        "/usr/bin/briskdb-import",
+        "/lib/systemd/system/briskdb.service",
+        "/etc/default/briskdb",
+        "dpkg-deb --build --root-owner-group",
+    ] {
+        assert!(
+            builder.contains(required),
+            "package builder is missing: {required}"
+        );
+    }
+
+    let postrm = include_str!("../packaging/debian/postrm");
+    assert!(postrm.contains("deliberately retained"));
+    assert!(!postrm.contains("rm -"));
+
+    let smoke = include_str!("../packaging/debian/test-deb-service.sh");
+    for required in [
+        "systemd-analyze verify",
+        "BriskDB is ready",
+        "package smoke-test local configuration",
+        "dpkg -r briskdb",
+        "package-smoke-state",
+    ] {
+        assert!(
+            smoke.contains(required),
+            "package smoke test is missing: {required}"
+        );
+    }
+}

--- a/tests/debian_packaging.rs
+++ b/tests/debian_packaging.rs
@@ -9,6 +9,7 @@ fn debian_service_uses_fhs_paths_journald_and_a_restricted_account() {
         "StateDirectory=briskdb",
         "StateDirectoryMode=0750",
         "ExecStart=/usr/bin/briskdb",
+        "ConditionFileIsExecutable=/usr/bin/briskdb",
         "StandardOutput=journal",
         "StandardError=journal",
         "ProtectSystem=strict",
@@ -78,6 +79,7 @@ fn debian_package_contract_preserves_configuration_and_database_state() {
         "systemd-analyze verify",
         "BriskDB is ready",
         "package smoke-test local configuration",
+        "wait_for_service",
         "dpkg -r briskdb",
         "package-smoke-state",
     ] {

--- a/tests/release_packaging.rs
+++ b/tests/release_packaging.rs
@@ -1,6 +1,6 @@
 #[test]
 fn alpha_release_contract_covers_every_native_archive_and_safety_boundary() {
-    assert_eq!(env!("CARGO_PKG_VERSION"), "0.1.0-alpha.1");
+    assert_eq!(env!("CARGO_PKG_VERSION"), "0.1.0-alpha.2");
 
     let workflow = include_str!("../.github/workflows/release.yml");
     for required in [
@@ -14,6 +14,10 @@ fn alpha_release_contract_covers_every_native_archive_and_safety_boundary() {
         "aarch64-apple-darwin",
         "cargo build --release --locked --bins",
         "Smoke-test native server",
+        "deb_architecture: amd64",
+        "deb_architecture: arm64",
+        "Install and smoke-test Debian service",
+        "packaging/debian/build-deb.sh",
         "docs/OFFLINE_BACKUP.md",
         "SHA256SUMS",
         "--prerelease",


### PR DESCRIPTION
## Summary

- build native Ubuntu 24.04 `amd64` and `arm64` Debian packages alongside release archives
- install an unprivileged, hardened `briskdb.service` with dpkg-managed configuration, persistent state, and journald logging
- smoke-test install, enable/start, HTTP readiness, journal output, conffile/state retention across reinstall, and safe package removal
- document direct `.deb` installation and the security boundary for a future signed GitHub Pages APT repository

## Verification

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --all-features --no-deps`
- shell syntax, release workflow YAML, and diff checks

Closes #153
