### PR TITLE
release: prepare 0.1.0-alpha.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "briskdb"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -258,7 +258,7 @@ dependencies = [
 
 [[package]]
 name = "briskdb-python"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 dependencies = [
  "briskdb",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 
 [package]
 name = "briskdb"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 edition = "2024"
 rust-version = "1.85"
 default-run = "briskdb"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,20 +1,32 @@
-# Changes after 0.1.0-alpha.4
+# BriskDB 0.1.0-alpha.5
 
-- Independent server, Rust, and Python processes may concurrently open one
-  ready data root on the same Linux or macOS host and local filesystem.
-- Schema, catalog, initialization, upgrade, and recovery work requires
-  sole-process ownership and returns retryable `Busy` while a peer is open.
-- Each process must open its own handle. Inherited live handles after `fork()`,
-  network filesystems, multi-host volumes, and online backup remain unsupported.
-- Installed-wheel and Rust subprocess tests cover overlapping writes,
-  checkpoints, generated IDs, abrupt exit, recovery, and service-plus-embedded
-  operation. See `docs/MULTIPROCESS.md`.
+Alpha 5 lets independently started BriskDB server, Rust, and Python processes
+safely share one ready data root on the same machine. It keeps the embedded
+library, Python wheels, HTTP/PostgreSQL server, and Debian service from alpha 4.
+This remains an evaluation and development release, not a production claim.
 
-# BriskDB 0.1.0-alpha.4
+## Multiple processes, one data root
 
-Alpha 4 makes BriskDB usable as an in-process Rust or Python database, while
-keeping the standalone HTTP/PostgreSQL server and Debian service from alpha 3.
-It is intended for local evaluation and development, not production deployment.
+- Reads and autocommit writes may overlap through SQLite WAL, including traffic
+  to the same shard. Normal writer contention can return retryable `Busy`.
+- Native and manifest-leased hi/lo generated IDs remain unique across
+  independently started processes.
+- Passive checkpoints may overlap. A competing checkpoint can report `busy`
+  with unavailable frame counts through the new `counts_available` field.
+- Schema, catalog, generated-table DDL, initialization, upgrade, and recovery
+  require sole-process ownership and return retryable `Busy` before mutation
+  while another process has the root open.
+
+The supported boundary is one Linux or macOS host and one local filesystem.
+Every process must open its own handle after it starts. Inherited live handles
+after `fork()`, NFS/SMB, cloud-synchronized folders, multi-host volumes, object
+storage, and online backup remain unsupported. The exact contract is in
+`docs/MULTIPROCESS.md`.
+
+Rust subprocess tests cover same- and cross-shard traffic, checkpoints,
+generated IDs, forced contention and retry, abrupt writer exit, final SQLite
+integrity, and a service sharing its root with an embedder. Installed-wheel
+tests repeat the public Python contract with spawned interpreters.
 
 ## Install from PyPI
 
@@ -22,7 +34,7 @@ Compiler-free `cp39-abi3` wheels support CPython 3.9 through 3.14 on Linux
 x86-64/ARM64 (`manylinux_2_28`) and macOS Intel/Apple Silicon (macOS 11+):
 
 ```bash
-python -m pip install briskdb==0.1.0a4
+python -m pip install briskdb==0.1.0a5
 ```
 
 ```python
@@ -44,13 +56,13 @@ the engine's native cancellation token.
 
 ## Embedded Rust library
 
-The root crate now separates its listener-free engine from optional HTTP,
+The root crate separates its listener-free engine from optional HTTP,
 PostgreSQL, importer, and CLI layers. Downstream Rust applications can select
 only the embedded API:
 
 ```toml
 [dependencies]
-briskdb = { git = "https://github.com/schapman1974/briskdb", tag = "v0.1.0-alpha.4", default-features = false, features = ["embedded"] }
+briskdb = { git = "https://github.com/schapman1974/briskdb", tag = "v0.1.0-alpha.5", default-features = false, features = ["embedded"] }
 ```
 
 `BriskDb` and owned `BriskSession` handles expose initialization, migrations,
@@ -90,8 +102,9 @@ GitHub build-provenance attestation.
 - General cross-shard transactions are unsupported. Global ordering,
   pagination, and aggregation pushdown are incomplete, and BriskDB does not
   claim full SQL compatibility.
-- Backups require a stopped server and a complete data-directory copy. Online
-  backup/restore, resharding, and online rebalance are unsupported.
+- Backups require every server and embedder to stop first. The supported
+  procedure is a complete data-directory copy. Online backup/restore,
+  resharding, and online rebalance are unsupported.
 - There is no production metrics or observability suite.
 - The Python package does not claim DB-API 2.0 compatibility, transaction
   methods, retained SQLite streaming cursors, or native document operations.
@@ -107,4 +120,4 @@ Before opening existing data, stop every process and make a complete backup as
 described in `docs/OFFLINE_BACKUP.md`. Startup may migrate the data.
 In-place downgrade is unsupported; rollback requires restoring the complete
 pre-upgrade backup. This release has no on-disk format change from alpha 1,
-alpha 2, or alpha 3.
+alpha 2, alpha 3, or alpha 4.

--- a/docs/CRATE_FEATURES.md
+++ b/docs/CRATE_FEATURES.md
@@ -9,7 +9,7 @@ handling dependencies:
 
 ```toml
 [dependencies]
-briskdb = { version = "0.1.0-alpha.4", default-features = false, features = ["embedded"] }
+briskdb = { version = "0.1.0-alpha.5", default-features = false, features = ["embedded"] }
 ```
 
 ## Feature map
@@ -48,7 +48,7 @@ See [Pre-1.0 compatibility](PRE_1_COMPATIBILITY.md) for the versioning policy.
 
 ## Packaging baseline
 
-Measured from the alpha.4 lockfile on macOS ARM64 with Cargo's normal-edge
+Measured from the alpha.5 lockfile on macOS ARM64 with Cargo's normal-edge
 dependency graph:
 
 | Build | Unique packages |

--- a/docs/DEBIAN_INSTALL.md
+++ b/docs/DEBIAN_INSTALL.md
@@ -12,13 +12,13 @@ the checksum before installation, then install the local package:
 
 ```bash
 sha256sum --check SHA256SUMS --ignore-missing
-sudo apt install ./briskdb_0.1.0.alpha.4-1_amd64.deb
+sudo apt install ./briskdb_0.1.0.alpha.5-1_amd64.deb
 ```
 
 Use the `_arm64.deb` package on 64-bit ARM. `apt` resolves the package's runtime
 dependencies and enables and starts `briskdb.service` during installation.
 The filename uses a GitHub-safe dot, while package metadata uses the Debian
-prerelease version `0.1.0~alpha.4-1` so it sorts before the final release.
+prerelease version `0.1.0~alpha.5-1` so it sorts before the final release.
 
 ## Filesystem contract
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.1.0-alpha.5 — 2026-08-14
+
 - Added installed-wheel `spawn` multiprocessing coverage for concurrent
   same-root writes, checkpoints, abrupt child exit, reopen, and retryable schema
   ownership contention.

--- a/python/COMPATIBILITY.md
+++ b/python/COMPATIBILITY.md
@@ -17,7 +17,7 @@ separately and requires Rust 1.85 or newer.
 
 The `briskdb-python` crate version must exactly equal the root `briskdb` Rust
 crate version. Python metadata and `briskdb.__version__` use the equivalent PEP
-440 spelling (`0.1.0-alpha.4` becomes `0.1.0a4`). Release automation rejects a
+440 spelling (`0.1.0-alpha.5` becomes `0.1.0a5`). Release automation rejects a
 tag or artifact when those versions are not equivalent. A Python alpha package
 supports only its exact bundled Rust engine; mixing an extension and core from
 different releases is unsupported.

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "briskdb-python"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 edition = "2024"
 rust-version = "1.85"
 description = "Native Python bindings for embedded BriskDB"

--- a/python/PUBLISHING.md
+++ b/python/PUBLISHING.md
@@ -26,7 +26,7 @@ Verify a downloaded artifact with:
 
 ```bash
 sha256sum --check SHA256SUMS
-gh attestation verify briskdb-0.1.0a4-*.whl --repo schapman1974/briskdb
+gh attestation verify briskdb-0.1.0a5-*.whl --repo schapman1974/briskdb
 ```
 
 Do not reuse or move a release tag. Update both Cargo package versions and the

--- a/tests/debian_packaging.rs
+++ b/tests/debian_packaging.rs
@@ -44,7 +44,7 @@ fn cargo_versions_convert_to_debian_versions_without_shell_tilde_expansion() {
         env!("CARGO_MANIFEST_DIR")
     );
 
-    for (cargo_version, expected) in [("0.1.0-alpha.4", "0.1.0~alpha.4-1"), ("0.1.0", "0.1.0-1")] {
+    for (cargo_version, expected) in [("0.1.0-alpha.5", "0.1.0~alpha.5-1"), ("0.1.0", "0.1.0-1")] {
         let output = Command::new(&builder)
             .args(["--print-debian-version", cargo_version])
             .output()
@@ -54,13 +54,13 @@ fn cargo_versions_convert_to_debian_versions_without_shell_tilde_expansion() {
     }
 
     let output = Command::new(&builder)
-        .args(["--print-package-filename", "0.1.0-alpha.4"])
+        .args(["--print-package-filename", "0.1.0-alpha.5"])
         .output()
         .expect("package builder must print its external filename");
     assert!(output.status.success());
     assert_eq!(
         String::from_utf8(output.stdout).unwrap().trim(),
-        "briskdb_0.1.0.alpha.4-1_ARCH.deb"
+        "briskdb_0.1.0.alpha.5-1_ARCH.deb"
     );
 }
 

--- a/tests/release_packaging.rs
+++ b/tests/release_packaging.rs
@@ -1,6 +1,6 @@
 #[test]
 fn alpha_release_contract_covers_every_native_archive_and_safety_boundary() {
-    assert_eq!(env!("CARGO_PKG_VERSION"), "0.1.0-alpha.4");
+    assert_eq!(env!("CARGO_PKG_VERSION"), "0.1.0-alpha.5");
 
     let workflow = include_str!("../.github/workflows/release.yml");
     for required in [


### PR DESCRIPTION
## Summary

- bump the Rust core and Python extension to 0.1.0-alpha.5
- publish the same-host shared-root process contract and its safety boundaries as the alpha 5 headline
- update Python, Rust, Debian, packaging-test, and artifact-verification version references

## User impact

Alpha 5 allows independently started server, Rust, and Python processes on one host and local filesystem to share a ready data root. Metadata mutations still require sole-process ownership; inherited fork handles, network filesystems, multi-host storage, and online backup remain unsupported.

## Local validation

- full 925-test Rust suite plus all integration targets
- full Clippy and Rust doc tests
- Cargo and Debian release packaging contracts
- cargo package verification
- Python native crate tests and strict typing contract
- built and inspected the alpha 5 macOS ARM64 abi3 wheel and sdist
- installed the alpha 5 wheel into a fresh Python 3.13 environment; all 20 Python tests passed

After this PR and the branch release-build workflow are green, the matching v0.1.0-alpha.5 tag will publish the GitHub prerelease and PyPI distributions.