### PR TITLE
Package BriskDB as a feature-gated crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,61 @@ env:
   RUST_BACKTRACE: "1"
 
 jobs:
+  features:
+    name: Features (${{ matrix.surface }}, Rust ${{ matrix.rust }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        rust:
+          - "1.85.0"
+          - stable
+        surface:
+          - core
+          - embedded
+          - http
+          - postgres
+          - sqlite-import
+          - default
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Rust ${{ matrix.rust }}
+        run: rustup toolchain install "${{ matrix.rust }}" --profile minimal
+
+      - name: Select Rust ${{ matrix.rust }}
+        run: rustup default "${{ matrix.rust }}"
+
+      - name: Restore Rust build cache
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          shared-key: features-${{ matrix.rust }}-${{ matrix.surface }}
+
+      - name: Check feature surface
+        run: |
+          case "${{ matrix.surface }}" in
+            core) cargo check --locked --lib --no-default-features ;;
+            default) cargo check --locked --lib ;;
+            *) cargo check --locked --lib --no-default-features --features "${{ matrix.surface }}" ;;
+          esac
+
+      - name: Verify embedded dependency boundary
+        if: matrix.surface == 'embedded'
+        run: |
+          forbidden_dependencies="$(
+            cargo tree --locked --no-default-features --features embedded --edges normal --prefix none |
+              awk '$1 ~ /^(anyhow|axum|clap|hyper|hyper-util|pgwire|tokio-util|tower|tracing-subscriber)$/ { print $1 }' |
+              sort -u
+          )"
+          if [ -n "$forbidden_dependencies" ]; then
+            echo "embedded feature unexpectedly includes: $forbidden_dependencies"
+            exit 1
+          fi
+
   quality:
     name: Format and Clippy (stable)
     runs-on: ubuntu-24.04
@@ -47,6 +102,16 @@ jobs:
 
       - name: Run Clippy
         run: cargo clippy --locked --all-targets --all-features -- -D warnings
+
+      - name: Verify publishable crate package
+        run: cargo package --locked --allow-dirty
+
+      - name: Reject Git-sourced dependencies
+        run: |
+          if awk '/source = "git\+/{ found = 1 } END { exit !found }' Cargo.lock; then
+            echo "Cargo.lock contains a Git-sourced dependency"
+            exit 1
+          fi
 
   test:
     name: Tests (${{ matrix.rust }})

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,15 +887,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,29 +990,6 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -1242,15 +1210,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "regex"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1355,12 +1314,6 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -1501,7 +1454,8 @@ dependencies = [
 [[package]]
 name = "sqlparser"
 version = "0.62.0"
-source = "git+https://github.com/apache/datafusion-sqlparser-rs?rev=33521a534eae72188e06ce0ce4836d19c7f3458a#33521a534eae72188e06ce0ce4836d19c7f3458a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c6d1b651dc4edf07eead2a0c6c78016ce971bc2c10da5266861b13f25e7cec"
 dependencies = [
  "log",
  "recursive",
@@ -1511,7 +1465,8 @@ dependencies = [
 [[package]]
 name = "sqlparser_derive"
 version = "0.5.0"
-source = "git+https://github.com/apache/datafusion-sqlparser-rs?rev=33521a534eae72188e06ce0ce4836d19c7f3458a#33521a534eae72188e06ce0ce4836d19c7f3458a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6dd45d8fc1c79299bfbb7190e42ccbbdf6a5f52e4a6ad98d92357ea965bd289"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1652,7 +1607,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,47 +7,89 @@ default-run = "briskdb"
 description = "Sharded SQLite with HTTP/PostgreSQL today and MongoDB/MySQL frontends planned"
 license = "MIT"
 repository = "https://github.com/schapman1974/briskdb"
-# Cargo packaging removes Git source pins from dependencies. Keep registry
-# publishing disabled while the exact post-0.62 parser snapshot is required.
-publish = false
+readme = "README.md"
+keywords = ["database", "sqlite", "sharding", "embedded"]
+categories = ["database-implementations"]
 
 [features]
-default = []
+default = ["server-cli", "sqlite-import-cli"]
+# Host-controlled, listener-free Rust API. SQL execution, routing, and the
+# bundled SQLite storage engine are the stable embedded surface.
+embedded = []
+# Network adapters can be selected independently by downstream applications.
+http = [
+    "dep:axum",
+    "dep:futures",
+    "dep:serde",
+    "dep:serde_json",
+    "dep:tower",
+    "dep:tracing",
+]
+postgres = [
+    "dep:async-trait",
+    "dep:futures",
+    "dep:pgwire",
+    "dep:tokio-util",
+    "tokio/io-util",
+    "tokio/net",
+]
+# Process assembly used by the shipped daemon.
+server = [
+    "embedded",
+    "http",
+    "postgres",
+    "dep:anyhow",
+    "dep:hyper",
+    "dep:hyper-util",
+    "tokio/signal",
+]
+server-cli = [
+    "server",
+    "dep:clap",
+    "dep:tracing-subscriber",
+    "tokio/macros",
+    "tokio/rt-multi-thread",
+]
+# The offline SQLite importer is separate from the embedded query surface.
+sqlite-import = ["dep:serde", "dep:serde_json", "dep:tracing"]
+sqlite-import-cli = ["sqlite-import", "dep:anyhow", "dep:clap"]
+# Reserved feature names establish the intended package boundaries without
+# claiming that these roadmap surfaces are implemented.
+documents = ["embedded"]
+mysql = []
+tls = []
 # Statically compile rusqlite's virtual-table API for the no-fork sharded-table
 # prototype. This does not enable SQLite's runtime extension loader.
 experimental-vtab = ["rusqlite/vtab"]
 
 [dependencies]
-anyhow = "1.0"
-async-trait = "0.1"
-axum = "0.8.9"
+anyhow = { version = "1.0", optional = true }
+async-trait = { version = "0.1", optional = true }
+axum = { version = "0.8.9", optional = true }
 blake3 = "1.8"
-clap = { version = "4.6.6", features = ["derive", "env"] }
+clap = { version = "4.6.6", features = ["derive", "env"], optional = true }
 getrandom = "=0.4.3"
-futures = "0.3"
-hyper = { version = "1.11", features = ["http1", "server"] }
-hyper-util = { version = "0.1.20", features = ["service", "tokio"] }
+futures = { version = "0.3", optional = true }
+hyper = { version = "1.11", features = ["http1", "server"], optional = true }
+hyper-util = { version = "0.1.20", features = ["service", "tokio"], optional = true }
 # 0.36.3 is the newest pgwire release that supports BriskDB's Rust 1.85
 # baseline. Keep the pre-1.0 dependency exact and enable only the plaintext
 # server surface; later roadmap work owns TLS and extended type adapters.
-pgwire = { version = "=0.36.3", default-features = false, features = ["server-api"] }
+pgwire = { version = "=0.36.3", default-features = false, features = ["server-api"], optional = true }
 rusqlite = { version = "0.39.0", features = ["bundled", "column_metadata", "hooks", "limits"] }
 same-file = "1.0"
-serde = { version = "1.0.229", features = ["derive"] }
-serde_json = "1.0"
-# The exact upstream revision contains the post-0.62.0 `parse_interval`
-# recursion fix. This must remain a direct source pin so downstream BriskDB
-# consumers inherit it; a root-only `[patch]` would not propagate.
-sqlparser = { version = "=0.62.0", git = "https://github.com/apache/datafusion-sqlparser-rs", rev = "33521a534eae72188e06ce0ce4836d19c7f3458a", default-features = false, features = ["std", "recursive-protection", "visitor"] }
+serde = { version = "1.0.229", features = ["derive"], optional = true }
+serde_json = { version = "1.0", optional = true }
+sqlparser = { version = "=0.62.0", default-features = false, features = ["std", "recursive-protection", "visitor"] }
 # `recursive` admits newer `psm` releases whose build dependencies require
 # Rust 1.88. The direct exact constraint preserves BriskDB's Rust 1.85 MSRV for
 # both this repository and downstream consumers until that graph is corrected.
 psm = "=0.1.28"
-tokio = { version = "1.53.1", features = ["full"] }
-tokio-util = { version = "0.7", features = ["codec"] }
-tower = { version = "0.5", features = ["util"] }
-tracing = "0.1"
-tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
+tokio = { version = "1.53.1", features = ["macros", "rt", "sync", "time"] }
+tokio-util = { version = "0.7", features = ["codec"], optional = true }
+tower = { version = "0.5", features = ["util"], optional = true }
+tracing = { version = "0.1", optional = true }
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"], optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.7", default-features = false }
@@ -58,3 +100,17 @@ tempfile = "3.23"
 [[bench]]
 name = "storage"
 harness = false
+
+[[bin]]
+name = "briskdb"
+path = "src/main.rs"
+required-features = ["server-cli"]
+
+[[bin]]
+name = "briskdb-import"
+path = "src/bin/briskdb-import.rs"
+required-features = ["sqlite-import-cli"]
+
+[[example]]
+name = "embedded"
+required-features = ["embedded"]

--- a/README.md
+++ b/README.md
@@ -43,14 +43,16 @@ flowchart LR
         PG[PostgreSQL clients]
         MONGO[MongoDB clients · planned]
         MYSQL[MySQL clients · planned]
-        EMBED[Rust + Python · planned]
+        RUST[Rust embedding]
+        PY[Python · planned]
     end
 
     WEB --> ENGINE
     PG --> ENGINE
     MONGO -.-> ENGINE
     MYSQL -.-> ENGINE
-    EMBED -.-> ENGINE
+    RUST --> ENGINE
+    PY -.-> ENGINE
 
     ENGINE[Protocol-neutral Rust engine] --> ROUTER[4,096 virtual buckets]
     ROUTER --> S0[(SQLite WAL · shard 0)]
@@ -150,7 +152,9 @@ macOS/Linux ARM64 and x86-64 archives plus Linux `.deb` packages.
 
 Embedding in Rust starts with `BriskDb::open()` or the validated builder. The
 [embedded Rust guide](docs/EMBEDDED_RUST.md) includes a complete listener-free
-example and documents every default.
+example and documents every default. Use `default-features = false` with the
+`embedded` feature to leave the network and CLI stacks out; see the
+[crate feature map](docs/CRATE_FEATURES.md).
 
 ## Still just inspectable files
 
@@ -198,6 +202,7 @@ Follow the [roadmap](ROADMAP.md) or browse the
 - [Architecture](docs/ARCHITECTURE.md)
 - [Embedded Rust](docs/EMBEDDED_RUST.md)
 - [Embedded SQL](docs/EMBEDDED_SQL.md)
+- [Crate features and support tiers](docs/CRATE_FEATURES.md)
 - [PostgreSQL quickstart](docs/POSTGRES_QUICKSTART.md)
 - [SQL compatibility](docs/SQL_COMPATIBILITY.md)
 - [Generated keys](docs/GENERATED_KEYS.md)

--- a/docs/CRATE_FEATURES.md
+++ b/docs/CRATE_FEATURES.md
@@ -1,0 +1,77 @@
+# Crate features and support tiers
+
+BriskDB is one crate with an embedded core and optional process/protocol
+layers. Normal `cargo build` behavior is unchanged: the default features build
+the `briskdb` server and `briskdb-import` binaries.
+
+For an embedded application with no HTTP, PostgreSQL, command-line, or signal
+handling dependencies:
+
+```toml
+[dependencies]
+briskdb = { version = "0.1.0-alpha.3", default-features = false, features = ["embedded"] }
+```
+
+## Feature map
+
+| Feature | Adds | Tier |
+| --- | --- | --- |
+| `embedded` | Listener-free `BriskDb` and `BriskSession` APIs | Alpha-supported |
+| `http` | Axum HTTP API and admin browser | Alpha-supported |
+| `postgres` | PostgreSQL wire adapter | Alpha-supported, bounded SQL subset |
+| `server` | HTTP/PostgreSQL listener assembly and shutdown handling | Process integration |
+| `server-cli` | `briskdb` binary, Clap, logging subscriber, multithread runtime | Process integration |
+| `sqlite-import` | Offline SQLite import library | Alpha-supported |
+| `sqlite-import-cli` | `briskdb-import` binary | Process integration |
+| `experimental-vtab` | Sharded virtual-table prototype | Experimental |
+| `documents` | Reserved Mongo/document boundary | Reserved; no API yet |
+| `mysql` | Reserved MySQL boundary | Reserved; no listener yet |
+| `tls` | Reserved transport-security boundary | Reserved; no TLS yet |
+
+`default = ["server-cli", "sqlite-import-cli"]`. `server` selects
+`embedded`, `http`, and `postgres`; applications using adapters directly may
+select `http` or `postgres` without process assembly.
+
+## Public API tiers
+
+- The crate-root engine value types and the `embedded` facade are the intended
+  downstream Rust API. They follow the documented pre-1.0 compatibility policy.
+- `protocol::http`, `protocol::postgres`, `import`, and `server` are public for
+  integration, but remain alpha surfaces that may evolve with their protocols.
+- `experimental-vtab` has no compatibility promise.
+- The public `core`, `sql`, and `storage` modules expose implementation-facing
+  building blocks used by current adapters. Prefer crate-root and `embedded`
+  APIs unless implementing a BriskDB adapter.
+- Reserved features compile but intentionally expose no claimed implementation.
+
+See [Pre-1.0 compatibility](PRE_1_COMPATIBILITY.md) for the versioning policy.
+
+## Packaging baseline
+
+Measured from the alpha.3 lockfile on macOS ARM64 with Cargo's normal-edge
+dependency graph:
+
+| Build | Unique packages |
+| --- | ---: |
+| `--no-default-features --features embedded` | 36 |
+| Default server + importer | 176 |
+
+The default graph currently has five version-skew families: `fallible-iterator`,
+`getrandom`, `rand`, `rand_core`, and `syn`. The release binary-size and clean
+compile-time measurements from the same host were:
+
+| Measurement | Baseline |
+| --- | ---: |
+| Clean embedded `cargo check` | 12.59 seconds |
+| Release `briskdb` binary | 16,611,376 bytes |
+| Release `briskdb-import` binary | 10,940,848 bytes |
+
+Reproduce the baseline with:
+
+```bash
+cargo tree --locked --duplicates --edges normal
+cargo build --release --locked --bins
+CARGO_TARGET_DIR=$(mktemp -d) cargo check --locked --no-default-features --features embedded --lib
+```
+
+These numbers are a regression baseline, not a size or build-time guarantee.

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -37,6 +37,7 @@ const MAX_SCATTER_CONCURRENCY: usize = 8;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ExecuteOwnerPolicy {
     Session,
+    #[cfg_attr(not(feature = "http"), allow(dead_code))]
     ReuseValidatedCatalogWrite,
 }
 
@@ -1387,6 +1388,7 @@ impl Engine {
     /// populated catalog, raw planning proves that the request is one routed
     /// common-subset write before the shared stateless ownership domain is
     /// selected.
+    #[cfg(feature = "http")]
     pub(crate) async fn execute_http_request(
         &self,
         session: &Session,
@@ -2099,6 +2101,7 @@ impl Engine {
     /// pool, worker, cancellation, and result-budget behavior. The SQL adapter
     /// verifies that the prepared SQLite statement is read-only before it is
     /// stepped.
+    #[cfg(any(feature = "http", test))]
     pub(crate) async fn inspect_shard(
         &self,
         session: &Session,
@@ -2110,6 +2113,7 @@ impl Engine {
     }
 
     /// Run an explicit-shard inspection with request-scoped controls.
+    #[cfg(any(feature = "http", test))]
     pub(crate) async fn inspect_shard_with_context(
         &self,
         session: &Session,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -45,6 +45,7 @@ pub use options::{
     MAX_RETAINED_BOUND_VALUE_BYTES, MAX_SHUTDOWN_GRACE_MS, PreparedStatementLimits, ResultLimits,
 };
 pub use planner::{BoundStatementPlan, PlannedRoute};
+#[cfg(any(test, feature = "experimental-vtab", feature = "sqlite-import"))]
 pub(crate) use planner::{CanonicalShardKeyRef, canonical_shard_key_bytes};
 pub(crate) use prepared::PreparedState;
 pub use prepared::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,10 @@
 pub mod core;
+#[cfg(feature = "embedded")]
 pub mod embedded;
+#[cfg(feature = "sqlite-import")]
 pub mod import;
 pub mod protocol;
+#[cfg(feature = "server")]
 pub mod server;
 pub mod sql;
 pub mod storage;
@@ -10,6 +13,7 @@ mod sqlite_error;
 
 // Preserve the original public module path while frontends migrate to the
 // explicit protocol namespace.
+#[cfg(feature = "http")]
 pub use protocol::http as api;
 
 pub use core::{
@@ -20,6 +24,7 @@ pub use core::{
     RequestContext, ResultLimits, ResultSet, ResultSetShapeError, Routed, Row, Session, SessionId,
     SessionState, ShutdownReport, Statement, Value, WriteResult,
 };
+#[cfg(feature = "embedded")]
 pub use embedded::{
     BriskDb, BriskDbBuilder, BriskSession, DEFAULT_EMBEDDED_SHARDS, DocumentSupport,
     RuntimeBehavior,

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,5 +1,7 @@
 //! Network protocol adapters.
 
 pub mod error;
+#[cfg(feature = "http")]
 pub mod http;
+#[cfg(feature = "postgres")]
 pub mod postgres;

--- a/src/protocol/postgres.rs
+++ b/src/protocol/postgres.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "server"), allow(dead_code))]
+
 //! BriskDB-owned boundary for the selected PostgreSQL wire library.
 //!
 //! The configured loopback listener delegates startup framing and dispatch to

--- a/src/sql/parser.rs
+++ b/src/sql/parser.rs
@@ -3,7 +3,9 @@ use std::{borrow::Cow, fmt, ops::ControlFlow};
 use sqlparser::{
     ast::{Expr, ObjectNamePart, ObjectType, Statement as AstStatement, visit_expressions},
     dialect::{Dialect, MySqlDialect, PostgreSqlDialect, SQLiteDialect},
+    keywords::Keyword,
     parser::{Parser, ParserError},
+    tokenizer::{Token, TokenWithSpan, Tokenizer, Whitespace},
 };
 
 use crate::core::{EngineError, EngineErrorKind, EngineResult};
@@ -121,9 +123,9 @@ pub fn parse<'a>(dialect: SqlDialect, source: impl Into<Cow<'a, str>>) -> Engine
     }
 
     let statements = match dialect {
-        SqlDialect::Sqlite => parse_with(&SQLiteDialect {}, &source),
-        SqlDialect::PostgreSql => parse_with(&PostgreSqlDialect {}, &source),
-        SqlDialect::MySql => parse_with(&MySqlDialect {}, &source),
+        SqlDialect::Sqlite => parse_with(&SQLiteDialect {}, &source, false),
+        SqlDialect::PostgreSql => parse_with(&PostgreSqlDialect {}, &source, true),
+        SqlDialect::MySql => parse_with(&MySqlDialect {}, &source, false),
     }
     .map_err(|error| classify_parser_error(dialect, error))?;
 
@@ -212,11 +214,68 @@ fn connection_local_counter_function(function: &str) -> bool {
         .any(|counter| function.eq_ignore_ascii_case(counter))
 }
 
-fn parse_with(dialect: &dyn Dialect, source: &str) -> Result<Vec<AstStatement>, ParserError> {
+fn parse_with(
+    dialect: &dyn Dialect,
+    source: &str,
+    postgres_abort_alias: bool,
+) -> Result<Vec<AstStatement>, ParserError> {
+    let mut tokens = Tokenizer::new(dialect, source).tokenize_with_location()?;
+    reject_unguarded_interval_recursion(&tokens)?;
+    if postgres_abort_alias {
+        rewrite_postgres_abort_alias(&mut tokens);
+    }
     let mut parser = Parser::new(dialect)
         .with_recursion_limit(SQL_PARSE_RECURSION_LIMIT)
-        .try_with_sql(source)?;
+        .with_tokens_with_locations(tokens);
     parser.parse_statements()
+}
+
+/// Protect the one recursive sqlparser 0.62 path that was missing its own
+/// recursion counter. Keeping the check at BriskDB's parser boundary lets the
+/// published crate use the registry release without losing the stack-safety
+/// guarantee covered by `deep_interval_recursion_is_rejected_without_aborting_the_process`.
+fn reject_unguarded_interval_recursion(tokens: &[TokenWithSpan]) -> Result<(), ParserError> {
+    let mut consecutive_intervals = 0;
+
+    for token in tokens {
+        match &token.token {
+            Token::Word(word) if word.keyword == Keyword::INTERVAL => {
+                consecutive_intervals += 1;
+                if consecutive_intervals > SQL_PARSE_RECURSION_LIMIT {
+                    return Err(ParserError::RecursionLimitExceeded);
+                }
+            }
+            Token::Whitespace(
+                Whitespace::Space
+                | Whitespace::Newline
+                | Whitespace::Tab
+                | Whitespace::SingleLineComment { .. }
+                | Whitespace::MultiLineComment(_),
+            ) => {}
+            _ => consecutive_intervals = 0,
+        }
+    }
+
+    Ok(())
+}
+
+/// sqlparser learned PostgreSQL's top-level `ABORT` alias after 0.62. Keep the
+/// source token spans while presenting that release's parser with the
+/// equivalent `ROLLBACK` keyword, including in multi-statement batches.
+fn rewrite_postgres_abort_alias(tokens: &mut [TokenWithSpan]) {
+    let mut statement_start = true;
+
+    for token in tokens {
+        match &mut token.token {
+            Token::Whitespace(_) => {}
+            Token::SemiColon => statement_start = true,
+            Token::Word(word) if statement_start && word.keyword == Keyword::ABORT => {
+                word.keyword = Keyword::ROLLBACK;
+                statement_start = false;
+            }
+            _ => statement_start = false,
+        }
+    }
 }
 
 fn classify_parser_error(dialect: SqlDialect, error: ParserError) -> EngineError {

--- a/src/sql/subset.rs
+++ b/src/sql/subset.rs
@@ -5,10 +5,10 @@ use sqlparser::ast::{
     CreateIndex, CreateTable, CreateTableOptions, DataType, Delete, Distinct, Expr, FromTable,
     Function, FunctionArg, FunctionArgExpr, FunctionArguments, GroupByExpr, HiveDistributionStyle,
     IndexColumn, Insert, LimitClause, NullsDistinctOption, ObjectName, ObjectNamePart, OrderBy,
-    OrderByExpr, OrderByKind, OrderBySort, PrimaryKeyConstraint, Query, Select, SelectFlavor,
-    SelectItem, SelectItemQualifiedWildcardKind, SetExpr, Statement as AstStatement,
-    TableConstraint, TableFactor, TableObject, TableWithJoins, UnaryOperator, UniqueConstraint,
-    Update, Value, WildcardAdditionalOptions,
+    OrderByExpr, OrderByKind, PrimaryKeyConstraint, Query, Select, SelectFlavor, SelectItem,
+    SelectItemQualifiedWildcardKind, SetExpr, Statement as AstStatement, TableConstraint,
+    TableFactor, TableObject, TableWithJoins, UnaryOperator, UniqueConstraint, Update, Value,
+    WildcardAdditionalOptions,
 };
 use sqlparser::tokenizer::Span;
 
@@ -209,7 +209,6 @@ fn validate_create_table(
     let CreateTable {
         or_replace,
         temporary,
-        unlogged,
         external,
         dynamic,
         global,
@@ -254,7 +253,6 @@ fn validate_create_table(
         with_storage_lifecycle_policy,
         with_tags,
         external_volume,
-        with_connection,
         base_location,
         catalog,
         catalog_sync,
@@ -268,14 +266,10 @@ fn validate_create_table(
         distkey,
         sortkey,
         backup,
-        multiset,
-        fallback,
-        with_data,
     } = table;
 
     if *or_replace
         || *temporary
-        || *unlogged
         || *external
         || *dynamic
         || global.is_some()
@@ -329,7 +323,6 @@ fn validate_create_table(
         || with_storage_lifecycle_policy.is_some()
         || with_tags.is_some()
         || external_volume.is_some()
-        || with_connection.is_some()
         || base_location.is_some()
         || catalog.is_some()
         || catalog_sync.is_some()
@@ -343,9 +336,6 @@ fn validate_create_table(
         || distkey.is_some()
         || sortkey.is_some()
         || backup.is_some()
-        || multiset.is_some()
-        || fallback.is_some()
-        || with_data.is_some()
     {
         return unsupported("vendor-specific CREATE TABLE options");
     }
@@ -407,7 +397,6 @@ fn validate_table_constraint(constraint: &TableConstraint) -> SubsetResult {
 fn validate_primary_key(constraint: &PrimaryKeyConstraint, allow_empty: bool) -> SubsetResult {
     if constraint.index_name.is_some()
         || constraint.index_type.is_some()
-        || !constraint.include.is_empty()
         || !constraint.index_options.is_empty()
         || constraint.characteristics.is_some()
     {
@@ -426,7 +415,6 @@ fn validate_unique(constraint: &UniqueConstraint, allow_empty: bool) -> SubsetRe
     if constraint.index_name.is_some()
         || !constraint.index_type_display.is_none()
         || constraint.index_type.is_some()
-        || !constraint.include.is_empty()
         || !constraint.index_options.is_empty()
         || constraint.characteristics.is_some()
         || !matches!(constraint.nulls_distinct, NullsDistinctOption::None)
@@ -464,7 +452,6 @@ fn validate_create_index(index: &CreateIndex) -> SubsetResult {
     }
     if index.using.is_some()
         || index.concurrently
-        || index.r#async
         || !index.include.is_empty()
         || index.nulls_distinct.is_some()
         || !index.with.is_empty()
@@ -484,7 +471,6 @@ fn validate_index_column(column: &IndexColumn) -> SubsetResult {
     if column.operator_class.is_some()
         || column.column.with_fill.is_some()
         || column.column.options.nulls_first.is_some()
-        || matches!(column.column.options.sort, Some(OrderBySort::Using(_)))
     {
         return unsupported("index column options");
     }
@@ -663,10 +649,7 @@ fn validate_order_by_expression(
     order_by: &OrderByExpr,
     validation: &mut ValidationState,
 ) -> SubsetResult {
-    if order_by.with_fill.is_some()
-        || order_by.options.nulls_first.is_some()
-        || matches!(order_by.options.sort, Some(OrderBySort::Using(_)))
-    {
+    if order_by.with_fill.is_some() || order_by.options.nulls_first.is_some() {
         return unsupported("ORDER BY options");
     }
     validate_expression(&order_by.expr, ExprContext::SELECT, validation)

--- a/src/sql/translator.rs
+++ b/src/sql/translator.rs
@@ -1,10 +1,11 @@
 use std::{fmt, ops::ControlFlow};
 
 use sqlparser::ast::{
-    BinaryLength, CharacterLength, DataType as AstDataType, ExactNumberInfo, Ident, LimitClause,
-    Offset, OffsetRows, Query as AstQuery, Statement as AstStatement, Value as AstValue,
-    ValueWithSpan, VisitMut, VisitorMut,
+    BinaryLength, CharacterLength, DataType as AstDataType, ExactNumberInfo, LimitClause, Offset,
+    OffsetRows, Query as AstQuery, Statement as AstStatement, Value as AstValue, ValueWithSpan,
+    VisitMut, VisitorMut,
 };
+use sqlparser::{dialect::MySqlDialect, tokenizer::Token, tokenizer::Tokenizer};
 
 use super::{GeneratedTableIntent, NormalizedSql, SqlDialect, StatementParameters, generated};
 use crate::core::{EngineError, EngineErrorKind, EngineResult};
@@ -212,6 +213,11 @@ fn translate_compatibility(
         .map(ToString::to_string)
         .collect::<Vec<_>>()
         .join("; ");
+    let sqlite_sql = if normalized.dialect() == SqlDialect::MySql {
+        canonicalize_mysql_identifier_quotes(&sqlite_sql)?
+    } else {
+        sqlite_sql
+    };
     if sqlite_sql.as_bytes().contains(&0) {
         return Err(EngineError::new(
             EngineErrorKind::InvalidQuery,
@@ -219,6 +225,29 @@ fn translate_compatibility(
         ));
     }
     Ok(sqlite_sql)
+}
+
+/// Convert only MySQL-delimited identifiers in parser-rendered SQL. String
+/// literals and comments remain token-distinct, and embedded double quotes are
+/// escaped for SQLite's standard identifier spelling.
+fn canonicalize_mysql_identifier_quotes(sql: &str) -> EngineResult<String> {
+    let tokens = Tokenizer::new(&MySqlDialect {}, sql)
+        .tokenize()
+        .map_err(|_| translation_invariant())?;
+    let mut output = String::with_capacity(sql.len());
+
+    for token in tokens {
+        match token {
+            Token::Word(word) if word.quote_style == Some('`') => {
+                output.push('"');
+                output.push_str(&word.value.replace('"', "\"\""));
+                output.push('"');
+            }
+            token => output.push_str(&token.to_string()),
+        }
+    }
+
+    Ok(output)
 }
 
 fn translate_column_types(
@@ -434,13 +463,6 @@ impl VisitorMut for CompatibilityVisitor<'_> {
                 value.value = AstValue::Number(if *boolean { "1" } else { "0" }.to_owned(), false);
             }
             _ => {}
-        }
-        ControlFlow::Continue(())
-    }
-
-    fn pre_visit_ident(&mut self, identifier: &mut Ident) -> ControlFlow<Self::Break> {
-        if identifier.quote_style == Some('`') {
-            identifier.quote_style = Some('"');
         }
         ControlFlow::Continue(())
     }

--- a/src/storage/hilo.rs
+++ b/src/storage/hilo.rs
@@ -5,6 +5,8 @@
 //! rollback, cancellation, constraint failures, and crashes can create gaps
 //! but cannot cause reuse.
 
+#![cfg_attr(not(feature = "experimental-vtab"), allow(dead_code))]
+
 use std::{
     collections::HashMap,
     sync::{Arc, Mutex},

--- a/src/storage/manifest.rs
+++ b/src/storage/manifest.rs
@@ -2143,6 +2143,7 @@ fn current_manifest_snapshot(
 /// lock is acquired. A commit failure is deliberately not reconciled into a
 /// returned lease: if SQLite committed despite the error, that block remains
 /// burned and the next reservation advances beyond it.
+#[cfg_attr(not(feature = "experimental-vtab"), allow(dead_code))]
 pub(super) fn reserve_hilo_v1_block(
     connection: &mut Connection,
     requested_shards: u16,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -55,6 +55,7 @@ use crate::{
 use crate::core::AllocationOwnerMap;
 
 pub(crate) const CONNECTION_BUSY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+#[cfg(feature = "sqlite-import")]
 pub(crate) const MAX_SCHEMA_MIGRATION_SQL_BYTES: usize = manifest::MAX_SCHEMA_MIGRATION_SQL_BYTES;
 
 #[derive(Debug)]
@@ -62,6 +63,7 @@ struct RootSchemaCoordination {
     gate: schema_gate::SchemaGate,
     catalogs: Mutex<Vec<Weak<CatalogSnapshot>>>,
     schema_digests: Mutex<RuntimeSchemaDigests>,
+    #[cfg_attr(not(feature = "experimental-vtab"), allow(dead_code))]
     hilo_allocator: hilo::HiloAllocator,
 }
 
@@ -814,12 +816,14 @@ impl Storage {
     }
 
     #[cfg(any(feature = "experimental-vtab", test))]
+    #[cfg_attr(not(feature = "experimental-vtab"), allow(dead_code))]
     pub(crate) fn generated_id_policy_is_active(&self, table_id: TableId) -> bool {
         self.catalog.native_id_policy_is_active(table_id)
             || self.catalog.hilo_id_policy_is_active(table_id)
     }
 
     #[cfg(any(feature = "experimental-vtab", test))]
+    #[cfg_attr(not(feature = "experimental-vtab"), allow(dead_code))]
     pub(crate) fn allocate_hilo_v1(&self, table_id: TableId) -> EngineResult<hilo::HiloAllocation> {
         if !self.catalog.hilo_id_policy_is_active(table_id) {
             return Err(EngineError::new(
@@ -843,6 +847,7 @@ impl Storage {
     }
 
     #[cfg(any(feature = "experimental-vtab", test))]
+    #[cfg_attr(not(feature = "experimental-vtab"), allow(dead_code))]
     pub(crate) fn hilo_owner_id(&self) -> [u8; 32] {
         self.schema_coordination.hilo_allocator.owner_id()
     }


### PR DESCRIPTION
Closes #193.

## Summary
- adds independent embedded, HTTP, PostgreSQL, importer, server, and CLI feature boundaries while preserving the default binaries
- removes all Git-sourced dependencies and restores the parser safety/compatibility behavior at BriskDB boundaries
- documents API tiers plus dependency, compile-time, and binary-size baselines
- adds Rust 1.85/stable CI coverage for each supported feature surface, verifies the embedded graph excludes protocol stacks, and packages the crate

## Local validation
- `cargo test --locked --all-targets --all-features`
- `cargo test --locked --doc --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- core/embedded/http/postgres/sqlite-import/default feature checks
- `cargo package --locked --allow-dirty`
- `cargo fmt --all --check`