### PR TITLE
Add the embedded PyO3 extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,3 +145,65 @@ jobs:
 
       - name: Run documentation tests
         run: cargo test --locked --doc --all-features
+
+  python:
+    name: Python source build (${{ matrix.python }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        python:
+          - "3.9"
+          - "3.14"
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Rust 1.85
+        run: rustup toolchain install 1.85.0 --profile minimal --component clippy
+
+      - name: Select Rust 1.85
+        run: rustup default 1.85.0
+
+      - name: Install Python ${{ matrix.python }}
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: ${{ matrix.python }}
+          cache: pip
+          cache-dependency-path: python/pyproject.toml
+
+      - name: Restore Rust build cache
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          shared-key: python-${{ matrix.python }}
+
+      - name: Install pinned build frontend
+        run: python -m pip install maturin==1.14.1
+
+      - name: Build wheel from source
+        run: maturin build --manifest-path python/Cargo.toml --locked --out dist
+
+      - name: Install wheel and run Python tests
+        run: |
+          python -m pip install --force-reinstall dist/*.whl
+          python -m unittest discover -s python/tests -v
+
+      - name: Test and lint the native extension
+        run: |
+          cargo test --locked -p briskdb-python
+          cargo clippy --locked -p briskdb-python --all-targets --no-deps -- -D warnings
+
+      - name: Verify Python dependency boundary
+        run: |
+          forbidden_dependencies="$(
+            cargo tree --locked -p briskdb-python --edges normal --prefix none |
+              awk '$1 ~ /^(anyhow|axum|clap|hyper|hyper-util|pgwire|tokio-util|tower|tracing-subscriber)$/ { print $1 }' |
+              sort -u
+          )"
+          if [ -n "$forbidden_dependencies" ]; then
+            echo "Python extension unexpectedly includes: $forbidden_dependencies"
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 /target
+/dist
+/.venv
+/python/python/briskdb/_briskdb*.so
+/python/python/briskdb/_briskdb*.pyd
+__pycache__/
+*.pyc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "briskdb-python"
+version = "0.1.0-alpha.3"
+dependencies = [
+ "briskdb",
+ "pyo3",
+ "tokio",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,6 +1040,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
 name = "postgres-protocol"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,6 +1120,63 @@ checksum = "d11f2fedc3b7dafdc2851bc52f277377c5473d378859be234bc7ebb593144d01"
 dependencies = [
  "ar_archive_writer",
  "cc",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4688ddedf473e32662b9b067670129a8afb8c18e351482c70d62ba4a88171e8b"
+dependencies = [
+ "libc",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f41027e41b4bd03f6e60f9f417fe24a6341a6bb744edd62b6f709f2a52ea30e9"
+dependencies = [
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e591a95526fead067432c3b3a33fc74770b87b1e04e73671090d9c2055a2b327"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73225868fc1cd84eef2c3c230ddb91273bf1de46aeb8a4248da76d32a0924a1c"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "571575aa3749fa6216757dd47d2a3e7ef360f329a40f0666a9fbd14889024952"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1530,6 +1602,12 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,8 @@
+[workspace]
+members = ["python"]
+default-members = ["."]
+resolver = "3"
+
 [package]
 name = "briskdb"
 version = "0.1.0-alpha.3"

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ engine. It keeps the durability, WAL, transactions, tooling, and boring
 reliability developers already trust—then adds routing, parallel writer domains,
 global reads, generated IDs, an HTTP API, and wire-protocol frontends.
 
-**HTTP, bounded PostgreSQL queries, and listener-free Rust embedding work today.
-Native MongoDB, MySQL, Python, and serverless use are on the roadmap.**
+**HTTP, bounded PostgreSQL queries, and listener-free Rust and Python embedding
+work today. Native MongoDB, MySQL, and serverless use are on the roadmap.**
 
 > [!WARNING]
 > BriskDB is an alpha. It is exciting infrastructure, not yet a production-ready
@@ -44,7 +44,7 @@ flowchart LR
         MONGO[MongoDB clients · planned]
         MYSQL[MySQL clients · planned]
         RUST[Rust embedding]
-        PY[Python · planned]
+        PY[Python embedding]
     end
 
     WEB --> ENGINE
@@ -52,7 +52,7 @@ flowchart LR
     MONGO -.-> ENGINE
     MYSQL -.-> ENGINE
     RUST --> ENGINE
-    PY -.-> ENGINE
+    PY --> ENGINE
 
     ENGINE[Protocol-neutral Rust engine] --> ROUTER[4,096 virtual buckets]
     ROUTER --> S0[(SQLite WAL · shard 0)]
@@ -114,7 +114,8 @@ experimental and opt-in; the exact contract lives in
 | Listener-free Rust library entrypoint | Working |
 | Native MongoDB wire protocol with TinyMongo parity | [Planned](https://github.com/schapman1974/briskdb/issues/160) |
 | MySQL wire protocol | [Planned](https://github.com/schapman1974/briskdb/issues/40) |
-| Python wheels and serverless lifecycle | [Planned](https://github.com/schapman1974/briskdb/issues/197) |
+| Native Python extension | Source builds working; release wheels [planned](https://github.com/schapman1974/briskdb/issues/200) |
+| Serverless lifecycle | [Planned](https://github.com/schapman1974/briskdb/issues/194) |
 
 ## Try it in 30 seconds
 
@@ -156,6 +157,16 @@ example and documents every default. Use `default-features = false` with the
 `embedded` feature to leave the network and CLI stacks out; see the
 [crate feature map](docs/CRATE_FEATURES.md).
 
+Python can run the same engine directly in-process with no server or listener:
+
+```bash
+python -m pip install ./python
+```
+
+See the [Python quickstart](python/README.md) for a write/read example. A Rust
+toolchain is required for this initial source distribution; prebuilt wheels are
+tracked in [#200](https://github.com/schapman1974/briskdb/issues/200).
+
 ## Still just inspectable files
 
 ```text
@@ -177,9 +188,9 @@ and integrity metadata. Application rows stay in ordinary SQLite files.
   indexes, cursors, aggregation, and differential TinyMongo parity.
 - **More wire protocols:** PostgreSQL extended queries and MySQL compatibility,
   all sharing the same engine behavior.
-- **Python and serverless:** Python/PyO3 wheels, atomic snapshots,
+- **Python and serverless:** prebuilt Python wheels, atomic snapshots,
   ephemeral-runtime helpers, and fenced single-writer operation over the
-  embedded Rust API.
+  embedded Rust API. The initial PyO3 source package already runs in-process.
 - **Future storage adapters:** SQLite is the first backend, while the engine
   boundaries are being kept reusable for other durable backends.
 

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "briskdb-python"
+version = "0.1.0-alpha.3"
+edition = "2024"
+rust-version = "1.85"
+description = "Native Python bindings for embedded BriskDB"
+license = "MIT"
+repository = "https://github.com/schapman1974/briskdb"
+publish = false
+
+[lib]
+name = "_briskdb"
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+briskdb = { path = "..", default-features = false, features = ["embedded"] }
+pyo3 = { version = "=0.29.2", features = ["abi3-py39"] }
+tokio = { version = "1.53.1", features = ["rt-multi-thread", "sync", "time"] }

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,41 @@
+# BriskDB for Python
+
+This package runs BriskDB's sharded SQLite engine in the Python process. It
+starts no listener, subprocess, signal handler, or global logger.
+
+Build and install it from the repository with Python 3.9+ and Rust 1.85+:
+
+```bash
+python -m pip install ./python
+```
+
+```python
+import briskdb
+
+db = briskdb.open("./data", shards=4)
+session = db.session(routing_key="account-1")
+session.migrate("CREATE TABLE notes (id INTEGER PRIMARY KEY, body TEXT NOT NULL)")
+session.execute("INSERT INTO notes VALUES (?1, ?2)", [1, "hello"])
+print(session.query("SELECT body FROM notes WHERE id = ?1", [1]))
+session.close()
+db.close()
+```
+
+Resource limits can be validated before the database opens:
+
+```python
+config = briskdb.Config(shards=4, max_result_rows=5_000)
+db = briskdb.open("./data", config=config)
+```
+
+Database and session handles own their native resources, `close()` is
+idempotent, and blocking engine work releases Python's GIL. Dropping live
+handles during interpreter shutdown is also safe.
+
+This is an alpha API. SQL supports `None`, `bool`, signed 64-bit integers,
+finite `float`, `str`, and `bytes` in the initial binding. The complete
+lossless conversion and exception contract is tracked separately in issue
+[#198](https://github.com/schapman1974/briskdb/issues/198).
+
+Native Mongo/document commands are not claimed until BriskDB's document engine
+lands. The extension uses only the listener-free `embedded` Rust feature.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["maturin==1.14.1"]
+build-backend = "maturin"
+
+[project]
+name = "briskdb"
+dynamic = ["version"]
+description = "In-process sharded SQLite through BriskDB's native Rust engine"
+readme = "README.md"
+requires-python = ">=3.9"
+license = "MIT"
+authors = [{ name = "BriskDB contributors" }]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Rust",
+    "Operating System :: MacOS",
+    "Operating System :: POSIX :: Linux",
+    "Topic :: Database :: Database Engines/Servers",
+]
+
+[project.urls]
+Repository = "https://github.com/schapman1974/briskdb"
+Issues = "https://github.com/schapman1974/briskdb/issues"
+
+[tool.maturin]
+manifest-path = "Cargo.toml"
+python-source = "python"
+module-name = "briskdb._briskdb"
+features = ["pyo3/extension-module"]
+strip = true

--- a/python/python/briskdb/__init__.py
+++ b/python/python/briskdb/__init__.py
@@ -1,0 +1,5 @@
+"""Listener-free native Python bindings for embedded BriskDB."""
+
+from ._briskdb import Config, Database, Session, __version__, open
+
+__all__ = ["Config", "Database", "Session", "open", "__version__"]

--- a/python/src/error.rs
+++ b/python/src/error.rs
@@ -1,0 +1,83 @@
+use std::{panic::AssertUnwindSafe, sync::PoisonError};
+
+use briskdb::EngineError;
+use pyo3::{
+    exceptions::{PyRuntimeError, PyValueError},
+    marker::Ungil,
+    prelude::*,
+};
+
+pub(crate) type NativeResult<T> = Result<T, NativeError>;
+
+#[derive(Debug)]
+pub(crate) enum NativeError {
+    Engine(EngineError),
+    Closed(&'static str),
+    Runtime(String),
+    Panic,
+}
+
+impl From<EngineError> for NativeError {
+    fn from(error: EngineError) -> Self {
+        Self::Engine(error)
+    }
+}
+
+impl<T> From<PoisonError<T>> for NativeError {
+    fn from(_: PoisonError<T>) -> Self {
+        Self::Runtime("a native handle lock was poisoned".to_owned())
+    }
+}
+
+impl NativeError {
+    fn into_python(self) -> PyErr {
+        match self {
+            Self::Engine(error) => {
+                PyRuntimeError::new_err(format!("BriskDB {}: {}", error.code(), error.diagnostic()))
+            }
+            Self::Closed(handle) => PyRuntimeError::new_err(format!("BriskDB {handle} is closed")),
+            Self::Runtime(message) => PyRuntimeError::new_err(message),
+            Self::Panic => PyRuntimeError::new_err("BriskDB native operation panicked"),
+        }
+    }
+}
+
+impl From<NativeError> for PyErr {
+    fn from(error: NativeError) -> Self {
+        error.into_python()
+    }
+}
+
+pub(crate) fn run_native<T, F>(py: Python<'_>, operation: F) -> PyResult<T>
+where
+    T: Ungil + Send,
+    F: Ungil + Send + FnOnce() -> NativeResult<T>,
+{
+    let outcome = py.detach(move || std::panic::catch_unwind(AssertUnwindSafe(operation)));
+    match outcome {
+        Ok(Ok(value)) => Ok(value),
+        Ok(Err(error)) => Err(error.into_python()),
+        Err(_) => Err(NativeError::Panic.into_python()),
+    }
+}
+
+pub(crate) fn invalid_value(message: impl Into<String>) -> PyErr {
+    PyValueError::new_err(message.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn panic_boundary_returns_an_error_instead_of_unwinding() {
+        let result = std::panic::catch_unwind(AssertUnwindSafe(|| -> NativeResult<()> {
+            panic!("test panic must not cross the binding boundary")
+        }));
+        let error = match result {
+            Ok(result) => result.unwrap_err(),
+            Err(_) => NativeError::Panic,
+        };
+        assert!(matches!(error, NativeError::Panic));
+    }
+}

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,0 +1,573 @@
+mod error;
+mod value;
+
+use std::{
+    path::PathBuf,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use briskdb::{
+    BriskDb, BriskSession, CheckpointReport, EngineOptions, EngineState, EngineStatus,
+    PreparedStatementLimits, ResultLimits, SessionState, Statement,
+};
+use pyo3::{
+    prelude::*,
+    types::{PyDict, PyModule},
+};
+use tokio::runtime::{Builder as RuntimeBuilder, Runtime};
+
+use crate::{
+    error::{NativeError, NativeResult, run_native},
+    value::{
+        extract_params, logical_result_to_python, routed_result_to_python, write_result_to_python,
+    },
+};
+
+struct RuntimeOwner {
+    runtime: Runtime,
+}
+
+struct DatabaseShared {
+    database: Mutex<Option<BriskDb>>,
+    runtime: Arc<RuntimeOwner>,
+    root: PathBuf,
+    config: Config,
+}
+
+impl DatabaseShared {
+    fn database(&self) -> NativeResult<BriskDb> {
+        self.database
+            .lock()?
+            .clone()
+            .ok_or(NativeError::Closed("database"))
+    }
+}
+
+impl Drop for DatabaseShared {
+    fn drop(&mut self) {
+        if let Ok(slot) = self.database.get_mut() {
+            if let Some(database) = slot.take() {
+                database.begin_close();
+            }
+        }
+    }
+}
+
+#[pyclass(module = "briskdb._briskdb", frozen, get_all, skip_from_py_object)]
+#[derive(Clone, Debug)]
+struct Config {
+    shards: u16,
+    connections_per_shard: usize,
+    queue_capacity_per_shard: usize,
+    max_result_rows: u64,
+    max_result_bytes: u64,
+    max_prepared_statements_per_session: usize,
+    max_portals_per_session: usize,
+    max_retained_bound_value_bytes: u64,
+    request_timeout_ms: u64,
+    shutdown_grace_ms: u64,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            shards: briskdb::DEFAULT_EMBEDDED_SHARDS,
+            connections_per_shard: briskdb::core::DEFAULT_CONNECTIONS_PER_SHARD,
+            queue_capacity_per_shard: briskdb::core::DEFAULT_QUEUE_CAPACITY_PER_SHARD,
+            max_result_rows: briskdb::core::DEFAULT_MAX_RESULT_ROWS,
+            max_result_bytes: briskdb::core::DEFAULT_MAX_RESULT_BYTES,
+            max_prepared_statements_per_session:
+                briskdb::core::DEFAULT_MAX_PREPARED_STATEMENTS_PER_SESSION,
+            max_portals_per_session: briskdb::core::DEFAULT_MAX_PORTALS_PER_SESSION,
+            max_retained_bound_value_bytes: briskdb::core::DEFAULT_MAX_RETAINED_BOUND_VALUE_BYTES,
+            request_timeout_ms: briskdb::core::DEFAULT_REQUEST_TIMEOUT_MS,
+            shutdown_grace_ms: briskdb::core::DEFAULT_SHUTDOWN_GRACE_MS,
+        }
+    }
+}
+
+impl Config {
+    fn engine_options(&self) -> NativeResult<EngineOptions> {
+        let result_limits = ResultLimits::new(self.max_result_rows, self.max_result_bytes)?;
+        let prepared_statement_limits = PreparedStatementLimits::new(
+            self.max_prepared_statements_per_session,
+            self.max_portals_per_session,
+            self.max_retained_bound_value_bytes,
+        )?;
+        let request_timeout =
+            (self.request_timeout_ms != 0).then(|| Duration::from_millis(self.request_timeout_ms));
+        let options =
+            EngineOptions::new(self.connections_per_shard, self.queue_capacity_per_shard)?
+                .with_result_limits(result_limits)
+                .with_prepared_statement_limits(prepared_statement_limits)
+                .with_request_timeout(request_timeout)?
+                .with_shutdown_grace(Duration::from_millis(self.shutdown_grace_ms))?;
+        options.validate_for_shards(self.shards)?;
+        Ok(options)
+    }
+}
+
+#[pymethods]
+impl Config {
+    #[new]
+    #[pyo3(signature = (
+        *,
+        shards = briskdb::DEFAULT_EMBEDDED_SHARDS,
+        connections_per_shard = briskdb::core::DEFAULT_CONNECTIONS_PER_SHARD,
+        queue_capacity_per_shard = briskdb::core::DEFAULT_QUEUE_CAPACITY_PER_SHARD,
+        max_result_rows = briskdb::core::DEFAULT_MAX_RESULT_ROWS,
+        max_result_bytes = briskdb::core::DEFAULT_MAX_RESULT_BYTES,
+        max_prepared_statements_per_session = briskdb::core::DEFAULT_MAX_PREPARED_STATEMENTS_PER_SESSION,
+        max_portals_per_session = briskdb::core::DEFAULT_MAX_PORTALS_PER_SESSION,
+        max_retained_bound_value_bytes = briskdb::core::DEFAULT_MAX_RETAINED_BOUND_VALUE_BYTES,
+        request_timeout_ms = briskdb::core::DEFAULT_REQUEST_TIMEOUT_MS,
+        shutdown_grace_ms = briskdb::core::DEFAULT_SHUTDOWN_GRACE_MS,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        shards: u16,
+        connections_per_shard: usize,
+        queue_capacity_per_shard: usize,
+        max_result_rows: u64,
+        max_result_bytes: u64,
+        max_prepared_statements_per_session: usize,
+        max_portals_per_session: usize,
+        max_retained_bound_value_bytes: u64,
+        request_timeout_ms: u64,
+        shutdown_grace_ms: u64,
+    ) -> PyResult<Self> {
+        let config = Self {
+            shards,
+            connections_per_shard,
+            queue_capacity_per_shard,
+            max_result_rows,
+            max_result_bytes,
+            max_prepared_statements_per_session,
+            max_portals_per_session,
+            max_retained_bound_value_bytes,
+            request_timeout_ms,
+            shutdown_grace_ms,
+        };
+        config.engine_options()?;
+        Ok(config)
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "Config(shards={}, connections_per_shard={}, queue_capacity_per_shard={})",
+            self.shards, self.connections_per_shard, self.queue_capacity_per_shard
+        )
+    }
+}
+
+struct SessionShared {
+    session: Mutex<Option<BriskSession>>,
+    runtime: Arc<RuntimeOwner>,
+}
+
+impl SessionShared {
+    fn session(&self) -> NativeResult<BriskSession> {
+        self.session
+            .lock()?
+            .clone()
+            .ok_or(NativeError::Closed("session"))
+    }
+}
+
+#[pyclass(module = "briskdb._briskdb", frozen)]
+struct Database {
+    shared: Arc<DatabaseShared>,
+}
+
+impl Database {
+    fn create(py: Python<'_>, root: PathBuf, config: Config) -> PyResult<Self> {
+        run_native(py, move || {
+            let engine_options = config.engine_options()?;
+            let runtime = RuntimeBuilder::new_multi_thread()
+                .enable_all()
+                .thread_name("briskdb-python")
+                .build()
+                .map_err(|error| NativeError::Runtime(error.to_string()))?;
+            let database = runtime.block_on(
+                BriskDb::builder(&root)
+                    .with_shard_count(config.shards)
+                    .with_engine_options(engine_options)
+                    .open(),
+            )?;
+            let runtime = Arc::new(RuntimeOwner { runtime });
+            Ok(Self {
+                shared: Arc::new(DatabaseShared {
+                    database: Mutex::new(Some(database)),
+                    runtime,
+                    root,
+                    config,
+                }),
+            })
+        })
+    }
+}
+
+#[pymethods]
+impl Database {
+    #[new]
+    #[pyo3(signature = (path, *, shards = None, config = None))]
+    fn new(
+        py: Python<'_>,
+        path: PathBuf,
+        shards: Option<u16>,
+        config: Option<PyRef<'_, Config>>,
+    ) -> PyResult<Self> {
+        let config = resolve_config(shards, config.as_deref())?;
+        Self::create(py, path, config)
+    }
+
+    #[getter]
+    fn path(&self) -> PathBuf {
+        self.shared.root.clone()
+    }
+
+    #[getter]
+    fn shard_count(&self) -> u16 {
+        self.shared.config.shards
+    }
+
+    #[getter]
+    fn config(&self) -> Config {
+        self.shared.config.clone()
+    }
+
+    #[getter]
+    fn closed(&self) -> PyResult<bool> {
+        Ok(self
+            .shared
+            .database
+            .lock()
+            .map_err(NativeError::from)?
+            .is_none())
+    }
+
+    #[getter]
+    fn state(&self) -> PyResult<&'static str> {
+        let state = self
+            .shared
+            .database
+            .lock()
+            .map_err(NativeError::from)?
+            .as_ref()
+            .map_or(EngineState::Stopped, BriskDb::state);
+        Ok(engine_state_name(state))
+    }
+
+    #[pyo3(signature = (*, routing_key = None))]
+    fn session(&self, py: Python<'_>, routing_key: Option<String>) -> PyResult<Session> {
+        let shared = Arc::clone(&self.shared);
+        run_native(py, move || {
+            let session = shared.database()?.owned_session();
+            if let Some(routing_key) = routing_key {
+                shared
+                    .runtime
+                    .runtime
+                    .block_on(session.set_routing_key(routing_key))?;
+            }
+            Ok(Session {
+                shared: Arc::new(SessionShared {
+                    session: Mutex::new(Some(session)),
+                    runtime: Arc::clone(&shared.runtime),
+                }),
+            })
+        })
+    }
+
+    fn checkpoint(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let shared = Arc::clone(&self.shared);
+        let report = run_native(py, move || {
+            let database = shared.database()?;
+            Ok(shared.runtime.runtime.block_on(database.checkpoint())?)
+        })?;
+        checkpoint_to_python(py, report)
+    }
+
+    fn close(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let shared = Arc::clone(&self.shared);
+        let report = run_native(py, move || {
+            let database = shared.database.lock()?.take();
+            match database {
+                Some(database) => Ok(Some(shared.runtime.runtime.block_on(database.close())?)),
+                None => Ok(None),
+            }
+        })?;
+        let output = PyDict::new(py);
+        output.set_item("already_closed", report.is_none())?;
+        output.set_item("forced", report.is_some_and(|report| report.forced()))?;
+        Ok(output.into_any().unbind())
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(format!(
+            "Database(path={:?}, shards={}, state={:?})",
+            self.shared.root,
+            self.shared.config.shards,
+            self.state()?
+        ))
+    }
+}
+
+#[pyclass(module = "briskdb._briskdb", frozen)]
+struct Session {
+    shared: Arc<SessionShared>,
+}
+
+#[pymethods]
+impl Session {
+    #[getter]
+    fn closed(&self) -> PyResult<bool> {
+        Ok(self
+            .shared
+            .session
+            .lock()
+            .map_err(NativeError::from)?
+            .is_none())
+    }
+
+    #[getter]
+    fn state(&self, py: Python<'_>) -> PyResult<&'static str> {
+        let shared = Arc::clone(&self.shared);
+        run_native(py, move || {
+            let session = match shared.session.lock()?.clone() {
+                Some(session) => session,
+                None => return Ok("closed"),
+            };
+            let state = shared.runtime.runtime.block_on(session.state());
+            Ok(session_state_name(state))
+        })
+    }
+
+    #[getter]
+    fn database_state(&self) -> PyResult<&'static str> {
+        let session = self.shared.session()?;
+        Ok(engine_state_name(session.database_state()))
+    }
+
+    #[getter]
+    fn routing_key(&self, py: Python<'_>) -> PyResult<Option<String>> {
+        let shared = Arc::clone(&self.shared);
+        run_native(py, move || {
+            let session = shared.session()?;
+            Ok(shared.runtime.runtime.block_on(session.routing_key()))
+        })
+    }
+
+    fn set_routing_key(&self, py: Python<'_>, routing_key: String) -> PyResult<()> {
+        let shared = Arc::clone(&self.shared);
+        run_native(py, move || {
+            let session = shared.session()?;
+            Ok(shared
+                .runtime
+                .runtime
+                .block_on(session.set_routing_key(routing_key))?)
+        })
+    }
+
+    fn clear_routing_key(&self, py: Python<'_>) -> PyResult<()> {
+        let shared = Arc::clone(&self.shared);
+        run_native(py, move || {
+            let session = shared.session()?;
+            Ok(shared
+                .runtime
+                .runtime
+                .block_on(session.clear_routing_key())?)
+        })
+    }
+
+    fn migrate(&self, py: Python<'_>, sql: String) -> PyResult<Vec<u16>> {
+        let shared = Arc::clone(&self.shared);
+        run_native(py, move || {
+            let session = shared.session()?;
+            Ok(shared.runtime.runtime.block_on(session.migrate(sql))?)
+        })
+    }
+
+    #[pyo3(signature = (sql, params = None))]
+    fn execute(
+        &self,
+        py: Python<'_>,
+        sql: String,
+        params: Option<Vec<Py<PyAny>>>,
+    ) -> PyResult<Py<PyAny>> {
+        let params = extract_params(py, params)?;
+        let shared = Arc::clone(&self.shared);
+        let result = run_native(py, move || {
+            let session = shared.session()?;
+            Ok(shared
+                .runtime
+                .runtime
+                .block_on(session.execute_write(Statement::new(sql, params)))?)
+        })?;
+        write_result_to_python(py, result)
+    }
+
+    #[pyo3(signature = (sql, params = None))]
+    fn query(
+        &self,
+        py: Python<'_>,
+        sql: String,
+        params: Option<Vec<Py<PyAny>>>,
+    ) -> PyResult<Py<PyAny>> {
+        let params = extract_params(py, params)?;
+        let shared = Arc::clone(&self.shared);
+        let result = run_native(py, move || {
+            let session = shared.session()?;
+            Ok(shared
+                .runtime
+                .runtime
+                .block_on(session.query(Statement::new(sql, params)))?)
+        })?;
+        routed_result_to_python(py, result)
+    }
+
+    #[pyo3(signature = (sql, params = None))]
+    fn query_logical(
+        &self,
+        py: Python<'_>,
+        sql: String,
+        params: Option<Vec<Py<PyAny>>>,
+    ) -> PyResult<Py<PyAny>> {
+        let params = extract_params(py, params)?;
+        let shared = Arc::clone(&self.shared);
+        let result = run_native(py, move || {
+            let session = shared.session()?;
+            Ok(shared
+                .runtime
+                .runtime
+                .block_on(session.query_logical(Statement::new(sql, params)))?)
+        })?;
+        logical_result_to_python(py, result)
+    }
+
+    fn status(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let shared = Arc::clone(&self.shared);
+        let status = run_native(py, move || {
+            let session = shared.session()?;
+            Ok(shared.runtime.runtime.block_on(session.status())?)
+        })?;
+        status_to_python(py, status)
+    }
+
+    fn close(&self, py: Python<'_>) -> PyResult<()> {
+        let shared = Arc::clone(&self.shared);
+        run_native(py, move || {
+            let session = shared.session.lock()?.take();
+            if let Some(session) = session {
+                shared.runtime.runtime.block_on(session.close())?;
+            }
+            Ok(())
+        })
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        let state = if self.closed()? { "closed" } else { "ready" };
+        Ok(format!("Session(state={state:?})"))
+    }
+}
+
+#[pyfunction(name = "open", signature = (path, *, shards = None, config = None))]
+fn open_database(
+    py: Python<'_>,
+    path: PathBuf,
+    shards: Option<u16>,
+    config: Option<PyRef<'_, Config>>,
+) -> PyResult<Database> {
+    let config = resolve_config(shards, config.as_deref())?;
+    Database::create(py, path, config)
+}
+
+fn resolve_config(shards: Option<u16>, config: Option<&Config>) -> PyResult<Config> {
+    match (shards, config) {
+        (Some(_), Some(_)) => Err(crate::error::invalid_value(
+            "pass either shards or config to open a database, not both",
+        )),
+        (Some(shards), None) => {
+            let config = Config {
+                shards,
+                ..Config::default()
+            };
+            config.engine_options()?;
+            Ok(config)
+        }
+        (None, Some(config)) => Ok(config.clone()),
+        (None, None) => Ok(Config::default()),
+    }
+}
+
+fn engine_state_name(state: EngineState) -> &'static str {
+    match state {
+        EngineState::Running => "running",
+        EngineState::Draining => "draining",
+        EngineState::Stopped => "stopped",
+        _ => "unknown",
+    }
+}
+
+fn session_state_name(state: SessionState) -> &'static str {
+    match state {
+        SessionState::Ready => "ready",
+        SessionState::Closed => "closed",
+        _ => "unknown",
+    }
+}
+
+fn status_to_python(py: Python<'_>, status: EngineStatus) -> PyResult<Py<PyAny>> {
+    let output = PyDict::new(py);
+    output.set_item("shards", status.shard_count())?;
+    output.set_item("max_blocking_workers", status.max_blocking_workers())?;
+    output.set_item("connections_per_shard", status.connections_per_shard())?;
+    output.set_item(
+        "queue_capacity_per_shard",
+        status.queue_capacity_per_shard(),
+    )?;
+    output.set_item("max_result_rows", status.max_result_rows())?;
+    output.set_item("max_result_bytes", status.max_result_bytes())?;
+    output.set_item(
+        "request_timeout_ms",
+        status
+            .request_timeout()
+            .map(|timeout| u64::try_from(timeout.as_millis()).unwrap_or(u64::MAX)),
+    )?;
+    output.set_item(
+        "shutdown_grace_ms",
+        u64::try_from(status.shutdown_grace().as_millis()).unwrap_or(u64::MAX),
+    )?;
+    Ok(output.into_any().unbind())
+}
+
+fn checkpoint_to_python(py: Python<'_>, report: CheckpointReport) -> PyResult<Py<PyAny>> {
+    let output = PyDict::new(py);
+    output.set_item("busy", report.busy())?;
+    output.set_item("complete", report.complete())?;
+    let shards = report
+        .shards()
+        .iter()
+        .map(|shard| {
+            let item = PyDict::new(py);
+            item.set_item("shard", shard.shard())?;
+            item.set_item("busy", shard.busy())?;
+            item.set_item("wal_frames", shard.wal_frames())?;
+            item.set_item("checkpointed_frames", shard.checkpointed_frames())?;
+            item.set_item("complete", shard.complete())?;
+            Ok(item.into_any().unbind())
+        })
+        .collect::<PyResult<Vec<_>>>()?;
+    output.set_item("shards", shards)?;
+    Ok(output.into_any().unbind())
+}
+
+#[pymodule]
+fn _briskdb(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    module.add_class::<Config>()?;
+    module.add_class::<Database>()?;
+    module.add_class::<Session>()?;
+    module.add_function(wrap_pyfunction!(open_database, module)?)?;
+    module.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    Ok(())
+}

--- a/python/src/value.rs
+++ b/python/src/value.rs
@@ -1,0 +1,144 @@
+use briskdb::{DataType, Executed, ResultSet, Routed, Value, WriteResult};
+use pyo3::{
+    conversion::IntoPyObjectExt,
+    exceptions::PyTypeError,
+    prelude::*,
+    types::{PyBool, PyBytes, PyDict, PyFloat, PyInt, PyList, PyString, PyTuple},
+};
+
+use crate::error::invalid_value;
+
+pub(crate) fn extract_params(
+    py: Python<'_>,
+    params: Option<Vec<Py<PyAny>>>,
+) -> PyResult<Vec<Value>> {
+    params
+        .unwrap_or_default()
+        .into_iter()
+        .map(|value| extract_value(value.bind(py)))
+        .collect()
+}
+
+fn extract_value(value: &Bound<'_, PyAny>) -> PyResult<Value> {
+    if value.is_none() {
+        return Ok(Value::Null);
+    }
+    if value.is_instance_of::<PyBool>() {
+        return value.extract::<bool>().map(Value::Boolean);
+    }
+    if value.is_instance_of::<PyInt>() {
+        return value.extract::<i64>().map(Value::Int64).map_err(|_| {
+            invalid_value("SQL integer parameters must fit in a signed 64-bit integer")
+        });
+    }
+    if value.is_instance_of::<PyFloat>() {
+        let number = value.extract::<f64>()?;
+        if !number.is_finite() {
+            return Err(invalid_value("SQL float parameters must be finite"));
+        }
+        return Ok(Value::Float64(number));
+    }
+    if value.is_instance_of::<PyString>() {
+        return value.extract::<String>().map(Value::Text);
+    }
+    if let Ok(bytes) = value.cast::<PyBytes>() {
+        return Ok(Value::Binary(bytes.as_bytes().to_vec()));
+    }
+
+    Err(PyTypeError::new_err(
+        "SQL parameters currently support None, bool, int64, finite float, str, and bytes",
+    ))
+}
+
+fn value_to_python(py: Python<'_>, value: Value) -> PyResult<Py<PyAny>> {
+    match value {
+        Value::Null => Ok(py.None()),
+        Value::Boolean(value) => value.into_py_any(py),
+        Value::Int64(value) => value.into_py_any(py),
+        Value::UInt64(value) => value.into_py_any(py),
+        Value::Float64(value) => value.into_py_any(py),
+        Value::Decimal(value) => value.into_string().into_py_any(py),
+        Value::Text(value) => value.into_py_any(py),
+        Value::InvalidText(value) | Value::Binary(value) => {
+            Ok(PyBytes::new(py, &value).into_any().unbind())
+        }
+    }
+}
+
+fn data_type_name(data_type: DataType) -> &'static str {
+    match data_type {
+        DataType::Unknown => "unknown",
+        DataType::Null => "null",
+        DataType::Boolean => "boolean",
+        DataType::Int64 => "int64",
+        DataType::UInt64 => "uint64",
+        DataType::Float64 => "float64",
+        DataType::Decimal => "decimal",
+        DataType::Text => "text",
+        DataType::Binary => "binary",
+    }
+}
+
+fn result_set_to_python(
+    py: Python<'_>,
+    shards: Vec<u16>,
+    result: ResultSet,
+) -> PyResult<Py<PyAny>> {
+    let output = PyDict::new(py);
+    output.set_item("shards", shards)?;
+
+    let (columns, rows) = result.into_parts();
+    let python_columns = PyList::empty(py);
+    for column in columns {
+        let item = PyDict::new(py);
+        item.set_item("name", column.name)?;
+        item.set_item("type", data_type_name(column.data_type))?;
+        python_columns.append(item)?;
+    }
+    output.set_item("columns", python_columns)?;
+
+    let python_rows = PyList::empty(py);
+    for row in rows {
+        let values = row
+            .into_values()
+            .into_iter()
+            .map(|value| value_to_python(py, value))
+            .collect::<PyResult<Vec<_>>>()?;
+        python_rows.append(PyTuple::new(py, values)?)?;
+    }
+    output.set_item("rows", python_rows)?;
+    Ok(output.into_any().unbind())
+}
+
+pub(crate) fn routed_result_to_python(
+    py: Python<'_>,
+    result: Routed<ResultSet>,
+) -> PyResult<Py<PyAny>> {
+    result_set_to_python(py, vec![result.shard], result.value)
+}
+
+pub(crate) fn logical_result_to_python(
+    py: Python<'_>,
+    result: Executed<ResultSet>,
+) -> PyResult<Py<PyAny>> {
+    result_set_to_python(py, result.shards, result.value)
+}
+
+pub(crate) fn write_result_to_python(
+    py: Python<'_>,
+    result: Routed<WriteResult>,
+) -> PyResult<Py<PyAny>> {
+    let output = PyDict::new(py);
+    output.set_item("shard", result.shard)?;
+    output.set_item("rows_affected", result.value.rows_affected)?;
+    match result.value.generated_key {
+        Some(key) => {
+            let generated = PyDict::new(py);
+            generated.set_item("column", key.column)?;
+            generated.set_item("value", value_to_python(py, key.value)?)?;
+            output.set_item("generated_key", generated)?;
+        }
+        None => output.set_item("generated_key", py.None())?,
+    }
+    Ok(output.into_any().unbind())
+}

--- a/python/tests/test_embedded.py
+++ b/python/tests/test_embedded.py
@@ -1,0 +1,157 @@
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+
+import briskdb
+
+
+class EmbeddedBriskDbTests(unittest.TestCase):
+    def test_validated_configuration_reaches_the_engine(self) -> None:
+        with tempfile.TemporaryDirectory() as data_dir:
+            config = briskdb.Config(
+                shards=2,
+                connections_per_shard=1,
+                queue_capacity_per_shard=8,
+                max_result_rows=500,
+                max_result_bytes=1024 * 1024,
+                request_timeout_ms=5000,
+                shutdown_grace_ms=5000,
+            )
+            database = briskdb.open(data_dir, config=config)
+            self.assertEqual(database.config.shards, 2)
+            status = database.session().status()
+            self.assertEqual(status["connections_per_shard"], 1)
+            self.assertEqual(status["queue_capacity_per_shard"], 8)
+            self.assertEqual(status["max_result_rows"], 500)
+            self.assertEqual(status["request_timeout_ms"], 5000)
+            database.close()
+
+            with self.assertRaisesRegex(ValueError, "either shards or config"):
+                briskdb.open(data_dir, shards=2, config=config)
+
+            with self.assertRaisesRegex(RuntimeError, "maximum result rows"):
+                briskdb.Config(max_result_rows=0)
+
+    def test_basic_write_read_checkpoint_close_and_restart(self) -> None:
+        with tempfile.TemporaryDirectory() as data_dir:
+            database = briskdb.open(data_dir, shards=2)
+            self.assertEqual(database.shard_count, 2)
+            self.assertEqual(database.state, "running")
+
+            session = database.session(routing_key="account-1")
+            self.assertEqual(session.routing_key, "account-1")
+            self.assertEqual(
+                session.migrate(
+                    "CREATE TABLE notes (id INTEGER PRIMARY KEY, body TEXT NOT NULL)"
+                ),
+                [0, 1],
+            )
+            write = session.execute(
+                "INSERT INTO notes (id, body) VALUES (?1, ?2)", [1, "hello"]
+            )
+            self.assertEqual(write["rows_affected"], 1)
+            self.assertIsNone(write["generated_key"])
+
+            result = session.query(
+                "SELECT id, body FROM notes WHERE id = ?1", [1]
+            )
+            self.assertEqual(
+                result["columns"],
+                [
+                    {"name": "id", "type": "unknown"},
+                    {"name": "body", "type": "unknown"},
+                ],
+            )
+            self.assertEqual(result["rows"], [(1, "hello")])
+            self.assertEqual(session.status()["shards"], 2)
+            self.assertEqual(len(database.checkpoint()["shards"]), 2)
+
+            session.close()
+            self.assertTrue(session.closed)
+            self.assertFalse(database.close()["forced"])
+            self.assertTrue(database.closed)
+            self.assertTrue(database.close()["already_closed"])
+
+            reopened = briskdb.Database(data_dir, shards=2)
+            reopened_session = reopened.session(routing_key="account-1")
+            self.assertEqual(
+                reopened_session.query(
+                    "SELECT body FROM notes WHERE id = ?1", [1]
+                )["rows"],
+                [("hello",)],
+            )
+            reopened_session.close()
+            reopened.close()
+
+    def test_use_after_close_is_safe_and_deterministic(self) -> None:
+        with tempfile.TemporaryDirectory() as data_dir:
+            database = briskdb.open(data_dir, shards=2)
+            session = database.session(routing_key="route")
+            session.close()
+            session.close()
+            with self.assertRaisesRegex(RuntimeError, "session is closed"):
+                session.query("SELECT 1")
+
+            database.close()
+            with self.assertRaisesRegex(RuntimeError, "database is closed"):
+                database.session()
+
+    def test_native_query_releases_the_gil(self) -> None:
+        with tempfile.TemporaryDirectory() as data_dir:
+            database = briskdb.open(data_dir, shards=2)
+            session = database.session(routing_key="route")
+            stop = threading.Event()
+            tick_lock = threading.Lock()
+            ticks = 0
+
+            def ticker() -> None:
+                nonlocal ticks
+                while not stop.is_set():
+                    with tick_lock:
+                        ticks += 1
+
+            thread = threading.Thread(target=ticker)
+            thread.start()
+            time.sleep(0.01)
+            with tick_lock:
+                before = ticks
+            result = session.query(
+                "WITH RECURSIVE counter(x) AS (VALUES(0) UNION ALL "
+                "SELECT x + 1 FROM counter WHERE x < 1000000) "
+                "SELECT sum(x) FROM counter"
+            )
+            with tick_lock:
+                progressed = ticks - before
+            stop.set()
+            thread.join(timeout=5)
+
+            self.assertEqual(result["rows"], [(500000500000,)])
+            self.assertGreater(progressed, 100)
+            session.close()
+            database.close()
+
+    def test_interpreter_shutdown_with_live_handles_does_not_abort(self) -> None:
+        script = """
+import briskdb
+import tempfile
+
+root = tempfile.mkdtemp()
+database = briskdb.open(root, shards=2)
+session = database.session(routing_key="shutdown")
+session.query("SELECT 1")
+"""
+        completed = subprocess.run(
+            [sys.executable, "-c", script],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #197

## What changed

- adds a separately packaged `briskdb` PyO3/maturin extension using only the listener-free `embedded` feature
- exposes validated `Config`, owned `Database`/`Session` handles, SQL write/read/migration, status, checkpoint, and idempotent close
- owns a per-database Tokio runtime without listeners, signal handlers, or process-global logging
- releases the GIL around native engine work and catches Rust panics at the binding boundary
- adds source-build CI on Python 3.9 and 3.14 with Rust 1.85 plus dependency-boundary enforcement
- documents source installation and the initial Python API

Native document methods are intentionally not advertised yet because the document engine tracked by #160 and #162-#164 has not landed.

## Local validation

- `cargo +1.85.0 fmt --all --check`
- `cargo +1.85.0 check --locked -p briskdb-python`
- `cargo +1.85.0 test --locked -p briskdb-python`
- `cargo +1.85.0 clippy --locked -p briskdb-python --all-targets --no-deps -- -D warnings`
- `maturin build --manifest-path python/Cargo.toml --locked --out dist`
- installed the resulting CPython 3.9 abi3 wheel into Python 3.12
- `python -m unittest discover -s python/tests -v` (5 passed)
- `cargo +1.85.0 package --locked --allow-dirty`
- verified the extension normal dependency graph contains no HTTP/PostgreSQL/CLI/server dependencies
