### PR TITLE
Expose protocol-neutral embedded SQL commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Follow the [roadmap](ROADMAP.md) or browse the
 
 - [Architecture](docs/ARCHITECTURE.md)
 - [Embedded Rust](docs/EMBEDDED_RUST.md)
+- [Embedded SQL](docs/EMBEDDED_SQL.md)
 - [PostgreSQL quickstart](docs/POSTGRES_QUICKSTART.md)
 - [SQL compatibility](docs/SQL_COMPATIBILITY.md)
 - [Generated keys](docs/GENERATED_KEYS.md)

--- a/docs/EMBEDDED_RUST.md
+++ b/docs/EMBEDDED_RUST.md
@@ -6,6 +6,9 @@ Status: implemented by issue #189
 engine inside a Rust application. Opening it does not bind sockets, install
 signal handlers, configure tracing, or change process-global state.
 
+See [Embedded SQL](EMBEDDED_SQL.md) for direct and prepared command APIs,
+value guarantees, and the foreign-language runtime boundary.
+
 ```rust
 use briskdb::{BriskDb, Statement, Value};
 

--- a/docs/EMBEDDED_SQL.md
+++ b/docs/EMBEDDED_SQL.md
@@ -1,0 +1,66 @@
+# Embedded SQL
+
+`BriskDb` exposes the same protocol-neutral SQL engine used by HTTP and
+PostgreSQL. Callers pass typed `Statement`/`Value` inputs directly; no wire
+message or server is involved.
+
+## Direct commands
+
+```rust
+use briskdb::{BriskDb, Statement, Value};
+
+# async fn run(db: &BriskDb) -> briskdb::EngineResult<()> {
+let session = db.session();
+session.set_routing_key("tenant-1").await?;
+
+let write = db.execute_write(
+    &session,
+    Statement::new(
+        "INSERT INTO notes (id, body) VALUES (?1, ?2)",
+        vec![Value::from(1_i64), Value::from("hello")],
+    ),
+).await?;
+assert_eq!(write.value.rows_affected, 1);
+
+let rows = db.query(
+    &session,
+    Statement::new("SELECT body FROM notes WHERE id = ?1", vec![1_i64.into()]),
+).await?;
+assert_eq!(rows.value.rows()[0].get(0), Some(&Value::from("hello")));
+# Ok(())
+# }
+```
+
+Use `query_logical()` when catalog placement may require scatter/gather. Every
+command also has a `_with_context` form for cancellation, deadlines, and
+narrower result limits.
+
+## Prepared commands
+
+The embedded facade exposes the complete prepare → bind → describe → execute →
+close lifecycle through `prepare`, `bind`, `describe`, `execute_bound`, and
+`execute_bound_logical`. Bound portals are immutable and retain the route and
+typed values captured at bind time.
+
+`ResultSet` keeps columns and rows positional, including duplicate column
+names. Nulls, blobs, invalid UTF-8 text, integers, and floating-point values are
+not coerced by the facade. SQLite has no native decimal or timestamp storage
+class: unsupported typed decimal bindings fail explicitly instead of becoming
+lossy, while applications should use their chosen canonical text/integer
+timestamp representation until a versioned logical type mapping is added.
+
+Generated-key writes return `WriteResult::generated_key` from the same logical
+operation that committed the row when the table's generated-ID policy is
+enabled.
+
+## Runtime boundary
+
+The Rust API is asynchronous and never creates a runtime. Rust hosts await it
+on their own Tokio runtime. Synchronous foreign-language bindings should own
+one finite runtime outside the GIL/host lock, submit these async calls to it,
+and map cancellation back through `RequestContext`; they must not create a new
+runtime per query.
+
+Native document commands remain unavailable until the BSON/document engine in
+#162–#164 lands. Selecting `DocumentSupport::Enabled` fails before storage is
+touched, so SQL-only embedding cannot accidentally claim Mongo compatibility.

--- a/src/embedded.rs
+++ b/src/embedded.rs
@@ -8,9 +8,10 @@
 use std::path::{Path, PathBuf};
 
 use crate::core::{
-    CancellationToken, Catalog, CheckpointReport, Engine, EngineOptions, EngineResult, EngineState,
-    EngineStatus, Executed, RequestContext, ResultSet, Routed, Session, ShutdownReport, Statement,
-    WriteResult,
+    CancellationToken, Catalog, CheckpointReport, DescribeTarget, Engine, EngineOptions,
+    EngineResult, EngineState, EngineStatus, Executed, PortalId, PrepareRequest, PreparedExecution,
+    PreparedStatementDescription, PreparedStatementId, RequestContext, ResultSet, Routed, Session,
+    ShutdownReport, Statement, Value, WriteResult,
 };
 use crate::{EngineError, EngineErrorKind};
 
@@ -216,6 +217,27 @@ impl BriskDb {
         self.engine.status(session).await
     }
 
+    /// Execute one routed write and return only its affected-row count.
+    pub async fn execute(
+        &self,
+        session: &Session,
+        statement: Statement,
+    ) -> EngineResult<Routed<usize>> {
+        self.engine.execute(session, statement).await
+    }
+
+    /// Execute one routed write with host-supplied request controls.
+    pub async fn execute_with_context(
+        &self,
+        session: &Session,
+        statement: Statement,
+        context: RequestContext,
+    ) -> EngineResult<Routed<usize>> {
+        self.engine
+            .execute_with_context(session, statement, context)
+            .await
+    }
+
     /// Execute one routed write and return the selected shard and write result.
     pub async fn execute_write(
         &self,
@@ -223,6 +245,18 @@ impl BriskDb {
         statement: Statement,
     ) -> EngineResult<Routed<WriteResult>> {
         self.engine.execute_write(session, statement).await
+    }
+
+    /// Execute one routed write with request controls and generated-key data.
+    pub async fn execute_write_with_context(
+        &self,
+        session: &Session,
+        statement: Statement,
+        context: RequestContext,
+    ) -> EngineResult<Routed<WriteResult>> {
+        self.engine
+            .execute_write_with_context(session, statement, context)
+            .await
     }
 
     /// Query one routed physical owner.
@@ -234,6 +268,18 @@ impl BriskDb {
         self.engine.query(session, statement).await
     }
 
+    /// Query one routed owner with cancellation, deadline, and result controls.
+    pub async fn query_with_context(
+        &self,
+        session: &Session,
+        statement: Statement,
+        context: RequestContext,
+    ) -> EngineResult<Routed<ResultSet>> {
+        self.engine
+            .query_with_context(session, statement, context)
+            .await
+    }
+
     /// Query the logical table view selected by catalog metadata.
     pub async fn query_logical(
         &self,
@@ -243,6 +289,143 @@ impl BriskDb {
         self.engine.query_logical(session, statement).await
     }
 
+    /// Query the logical table view with host-supplied request controls.
+    pub async fn query_logical_with_context(
+        &self,
+        session: &Session,
+        statement: Statement,
+        context: RequestContext,
+    ) -> EngineResult<Executed<ResultSet>> {
+        self.engine
+            .query_logical_with_context(session, statement, context)
+            .await
+    }
+
+    /// Parse, validate, translate, and compile one prepared SQL statement.
+    pub async fn prepare(
+        &self,
+        session: &Session,
+        request: PrepareRequest,
+    ) -> EngineResult<PreparedStatementId> {
+        self.engine.prepare_statement(session, request).await
+    }
+
+    /// Prepare one statement with host-supplied request controls.
+    pub async fn prepare_with_context(
+        &self,
+        session: &Session,
+        request: PrepareRequest,
+        context: RequestContext,
+    ) -> EngineResult<PreparedStatementId> {
+        self.engine
+            .prepare_statement_with_context(session, request, context)
+            .await
+    }
+
+    /// Bind typed values and the session's current route into a portal.
+    pub async fn bind(
+        &self,
+        session: &Session,
+        statement: PreparedStatementId,
+        parameters: Vec<Value>,
+    ) -> EngineResult<PortalId> {
+        self.engine
+            .bind_statement(session, statement, parameters)
+            .await
+    }
+
+    /// Bind a prepared statement with host-supplied request controls.
+    pub async fn bind_with_context(
+        &self,
+        session: &Session,
+        statement: PreparedStatementId,
+        parameters: Vec<Value>,
+        context: RequestContext,
+    ) -> EngineResult<PortalId> {
+        self.engine
+            .bind_statement_with_context(session, statement, parameters, context)
+            .await
+    }
+
+    /// Describe a prepared statement or bound portal.
+    pub async fn describe(
+        &self,
+        session: &Session,
+        target: DescribeTarget,
+    ) -> EngineResult<PreparedStatementDescription> {
+        self.engine.describe_prepared(session, target).await
+    }
+
+    /// Describe a prepared object with host-supplied request controls.
+    pub async fn describe_with_context(
+        &self,
+        session: &Session,
+        target: DescribeTarget,
+        context: RequestContext,
+    ) -> EngineResult<PreparedStatementDescription> {
+        self.engine
+            .describe_prepared_with_context(session, target, context)
+            .await
+    }
+
+    /// Execute one immutable bound portal on its selected physical owner.
+    pub async fn execute_bound(
+        &self,
+        session: &Session,
+        portal: PortalId,
+    ) -> EngineResult<Routed<PreparedExecution>> {
+        self.engine.execute_portal(session, portal).await
+    }
+
+    /// Execute a bound portal with host-supplied request controls.
+    pub async fn execute_bound_with_context(
+        &self,
+        session: &Session,
+        portal: PortalId,
+        context: RequestContext,
+    ) -> EngineResult<Routed<PreparedExecution>> {
+        self.engine
+            .execute_portal_with_context(session, portal, context)
+            .await
+    }
+
+    /// Execute a bound portal through logical point/scatter planning.
+    pub async fn execute_bound_logical(
+        &self,
+        session: &Session,
+        portal: PortalId,
+    ) -> EngineResult<Executed<PreparedExecution>> {
+        self.engine.execute_portal_logical(session, portal).await
+    }
+
+    /// Execute a logical bound portal with host-supplied request controls.
+    pub async fn execute_bound_logical_with_context(
+        &self,
+        session: &Session,
+        portal: PortalId,
+        context: RequestContext,
+    ) -> EngineResult<Executed<PreparedExecution>> {
+        self.engine
+            .execute_portal_logical_with_context(session, portal, context)
+            .await
+    }
+
+    /// Close a prepared statement and every portal bound from it.
+    pub async fn close_prepared(
+        &self,
+        session: &Session,
+        statement: PreparedStatementId,
+    ) -> EngineResult<bool> {
+        self.engine
+            .close_prepared_statement(session, statement)
+            .await
+    }
+
+    /// Close one bound portal while retaining its prepared statement.
+    pub async fn close_bound(&self, session: &Session, portal: PortalId) -> EngineResult<bool> {
+        self.engine.close_portal(session, portal).await
+    }
+
     /// Apply one durable parameterless schema batch to every shard.
     pub async fn migrate(
         &self,
@@ -250,6 +433,18 @@ impl BriskDb {
         sql: impl Into<String>,
     ) -> EngineResult<Vec<u16>> {
         self.engine.broadcast(session, sql.into()).await
+    }
+
+    /// Apply one durable schema batch with host-supplied request controls.
+    pub async fn migrate_with_context(
+        &self,
+        session: &Session,
+        sql: impl Into<String>,
+        context: RequestContext,
+    ) -> EngineResult<Vec<u16>> {
+        self.engine
+            .broadcast_with_context(session, sql.into(), context)
+            .await
     }
 
     /// Ask SQLite to passively checkpoint every physical shard.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,11 +13,14 @@ mod sqlite_error;
 pub use protocol::http as api;
 
 pub use core::{
-    CancellationToken, CheckpointReport, CheckpointShardReport, EngineError, EngineErrorKind,
-    EngineOptions, EngineResult, EngineState, EngineStatus, Executed, PreparedStatementLimits,
-    RequestContext, ResultLimits, ResultSet, Routed, Session, ShutdownReport, Statement, Value,
-    WriteResult,
+    CancellationToken, CheckpointReport, CheckpointShardReport, Column, DataType, Decimal,
+    DescribeTarget, EngineError, EngineErrorKind, EngineOptions, EngineResult, EngineState,
+    EngineStatus, Executed, GeneratedKey, ParseDecimalError, PortalId, PrepareRequest,
+    PreparedExecution, PreparedStatementDescription, PreparedStatementId, PreparedStatementLimits,
+    RequestContext, ResultLimits, ResultSet, ResultSetShapeError, Routed, Row, Session, SessionId,
+    SessionState, ShutdownReport, Statement, Value, WriteResult,
 };
 pub use embedded::{
     BriskDb, BriskDbBuilder, DEFAULT_EMBEDDED_SHARDS, DocumentSupport, RuntimeBehavior,
 };
+pub use sql::{SqlDialect, SqlTranslationMode, StatementBehavior};

--- a/tests/embedded_sql_api.rs
+++ b/tests/embedded_sql_api.rs
@@ -1,0 +1,186 @@
+use axum::{
+    body::{Body, to_bytes},
+    http::{Method, Request, StatusCode},
+};
+use briskdb::{
+    BriskDb, DataType, DescribeTarget, PrepareRequest, PreparedExecution, SqlDialect,
+    SqlTranslationMode, Statement, Value,
+};
+use serde_json::{Value as JsonValue, json};
+use tower::ServiceExt;
+
+async fn request_json(router: axum::Router, uri: &str, body: JsonValue) -> (StatusCode, JsonValue) {
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    let response = router.oneshot(request).await.unwrap();
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+    (status, serde_json::from_slice(&bytes).unwrap())
+}
+
+#[tokio::test]
+async fn embedded_prepared_commands_preserve_order_values_and_handle_lifecycle() {
+    let temp = tempfile::tempdir().unwrap();
+    let database = BriskDb::builder(temp.path())
+        .with_shard_count(2)
+        .open()
+        .await
+        .unwrap();
+    let session = database.session();
+    session.set_routing_key("prepared-owner").await.unwrap();
+
+    let statement = database
+        .prepare(
+            &session,
+            PrepareRequest::new(
+                database.catalog().default_database().id(),
+                SqlDialect::Sqlite,
+                SqlTranslationMode::StrictSqlite,
+                "SELECT ?1 AS duplicate, ?2 AS duplicate, ?3 AS nullable, ?4 AS happened_at",
+            ),
+        )
+        .await
+        .unwrap();
+    let description = database
+        .describe(&session, DescribeTarget::Statement(statement))
+        .await
+        .unwrap();
+    assert_eq!(
+        description
+            .columns()
+            .iter()
+            .map(|column| column.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["duplicate", "duplicate", "nullable", "happened_at"]
+    );
+    assert_eq!(description.parameter_types(), &[DataType::Unknown; 4]);
+
+    let decimal_error = database
+        .bind(
+            &session,
+            statement,
+            vec![
+                Value::Binary(vec![0, 0xff]),
+                Value::decimal("12.3400").unwrap(),
+                Value::Null,
+                Value::Text("2026-08-14T00:00:00Z".to_owned()),
+            ],
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(decimal_error.kind(), briskdb::EngineErrorKind::Unsupported);
+
+    let portal = database
+        .bind(
+            &session,
+            statement,
+            vec![
+                Value::Binary(vec![0, 0xff]),
+                Value::Text("12.3400".into()),
+                Value::Null,
+                Value::Text("2026-08-14T00:00:00Z".to_owned()),
+            ],
+        )
+        .await
+        .unwrap();
+    let executed = database
+        .execute_bound_logical(&session, portal)
+        .await
+        .unwrap();
+    assert_eq!(executed.shards.len(), 1);
+    let PreparedExecution::Rows(rows) = executed.value else {
+        panic!("read portal must return rows");
+    };
+    assert_eq!(rows.columns()[0].name, "duplicate");
+    assert_eq!(rows.columns()[1].name, "duplicate");
+    assert_eq!(rows.rows()[0].get(0), Some(&Value::Binary(vec![0, 0xff])));
+    assert_eq!(rows.rows()[0].get(1), Some(&Value::Text("12.3400".into())));
+    assert_eq!(rows.rows()[0].get(2), Some(&Value::Null));
+    assert_eq!(
+        rows.rows()[0].get(3),
+        Some(&Value::Text("2026-08-14T00:00:00Z".into()))
+    );
+
+    assert!(database.close_bound(&session, portal).await.unwrap());
+    assert!(database.close_prepared(&session, statement).await.unwrap());
+    session.close().await.unwrap();
+    database.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn embedded_and_http_calls_observe_the_same_engine_outcome() {
+    let temp = tempfile::tempdir().unwrap();
+    let database = BriskDb::builder(temp.path())
+        .with_shard_count(2)
+        .open()
+        .await
+        .unwrap();
+    let session = database.session();
+    session.set_routing_key("shared-outcome").await.unwrap();
+    database
+        .migrate(
+            &session,
+            "CREATE TABLE records (id TEXT PRIMARY KEY, payload BLOB, note TEXT)",
+        )
+        .await
+        .unwrap();
+    let written = database
+        .execute_write(
+            &session,
+            Statement::new(
+                "INSERT INTO records (id, payload, note) VALUES (?1, ?2, ?3)",
+                vec![
+                    Value::from("shared-outcome"),
+                    Value::Binary(vec![1, 2, 255]),
+                    Value::Null,
+                ],
+            ),
+        )
+        .await
+        .unwrap();
+    assert_eq!(written.value.rows_affected, 1);
+
+    let embedded = database
+        .query_logical(
+            &session,
+            Statement::new(
+                "SELECT id, payload, note FROM records WHERE id = ?1",
+                vec![Value::from("shared-outcome")],
+            ),
+        )
+        .await
+        .unwrap();
+    let application = briskdb::api::router_with_engine(database.engine().clone());
+    let http = request_json(
+        application,
+        "/v1/query",
+        json!({
+            "shard_key": "shared-outcome",
+            "sql": "SELECT id, payload, note FROM records WHERE id = ?1",
+            "params": ["shared-outcome"]
+        }),
+    )
+    .await;
+
+    assert_eq!(http.0, StatusCode::OK);
+    assert_eq!(http.1["shard"], json!(embedded.shards[0]));
+    assert_eq!(
+        http.1["rows"],
+        json!([["shared-outcome", [1, 2, 255], null]])
+    );
+    assert_eq!(
+        embedded.value.rows()[0].values(),
+        &[
+            Value::Text("shared-outcome".into()),
+            Value::Binary(vec![1, 2, 255]),
+            Value::Null,
+        ]
+    );
+
+    session.close().await.unwrap();
+    database.close().await.unwrap();
+}


### PR DESCRIPTION
## Summary

- expose direct routed/logical query and write methods, including request-controlled variants, on `BriskDb`
- expose the complete prepare, bind, describe, physical/logical execute, and close lifecycle
- re-export the protocol-neutral SQL value, row, result, prepared-handle, dialect, and generated-key types at the crate root
- add embedded-vs-HTTP differential coverage and document value/runtime guarantees

## Why

The protocol-neutral engine already owned these semantics, but embedded users had to escape through `BriskDb::engine()` for prepared statements and request-controlled operations. This makes the high-level library facade sufficient for SQL consumers and the upcoming Python wrapper.

## Scope note

This advances #191 but intentionally does not close it. Native BSON/document commands depend on the open document engine and BSON work in #162–#164. `DocumentSupport::Enabled` remains fail-closed before storage is touched; this PR does not claim Mongo compatibility.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked --all-targets --all-features`
- `cargo test --locked --doc --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`

Refs #191
