### PR TITLE
Python: validate multiprocessing access and document shared roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ experimental and opt-in; the exact contract lives in
 | Ubuntu/macOS x86-64 and ARM64 release artifacts | Published |
 | Debian package and hardened systemd service | Published |
 | Listener-free Rust library entrypoint | Working |
+| Same-host service and embedded processes sharing one ready root | Working on local filesystems |
 | Native MongoDB wire protocol with TinyMongo parity | [Planned](https://github.com/schapman1974/briskdb/issues/160) |
 | MySQL wire protocol | [Planned](https://github.com/schapman1974/briskdb/issues/40) |
 | Native Python extension | Sync/async API working; tagged releases build audited macOS/Linux ARM/x86 wheels |
@@ -166,12 +167,16 @@ python -m pip install ./python
 See the [Python quickstart](python/README.md) for sync and asyncio write/read
 examples. Tagged releases publish compiler-free `cp39-abi3` wheels for the
 [supported platform matrix](python/COMPATIBILITY.md); repository checkouts can
-still be installed from source with Rust 1.85+.
+still be installed from source with Rust 1.85+. Independently spawned Python,
+Rust, and server processes can share a ready local data directory; read the
+[multi-process contract](docs/MULTIPROCESS.md) before deploying that pattern.
 
 ## Still just inspectable files
 
 ```text
 briskdb-data/
+├── .briskdb-process.lock
+├── .briskdb-startup.lock
 ├── manifest.sqlite
 └── shards/
     ├── 0000.sqlite
@@ -203,7 +208,10 @@ Follow the [roadmap](ROADMAP.md) or browse the
 - No general atomic transaction across multiple shard files.
 - Global ordering/pagination and general aggregate pushdown are still limited.
 - The supported backup today is a stopped-server copy of the complete data
-  directory; online/serverless snapshots are planned.
+  directory after every server and embedder exits; online/serverless snapshots
+  are planned.
+- Multi-process access is same-host/local-filesystem only. Schema, catalog,
+  upgrade, and recovery work requires sole-process ownership.
 - Pre-1.0 storage and public-library compatibility can change between releases.
 - Ubuntu 24.04 x86-64 receives the full required Rust CI suite. Python wheels
   receive native build, audit, install, restart, corruption, and concurrency
@@ -219,6 +227,7 @@ Follow the [roadmap](ROADMAP.md) or browse the
 - [SQL compatibility](docs/SQL_COMPATIBILITY.md)
 - [Generated keys](docs/GENERATED_KEYS.md)
 - [Storage format](docs/STORAGE_FORMAT.md)
+- [Sharing one data directory between processes](docs/MULTIPROCESS.md)
 - [Debian and systemd installation](docs/DEBIAN_INSTALL.md)
 - [Pre-1.0 compatibility policy](docs/PRE_1_COMPATIBILITY.md)
 - [Contributing](CONTRIBUTING.md)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,15 @@
+# Changes after 0.1.0-alpha.4
+
+- Independent server, Rust, and Python processes may concurrently open one
+  ready data root on the same Linux or macOS host and local filesystem.
+- Schema, catalog, initialization, upgrade, and recovery work requires
+  sole-process ownership and returns retryable `Busy` while a peer is open.
+- Each process must open its own handle. Inherited live handles after `fork()`,
+  network filesystems, multi-host volumes, and online backup remain unsupported.
+- Installed-wheel and Rust subprocess tests cover overlapping writes,
+  checkpoints, generated IDs, abrupt exit, recovery, and service-plus-embedded
+  operation. See `docs/MULTIPROCESS.md`.
+
 # BriskDB 0.1.0-alpha.4
 
 Alpha 4 makes BriskDB usable as an in-process Rust or Python database, while

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -538,11 +538,14 @@ the fence, and installs checksum version 5 without changing a shard.
 There is no automatic downgrade; an older binary requires a backup from before
 the newer format.
 
-Startup first canonicalizes the data-directory path and joins the process-wide
-root coordination keyed by that path. It acquires the shared schema gate before
-loading the manifest, so independent `Storage`, `Database`, and `Engine` handles
-in one process serialize startup and migration against ordinary admission and
-share catalog-generation publication.
+Startup first canonicalizes the data-directory path, takes the root startup
+lock, and joins the in-memory coordination keyed by that path. Each process
+holds a shared root lease for its handle lifetime. Initialization, format
+upgrade, recovery, schema migration, catalog registration, and generated-table
+DDL must upgrade that lease to sole-process ownership before mutation. Current
+`Ready`/`Degraded` opens retain the shared lease, so independent processes may
+serve steady-state work while in-process handles continue to share schema
+admission and catalog-generation publication.
 
 Each manifest connection enables and reads back SQLite cell-size checks and
 requires a full manifest integrity check before parsing control-plane state.
@@ -797,11 +800,10 @@ the first value. Independent BriskDB processes that reach this narrow allocator
 path serialize only that refill transaction through SQLite and receive
 non-overlapping ranges. The fence distinguishes successive durable reservations;
 it is not an expiry time and does not revoke earlier IDs. There are no clocks,
-heartbeats, or reclaim decisions. This cross-process uniqueness property does
-not by itself broaden the rest of BriskDB's single-process-per-root deployment
-boundary. Independently started processes, including processes after `exec`,
-are the tested allocator model. Continuing to use an inherited live handle or
-lease cache after `fork()` is unsupported.
+heartbeats, or reclaim decisions. The same lifetime process lease permits
+independently started same-host processes to serve steady-state work on a ready
+local root. Processes after `exec` are supported; continuing to use an inherited
+live handle or lease cache after `fork()` is not.
 
 Committed leases are irrevocable. The process cache advances before the target
 shard insert, never returns an ID after rollback, cancellation, constraint
@@ -994,8 +996,10 @@ receives non-retryable `FailedPrecondition`, while a new migration call may
 enter `Migrating` to resume the byte-identical SQL. Startup recovery completes
 an active journal while holding the same in-process gate. Independent handles
 for the same canonical root share the gate and live catalog publication.
-Separate server processes for one data directory are unsupported; the gate is
-not a distributed coordination mechanism.
+An outer filesystem lease requires sole-process ownership before the migration
+can inspect or publish durable state. A live peer therefore receives no schema
+change; the coordinator returns retryable `Busy`. This is local-host advisory
+coordination, not a distributed lock for network filesystems or object storage.
 
 Every-shard preflight executes the complete batch inside a rollback-only
 transaction. When the authoritative table catalog is populated, that tentative

--- a/docs/DEBIAN_INSTALL.md
+++ b/docs/DEBIAN_INSTALL.md
@@ -36,6 +36,14 @@ The package creates a locked, unprivileged `briskdb` system account. systemd's
 mode `0750`. The service has no writable access to `/etc`, `/usr`, home
 directories, devices, kernel controls, or other application state.
 
+An embedded Rust or Python application may share the ready data root with the
+service on this host, but it must run with the same effective `briskdb` UID.
+The coordination sidecars are deliberately owner-only (`0600`), so adding an
+application user to the `briskdb` group is not sufficient. Run the worker as
+`briskdb`, configure the same path and shard count, and stop every peer before
+schema changes, upgrades, imports, backups, or restores. See the
+[multi-process contract](MULTIPROCESS.md).
+
 `/etc/default/briskdb` is a dpkg conffile: administrator edits survive upgrades
 and removals. Edit it with `sudoedit`, validate the loopback/security boundary,
 then restart:

--- a/docs/EMBEDDED_RUST.md
+++ b/docs/EMBEDDED_RUST.md
@@ -76,6 +76,13 @@ data directories can be opened independently in one process. Create a distinct
 work ends, and explicitly await `BriskDb::close()` before the final handle is
 dropped.
 
+Independent processes may also open the same ready root on one local Linux or
+macOS host. Every process must construct its own handle after it starts; using
+an inherited handle after `fork()` is unsupported. Reads, autocommit writes,
+generated IDs, and passive checkpoints may overlap. Schema/catalog/layout
+changes require sole-process ownership and return retryable `Busy` while a peer
+is open. See [sharing one data directory between processes](MULTIPROCESS.md).
+
 `BriskDb::owned_session()` returns a cloneable `BriskSession` that retains its
 owning database identity and exposes direct/prepared SQL methods without a
 separate database argument. Clones share routing, prepared state, and terminal
@@ -88,7 +95,9 @@ machine-readable `EngineError::code()`; diagnostic text is intended for trusted
 logs and is not a compatibility contract.
 
 Schema changes use `BriskDb::migrate()` and the crash-resumable migration
-journal. Ordinary DDL is deliberately rejected through the write method.
+journal. Ordinary DDL is deliberately rejected through the write method. Stop
+other processes before migrating, then retry the exact migration if ownership
+contention returned `Busy`.
 
 The embedding host owns process cancellation. It can call `begin_close()` to
 stop admission synchronously, `close_with_grace()` to select a finite drain

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -100,12 +100,17 @@ and proven sequence-exhausted does it return non-retryable `LimitExceeded`.
 Hi/lo instead reserves all possible target pools before it consumes an
 irrevocable allocation.
 
-Schema migration instead uses an in-process gate shared by handles for the same
-canonical root, plus fresh coordinator-owned connections.
-While that gate is `Migrating`, new
+Schema migration uses an in-process gate shared by handles for the same
+canonical root, plus fresh coordinator-owned connections. Before durable
+inspection or mutation, the coordinator also requires a sole-process root
+lease. A peer process holding its lifetime shared lease makes the migration
+return retryable `Busy` without changing the manifest or shards.
+While the local gate is `Migrating`, new
 ordinary operations and another migration coordinator receive retryable
 `Busy`. Clients that retry should use the same bounded exponential backoff and
-jitter as for SQLite-originated `Busy` failures.
+jitter as for SQLite-originated `Busy` failures. Catalog registration,
+generated-table DDL, initialization, upgrade, and recovery use the same
+cross-process fence; see the [multi-process contract](MULTIPROCESS.md).
 
 If a failed, cancelled, or dropped migration has already published a durable
 journal row, the gate becomes `Pending`. Ordinary operations then receive

--- a/docs/MULTIPROCESS.md
+++ b/docs/MULTIPROCESS.md
@@ -1,0 +1,102 @@
+# Sharing one data directory between processes
+
+BriskDB supports multiple independently started processes opening one ready
+data directory on the same Linux or macOS host. The server, Rust library, and
+Python wheel use the same locks and SQLite WAL files.
+
+## Supported contract
+
+| Operation | While peers are open |
+| --- | --- |
+| Reads and autocommit writes | Supported; normal SQLite writer contention can return retryable `Busy` |
+| Generated IDs | Supported; native ranges and manifest-leased hi/lo blocks remain unique |
+| Passive checkpoints | Supported; a competing checkpoint can report `busy` with unavailable frame counts |
+| Opening a current `Ready`/`Degraded` root | Supported; startup inspection is serialized |
+| Schema migration, catalog registration, generated-table DDL, initialization, upgrade, or recovery | Requires sole-process ownership; retryable `Busy` is returned before mutation when a peer is open |
+| Offline import or backup/restore | Stop every server and embedder first |
+
+This contract is limited to one host and one local filesystem with working
+SQLite and advisory-file locks. NFS, SMB, cloud-synchronized folders, shared
+volumes between hosts, and object storage are unsupported. Provider fencing for
+serverless storage is separate work tracked by issue #196.
+
+Each process must open its own `Database`, `Engine`, or `BriskDb` after that
+process starts. A live handle, SQLite connection, Tokio runtime, or cached
+generated-ID lease inherited across `fork()` must not be used. Python code
+should use the `spawn` multiprocessing context or start a fresh interpreter.
+
+## Coordination files
+
+Two owner-only regular files live beside `manifest.sqlite`:
+
+```text
+.briskdb-process.lock   lifetime shared lease and sole-process mutation fence
+.briskdb-startup.lock   startup and recovery serialization
+```
+
+They are created with mode `0600`, opened without following symbolic links,
+and released by the kernel when a process exits, including an abrupt exit. The
+files may remain after shutdown; lock ownership is not stored in their bytes.
+Do not delete, replace, or edit them while any BriskDB process is running.
+
+The lock order is startup lock, process mutation fence when needed, in-process
+schema gate, manifest transaction, then shard work. Steady-state data requests
+hold only the lifetime shared process lease plus ordinary SQLite locks.
+
+## Python processes
+
+Create the schema before workers start, then let each spawned process reopen
+the same path:
+
+```python
+from multiprocessing import get_context
+import briskdb
+
+def worker(path, account_id):
+    with briskdb.open(path, shards=4) as db:
+        with db.session(routing_key=account_id) as session:
+            session.execute(
+                "INSERT INTO jobs (id, body) VALUES (?1, ?2)",
+                [1, "ready"],
+            )
+
+if __name__ == "__main__":
+    context = get_context("spawn")
+    workers = [context.Process(target=worker, args=("./data", str(i)))
+               for i in range(2)]
+    for process in workers:
+        process.start()
+    for process in workers:
+        process.join()
+```
+
+Every worker owns and closes its own handle. If a process receives `Busy`,
+retry the same autocommit operation with bounded exponential backoff and
+jitter. Do not automatically retry non-retryable errors.
+
+## systemd service plus an embedded app
+
+The Debian package runs the service as Unix user and group `briskdb`. Because
+the coordination files are owner-only, an embedded app sharing
+`/var/lib/briskdb/data` must run with the same effective UID:
+
+```bash
+sudo -u briskdb /opt/myapp/bin/worker
+```
+
+Configure both processes with the exact same data path and shard count. A
+supplementary group alone is not enough for the `0600` lock files. Separate
+service accounts are outside the current support contract.
+
+Apply schema/catalog changes during a maintenance window after stopping every
+peer. The same all-process stop is required before copying or restoring the
+directory. See [offline backup](OFFLINE_BACKUP.md) and the
+[Debian/systemd guide](DEBIAN_INSTALL.md).
+
+## Automated evidence
+
+`tests/multiprocess_shared_root.rs` covers overlapping same- and cross-shard
+traffic, pooled handles, checkpoints, generated IDs, retryable contention,
+abrupt termination, reopen/integrity validation, and one service plus one
+embedder. `python/tests/test_multiprocess.py` repeats the public wheel contract
+with independently spawned interpreters.

--- a/docs/OFFLINE_BACKUP.md
+++ b/docs/OFFLINE_BACKUP.md
@@ -13,17 +13,19 @@ issue #67.
 
 1. Record the BriskDB version, configured shard count, and absolute data
    directory path.
-2. Stop the BriskDB process cleanly and wait for it to exit. A service manager
-   must report the process stopped before copying begins.
+2. Stop every BriskDB server and embedded application cleanly and wait for each
+   to exit. A service manager must report its service stopped before copying.
 3. Verify that no other BriskDB process or embedder is using the directory.
 4. Copy the complete data directory into a new backup directory. Include
    `manifest.sqlite`, the entire `shards` directory, the import receipt when
-   present, and every SQLite `-wal`, `-shm`, or journal sidecar that exists.
-   Do not select individual database files.
+   present, `.briskdb-process.lock`, `.briskdb-startup.lock`, and every SQLite
+   `-wal`, `-shm`, or journal sidecar that exists. The lock files contain no
+   persistent ownership, but a complete-directory copy includes them. Do not
+   select individual database files.
 5. Make the backup durable using the snapshot, archive, or copy tool's normal
    completion and sync guarantees. Retain the recorded BriskDB version and
    shard count with the backup.
-6. Restart the original server only after the copy has completed.
+6. Restart servers and embedders only after the copy has completed.
 
 On the supported Linux platform, one simple local-filesystem copy is:
 

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -13,6 +13,13 @@ permitted; later migration opens never create a missing replacement, use
 SQLite's no-follow mode, and revalidate the freshly opened layout identity
 inside the same manifest transaction before changing journal state.
 
+The root also contains `.briskdb-process.lock` and
+`.briskdb-startup.lock`. They are owner-only regular coordination files, not
+SQLite databases or manifest state. Their bytes do not record ownership; the
+kernel releases their advisory locks when the process exits. They must not be
+replaced while a process is live. See the
+[multi-process contract](MULTIPROCESS.md).
+
 ## Current format: version 12
 
 SQLite header fields identify the file and its format:
@@ -684,13 +691,11 @@ file, timestamp, expiry, or revocation of IDs issued under an older fence. No
 wall or monotonic clock is stored or consulted. Independent processes contend
 on SQLite's manifest transaction and therefore cannot commit overlapping
 ranges. Process-local handles for the same canonical root share one cache per
-table and write the manifest once per block, not once per row. This narrow
-cross-process allocator property does not change the wider deployment boundary
-for simultaneously serving one data root from multiple BriskDB processes.
-Here, independent processes means processes that initialize BriskDB after their
-own start (including an `exec` boundary). A child must not inherit and continue
-using a live BriskDB handle or cached lease across `fork()`; inherited handles
-are outside the supported process model.
+table and write the manifest once per block, not once per row. Independently
+started same-host processes may also serve ordinary work on the same ready
+local root. Each must initialize BriskDB after its own start, including after an
+`exec` boundary. A child must not inherit and continue using a live BriskDB
+handle or cached lease across `fork()`.
 
 Every committed block is irrevocable. The allocator consumes an ID before
 taking the target-shard write lock and never returns it to the cache after a
@@ -1790,19 +1795,16 @@ the known-good manifest, rather than the terminal `Degraded` manifest from the
 failed root. A corrupt semantic root likewise must be restored, because
 BriskDB will not sign altered manifest payload while reporting the failure.
 
-The current deployment boundary remains local storage and one BriskDB process
-per data directory. Independent handles inside that process share a gate,
-schema fingerprints, and live catalog coordination keyed by the canonical
-root. The supported alpha recovery workflow is the complete stopped-directory
-copy documented in [offline backup](OFFLINE_BACKUP.md); coordinated online
-backup remains unimplemented. Recovery to an older binary requires a backup
-from before the unsupported format. Separate server processes against one data
-directory are unsupported even though SQLite and the manifest use file locks;
-the in-process coordination is intentionally not a distributed lock. The
-`hilo_v1` reservation transaction is deliberately stronger at its narrow
-boundary: competing processes obtain non-overlapping fenced blocks. That
-allocator guarantee is tested independently and does not certify concurrent
-multi-server operation for the rest of the root.
+The deployment boundary remains one host and local storage. Independent
+processes hold shared root leases for steady-state operations; schema, catalog,
+initialization, upgrade, and recovery work requires a sole-process lease.
+In-process handles additionally share a gate, schema fingerprints, and live
+catalog publication keyed by the canonical root. This coordination is not a
+distributed lock and does not support NFS, SMB, shared multi-host volumes, or
+object storage. The supported recovery workflow is the complete
+stopped-directory copy documented in [offline backup](OFFLINE_BACKUP.md);
+coordinated online backup remains unimplemented. Recovery to an older binary
+requires a backup from before the unsupported format.
 
 ## Verification contract
 

--- a/docs/SUPPORTED_PLATFORMS.md
+++ b/docs/SUPPORTED_PLATFORMS.md
@@ -99,19 +99,22 @@ layout members by themselves. The directory must nevertheless permit SQLite to
 create and recover its sidecars. Do not infer damage from a missing sidecar;
 BriskDB validates the database's persistent journal mode instead.
 
-Only a single BriskDB server process per data directory is supported. The
-process-wide registry makes independent `Database` and `Engine` handles that
-resolve to the same canonical root share schema admission and catalog
-publication. It does not coordinate separate server processes.
+Multiple independently started server and embedded processes may open one
+current ready data directory on the same host. Lifetime advisory leases fence
+schema, catalog, initialization, upgrade, and recovery mutations to a sole
+process while SQLite WAL coordinates steady-state reads and writes. Startup is
+serialized. The exact operation matrix, lock files, retry behavior, and
+post-`fork()` exclusion are defined in the
+[multi-process contract](MULTIPROCESS.md).
 Admin browser sessions likewise belong to one process, but are not part of that
 data-directory registry: their absolute eight-hour state is memory-only and is
 discarded on restart.
 Do not copy, move, edit, or separately open the manifest, shard, WAL, or shared
 memory files while the server is running. The stopped-server,
 complete-directory procedure in [offline backup](OFFLINE_BACKUP.md) is supported
-and tested. Live or partial copies, coordinated online backup, multi-process
-access, filesystem-fault behavior, and broader crash-recovery guarantees remain
-unsupported until their roadmap issues add corresponding automated tests.
+and tested. Live or partial copies, coordinated online backup, filesystem-fault
+behavior, and broader crash-recovery guarantees remain unsupported until their
+roadmap issues add corresponding automated tests.
 
 Opening a data directory can transactionally upgrade `manifest.sqlite` and can
 resume a manifest-recorded cross-file shard provisioning, adoption, or
@@ -141,10 +144,10 @@ against accidental wrong-file placement. They are not authentication or
 protection from a process that can write the data directory. The semantic and
 schema checksums introduced in v7 and retained by v8 are likewise unkeyed
 corruption detectors, not authentication, and do not checksum application row
-values. Targeted
-subprocess-abort tests cover schema-journal persistence boundaries, but
-arbitrary process-kill timing, power-loss, and filesystem-fault certification
-remain later hardening work.
+values. Targeted subprocess-abort tests cover schema-journal persistence
+boundaries and an abruptly terminated steady-state writer, but arbitrary
+process-kill timing, power-loss, and filesystem-fault certification remain
+later hardening work.
 
 When reporting a platform problem, include the BriskDB revision, `rustc -Vv`,
 operating-system and architecture details, filesystem type, mount options, and

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Added installed-wheel `spawn` multiprocessing coverage for concurrent
+  same-root writes, checkpoints, abrupt child exit, reopen, and retryable schema
+  ownership contention.
+- Documented the same-host/local-filesystem boundary and the prohibition on
+  inherited post-`fork()` handles.
+
 ## 0.1.0-alpha.4 — 2026-08-13
 
 - Added `cp39-abi3` wheel automation for macOS and manylinux on x86-64/ARM64.

--- a/python/COMPATIBILITY.md
+++ b/python/COMPATIBILITY.md
@@ -32,6 +32,14 @@ The wheel uses the same files, manifest version, migrations, downgrade fence,
 and recovery rules as the matching Rust release. There is no separate Python
 storage format and no stable pre-1.0 compatibility promise.
 
+Independently spawned interpreters may concurrently read and write one ready
+root on the same supported host and local filesystem. Each interpreter must
+open and close its own handle. Inherited post-`fork()` handles and network or
+multi-host filesystems are unsupported. Schema/catalog/layout changes require
+sole-process ownership and return retryable `BusyError` while a peer remains
+open. The complete boundary and systemd account requirements are documented in
+[sharing one data directory between processes](../docs/MULTIPROCESS.md).
+
 Before upgrading a wheel that opens existing data, stop every user of the data
 directory and retain a complete stopped-database backup. Startup can migrate
 the directory. In-place downgrade is unsupported; rollback means restoring the

--- a/python/README.md
+++ b/python/README.md
@@ -39,6 +39,13 @@ Database and session handles own their native resources, `close()` is
 idempotent, and blocking engine work releases Python's GIL. Dropping live
 handles during interpreter shutdown is also safe.
 
+Multiple independently spawned Python processes may open the same ready data
+directory on one local Linux or macOS host. Each process must create its own
+handle; use `multiprocessing.get_context("spawn")`, not an inherited live
+handle after `fork()`. Schema changes require every peer to close first and
+otherwise return retryable `BusyError`. See the
+[multi-process contract](../docs/MULTIPROCESS.md).
+
 Synchronous handles support `with`; the asyncio facade keeps engine work off
 the event loop and propagates task cancellation into Rust:
 

--- a/python/SERVERLESS.md
+++ b/python/SERVERLESS.md
@@ -20,12 +20,14 @@ def handler(event, _context):
         return {"rows": result["rows"]}
 ```
 
-The path must be writable, durable for the desired lifetime, and owned by one
-coordinated BriskDB instance. `/tmp` is suitable only for disposable data.
-Independent autoscaled instances pointed at independent local files are
+The path must be writable and durable for the desired lifetime. `/tmp` is
+suitable only for disposable data. Independently spawned processes on one host
+may share one local path under the [multi-process contract](../docs/MULTIPROCESS.md).
+Independent autoscaled instances pointed at independent local files remain
 independent databases.
 
 This is an embedded warm-handler pattern, not a production serverless storage
-claim. Atomic object-store snapshots, restore fencing, provider adapters, and
-multi-instance coordination remain tracked in issues #194–#196. Do not upload
-live SQLite/WAL files individually as a backup.
+claim. A shared network mount or object store does not become safe because
+local multi-process locking exists. Atomic snapshots, provider adapters, and
+multi-host fencing remain tracked in issues #194–#196. Do not upload live
+SQLite/WAL files individually as a backup.

--- a/python/tests/test_multiprocess.py
+++ b/python/tests/test_multiprocess.py
@@ -1,0 +1,242 @@
+import multiprocessing
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from typing import Optional
+
+import briskdb
+
+SHARDS = 4
+WRITES_PER_PROCESS = 24
+WAIT_SECONDS = 20.0
+SUPPORTED_HOST = sys.platform == "darwin" or sys.platform.startswith("linux")
+
+
+def _wait_for(path: Path) -> None:
+    deadline = time.monotonic() + WAIT_SECONDS
+    while not path.exists() and time.monotonic() < deadline:
+        time.sleep(0.005)
+    if not path.exists():
+        raise TimeoutError(f"timed out waiting for {path.name}")
+
+
+def _process_worker(
+    root: str,
+    mode: str,
+    route: str,
+    worker: int,
+    ready: str,
+    go: str,
+    output: str,
+) -> None:
+    database = briskdb.open(root, shards=SHARDS)
+    session = database.session(routing_key=route)
+    Path(ready).touch()
+    _wait_for(Path(go))
+
+    if mode in ("writer", "crash"):
+        for ordinal in range(WRITES_PER_PROCESS):
+            session.execute(
+                "INSERT INTO events (tenant_id, id, payload) VALUES (?1, ?2, ?3)",
+                [
+                    route,
+                    worker * 10_000 + ordinal,
+                    f"worker-{worker}-{ordinal}",
+                ],
+            )
+            if ordinal == WRITES_PER_PROCESS // 2:
+                database.checkpoint()
+            time.sleep(0.001)
+        Path(output).write_text("committed", encoding="utf-8")
+        if mode == "crash":
+            while True:
+                time.sleep(1)
+
+    session.close()
+    database.close()
+
+
+def _setup_root(root: str) -> None:
+    database = briskdb.open(root, shards=SHARDS)
+    session = database.session(routing_key="setup")
+    session.migrate(
+        "CREATE TABLE events ("
+        "tenant_id TEXT NOT NULL, "
+        "id INTEGER NOT NULL, "
+        "payload TEXT NOT NULL, "
+        "PRIMARY KEY (tenant_id, id)"
+        ")"
+    )
+    session.close()
+    database.close()
+
+
+def _route_shard(database: briskdb.Database, route: str) -> int:
+    session = database.session(routing_key=route)
+    try:
+        return int(session.query("SELECT 1")["shards"][0])
+    finally:
+        session.close()
+
+
+def _different_routes(root: str) -> tuple[str, str]:
+    database = briskdb.open(root, shards=SHARDS)
+    try:
+        first = "same-shard"
+        first_shard = _route_shard(database, first)
+        for ordinal in range(10_000):
+            candidate = f"different-{ordinal}"
+            if _route_shard(database, candidate) != first_shard:
+                return first, candidate
+    finally:
+        database.close()
+    raise AssertionError("failed to find routes on different shards")
+
+
+def _join_process(process: multiprocessing.Process) -> Optional[int]:
+    process.join(WAIT_SECONDS)
+    if process.is_alive():
+        process.kill()
+        process.join(WAIT_SECONDS)
+        raise TimeoutError(f"child process {process.pid} did not exit")
+    return process.exitcode
+
+
+@unittest.skipUnless(SUPPORTED_HOST, "shared-root process locks require Linux or macOS")
+class MultiprocessBriskDbTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.context = multiprocessing.get_context("spawn")
+
+    def _spawn(
+        self,
+        root: str,
+        mode: str,
+        route: str,
+        worker: int,
+        ready: Path,
+        go: Path,
+        output: Path,
+    ) -> multiprocessing.Process:
+        process = self.context.Process(
+            target=_process_worker,
+            args=(
+                root,
+                mode,
+                route,
+                worker,
+                str(ready),
+                str(go),
+                str(output),
+            ),
+        )
+        process.start()
+        self.addCleanup(self._stop_process, process)
+        return process
+
+    @staticmethod
+    def _stop_process(process: multiprocessing.Process) -> None:
+        if process.is_alive():
+            process.kill()
+            process.join(WAIT_SECONDS)
+
+    def test_spawned_processes_overlap_same_and_cross_shard_writes(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            _setup_root(root)
+            same_route, different_route = _different_routes(root)
+            go = Path(root) / "writers-go"
+            processes = []
+            ready_paths = []
+            for worker, route in enumerate((same_route, same_route, different_route)):
+                ready = Path(root) / f"writer-ready-{worker}"
+                output = Path(root) / f"writer-output-{worker}"
+                processes.append(
+                    self._spawn(root, "writer", route, worker, ready, go, output)
+                )
+                ready_paths.append(ready)
+
+            for ready in ready_paths:
+                _wait_for(ready)
+            go.touch()
+            for process in processes:
+                self.assertEqual(_join_process(process), 0)
+
+            database = briskdb.open(root, shards=SHARDS)
+            same_session = database.session(routing_key=same_route)
+            different_session = database.session(routing_key=different_route)
+            self.assertEqual(
+                same_session.query("SELECT COUNT(*) FROM events")["rows"],
+                [(WRITES_PER_PROCESS * 2,)],
+            )
+            self.assertEqual(
+                different_session.query("SELECT COUNT(*) FROM events")["rows"],
+                [(WRITES_PER_PROCESS,)],
+            )
+            same_session.close()
+            different_session.close()
+            database.close()
+
+            reopened = briskdb.open(root, shards=SHARDS)
+            self.assertEqual(len(reopened.checkpoint()["shards"]), SHARDS)
+            reopened.close()
+
+    def test_killed_process_releases_the_root_and_survivor_continues(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            _setup_root(root)
+            ready = Path(root) / "crash-ready"
+            go = Path(root) / "crash-go"
+            committed = Path(root) / "crash-committed"
+            route = "crash-route"
+            process = self._spawn(root, "crash", route, 7, ready, go, committed)
+            _wait_for(ready)
+
+            survivor = briskdb.open(root, shards=SHARDS)
+            session = survivor.session(routing_key=route)
+            go.touch()
+            _wait_for(committed)
+            process.kill()
+            process.join(WAIT_SECONDS)
+            self.assertFalse(process.is_alive())
+            self.assertNotEqual(process.exitcode, 0)
+
+            session.execute(
+                "INSERT INTO events (tenant_id, id, payload) VALUES (?1, ?2, ?3)",
+                [route, 999_999, "survivor"],
+            )
+            self.assertEqual(
+                session.query("SELECT COUNT(*) FROM events")["rows"],
+                [(WRITES_PER_PROCESS + 1,)],
+            )
+            session.close()
+            survivor.close()
+
+            reopened = briskdb.open(root, shards=SHARDS)
+            reopened.close()
+
+    def test_schema_change_is_retryable_busy_until_peer_closes(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            _setup_root(root)
+            ready = Path(root) / "holder-ready"
+            release = Path(root) / "holder-release"
+            output = Path(root) / "holder-output"
+            process = self._spawn(root, "hold", "holder", 0, ready, release, output)
+            _wait_for(ready)
+
+            database = briskdb.open(root, shards=SHARDS)
+            session = database.session(routing_key="schema")
+            migration = "CREATE INDEX events_payload_idx ON events(payload)"
+            with self.assertRaises(briskdb.BusyError) as raised:
+                session.migrate(migration)
+            self.assertEqual(raised.exception.code, "busy")
+            self.assertTrue(raised.exception.retryable)
+
+            release.touch()
+            self.assertEqual(_join_process(process), 0)
+            self.assertEqual(session.migrate(migration), list(range(SHARDS)))
+            session.close()
+            database.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #215

## Summary
- add installed-wheel spawn-based tests for same-root concurrent writers, checkpoints, abrupt child exit, reopen, and retryable schema contention
- publish the supported same-host/local-filesystem process contract for Rust, Python, and the service
- document fork exclusions, lock sidecars, systemd ownership, and all-process offline backup requirements

## Local validation
- cargo fmt --all --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-targets --all-features --quiet
- cargo test --locked --doc --all-features
- cargo package --locked --allow-dirty
- cargo test and Clippy for briskdb-python
- installed-wheel Python suite: 20 tests passed
- spawn multiprocessing suite repeated successfully