### PR TITLE
Add host-safe owned embedded sessions

### DIFF
--- a/docs/EMBEDDED_RUST.md
+++ b/docs/EMBEDDED_RUST.md
@@ -76,6 +76,13 @@ data directories can be opened independently in one process. Create a distinct
 work ends, and explicitly await `BriskDb::close()` before the final handle is
 dropped.
 
+`BriskDb::owned_session()` returns a cloneable `BriskSession` that retains its
+owning database identity and exposes direct/prepared SQL methods without a
+separate database argument. Clones share routing, prepared state, and terminal
+close. Database shutdown is monotonic: a retained session can be closed after
+shutdown, but it cannot submit work or resurrect the stopped engine. This is
+the preferred handle for foreign-language wrappers.
+
 Failures use `EngineError`. Match `EngineError::kind()` or the stable
 machine-readable `EngineError::code()`; diagnostic text is intended for trusted
 logs and is not a compatibility contract.
@@ -95,3 +102,8 @@ typed dedicated-runtime and document-support modes are reserved and fail with
 `unsupported` before storage is touched until their implementations land.
 The host may install any tracing subscriber it wants; the library emits through
 the normal `tracing` facade and never configures global logging itself.
+
+Explicit single-shard transaction handles and streaming cursors are not yet
+part of the embedded contract; they remain tracked by #34 and #39. Autocommit
+commands, prepared portals, cancellation, bounded queueing, and materialized
+result limits use the same engine semantics as protocol adapters.

--- a/src/embedded.rs
+++ b/src/embedded.rs
@@ -5,13 +5,17 @@
 //! Tokio runtime and should explicitly call [`BriskDb::close`] before dropping
 //! its last database handle.
 
-use std::path::{Path, PathBuf};
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use crate::core::{
     CancellationToken, Catalog, CheckpointReport, DescribeTarget, Engine, EngineOptions,
     EngineResult, EngineState, EngineStatus, Executed, PortalId, PrepareRequest, PreparedExecution,
     PreparedStatementDescription, PreparedStatementId, RequestContext, ResultSet, Routed, Session,
-    ShutdownReport, Statement, Value, WriteResult,
+    SessionId, SessionState, ShutdownReport, Statement, Value, WriteResult,
 };
 use crate::{EngineError, EngineErrorKind};
 
@@ -171,6 +175,28 @@ pub struct BriskDb {
     document_support: DocumentSupport,
 }
 
+/// Cloneable, database-owning session handle for embedded applications.
+///
+/// Every clone shares one serialized session state, including routing context,
+/// prepared statements, and terminal close. The retained [`BriskDb`] handle
+/// keeps the owning engine identity available, but cannot resurrect it after
+/// database shutdown.
+#[derive(Clone)]
+pub struct BriskSession {
+    database: BriskDb,
+    session: Arc<Session>,
+}
+
+impl fmt::Debug for BriskSession {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BriskSession")
+            .field("id", &self.id())
+            .field("database_state", &self.database.state())
+            .finish_non_exhaustive()
+    }
+}
+
 impl BriskDb {
     /// Start a builder for one data directory.
     pub fn builder(root: impl Into<PathBuf>) -> BriskDbBuilder {
@@ -210,6 +236,17 @@ impl BriskDb {
     /// Create an independent frontend session owned by this database.
     pub fn session(&self) -> Session {
         self.engine.session()
+    }
+
+    /// Create a cloneable session that retains its owning database handle.
+    ///
+    /// This is the preferred session form for foreign-language wrappers and
+    /// application components that need to move or clone owned handles.
+    pub fn owned_session(&self) -> BriskSession {
+        BriskSession {
+            database: self.clone(),
+            session: Arc::new(self.session()),
+        }
     }
 
     /// Return immutable engine and resource-limit status.
@@ -507,5 +544,203 @@ impl BriskDb {
     ) -> EngineResult<ShutdownReport> {
         cancellation.cancelled().await;
         self.close().await
+    }
+}
+
+impl BriskSession {
+    /// Return the process-unique session identity.
+    pub fn id(&self) -> SessionId {
+        self.session.id()
+    }
+
+    /// Return the lifecycle state shared by every clone of this handle.
+    pub async fn state(&self) -> SessionState {
+        self.session.state().await
+    }
+
+    /// Return the owning database lifecycle state.
+    pub fn database_state(&self) -> EngineState {
+        self.database.state()
+    }
+
+    /// Return a copy of the current explicit route, if one is set.
+    pub async fn routing_key(&self) -> Option<String> {
+        self.session.routing_key().await
+    }
+
+    /// Replace the explicit route used by subsequent operations.
+    pub async fn set_routing_key(&self, routing_key: impl Into<String>) -> EngineResult<()> {
+        self.session.set_routing_key(routing_key).await
+    }
+
+    /// Clear the explicit route used by subsequent operations.
+    pub async fn clear_routing_key(&self) -> EngineResult<()> {
+        self.session.clear_routing_key().await
+    }
+
+    /// Return immutable engine and resource-limit status.
+    pub async fn status(&self) -> EngineResult<EngineStatus> {
+        self.database.status(self.session.as_ref()).await
+    }
+
+    /// Execute one routed write and return only its affected-row count.
+    pub async fn execute(&self, statement: Statement) -> EngineResult<Routed<usize>> {
+        self.database
+            .execute(self.session.as_ref(), statement)
+            .await
+    }
+
+    /// Execute one routed write with host-supplied request controls.
+    pub async fn execute_with_context(
+        &self,
+        statement: Statement,
+        context: RequestContext,
+    ) -> EngineResult<Routed<usize>> {
+        self.database
+            .execute_with_context(self.session.as_ref(), statement, context)
+            .await
+    }
+
+    /// Execute one routed write with complete generated-key data.
+    pub async fn execute_write(&self, statement: Statement) -> EngineResult<Routed<WriteResult>> {
+        self.database
+            .execute_write(self.session.as_ref(), statement)
+            .await
+    }
+
+    /// Execute one routed write with request controls and generated-key data.
+    pub async fn execute_write_with_context(
+        &self,
+        statement: Statement,
+        context: RequestContext,
+    ) -> EngineResult<Routed<WriteResult>> {
+        self.database
+            .execute_write_with_context(self.session.as_ref(), statement, context)
+            .await
+    }
+
+    /// Query one routed physical owner.
+    pub async fn query(&self, statement: Statement) -> EngineResult<Routed<ResultSet>> {
+        self.database.query(self.session.as_ref(), statement).await
+    }
+
+    /// Query one routed owner with host-supplied request controls.
+    pub async fn query_with_context(
+        &self,
+        statement: Statement,
+        context: RequestContext,
+    ) -> EngineResult<Routed<ResultSet>> {
+        self.database
+            .query_with_context(self.session.as_ref(), statement, context)
+            .await
+    }
+
+    /// Query the logical table view through point/scatter planning.
+    pub async fn query_logical(&self, statement: Statement) -> EngineResult<Executed<ResultSet>> {
+        self.database
+            .query_logical(self.session.as_ref(), statement)
+            .await
+    }
+
+    /// Query the logical table view with host-supplied request controls.
+    pub async fn query_logical_with_context(
+        &self,
+        statement: Statement,
+        context: RequestContext,
+    ) -> EngineResult<Executed<ResultSet>> {
+        self.database
+            .query_logical_with_context(self.session.as_ref(), statement, context)
+            .await
+    }
+
+    /// Compile one protocol-neutral prepared SQL statement.
+    pub async fn prepare(&self, request: PrepareRequest) -> EngineResult<PreparedStatementId> {
+        self.database.prepare(self.session.as_ref(), request).await
+    }
+
+    /// Prepare one statement with host-supplied request controls.
+    pub async fn prepare_with_context(
+        &self,
+        request: PrepareRequest,
+        context: RequestContext,
+    ) -> EngineResult<PreparedStatementId> {
+        self.database
+            .prepare_with_context(self.session.as_ref(), request, context)
+            .await
+    }
+
+    /// Bind typed values and the current route into an immutable portal.
+    pub async fn bind(
+        &self,
+        statement: PreparedStatementId,
+        parameters: Vec<Value>,
+    ) -> EngineResult<PortalId> {
+        self.database
+            .bind(self.session.as_ref(), statement, parameters)
+            .await
+    }
+
+    /// Bind a prepared statement with host-supplied request controls.
+    pub async fn bind_with_context(
+        &self,
+        statement: PreparedStatementId,
+        parameters: Vec<Value>,
+        context: RequestContext,
+    ) -> EngineResult<PortalId> {
+        self.database
+            .bind_with_context(self.session.as_ref(), statement, parameters, context)
+            .await
+    }
+
+    /// Describe a prepared statement or bound portal.
+    pub async fn describe(
+        &self,
+        target: DescribeTarget,
+    ) -> EngineResult<PreparedStatementDescription> {
+        self.database.describe(self.session.as_ref(), target).await
+    }
+
+    /// Execute one immutable bound portal on its selected owner.
+    pub async fn execute_bound(&self, portal: PortalId) -> EngineResult<Routed<PreparedExecution>> {
+        self.database
+            .execute_bound(self.session.as_ref(), portal)
+            .await
+    }
+
+    /// Execute a bound portal through logical point/scatter planning.
+    pub async fn execute_bound_logical(
+        &self,
+        portal: PortalId,
+    ) -> EngineResult<Executed<PreparedExecution>> {
+        self.database
+            .execute_bound_logical(self.session.as_ref(), portal)
+            .await
+    }
+
+    /// Close a prepared statement and every bound portal derived from it.
+    pub async fn close_prepared(&self, statement: PreparedStatementId) -> EngineResult<bool> {
+        self.database
+            .close_prepared(self.session.as_ref(), statement)
+            .await
+    }
+
+    /// Close one bound portal while retaining its prepared statement.
+    pub async fn close_bound(&self, portal: PortalId) -> EngineResult<bool> {
+        self.database
+            .close_bound(self.session.as_ref(), portal)
+            .await
+    }
+
+    /// Apply one durable parameterless schema batch to every shard.
+    pub async fn migrate(&self, sql: impl Into<String>) -> EngineResult<Vec<u16>> {
+        self.database.migrate(self.session.as_ref(), sql).await
+    }
+
+    /// Close this session terminally and clear all retained session state.
+    ///
+    /// Closing one clone closes every clone. It remains available while the
+    /// database is draining and is deterministic and idempotent.
+    pub async fn close(&self) -> EngineResult<()> {
+        self.session.close().await
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub use core::{
     SessionState, ShutdownReport, Statement, Value, WriteResult,
 };
 pub use embedded::{
-    BriskDb, BriskDbBuilder, DEFAULT_EMBEDDED_SHARDS, DocumentSupport, RuntimeBehavior,
+    BriskDb, BriskDbBuilder, BriskSession, DEFAULT_EMBEDDED_SHARDS, DocumentSupport,
+    RuntimeBehavior,
 };
 pub use sql::{SqlDialect, SqlTranslationMode, StatementBehavior};

--- a/tests/embedded_host_safety.rs
+++ b/tests/embedded_host_safety.rs
@@ -1,0 +1,164 @@
+use std::time::Duration;
+
+use briskdb::{
+    BriskDb, BriskSession, EngineErrorKind, EngineOptions, EngineState, SessionState, Statement,
+    Value,
+};
+
+fn assert_send_sync_static<T: Send + Sync + 'static>() {}
+
+async fn open(path: &std::path::Path) -> BriskDb {
+    BriskDb::builder(path)
+        .with_shard_count(2)
+        .with_engine_options(EngineOptions::new(1, 2).unwrap())
+        .open()
+        .await
+        .unwrap()
+}
+
+#[test]
+fn owned_session_is_send_sync_cloneable_and_runtime_teardown_safe() {
+    assert_send_sync_static::<BriskSession>();
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().to_path_buf();
+
+    std::thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async move {
+            let database = open(&path).await;
+            let session = database.owned_session();
+            session.set_routing_key("runtime-owner").await.unwrap();
+            session
+                .migrate("CREATE TABLE events (id INTEGER PRIMARY KEY, value INTEGER NOT NULL)")
+                .await
+                .unwrap();
+            session.close().await.unwrap();
+            database.close().await.unwrap();
+        });
+    })
+    .join()
+    .unwrap();
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        let reopened = open(temp.path()).await;
+        assert_eq!(reopened.state(), EngineState::Running);
+        reopened.close().await.unwrap();
+    });
+}
+
+#[tokio::test]
+async fn clones_share_terminal_session_state_and_cannot_resurrect_database() {
+    let temp = tempfile::tempdir().unwrap();
+    let database = open(temp.path()).await;
+    let session = database.owned_session();
+    let clone = session.clone();
+    assert_eq!(session.id(), clone.id());
+    session.set_routing_key("shared-session").await.unwrap();
+    assert_eq!(clone.routing_key().await.as_deref(), Some("shared-session"));
+
+    clone.close().await.unwrap();
+    assert_eq!(session.state().await, SessionState::Closed);
+    let closed = session
+        .query(Statement::new("SELECT 1", Vec::new()))
+        .await
+        .unwrap_err();
+    assert_eq!(closed.kind(), EngineErrorKind::FailedPrecondition);
+
+    let leaked = database.owned_session();
+    leaked.set_routing_key("leaked").await.unwrap();
+    database.close().await.unwrap();
+    drop(database);
+    assert_eq!(leaked.database_state(), EngineState::Stopped);
+    let stopped = leaked
+        .query(Statement::new("SELECT 1", Vec::new()))
+        .await
+        .unwrap_err();
+    assert_eq!(stopped.kind(), EngineErrorKind::ShuttingDown);
+    leaked.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn shared_session_concurrency_serializes_and_concurrent_close_is_idempotent() {
+    let temp = tempfile::tempdir().unwrap();
+    let database = open(temp.path()).await;
+    let session = database.owned_session();
+    session.set_routing_key("concurrent-owner").await.unwrap();
+    session
+        .migrate("CREATE TABLE counters (id INTEGER PRIMARY KEY, value INTEGER NOT NULL)")
+        .await
+        .unwrap();
+    session
+        .execute_write(Statement::new(
+            "INSERT INTO counters (id, value) VALUES (?1, ?2)",
+            vec![Value::from(1_i64), Value::from(0_i64)],
+        ))
+        .await
+        .unwrap();
+
+    let mut work = tokio::task::JoinSet::new();
+    for _ in 0..16 {
+        let session = session.clone();
+        work.spawn(async move {
+            session
+                .execute_write(Statement::new(
+                    "UPDATE counters SET value = value + 1 WHERE id = ?1",
+                    vec![Value::from(1_i64)],
+                ))
+                .await
+        });
+    }
+    while let Some(result) = work.join_next().await {
+        assert_eq!(result.unwrap().unwrap().value.rows_affected, 1);
+    }
+    let rows = session
+        .query(Statement::new(
+            "SELECT value FROM counters WHERE id = ?1",
+            vec![Value::from(1_i64)],
+        ))
+        .await
+        .unwrap();
+    assert_eq!(rows.value.rows()[0].get(0), Some(&Value::from(16_i64)));
+
+    session.close().await.unwrap();
+    let first = database.clone();
+    let second = database.clone();
+    let (first, second) = tokio::join!(first.close(), second.close());
+    assert_eq!(first.unwrap(), second.unwrap());
+    assert_eq!(database.state(), EngineState::Stopped);
+}
+
+#[tokio::test]
+async fn request_cancellation_reaches_owned_session_commands() {
+    let temp = tempfile::tempdir().unwrap();
+    let database = open(temp.path()).await;
+    let session = database.owned_session();
+    session.set_routing_key("cancel-owner").await.unwrap();
+    let cancellation = briskdb::CancellationToken::new();
+    cancellation.cancel();
+    let error = session
+        .query_with_context(
+            Statement::new("SELECT 1", Vec::new()),
+            briskdb::RequestContext::new().with_cancellation_token(cancellation),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::Cancelled);
+
+    assert_eq!(
+        session.status().await.unwrap().queue_capacity_per_shard(),
+        2
+    );
+    session.close().await.unwrap();
+    tokio::time::timeout(Duration::from_secs(2), database.close())
+        .await
+        .unwrap()
+        .unwrap();
+}


### PR DESCRIPTION
## Summary

- add cloneable `BriskSession` handles that retain their owning database identity
- expose direct and prepared SQL operations without passing a separate database/session pair
- make clone-shared routing, prepared state, terminal close, and stopped-database behavior explicit
- cover runtime teardown/reopen, leaked handles, cancellation, same-session concurrency, use-after-close, and concurrent database close

## Why

Raw `Session` is intentionally non-cloneable and requires a separate engine reference. Foreign-language wrappers and component-oriented hosts need one owned handle whose database/session relationship cannot be mixed up or silently resurrected after shutdown.

## Scope note

This advances #192 but intentionally does not close it. Single-shard transaction pinning and streaming cursor handles remain tracked by #34 and #39. Existing bounded worker, backpressure, cancellation, panic cleanup, and shutdown behavior remains shared with protocol adapters.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked --all-targets --all-features` (solo full rerun passed)
- `cargo test --locked --doc --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- isolated retry of the pre-existing tight-grace shutdown test passed after a contention-only failure while Clippy ran concurrently

Refs #192
