### PR TITLE
Detect stored shard counts for embedded opens

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,8 @@ macOS/Linux ARM64 and x86-64 archives plus Linux `.deb` packages.
 
 Embedding in Rust starts with `BriskDb::open()` or the validated builder. The
 [embedded Rust guide](docs/EMBEDDED_RUST.md) includes a complete listener-free
-example and documents every default. Use `default-features = false` with the
+example. Choose a shard count when creating data; later opens detect it from
+the manifest and reject explicit mismatches. Use `default-features = false` with the
 `embedded` feature to leave the network and CLI stacks out; see the
 [crate feature map](docs/CRATE_FEATURES.md).
 

--- a/docs/EMBEDDED_RUST.md
+++ b/docs/EMBEDDED_RUST.md
@@ -50,11 +50,16 @@ Run the complete example with:
 cargo run --example embedded -- ./briskdb-embedded-example
 ```
 
+Creating a database requires `.with_shard_count(...)`. After that,
+`BriskDb::open(path)` detects the immutable count from the manifest. Supplying
+a different explicit count fails with `FailedPrecondition` instead of opening
+the data under the wrong layout.
+
 ## Defaults
 
 | Setting | Default |
 | --- | ---: |
-| Physical shards | 4 |
+| Physical shards | Detected when opening; explicit when creating |
 | Active SQLite connections per shard | 4 |
 | Queued operations per shard | 32 |
 | Result rows | 10,000 |
@@ -65,8 +70,9 @@ cargo run --example embedded -- ./briskdb-embedded-example
 | Native document support | Disabled |
 
 Use `EngineOptions`, `ResultLimits`, and `PreparedStatementLimits` to replace
-resource defaults. The builder validates the complete shard/runtime/document
-configuration before opening or creating storage.
+resource defaults. Explicit shard counts are validated before storage is
+created; count-dependent limits are validated after an existing manifest is
+detected.
 
 ## Lifecycle and errors
 

--- a/python/API.md
+++ b/python/API.md
@@ -13,6 +13,11 @@ files; the signatures below are the compact API map.
 - `Config(...)` validates shard, pool, queue, result, prepared-object,
   deadline, and shutdown limits before opening storage.
 
+`shards` is required to create storage and optional when reopening it. An
+omitted count is read from the validated manifest; an explicit mismatch raises
+`FailedPreconditionError`. `Database.shard_count` and `Database.config.shards`
+always report the resolved count.
+
 ## Database and session
 
 `Database` exposes `session()`, `checkpoint()`, `close()`, state/config

--- a/python/README.md
+++ b/python/README.md
@@ -28,6 +28,11 @@ session.close()
 db.close()
 ```
 
+Pass `shards` when creating a data directory. Later calls may omit it and use
+the count stored in the manifest. Passing the wrong count raises
+`FailedPreconditionError`; omitting it for new/empty storage asks you to choose
+one without creating files.
+
 Resource limits can be validated before the database opens:
 
 ```python
@@ -50,7 +55,7 @@ Synchronous handles support `with`; the asyncio facade keeps engine work off
 the event loop and propagates task cancellation into Rust:
 
 ```python
-async with await briskdb.open_async("./data", shards=4) as db:
+async with await briskdb.open_async("./data") as db:
     async with await db.session(routing_key="account-1") as session:
         rows = await session.query("SELECT body FROM notes WHERE id = ?1", [1])
 ```

--- a/python/python/briskdb/_briskdb.pyi
+++ b/python/python/briskdb/_briskdb.pyi
@@ -84,7 +84,7 @@ class DataCorruptionError(OperationalError): ...
 class InternalError(OperationalError): ...
 
 class Config:
-    shards: int
+    shards: Optional[int]
     connections_per_shard: int
     queue_capacity_per_shard: int
     max_result_rows: int
@@ -97,7 +97,7 @@ class Config:
     def __init__(
         self,
         *,
-        shards: int = ...,
+        shards: Optional[int] = ...,
         connections_per_shard: int = ...,
         queue_capacity_per_shard: int = ...,
         max_result_rows: int = ...,

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -60,7 +60,7 @@ impl Drop for DatabaseShared {
 #[pyclass(module = "briskdb._briskdb", frozen, get_all, skip_from_py_object)]
 #[derive(Clone, Debug)]
 struct Config {
-    shards: u16,
+    shards: Option<u16>,
     connections_per_shard: usize,
     queue_capacity_per_shard: usize,
     max_result_rows: u64,
@@ -75,7 +75,7 @@ struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            shards: briskdb::DEFAULT_EMBEDDED_SHARDS,
+            shards: None,
             connections_per_shard: briskdb::core::DEFAULT_CONNECTIONS_PER_SHARD,
             queue_capacity_per_shard: briskdb::core::DEFAULT_QUEUE_CAPACITY_PER_SHARD,
             max_result_rows: briskdb::core::DEFAULT_MAX_RESULT_ROWS,
@@ -106,7 +106,9 @@ impl Config {
                 .with_prepared_statement_limits(prepared_statement_limits)
                 .with_request_timeout(request_timeout)?
                 .with_shutdown_grace(Duration::from_millis(self.shutdown_grace_ms))?;
-        options.validate_for_shards(self.shards)?;
+        if let Some(shards) = self.shards {
+            options.validate_for_shards(shards)?;
+        }
         Ok(options)
     }
 }
@@ -116,7 +118,7 @@ impl Config {
     #[new]
     #[pyo3(signature = (
         *,
-        shards = briskdb::DEFAULT_EMBEDDED_SHARDS,
+        shards = None,
         connections_per_shard = briskdb::core::DEFAULT_CONNECTIONS_PER_SHARD,
         queue_capacity_per_shard = briskdb::core::DEFAULT_QUEUE_CAPACITY_PER_SHARD,
         max_result_rows = briskdb::core::DEFAULT_MAX_RESULT_ROWS,
@@ -129,7 +131,7 @@ impl Config {
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
-        shards: u16,
+        shards: Option<u16>,
         connections_per_shard: usize,
         queue_capacity_per_shard: usize,
         max_result_rows: u64,
@@ -157,9 +159,12 @@ impl Config {
     }
 
     fn __repr__(&self) -> String {
+        let shards = self
+            .shards
+            .map_or_else(|| "None".to_owned(), |shards| shards.to_string());
         format!(
-            "Config(shards={}, connections_per_shard={}, queue_capacity_per_shard={})",
-            self.shards, self.connections_per_shard, self.queue_capacity_per_shard
+            "Config(shards={shards}, connections_per_shard={}, queue_capacity_per_shard={})",
+            self.connections_per_shard, self.queue_capacity_per_shard
         )
     }
 }
@@ -372,12 +377,14 @@ impl Database {
                 .thread_name("briskdb-python")
                 .build()
                 .map_err(|error| NativeError::Runtime(error.to_string()))?;
-            let database = runtime.block_on(
-                BriskDb::builder(&root)
-                    .with_shard_count(config.shards)
-                    .with_engine_options(engine_options)
-                    .open(),
-            )?;
+            let builder = BriskDb::builder(&root).with_engine_options(engine_options);
+            let builder = match config.shards {
+                Some(shards) => builder.with_shard_count(shards),
+                None => builder,
+            };
+            let database = runtime.block_on(builder.open())?;
+            let mut config = config;
+            config.shards = Some(database.shard_count());
             let runtime = Arc::new(RuntimeOwner { runtime });
             Ok(Self {
                 shared: Arc::new(DatabaseShared {
@@ -412,7 +419,10 @@ impl Database {
 
     #[getter]
     fn shard_count(&self) -> u16 {
-        self.shared.config.shards
+        self.shared
+            .config
+            .shards
+            .expect("an opened database always has a resolved shard count")
     }
 
     #[getter]
@@ -500,7 +510,7 @@ impl Database {
         Ok(format!(
             "Database(path={:?}, shards={}, state={:?})",
             self.shared.root,
-            self.shared.config.shards,
+            self.shard_count(),
             self.state()?
         ))
     }
@@ -777,7 +787,7 @@ fn resolve_config(shards: Option<u16>, config: Option<&Config>) -> PyResult<Conf
         )),
         (Some(shards), None) => {
             let config = Config {
-                shards,
+                shards: Some(shards),
                 ..Config::default()
             };
             config.engine_options()?;

--- a/python/tests/test_api.py
+++ b/python/tests/test_api.py
@@ -109,6 +109,8 @@ class AsyncApiTests(unittest.IsolatedAsyncioTestCase):
 
                 self.assertTrue(session.closed)
             self.assertTrue(database.closed)
+            async with await briskdb.open_async(data_dir) as reopened:
+                self.assertEqual(reopened.shard_count, 2)
 
     async def test_async_queries_do_not_block_the_event_loop(self) -> None:
         with tempfile.TemporaryDirectory() as data_dir:

--- a/python/tests/test_embedded.py
+++ b/python/tests/test_embedded.py
@@ -49,6 +49,38 @@ class EmbeddedBriskDbTests(unittest.TestCase):
             ):
                 briskdb.Config(max_result_rows=0)
 
+    def test_shard_count_is_required_for_creation_and_detected_for_reopen(self) -> None:
+        with tempfile.TemporaryDirectory() as parent:
+            missing = Path(parent) / "missing"
+            with self.assertRaisesRegex(
+                briskdb.FailedPreconditionError, "set a shard count to create it"
+            ):
+                briskdb.open(missing)
+            self.assertFalse(missing.exists())
+
+            empty = Path(parent) / "empty"
+            empty.mkdir()
+            with self.assertRaisesRegex(
+                briskdb.FailedPreconditionError, "set a shard count to create it"
+            ):
+                briskdb.open(empty)
+            self.assertEqual(list(empty.iterdir()), [])
+
+            data_dir = Path(parent) / "data"
+            briskdb.open(data_dir, shards=6).close()
+            with self.assertRaisesRegex(
+                briskdb.FailedPreconditionError,
+                "database was created with 6 shards, but 4 were requested",
+            ):
+                briskdb.open(data_dir, shards=4)
+
+            config = briskdb.Config(connections_per_shard=1)
+            self.assertIsNone(config.shards)
+            reopened = briskdb.open(data_dir, config=config)
+            self.assertEqual(reopened.shard_count, 6)
+            self.assertEqual(reopened.config.shards, 6)
+            reopened.close()
+
     def test_basic_write_read_checkpoint_close_and_restart(self) -> None:
         with tempfile.TemporaryDirectory() as data_dir:
             database = briskdb.open(data_dir, shards=2)
@@ -296,7 +328,7 @@ session.query("SELECT 1")
             manifest = Path(data_dir) / "manifest.sqlite"
             manifest.write_bytes(b"not a SQLite database")
             with self.assertRaises(briskdb.DataCorruptionError) as raised:
-                briskdb.open(data_dir, shards=2)
+                briskdb.open(data_dir)
             self.assertEqual(raised.exception.code, "data_corruption")
 
 

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -394,6 +394,30 @@ impl Engine {
         Self::from_parts(Arc::new(database), options, workers)
     }
 
+    /// Detect an initialized database's immutable shard count and open it.
+    ///
+    /// Detection runs on a blocking worker and does not create a missing data
+    /// directory or manifest. The normal open validates the same count again
+    /// before establishing pools, closing replacement races safely.
+    pub async fn open_detected_with_options(
+        root: impl AsRef<Path>,
+        options: EngineOptions,
+    ) -> EngineResult<Self> {
+        let root = PathBuf::from(root.as_ref());
+        let detect_root = root.clone();
+        let requested_shards =
+            tokio::task::spawn_blocking(move || Database::detect_shard_count(detect_root))
+                .await
+                .map_err(|error| {
+                    EngineError::from_source(
+                        EngineErrorKind::Internal,
+                        "shard-count discovery worker failed",
+                        error,
+                    )
+                })??;
+        Self::open_with_options(root, requested_shards, options).await
+    }
+
     /// Wrap the synchronous compatibility API in the shared async boundary.
     pub fn from_database(database: Arc<Database>) -> Self {
         Self::from_database_with_options(database, EngineOptions::default())

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -173,6 +173,12 @@ impl Database {
         })
     }
 
+    /// Detect the immutable shard count from an initialized data directory
+    /// without creating or upgrading storage.
+    pub fn detect_shard_count(root: impl AsRef<Path>) -> EngineResult<u16> {
+        crate::storage::detect_shard_count(root)
+    }
+
     pub fn shard_count(&self) -> u16 {
         self.storage.shard_count()
     }

--- a/src/embedded.rs
+++ b/src/embedded.rs
@@ -19,7 +19,10 @@ use crate::core::{
 };
 use crate::{EngineError, EngineErrorKind};
 
-/// Default number of physical shards created by the embedded convenience API.
+/// Recommended number of physical shards for small embedded deployments.
+///
+/// New databases still require callers to select a count explicitly; this
+/// constant is retained as a convenient documented choice.
 pub const DEFAULT_EMBEDDED_SHARDS: u16 = 4;
 
 /// Tokio runtime ownership selected for an embedded database.
@@ -57,18 +60,19 @@ pub enum DocumentSupport {
 #[must_use = "a builder must be opened to create a BriskDB instance"]
 pub struct BriskDbBuilder {
     root: PathBuf,
-    shard_count: u16,
+    shard_count: Option<u16>,
     engine_options: EngineOptions,
     runtime_behavior: RuntimeBehavior,
     document_support: DocumentSupport,
 }
 
 impl BriskDbBuilder {
-    /// Create a builder with documented embedded defaults.
+    /// Create a builder that detects existing storage and uses documented
+    /// resource defaults.
     pub fn new(root: impl Into<PathBuf>) -> Self {
         Self {
             root: root.into(),
-            shard_count: DEFAULT_EMBEDDED_SHARDS,
+            shard_count: None,
             engine_options: EngineOptions::default(),
             runtime_behavior: RuntimeBehavior::default(),
             document_support: DocumentSupport::default(),
@@ -80,14 +84,14 @@ impl BriskDbBuilder {
         &self.root
     }
 
-    /// Return the configured physical shard count.
-    pub const fn shard_count(&self) -> u16 {
+    /// Return the requested count, or `None` when existing data will decide.
+    pub const fn shard_count(&self) -> Option<u16> {
         self.shard_count
     }
 
     /// Set the fixed physical shard count used for a new database.
     pub const fn with_shard_count(mut self, shard_count: u16) -> Self {
-        self.shard_count = shard_count;
+        self.shard_count = Some(shard_count);
         self
     }
 
@@ -132,7 +136,9 @@ impl BriskDbBuilder {
                 "the embedded data-directory path must not be empty",
             ));
         }
-        self.engine_options.validate_for_shards(self.shard_count)?;
+        if let Some(shard_count) = self.shard_count {
+            self.engine_options.validate_for_shards(shard_count)?;
+        }
         if self.runtime_behavior != RuntimeBehavior::CallerManaged {
             return Err(EngineError::new(
                 EngineErrorKind::Unsupported,
@@ -151,8 +157,12 @@ impl BriskDbBuilder {
     /// Validate and open one embedded database on the caller's Tokio runtime.
     pub async fn open(self) -> EngineResult<BriskDb> {
         self.validate()?;
-        let engine =
-            Engine::open_with_options(&self.root, self.shard_count, self.engine_options).await?;
+        let engine = match self.shard_count {
+            Some(shard_count) => {
+                Engine::open_with_options(&self.root, shard_count, self.engine_options).await?
+            }
+            None => Engine::open_detected_with_options(&self.root, self.engine_options).await?,
+        };
         Ok(BriskDb {
             engine,
             root: self.root,
@@ -203,7 +213,7 @@ impl BriskDb {
         BriskDbBuilder::new(root)
     }
 
-    /// Open one database with the documented embedded defaults.
+    /// Open an initialized database by detecting its physical shard count.
     pub async fn open(root: impl Into<PathBuf>) -> EngineResult<Self> {
         Self::builder(root).open().await
     }

--- a/src/storage/manifest.rs
+++ b/src/storage/manifest.rs
@@ -8599,6 +8599,13 @@ fn validate_manifest_configuration(
     connection: &Connection,
     requested_shards: u16,
 ) -> EngineResult<u16> {
+    let shard_count = read_manifest_shard_count(connection)?;
+    ensure_requested_shards(shard_count, requested_shards)?;
+
+    Ok(shard_count)
+}
+
+fn read_manifest_shard_count(connection: &Connection) -> EngineResult<u16> {
     let mut config_statement = connection
         .prepare("SELECT singleton, shard_count FROM briskdb_manifest ORDER BY singleton LIMIT 3")
         .map_err(|error| manifest_read_error(error, "failed to read manifest configuration"))?;
@@ -8621,9 +8628,71 @@ fn validate_manifest_configuration(
         )
     })?;
     validate_shard_range(shard_count)?;
-    ensure_requested_shards(shard_count, requested_shards)?;
-
     Ok(shard_count)
+}
+
+/// Read and validate the immutable shard count without upgrading storage.
+///
+/// This is the discovery half of an embedded open with no requested count.
+/// The normal startup path validates the manifest again after discovery, so a
+/// concurrently replaced or damaged manifest still fails closed.
+pub(super) fn detect_shard_count(connection: &Connection) -> EngineResult<u16> {
+    let (application_id, version) = read_identity(connection)?;
+    let candidate = if application_id == MANIFEST_APPLICATION_ID {
+        if version > i64::from(CURRENT_SCHEMA_VERSION) {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "manifest schema version {version} is newer than this BriskDB build supports ({CURRENT_SCHEMA_VERSION})"
+                ),
+            ));
+        }
+        read_manifest_shard_count(connection)?
+    } else if application_id == 0 {
+        let objects = schema_objects(connection)?;
+        if version == 0 && objects.is_empty() {
+            return Err(shard_count_required());
+        }
+        if (version == 0 || version == i64::from(LEGACY_SCHEMA_VERSION))
+            && objects == legacy_objects()
+        {
+            match read_legacy_metadata(connection)? {
+                LegacyMetadata::Initialized { shard_count } => shard_count,
+                LegacyMetadata::Empty => return Err(shard_count_required()),
+            }
+        } else if objects
+            .iter()
+            .any(|object| object.name.starts_with("briskdb_"))
+        {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "manifest identity and BriskDB schema objects are inconsistent",
+            ));
+        } else {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "manifest.sqlite is not an empty or recognized BriskDB manifest",
+            ));
+        }
+    } else {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!("manifest.sqlite has foreign application identifier {application_id:#010x}"),
+        ));
+    };
+
+    match inspect_with_plan(connection, candidate, CURRENT_PLAN)? {
+        ManifestState::LegacyV1 { shard_count } => Ok(shard_count),
+        ManifestState::Versioned { snapshot, .. } => Ok(snapshot.shard_count),
+        ManifestState::Empty | ManifestState::LegacyUninitialized => Err(shard_count_required()),
+    }
+}
+
+fn shard_count_required() -> EngineError {
+    EngineError::new(
+        EngineErrorKind::FailedPrecondition,
+        "data directory has no initialized BriskDB manifest; set a shard count to create it",
+    )
 }
 
 fn validate_downgrade_fence(connection: &Connection, expected_version: u32) -> EngineResult<()> {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -2041,6 +2041,62 @@ impl Storage {
     }
 }
 
+/// Detect the immutable physical shard count without creating or upgrading
+/// any database files.
+pub(crate) fn detect_shard_count(root: impl AsRef<Path>) -> EngineResult<u16> {
+    let root = root.as_ref();
+    let metadata = fs::symlink_metadata(root).map_err(|error| {
+        if error.kind() == std::io::ErrorKind::NotFound {
+            EngineError::from_source(
+                EngineErrorKind::FailedPrecondition,
+                "data directory has no initialized BriskDB manifest; set a shard count to create it",
+                error,
+            )
+        } else {
+            sqlite_error::storage_io(error, format!("failed to inspect {}", root.display()))
+        }
+    })?;
+    if !metadata.is_dir() && !metadata.file_type().is_symlink() {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!("data path {} is not a directory", root.display()),
+        ));
+    }
+    let root = fs::canonicalize(root).map_err(|error| {
+        sqlite_error::storage_io(error, format!("failed to resolve {}", root.display()))
+    })?;
+    if !fs::metadata(&root)
+        .map_err(|error| {
+            sqlite_error::storage_io(error, format!("failed to inspect {}", root.display()))
+        })?
+        .is_dir()
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!("data path {} is not a directory", root.display()),
+        ));
+    }
+    let manifest_path = root.join("manifest.sqlite");
+    match fs::symlink_metadata(&manifest_path) {
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "data directory has no initialized BriskDB manifest; set a shard count to create it",
+            ));
+        }
+        Err(error) => {
+            return Err(sqlite_error::storage_io(
+                error,
+                format!("failed to inspect {}", manifest_path.display()),
+            ));
+        }
+    }
+    let connection = open_existing_manifest_read_only(&manifest_path)?;
+    configure_manifest_connection(&connection)?;
+    manifest::detect_shard_count(&connection)
+}
+
 fn declarations_match_catalog(catalog: &Catalog, declarations: &[TableDeclaration]) -> bool {
     if catalog.tables().len() != declarations.len() {
         return false;
@@ -2539,6 +2595,20 @@ pub(super) fn open_existing_manifest(path: &Path) -> EngineResult<Connection> {
     let open_path = canonical_manifest_open_path(path)?;
     let connection = Connection::open_with_flags(open_path, flags).map_err(|error| {
         sqlite_error::storage(error).context(format!("failed to open {}", path.display()))
+    })?;
+    validate_existing_manifest_file(path)?;
+    Ok(connection)
+}
+
+fn open_existing_manifest_read_only(path: &Path) -> EngineResult<Connection> {
+    validate_existing_manifest_file(path)?;
+    let flags = OpenFlags::SQLITE_OPEN_READ_ONLY
+        | OpenFlags::SQLITE_OPEN_NO_MUTEX
+        | OpenFlags::SQLITE_OPEN_NOFOLLOW
+        | OpenFlags::SQLITE_OPEN_EXRESCODE;
+    let open_path = canonical_manifest_open_path(path)?;
+    let connection = Connection::open_with_flags(open_path, flags).map_err(|error| {
+        sqlite_error::storage(error).context(format!("failed to open {} read-only", path.display()))
     })?;
     validate_existing_manifest_file(path)?;
     Ok(connection)

--- a/tests/embedded_api.rs
+++ b/tests/embedded_api.rs
@@ -1,9 +1,10 @@
 use std::{path::PathBuf, time::Duration};
 
 use briskdb::{
-    BriskDb, BriskDbBuilder, DEFAULT_EMBEDDED_SHARDS, DocumentSupport, EngineErrorKind,
-    EngineOptions, EngineState, RuntimeBehavior, Statement, Value,
+    BriskDb, BriskDbBuilder, DocumentSupport, EngineErrorKind, EngineOptions, EngineState,
+    RuntimeBehavior, Statement, Value,
 };
+use rusqlite::Connection;
 
 fn assert_send_sync_static<T: Send + Sync + 'static>() {}
 
@@ -48,16 +49,118 @@ async fn note_body(db: &BriskDb, route: &str) -> String {
 }
 
 #[test]
-fn builder_defaults_are_public_deterministic_and_host_safe() {
+fn builder_defaults_detect_existing_storage_and_are_host_safe() {
     assert_send_sync_static::<BriskDb>();
     assert_send_sync_static::<BriskDbBuilder>();
 
     let builder = BriskDb::builder("data");
     assert_eq!(builder.root(), PathBuf::from("data"));
-    assert_eq!(builder.shard_count(), DEFAULT_EMBEDDED_SHARDS);
+    assert_eq!(builder.shard_count(), None);
     assert_eq!(builder.engine_options(), EngineOptions::default());
     assert_eq!(builder.runtime_behavior(), RuntimeBehavior::CallerManaged);
     assert_eq!(builder.document_support(), DocumentSupport::Disabled);
+}
+
+#[tokio::test]
+async fn omitted_shards_require_initialized_storage_without_creating_files() {
+    let parent = tempfile::tempdir().unwrap();
+    let missing = parent.path().join("missing");
+    let error = BriskDb::open(&missing).await.unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+    assert!(error.to_string().contains("set a shard count to create it"));
+    assert!(!missing.exists());
+
+    let empty = parent.path().join("empty");
+    std::fs::create_dir(&empty).unwrap();
+    let error = BriskDb::open(&empty).await.unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+    assert_eq!(std::fs::read_dir(&empty).unwrap().count(), 0);
+}
+
+#[tokio::test]
+async fn omitted_shards_detect_existing_data_and_explicit_mismatch_is_stable() {
+    let temp = tempfile::tempdir().unwrap();
+    let created = BriskDb::builder(temp.path())
+        .with_shard_count(6)
+        .open()
+        .await
+        .unwrap();
+    created.close().await.unwrap();
+
+    let mismatch = BriskDb::builder(temp.path())
+        .with_shard_count(4)
+        .open()
+        .await
+        .unwrap_err();
+    assert_eq!(mismatch.kind(), EngineErrorKind::FailedPrecondition);
+    assert_eq!(
+        mismatch.to_string(),
+        "database was created with 6 shards, but 4 were requested"
+    );
+
+    let detected = BriskDb::open(temp.path()).await.unwrap();
+    assert_eq!(detected.shard_count(), 6);
+    detected.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn detected_shards_validate_count_dependent_resource_limits() {
+    let temp = tempfile::tempdir().unwrap();
+    BriskDb::builder(temp.path())
+        .with_shard_count(33)
+        .open()
+        .await
+        .unwrap()
+        .close()
+        .await
+        .unwrap();
+
+    let options = EngineOptions::new(16, 1).unwrap();
+    let error = BriskDb::builder(temp.path())
+        .with_engine_options(options)
+        .open()
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::InvalidArgument);
+    assert!(error.to_string().contains("512 total active connections"));
+}
+
+#[tokio::test]
+async fn shard_detection_fails_closed_for_corrupt_foreign_and_newer_manifests() {
+    let parent = tempfile::tempdir().unwrap();
+
+    let corrupt = parent.path().join("corrupt");
+    std::fs::create_dir(&corrupt).unwrap();
+    let corrupt_manifest = corrupt.join("manifest.sqlite");
+    let corrupt_bytes = b"not a SQLite database";
+    std::fs::write(&corrupt_manifest, corrupt_bytes).unwrap();
+    let error = BriskDb::open(&corrupt).await.unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+    assert_eq!(std::fs::read(&corrupt_manifest).unwrap(), corrupt_bytes);
+    assert_eq!(std::fs::read_dir(&corrupt).unwrap().count(), 1);
+
+    let foreign = parent.path().join("foreign");
+    std::fs::create_dir(&foreign).unwrap();
+    Connection::open(foreign.join("manifest.sqlite"))
+        .unwrap()
+        .execute_batch("CREATE TABLE application_data (value TEXT)")
+        .unwrap();
+    let error = BriskDb::open(&foreign).await.unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+    assert!(error.to_string().contains("not an empty or recognized"));
+
+    let newer = parent.path().join("newer");
+    std::fs::create_dir(&newer).unwrap();
+    Connection::open(newer.join("manifest.sqlite"))
+        .unwrap()
+        .execute_batch(
+            "PRAGMA application_id = 1112687682;
+             PRAGMA user_version = 999;",
+        )
+        .unwrap();
+    let error = BriskDb::open(&newer).await.unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+    assert!(error.to_string().contains("newer than this BriskDB build"));
 }
 
 #[tokio::test]
@@ -141,11 +244,7 @@ async fn embedded_handle_opens_writes_queries_reports_status_closes_and_reopens(
     assert_eq!(db.state(), EngineState::Stopped);
     db.close().await.unwrap();
 
-    let reopened = BriskDb::builder(temp.path())
-        .with_shard_count(2)
-        .open()
-        .await
-        .unwrap();
+    let reopened = BriskDb::open(temp.path()).await.unwrap();
     assert_eq!(note_body(&reopened, "account-1").await, "persistent");
     reopened.close().await.unwrap();
 }


### PR DESCRIPTION
## Summary

- detect the immutable shard count from an existing validated manifest when Rust or Python callers omit it
- require an explicit count for new/empty storage without creating files on failure
- preserve stable explicit mismatch errors and resolve Python `Config.shards` after open
- fail closed for corrupt, foreign, incomplete, and newer manifests using read-only discovery

## Testing

- `cargo test --locked --all-targets --all-features`
- `cargo test --locked --doc --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo package --locked --allow-dirty`
- built and installed the local macOS arm64 abi3 wheel; all 21 Python tests pass
- `mypy --strict --python-version 3.9 python/tests/typing_contract.py`

Fixes #221