### PR TITLE
Use GitHub-safe Debian asset filenames

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -24,8 +24,8 @@ Ubuntu 24.04 x86-64 is the only full-suite CI-supported platform. The other
 archives are preview builds that are compiled and startup-smoke-tested on native
 GitHub-hosted runners. Verify downloads against `SHA256SUMS`.
 
-The Linux release assets also contain `briskdb_0.1.0~alpha.2-1_amd64.deb` and
-`briskdb_0.1.0~alpha.2-1_arm64.deb`. Each package is installed, started through
+The Linux release assets also contain `briskdb_0.1.0.alpha.2-1_amd64.deb` and
+`briskdb_0.1.0.alpha.2-1_arm64.deb`. Each package is installed, started through
 systemd, queried over loopback HTTP, checked through journald, reinstalled with
 a locally modified conffile, and removed while retaining configuration and
 database state on its native Ubuntu 24.04 release runner.

--- a/docs/DEBIAN_INSTALL.md
+++ b/docs/DEBIAN_INSTALL.md
@@ -12,11 +12,13 @@ the checksum before installation, then install the local package:
 
 ```bash
 sha256sum --check SHA256SUMS --ignore-missing
-sudo apt install ./briskdb_0.1.0~alpha.2-1_amd64.deb
+sudo apt install ./briskdb_0.1.0.alpha.2-1_amd64.deb
 ```
 
 Use the `_arm64.deb` package on 64-bit ARM. `apt` resolves the package's runtime
 dependencies and enables and starts `briskdb.service` during installation.
+The filename uses a GitHub-safe dot, while package metadata uses the Debian
+prerelease version `0.1.0~alpha.2-1` so it sorts before the final release.
 
 ## Filesystem contract
 

--- a/packaging/debian/build-deb.sh
+++ b/packaging/debian/build-deb.sh
@@ -15,6 +15,12 @@ if [[ $# -eq 2 && "$1" == "--print-debian-version" ]]; then
     exit 0
 fi
 
+if [[ $# -eq 2 && "$1" == "--print-package-filename" ]]; then
+    debian_version=$(to_debian_version "$2")
+    printf 'briskdb_%s_ARCH.deb\n' "${debian_version//\~/.}"
+    exit 0
+fi
+
 if [[ $# -ne 4 ]]; then
     echo "usage: $0 BINARY_DIRECTORY DEBIAN_ARCHITECTURE CARGO_VERSION OUTPUT_DIRECTORY" >&2
     exit 2
@@ -41,7 +47,8 @@ for binary in briskdb briskdb-import; do
 done
 
 debian_version=$(to_debian_version "$cargo_version")
-package_basename="briskdb_${debian_version}_${architecture}"
+filename_version=${debian_version//\~/.}
+package_basename="briskdb_${filename_version}_${architecture}"
 temporary_directory=$(mktemp -d)
 package_root="$temporary_directory/$package_basename"
 cleanup() {

--- a/tests/debian_packaging.rs
+++ b/tests/debian_packaging.rs
@@ -52,6 +52,16 @@ fn cargo_versions_convert_to_debian_versions_without_shell_tilde_expansion() {
         assert!(output.status.success());
         assert_eq!(String::from_utf8(output.stdout).unwrap().trim(), expected);
     }
+
+    let output = Command::new(&builder)
+        .args(["--print-package-filename", "0.1.0-alpha.2"])
+        .output()
+        .expect("package builder must print its external filename");
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap().trim(),
+        "briskdb_0.1.0.alpha.2-1_ARCH.deb"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- retain Debian's internal prerelease ordering version (`0.1.0~alpha.2-1`)
- emit external `.deb` filenames with a GitHub-safe dot because release uploads normalize `~`
- test both the metadata version and release filename and update install/release documentation

## Verification

- `cargo fmt --all --check`
- `cargo test --locked --test debian_packaging --test release_packaging`
- shell syntax and diff checks

Closes #155
