### PR TITLE
Add embedded BriskDb builder and library entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ engine. It keeps the durability, WAL, transactions, tooling, and boring
 reliability developers already trust—then adds routing, parallel writer domains,
 global reads, generated IDs, an HTTP API, and wire-protocol frontends.
 
-**HTTP and bounded PostgreSQL queries work today. Native MongoDB, MySQL,
-embedded Rust, Python, and serverless use are on the roadmap.**
+**HTTP, bounded PostgreSQL queries, and listener-free Rust embedding work today.
+Native MongoDB, MySQL, Python, and serverless use are on the roadmap.**
 
 > [!WARNING]
 > BriskDB is an alpha. It is exciting infrastructure, not yet a production-ready
@@ -109,9 +109,10 @@ experimental and opt-in; the exact contract lives in
 | Native-range and hi/lo generated IDs | Experimental, opt-in |
 | Ubuntu/macOS x86-64 and ARM64 release artifacts | Published |
 | Debian package and hardened systemd service | Published |
+| Listener-free Rust library entrypoint | Working |
 | Native MongoDB wire protocol with TinyMongo parity | [Planned](https://github.com/schapman1974/briskdb/issues/160) |
 | MySQL wire protocol | [Planned](https://github.com/schapman1974/briskdb/issues/40) |
-| Embedded Rust, Python wheels, and serverless lifecycle | [Planned](https://github.com/schapman1974/briskdb/issues/189) |
+| Python wheels and serverless lifecycle | [Planned](https://github.com/schapman1974/briskdb/issues/197) |
 
 ## Try it in 30 seconds
 
@@ -147,6 +148,10 @@ Have an existing SQLite database? Use the offline
 [GitHub release](https://github.com/schapman1974/briskdb/releases), including
 macOS/Linux ARM64 and x86-64 archives plus Linux `.deb` packages.
 
+Embedding in Rust starts with `BriskDb::open()` or the validated builder. The
+[embedded Rust guide](docs/EMBEDDED_RUST.md) includes a complete listener-free
+example and documents every default.
+
 ## Still just inspectable files
 
 ```text
@@ -168,8 +173,9 @@ and integrity metadata. Application rows stay in ordinary SQLite files.
   indexes, cursors, aggregation, and differential TinyMongo parity.
 - **More wire protocols:** PostgreSQL extended queries and MySQL compatibility,
   all sharing the same engine behavior.
-- **Embedded and serverless:** a clean Rust library, Python/PyO3 wheels, atomic
-  snapshots, ephemeral-runtime helpers, and fenced single-writer operation.
+- **Python and serverless:** Python/PyO3 wheels, atomic snapshots,
+  ephemeral-runtime helpers, and fenced single-writer operation over the
+  embedded Rust API.
 - **Future storage adapters:** SQLite is the first backend, while the engine
   boundaries are being kept reusable for other durable backends.
 
@@ -190,6 +196,7 @@ Follow the [roadmap](ROADMAP.md) or browse the
 ## Go deeper
 
 - [Architecture](docs/ARCHITECTURE.md)
+- [Embedded Rust](docs/EMBEDDED_RUST.md)
 - [PostgreSQL quickstart](docs/POSTGRES_QUICKSTART.md)
 - [SQL compatibility](docs/SQL_COMPATIBILITY.md)
 - [Generated keys](docs/GENERATED_KEYS.md)

--- a/docs/EMBEDDED_RUST.md
+++ b/docs/EMBEDDED_RUST.md
@@ -1,0 +1,85 @@
+# Embedded Rust
+
+Status: implemented by issue #189
+
+`BriskDb` is the listener-free entrypoint for using the same protocol-neutral
+engine inside a Rust application. Opening it does not bind sockets, install
+signal handlers, configure tracing, or change process-global state.
+
+```rust
+use briskdb::{BriskDb, Statement, Value};
+
+# async fn run() -> briskdb::EngineResult<()> {
+let db = BriskDb::builder("./data")
+    .with_shard_count(4)
+    .open()
+    .await?;
+let session = db.session();
+session.set_routing_key("tenant-1").await?;
+
+db.migrate(
+    &session,
+    "CREATE TABLE notes (id INTEGER PRIMARY KEY, body TEXT NOT NULL)",
+).await?;
+db.execute_write(
+    &session,
+    Statement::new(
+        "INSERT INTO notes (id, body) VALUES (?1, ?2)",
+        vec![Value::from(1_i64), Value::from("hello")],
+    ),
+).await?;
+
+let result = db.query(
+    &session,
+    Statement::new("SELECT body FROM notes WHERE id = ?1", vec![1_i64.into()]),
+).await?;
+assert_eq!(result.value.rows()[0].get(0), Some(&Value::from("hello")));
+
+session.close().await?;
+db.close().await?;
+# Ok(())
+# }
+```
+
+Run the complete example with:
+
+```bash
+cargo run --example embedded -- ./briskdb-embedded-example
+```
+
+## Defaults
+
+| Setting | Default |
+| --- | ---: |
+| Physical shards | 4 |
+| Active SQLite connections per shard | 4 |
+| Queued operations per shard | 32 |
+| Result rows | 10,000 |
+| Result logical bytes | 16 MiB |
+| Request timeout | 30 seconds |
+| Shutdown grace | 30 seconds |
+| Runtime | Caller-managed Tokio runtime |
+| Native document support | Disabled |
+
+Use `EngineOptions`, `ResultLimits`, and `PreparedStatementLimits` to replace
+resource defaults. The builder validates the complete shard/runtime/document
+configuration before opening or creating storage.
+
+## Lifecycle and errors
+
+`BriskDb` clones share one engine lifecycle and connection pools. Different
+data directories can be opened independently in one process. Create a distinct
+`Session` for each logical connection or request, close sessions when their
+work ends, and explicitly await `BriskDb::close()` before the final handle is
+dropped.
+
+Failures use `EngineError`. Match `EngineError::kind()` or the stable
+machine-readable `EngineError::code()`; diagnostic text is intended for trusted
+logs and is not a compatibility contract.
+
+Schema changes use `BriskDb::migrate()` and the crash-resumable migration
+journal. Ordinary DDL is deliberately rejected through the write method.
+
+The initial library is async and requires a caller-managed Tokio runtime. The
+typed dedicated-runtime and document-support modes are reserved and fail with
+`unsupported` before storage is touched until their implementations land.

--- a/examples/embedded.rs
+++ b/examples/embedded.rs
@@ -1,0 +1,49 @@
+//! Minimal listener-free BriskDB program.
+
+use std::path::PathBuf;
+
+use briskdb::{BriskDb, Statement, Value};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let data_dir = std::env::args_os()
+        .nth(1)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("./briskdb-embedded-example"));
+    let db = BriskDb::builder(data_dir)
+        .with_shard_count(4)
+        .open()
+        .await?;
+    let session = db.session();
+    session.set_routing_key("example").await?;
+
+    db.migrate(
+        &session,
+        "CREATE TABLE IF NOT EXISTS notes (id INTEGER PRIMARY KEY, body TEXT NOT NULL)",
+    )
+    .await?;
+    db.execute_write(
+        &session,
+        Statement::new(
+            "INSERT OR REPLACE INTO notes (id, body) VALUES (?1, ?2)",
+            vec![Value::from(1_i64), Value::from("hello from embedded Rust")],
+        ),
+    )
+    .await?;
+
+    let result = db
+        .query(
+            &session,
+            Statement::new(
+                "SELECT id, body FROM notes WHERE id = ?1",
+                vec![1_i64.into()],
+            ),
+        )
+        .await?;
+    println!("shard {}: {:?}", result.shard, result.value.rows());
+    println!("{} shards ready", db.status(&session).await?.shard_count());
+
+    session.close().await?;
+    db.close().await?;
+    Ok(())
+}

--- a/src/core/options.rs
+++ b/src/core/options.rs
@@ -353,6 +353,15 @@ impl EngineOptions {
 
         Ok(total_active_connections)
     }
+
+    /// Validate limits that depend on one embedded database's shard count.
+    ///
+    /// This performs no filesystem access and allows builders and other hosts
+    /// to reject a complete configuration before opening or creating storage.
+    pub fn validate_for_shards(self, shard_count: u16) -> EngineResult<()> {
+        crate::storage::validate_shard_count(shard_count)?;
+        self.worker_limit(shard_count).map(|_| ())
+    }
 }
 
 impl Default for EngineOptions {

--- a/src/embedded.rs
+++ b/src/embedded.rs
@@ -1,0 +1,268 @@
+//! Stable, listener-free entry point for embedding BriskDB.
+//!
+//! Opening this API never binds a socket, installs a signal handler or tracing
+//! subscriber, or otherwise changes process-global state. The caller owns the
+//! Tokio runtime and should explicitly call [`BriskDb::close`] before dropping
+//! its last database handle.
+
+use std::path::{Path, PathBuf};
+
+use crate::core::{
+    Catalog, Engine, EngineOptions, EngineResult, EngineState, EngineStatus, Executed, ResultSet,
+    Routed, Session, ShutdownReport, Statement, WriteResult,
+};
+use crate::{EngineError, EngineErrorKind};
+
+/// Default number of physical shards created by the embedded convenience API.
+pub const DEFAULT_EMBEDDED_SHARDS: u16 = 4;
+
+/// Tokio runtime ownership selected for an embedded database.
+///
+/// The initial embedded API is intentionally async and uses the runtime that
+/// polls [`BriskDbBuilder::open`]. A dedicated runtime is reserved for future
+/// synchronous foreign-language wrappers and is rejected before storage opens.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum RuntimeBehavior {
+    /// Use the embedding application's current Tokio runtime.
+    #[default]
+    CallerManaged,
+    /// Reserve a dedicated BriskDB runtime owned by the handle.
+    Dedicated,
+}
+
+/// Optional native document-command surface for an embedded database.
+///
+/// Document support is an explicit configuration choice so enabling it later
+/// cannot silently change a SQL-only application's storage contract. The
+/// current build rejects [`DocumentSupport::Enabled`] before touching storage.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum DocumentSupport {
+    /// Open only the established SQL engine.
+    #[default]
+    Disabled,
+    /// Enable the native BSON/document engine when that feature is available.
+    Enabled,
+}
+
+/// Validated configuration for opening one listener-free BriskDB instance.
+#[derive(Debug, Clone)]
+#[must_use = "a builder must be opened to create a BriskDB instance"]
+pub struct BriskDbBuilder {
+    root: PathBuf,
+    shard_count: u16,
+    engine_options: EngineOptions,
+    runtime_behavior: RuntimeBehavior,
+    document_support: DocumentSupport,
+}
+
+impl BriskDbBuilder {
+    /// Create a builder with documented embedded defaults.
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self {
+            root: root.into(),
+            shard_count: DEFAULT_EMBEDDED_SHARDS,
+            engine_options: EngineOptions::default(),
+            runtime_behavior: RuntimeBehavior::default(),
+            document_support: DocumentSupport::default(),
+        }
+    }
+
+    /// Return the configured data-directory path.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Return the configured physical shard count.
+    pub const fn shard_count(&self) -> u16 {
+        self.shard_count
+    }
+
+    /// Set the fixed physical shard count used for a new database.
+    pub const fn with_shard_count(mut self, shard_count: u16) -> Self {
+        self.shard_count = shard_count;
+        self
+    }
+
+    /// Return the configured engine resource limits.
+    pub const fn engine_options(&self) -> EngineOptions {
+        self.engine_options
+    }
+
+    /// Replace the complete validated engine resource-limit set.
+    pub const fn with_engine_options(mut self, engine_options: EngineOptions) -> Self {
+        self.engine_options = engine_options;
+        self
+    }
+
+    /// Return the configured runtime ownership behavior.
+    pub const fn runtime_behavior(&self) -> RuntimeBehavior {
+        self.runtime_behavior
+    }
+
+    /// Select how the asynchronous runtime is owned.
+    pub const fn with_runtime_behavior(mut self, runtime_behavior: RuntimeBehavior) -> Self {
+        self.runtime_behavior = runtime_behavior;
+        self
+    }
+
+    /// Return the configured native document support.
+    pub const fn document_support(&self) -> DocumentSupport {
+        self.document_support
+    }
+
+    /// Enable or disable native document support explicitly.
+    pub const fn with_document_support(mut self, document_support: DocumentSupport) -> Self {
+        self.document_support = document_support;
+        self
+    }
+
+    /// Validate the complete configuration without touching the filesystem.
+    pub fn validate(&self) -> EngineResult<()> {
+        if self.root.as_os_str().is_empty() {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "the embedded data-directory path must not be empty",
+            ));
+        }
+        self.engine_options.validate_for_shards(self.shard_count)?;
+        if self.runtime_behavior != RuntimeBehavior::CallerManaged {
+            return Err(EngineError::new(
+                EngineErrorKind::Unsupported,
+                "a dedicated embedded runtime is not implemented; use CallerManaged",
+            ));
+        }
+        if self.document_support != DocumentSupport::Disabled {
+            return Err(EngineError::new(
+                EngineErrorKind::Unsupported,
+                "native embedded document support is not implemented in this build",
+            ));
+        }
+        Ok(())
+    }
+
+    /// Validate and open one embedded database on the caller's Tokio runtime.
+    pub async fn open(self) -> EngineResult<BriskDb> {
+        self.validate()?;
+        let engine =
+            Engine::open_with_options(&self.root, self.shard_count, self.engine_options).await?;
+        Ok(BriskDb {
+            engine,
+            root: self.root,
+            runtime_behavior: self.runtime_behavior,
+            document_support: self.document_support,
+        })
+    }
+}
+
+/// A cloneable, listener-free handle to one BriskDB engine.
+///
+/// Clones share lifecycle and connection pools. Different calls to
+/// [`BriskDb::open`] create independent instances when given different data
+/// directories.
+#[derive(Debug, Clone)]
+pub struct BriskDb {
+    engine: Engine,
+    root: PathBuf,
+    runtime_behavior: RuntimeBehavior,
+    document_support: DocumentSupport,
+}
+
+impl BriskDb {
+    /// Start a builder for one data directory.
+    pub fn builder(root: impl Into<PathBuf>) -> BriskDbBuilder {
+        BriskDbBuilder::new(root)
+    }
+
+    /// Open one database with the documented embedded defaults.
+    pub async fn open(root: impl Into<PathBuf>) -> EngineResult<Self> {
+        Self::builder(root).open().await
+    }
+
+    /// Return the data-directory path used to open this database.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Return the selected runtime behavior.
+    pub const fn runtime_behavior(&self) -> RuntimeBehavior {
+        self.runtime_behavior
+    }
+
+    /// Return the selected document-support behavior.
+    pub const fn document_support(&self) -> DocumentSupport {
+        self.document_support
+    }
+
+    /// Borrow the protocol-neutral engine for advanced APIs.
+    pub const fn engine(&self) -> &Engine {
+        &self.engine
+    }
+
+    /// Create an independent frontend session owned by this database.
+    pub fn session(&self) -> Session {
+        self.engine.session()
+    }
+
+    /// Return immutable engine and resource-limit status.
+    pub async fn status(&self, session: &Session) -> EngineResult<EngineStatus> {
+        self.engine.status(session).await
+    }
+
+    /// Execute one routed write and return the selected shard and write result.
+    pub async fn execute_write(
+        &self,
+        session: &Session,
+        statement: Statement,
+    ) -> EngineResult<Routed<WriteResult>> {
+        self.engine.execute_write(session, statement).await
+    }
+
+    /// Query one routed physical owner.
+    pub async fn query(
+        &self,
+        session: &Session,
+        statement: Statement,
+    ) -> EngineResult<Routed<ResultSet>> {
+        self.engine.query(session, statement).await
+    }
+
+    /// Query the logical table view selected by catalog metadata.
+    pub async fn query_logical(
+        &self,
+        session: &Session,
+        statement: Statement,
+    ) -> EngineResult<Executed<ResultSet>> {
+        self.engine.query_logical(session, statement).await
+    }
+
+    /// Apply one durable parameterless schema batch to every shard.
+    pub async fn migrate(
+        &self,
+        session: &Session,
+        sql: impl Into<String>,
+    ) -> EngineResult<Vec<u16>> {
+        self.engine.broadcast(session, sql.into()).await
+    }
+
+    /// Return the immutable logical database and table catalog.
+    pub fn catalog(&self) -> &Catalog {
+        self.engine.catalog()
+    }
+
+    /// Return the configured physical shard count.
+    pub fn shard_count(&self) -> u16 {
+        self.engine.shard_count()
+    }
+
+    /// Return the engine lifecycle state shared by every clone.
+    pub fn state(&self) -> EngineState {
+        self.engine.state()
+    }
+
+    /// Explicitly drain work and close idle SQLite handles.
+    pub async fn close(&self) -> EngineResult<ShutdownReport> {
+        self.engine.shutdown().await
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod core;
+pub mod embedded;
 pub mod import;
 pub mod protocol;
 pub mod server;
@@ -10,3 +11,12 @@ mod sqlite_error;
 // Preserve the original public module path while frontends migrate to the
 // explicit protocol namespace.
 pub use protocol::http as api;
+
+pub use core::{
+    CancellationToken, EngineError, EngineErrorKind, EngineOptions, EngineResult, EngineState,
+    EngineStatus, Executed, PreparedStatementLimits, RequestContext, ResultLimits, ResultSet,
+    Routed, Session, ShutdownReport, Statement, Value, WriteResult,
+};
+pub use embedded::{
+    BriskDb, BriskDbBuilder, DEFAULT_EMBEDDED_SHARDS, DocumentSupport, RuntimeBehavior,
+};

--- a/tests/embedded_api.rs
+++ b/tests/embedded_api.rs
@@ -1,0 +1,176 @@
+use std::{path::PathBuf, time::Duration};
+
+use briskdb::{
+    BriskDb, BriskDbBuilder, DEFAULT_EMBEDDED_SHARDS, DocumentSupport, EngineErrorKind,
+    EngineOptions, EngineState, RuntimeBehavior, Statement, Value,
+};
+
+fn assert_send_sync_static<T: Send + Sync + 'static>() {}
+
+async fn create_notes(db: &BriskDb, route: &str, body: &str) {
+    let session = db.session();
+    session.set_routing_key(route).await.unwrap();
+    db.migrate(
+        &session,
+        "CREATE TABLE IF NOT EXISTS notes (id INTEGER PRIMARY KEY, body TEXT NOT NULL)",
+    )
+    .await
+    .unwrap();
+    db.execute_write(
+        &session,
+        Statement::new(
+            "INSERT INTO notes (id, body) VALUES (?1, ?2)",
+            vec![Value::from(1_i64), Value::from(body)],
+        ),
+    )
+    .await
+    .unwrap();
+    session.close().await.unwrap();
+}
+
+async fn note_body(db: &BriskDb, route: &str) -> String {
+    let session = db.session();
+    session.set_routing_key(route).await.unwrap();
+    let result = db
+        .query(
+            &session,
+            Statement::new("SELECT body FROM notes WHERE id = ?1", vec![1_i64.into()]),
+        )
+        .await
+        .unwrap();
+    let body = result.value.rows()[0]
+        .get(0)
+        .and_then(Value::as_str)
+        .unwrap()
+        .to_owned();
+    session.close().await.unwrap();
+    body
+}
+
+#[test]
+fn builder_defaults_are_public_deterministic_and_host_safe() {
+    assert_send_sync_static::<BriskDb>();
+    assert_send_sync_static::<BriskDbBuilder>();
+
+    let builder = BriskDb::builder("data");
+    assert_eq!(builder.root(), PathBuf::from("data"));
+    assert_eq!(builder.shard_count(), DEFAULT_EMBEDDED_SHARDS);
+    assert_eq!(builder.engine_options(), EngineOptions::default());
+    assert_eq!(builder.runtime_behavior(), RuntimeBehavior::CallerManaged);
+    assert_eq!(builder.document_support(), DocumentSupport::Disabled);
+}
+
+#[tokio::test]
+async fn invalid_complete_configuration_fails_before_creating_storage() {
+    let parent = tempfile::tempdir().unwrap();
+    let invalid_shards = parent.path().join("invalid-shards");
+    let error = BriskDb::builder(&invalid_shards)
+        .with_shard_count(1)
+        .open()
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::InvalidArgument);
+    assert!(!invalid_shards.exists());
+
+    let unsupported_runtime = parent.path().join("unsupported-runtime");
+    let error = BriskDb::builder(&unsupported_runtime)
+        .with_runtime_behavior(RuntimeBehavior::Dedicated)
+        .open()
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::Unsupported);
+    assert!(!unsupported_runtime.exists());
+
+    let unsupported_documents = parent.path().join("unsupported-documents");
+    let error = BriskDb::builder(&unsupported_documents)
+        .with_document_support(DocumentSupport::Enabled)
+        .open()
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::Unsupported);
+    assert!(!unsupported_documents.exists());
+
+    let empty = BriskDb::builder("").validate().unwrap_err();
+    assert_eq!(empty.kind(), EngineErrorKind::InvalidArgument);
+}
+
+#[tokio::test]
+async fn embedded_handle_opens_writes_queries_reports_status_closes_and_reopens() {
+    let temp = tempfile::tempdir().unwrap();
+    let options = EngineOptions::new(1, 2)
+        .unwrap()
+        .with_request_timeout(Some(Duration::from_secs(2)))
+        .unwrap();
+    let db = BriskDb::builder(temp.path())
+        .with_shard_count(2)
+        .with_engine_options(options)
+        .open()
+        .await
+        .unwrap();
+    let session = db.session();
+    session.set_routing_key("account-1").await.unwrap();
+
+    db.migrate(
+        &session,
+        "CREATE TABLE notes (id INTEGER PRIMARY KEY, body TEXT NOT NULL)",
+    )
+    .await
+    .unwrap();
+    let written = db
+        .execute_write(
+            &session,
+            Statement::new(
+                "INSERT INTO notes (id, body) VALUES (?1, ?2)",
+                vec![1_i64.into(), "persistent".into()],
+            ),
+        )
+        .await
+        .unwrap();
+    assert_eq!(written.value.rows_affected, 1);
+    assert_eq!(note_body(&db, "account-1").await, "persistent");
+    assert_eq!(
+        db.status(&session).await.unwrap().connections_per_shard(),
+        1
+    );
+    assert_eq!(db.root(), temp.path());
+    assert_eq!(db.shard_count(), 2);
+    assert_eq!(db.state(), EngineState::Running);
+
+    session.close().await.unwrap();
+    db.close().await.unwrap();
+    assert_eq!(db.state(), EngineState::Stopped);
+    db.close().await.unwrap();
+
+    let reopened = BriskDb::builder(temp.path())
+        .with_shard_count(2)
+        .open()
+        .await
+        .unwrap();
+    assert_eq!(note_body(&reopened, "account-1").await, "persistent");
+    reopened.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn independent_instances_coexist_without_state_or_data_leakage() {
+    let parent = tempfile::tempdir().unwrap();
+    let first = BriskDb::builder(parent.path().join("first"))
+        .with_shard_count(2)
+        .open()
+        .await
+        .unwrap();
+    let second = BriskDb::builder(parent.path().join("second"))
+        .with_shard_count(2)
+        .open()
+        .await
+        .unwrap();
+
+    create_notes(&first, "same-route", "first").await;
+    create_notes(&second, "same-route", "second").await;
+    assert_eq!(note_body(&first, "same-route").await, "first");
+    assert_eq!(note_body(&second, "same-route").await, "second");
+
+    first.close().await.unwrap();
+    assert_eq!(second.state(), EngineState::Running);
+    assert_eq!(note_body(&second, "same-route").await, "second");
+    second.close().await.unwrap();
+}


### PR DESCRIPTION
## Summary

- add a stable, listener-free `BriskDb` builder and convenience entrypoint
- expose typed shard, engine-limit, runtime, and document-support configuration
- document lifecycle, defaults, errors, and a complete embedded Rust example
- verify open/reopen, query/write/status/close, invalid configuration, and independent instances

## Why

BriskDB's protocol-neutral engine was public, but embedding it required downstream users to assemble lower-level modules and infer lifecycle guarantees. This gives applications one intentional API that does not bind listeners, install signals, configure logging, or mutate process-global state.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked --all-targets --all-features`
- `cargo test --locked --doc --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo run --locked --example embedded --features experimental-vtab-writes -- /tmp/briskdb-embedded-example`

Closes #189
