### PR TITLE
Python sync and asyncio APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,10 @@ Python can run the same engine directly in-process with no server or listener:
 python -m pip install ./python
 ```
 
-See the [Python quickstart](python/README.md) for a write/read example. A Rust
-toolchain is required for this initial source distribution; prebuilt wheels are
-tracked in [#200](https://github.com/schapman1974/briskdb/issues/200).
+See the [Python quickstart](python/README.md) for sync and asyncio write/read
+examples. A Rust toolchain is required for this initial source distribution;
+prebuilt wheels are tracked in
+[#200](https://github.com/schapman1974/briskdb/issues/200).
 
 ## Still just inspectable files
 

--- a/python/ASYNC_API.md
+++ b/python/ASYNC_API.md
@@ -1,0 +1,75 @@
+# Sync and asyncio API
+
+BriskDB offers synchronous native handles and an asyncio facade over the same
+listener-free engine. Both use the engine's existing queue limits, deadlines,
+cancellation, and owned session lifecycle.
+
+## Synchronous use
+
+```python
+import briskdb
+
+with briskdb.connect("./data", shards=4) as db:
+    with db.session(routing_key="account-1") as session:
+        session.migrate("CREATE TABLE notes (id INTEGER PRIMARY KEY, body TEXT)")
+        session.execute("INSERT INTO notes VALUES (?1, ?2)", [1, "hello"])
+        with session.cursor("SELECT id, body FROM notes", batch_size=100) as rows:
+            for row in rows:
+                print(row)
+```
+
+`Database`, `Session`, and `Cursor` may be shared across threads. Session state
+changes and operations are serialized by the native engine; using one session
+per request is usually clearer and allows independent routing state.
+
+Every query is bounded by `Config.max_result_rows` and
+`Config.max_result_bytes`. The current `Cursor` batches an already bounded
+native result and releases unread rows on `close()`, context exit, or garbage
+collection. A true SQLite-streaming cursor depends on the retained cursor work
+in [#39](https://github.com/schapman1974/briskdb/issues/39).
+
+## Asyncio use
+
+```python
+import briskdb
+
+async def handle(account_id: str):
+    async with await briskdb.open_async("./data", shards=4) as db:
+        async with await db.session(routing_key=account_id) as session:
+            result = await session.query(
+                "SELECT body FROM notes WHERE id = ?1",
+                [1],
+                timeout_ms=2_000,
+            )
+            return result["rows"]
+```
+
+Async methods move native calls off the event-loop thread. Native engine work
+already releases the GIL. Cancelling a Python task cancels the exact
+`CancellationToken` passed to the Rust `RequestContext`, which interrupts
+admitted SQLite work. A token can also be supplied explicitly:
+
+```python
+token = briskdb.CancellationToken()
+task = asyncio.create_task(session.query(sql, cancellation=token))
+task.cancel()                 # also calls token.cancel()
+```
+
+`AsyncDatabase` is safe to retain in a FastAPI-style application lifespan or
+a warm function instance. Create an `AsyncSession` per request/task when their
+routing keys differ. BriskDB does not install an event-loop policy, signal
+handler, logger, listener, or framework dependency.
+
+## Transaction and DB-API boundaries
+
+This package does not claim Python DB-API 2.0 compliance yet. BriskDB currently
+executes supported writes in autocommit mode, so it does not expose misleading
+`commit()` or `rollback()` methods. Native transaction handles are tracked by
+[#34](https://github.com/schapman1974/briskdb/issues/34); retained streaming
+cursors are tracked by #39.
+
+Context-manager exit deterministically closes the handle. It does not imply a
+transaction commit or rollback. Mongo document CRUD/aggregation waits for the
+native document engine in [#160](https://github.com/schapman1974/briskdb/issues/160),
+and snapshot/fencing helpers for real serverless deployments remain in
+[#194–#196](https://github.com/schapman1974/briskdb/issues/194).

--- a/python/README.md
+++ b/python/README.md
@@ -32,6 +32,18 @@ Database and session handles own their native resources, `close()` is
 idempotent, and blocking engine work releases Python's GIL. Dropping live
 handles during interpreter shutdown is also safe.
 
+Synchronous handles support `with`; the asyncio facade keeps engine work off
+the event loop and propagates task cancellation into Rust:
+
+```python
+async with await briskdb.open_async("./data", shards=4) as db:
+    async with await db.session(routing_key="account-1") as session:
+        rows = await session.query("SELECT body FROM notes WHERE id = ?1", [1])
+```
+
+See [sync and asyncio usage](ASYNC_API.md) for cursors, deadlines, cancellation,
+thread/task safety, and the intentionally unclaimed DB-API transaction surface.
+
 This is an alpha API. SQL supports `None`, `bool`, bounded integers, `float`,
 `str`, bytes-like values, and exact `decimal.Decimal` conversion with explicit
 errors when SQLite cannot store a value losslessly. See the executable

--- a/python/python/briskdb/__init__.py
+++ b/python/python/briskdb/__init__.py
@@ -4,9 +4,11 @@ from ._briskdb import (
     BriskDBError,
     BusyError,
     CancelledError,
+    CancellationToken,
     CheckViolationError,
     Config,
     ConstraintViolationError,
+    Cursor,
     DataCorruptionError,
     DataError,
     Database,
@@ -36,14 +38,17 @@ from ._briskdb import (
     __version__,
     open,
 )
+from .api import AsyncCursor, AsyncDatabase, AsyncSession, connect, connect_async, open_async
 
 __all__ = [
     "BriskDBError",
     "BusyError",
     "CancelledError",
+    "CancellationToken",
     "CheckViolationError",
     "Config",
     "ConstraintViolationError",
+    "Cursor",
     "DataCorruptionError",
     "DataError",
     "Database",
@@ -70,6 +75,12 @@ __all__ = [
     "TypeMismatchError",
     "UniqueViolationError",
     "UnsupportedError",
+    "AsyncCursor",
+    "AsyncDatabase",
+    "AsyncSession",
     "__version__",
+    "connect",
+    "connect_async",
+    "open_async",
     "open",
 ]

--- a/python/python/briskdb/api.py
+++ b/python/python/briskdb/api.py
@@ -1,0 +1,317 @@
+"""Ergonomic synchronous and asyncio wrappers around the native extension."""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+from collections.abc import AsyncIterator
+from os import PathLike
+from typing import Any, Optional, Union
+
+from ._briskdb import (
+    CancellationToken,
+    Config,
+    Cursor,
+    Database,
+    Session,
+    open as _native_open,
+)
+
+
+def connect(
+    path: Union[str, PathLike[str]],
+    *,
+    shards: Optional[int] = None,
+    config: Optional[Config] = None,
+) -> Database:
+    """Open a synchronous, listener-free database connection."""
+
+    return _native_open(path, shards=shards, config=config)
+
+
+async def _cancelable_call(
+    method: Any,
+    /,
+    *args: Any,
+    timeout_ms: Optional[int] = None,
+    cancellation: Optional[CancellationToken] = None,
+    **kwargs: Any,
+) -> Any:
+    token = cancellation if cancellation is not None else CancellationToken()
+    call = functools.partial(
+        method,
+        *args,
+        timeout_ms=timeout_ms,
+        cancellation=token,
+        **kwargs,
+    )
+    try:
+        return await asyncio.to_thread(call)
+    except asyncio.CancelledError:
+        token.cancel()
+        raise
+
+
+class AsyncCursor(AsyncIterator[tuple[Any, ...]]):
+    """Async iteration over one already bounded native result."""
+
+    def __init__(self, cursor: Cursor) -> None:
+        self._cursor = cursor
+
+    @property
+    def columns(self) -> list[dict[str, str]]:
+        return self._cursor.columns
+
+    @property
+    def shards(self) -> list[int]:
+        return self._cursor.shards
+
+    @property
+    def closed(self) -> bool:
+        return self._cursor.closed
+
+    @property
+    def remaining(self) -> int:
+        return self._cursor.remaining
+
+    async def fetchone(self) -> Optional[tuple[Any, ...]]:
+        return await asyncio.to_thread(self._cursor.fetchone)
+
+    async def fetchmany(self, size: Optional[int] = None) -> list[tuple[Any, ...]]:
+        return await asyncio.to_thread(self._cursor.fetchmany, size)
+
+    async def fetchall(self) -> list[tuple[Any, ...]]:
+        return await asyncio.to_thread(self._cursor.fetchall)
+
+    async def close(self) -> None:
+        await asyncio.to_thread(self._cursor.close)
+
+    def __aiter__(self) -> AsyncCursor:
+        return self
+
+    async def __anext__(self) -> tuple[Any, ...]:
+        row = await self.fetchone()
+        if row is None:
+            raise StopAsyncIteration
+        return row
+
+    async def __aenter__(self) -> AsyncCursor:
+        return self
+
+    async def __aexit__(self, *_exception: object) -> bool:
+        await self.close()
+        return False
+
+
+class AsyncSession:
+    """Asyncio facade for an owned native BriskDB session."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    @property
+    def native(self) -> Session:
+        return self._session
+
+    @property
+    def closed(self) -> bool:
+        return self._session.closed
+
+    @property
+    def database_state(self) -> str:
+        return self._session.database_state
+
+    async def get_state(self) -> str:
+        return await asyncio.to_thread(lambda: self._session.state)
+
+    async def get_routing_key(self) -> Optional[str]:
+        return await asyncio.to_thread(lambda: self._session.routing_key)
+
+    async def set_routing_key(self, routing_key: str) -> None:
+        await asyncio.to_thread(self._session.set_routing_key, routing_key)
+
+    async def clear_routing_key(self) -> None:
+        await asyncio.to_thread(self._session.clear_routing_key)
+
+    async def migrate(
+        self,
+        sql: str,
+        *,
+        timeout_ms: Optional[int] = None,
+        cancellation: Optional[CancellationToken] = None,
+    ) -> list[int]:
+        return await _cancelable_call(
+            self._session.migrate,
+            sql,
+            timeout_ms=timeout_ms,
+            cancellation=cancellation,
+        )
+
+    async def execute(
+        self,
+        sql: str,
+        params: Optional[Union[list[Any], tuple[Any, ...]]] = None,
+        *,
+        timeout_ms: Optional[int] = None,
+        cancellation: Optional[CancellationToken] = None,
+    ) -> dict[str, Any]:
+        return await _cancelable_call(
+            self._session.execute,
+            sql,
+            params,
+            timeout_ms=timeout_ms,
+            cancellation=cancellation,
+        )
+
+    async def query(
+        self,
+        sql: str,
+        params: Optional[Union[list[Any], tuple[Any, ...]]] = None,
+        *,
+        timeout_ms: Optional[int] = None,
+        cancellation: Optional[CancellationToken] = None,
+    ) -> dict[str, Any]:
+        return await _cancelable_call(
+            self._session.query,
+            sql,
+            params,
+            timeout_ms=timeout_ms,
+            cancellation=cancellation,
+        )
+
+    async def query_logical(
+        self,
+        sql: str,
+        params: Optional[Union[list[Any], tuple[Any, ...]]] = None,
+        *,
+        timeout_ms: Optional[int] = None,
+        cancellation: Optional[CancellationToken] = None,
+    ) -> dict[str, Any]:
+        return await _cancelable_call(
+            self._session.query_logical,
+            sql,
+            params,
+            timeout_ms=timeout_ms,
+            cancellation=cancellation,
+        )
+
+    async def cursor(
+        self,
+        sql: str,
+        params: Optional[Union[list[Any], tuple[Any, ...]]] = None,
+        *,
+        batch_size: int = 1_000,
+        timeout_ms: Optional[int] = None,
+        cancellation: Optional[CancellationToken] = None,
+    ) -> AsyncCursor:
+        cursor = await _cancelable_call(
+            self._session.cursor,
+            sql,
+            params,
+            batch_size=batch_size,
+            timeout_ms=timeout_ms,
+            cancellation=cancellation,
+        )
+        return AsyncCursor(cursor)
+
+    async def logical_cursor(
+        self,
+        sql: str,
+        params: Optional[Union[list[Any], tuple[Any, ...]]] = None,
+        *,
+        batch_size: int = 1_000,
+        timeout_ms: Optional[int] = None,
+        cancellation: Optional[CancellationToken] = None,
+    ) -> AsyncCursor:
+        cursor = await _cancelable_call(
+            self._session.logical_cursor,
+            sql,
+            params,
+            batch_size=batch_size,
+            timeout_ms=timeout_ms,
+            cancellation=cancellation,
+        )
+        return AsyncCursor(cursor)
+
+    async def status(self) -> dict[str, Any]:
+        return await asyncio.to_thread(self._session.status)
+
+    async def close(self) -> None:
+        await asyncio.to_thread(self._session.close)
+
+    async def __aenter__(self) -> AsyncSession:
+        return self
+
+    async def __aexit__(self, *_exception: object) -> bool:
+        await self.close()
+        return False
+
+
+class AsyncDatabase:
+    """Asyncio facade for one listener-free native BriskDB database."""
+
+    def __init__(self, database: Database) -> None:
+        self._database = database
+
+    @property
+    def native(self) -> Database:
+        return self._database
+
+    @property
+    def path(self) -> PathLike[str]:
+        return self._database.path
+
+    @property
+    def shard_count(self) -> int:
+        return self._database.shard_count
+
+    @property
+    def closed(self) -> bool:
+        return self._database.closed
+
+    @property
+    def state(self) -> str:
+        return self._database.state
+
+    async def session(self, *, routing_key: Optional[str] = None) -> AsyncSession:
+        session = await asyncio.to_thread(
+            self._database.session, routing_key=routing_key
+        )
+        return AsyncSession(session)
+
+    async def checkpoint(
+        self,
+        *,
+        timeout_ms: Optional[int] = None,
+        cancellation: Optional[CancellationToken] = None,
+    ) -> dict[str, Any]:
+        return await _cancelable_call(
+            self._database.checkpoint,
+            timeout_ms=timeout_ms,
+            cancellation=cancellation,
+        )
+
+    async def close(self) -> dict[str, Any]:
+        return await asyncio.to_thread(self._database.close)
+
+    async def __aenter__(self) -> AsyncDatabase:
+        return self
+
+    async def __aexit__(self, *_exception: object) -> bool:
+        await self.close()
+        return False
+
+
+async def connect_async(
+    path: Union[str, PathLike[str]],
+    *,
+    shards: Optional[int] = None,
+    config: Optional[Config] = None,
+) -> AsyncDatabase:
+    """Open a listener-free database without blocking the event loop."""
+
+    database = await asyncio.to_thread(connect, path, shards=shards, config=config)
+    return AsyncDatabase(database)
+
+
+open_async = connect_async

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -2,25 +2,28 @@ mod error;
 mod value;
 
 use std::{
+    collections::VecDeque,
     path::PathBuf,
     sync::{Arc, Mutex},
     time::Duration,
 };
 
 use briskdb::{
-    BriskDb, BriskSession, CheckpointReport, EngineOptions, EngineState, EngineStatus,
-    PreparedStatementLimits, ResultLimits, SessionState, Statement,
+    BriskDb, BriskSession, CancellationToken as EngineCancellationToken, CheckpointReport, Column,
+    EngineOptions, EngineState, EngineStatus, Executed, PreparedStatementLimits, RequestContext,
+    ResultLimits, ResultSet, Routed, SessionState, Statement, Value,
 };
 use pyo3::{
     prelude::*,
-    types::{PyDict, PyModule},
+    types::{PyAny, PyDict, PyList, PyModule, PyTuple},
 };
 use tokio::runtime::{Builder as RuntimeBuilder, Runtime};
 
 use crate::{
     error::{NativeError, NativeResult, run_native},
     value::{
-        extract_params, logical_result_to_python, routed_result_to_python, write_result_to_python,
+        data_type_name, extract_params, logical_result_to_python, routed_result_to_python,
+        value_to_python, write_result_to_python,
     },
 };
 
@@ -161,6 +164,186 @@ impl Config {
     }
 }
 
+#[pyclass(module = "briskdb._briskdb", frozen, skip_from_py_object)]
+#[derive(Clone, Debug)]
+struct CancellationToken {
+    inner: EngineCancellationToken,
+}
+
+impl Default for CancellationToken {
+    fn default() -> Self {
+        Self {
+            inner: EngineCancellationToken::new(),
+        }
+    }
+}
+
+#[pymethods]
+impl CancellationToken {
+    #[new]
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn cancel(&self) -> bool {
+        self.inner.cancel()
+    }
+
+    #[getter]
+    fn cancelled(&self) -> bool {
+        self.inner.is_cancelled()
+    }
+
+    fn __repr__(&self) -> String {
+        format!("CancellationToken(cancelled={})", self.cancelled())
+    }
+}
+
+struct CursorState {
+    rows: VecDeque<Vec<Value>>,
+    closed: bool,
+}
+
+#[pyclass(module = "briskdb._briskdb", frozen)]
+struct Cursor {
+    shards: Vec<u16>,
+    columns: Vec<(String, &'static str)>,
+    batch_size: usize,
+    state: Mutex<CursorState>,
+}
+
+impl Cursor {
+    fn from_routed(result: Routed<ResultSet>, batch_size: usize) -> PyResult<Self> {
+        Self::from_parts(vec![result.shard], result.value, batch_size)
+    }
+
+    fn from_logical(result: Executed<ResultSet>, batch_size: usize) -> PyResult<Self> {
+        Self::from_parts(result.shards, result.value, batch_size)
+    }
+
+    fn from_parts(shards: Vec<u16>, result: ResultSet, batch_size: usize) -> PyResult<Self> {
+        if batch_size == 0 {
+            return Err(crate::error::invalid_value(
+                "cursor batch_size must be at least 1",
+            ));
+        }
+        let (columns, rows) = result.into_parts();
+        Ok(Self {
+            shards,
+            columns: cursor_columns(columns),
+            batch_size,
+            state: Mutex::new(CursorState {
+                rows: rows.into_iter().map(briskdb::Row::into_values).collect(),
+                closed: false,
+            }),
+        })
+    }
+
+    fn take_rows(&self, count: usize) -> PyResult<Vec<Vec<Value>>> {
+        let mut state = self.state.lock().map_err(NativeError::from)?;
+        if state.closed {
+            return Err(NativeError::Closed("cursor").into());
+        }
+        let count = count.min(state.rows.len());
+        Ok(state.rows.drain(..count).collect())
+    }
+}
+
+#[pymethods]
+impl Cursor {
+    #[getter]
+    fn shards(&self) -> Vec<u16> {
+        self.shards.clone()
+    }
+
+    #[getter]
+    fn columns(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let output = PyList::empty(py);
+        for (name, data_type) in &self.columns {
+            let column = PyDict::new(py);
+            column.set_item("name", name)?;
+            column.set_item("type", data_type)?;
+            output.append(column)?;
+        }
+        Ok(output.into_any().unbind())
+    }
+
+    #[getter]
+    fn closed(&self) -> PyResult<bool> {
+        Ok(self.state.lock().map_err(NativeError::from)?.closed)
+    }
+
+    #[getter]
+    fn remaining(&self) -> PyResult<usize> {
+        let state = self.state.lock().map_err(NativeError::from)?;
+        if state.closed {
+            return Err(NativeError::Closed("cursor").into());
+        }
+        Ok(state.rows.len())
+    }
+
+    fn fetchone(&self, py: Python<'_>) -> PyResult<Option<Py<PyAny>>> {
+        self.take_rows(1)?
+            .pop()
+            .map(|row| cursor_row_to_python(py, row))
+            .transpose()
+    }
+
+    #[pyo3(signature = (size = None))]
+    fn fetchmany(&self, py: Python<'_>, size: Option<usize>) -> PyResult<Py<PyAny>> {
+        let size = size.unwrap_or(self.batch_size);
+        if size == 0 {
+            return Err(crate::error::invalid_value(
+                "cursor fetch size must be at least 1",
+            ));
+        }
+        cursor_rows_to_python(py, self.take_rows(size)?)
+    }
+
+    fn fetchall(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        cursor_rows_to_python(py, self.take_rows(usize::MAX)?)
+    }
+
+    fn close(&self) -> PyResult<()> {
+        let mut state = self.state.lock().map_err(NativeError::from)?;
+        state.rows.clear();
+        state.closed = true;
+        Ok(())
+    }
+
+    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    fn __next__(&self, py: Python<'_>) -> PyResult<Option<Py<PyAny>>> {
+        self.fetchone(py)
+    }
+
+    fn __enter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    fn __exit__(
+        &self,
+        _exception_type: Option<&Bound<'_, PyAny>>,
+        _exception: Option<&Bound<'_, PyAny>>,
+        _traceback: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<bool> {
+        self.close()?;
+        Ok(false)
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        let state = self.state.lock().map_err(NativeError::from)?;
+        Ok(format!(
+            "Cursor(columns={}, remaining={}, closed={})",
+            self.columns.len(),
+            state.rows.len(),
+            state.closed
+        ))
+    }
+}
+
 struct SessionShared {
     session: Mutex<Option<BriskSession>>,
     runtime: Arc<RuntimeOwner>,
@@ -279,11 +462,21 @@ impl Database {
         })
     }
 
-    fn checkpoint(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+    #[pyo3(signature = (*, timeout_ms = None, cancellation = None))]
+    fn checkpoint(
+        &self,
+        py: Python<'_>,
+        timeout_ms: Option<u64>,
+        cancellation: Option<PyRef<'_, CancellationToken>>,
+    ) -> PyResult<Py<PyAny>> {
+        let context = request_context(timeout_ms, cancellation.as_deref())?;
         let shared = Arc::clone(&self.shared);
         let report = run_native(py, move || {
             let database = shared.database()?;
-            Ok(shared.runtime.runtime.block_on(database.checkpoint())?)
+            Ok(shared
+                .runtime
+                .runtime
+                .block_on(database.checkpoint_with_context(context))?)
         })?;
         checkpoint_to_python(py, report)
     }
@@ -310,6 +503,21 @@ impl Database {
             self.shared.config.shards,
             self.state()?
         ))
+    }
+
+    fn __enter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    fn __exit__(
+        &self,
+        py: Python<'_>,
+        _exception_type: Option<&Bound<'_, PyAny>>,
+        _exception: Option<&Bound<'_, PyAny>>,
+        _traceback: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<bool> {
+        self.close(py)?;
+        Ok(false)
     }
 }
 
@@ -380,69 +588,134 @@ impl Session {
         })
     }
 
-    fn migrate(&self, py: Python<'_>, sql: String) -> PyResult<Vec<u16>> {
+    #[pyo3(signature = (sql, *, timeout_ms = None, cancellation = None))]
+    fn migrate(
+        &self,
+        py: Python<'_>,
+        sql: String,
+        timeout_ms: Option<u64>,
+        cancellation: Option<PyRef<'_, CancellationToken>>,
+    ) -> PyResult<Vec<u16>> {
+        let context = request_context(timeout_ms, cancellation.as_deref())?;
         let shared = Arc::clone(&self.shared);
         run_native(py, move || {
             let session = shared.session()?;
-            Ok(shared.runtime.runtime.block_on(session.migrate(sql))?)
+            Ok(shared
+                .runtime
+                .runtime
+                .block_on(session.migrate_with_context(sql, context))?)
         })
     }
 
-    #[pyo3(signature = (sql, params = None))]
+    #[pyo3(signature = (sql, params = None, *, timeout_ms = None, cancellation = None))]
     fn execute(
         &self,
         py: Python<'_>,
         sql: String,
         params: Option<Vec<Py<PyAny>>>,
+        timeout_ms: Option<u64>,
+        cancellation: Option<PyRef<'_, CancellationToken>>,
     ) -> PyResult<Py<PyAny>> {
         let params = extract_params(py, params)?;
+        let context = request_context(timeout_ms, cancellation.as_deref())?;
         let shared = Arc::clone(&self.shared);
         let result = run_native(py, move || {
             let session = shared.session()?;
-            Ok(shared
-                .runtime
-                .runtime
-                .block_on(session.execute_write(Statement::new(sql, params)))?)
+            Ok(shared.runtime.runtime.block_on(
+                session.execute_write_with_context(Statement::new(sql, params), context),
+            )?)
         })?;
         write_result_to_python(py, result)
     }
 
-    #[pyo3(signature = (sql, params = None))]
+    #[pyo3(signature = (sql, params = None, *, timeout_ms = None, cancellation = None))]
     fn query(
         &self,
         py: Python<'_>,
         sql: String,
         params: Option<Vec<Py<PyAny>>>,
+        timeout_ms: Option<u64>,
+        cancellation: Option<PyRef<'_, CancellationToken>>,
     ) -> PyResult<Py<PyAny>> {
         let params = extract_params(py, params)?;
+        let context = request_context(timeout_ms, cancellation.as_deref())?;
         let shared = Arc::clone(&self.shared);
         let result = run_native(py, move || {
             let session = shared.session()?;
             Ok(shared
                 .runtime
                 .runtime
-                .block_on(session.query(Statement::new(sql, params)))?)
+                .block_on(session.query_with_context(Statement::new(sql, params), context))?)
         })?;
         routed_result_to_python(py, result)
     }
 
-    #[pyo3(signature = (sql, params = None))]
+    #[pyo3(signature = (sql, params = None, *, timeout_ms = None, cancellation = None))]
     fn query_logical(
         &self,
         py: Python<'_>,
         sql: String,
         params: Option<Vec<Py<PyAny>>>,
+        timeout_ms: Option<u64>,
+        cancellation: Option<PyRef<'_, CancellationToken>>,
     ) -> PyResult<Py<PyAny>> {
         let params = extract_params(py, params)?;
+        let context = request_context(timeout_ms, cancellation.as_deref())?;
+        let shared = Arc::clone(&self.shared);
+        let result = run_native(py, move || {
+            let session = shared.session()?;
+            Ok(shared.runtime.runtime.block_on(
+                session.query_logical_with_context(Statement::new(sql, params), context),
+            )?)
+        })?;
+        logical_result_to_python(py, result)
+    }
+
+    #[pyo3(signature = (sql, params = None, *, batch_size = 1_000, timeout_ms = None, cancellation = None))]
+    #[allow(clippy::too_many_arguments)]
+    fn cursor(
+        &self,
+        py: Python<'_>,
+        sql: String,
+        params: Option<Vec<Py<PyAny>>>,
+        batch_size: usize,
+        timeout_ms: Option<u64>,
+        cancellation: Option<PyRef<'_, CancellationToken>>,
+    ) -> PyResult<Cursor> {
+        let params = extract_params(py, params)?;
+        let context = request_context(timeout_ms, cancellation.as_deref())?;
         let shared = Arc::clone(&self.shared);
         let result = run_native(py, move || {
             let session = shared.session()?;
             Ok(shared
                 .runtime
                 .runtime
-                .block_on(session.query_logical(Statement::new(sql, params)))?)
+                .block_on(session.query_with_context(Statement::new(sql, params), context))?)
         })?;
-        logical_result_to_python(py, result)
+        Cursor::from_routed(result, batch_size)
+    }
+
+    #[pyo3(signature = (sql, params = None, *, batch_size = 1_000, timeout_ms = None, cancellation = None))]
+    #[allow(clippy::too_many_arguments)]
+    fn logical_cursor(
+        &self,
+        py: Python<'_>,
+        sql: String,
+        params: Option<Vec<Py<PyAny>>>,
+        batch_size: usize,
+        timeout_ms: Option<u64>,
+        cancellation: Option<PyRef<'_, CancellationToken>>,
+    ) -> PyResult<Cursor> {
+        let params = extract_params(py, params)?;
+        let context = request_context(timeout_ms, cancellation.as_deref())?;
+        let shared = Arc::clone(&self.shared);
+        let result = run_native(py, move || {
+            let session = shared.session()?;
+            Ok(shared.runtime.runtime.block_on(
+                session.query_logical_with_context(Statement::new(sql, params), context),
+            )?)
+        })?;
+        Cursor::from_logical(result, batch_size)
     }
 
     fn status(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
@@ -468,6 +741,21 @@ impl Session {
     fn __repr__(&self) -> PyResult<String> {
         let state = if self.closed()? { "closed" } else { "ready" };
         Ok(format!("Session(state={state:?})"))
+    }
+
+    fn __enter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    fn __exit__(
+        &self,
+        py: Python<'_>,
+        _exception_type: Option<&Bound<'_, PyAny>>,
+        _exception: Option<&Bound<'_, PyAny>>,
+        _traceback: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<bool> {
+        self.close(py)?;
+        Ok(false)
     }
 }
 
@@ -498,6 +786,46 @@ fn resolve_config(shards: Option<u16>, config: Option<&Config>) -> PyResult<Conf
         (None, Some(config)) => Ok(config.clone()),
         (None, None) => Ok(Config::default()),
     }
+}
+
+fn request_context(
+    timeout_ms: Option<u64>,
+    cancellation: Option<&CancellationToken>,
+) -> PyResult<RequestContext> {
+    let cancellation = cancellation
+        .map(|cancellation| cancellation.inner.clone())
+        .unwrap_or_default();
+    let context = RequestContext::new().with_cancellation_token(cancellation);
+    match timeout_ms {
+        Some(timeout_ms) => context
+            .with_timeout(Duration::from_millis(timeout_ms))
+            .map_err(NativeError::from)
+            .map_err(PyErr::from),
+        None => Ok(context),
+    }
+}
+
+fn cursor_columns(columns: Vec<Column>) -> Vec<(String, &'static str)> {
+    columns
+        .into_iter()
+        .map(|column| (column.name, data_type_name(column.data_type)))
+        .collect()
+}
+
+fn cursor_row_to_python(py: Python<'_>, row: Vec<Value>) -> PyResult<Py<PyAny>> {
+    let values = row
+        .into_iter()
+        .map(|value| value_to_python(py, value))
+        .collect::<PyResult<Vec<_>>>()?;
+    Ok(PyTuple::new(py, values)?.into_any().unbind())
+}
+
+fn cursor_rows_to_python(py: Python<'_>, rows: Vec<Vec<Value>>) -> PyResult<Py<PyAny>> {
+    let output = PyList::empty(py);
+    for row in rows {
+        output.append(cursor_row_to_python(py, row)?)?;
+    }
+    Ok(output.into_any().unbind())
 }
 
 fn engine_state_name(state: EngineState) -> &'static str {
@@ -565,7 +893,9 @@ fn checkpoint_to_python(py: Python<'_>, report: CheckpointReport) -> PyResult<Py
 #[pymodule]
 fn _briskdb(module: &Bound<'_, PyModule>) -> PyResult<()> {
     error::register(module)?;
+    module.add_class::<CancellationToken>()?;
     module.add_class::<Config>()?;
+    module.add_class::<Cursor>()?;
     module.add_class::<Database>()?;
     module.add_class::<Session>()?;
     module.add_function(wrap_pyfunction!(open_database, module)?)?;

--- a/python/src/value.rs
+++ b/python/src/value.rs
@@ -81,7 +81,7 @@ fn extract_value(value: &Bound<'_, PyAny>) -> PyResult<Value> {
     )))
 }
 
-fn value_to_python(py: Python<'_>, value: Value) -> PyResult<Py<PyAny>> {
+pub(crate) fn value_to_python(py: Python<'_>, value: Value) -> PyResult<Py<PyAny>> {
     match value {
         Value::Null => Ok(py.None()),
         Value::Boolean(value) => value.into_py_any(py),
@@ -100,7 +100,7 @@ fn value_to_python(py: Python<'_>, value: Value) -> PyResult<Py<PyAny>> {
     }
 }
 
-fn data_type_name(data_type: DataType) -> &'static str {
+pub(crate) fn data_type_name(data_type: DataType) -> &'static str {
     match data_type {
         DataType::Unknown => "unknown",
         DataType::Null => "null",

--- a/python/tests/test_api.py
+++ b/python/tests/test_api.py
@@ -1,0 +1,172 @@
+import asyncio
+import concurrent.futures
+import tempfile
+import time
+import unittest
+
+import briskdb
+
+
+LONG_QUERY = (
+    "WITH RECURSIVE counter(x) AS (VALUES(0) UNION ALL "
+    "SELECT x + 1 FROM counter WHERE x < 1000000000) "
+    "SELECT sum(x) FROM counter"
+)
+
+
+class SyncApiTests(unittest.TestCase):
+    def test_context_managers_and_bounded_cursor_batches(self) -> None:
+        with tempfile.TemporaryDirectory() as data_dir:
+            with briskdb.connect(data_dir, shards=2) as database:
+                with database.session(routing_key="cursor") as session:
+                    cursor = session.cursor(
+                        "SELECT 1 AS value UNION ALL SELECT 2 UNION ALL SELECT 3",
+                        batch_size=2,
+                    )
+                    self.assertEqual(cursor.remaining, 3)
+                    self.assertEqual(cursor.fetchmany(), [(1,), (2,)])
+                    self.assertEqual(list(cursor), [(3,)])
+                    self.assertEqual(cursor.fetchall(), [])
+                    cursor.close()
+                    cursor.close()
+                    self.assertTrue(cursor.closed)
+                    with self.assertRaises(briskdb.FailedPreconditionError):
+                        cursor.fetchone()
+
+                self.assertTrue(session.closed)
+            self.assertTrue(database.closed)
+
+    def test_deadline_and_explicit_cancellation_recover_the_session(self) -> None:
+        with tempfile.TemporaryDirectory() as data_dir:
+            with briskdb.connect(data_dir, shards=2) as database:
+                with database.session(routing_key="cancel") as session:
+                    with self.assertRaises(briskdb.DeadlineExceededError):
+                        session.query(LONG_QUERY, timeout_ms=1)
+
+                    token = briskdb.CancellationToken()
+                    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                        future = pool.submit(
+                            session.query,
+                            LONG_QUERY,
+                            None,
+                            cancellation=token,
+                        )
+                        time.sleep(0.02)
+                        self.assertTrue(token.cancel())
+                        with self.assertRaises(briskdb.CancelledError):
+                            future.result(timeout=5)
+
+                    self.assertEqual(session.query("SELECT 1")["rows"], [(1,)])
+
+    def test_shared_handles_are_safe_for_flask_style_worker_threads(self) -> None:
+        with tempfile.TemporaryDirectory() as data_dir:
+            with briskdb.connect(data_dir, shards=2) as database:
+
+                def request_handler(value: int) -> int:
+                    with database.session(routing_key=f"request-{value}") as session:
+                        return session.query("SELECT ?1", [value])["rows"][0][0]
+
+                with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+                    self.assertEqual(
+                        list(pool.map(request_handler, range(32))), list(range(32))
+                    )
+
+
+class AsyncApiTests(unittest.IsolatedAsyncioTestCase):
+    async def test_async_crud_cursor_and_context_management(self) -> None:
+        with tempfile.TemporaryDirectory() as data_dir:
+            database = await briskdb.open_async(data_dir, shards=2)
+            async with database:
+                session = await database.session(routing_key="async-crud")
+                async with session:
+                    self.assertEqual(
+                        await session.migrate(
+                            "CREATE TABLE async_notes "
+                            "(id INTEGER PRIMARY KEY, body TEXT NOT NULL)"
+                        ),
+                        [0, 1],
+                    )
+                    write = await session.execute(
+                        "INSERT INTO async_notes VALUES (?1, ?2)", [1, "hello"]
+                    )
+                    self.assertEqual(write["rows_affected"], 1)
+                    result = await session.query(
+                        "SELECT body FROM async_notes WHERE id = ?1", [1]
+                    )
+                    self.assertEqual(result["rows"], [("hello",)])
+
+                    cursor = await session.cursor(
+                        "SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3",
+                        batch_size=2,
+                    )
+                    async with cursor:
+                        self.assertEqual(await cursor.fetchmany(), [(1,), (2,)])
+                        self.assertEqual(
+                            [row async for row in cursor],
+                            [(3,)],
+                        )
+                    self.assertTrue(cursor.closed)
+
+                self.assertTrue(session.closed)
+            self.assertTrue(database.closed)
+
+    async def test_async_queries_do_not_block_the_event_loop(self) -> None:
+        with tempfile.TemporaryDirectory() as data_dir:
+            async with await briskdb.connect_async(data_dir, shards=2) as database:
+                async with await database.session(routing_key="event-loop") as session:
+                    ticks = 0
+                    finished = asyncio.Event()
+
+                    async def ticker() -> None:
+                        nonlocal ticks
+                        while not finished.is_set():
+                            ticks += 1
+                            await asyncio.sleep(0)
+
+                    ticker_task = asyncio.create_task(ticker())
+                    result = await session.query(
+                        "WITH RECURSIVE counter(x) AS (VALUES(0) UNION ALL "
+                        "SELECT x + 1 FROM counter WHERE x < 1000000) "
+                        "SELECT sum(x) FROM counter"
+                    )
+                    finished.set()
+                    await ticker_task
+                    self.assertEqual(result["rows"], [(500000500000,)])
+                    self.assertGreater(ticks, 100)
+
+    async def test_python_task_cancellation_reaches_rust(self) -> None:
+        with tempfile.TemporaryDirectory() as data_dir:
+            async with await briskdb.open_async(data_dir, shards=2) as database:
+                async with await database.session(routing_key="task-cancel") as session:
+                    token = briskdb.CancellationToken()
+                    query = asyncio.create_task(
+                        session.query(LONG_QUERY, cancellation=token)
+                    )
+                    await asyncio.sleep(0.02)
+                    query.cancel()
+                    with self.assertRaises(asyncio.CancelledError):
+                        await query
+                    self.assertTrue(token.cancelled)
+                    recovered = await asyncio.wait_for(session.query("SELECT 1"), 5)
+                    self.assertEqual(recovered["rows"], [(1,)])
+
+    async def test_fastapi_and_warm_handler_patterns_share_one_database(self) -> None:
+        with tempfile.TemporaryDirectory() as data_dir:
+            database = await briskdb.open_async(data_dir, shards=2)
+
+            async def fastapi_style_handler(value: int) -> int:
+                async with await database.session(
+                    routing_key=f"handler-{value}"
+                ) as session:
+                    result = await session.query("SELECT ?1", [value])
+                    return result["rows"][0][0]
+
+            results = await asyncio.gather(
+                *(fastapi_style_handler(value) for value in range(32))
+            )
+            self.assertEqual(results, list(range(32)))
+            await database.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/embedded.rs
+++ b/src/embedded.rs
@@ -736,6 +736,17 @@ impl BriskSession {
         self.database.migrate(self.session.as_ref(), sql).await
     }
 
+    /// Apply one durable schema batch with host-supplied request controls.
+    pub async fn migrate_with_context(
+        &self,
+        sql: impl Into<String>,
+        context: RequestContext,
+    ) -> EngineResult<Vec<u16>> {
+        self.database
+            .migrate_with_context(self.session.as_ref(), sql, context)
+            .await
+    }
+
     /// Close this session terminally and clear all retained session state.
     ///
     /// Closing one clone closes every clone. It remains available while the


### PR DESCRIPTION
Addresses the currently implementable SQL and lifecycle portions of #199.

- adds sync context managers and bounded native cursors
- adds asyncio database/session/cursor facades without blocking the event loop
- propagates Python task cancellation and deadlines into Rust RequestContext
- validates thread/task safety with Flask-, FastAPI-, and warm-handler patterns
- documents lifecycle, backpressure, and DB-API boundaries

Deferred dependencies remain tracked: native transactions (#34), retained SQLite streaming cursors (#39), document operations (#160), and serverless snapshot/fencing work (#194-#196).

Validation: full Rust tests, clippy, rustdoc, package verification, and 15 installed-wheel tests on Python 3.9/3.12 compatibility targets.