### PR TITLE
Separate embedded lifecycle from the server binary

### DIFF
--- a/docs/EMBEDDED_RUST.md
+++ b/docs/EMBEDDED_RUST.md
@@ -80,6 +80,15 @@ logs and is not a compatibility contract.
 Schema changes use `BriskDb::migrate()` and the crash-resumable migration
 journal. Ordinary DDL is deliberately rejected through the write method.
 
+The embedding host owns process cancellation. It can call `begin_close()` to
+stop admission synchronously, `close_with_grace()` to select a finite drain
+period, or await `close_when_cancelled()` with a host-owned `CancellationToken`.
+BriskDB does not install signal handlers. `checkpoint()` performs a passive,
+bounded WAL checkpoint on every shard and reports incomplete progress without
+blocking active writers.
+
 The initial library is async and requires a caller-managed Tokio runtime. The
 typed dedicated-runtime and document-support modes are reserved and fail with
 `unsupported` before storage is touched until their implementations land.
+The host may install any tracing subscriber it wants; the library emits through
+the normal `tracing` facade and never configures global logging itself.

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -108,6 +108,65 @@ pub struct EngineStatus {
     shutdown_grace: Duration,
 }
 
+/// Result of one passive WAL checkpoint on a physical shard.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CheckpointShardReport {
+    shard: u16,
+    busy: bool,
+    wal_frames: u64,
+    checkpointed_frames: u64,
+}
+
+impl CheckpointShardReport {
+    /// Return the physical shard that was checkpointed.
+    pub const fn shard(self) -> u16 {
+        self.shard
+    }
+
+    /// Return whether SQLite reported a competing checkpoint operation.
+    pub const fn busy(self) -> bool {
+        self.busy
+    }
+
+    /// Return the number of frames SQLite observed in the WAL.
+    pub const fn wal_frames(self) -> u64 {
+        self.wal_frames
+    }
+
+    /// Return the number of frames SQLite copied into the database file.
+    pub const fn checkpointed_frames(self) -> u64 {
+        self.checkpointed_frames
+    }
+
+    /// Return whether every WAL frame observed by this attempt was copied.
+    pub const fn complete(self) -> bool {
+        self.checkpointed_frames >= self.wal_frames
+    }
+}
+
+/// Ordered result of a passive checkpoint across every physical shard.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckpointReport {
+    shards: Vec<CheckpointShardReport>,
+}
+
+impl CheckpointReport {
+    /// Return one report for every physical shard, ordered by shard ID.
+    pub fn shards(&self) -> &[CheckpointShardReport] {
+        &self.shards
+    }
+
+    /// Return whether any shard reported incomplete checkpoint progress.
+    pub fn busy(&self) -> bool {
+        self.shards.iter().any(|shard| shard.busy())
+    }
+
+    /// Return whether every shard checkpoint copied all frames it observed.
+    pub fn complete(&self) -> bool {
+        self.shards.iter().all(|shard| shard.complete())
+    }
+}
+
 impl EngineStatus {
     /// Return the number of physical shards opened by the engine.
     pub const fn shard_count(&self) -> u16 {
@@ -665,6 +724,106 @@ impl Engine {
         }
         .await;
         operation.finish(result)
+    }
+
+    /// Ask SQLite to passively checkpoint every shard without blocking writers.
+    ///
+    /// The operation participates in ordinary engine admission, cancellation,
+    /// deadlines, schema coordination, pool limits, and graceful shutdown. A
+    /// successful report can still be `busy` when active readers prevent every
+    /// eligible WAL frame from being copied; callers may retry later.
+    pub async fn checkpoint(&self) -> EngineResult<CheckpointReport> {
+        self.checkpoint_with_context(RequestContext::new()).await
+    }
+
+    /// Passively checkpoint every shard with host-supplied request controls.
+    pub async fn checkpoint_with_context(
+        &self,
+        context: RequestContext,
+    ) -> EngineResult<CheckpointReport> {
+        let mut operation = self.operation(context)?;
+        let schema_operation = match self.inner.database.storage.enter_schema_operation() {
+            Ok(guard) => guard,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let permits = match operation
+            .wait_pending(
+                self.inner
+                    .connections
+                    .acquire_all_for_owner(ConnectionOwner::stateless_catalog_write()),
+            )
+            .await
+        {
+            Ok(permits) => permits,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let worker = match operation.wait_pending(self.inner.workers.acquire()).await {
+            Ok(worker) => worker,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        if let Err(error) = operation.check_before_start() {
+            return operation.finish(Err(error));
+        }
+
+        let lease = operation.take_lease();
+        let control = Arc::clone(&operation.control);
+        let worker_control = Arc::clone(&control);
+        let join = worker.spawn(move || {
+            let _lease = lease;
+            let _schema_operation = schema_operation;
+            let result = permits
+                .into_iter()
+                .map(|(shard, permit)| {
+                    permit
+                        .checkout_controlled(Arc::clone(&worker_control))
+                        .and_then(|mut connection| {
+                            let result = connection.run_controlled(
+                                Arc::clone(&worker_control),
+                                |connection| {
+                                    let (busy, wal_frames, checkpointed_frames) = connection
+                                        .query_row(
+                                            "PRAGMA main.wal_checkpoint(PASSIVE)",
+                                            [],
+                                            |row| {
+                                                Ok((
+                                                    row.get::<_, i64>(0)?,
+                                                    row.get::<_, i64>(1)?,
+                                                    row.get::<_, i64>(2)?,
+                                                ))
+                                            },
+                                        )
+                                        .map_err(crate::sqlite_error::storage)?;
+                                    let wal_frames = u64::try_from(wal_frames).map_err(|_| {
+                                        EngineError::new(
+                                            EngineErrorKind::DataCorruption,
+                                            "SQLite returned a negative WAL frame count",
+                                        )
+                                    })?;
+                                    let checkpointed_frames =
+                                        u64::try_from(checkpointed_frames).map_err(|_| {
+                                            EngineError::new(
+                                                EngineErrorKind::DataCorruption,
+                                                "SQLite returned a negative checkpointed frame count",
+                                            )
+                                        })?;
+                                    Ok(CheckpointShardReport {
+                                        shard,
+                                        busy: busy != 0,
+                                        wal_frames,
+                                        checkpointed_frames,
+                                    })
+                                },
+                            );
+                            retire_if_broken(&mut connection, &result);
+                            result
+                        })
+                })
+                .collect::<EngineResult<Vec<_>>>()
+                .map(|shards| CheckpointReport { shards });
+            worker_control.complete(result)
+        });
+        let result = operation.wait_started(join).await;
+        operation.finish_started(result)
     }
 
     /// Parse, validate, translate, and transiently compile one prepared statement.

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -30,7 +30,7 @@ pub(crate) use control::{
     CancelOnDrop, CancellationReason, OperationControl, wait_for_cancellation, wait_pending,
 };
 pub use control::{CancellationToken, RequestContext};
-pub use engine::{Engine, EngineStatus, Statement};
+pub use engine::{CheckpointReport, CheckpointShardReport, Engine, EngineStatus, Statement};
 pub use error::{EngineError, EngineErrorKind, EngineResult};
 pub(crate) use generated_id::AllocationOwnerMap;
 pub use lifecycle::{EngineState, ShutdownReport};

--- a/src/embedded.rs
+++ b/src/embedded.rs
@@ -8,8 +8,9 @@
 use std::path::{Path, PathBuf};
 
 use crate::core::{
-    Catalog, Engine, EngineOptions, EngineResult, EngineState, EngineStatus, Executed, ResultSet,
-    Routed, Session, ShutdownReport, Statement, WriteResult,
+    CancellationToken, Catalog, CheckpointReport, Engine, EngineOptions, EngineResult, EngineState,
+    EngineStatus, Executed, RequestContext, ResultSet, Routed, Session, ShutdownReport, Statement,
+    WriteResult,
 };
 use crate::{EngineError, EngineErrorKind};
 
@@ -200,6 +201,11 @@ impl BriskDb {
         &self.engine
     }
 
+    /// Return the immutable engine resource and lifecycle options.
+    pub fn options(&self) -> EngineOptions {
+        self.engine.options()
+    }
+
     /// Create an independent frontend session owned by this database.
     pub fn session(&self) -> Session {
         self.engine.session()
@@ -246,6 +252,19 @@ impl BriskDb {
         self.engine.broadcast(session, sql.into()).await
     }
 
+    /// Ask SQLite to passively checkpoint every physical shard.
+    pub async fn checkpoint(&self) -> EngineResult<CheckpointReport> {
+        self.engine.checkpoint().await
+    }
+
+    /// Passively checkpoint every shard with host-supplied request controls.
+    pub async fn checkpoint_with_context(
+        &self,
+        context: RequestContext,
+    ) -> EngineResult<CheckpointReport> {
+        self.engine.checkpoint_with_context(context).await
+    }
+
     /// Return the immutable logical database and table catalog.
     pub fn catalog(&self) -> &Catalog {
         self.engine.catalog()
@@ -261,8 +280,37 @@ impl BriskDb {
         self.engine.state()
     }
 
+    /// Stop admitting new work without waiting for active work to drain.
+    ///
+    /// This is synchronous and idempotent. Call [`BriskDb::close`] or
+    /// [`BriskDb::close_with_grace`] afterward to finish cleanup.
+    pub fn begin_close(&self) -> EngineState {
+        self.engine.begin_shutdown()
+    }
+
     /// Explicitly drain work and close idle SQLite handles.
     pub async fn close(&self) -> EngineResult<ShutdownReport> {
         self.engine.shutdown().await
+    }
+
+    /// Explicitly close using a host-selected finite grace period.
+    pub async fn close_with_grace(
+        &self,
+        grace: std::time::Duration,
+    ) -> EngineResult<ShutdownReport> {
+        self.engine.shutdown_with_grace(grace).await
+    }
+
+    /// Wait for a host-owned cancellation token, then close explicitly.
+    ///
+    /// Dropping this future before cancellation has no side effects. This lets
+    /// an embedding host compose its own signal, task, or service lifecycle
+    /// without BriskDB installing a process signal handler.
+    pub async fn close_when_cancelled(
+        &self,
+        cancellation: CancellationToken,
+    ) -> EngineResult<ShutdownReport> {
+        cancellation.cancelled().await;
+        self.close().await
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,10 @@ mod sqlite_error;
 pub use protocol::http as api;
 
 pub use core::{
-    CancellationToken, EngineError, EngineErrorKind, EngineOptions, EngineResult, EngineState,
-    EngineStatus, Executed, PreparedStatementLimits, RequestContext, ResultLimits, ResultSet,
-    Routed, Session, ShutdownReport, Statement, Value, WriteResult,
+    CancellationToken, CheckpointReport, CheckpointShardReport, EngineError, EngineErrorKind,
+    EngineOptions, EngineResult, EngineState, EngineStatus, Executed, PreparedStatementLimits,
+    RequestContext, ResultLimits, ResultSet, Routed, Session, ShutdownReport, Statement, Value,
+    WriteResult,
 };
 pub use embedded::{
     BriskDb, BriskDbBuilder, DEFAULT_EMBEDDED_SHARDS, DocumentSupport, RuntimeBehavior,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -18,6 +18,7 @@ use tracing::{debug, info, warn};
 
 use crate::{
     core::{Engine, EngineOptions},
+    embedded::BriskDb,
     protocol::{http, postgres},
 };
 
@@ -73,12 +74,16 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
 /// [`EngineOptions::default`].
 pub async fn run_with_engine_options(config: Config, options: EngineOptions) -> anyhow::Result<()> {
     validate_listener_addresses(&config)?;
-    let engine = Engine::open_with_options(&config.data_dir, config.shards, options).await?;
+    let database = BriskDb::builder(&config.data_dir)
+        .with_shard_count(config.shards)
+        .with_engine_options(options)
+        .open()
+        .await?;
     let listeners = match BoundListeners::bind(&config).await {
         Ok(listeners) => listeners,
         Err(error) => {
-            engine.begin_shutdown();
-            if let Err(shutdown_error) = engine.shutdown().await {
+            database.begin_close();
+            if let Err(shutdown_error) = database.close().await {
                 warn!(error = %shutdown_error, "failed to clean up after listener startup error");
             }
             return Err(error);
@@ -90,13 +95,14 @@ pub async fn run_with_engine_options(config: Config, options: EngineOptions) -> 
     let signal = match shutdown_signal() {
         Ok(signal) => signal,
         Err(error) => {
-            engine.begin_shutdown();
-            if let Err(shutdown_error) = engine.shutdown().await {
+            database.begin_close();
+            if let Err(shutdown_error) = database.close().await {
                 warn!(error = %shutdown_error, "failed to clean up after signal startup error");
             }
             return Err(error);
         }
     };
+    let engine = database.engine().clone();
 
     #[cfg(feature = "experimental-vtab")]
     let experimental_vtab_writes = engine.options().experimental_vtab_writes();
@@ -136,7 +142,9 @@ pub async fn run_with_engine_options(config: Config, options: EngineOptions) -> 
         "BriskDB is ready"
     );
 
-    serve_listeners_with_shutdown(listeners, engine, signal).await
+    let result = serve_listeners_with_shutdown(listeners, engine, signal).await;
+    drop(database);
+    result
 }
 
 fn validate_listener_addresses(config: &Config) -> anyhow::Result<()> {

--- a/src/storage/pool.rs
+++ b/src/storage/pool.rs
@@ -212,7 +212,6 @@ impl ConnectionPools {
     }
 
     /// Reserve one slot on every shard in deterministic shard order.
-    #[cfg(test)]
     pub(crate) async fn acquire_all_for_owner(
         &self,
         owner: ConnectionOwner,

--- a/tests/embedded_lifecycle.rs
+++ b/tests/embedded_lifecycle.rs
@@ -1,0 +1,135 @@
+use std::time::Duration;
+
+use briskdb::{BriskDb, CancellationToken, EngineErrorKind, EngineState, Statement, Value};
+
+async fn open_two_shards(path: &std::path::Path) -> BriskDb {
+    BriskDb::builder(path)
+        .with_shard_count(2)
+        .open()
+        .await
+        .unwrap()
+}
+
+#[test]
+fn embedded_module_has_no_process_or_listener_assembly_dependencies() {
+    let source = include_str!("../src/embedded.rs");
+    for forbidden in [
+        "tokio::net",
+        "tokio::signal",
+        "tracing_subscriber",
+        "std::process",
+        "crate::server",
+    ] {
+        assert!(
+            !source.contains(forbidden),
+            "embedded lifecycle must not depend on {forbidden}"
+        );
+    }
+
+    let server = include_str!("../src/server/mod.rs");
+    assert!(server.contains("BriskDb::builder"));
+}
+
+#[tokio::test]
+async fn host_cancellation_and_grace_control_explicit_shutdown() {
+    let temp = tempfile::tempdir().unwrap();
+    let database = open_two_shards(temp.path()).await;
+
+    let invalid = database.close_with_grace(Duration::ZERO).await.unwrap_err();
+    assert_eq!(invalid.kind(), EngineErrorKind::InvalidArgument);
+    assert_eq!(database.state(), EngineState::Running);
+
+    let cancellation = CancellationToken::new();
+    let waiter_database = database.clone();
+    let waiter_token = cancellation.clone();
+    let mut waiter =
+        tokio::spawn(async move { waiter_database.close_when_cancelled(waiter_token).await });
+    assert!(
+        tokio::time::timeout(Duration::from_millis(20), &mut waiter)
+            .await
+            .is_err()
+    );
+    assert_eq!(database.state(), EngineState::Running);
+
+    assert!(cancellation.cancel());
+    let report = tokio::time::timeout(Duration::from_secs(2), waiter)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert!(!report.forced());
+    assert_eq!(database.state(), EngineState::Stopped);
+}
+
+#[tokio::test]
+async fn passive_checkpoint_is_ordered_bounded_and_host_cancellable() {
+    let temp = tempfile::tempdir().unwrap();
+    let database = open_two_shards(temp.path()).await;
+    let session = database.session();
+    session.set_routing_key("checkpoint-owner").await.unwrap();
+    database
+        .migrate(
+            &session,
+            "CREATE TABLE events (id INTEGER PRIMARY KEY, body TEXT NOT NULL)",
+        )
+        .await
+        .unwrap();
+    database
+        .execute_write(
+            &session,
+            Statement::new(
+                "INSERT INTO events (id, body) VALUES (?1, ?2)",
+                vec![Value::from(1_i64), Value::from("checkpoint")],
+            ),
+        )
+        .await
+        .unwrap();
+
+    let report = database.checkpoint().await.unwrap();
+    assert_eq!(
+        report
+            .shards()
+            .iter()
+            .map(|report| report.shard())
+            .collect::<Vec<_>>(),
+        vec![0, 1]
+    );
+    for shard in report.shards() {
+        assert!(shard.checkpointed_frames() <= shard.wal_frames());
+        assert_eq!(
+            shard.complete(),
+            shard.checkpointed_frames() == shard.wal_frames()
+        );
+    }
+    assert_eq!(
+        report.complete(),
+        report.shards().iter().all(|s| s.complete())
+    );
+
+    let cancelled = CancellationToken::new();
+    cancelled.cancel();
+    let error = database
+        .checkpoint_with_context(briskdb::RequestContext::new().with_cancellation_token(cancelled))
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::Cancelled);
+
+    session.close().await.unwrap();
+    database.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn repeated_cold_warm_drop_and_close_cycles_remain_reopenable() {
+    let temp = tempfile::tempdir().unwrap();
+
+    let dropped = open_two_shards(temp.path()).await;
+    drop(dropped);
+
+    for _ in 0..8 {
+        let database = open_two_shards(temp.path()).await;
+        assert_eq!(database.state(), EngineState::Running);
+        assert_eq!(database.shard_count(), 2);
+        assert!(!database.close().await.unwrap().forced());
+        assert_eq!(database.state(), EngineState::Stopped);
+    }
+}


### PR DESCRIPTION
## Summary

- make the server binary open BriskDB through the listener-free `BriskDb` library entrypoint
- add host-controlled begin-close, cancellation-driven close, and explicit shutdown-grace APIs
- add a bounded passive WAL checkpoint API with per-shard progress reports and request controls
- cover process-boundary separation, cancellation, invalid grace, checkpointing, drop safety, and repeated cold/warm reopen cycles

## Why

The server still opened the lower-level engine directly, while embedded hosts lacked direct lifecycle controls for service cancellation and maintenance checkpoints. This makes the server one consumer of the same embedded API and keeps sockets, process signals, logging setup, and exit behavior outside the library boundary.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked --all-targets --all-features`
- `cargo test --locked --doc --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`

Closes #190
