### PR TITLE
PostgreSQL: implement the extended query lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ experimental and opt-in; the exact contract lives in
 | Durable virtual-bucket routing over independent SQLite WAL files | Working |
 | Exact-key routing and bounded scatter/gather reads | Working |
 | HTTP query/write API and admin data browser | Working, loopback-only |
-| PostgreSQL wire protocol | Simple `SELECT`/`INSERT`/`UPDATE`/`DELETE` |
+| PostgreSQL wire protocol | Simple and zero-parameter prepared `SELECT`/`INSERT`/`UPDATE`/`DELETE` |
 | Offline import from a standard SQLite database | Working |
 | Native-range and hi/lo generated IDs | Experimental, opt-in |
 | Ubuntu/macOS x86-64 and ARM64 release artifacts | Published |
@@ -133,7 +133,8 @@ Then open the [data browser](http://127.0.0.1:7654/admin) or check the server:
 curl http://127.0.0.1:7654/health
 ```
 
-Enable the current PostgreSQL simple-query listener explicitly:
+Enable the PostgreSQL listener explicitly. Simple queries and zero-parameter
+text-format prepared queries share the same bounded engine path:
 
 ```bash
 cargo run --release -- --postgres-listen 127.0.0.1:5433
@@ -201,8 +202,8 @@ and integrity metadata. Application rows stay in ordinary SQLite files.
 
 - **MongoDB:** a native Rust Mongo listener with BSON, queries, updates,
   indexes, cursors, aggregation, and differential TinyMongo parity.
-- **More wire protocols:** PostgreSQL extended queries and MySQL compatibility,
-  all sharing the same engine behavior.
+- **More wire protocols:** broader PostgreSQL client compatibility and a MySQL
+  listener, all sharing the same engine behavior.
 - **Serverless storage:** atomic snapshots, object-store adapters, and fenced
   single-writer operation beyond today's embedded warm-handler pattern.
 - **Future storage adapters:** SQLite is the first backend, while the engine

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -247,7 +247,7 @@ the engine regardless of its eventual wire protocol.
 - [x] Support protocol 3.0 startup, exact logical database/user selection,
   BriskDB-owned parameter status, clean termination and session cleanup, and
   useful `<package-version>-briskdb` server identification on loopback.
-- [ ] Support simple query flow and extended Parse/Bind/Describe/Execute/Sync,
+- [x] Support simple query flow and extended Parse/Bind/Describe/Execute/Sync,
   including named and unnamed statements/portals, Flush/Close, protocol error
   resynchronization, and portal suspension.
 - [ ] Negotiate explicitly supported newer protocol minor versions from the

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,7 +34,7 @@ server ---------> protocol::http
 | `import` | Offline source-schema preflight, explicit placement and generated-ID plan validation, exact-value row routing into private staging, independent verification, durable receipt creation, and atomic publication | Network handlers, live/incremental migration, generated-ID inference, implicit Global placement, or protocol-specific behavior |
 | `sql` | Dialect-explicit SQL syntax parsing, recursive common-subset validation, protocol-neutral statement/batch classification, source-preserving placeholder normalization, explicit strict/compatibility translation, catalog-aware typed shard-key inference, and narrow crate-private DML-shape inspection behind BriskDB-owned boundaries; exact source retention; SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, key hashing or shard selection, mutable session state, physical write-routing policy, filesystem layout, protocol responses, protocol-buffer ownership, or protocol-specific support policy |
 | `protocol::http` | Existing HTTP request extraction, shared JSON/BriskDB value and RFC 9457 problem-detail encoding, and the embedded admin shell/assets, temporary browser sessions, metadata-driven logical discovery, exact logical counts, and bounded shard-major page handlers | BLAKE3 routing, shard files, direct SQLite access, or rusqlite calls |
-| `protocol::postgres` | BriskDB-owned bounded protocol-3.0 framing, finite parameter validation, selected identity/status, per-connection core-session ownership, query-deferral responses, and private compile/query-parser seam around the exactly pinned `pgwire` library | Listener binding, direct SQLite access, routing, unbounded authoritative prepared state, or public dependency-owned types |
+| `protocol::postgres` | BriskDB-owned bounded protocol-3.0 framing, selected identity/status, per-connection core-session ownership, simple query execution, bounded zero-parameter extended lifecycle, fixed error recovery, and private compile/query-parser seam around exactly pinned `pgwire` | Listener binding, direct SQLite access, routing, unbounded authoritative prepared state, or public dependency-owned types |
 | `protocol::error` | Exhaustive HTTP, PostgreSQL, and MySQL mappings from stable engine error kinds | SQLite errors, routing decisions, or wire-protocol session state |
 | `server` | Process configuration, database assembly, loopback validation, separate HTTP/PostgreSQL listener binding, finite connection-task supervision, and shared graceful/forced draining | SQL parsing, PostgreSQL wire framing, or storage implementation details |
 
@@ -111,14 +111,15 @@ startup order.
 Issue #29 selects exact `pgwire` 0.36.3 with only `server-api` and adds the
 BriskDB-owned `protocol::postgres::{Adapter, Connection}` seam. Issue #30
 connects the production loopback listener to that adapter for exact protocol
-3.0 startup. Parameter validation, logical database/user selection, fixed
-status/error frames, and terminal session cleanup stay in
+3.0 startup. Issue #31 adds bounded named and unnamed prepared statements and
+portals, zero-parameter text-format Describe/Execute, suspension without
+re-execution, cascading Close, Flush, and Sync recovery. Parameter validation,
+logical database/user selection, fixed status/error frames, and terminal session cleanup stay in
 `protocol::postgres`; socket binding, the 256-task cap, and task draining stay
 in `server`. A successful startup creates one core `Session` only after
 validation. `Terminate`, EOF, and protocol failure close it; shutdown hands it
 to the bounded cleanup lifecycle described below. No dependency-owned type
-crosses into core or the public server contract. SQL message execution remains
-issue #31. See the
+crosses into core or the public server contract. See the
 [adapter decision record](POSTGRES_ADAPTER.md).
 
 ## Admin browser boundary

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -50,9 +50,11 @@ PostgreSQL startup also has a finite protocol-specific table: invalid user
 labels use `28000`, unknown logical databases use `3D000`, invalid startup
 values use `22023`, unsupported startup features use `0A000`, and malformed or
 unsupported protocol versions use `08P01`. These are fixed `FATAL` responses
-followed by socket close, without `ReadyForQuery`. Simple-query Engine failures
-use their mapped SQLSTATE; extended `Parse` remains `Unsupported` (`0A000`).
-Neither path includes query text. The complete sequencing is in
+followed by socket close, without `ReadyForQuery`. Simple and extended-query
+Engine failures use their mapped SQLSTATE. Extended-flow name conflicts use
+fixed `42P03`/`42P05`, missing handles use fixed `34000`/`26000`, and unsupported
+OID, parameter, or binary-format requests use `0A000`. Neither path includes
+query text. The complete sequencing is in
 [PostgreSQL startup and listener](POSTGRES_LISTENER.md).
 
 ### Experimental virtual-table rollout boundary
@@ -64,7 +66,7 @@ is intentionally asymmetric:
 | Surface | Reachability and tested unsupported behavior | Remaining dependency |
 | --- | --- | --- |
 | HTTP | A populated catalog with `experimental-vtab` and the write opt-in can reach the coordinator. The execute endpoint maps `BEGIN`, `COMMIT`, `ROLLBACK`, savepoints, and attachments to the fixed `Unsupported` 501 problem; caller-authored DML `RETURNING` has that result through both data endpoints. All fail before pool admission, and protocol tests verify that the shard files are unchanged. | Transaction support still requires a protocol-neutral pinned transaction state machine. |
-| PostgreSQL | Production simple `Query` executes registered-table reads and explicit-key writes through the Engine. Unsupported session/schema statements fail before mutation and return idle recovery state. Extended `Parse` remains fixed `Unsupported` / `0A000`. | Extended query execution remains issue #31/#33; transaction state and shard pinning are issue #34. |
+| PostgreSQL | Production simple `Query` and zero-parameter text-format extended queries execute registered-table reads and explicit-key writes through the Engine. Unsupported session/schema statements fail before mutation and extended errors discard input through `Sync`. | Parameter/OID/binary mapping remains issue #33; transaction state and shard pinning are issue #34. |
 | MySQL | There is no listener or command state machine. `mysql_error(Unsupported)` is only the deterministic future-adapter contract: error 1235, SQLSTATE `42000`, and the same safe message. | Listener and query flow are issues #40–#43; result/error encoding is issue #44; transactions are issue #47. |
 
 Consequently, issue #131 cannot declare cross-wire facade rollout complete

--- a/docs/POSTGRES_ADAPTER.md
+++ b/docs/POSTGRES_ADAPTER.md
@@ -1,7 +1,7 @@
 # PostgreSQL adapter decision record
 
 Status: accepted for roadmap issue #29; amended by issue #30 production startup
-activation
+activation and issue #31 extended-query execution
 
 BriskDB needs a PostgreSQL frontend library that can own protocol framing and
 message dispatch without becoming the database engine, routing policy,
@@ -34,7 +34,7 @@ behavior, and MSRV decision followed by the complete verification matrix.
 
 Only `server-api` is enabled. That supplies the Tokio socket entrypoint,
 frontend/backend messages, handler traits, PostgreSQL type descriptors, and
-row encoders used by startup and the planned query adapter.
+row encoders used by startup and the query adapter.
 
 The dependency's defaults are disabled because they additionally select an
 AWS-LC TLS backend and extended chrono, decimal, and JSON adapters. BriskDB does
@@ -83,8 +83,9 @@ guessing which raw value produced it.
 The private prepared wrapper contains only a BriskDB
 `PreparedStatementId` and `PreparedStatementDescription`. It does not expose
 the dependency's statement, portal, message, or type objects through a BriskDB
-signature. Production Parse/Bind name management and cleanup do not use this
-probe yet; issue #31 owns that state machine.
+signature. Production Parse/Bind name management mirrors the wire store into
+bounded core handles. Statement closure cascades to dependent portals, and
+unnamed replacement performs the same cleanup before installing its successor.
 
 ## Compatibility probe
 
@@ -132,13 +133,13 @@ particular:
   documented in `POSTGRES_LISTENER.md`.
 - Its default in-memory statement/portal store is unbounded, replacement does
   not return the old object for cleanup, and statement removal does not cascade
-  into BriskDB handles. Issue #31 must keep the engine's existing finite
-  per-session prepared-statement, portal, and retained-value budgets
-  authoritative.
+  into BriskDB handles. The adapter therefore mirrors every bound portal and
+  makes the Engine's finite per-session prepared-statement, portal, and
+  retained-value budgets authoritative.
 - The default Bind path retains dependency-owned raw parameter bytes and does
-  not call `Engine::bind_statement`. The production adapter must decode into
-  BriskDB `Value` objects and bind at Bind time so the route snapshot is
-  immutable before Execute.
+  not call `Engine::bind_statement`. The production adapter already binds the
+  zero-parameter slice into a core portal so its route snapshot is immutable
+  before Execute; issue #33 owns decoding typed values into BriskDB `Value`s.
 - The selected socket loop does not treat `Terminate` as terminal and has no
   BriskDB session-close callback. Production uses a narrow BriskDB-owned loop
   around the library's public decoder/dispatcher and closes its `Connection`
@@ -150,10 +151,11 @@ particular:
   negotiation: `SSLRequest` and `GSSENCRequest` must each be exactly eight bytes
   before the dependency identifies them, so a malformed negotiation cannot
   consume a following startup. Startup frames have a maximum declared length
-  of 10,000 bytes. After startup, only `Query`, `Parse`, `Sync`, and `Terminate`
-  are admitted, with a maximum declared length of 65,541 bytes; strings must be
-  valid UTF-8 and each frame must satisfy its exact structural boundary. Other
-  frontend message types are rejected until their owning roadmap issues.
+  of 10,000 bytes. After startup, the simple and extended query lifecycle plus
+  `Terminate` are admitted, with a maximum declared length of 65,541 bytes;
+  strings, counts, lengths, formats, targets, and each frame boundary are
+  validated before dependency decoding. Other frontend message types are
+  rejected until their owning roadmap issues.
   Malformed or oversized input receives BriskDB's fixed `08P01` response when a
   response can be sent, the socket closes, and an already-selected core session
   is still closed. Raw-frame regression tests cover malformed input both before
@@ -164,10 +166,9 @@ particular:
 - The raw-frame caps are transport-retention boundaries, not budgets for SQL,
   names, raw parameters, prepared objects, or rows. Those values and connection
   tasks still require their BriskDB-owned finite limits.
-- Portal suspension in the dependency cannot cause a BriskDB portal to execute
-  twice. The core currently returns a complete bounded materialized result;
-  issue #31 must retain and resume the already produced response or provide a
-  separately reviewed streaming contract.
+- Portal suspension cannot cause a BriskDB portal to execute twice. The adapter
+  retains and resumes the already produced bounded materialized response;
+  issue #39 owns a separately reviewed streaming contract.
 
 These are adapter requirements, not reasons to move protocol state into core.
 The library remains replaceable as long as the BriskDB seam and conformance
@@ -182,14 +183,13 @@ validation, emits BriskDB-owned status, and tracks that session through
 termination and server shutdown. It does not use the dependency's default
 startup values or protocol-version state.
 
-Issue #157 adds the bounded first slice of issue #31: one simple-query statement
-can execute registered-table reads and writes through the Engine, return
-text-format rows or command tags, clean up its temporary prepared objects, and
-recover after fixed public errors. Extended `Parse` remains fixed `0A000` with
-no retained dependency statement. Later roadmap issues retain their existing
-extended-query, minor-version negotiation, broader type, transaction,
-cancellation, TLS/SCRAM, client-matrix, and row-streaming scopes. The exact
-live contract and user workflow are in the
+Issue #157 adds the simple-query slice. Issue #31 adds bounded named/unnamed
+Parse, zero-parameter Bind, statement/portal Describe, resumable Execute,
+Flush, Sync error recovery, and cascading Close. Both paths execute registered
+table reads and writes through the Engine and return text-format rows or
+command tags. Later roadmap issues retain their minor-version negotiation,
+broader type, transaction, cancellation, TLS/SCRAM, client-matrix, and
+row-streaming scopes. The exact live contract and user workflow are in the
 [PostgreSQL listener document](POSTGRES_LISTENER.md) and
 [query quickstart](POSTGRES_QUICKSTART.md).
 

--- a/docs/POSTGRES_LISTENER.md
+++ b/docs/POSTGRES_LISTENER.md
@@ -1,10 +1,11 @@
 # PostgreSQL startup and listener contract
 
-BriskDB serves PostgreSQL protocol 3.0 startup and bounded simple queries on a
-disabled-by-default, separately configured loopback TCP listener. A successful
-startup selects one logical database, creates one protocol-neutral core
-session, publishes BriskDB-owned parameter status, and keeps the socket alive
-until `Terminate`, EOF, server shutdown, or a protocol failure.
+BriskDB serves PostgreSQL protocol 3.0 startup plus bounded simple and
+zero-parameter extended queries on a disabled-by-default, separately configured
+loopback TCP listener. A successful startup selects one logical database,
+creates one protocol-neutral core session, publishes BriskDB-owned parameter
+status, and keeps the socket alive until `Terminate`, EOF, server shutdown, or
+a protocol failure.
 
 ## Process configuration
 
@@ -72,14 +73,15 @@ creating a core session.
 For the startup packet and subsequent typed messages, a BriskDB-owned raw-frame
 gate runs before general dependency decoding and releases exactly one complete
 frame at a time. A startup packet's declared length may not exceed 10,000
-bytes. After successful startup, only `Query`, `Parse`, `Sync`, and `Terminate`
-frontend messages are admitted, and their declared length may not exceed 65,541
-bytes (the one-byte message type is outside that declared length). Query and
-Parse strings must be valid UTF-8, all four message types must match their exact
-structural boundaries, and startup key/value pairs must be structurally
-complete valid UTF-8 with no duplicate key. Other frontend message types are
-rejected until their owning roadmap issues. Malformed and oversized frames
-follow the fixed `08P01` protocol-failure path when a response can be sent.
+bytes. After successful startup, `Query`, `Parse`, `Bind`, `Describe`,
+`Execute`, `Close`, `Flush`, `Sync`, and `Terminate` frontend messages are
+admitted, and their declared length may not exceed 65,541 bytes (the one-byte
+message type is outside that declared length). Query, statement, and portal
+strings must be valid UTF-8. Format codes, counts, lengths, target bytes, and
+every message boundary are validated before dependency decoding. Other
+frontend message types are rejected until their owning roadmap issues.
+Malformed and oversized frames follow the fixed `08P01` protocol-failure path
+when a response can be sent.
 
 The accepted startup keys are finite:
 
@@ -150,10 +152,29 @@ instead of replaced. Write responses use ordinary
 one exact owner from their literal shard-key values. Reads retain the Engine's
 existing point/scatter limits and semantics.
 
-Extended `Parse` remains a fixed `0A000` error before a dependency-owned
-statement is stored, and `Sync` restores `ReadyForQuery(I)`. Bind parameters,
-DDL, transactions, `COPY`, and binary results are not supported. The offline
-importer is the supported way to establish registered tables. See the
+## Extended-query boundary
+
+The text-format, zero-parameter extended flow uses the same Engine lifecycle:
+
+- `Parse` prepares exactly one statement. Named statements must be unique;
+  replacing the unnamed statement closes it and every portal bound from it.
+- `Bind` accepts no values or parameter formats yet. Named portals must be
+  unique; replacing the unnamed portal closes its core handle.
+- `Describe` returns zero parameter OIDs plus statement fields, or portal
+  fields, without execution.
+- `Execute` returns rows or a command tag. A positive row limit suspends and
+  resumes the already materialized bounded response without rerunning the core
+  portal; a completed portal cannot replay a write.
+- `Close` releases a portal or cascades statement closure to its portals;
+  `Flush` flushes pending output; `Sync` restores `ReadyForQuery(I)` after an
+  error and causes skipped extended messages to be accepted again.
+
+Statement and portal names are at most 63 UTF-8 bytes. Engine limits remain
+authoritative for per-session prepared statements, portals, retained values,
+rows, and bytes. Explicit parameter OIDs, bound values, parameter formats, and
+binary results remain issue #33. DDL, transactions, and `COPY` are not
+supported. The offline importer is the supported way to establish registered
+tables. See the
 [copy/paste query quickstart](POSTGRES_QUICKSTART.md).
 
 ## Connection ownership and shutdown
@@ -215,8 +236,10 @@ Automated coverage includes:
   unknown-key, replication, and truncated-message cases before and after
   session creation, followed by successful recovery;
 - end-to-end simple-query insert, select, update, delete, row/type encoding,
-  empty-query handling, fixed-error recovery, and extended-query `Sync`
-  recovery;
+  and empty-query handling;
+- named and unnamed extended write/read/describe/execute, suspension without
+  replay, cascading close, flush, fixed-error `Sync` recovery, and raw frame
+  validation;
 - immediate `Terminate`, client EOF, partial startup, normal shutdown, forced
   server-task cancellation, and core-session cleanup;
 - the 256-task admission boundary, deterministic overflow close, and slot reuse

--- a/docs/POSTGRES_QUICKSTART.md
+++ b/docs/POSTGRES_QUICKSTART.md
@@ -89,9 +89,10 @@ and inspect it with `systemctl status briskdb` and
   or bytea OIDs. Stored non-UTF-8 text is rejected instead of being replaced.
 - Sharded writes must contain enough literal shard-key information to select
   exactly one owner. Reads use the engine's bounded logical read path.
-- Parameters and the extended Parse/Bind/Describe/Execute protocol are not yet
-  supported. Drivers that default to prepared or extended queries must select
-  their simple-query API for now.
+- Zero-parameter text-format prepared queries support named and unnamed
+  `Parse`/`Bind`/`Describe`/`Execute`, portal suspension, `Flush`, `Sync`, and
+  cascading `Close`. Bind parameters, explicit parameter OIDs, and binary
+  formats remain deferred to type mapping in issue #33.
 - DDL, transactions, `COPY`, authentication, authorization, TLS, and full
   PostgreSQL compatibility are not supported. Initialize the catalog offline
   with `briskdb-import` before starting the server.

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -48,13 +48,12 @@ claiming to be a drop-in PostgreSQL or MySQL replacement.
 
 ## Current implementation
 
-The initial alpha is HTTP-first: only the experimental HTTP network interface
-can execute SQL network requests today. The disabled-by-default, separately
-configured loopback PostgreSQL listener implements exact
+The initial alpha exposes experimental HTTP plus a disabled-by-default,
+separately configured loopback PostgreSQL listener. PostgreSQL implements exact
 protocol-3.0 startup, logical database/user selection, BriskDB parameter
-status, and tracked session termination through a pinned `pgwire` 0.36.3
-boundary. It rejects SQL with fixed `0A000` responses until issue #31. There is
-no MySQL listener. The public Rust SQL facade
+status, tracked session termination, simple queries, and zero-parameter
+text-format extended queries through a pinned `pgwire` 0.36.3 boundary. There
+is no MySQL listener. The public Rust SQL facade
 can parse an explicitly selected SQLite, PostgreSQL, or MySQL dialect, consume
 that result with
 `validate_common_subset(ParsedSql)`, borrow the result with
@@ -95,7 +94,7 @@ set, every shard for an unconstrained Sharded read, or shard 0 once for a
 | HTTP `/v1/query` | Experimental | Empty catalog: legacy raw SQLite query. Populated catalog: exactly one SQLite common-subset read; no session cache; multi-shard execution is limited to the row-local scatter-safe subset | Empty catalog requires caller `shard_key`; populated catalog derives targets from registered metadata, reads Global data once on shard 0, and denies Catalog/undeclared tables |
 | HTTP `/v1/admin/broadcast` | Experimental | A journaled parameterless SQLite schema batch; populated catalogs reject row-moving DML, table drops, and trigger creation | Preflight on every shard, then ascending resumable apply |
 | HTTP `/admin` browser | Experimental, read-only | No caller SQL; metadata-driven logical table discovery, specialized exact logical `COUNT(*)`, and bounded deterministic `SELECT *` page slices | Sharded tables visit all files; Global tables visit shard 0 once; no browser shard selector or arbitrary SQL |
-| PostgreSQL wire protocol | Protocol-3.0 startup plus one statement per simple `Query` on loopback | Registered-table `SELECT`, `INSERT`, `UPDATE`, and `DELETE`; extended `Parse`, parameters, DDL, and transactions remain unsupported | Startup selects an exact logical database; simple queries use Engine prepare/bind/logical execution and fixed SQLSTATE mapping |
+| PostgreSQL wire protocol | Protocol-3.0 startup plus simple `Query` and zero-parameter text-format extended flow on loopback | Registered-table `SELECT`, `INSERT`, `UPDATE`, and `DELETE`; parameters, binary formats, DDL, and transactions remain unsupported | Startup selects an exact logical database; both flows use Engine prepare/bind/logical execution and fixed SQLSTATE mapping |
 | MySQL wire protocol | Planned | Rust parsing, validation, classification, placeholder normalization, finite compatibility translation, and prepared lifecycle implemented; listener adoption planned | Core batch/write policy, bind validation, routing snapshots, current execute-time planning, and supported target execution implemented; wire mapping planned |
 
 The parser, subset validator, statement classifier, placeholder normalizer, SQL
@@ -785,16 +784,17 @@ boundary are normative in
 The PostgreSQL TCP listener hosts the selected `pgwire` 0.36.3 boundary for
 exact protocol-3.0 startup on loopback. It validates a finite parameter set,
 selects one logical database and user label, advertises BriskDB-owned status,
-and tracks the selected core session through termination. SQL messages remain
-at a fixed error/resynchronization boundary until issue #31. PostgreSQL-specific
-behavior is not implemented unless listed as implemented in this document.
+and tracks the selected core session through termination. Simple and
+zero-parameter extended SQL messages use the bounded Engine lifecycle;
+extended errors discard messages until `Sync`. PostgreSQL-specific behavior is
+not implemented unless listed as implemented in this document.
 Configuration and lifecycle semantics are normative in the [PostgreSQL listener
 contract](POSTGRES_LISTENER.md); dependency and adapter constraints are
 normative in the [adapter decision record](POSTGRES_ADAPTER.md).
 
 | Area | PostgreSQL | BriskDB contract |
 | --- | --- | --- |
-| Parameters | `$1`, `$2`, ... | Rust normalization and session-scoped prepare/bind/describe/execute are implemented; PostgreSQL message/name/type mapping remains planned |
+| Parameters | `$1`, `$2`, ... | Named/unnamed wire prepare/bind/describe/execute works for zero parameters; OID/value mapping remains issue #33 |
 | Identifier quoting | Double quotes | Retained by opt-in compatibility translation; PostgreSQL case folding and catalog equivalence are not claimed |
 | Type system | Static types identified by OIDs | Opt-in Rust translation maps a finite declaration set to `BIGINT`, `BOOLEAN`, `REAL`, `TEXT`, or `BLOB`; OID and value/result adaptation remain planned |
 | Boolean | Dedicated `boolean` type | Opt-in translation maps the declaration to `BOOLEAN` and literals to `1`/`0`; Boolean wire/result metadata remains planned |
@@ -807,7 +807,7 @@ normative in the [adapter decision record](POSTGRES_ADAPTER.md).
 | `ON CONFLICT` | PostgreSQL upsert syntax | Outside the initial common subset and unsupported |
 | Functions/operators | PostgreSQL catalog | SQLite functions/operators unless an explicit shim is documented |
 | System catalogs | `pg_catalog`, `information_schema` | Only queries required by named, tested clients will be emulated |
-| Error behavior | SQLSTATE and failed transaction state | Startup and query-deferral errors are encoded now; the complete execution mapping and `I`/`T`/`E` transaction states remain planned |
+| Error behavior | SQLSTATE and failed transaction state | Startup and execution errors are encoded; extended flow resynchronizes at `Sync`, while complete `I`/`T`/`E` transaction states remain planned |
 | `COPY`, replication, `LISTEN/NOTIFY` | PostgreSQL subprotocols/features | Deferred and unsupported initially |
 
 PostgreSQL's static result metadata does not always have an exact equivalent in

--- a/docs/SQL_PREPARED_STATEMENTS.md
+++ b/docs/SQL_PREPARED_STATEMENTS.md
@@ -455,10 +455,10 @@ typed Rust input paths share the same planning and result path:
 Each protocol adapter owns its message framing, authentication,
 statement/portal naming, wire parameter decoding, result type encoding, close
 acknowledgement, and protocol resynchronization. PostgreSQL startup framing,
-session ownership, and parameter-free simple queries are implemented; issue
-#31 must map extended query messages into this lifecycle rather than retain a
-SQLite handle, implement a second cache, interpolate values into SQL, or choose
-a physical shard itself.
+session ownership, parameter-free simple queries, and zero-parameter extended
+queries map into this lifecycle without retaining a SQLite handle, implementing
+a second authoritative cache, interpolating values into SQL, or choosing a
+physical shard in the adapter.
 
 ## Storage-format boundary
 

--- a/docs/SQL_STATEMENT_CLASSIFICATION.md
+++ b/docs/SQL_STATEMENT_CLASSIFICATION.md
@@ -224,8 +224,8 @@ classifier rejects, subject to the populated-catalog ban on row-moving DML,
 table drops, and trigger creation.
 At the issue-28 milestone, the PostgreSQL endpoint was only an accept/close
 scaffold. Issue #30 connected startup, catalog selection, status, and session
-cleanup, but SQL messages still stop before classification or any other shared
-SQL layer until issue #31.
+cleanup; issue #31 connects simple and zero-parameter extended SQL messages to
+the shared classification and Engine lifecycle.
 
 ## Storage-format and configuration boundary
 

--- a/docs/VTAB_ROLLOUT.md
+++ b/docs/VTAB_ROLLOUT.md
@@ -76,14 +76,14 @@ production-hardening work.
 With the write opt-in enabled, HTTP rejects transactions, savepoints,
 attachments, and caller-authored DML `RETURNING` as `Unsupported` before pool
 admission; tests also verify every shard remains unchanged. The PostgreSQL
-listener now permits simple Query to enter the shared Engine lifecycle, while
-extended Parse remains at the fixed SQLSTATE `0A000` boundary. Unsupported
-session statements return to idle without reaching storage.
+listener now permits simple Query and zero-parameter text-format extended
+queries to enter the shared Engine lifecycle. Unsupported session statements
+return to idle without reaching storage.
 
 There is not yet a MySQL listener or command state machine. The shared mapping
 already freezes `Unsupported` as MySQL error 1235 / SQLSTATE `42000`, but a
-mapping function is not a live wire conformance test. PostgreSQL extended query
-execution and transactions remain tracked by #31 and #34. MySQL listener/query,
+mapping function is not a live wire conformance test. PostgreSQL parameter/type
+mapping and transactions remain tracked by #33 and #34. MySQL listener/query,
 result/error, and transaction work remains tracked by #40-#44 and #47.
 
 ## Benchmark evidence

--- a/src/protocol/postgres.rs
+++ b/src/protocol/postgres.rs
@@ -8,10 +8,10 @@
 //! not accept or return `pgwire` types.
 
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeMap, BTreeSet},
     fmt, io,
     pin::Pin,
-    sync::{Arc, OnceLock},
+    sync::{Arc, Mutex, OnceLock},
     task::{Context, Poll},
     time::Duration,
 };
@@ -20,22 +20,29 @@ use async_trait::async_trait;
 use futures::{Sink, SinkExt, StreamExt, stream};
 use pgwire::{
     api::{
-        ClientInfo, ClientPortalStore, DefaultClient, ErrorHandler, PgWireConnectionState,
-        PgWireServerHandlers, Type,
+        ClientInfo, ClientPortalStore, DEFAULT_NAME, DefaultClient, ErrorHandler,
+        PgWireConnectionState, PgWireServerHandlers, Type,
         auth::StartupHandler,
-        portal::Portal,
-        query::{ExtendedQueryHandler, SimpleQueryHandler},
+        portal::{Portal, PortalExecutionState},
+        query::{
+            ExtendedQueryHandler, SimpleQueryHandler, send_execution_response,
+            send_partial_query_response, send_query_response,
+        },
         results::{
             DataRowEncoder, DescribePortalResponse, DescribeStatementResponse, FieldFormat,
             FieldInfo, QueryResponse, Response, Tag,
         },
-        stmt::{NoopQueryParser, QueryParser, StoredStatement},
+        stmt::{QueryParser, StoredStatement},
         store::PortalStore,
     },
     error::{ErrorInfo, PgWireError, PgWireResult},
     messages::{
         PgWireBackendMessage, PgWireFrontendMessage, ProtocolVersion, SslNegotiationMetaMessage,
-        extendedquery::Parse,
+        data::NoData,
+        extendedquery::{
+            Bind, BindComplete, Close, CloseComplete, Execute, Parse, ParseComplete,
+            TARGET_TYPE_BYTE_PORTAL, TARGET_TYPE_BYTE_STATEMENT,
+        },
         response::{GssEncResponse, ReadyForQuery, SslResponse, TransactionStatus},
         startup::{Authentication, ParameterStatus},
     },
@@ -50,8 +57,8 @@ use tokio_util::codec::Framed;
 use crate::{
     core::{
         DataType, DescribeTarget, Engine, EngineError, EngineResult, EngineStatus,
-        LogicalDatabaseId, PrepareRequest, PreparedExecution, PreparedStatementDescription,
-        PreparedStatementId, ResultSet, Session, SessionId, Value,
+        LogicalDatabaseId, PortalId, PrepareRequest, PreparedExecution,
+        PreparedStatementDescription, PreparedStatementId, ResultSet, Session, SessionId, Value,
     },
     protocol::error::postgres_error,
     sql::{MAX_PARSED_SQL_BYTES, SqlDialect, SqlTranslationMode, StatementBehavior, WriteBehavior},
@@ -61,6 +68,7 @@ const POSTGRES_PROTOCOL_MAJOR: u16 = 3;
 const POSTGRES_PROTOCOL_MINOR: u16 = 0;
 const STARTUP_TIMEOUT: Duration = Duration::from_secs(60);
 const MAX_STARTUP_NAME_BYTES: usize = 63;
+const MAX_EXTENDED_NAME_BYTES: usize = 63;
 const MAX_STARTUP_PACKET_LENGTH: usize = 10_000;
 const MAX_FRONTEND_MESSAGE_LENGTH: usize = MAX_PARSED_SQL_BYTES + 5;
 const CANCEL_REQUEST_CODE: i32 = 80_877_102;
@@ -345,9 +353,115 @@ fn validate_typed_frame(frame: &[u8]) -> io::Result<()> {
                 Err(invalid_frontend_frame())
             }
         }
-        Some(b'S') | Some(b'X') if body.is_empty() => Ok(()),
+        Some(b'B') => validate_bind_frame_body(body),
+        Some(b'D') | Some(b'C') => validate_named_target_frame_body(body),
+        Some(b'E') => validate_execute_frame_body(body),
+        Some(b'H') | Some(b'S') | Some(b'X') if body.is_empty() => Ok(()),
         _ => Err(invalid_frontend_frame()),
     }
+}
+
+fn validate_bind_frame_body(body: &[u8]) -> io::Result<()> {
+    let (_, cursor) = consume_utf8_cstring(body, 0).ok_or_else(invalid_frontend_frame)?;
+    let (_, mut cursor) = consume_utf8_cstring(body, cursor).ok_or_else(invalid_frontend_frame)?;
+
+    let (format_count, next) = consume_u16(body, cursor)?;
+    cursor = next;
+    for _ in 0..format_count {
+        let (format, next) = consume_i16(body, cursor)?;
+        if !matches!(format, 0 | 1) {
+            return Err(invalid_frontend_frame());
+        }
+        cursor = next;
+    }
+
+    let (parameter_count, next) = consume_u16(body, cursor)?;
+    cursor = next;
+    if !matches!(format_count, 0 | 1) && format_count != parameter_count {
+        return Err(invalid_frontend_frame());
+    }
+    for _ in 0..parameter_count {
+        let (length, next) = consume_i32(body, cursor)?;
+        cursor = next;
+        if length < -1 {
+            return Err(invalid_frontend_frame());
+        }
+        if length >= 0 {
+            let length = usize::try_from(length).map_err(|_| invalid_frontend_frame())?;
+            cursor = cursor
+                .checked_add(length)
+                .filter(|end| *end <= body.len())
+                .ok_or_else(invalid_frontend_frame)?;
+        }
+    }
+
+    let (result_count, next) = consume_i16(body, cursor)?;
+    let result_count = u16::try_from(result_count).map_err(|_| invalid_frontend_frame())?;
+    cursor = next;
+    for _ in 0..result_count {
+        let (format, next) = consume_i16(body, cursor)?;
+        if !matches!(format, 0 | 1) {
+            return Err(invalid_frontend_frame());
+        }
+        cursor = next;
+    }
+    if cursor == body.len() {
+        Ok(())
+    } else {
+        Err(invalid_frontend_frame())
+    }
+}
+
+fn validate_named_target_frame_body(body: &[u8]) -> io::Result<()> {
+    if !matches!(body.first(), Some(b'S' | b'P')) {
+        return Err(invalid_frontend_frame());
+    }
+    let (_, end) = consume_utf8_cstring(body, 1).ok_or_else(invalid_frontend_frame)?;
+    if end == body.len() {
+        Ok(())
+    } else {
+        Err(invalid_frontend_frame())
+    }
+}
+
+fn validate_execute_frame_body(body: &[u8]) -> io::Result<()> {
+    let (_, cursor) = consume_utf8_cstring(body, 0).ok_or_else(invalid_frontend_frame)?;
+    let (max_rows, end) = consume_i32(body, cursor)?;
+    if max_rows >= 0 && end == body.len() {
+        Ok(())
+    } else {
+        Err(invalid_frontend_frame())
+    }
+}
+
+fn consume_u16(buffer: &[u8], start: usize) -> io::Result<(u16, usize)> {
+    let end = start.checked_add(2).ok_or_else(invalid_frontend_frame)?;
+    let bytes = buffer.get(start..end).ok_or_else(invalid_frontend_frame)?;
+    Ok((
+        u16::from_be_bytes(
+            bytes
+                .try_into()
+                .expect("the guarded two-byte field length was checked"),
+        ),
+        end,
+    ))
+}
+
+fn consume_i16(buffer: &[u8], start: usize) -> io::Result<(i16, usize)> {
+    consume_u16(buffer, start).map(|(value, end)| (value as i16, end))
+}
+
+fn consume_i32(buffer: &[u8], start: usize) -> io::Result<(i32, usize)> {
+    let end = start.checked_add(4).ok_or_else(invalid_frontend_frame)?;
+    let bytes = buffer.get(start..end).ok_or_else(invalid_frontend_frame)?;
+    Ok((
+        i32::from_be_bytes(
+            bytes
+                .try_into()
+                .expect("the guarded four-byte field length was checked"),
+        ),
+        end,
+    ))
 }
 
 fn declared_frame_length_matches(frame: &[u8], offset: usize, type_length: usize) -> bool {
@@ -445,6 +559,7 @@ impl Adapter {
             user: user.map(Into::into),
             database,
             database_name: database_name.into(),
+            extended: Mutex::new(PgWireExtendedState::default()),
         });
         let wire_parser = Arc::new(PgWireQueryParser {
             state: Arc::clone(&state),
@@ -478,6 +593,18 @@ struct ConnectionState {
     user: Option<Box<str>>,
     database: LogicalDatabaseId,
     database_name: Box<str>,
+    extended: Mutex<PgWireExtendedState>,
+}
+
+#[derive(Default)]
+struct PgWireExtendedState {
+    portals: BTreeMap<String, PgWireBoundPortal>,
+}
+
+#[derive(Clone, Copy)]
+struct PgWireBoundPortal {
+    id: PortalId,
+    statement: PreparedStatementId,
 }
 
 /// Protocol-owned state for one PostgreSQL connection.
@@ -711,6 +838,55 @@ struct WireHandlers {
     connection: WireConnection,
 }
 
+impl WireHandlers {
+    async fn remove_statement<C>(&self, client: &mut C, name: &str) -> PgWireResult<()>
+    where
+        C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::PortalStore: PortalStore<Statement = PgWirePrepared>,
+        C::Error: fmt::Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        let Some(statement) = client.portal_store().get_statement(name) else {
+            return Ok(());
+        };
+        let connection = self.connection.installed()?;
+        connection
+            .state
+            .engine
+            .close_prepared_statement(&connection.state.session, statement.statement.id)
+            .await
+            .map_err(engine_error_to_pgwire)?;
+        let portals =
+            remove_bound_portals_for_statement(&connection.state, statement.statement.id)?;
+        for portal in portals {
+            client.portal_store().rm_portal(&portal);
+        }
+        client.portal_store().rm_statement(name);
+        Ok(())
+    }
+
+    async fn remove_portal<C>(&self, client: &mut C, name: &str) -> PgWireResult<()>
+    where
+        C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::PortalStore: PortalStore<Statement = PgWirePrepared>,
+        C::Error: fmt::Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        let connection = self.connection.installed()?;
+        if let Some(portal) = bound_portal(&connection.state, name)? {
+            connection
+                .state
+                .engine
+                .close_portal(&connection.state.session, portal.id)
+                .await
+                .map_err(engine_error_to_pgwire)?;
+            remove_bound_portal(&connection.state, name)?;
+        }
+        client.portal_store().rm_portal(name);
+        Ok(())
+    }
+}
+
 #[async_trait]
 impl StartupHandler for WireHandlers {
     async fn on_startup<C>(
@@ -910,6 +1086,22 @@ fn result_set_response(result: ResultSet) -> PgWireResult<Response> {
     )))
 }
 
+fn description_fields(description: &PreparedStatementDescription) -> Vec<FieldInfo> {
+    description
+        .columns()
+        .iter()
+        .map(|column| {
+            FieldInfo::new(
+                column.name.clone(),
+                None,
+                None,
+                postgres_type(column.data_type),
+                FieldFormat::Text,
+            )
+        })
+        .collect()
+}
+
 fn postgres_type(data_type: DataType) -> Type {
     match data_type {
         DataType::Boolean => Type::BOOL,
@@ -958,27 +1150,250 @@ fn invalid_text_query_error() -> PgWireError {
 
 #[async_trait]
 impl ExtendedQueryHandler for WireHandlers {
-    type Statement = String;
-    type QueryParser = NoopQueryParser;
+    type Statement = PgWirePrepared;
+    type QueryParser = PgWireQueryParser;
 
     fn query_parser(&self) -> Arc<Self::QueryParser> {
-        Arc::new(NoopQueryParser)
+        Arc::clone(
+            &self
+                .connection
+                .installed()
+                .expect("the extended-query handler is called only after PostgreSQL startup")
+                .wire_parser,
+        )
     }
 
-    async fn on_parse<C>(&self, _client: &mut C, _message: Parse) -> PgWireResult<()>
+    async fn on_parse<C>(&self, client: &mut C, message: Parse) -> PgWireResult<()>
     where
         C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
         C::PortalStore: PortalStore<Statement = Self::Statement>,
         C::Error: fmt::Debug,
         PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
     {
-        Err(unsupported_query_error())
+        let name = valid_extended_name(message.name.as_deref())?;
+        if name != DEFAULT_NAME && client.portal_store().get_statement(name).is_some() {
+            return Err(query_wire_error(
+                "42P05",
+                "a prepared statement with that name already exists",
+            ));
+        }
+
+        if name == DEFAULT_NAME {
+            self.remove_statement(client, name).await?;
+        }
+
+        if !message.type_oids.is_empty() {
+            return Err(query_wire_error(
+                "0A000",
+                "PostgreSQL parameter OID lists are deferred to type mapping",
+            ));
+        }
+        let statement = self
+            .query_parser()
+            .parse_sql(client, &message.query, &[])
+            .await?;
+        if !statement.description.parameter_types().is_empty() {
+            let connection = self.connection.installed()?;
+            let _ = connection
+                .state
+                .engine
+                .close_prepared_statement(&connection.state.session, statement.id)
+                .await;
+            return Err(query_wire_error(
+                "0A000",
+                "PostgreSQL bound parameters are deferred to type mapping",
+            ));
+        }
+        let statement = StoredStatement::new(name.to_owned(), statement, Vec::new());
+        client.portal_store().put_statement(Arc::new(statement));
+        client
+            .send(PgWireBackendMessage::ParseComplete(ParseComplete::new()))
+            .await?;
+        Ok(())
+    }
+
+    async fn on_bind<C>(&self, client: &mut C, message: Bind) -> PgWireResult<()>
+    where
+        C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::PortalStore: PortalStore<Statement = Self::Statement>,
+        C::Error: fmt::Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        let portal_name = valid_extended_name(message.portal_name.as_deref())?;
+        let statement_name = valid_extended_name(message.statement_name.as_deref())?;
+        let statement = client
+            .portal_store()
+            .get_statement(statement_name)
+            .ok_or_else(|| PgWireError::StatementNotFound(statement_name.to_owned()))?;
+
+        if !message.parameters.is_empty()
+            || !matches!(message.parameter_format_codes.as_slice(), [] | [0])
+        {
+            return Err(query_wire_error(
+                "0A000",
+                "PostgreSQL bound parameters are deferred to type mapping",
+            ));
+        }
+        let result_formats = message.result_column_format_codes.as_slice();
+        if !result_formats.iter().all(|format| *format == 0) {
+            return Err(query_wire_error(
+                "0A000",
+                "PostgreSQL binary result formats are deferred to type mapping",
+            ));
+        }
+        if portal_name != DEFAULT_NAME && client.portal_store().get_portal(portal_name).is_some() {
+            return Err(query_wire_error(
+                "42P03",
+                "a portal with that name already exists",
+            ));
+        }
+        let connection = self.connection.installed()?;
+        let description = connection
+            .state
+            .engine
+            .describe_prepared(
+                &connection.state.session,
+                DescribeTarget::Statement(statement.statement.id),
+            )
+            .await
+            .map_err(engine_error_to_pgwire)?;
+        if !(result_formats.is_empty()
+            || result_formats.len() == 1
+            || result_formats.len() == description.columns().len())
+        {
+            return Err(query_wire_error(
+                "22023",
+                "the PostgreSQL result format count does not match the columns",
+            ));
+        }
+        if portal_name == DEFAULT_NAME {
+            self.remove_portal(client, portal_name).await?;
+        }
+
+        let portal_id = connection
+            .state
+            .engine
+            .bind_statement(
+                &connection.state.session,
+                statement.statement.id,
+                Vec::new(),
+            )
+            .await
+            .map_err(engine_error_to_pgwire)?;
+        let portal = match Portal::try_new(&message, Arc::clone(&statement)) {
+            Ok(portal) => portal,
+            Err(error) => {
+                let _ = connection
+                    .state
+                    .engine
+                    .close_portal(&connection.state.session, portal_id)
+                    .await;
+                return Err(error);
+            }
+        };
+        if let Err(error) = insert_bound_portal(
+            &connection.state,
+            portal_name,
+            PgWireBoundPortal {
+                id: portal_id,
+                statement: statement.statement.id,
+            },
+        ) {
+            let _ = connection
+                .state
+                .engine
+                .close_portal(&connection.state.session, portal_id)
+                .await;
+            return Err(error);
+        }
+        client.portal_store().put_portal(Arc::new(portal));
+        client
+            .send(PgWireBackendMessage::BindComplete(BindComplete::new()))
+            .await?;
+        Ok(())
+    }
+
+    async fn on_execute<C>(&self, client: &mut C, message: Execute) -> PgWireResult<()>
+    where
+        C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::PortalStore: PortalStore<Statement = Self::Statement>,
+        C::Error: fmt::Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        if !matches!(client.state(), PgWireConnectionState::ReadyForQuery) {
+            return Err(PgWireError::NotReadyForQuery);
+        }
+        let portal_name = valid_extended_name(message.name.as_deref())?;
+        let max_rows = usize::try_from(message.max_rows).map_err(|_| {
+            query_wire_error("22023", "the PostgreSQL Execute row limit is invalid")
+        })?;
+        let portal = client
+            .portal_store()
+            .get_portal(portal_name)
+            .ok_or_else(|| PgWireError::PortalNotFound(portal_name.to_owned()))?;
+
+        client.set_state(PgWireConnectionState::QueryInProgress);
+        let portal_state_lock = portal.state();
+        let mut portal_state = portal_state_lock.lock().await;
+        match &mut *portal_state {
+            PortalExecutionState::Initial => {
+                match ExtendedQueryHandler::do_query(self, client, &portal, max_rows).await? {
+                    Response::Query(mut response) if max_rows > 0 => {
+                        if send_partial_query_response(client, &mut response, max_rows).await? {
+                            *portal_state = PortalExecutionState::Suspended(response);
+                        } else {
+                            *portal_state = PortalExecutionState::Finished;
+                        }
+                    }
+                    Response::Query(mut response) => {
+                        send_query_response(client, &mut response, false).await?;
+                        *portal_state = PortalExecutionState::Finished;
+                    }
+                    Response::Execution(tag) => {
+                        send_execution_response(client, tag).await?;
+                        *portal_state = PortalExecutionState::Finished;
+                    }
+                    _ => return Err(internal_query_error()),
+                }
+            }
+            PortalExecutionState::Suspended(response) => {
+                if !send_partial_query_response(client, response, max_rows).await? {
+                    *portal_state = PortalExecutionState::Finished;
+                }
+            }
+            PortalExecutionState::Finished => {
+                client
+                    .send(PgWireBackendMessage::NoData(NoData::new()))
+                    .await?;
+            }
+        }
+        client.set_state(PgWireConnectionState::ReadyForQuery);
+        Ok(())
+    }
+
+    async fn on_close<C>(&self, client: &mut C, message: Close) -> PgWireResult<()>
+    where
+        C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::PortalStore: PortalStore<Statement = Self::Statement>,
+        C::Error: fmt::Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        let name = valid_extended_name(message.name.as_deref())?;
+        match message.target_type {
+            TARGET_TYPE_BYTE_STATEMENT => self.remove_statement(client, name).await?,
+            TARGET_TYPE_BYTE_PORTAL => self.remove_portal(client, name).await?,
+            target => return Err(PgWireError::InvalidTargetType(target)),
+        }
+        client
+            .send(PgWireBackendMessage::CloseComplete(CloseComplete::new()))
+            .await?;
+        Ok(())
     }
 
     async fn do_describe_statement<C>(
         &self,
         _client: &mut C,
-        _target: &StoredStatement<Self::Statement>,
+        target: &StoredStatement<Self::Statement>,
     ) -> PgWireResult<DescribeStatementResponse>
     where
         C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
@@ -986,13 +1401,32 @@ impl ExtendedQueryHandler for WireHandlers {
         C::Error: fmt::Debug,
         PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
     {
-        Err(unsupported_query_error())
+        let description = self
+            .connection
+            .installed()?
+            .state
+            .engine
+            .describe_prepared(
+                &self.connection.installed()?.state.session,
+                DescribeTarget::Statement(target.statement.id),
+            )
+            .await
+            .map_err(engine_error_to_pgwire)?;
+        Ok(DescribeStatementResponse::new(
+            description
+                .parameter_types()
+                .iter()
+                .copied()
+                .map(postgres_type)
+                .collect(),
+            description_fields(&description),
+        ))
     }
 
     async fn do_describe_portal<C>(
         &self,
         _client: &mut C,
-        _target: &Portal<Self::Statement>,
+        target: &Portal<Self::Statement>,
     ) -> PgWireResult<DescribePortalResponse>
     where
         C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
@@ -1000,13 +1434,24 @@ impl ExtendedQueryHandler for WireHandlers {
         C::Error: fmt::Debug,
         PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
     {
-        Err(unsupported_query_error())
+        let portal = bound_portal(&self.connection.installed()?.state, target.name.as_str())?
+            .ok_or_else(|| PgWireError::PortalNotFound(target.name.clone()))?;
+        let connection = self.connection.installed()?;
+        let description = connection
+            .state
+            .engine
+            .describe_prepared(&connection.state.session, DescribeTarget::Portal(portal.id))
+            .await
+            .map_err(engine_error_to_pgwire)?;
+        Ok(DescribePortalResponse::new(description_fields(
+            &description,
+        )))
     }
 
     async fn do_query<C>(
         &self,
         _client: &mut C,
-        _portal: &Portal<Self::Statement>,
+        portal: &Portal<Self::Statement>,
         _max_rows: usize,
     ) -> PgWireResult<Response>
     where
@@ -1015,7 +1460,23 @@ impl ExtendedQueryHandler for WireHandlers {
         C::Error: fmt::Debug,
         PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
     {
-        Err(unsupported_query_error())
+        let connection = self.connection.installed()?;
+        let bound = bound_portal(&connection.state, portal.name.as_str())?
+            .ok_or_else(|| PgWireError::PortalNotFound(portal.name.clone()))?;
+        let behavior = connection
+            .state
+            .engine
+            .describe_prepared(&connection.state.session, DescribeTarget::Portal(bound.id))
+            .await
+            .map_err(engine_error_to_pgwire)?
+            .behavior();
+        let execution = connection
+            .state
+            .engine
+            .execute_portal_logical(&connection.state.session, bound.id)
+            .await
+            .map_err(engine_error_to_pgwire)?;
+        simple_query_response(behavior, execution.value)
     }
 }
 
@@ -1025,6 +1486,14 @@ impl ErrorHandler for WireHandlers {
         C: ClientInfo,
     {
         if matches!(error, PgWireError::UserError(_)) {
+            return;
+        }
+        if matches!(error, PgWireError::PortalNotFound(_)) {
+            *error = query_wire_error("34000", "the PostgreSQL portal does not exist");
+            return;
+        }
+        if matches!(error, PgWireError::StatementNotFound(_)) {
+            *error = query_wire_error("26000", "the PostgreSQL prepared statement does not exist");
             return;
         }
         *error = if matches!(
@@ -1065,7 +1534,7 @@ impl PgWireServerHandlers for WireHandlers {
     }
 }
 
-type GuardedSocket = Framed<GuardedPgStream<TcpStream>, PgWireMessageServerCodec<String>>;
+type GuardedSocket = Framed<GuardedPgStream<TcpStream>, PgWireMessageServerCodec<PgWirePrepared>>;
 
 async fn negotiate_plaintext(stream: TcpStream) -> io::Result<Option<GuardedSocket>> {
     let peer = stream.peer_addr()?;
@@ -1079,7 +1548,7 @@ async fn negotiate_plaintext(stream: TcpStream) -> io::Result<Option<GuardedSock
         return Ok(None);
     }
 
-    let client = DefaultClient::<String>::new(peer, false);
+    let client = DefaultClient::<PgWirePrepared>::new(peer, false);
     let codec = PgWireMessageServerCodec::new(client);
     let mut socket = Framed::new(GuardedPgStream::new(stream, Vec::new()), codec);
 
@@ -1218,11 +1687,81 @@ fn fatal_wire_error(code: &'static str, message: &'static str) -> PgWireError {
     )))
 }
 
+fn query_wire_error(code: &'static str, message: &'static str) -> PgWireError {
+    PgWireError::UserError(Box::new(ErrorInfo::new(
+        "ERROR".to_owned(),
+        code.to_owned(),
+        message.to_owned(),
+    )))
+}
+
 fn unsupported_query_error() -> PgWireError {
     engine_error_to_pgwire(EngineError::new(
         crate::core::EngineErrorKind::Unsupported,
         "the PostgreSQL extended query flow is not implemented yet",
     ))
+}
+
+fn valid_extended_name(name: Option<&str>) -> PgWireResult<&str> {
+    let name = name.unwrap_or(DEFAULT_NAME);
+    if name.len() <= MAX_EXTENDED_NAME_BYTES {
+        Ok(name)
+    } else {
+        Err(query_wire_error(
+            "42622",
+            "the PostgreSQL statement or portal name is too long",
+        ))
+    }
+}
+
+fn lock_extended_state(
+    state: &ConnectionState,
+) -> PgWireResult<std::sync::MutexGuard<'_, PgWireExtendedState>> {
+    state.extended.lock().map_err(|_| internal_query_error())
+}
+
+fn bound_portal(state: &ConnectionState, name: &str) -> PgWireResult<Option<PgWireBoundPortal>> {
+    Ok(lock_extended_state(state)?.portals.get(name).copied())
+}
+
+fn insert_bound_portal(
+    state: &ConnectionState,
+    name: &str,
+    portal: PgWireBoundPortal,
+) -> PgWireResult<()> {
+    let mut extended = lock_extended_state(state)?;
+    if extended.portals.contains_key(name) {
+        return Err(query_wire_error(
+            "42P03",
+            "a portal with that name already exists",
+        ));
+    }
+    extended.portals.insert(name.to_owned(), portal);
+    Ok(())
+}
+
+fn remove_bound_portal(
+    state: &ConnectionState,
+    name: &str,
+) -> PgWireResult<Option<PgWireBoundPortal>> {
+    Ok(lock_extended_state(state)?.portals.remove(name))
+}
+
+fn remove_bound_portals_for_statement(
+    state: &ConnectionState,
+    statement: PreparedStatementId,
+) -> PgWireResult<Vec<String>> {
+    let mut extended = lock_extended_state(state)?;
+    let names = extended
+        .portals
+        .iter()
+        .filter(|(_, portal)| portal.statement == statement)
+        .map(|(name, _)| name.clone())
+        .collect::<Vec<_>>();
+    for name in &names {
+        extended.portals.remove(name);
+    }
+    Ok(names)
 }
 
 fn valid_user_label(user: &str) -> bool {
@@ -1467,6 +2006,48 @@ mod tests {
         packet.extend_from_slice(&length.to_be_bytes());
         packet.extend_from_slice(body);
         packet
+    }
+
+    fn push_cstring(body: &mut Vec<u8>, value: &str) {
+        body.extend_from_slice(value.as_bytes());
+        body.push(0);
+    }
+
+    fn parse_packet(name: &str, query: &str) -> Vec<u8> {
+        let mut body = Vec::new();
+        push_cstring(&mut body, name);
+        push_cstring(&mut body, query);
+        body.extend_from_slice(&0_u16.to_be_bytes());
+        typed_packet(b'P', &body)
+    }
+
+    fn bind_packet(portal: &str, statement: &str) -> Vec<u8> {
+        let mut body = Vec::new();
+        push_cstring(&mut body, portal);
+        push_cstring(&mut body, statement);
+        body.extend_from_slice(&0_u16.to_be_bytes());
+        body.extend_from_slice(&0_u16.to_be_bytes());
+        body.extend_from_slice(&0_i16.to_be_bytes());
+        typed_packet(b'B', &body)
+    }
+
+    fn describe_packet(target: u8, name: &str) -> Vec<u8> {
+        let mut body = vec![target];
+        push_cstring(&mut body, name);
+        typed_packet(b'D', &body)
+    }
+
+    fn execute_packet(portal: &str, max_rows: i32) -> Vec<u8> {
+        let mut body = Vec::new();
+        push_cstring(&mut body, portal);
+        body.extend_from_slice(&max_rows.to_be_bytes());
+        typed_packet(b'E', &body)
+    }
+
+    fn close_packet(target: u8, name: &str) -> Vec<u8> {
+        let mut body = vec![target];
+        push_cstring(&mut body, name);
+        typed_packet(b'C', &body)
     }
 
     async fn read_frame(stream: &mut TcpStream) -> (u8, Vec<u8>) {
@@ -2205,9 +2786,8 @@ mod tests {
         engine.shutdown().await.unwrap();
     }
 
-    #[cfg(feature = "experimental-vtab")]
     #[tokio::test]
-    async fn extended_query_remains_blocked_when_simple_writes_are_enabled() {
+    async fn extended_query_executes_named_writes_reads_describe_and_close() {
         let temp = tempfile::tempdir().unwrap();
         let mut database = crate::core::Database::open(temp.path(), 2).unwrap();
         database
@@ -2234,58 +2814,83 @@ mod tests {
             ])
             .unwrap();
         let database = Arc::new(database);
-        let options = crate::core::EngineOptions::new(2, 16)
-            .unwrap()
-            .with_experimental_vtab_writes(true);
-        let engine = Engine::from_database_with_options(Arc::clone(&database), options).unwrap();
+        let engine = Engine::from_database(Arc::clone(&database));
         let adapter = Adapter::new(engine.clone());
         let (address, wire, server) = spawn_wire_server(&adapter).await;
         let mut client = TcpStream::connect(address).await.unwrap();
         client.write_all(&startup_packet()).await.unwrap();
         read_until_ready(&mut client).await;
-        let expected = postgres_error(EngineErrorKind::Unsupported);
 
-        for sql in ["BEGIN", "COMMIT", "ROLLBACK"] {
-            let mut body = sql.as_bytes().to_vec();
-            body.push(0);
-            client.write_all(&typed_packet(b'Q', &body)).await.unwrap();
-            let frames = read_until_ready(&mut client).await;
-            assert_eq!(frames.len(), 2, "simple-query response for {sql}");
-            let fields = message_fields(&frames[0].1);
-            assert_eq!(fields.get(&b'S').map(String::as_str), Some("ERROR"));
-            assert_eq!(
-                fields.get(&b'C').map(String::as_str),
-                Some(expected.sqlstate)
-            );
-            assert_eq!(
-                fields.get(&b'M').map(String::as_str),
-                Some(expected.message)
-            );
-            assert!(!fields.get(&b'M').unwrap().contains(sql));
-            assert_eq!(frames[1], (b'Z', vec![b'I']));
-        }
+        let write_flow = [
+            parse_packet(
+                "write_record",
+                "INSERT INTO records (tenant_id, payload) VALUES ('tenant-e', 'extended')",
+            ),
+            bind_packet("write_portal", "write_record"),
+            execute_packet("write_portal", 0),
+            execute_packet("write_portal", 0),
+            typed_packet(b'S', &[]),
+        ]
+        .concat();
+        client.write_all(&write_flow).await.unwrap();
+        let frames = read_until_ready(&mut client).await;
+        assert_eq!(
+            frames.iter().map(|frame| frame.0).collect::<Vec<_>>(),
+            [b'1', b'2', b'C', b'n', b'Z']
+        );
+        assert_eq!(command_tag(&frames[2].1), "INSERT 0 1");
 
-        let extended_sql = "INSERT INTO records (tenant_id, payload) VALUES ('extended-blocked', 'must-not-be-stored')";
-        let mut parse = Vec::new();
-        parse.push(0);
-        parse.extend_from_slice(extended_sql.as_bytes());
-        parse.push(0);
-        parse.extend_from_slice(&0_u16.to_be_bytes());
-        client.write_all(&typed_packet(b'P', &parse)).await.unwrap();
-        let error = read_frame(&mut client).await;
-        assert_eq!(error.0, b'E');
-        let fields = message_fields(&error.1);
+        let read_flow = [
+            parse_packet(
+                "read_record",
+                "SELECT tenant_id, payload FROM records WHERE tenant_id = 'tenant-e'",
+            ),
+            bind_packet("read_portal", "read_record"),
+            describe_packet(TARGET_TYPE_BYTE_STATEMENT, "read_record"),
+            describe_packet(TARGET_TYPE_BYTE_PORTAL, "read_portal"),
+            execute_packet("read_portal", 1),
+            execute_packet("read_portal", 1),
+            typed_packet(b'H', &[]),
+            typed_packet(b'S', &[]),
+        ]
+        .concat();
+        client.write_all(&read_flow).await.unwrap();
+        let frames = read_until_ready(&mut client).await;
         assert_eq!(
-            fields.get(&b'C').map(String::as_str),
-            Some(expected.sqlstate)
+            frames.iter().map(|frame| frame.0).collect::<Vec<_>>(),
+            [b'1', b'2', b't', b'T', b'T', b'D', b's', b'C', b'Z']
         );
+        assert_eq!(u16::from_be_bytes(frames[2].1[..2].try_into().unwrap()), 0);
+        assert_eq!(row_description(&frames[3].1), row_description(&frames[4].1));
         assert_eq!(
-            fields.get(&b'M').map(String::as_str),
-            Some(expected.message)
+            data_row(&frames[5].1),
+            [Some(b"tenant-e".to_vec()), Some(b"extended".to_vec())]
         );
-        assert!(!fields.get(&b'M').unwrap().contains(extended_sql));
-        client.write_all(&typed_packet(b'S', &[])).await.unwrap();
-        assert_eq!(read_frame(&mut client).await, (b'Z', vec![b'I']));
+
+        client
+            .write_all(
+                &[
+                    close_packet(TARGET_TYPE_BYTE_STATEMENT, "read_record"),
+                    typed_packet(b'S', &[]),
+                ]
+                .concat(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            read_until_ready(&mut client).await,
+            [(b'3', vec![]), (b'Z', vec![b'I'])]
+        );
+
+        client
+            .write_all(&[execute_packet("read_portal", 0), typed_packet(b'S', &[])].concat())
+            .await
+            .unwrap();
+        let frames = read_until_ready(&mut client).await;
+        assert_eq!(
+            frames.iter().map(|frame| frame.0).collect::<Vec<_>>(),
+            [b'E', b'Z']
+        );
 
         for shard in 0..database.shard_count() {
             let rows =
@@ -2295,11 +2900,19 @@ mod tests {
                         row.get::<_, i64>(0)
                     })
                     .unwrap();
-            assert_eq!(
-                rows, 0,
-                "extended PostgreSQL query mutated physical shard {shard}"
-            );
+            assert!(rows <= 1, "write was replayed on physical shard {shard}");
         }
+        let total_rows = (0..database.shard_count())
+            .map(|shard| {
+                rusqlite::Connection::open(temp.path().join(format!("shards/{shard:04}.sqlite")))
+                    .unwrap()
+                    .query_row("SELECT COUNT(*) FROM records", [], |row| {
+                        row.get::<_, i64>(0)
+                    })
+                    .unwrap()
+            })
+            .sum::<i64>();
+        assert_eq!(total_rows, 1, "a finished write portal must not re-execute");
 
         finish_wire_server(&mut client, server).await;
         assert_eq!(
@@ -2310,7 +2923,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn extended_query_rejects_before_storage_and_sync_recovers() {
+    async fn extended_query_errors_resync_and_unnamed_replacement_cleans_up_portals() {
         let (_temp, engine) = engine(2).await;
         let adapter = Adapter::new(engine.clone());
         let (address, wire, server) = spawn_wire_server(&adapter).await;
@@ -2320,9 +2933,10 @@ mod tests {
         let core = Arc::clone(wire.connection().unwrap());
 
         let mut parse = Vec::new();
-        parse.push(0);
-        parse.extend_from_slice(b"SELECT 'private extended text'\0");
-        parse.extend_from_slice(&0_u16.to_be_bytes());
+        push_cstring(&mut parse, "private_statement");
+        push_cstring(&mut parse, "SELECT 'private extended text'");
+        parse.extend_from_slice(&1_u16.to_be_bytes());
+        parse.extend_from_slice(&Type::INT4.oid().to_be_bytes());
         client.write_all(&typed_packet(b'P', &parse)).await.unwrap();
         let error = read_frame(&mut client).await;
         assert_eq!(error.0, b'E');
@@ -2330,12 +2944,123 @@ mod tests {
         assert_eq!(fields.get(&b'C').map(String::as_str), Some("0A000"));
         assert_eq!(
             fields.get(&b'M').map(String::as_str),
-            Some(postgres_error(crate::core::EngineErrorKind::Unsupported).message)
+            Some("PostgreSQL parameter OID lists are deferred to type mapping")
         );
         assert!(!fields.get(&b'M').unwrap().contains("private extended text"));
 
         client.write_all(&typed_packet(b'S', &[])).await.unwrap();
         assert_eq!(read_frame(&mut client).await, (b'Z', vec![b'I']));
+
+        client
+            .write_all(&parse_packet("parameterized", "SELECT $1"))
+            .await
+            .unwrap();
+        let error = read_frame(&mut client).await;
+        assert_eq!(error.0, b'E');
+        let fields = message_fields(&error.1);
+        assert_eq!(fields.get(&b'C').map(String::as_str), Some("0A000"));
+        client.write_all(&typed_packet(b'S', &[])).await.unwrap();
+        assert_eq!(read_frame(&mut client).await, (b'Z', vec![b'I']));
+
+        client
+            .write_all(&parse_packet(
+                &"n".repeat(MAX_EXTENDED_NAME_BYTES + 1),
+                "SELECT 1",
+            ))
+            .await
+            .unwrap();
+        let error = read_frame(&mut client).await;
+        assert_eq!(
+            message_fields(&error.1).get(&b'C').map(String::as_str),
+            Some("42622")
+        );
+        client.write_all(&typed_packet(b'S', &[])).await.unwrap();
+        assert_eq!(read_frame(&mut client).await, (b'Z', vec![b'I']));
+
+        client
+            .write_all(&parse_packet("duplicate_statement", "SELECT 1"))
+            .await
+            .unwrap();
+        assert_eq!(read_frame(&mut client).await, (b'1', vec![]));
+        client
+            .write_all(&parse_packet("duplicate_statement", "SELECT 2"))
+            .await
+            .unwrap();
+        let error = read_frame(&mut client).await;
+        assert_eq!(
+            message_fields(&error.1).get(&b'C').map(String::as_str),
+            Some("42P05")
+        );
+        client.write_all(&typed_packet(b'S', &[])).await.unwrap();
+        assert_eq!(read_frame(&mut client).await, (b'Z', vec![b'I']));
+
+        client
+            .write_all(&bind_packet("duplicate_portal", "duplicate_statement"))
+            .await
+            .unwrap();
+        assert_eq!(read_frame(&mut client).await, (b'2', vec![]));
+        client
+            .write_all(&bind_packet("duplicate_portal", "duplicate_statement"))
+            .await
+            .unwrap();
+        let error = read_frame(&mut client).await;
+        assert_eq!(
+            message_fields(&error.1).get(&b'C').map(String::as_str),
+            Some("42P03")
+        );
+        client.write_all(&typed_packet(b'S', &[])).await.unwrap();
+        assert_eq!(read_frame(&mut client).await, (b'Z', vec![b'I']));
+        client
+            .write_all(
+                &[
+                    close_packet(TARGET_TYPE_BYTE_STATEMENT, "duplicate_statement"),
+                    typed_packet(b'S', &[]),
+                ]
+                .concat(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(read_until_ready(&mut client).await[0].0, b'3');
+
+        let replacement_flow = [
+            parse_packet("", "SELECT 1 AS first_value"),
+            bind_packet("", ""),
+            parse_packet("", "SELECT 2 AS replacement_value"),
+            execute_packet("", 0),
+            typed_packet(b'S', &[]),
+        ]
+        .concat();
+        client.write_all(&replacement_flow).await.unwrap();
+        let frames = read_until_ready(&mut client).await;
+        assert_eq!(
+            frames.iter().map(|frame| frame.0).collect::<Vec<_>>(),
+            [b'1', b'2', b'1', b'E', b'Z']
+        );
+        let fields = message_fields(&frames[3].1);
+        assert_eq!(fields.get(&b'C').map(String::as_str), Some("34000"));
+
+        let replacement_execute = [
+            bind_packet("", ""),
+            execute_packet("", 0),
+            close_packet(TARGET_TYPE_BYTE_PORTAL, ""),
+            close_packet(TARGET_TYPE_BYTE_STATEMENT, ""),
+            typed_packet(b'S', &[]),
+        ]
+        .concat();
+        client.write_all(&replacement_execute).await.unwrap();
+        let frames = read_until_ready(&mut client).await;
+        assert_eq!(frames.first().unwrap().0, b'2');
+        assert!(frames.iter().any(|frame| frame.0 == b'D'));
+        assert_eq!(
+            frames
+                .iter()
+                .rev()
+                .take(3)
+                .map(|frame| frame.0)
+                .collect::<Vec<_>>(),
+            [b'Z', b'3', b'3']
+        );
+        assert!(core.state.extended.lock().unwrap().portals.is_empty());
         assert_eq!(core.status().await.unwrap().shard_count(), 2);
 
         finish_wire_server(&mut client, server).await;
@@ -2597,8 +3322,26 @@ mod tests {
         parse.extend_from_slice(&1_u16.to_be_bytes());
         parse.extend_from_slice(&23_u32.to_be_bytes());
         validate_typed_frame(&typed_packet(b'P', &parse)).unwrap();
+        validate_typed_frame(&bind_packet("portal", "statement")).unwrap();
+        validate_typed_frame(&describe_packet(TARGET_TYPE_BYTE_STATEMENT, "statement")).unwrap();
+        validate_typed_frame(&describe_packet(TARGET_TYPE_BYTE_PORTAL, "portal")).unwrap();
+        validate_typed_frame(&execute_packet("portal", 1)).unwrap();
+        validate_typed_frame(&close_packet(TARGET_TYPE_BYTE_STATEMENT, "statement")).unwrap();
+        validate_typed_frame(&close_packet(TARGET_TYPE_BYTE_PORTAL, "portal")).unwrap();
+        validate_typed_frame(&typed_packet(b'H', &[])).unwrap();
         validate_typed_frame(&typed_packet(b'S', &[])).unwrap();
         validate_typed_frame(&typed_packet(b'X', &[])).unwrap();
+
+        let mut negative_parameter_length = Vec::new();
+        push_cstring(&mut negative_parameter_length, "portal");
+        push_cstring(&mut negative_parameter_length, "statement");
+        negative_parameter_length.extend_from_slice(&0_u16.to_be_bytes());
+        negative_parameter_length.extend_from_slice(&1_u16.to_be_bytes());
+        negative_parameter_length.extend_from_slice(&(-2_i32).to_be_bytes());
+        negative_parameter_length.extend_from_slice(&0_i16.to_be_bytes());
+        let mut negative_result_count = bind_packet("portal", "statement");
+        let end = negative_result_count.len();
+        negative_result_count[end - 2..].copy_from_slice(&(-1_i16).to_be_bytes());
 
         let mut oversized_query_body = vec![b'a'; MAX_PARSED_SQL_BYTES + 1];
         oversized_query_body.push(0);
@@ -2611,8 +3354,14 @@ mod tests {
             typed_packet(b'P', b"statement\0SELECT 1\0\0\x01"),
             typed_packet(b'P', b"statement\0SELECT 1\0\0\x01\0\0\0"),
             typed_packet(b'S', &[0]),
+            typed_packet(b'H', &[0]),
             typed_packet(b'X', &[0]),
             typed_packet(b'B', &[]),
+            typed_packet(b'B', &negative_parameter_length),
+            negative_result_count,
+            describe_packet(b'X', "statement"),
+            execute_packet("portal", -1),
+            close_packet(b'X', "statement"),
         ];
         for rejected in invalid_typed_frames {
             assert!(


### PR DESCRIPTION
Closes #31

## Summary

- implement bounded named and unnamed Parse/Bind/Describe/Execute state over BriskDB prepared statements and portals
- support zero-parameter text-format reads and writes, portal suspension without re-execution, Flush, Sync recovery, and cascading Close
- validate all newly admitted frontend frames before pgwire decoding and return fixed safe SQLSTATE errors
- update the README, roadmap, architecture, compatibility, listener, error, and quickstart contracts

## Testing

- cargo fmt --all --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-targets --all-features (927 tests)
- cargo test --locked --doc --all-features
- cargo package --locked --allow-dirty
- cargo +1.85.0 check --locked --all-targets --all-features