### PR TITLE
PostgreSQL typed parameters and binary results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,7 @@ dependencies = [
  "async-trait",
  "axum",
  "blake3",
+ "bytes",
  "clap",
  "criterion",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ http = [
 ]
 postgres = [
     "dep:async-trait",
+    "dep:bytes",
     "dep:futures",
     "dep:pgwire",
     "dep:tokio-util",
@@ -77,6 +78,7 @@ anyhow = { version = "1.0", optional = true }
 async-trait = { version = "0.1", optional = true }
 axum = { version = "0.8.9", optional = true }
 blake3 = "1.8"
+bytes = { version = "1.12", optional = true }
 clap = { version = "4.6.6", features = ["derive", "env"], optional = true }
 getrandom = "=0.4.3"
 futures = { version = "0.3", optional = true }
@@ -87,7 +89,7 @@ libc = "0.2"
 # baseline. Keep the pre-1.0 dependency exact and enable only the plaintext
 # server surface; later roadmap work owns TLS and extended type adapters.
 pgwire = { version = "=0.36.3", default-features = false, features = ["server-api"], optional = true }
-rusqlite = { version = "0.39.0", features = ["bundled", "column_metadata", "hooks", "limits"] }
+rusqlite = { version = "0.39.0", features = ["bundled", "column_decltype", "column_metadata", "hooks", "limits"] }
 same-file = "1.0"
 serde = { version = "1.0.229", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ experimental and opt-in; the exact contract lives in
 | Durable virtual-bucket routing over independent SQLite WAL files | Working |
 | Exact-key routing and bounded scatter/gather reads | Working |
 | HTTP query/write API and admin data browser | Working, loopback-only |
-| PostgreSQL wire protocol | Simple and zero-parameter prepared `SELECT`/`INSERT`/`UPDATE`/`DELETE` |
+| PostgreSQL wire protocol | Simple and parameterized text/binary prepared `SELECT`/`INSERT`/`UPDATE`/`DELETE` |
 | Offline import from a standard SQLite database | Working |
 | Native-range and hi/lo generated IDs | Experimental, opt-in |
 | Ubuntu/macOS x86-64 and ARM64 release artifacts | Published |
@@ -133,8 +133,8 @@ Then open the [data browser](http://127.0.0.1:7654/admin) or check the server:
 curl http://127.0.0.1:7654/health
 ```
 
-Enable the PostgreSQL listener explicitly. Simple queries and zero-parameter
-text-format prepared queries share the same bounded engine path:
+Enable the PostgreSQL listener explicitly. Simple and parameterized
+text/binary prepared queries share the same bounded engine path:
 
 ```bash
 cargo run --release -- --postgres-listen 127.0.0.1:5433

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -252,7 +252,7 @@ the engine regardless of its eventual wire protocol.
   resynchronization, and portal suspension.
 - [x] Negotiate explicitly supported newer protocol minor versions from the
   exact 3.0 baseline rather than conflating protocol and server versions.
-- [ ] Map BriskDB types to PostgreSQL OIDs and support text format first, then
+- [x] Map BriskDB types to PostgreSQL OIDs and support text format first, then
   the binary formats required by tested drivers (issue #33, including the
   generated-key result contract).
 - [ ] Implement `BEGIN`/`COMMIT`/`ROLLBACK`, failed-transaction state, and shard

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,7 +34,7 @@ server ---------> protocol::http
 | `import` | Offline source-schema preflight, explicit placement and generated-ID plan validation, exact-value row routing into private staging, independent verification, durable receipt creation, and atomic publication | Network handlers, live/incremental migration, generated-ID inference, implicit Global placement, or protocol-specific behavior |
 | `sql` | Dialect-explicit SQL syntax parsing, recursive common-subset validation, protocol-neutral statement/batch classification, source-preserving placeholder normalization, explicit strict/compatibility translation, catalog-aware typed shard-key inference, and narrow crate-private DML-shape inspection behind BriskDB-owned boundaries; exact source retention; SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, key hashing or shard selection, mutable session state, physical write-routing policy, filesystem layout, protocol responses, protocol-buffer ownership, or protocol-specific support policy |
 | `protocol::http` | Existing HTTP request extraction, shared JSON/BriskDB value and RFC 9457 problem-detail encoding, and the embedded admin shell/assets, temporary browser sessions, metadata-driven logical discovery, exact logical counts, and bounded shard-major page handlers | BLAKE3 routing, shard files, direct SQLite access, or rusqlite calls |
-| `protocol::postgres` | BriskDB-owned bounded protocol-3.0 baseline and newer-minor downgrade, selected identity/status, per-connection core-session ownership, simple query execution, bounded zero-parameter extended lifecycle, fixed error recovery, and private compile/query-parser seam around exactly pinned `pgwire` | Listener binding, direct SQLite access, routing, unbounded authoritative prepared state, or public dependency-owned types |
+| `protocol::postgres` | BriskDB-owned bounded protocol-3.0 baseline and newer-minor downgrade, selected identity/status, per-connection core-session ownership, simple query execution, bounded parameterized text/binary extended lifecycle, fixed error recovery, and private compile/query-parser seam around exactly pinned `pgwire` | Listener binding, direct SQLite access, routing, unbounded authoritative prepared state, or public dependency-owned types |
 | `protocol::error` | Exhaustive HTTP, PostgreSQL, and MySQL mappings from stable engine error kinds | SQLite errors, routing decisions, or wire-protocol session state |
 | `server` | Process configuration, database assembly, loopback validation, separate HTTP/PostgreSQL listener binding, finite connection-task supervision, and shared graceful/forced draining | SQL parsing, PostgreSQL wire framing, or storage implementation details |
 
@@ -112,11 +112,12 @@ Issue #29 selects exact `pgwire` 0.36.3 with only `server-api` and adds the
 BriskDB-owned `protocol::postgres::{Adapter, Connection}` seam. Issue #30
 connects the production loopback listener to that adapter for exact protocol
 3.0 startup. Issue #31 adds bounded named and unnamed prepared statements and
-portals, zero-parameter text-format Describe/Execute, suspension without
-re-execution, cascading Close, Flush, and Sync recovery. Parameter validation,
-logical database/user selection, fixed status/error frames, and terminal session cleanup stay in
-`protocol::postgres`; socket binding, the 256-task cap, and task draining stay
-in `server`. A successful startup creates one core `Session` only after
+portals, Describe/Execute, suspension without re-execution, cascading Close,
+Flush, and Sync recovery. Issue #33 adds declared protocol-neutral result types
+and adapter-owned PostgreSQL OID plus text/binary codecs. Parameter validation,
+logical database/user selection, fixed status/error frames, and terminal
+session cleanup stay in `protocol::postgres`; socket binding, the 256-task cap,
+and task draining stay in `server`. A successful startup creates one core `Session` only after
 validation. `Terminate`, EOF, and protocol failure close it; shutdown hands it
 to the bounded cleanup lifecycle described below. No dependency-owned type
 crosses into core or the public server contract. See the

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -54,8 +54,10 @@ downgraded to the 3.0 baseline rather than rejected. These are fixed `FATAL` res
 followed by socket close, without `ReadyForQuery`. Simple and extended-query
 Engine failures use their mapped SQLSTATE. Extended-flow name conflicts use
 fixed `42P03`/`42P05`, missing handles use fixed `34000`/`26000`, and unsupported
-OID, parameter, or binary-format requests use `0A000`. Neither path includes
-query text. The complete sequencing is in
+OIDs use `0A000`. Invalid parameter values use `22P02`, invalid parameter text
+uses `22021`, decoded count mismatches use `08P01`, and dynamic result/type
+mismatches use `42804`. Invalid raw format codes remain protocol failures.
+Neither path includes query text or parameter bytes. The complete sequencing is in
 [PostgreSQL startup and listener](POSTGRES_LISTENER.md).
 
 ### Experimental virtual-table rollout boundary
@@ -67,7 +69,7 @@ is intentionally asymmetric:
 | Surface | Reachability and tested unsupported behavior | Remaining dependency |
 | --- | --- | --- |
 | HTTP | A populated catalog with `experimental-vtab` and the write opt-in can reach the coordinator. The execute endpoint maps `BEGIN`, `COMMIT`, `ROLLBACK`, savepoints, and attachments to the fixed `Unsupported` 501 problem; caller-authored DML `RETURNING` has that result through both data endpoints. All fail before pool admission, and protocol tests verify that the shard files are unchanged. | Transaction support still requires a protocol-neutral pinned transaction state machine. |
-| PostgreSQL | Production simple `Query` and zero-parameter text-format extended queries execute registered-table reads and explicit-key writes through the Engine. Unsupported session/schema statements fail before mutation and extended errors discard input through `Sync`. | Parameter/OID/binary mapping remains issue #33; transaction state and shard pinning are issue #34. |
+| PostgreSQL | Production simple `Query` and parameterized text/binary extended queries execute registered-table reads and writes through the Engine. Unsupported session/schema statements fail before mutation and extended errors discard input through `Sync`. | Transaction state and shard pinning are issue #34. |
 | MySQL | There is no listener or command state machine. `mysql_error(Unsupported)` is only the deterministic future-adapter contract: error 1235, SQLSTATE `42000`, and the same safe message. | Listener and query flow are issues #40–#43; result/error encoding is issue #44; transactions are issue #47. |
 
 Consequently, issue #131 cannot declare cross-wire facade rollout complete

--- a/docs/GENERATED_KEYS.md
+++ b/docs/GENERATED_KEYS.md
@@ -312,15 +312,15 @@ translation are pure SQL operations and do not require these execution gates.
 `SQLite`, `PostgreSQL`, and `MySQL` in the DDL table identify the selected
 source-language parsers; they do not imply completed PostgreSQL or MySQL wire
 behavior. The HTTP adapter and protocol-neutral Rust result are implemented
-now. PostgreSQL generated-key
-type/OID and result behavior remains coordinated with
-[issue #33](https://github.com/schapman1974/briskdb/issues/33). MySQL
+now. PostgreSQL maps a generated `Int64` value to `int8` when it is part of a
+row, but a successful insert sends the standard `INSERT 0 n` command tag and
+never invents an unsolicited generated-key row. Caller-authored `RETURNING`
+remains outside the SQL subset. MySQL
 `AUTO_INCREMENT` result/status encoding remains coordinated with
 [issue #44](https://github.com/schapman1974/briskdb/issues/44). There is
-currently no MySQL listener. PostgreSQL simple queries can execute explicit-key
-writes; omitted generated-key inserts still depend on the documented compile
-and runtime coordinator gates, and the wire response exposes only the affected
-row command tag in this initial slice.
+currently no MySQL listener. PostgreSQL omitted generated-key inserts still
+depend on the documented compile and runtime coordinator gates, and the wire
+response exposes only the affected-row command tag.
 
 This release does not promise PostgreSQL sequence objects or sequence options,
 MySQL session variables such as `LAST_INSERT_ID()`, caller-authored

--- a/docs/POSTGRES_ADAPTER.md
+++ b/docs/POSTGRES_ADAPTER.md
@@ -1,8 +1,8 @@
 # PostgreSQL adapter decision record
 
 Status: accepted for roadmap issue #29; amended by issue #30 production startup
-activation, issue #31 extended-query execution, and issue #32 protocol
-negotiation
+activation, issue #31 extended-query execution, issue #32 protocol
+negotiation, and issue #33 type/format mapping
 
 BriskDB needs a PostgreSQL frontend library that can own protocol framing and
 message dispatch without becoming the database engine, routing policy,
@@ -35,7 +35,7 @@ behavior, and MSRV decision followed by the complete verification matrix.
 
 Only `server-api` is enabled. That supplies the Tokio socket entrypoint,
 frontend/backend messages, handler traits, PostgreSQL type descriptors, and
-row encoders used by startup and the query adapter.
+row messages used by startup and the query adapter.
 
 The dependency's defaults are disabled because they additionally select an
 AWS-LC TLS backend and extended chrono, decimal, and JSON adapters. BriskDB does
@@ -45,9 +45,9 @@ not need those dependencies for the issue-29 fit check:
 | --- | --- | --- |
 | Plain server API | Enabled | Foundation for issues #30 and #31 |
 | AWS-LC or ring TLS provider | Not enabled | TLS and SCRAM issue #36 |
-| Chrono type adapter | Not enabled | Type mapping issue #33 |
-| Rust-decimal adapter | Not enabled | Type mapping issue #33 |
-| Serde-JSON adapter | Not enabled | Type mapping issue #33 |
+| Chrono type adapter | Not enabled | No BriskDB date/time value type yet |
+| Rust-decimal adapter | Not enabled | BriskDB-owned arbitrary decimal wire codec |
+| Serde-JSON adapter | Not enabled | JSON parameters remain protocol-neutral text |
 | Client API | Not enabled | Named external-client matrix issue #38 |
 
 The resolved graph uses the repository's existing Tokio 1.53.1 rather than a
@@ -75,18 +75,18 @@ The connection retains a private implementation of `pgwire`'s `QueryParser`
 trait as the compile-time bridge. Its probe path prepares PostgreSQL-dialect
 SQL through `Engine::prepare_statement` with compatibility translation and
 describes the resulting BriskDB handle. It neither opens SQLite directly nor
-computes a route. PostgreSQL parameter OID lists are rejected as `Unsupported`
-until issue #33 defines their exact mapping. Because `pgwire`
-collapses both raw OID zero and unknown/custom OIDs to `None` before invoking
-`QueryParser`, the probe rejects every nonempty parameter-type list rather than
-guessing which raw value produced it.
+computes a route. Production Parse validates raw OIDs before `pgwire` can
+collapse both OID zero and unknown/custom OIDs to `None`. The private parser
+therefore receives only validated types, treats `None` as inference-to-text,
+and retains the resolved PostgreSQL types beside the protocol-neutral handle.
 
-The private prepared wrapper contains only a BriskDB
-`PreparedStatementId` and `PreparedStatementDescription`. It does not expose
-the dependency's statement, portal, message, or type objects through a BriskDB
-signature. Production Parse/Bind name management mirrors the wire store into
-bounded core handles. Statement closure cascades to dependent portals, and
-unnamed replacement performs the same cleanup before installing its successor.
+The private prepared wrapper contains a BriskDB `PreparedStatementId` and
+`PreparedStatementDescription` plus connection-local PostgreSQL parameter
+descriptors. It does not expose the dependency's statement, portal, message,
+or type objects through a BriskDB signature. Production Parse/Bind name
+management mirrors the wire store into bounded core handles. Statement closure
+cascades to dependent portals, and unnamed replacement performs the same
+cleanup before installing its successor.
 
 ## Compatibility probe
 
@@ -122,7 +122,7 @@ The selected version provides the protocol pieces required by the roadmap:
 - startup, simple-query, extended-query, copy, error, and cancellation handler
   traits selected by a per-socket factory;
 - Parse/Bind/Describe/Execute/Flush/Sync/Close message dispatch;
-- text and binary field descriptors and row encoders; and
+- text and binary field descriptors and data-row messages; and
 - PostgreSQL connection and transaction-status tracking.
 
 Those conveniences do not transfer product ownership to the library. In
@@ -138,9 +138,9 @@ particular:
   makes the Engine's finite per-session prepared-statement, portal, and
   retained-value budgets authoritative.
 - The default Bind path retains dependency-owned raw parameter bytes and does
-  not call `Engine::bind_statement`. The production adapter already binds the
-  zero-parameter slice into a core portal so its route snapshot is immutable
-  before Execute; issue #33 owns decoding typed values into BriskDB `Value`s.
+  not call `Engine::bind_statement`. BriskDB's handler decodes supported
+  text/binary values into BriskDB `Value`s first, binds one core portal, and
+  snapshots the portal's result fields/formats before Execute.
 - The selected socket loop does not treat `Terminate` as terminal and has no
   BriskDB session-close callback. Production uses a narrow BriskDB-owned loop
   around the library's public decoder/dispatcher and closes its `Connection`
@@ -189,12 +189,13 @@ newer-minor and protocol-option negotiation without expanding the implemented
 3.0 message semantics.
 
 Issue #157 adds the simple-query slice. Issue #31 adds bounded named/unnamed
-Parse, zero-parameter Bind, statement/portal Describe, resumable Execute,
-Flush, Sync error recovery, and cascading Close. Both paths execute registered
-table reads and writes through the Engine and return text-format rows or
-command tags. Later roadmap issues retain their minor-version negotiation,
-broader type, transaction, cancellation, TLS/SCRAM, client-matrix, and
-row-streaming scopes. The exact live contract and user workflow are in the
+Parse, Bind, statement/portal Describe, resumable Execute, Flush, Sync error
+recovery, and cascading Close. Issue #33 adds declared result types, resolved
+parameter OIDs, and basic text/binary value codecs while keeping PostgreSQL
+types and raw bytes at this adapter edge. Both paths execute registered table
+reads and writes through the Engine. Later roadmap issues retain transaction,
+cancellation, TLS/SCRAM, client-matrix, and row-streaming scopes. The exact
+live contract and user workflow are in the
 [PostgreSQL listener document](POSTGRES_LISTENER.md) and
 [query quickstart](POSTGRES_QUICKSTART.md).
 

--- a/docs/POSTGRES_LISTENER.md
+++ b/docs/POSTGRES_LISTENER.md
@@ -1,7 +1,7 @@
 # PostgreSQL startup and listener contract
 
 BriskDB serves a PostgreSQL protocol 3.0 baseline plus bounded simple and
-zero-parameter extended queries on a disabled-by-default, separately configured
+parameterized extended queries on a disabled-by-default, separately configured
 loopback TCP listener. A successful startup selects one logical database,
 creates one protocol-neutral core session, publishes BriskDB-owned parameter
 status, and keeps the socket alive until `Terminate`, EOF, server shutdown, or
@@ -151,24 +151,33 @@ fixed Engine-to-SQLSTATE mapping, appends `ReadyForQuery(I)`, never includes
 query text, and leaves the connection reusable.
 
 Rows are bounded and materialized by the Engine, then returned in PostgreSQL
-text format. Known protocol-neutral metadata has stable boolean, signed integer,
-numeric, double precision, text, and bytea OIDs; SQLite's unknown compile
-metadata is reported conservatively as text. Invalid UTF-8 text is rejected
-instead of replaced. Write responses use ordinary
+text format. Declared SQLite columns map `BOOL`/`BOOLEAN` to `bool`, names
+containing `INT` to `int8`, `REAL`/`FLOA`/`DOUB` to `float8`,
+`DECIMAL`/`NUMERIC` to `numeric`, `CHAR`/`CLOB`/`TEXT` to `text`, and `BLOB` to
+`bytea`. Unknown declarations and expressions remain conservative `text`.
+Invalid UTF-8 text is rejected instead of replaced. Write responses use ordinary
 `INSERT 0 n`, `UPDATE n`, and `DELETE n` command tags. Sharded writes must infer
 one exact owner from their literal shard-key values. Reads retain the Engine's
 existing point/scatter limits and semantics.
 
 ## Extended-query boundary
 
-The text-format, zero-parameter extended flow uses the same Engine lifecycle:
+The parameterized text/binary extended flow uses the same Engine lifecycle:
 
 - `Parse` prepares exactly one statement. Named statements must be unique;
   replacing the unnamed statement closes it and every portal bound from it.
-- `Bind` accepts no values or parameter formats yet. Named portals must be
-  unique; replacing the unnamed portal closes its core handle.
-- `Describe` returns zero parameter OIDs plus statement fields, or portal
-  fields, without execution.
+  Explicit OIDs are accepted for `bool`, `int2`/`int4`/`int8`, `oid`,
+  `float4`/`float8`, `numeric`, `bytea`, PostgreSQL text families, and
+  `json`/`jsonb`. OID zero, omitted OIDs, and trailing uninferred parameters
+  conservatively become `text`; unsupported OIDs fail before a core prepared
+  handle is retained.
+- `Bind` requires the exact value count and accepts PostgreSQL's zero, unified,
+  or per-parameter text/binary format list. Values are decoded into
+  protocol-neutral `Value`s before Engine bind, planning, or routing. Named
+  portals must be unique; replacing the unnamed portal closes its core handle.
+- `Describe` returns the resolved parameter OIDs and text-format statement
+  fields, or the bound portal's immutable requested result formats, without
+  execution.
 - `Execute` returns rows or a command tag. A positive row limit suspends and
   resumes the already materialized bounded response without rerunning the core
   portal; a completed portal cannot replay a write.
@@ -176,12 +185,19 @@ The text-format, zero-parameter extended flow uses the same Engine lifecycle:
   `Flush` flushes pending output; `Sync` restores `ReadyForQuery(I)` after an
   error and causes skipped extended messages to be accepted again.
 
+Result format lists may be empty, unified, or match the result-column count.
+Binary results use PostgreSQL's native encodings for `bool`, `int8`, `float8`,
+and `numeric`, raw bytes for `bytea`, and UTF-8 bytes for text. Text results use
+canonical PostgreSQL spellings, including hex `bytea`. A dynamically stored
+SQLite value that cannot satisfy its declared static type fails as `42804`
+instead of emitting corrupt bytes. Decimal parameters decode correctly but the
+current Engine still rejects them before mutation because SQLite has no
+lossless decimal binding.
+
 Statement and portal names are at most 63 UTF-8 bytes. Engine limits remain
 authoritative for per-session prepared statements, portals, retained values,
-rows, and bytes. Explicit parameter OIDs, bound values, parameter formats, and
-binary results remain issue #33. DDL, transactions, and `COPY` are not
-supported. The offline importer is the supported way to establish registered
-tables. See the
+rows, and bytes. DDL, transactions, and `COPY` are not supported. The offline
+importer is the supported way to establish registered tables. See the
 [copy/paste query quickstart](POSTGRES_QUICKSTART.md).
 
 ## Connection ownership and shutdown
@@ -217,10 +233,11 @@ only `server-api` enabled. Production framing is contained in
 not accept or return dependency types. The adapter uses BriskDB's catalog,
 session lifecycle, fixed SQLSTATE table, and safe messages.
 
-This startup work changes no HTTP route, JSON body, SQL subset, planner rule,
-typed result, manifest table, shard header, migration journal, stored row, or
-storage-format version. Startup identity, parameter metadata, and connection
-tasks exist only in process memory.
+This work changes no HTTP route, JSON body, SQL subset, planner rule, manifest
+table, shard header, migration journal, stored row, or storage-format version.
+Declared SQLite type metadata is now retained in protocol-neutral statement
+descriptions; PostgreSQL OIDs, formats, and raw parameter bytes remain confined
+to the adapter and connection memory.
 
 Library selection details and upgrade constraints are normative in the
 [PostgreSQL adapter decision record](POSTGRES_ADAPTER.md).
@@ -249,6 +266,9 @@ Automated coverage includes:
 - named and unnamed extended write/read/describe/execute, suspension without
   replay, cascading close, flush, fixed-error `Sync` recovery, and raw frame
   validation;
+- explicit and inferred parameter OIDs, mixed text/binary values, declared
+  result OIDs, statement-versus-portal format descriptions, native binary
+  rows, numeric base-10,000 framing, fixed decode errors, and recovery;
 - immediate `Terminate`, client EOF, partial startup, normal shutdown, forced
   server-task cancellation, and core-session cleanup;
 - the 256-task admission boundary, deterministic overflow close, and slot reuse

--- a/docs/POSTGRES_QUICKSTART.md
+++ b/docs/POSTGRES_QUICKSTART.md
@@ -83,16 +83,16 @@ and inspect it with `systemctl status briskdb` and
 - Registered-table `SELECT`, `INSERT`, `UPDATE`, and `DELETE` execute through
   the same catalog, routing, limits, and fixed-error boundary as the core
   engine.
-- Results use PostgreSQL text format. Unknown SQLite compile metadata is
-  reported conservatively as PostgreSQL `text`; known protocol-neutral
-  metadata maps to boolean, signed integer, numeric, double precision, text,
-  or bytea OIDs. Stored non-UTF-8 text is rejected instead of being replaced.
+- Simple-query results use PostgreSQL text format. Recognized SQLite declared
+  types map to boolean, signed integer, numeric, double precision, text, or
+  bytea OIDs; expressions and unrecognized declarations remain conservative
+  PostgreSQL `text`. Stored non-UTF-8 text is rejected instead of being
+  replaced.
 - Sharded writes must contain enough literal shard-key information to select
   exactly one owner. Reads use the engine's bounded logical read path.
-- Zero-parameter text-format prepared queries support named and unnamed
-  `Parse`/`Bind`/`Describe`/`Execute`, portal suspension, `Flush`, `Sync`, and
-  cascading `Close`. Bind parameters, explicit parameter OIDs, and binary
-  formats remain deferred to type mapping in issue #33.
+- Parameterized prepared queries support named and unnamed
+  `Parse`/`Bind`/`Describe`/`Execute`, basic OIDs, mixed text/binary values and
+  results, portal suspension, `Flush`, `Sync`, and cascading `Close`.
 - DDL, transactions, `COPY`, authentication, authorization, TLS, and full
   PostgreSQL compatibility are not supported. Initialize the catalog offline
   with `briskdb-import` before starting the server.

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -50,10 +50,10 @@ claiming to be a drop-in PostgreSQL or MySQL replacement.
 
 The initial alpha exposes experimental HTTP plus a disabled-by-default,
 separately configured loopback PostgreSQL listener. PostgreSQL implements exact
-protocol-3.0 baseline and newer-minor downgrade, logical database/user selection, BriskDB parameter
-status, tracked session termination, simple queries, and zero-parameter
-text-format extended queries through a pinned `pgwire` 0.36.3 boundary. There
-is no MySQL listener. The public Rust SQL facade
+protocol-3.0 baseline and newer-minor downgrade, logical database/user
+selection, BriskDB parameter status, tracked session termination, simple
+queries, and parameterized text/binary extended queries through a pinned
+`pgwire` 0.36.3 boundary. There is no MySQL listener. The public Rust SQL facade
 can parse an explicitly selected SQLite, PostgreSQL, or MySQL dialect, consume
 that result with
 `validate_common_subset(ParsedSql)`, borrow the result with
@@ -94,7 +94,7 @@ set, every shard for an unconstrained Sharded read, or shard 0 once for a
 | HTTP `/v1/query` | Experimental | Empty catalog: legacy raw SQLite query. Populated catalog: exactly one SQLite common-subset read; no session cache; multi-shard execution is limited to the row-local scatter-safe subset | Empty catalog requires caller `shard_key`; populated catalog derives targets from registered metadata, reads Global data once on shard 0, and denies Catalog/undeclared tables |
 | HTTP `/v1/admin/broadcast` | Experimental | A journaled parameterless SQLite schema batch; populated catalogs reject row-moving DML, table drops, and trigger creation | Preflight on every shard, then ascending resumable apply |
 | HTTP `/admin` browser | Experimental, read-only | No caller SQL; metadata-driven logical table discovery, specialized exact logical `COUNT(*)`, and bounded deterministic `SELECT *` page slices | Sharded tables visit all files; Global tables visit shard 0 once; no browser shard selector or arbitrary SQL |
-| PostgreSQL wire protocol | Protocol-3.0 baseline with newer 3.x minor downgrade, plus simple `Query` and zero-parameter text-format extended flow on loopback | Registered-table `SELECT`, `INSERT`, `UPDATE`, and `DELETE`; parameters, binary formats, DDL, and transactions remain unsupported | Startup selects an exact logical database; both flows use Engine prepare/bind/logical execution and fixed SQLSTATE mapping |
+| PostgreSQL wire protocol | Protocol-3.0 baseline with newer 3.x minor downgrade, plus simple `Query` and parameterized text/binary extended flow on loopback | Registered-table `SELECT`, `INSERT`, `UPDATE`, and `DELETE`; basic OIDs and value formats are implemented, while DDL and transactions remain unsupported | Startup selects an exact logical database; both flows use Engine prepare/bind/logical execution and fixed SQLSTATE mapping |
 | MySQL wire protocol | Planned | Rust parsing, validation, classification, placeholder normalization, finite compatibility translation, and prepared lifecycle implemented; listener adoption planned | Core batch/write policy, bind validation, routing snapshots, current execute-time planning, and supported target execution implemented; wire mapping planned |
 
 The parser, subset validator, statement classifier, placeholder normalizer, SQL
@@ -403,8 +403,9 @@ For every row, `rows[row_index][column_index]` is described by
 used as JSON object keys. A query that produces no rows still returns all of its
 ordered column metadata with `"rows": []`. The `data_type` label is one of
 `unknown`, `null`, `boolean`, `int64`, `uint64`, `float64`, `decimal`, `text`,
-or `binary`. SQLite result columns currently report `unknown` because SQLite
-does not guarantee one static result type.
+or `binary`. Direct SQLite columns now retain the conservative declared-type
+mapping documented for PostgreSQL; expressions and unrecognized declarations
+remain `unknown` because SQLite does not guarantee one static result type.
 
 The `/v1/query` cell encoding retains the existing HTTP policy: nulls, booleans,
 signed and unsigned integers, finite floats, and valid text use their direct
@@ -786,7 +787,7 @@ an exact protocol-3.0 baseline on loopback and downgrades newer 3.x minor
 requests explicitly. It validates a finite parameter set,
 selects one logical database and user label, advertises BriskDB-owned status,
 and tracks the selected core session through termination. Simple and
-zero-parameter extended SQL messages use the bounded Engine lifecycle;
+parameterized extended SQL messages use the bounded Engine lifecycle;
 extended errors discard messages until `Sync`. PostgreSQL-specific behavior is
 not implemented unless listed as implemented in this document.
 Configuration and lifecycle semantics are normative in the [PostgreSQL listener
@@ -795,13 +796,13 @@ normative in the [adapter decision record](POSTGRES_ADAPTER.md).
 
 | Area | PostgreSQL | BriskDB contract |
 | --- | --- | --- |
-| Parameters | `$1`, `$2`, ... | Named/unnamed wire prepare/bind/describe/execute works for zero parameters; OID/value mapping remains issue #33 |
+| Parameters | `$1`, `$2`, ... | Named/unnamed prepare/bind/describe/execute supports basic explicit OIDs plus conservative text inference, exact counts, and mixed text/binary values |
 | Identifier quoting | Double quotes | Retained by opt-in compatibility translation; PostgreSQL case folding and catalog equivalence are not claimed |
-| Type system | Static types identified by OIDs | Opt-in Rust translation maps a finite declaration set to `BIGINT`, `BOOLEAN`, `REAL`, `TEXT`, or `BLOB`; OID and value/result adaptation remain planned |
-| Boolean | Dedicated `boolean` type | Opt-in translation maps the declaration to `BOOLEAN` and literals to `1`/`0`; Boolean wire/result metadata remains planned |
-| `BIGSERIAL`, identity, sequences | Sequence-backed generation | Compatibility translation accepts exactly inline `BIGSERIAL PRIMARY KEY` or `BIGINT PRIMARY KEY GENERATED BY DEFAULT AS IDENTITY` as `native_range_v1` intent and canonical SQLite `AUTOINCREMENT`; sequence objects/options and PostgreSQL wire result behavior remain unsupported |
-| `bytea` | Binary value | Opt-in declaration translation maps it to SQLite `BLOB`; binary value and wire adaptation remain planned |
-| `json` / `jsonb` | Distinct PostgreSQL types | Planned JSON validation; no promise of PostgreSQL `jsonb` storage or operators |
+| Type system | Static types identified by OIDs | Declared SQLite columns map conservatively to `bool`, `int8`, `float8`, `numeric`, `text`, or `bytea`; expressions and unknown declarations use `text` |
+| Boolean | Dedicated `boolean` type | Translation maps literals to SQLite `1`/`0`; declared Boolean results return OID `bool` and canonical text or one-byte binary values |
+| `BIGSERIAL`, identity, sequences | Sequence-backed generation | Compatibility translation accepts exactly inline `BIGSERIAL PRIMARY KEY` or `BIGINT PRIMARY KEY GENERATED BY DEFAULT AS IDENTITY` as `native_range_v1` intent and canonical SQLite `AUTOINCREMENT`; successful wire inserts use standard `INSERT 0 n` and never invent a generated-key row without `RETURNING` |
+| `bytea` | Binary value | Translation maps it to SQLite `BLOB`; parameters accept hex/escape text or raw binary and results use hex text or raw binary |
+| `json` / `jsonb` | Distinct PostgreSQL types | Parameters decode to protocol-neutral text (including the JSONB binary version byte); JSON validation, storage semantics, and operators are not claimed |
 | Arrays, ranges, enums, domains | Native PostgreSQL types | Unsupported initially |
 | Schemas and `search_path` | Multiple schemas per database | Unsupported initially; compatibility shims may expose one logical schema |
 | `RETURNING` | Common DML feature | Not in the initial common subset |
@@ -812,9 +813,9 @@ normative in the [adapter decision record](POSTGRES_ADAPTER.md).
 | `COPY`, replication, `LISTEN/NOTIFY` | PostgreSQL subprotocols/features | Deferred and unsupported initially |
 
 PostgreSQL's static result metadata does not always have an exact equivalent in
-SQLite's dynamic type system. BriskDB will honor declared and bound types where
-safe, infer expression types conservatively, and reject indeterminate binary
-parameters instead of guessing.
+SQLite's dynamic type system. BriskDB honors recognized declared types, reports
+expressions conservatively as text, and rejects a dynamic stored value that
+cannot satisfy the advertised type instead of emitting corrupt wire bytes.
 
 ## MySQL differences
 

--- a/docs/SQL_PREPARED_STATEMENTS.md
+++ b/docs/SQL_PREPARED_STATEMENTS.md
@@ -443,19 +443,20 @@ The lifecycle is implemented as a Rust engine API. Production PostgreSQL
 startup validates identity and creates one selected core session. Each
 simple-query statement enters this lifecycle with no parameters, then closes
 its temporary statement and portal after execution or failure. Extended
-`Parse` still stops at fixed `0A000`. There is no MySQL listener. All three
-typed Rust input paths share the same planning and result path:
+Parse/Bind decodes supported PostgreSQL OIDs and text/binary values into this
+lifecycle. There is no MySQL listener. All three typed Rust input paths share
+the same planning and result path:
 
 | Input | Required mode and parameter form | Prepared execution result |
 | --- | --- | --- |
 | SQLite | `StrictSqlite` for exact normalized SQLite, or explicit finite `Compatibility`; `?` / `?N` | Protocol-neutral routed/logical rows, affected-row count, or generated write |
-| PostgreSQL | `Compatibility`; `$N` identities, including repeats and gaps | Same protocol-neutral result; PostgreSQL OID/wire mapping remains issue #33 |
+| PostgreSQL | `Compatibility`; `$N` identities, including repeats and gaps | Same protocol-neutral result with adapter-owned basic OID and text/binary mapping |
 | MySQL | `Compatibility`; each `?` numbered left-to-right | Same protocol-neutral result; MySQL generated-key/wire mapping remains issue #44 |
 
 Each protocol adapter owns its message framing, authentication,
 statement/portal naming, wire parameter decoding, result type encoding, close
 acknowledgement, and protocol resynchronization. PostgreSQL startup framing,
-session ownership, parameter-free simple queries, and zero-parameter extended
+session ownership, parameter-free simple queries, and parameterized extended
 queries map into this lifecycle without retaining a SQLite handle, implementing
 a second authoritative cache, interpolating values into SQL, or choosing a
 physical shard in the adapter.

--- a/docs/SQL_STATEMENT_CLASSIFICATION.md
+++ b/docs/SQL_STATEMENT_CLASSIFICATION.md
@@ -224,8 +224,8 @@ classifier rejects, subject to the populated-catalog ban on row-moving DML,
 table drops, and trigger creation.
 At the issue-28 milestone, the PostgreSQL endpoint was only an accept/close
 scaffold. Issue #30 connected startup, catalog selection, status, and session
-cleanup; issue #31 connects simple and zero-parameter extended SQL messages to
-the shared classification and Engine lifecycle.
+cleanup; issues #31 and #33 connect simple and parameterized text/binary
+extended SQL messages to the shared classification and Engine lifecycle.
 
 ## Storage-format and configuration boundary
 

--- a/docs/VTAB_ROLLOUT.md
+++ b/docs/VTAB_ROLLOUT.md
@@ -76,14 +76,14 @@ production-hardening work.
 With the write opt-in enabled, HTTP rejects transactions, savepoints,
 attachments, and caller-authored DML `RETURNING` as `Unsupported` before pool
 admission; tests also verify every shard remains unchanged. The PostgreSQL
-listener now permits simple Query and zero-parameter text-format extended
+listener now permits simple Query and parameterized text/binary extended
 queries to enter the shared Engine lifecycle. Unsupported session statements
 return to idle without reaching storage.
 
 There is not yet a MySQL listener or command state machine. The shared mapping
 already freezes `Unsupported` as MySQL error 1235 / SQLSTATE `42000`, but a
 mapping function is not a live wire conformance test. PostgreSQL parameter/type
-mapping and transactions remain tracked by #33 and #34. MySQL listener/query,
+transactions remain tracked by #34. MySQL listener/query,
 result/error, and transaction work remains tracked by #40-#44 and #47.
 
 ## Benchmark evidence

--- a/python/tests/test_embedded.py
+++ b/python/tests/test_embedded.py
@@ -107,8 +107,8 @@ class EmbeddedBriskDbTests(unittest.TestCase):
             self.assertEqual(
                 result["columns"],
                 [
-                    {"name": "id", "type": "unknown"},
-                    {"name": "body", "type": "unknown"},
+                    {"name": "id", "type": "int64"},
+                    {"name": "body", "type": "text"},
                 ],
             )
             self.assertEqual(result["rows"], [(1, "hello")])

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -3631,8 +3631,8 @@ mod tests {
         ];
         let expected = ResultSet::new(
             vec![
-                Column::new("tenant_id", DataType::Unknown),
-                Column::new("payload", DataType::Unknown),
+                Column::new("tenant_id", DataType::Int64),
+                Column::new("payload", DataType::Text),
             ],
             vec![Row::new(vec![Value::from(7_i64), Value::from("seven")])],
         )
@@ -4957,8 +4957,8 @@ mod tests {
             read.value,
             ResultSet::new(
                 vec![
-                    Column::new("id", DataType::Unknown),
-                    Column::new("name", DataType::Unknown),
+                    Column::new("id", DataType::Text),
+                    Column::new("name", DataType::Text),
                 ],
                 vec![Row::new(vec![
                     Value::from("widget-1"),
@@ -5166,8 +5166,8 @@ mod tests {
                 result,
                 ResultSet::new(
                     vec![
-                        Column::new("id", DataType::Unknown),
-                        Column::new("label", DataType::Unknown),
+                        Column::new("id", DataType::Int64),
+                        Column::new("label", DataType::Text),
                     ],
                     vec![Row::new(vec![
                         Value::from(i64::from(shard)),

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -717,8 +717,8 @@ mod tests {
             read.value,
             ResultSet::new(
                 vec![
-                    Column::new("id", DataType::Unknown),
-                    Column::new("name", DataType::Unknown),
+                    Column::new("id", DataType::Text),
+                    Column::new("name", DataType::Text),
                 ],
                 vec![Row::new(vec![
                     Value::from("widget-1"),
@@ -760,8 +760,8 @@ mod tests {
                 .unwrap(),
             ResultSet::new(
                 vec![
-                    Column::new("id", DataType::Unknown),
-                    Column::new("name", DataType::Unknown),
+                    Column::new("id", DataType::Text),
+                    Column::new("name", DataType::Text),
                 ],
                 vec![Row::new(vec![
                     Value::from("widget-1"),

--- a/src/protocol/http.rs
+++ b/src/protocol/http.rs
@@ -474,8 +474,8 @@ mod tests {
                 json!({
                     "shard": expected_shard,
                     "columns": [
-                        {"name": "id", "data_type": "unknown"},
-                        {"name": "name", "data_type": "unknown"}
+                        {"name": "id", "data_type": "text"},
+                        {"name": "name", "data_type": "text"}
                     ],
                     "rows": [["widget-1", "First widget"]]
                 }),
@@ -827,9 +827,9 @@ mod tests {
                 json!({
                     "shards": [0, 1, 2, 3],
                     "columns": [
-                        {"name": "tenant_id", "data_type": "unknown"},
-                        {"name": "record_id", "data_type": "unknown"},
-                        {"name": "payload", "data_type": "unknown"}
+                        {"name": "tenant_id", "data_type": "text"},
+                        {"name": "record_id", "data_type": "int64"},
+                        {"name": "payload", "data_type": "text"}
                     ],
                     "rows": [
                         [tenant_keys[0], 1, "updated-0"],
@@ -1142,8 +1142,8 @@ mod tests {
                 json!({
                     "shards": [0, 1],
                     "columns": [
-                        {"name": "tenant_key", "data_type": "unknown"},
-                        {"name": "payload", "data_type": "unknown"}
+                        {"name": "tenant_key", "data_type": "text"},
+                        {"name": "payload", "data_type": "text"}
                     ],
                     "rows": [
                         [tenant_keys[0], "zero payload"],
@@ -1168,8 +1168,8 @@ mod tests {
                 json!({
                     "shards": [0, 1],
                     "columns": [
-                        {"name": "tenant_key", "data_type": "unknown"},
-                        {"name": "payload", "data_type": "unknown"}
+                        {"name": "tenant_key", "data_type": "text"},
+                        {"name": "payload", "data_type": "text"}
                     ],
                     "rows": [
                         [tenant_keys[0], "zero payload"],

--- a/src/protocol/http/admin.rs
+++ b/src/protocol/http/admin.rs
@@ -1698,10 +1698,10 @@ mod tests {
         assert_eq!(
             first_page["columns"],
             json!([
-                {"name":"id","data_type":"unknown"},
-                {"name":"label","data_type":"unknown"},
-                {"name":"payload","data_type":"unknown"},
-                {"name":"note","data_type":"unknown"}
+                {"name":"id","data_type":"int64"},
+                {"name":"label","data_type":"text"},
+                {"name":"payload","data_type":"binary"},
+                {"name":"note","data_type":"text"}
             ])
         );
         assert_eq!(
@@ -1735,10 +1735,10 @@ mod tests {
                     "offset": 2,
                     "has_more": true,
                     "columns": [
-                        {"name":"id","data_type":"unknown"},
-                        {"name":"label","data_type":"unknown"},
-                        {"name":"payload","data_type":"unknown"},
-                        {"name":"note","data_type":"unknown"}
+                        {"name":"id","data_type":"int64"},
+                        {"name":"label","data_type":"text"},
+                        {"name":"payload","data_type":"binary"},
+                        {"name":"note","data_type":"text"}
                     ],
                     "rows": [
                         [1, "shard-1-row-1", [1, 1], null],

--- a/src/protocol/postgres.rs
+++ b/src/protocol/postgres.rs
@@ -17,6 +17,7 @@ use std::{
 };
 
 use async_trait::async_trait;
+use bytes::{BufMut, BytesMut};
 use futures::{Sink, SinkExt, StreamExt, stream};
 use pgwire::{
     api::{
@@ -29,8 +30,8 @@ use pgwire::{
             send_partial_query_response, send_query_response,
         },
         results::{
-            DataRowEncoder, DescribePortalResponse, DescribeStatementResponse, FieldFormat,
-            FieldInfo, QueryResponse, Response, Tag,
+            DescribePortalResponse, DescribeStatementResponse, FieldFormat, FieldInfo,
+            QueryResponse, Response, Tag,
         },
         stmt::{QueryParser, StoredStatement},
         store::PortalStore,
@@ -38,7 +39,7 @@ use pgwire::{
     error::{ErrorInfo, PgWireError, PgWireResult},
     messages::{
         PgWireBackendMessage, PgWireFrontendMessage, ProtocolVersion, SslNegotiationMetaMessage,
-        data::NoData,
+        data::{DataRow, NoData},
         extendedquery::{
             Bind, BindComplete, Close, CloseComplete, Execute, Parse, ParseComplete,
             TARGET_TYPE_BYTE_PORTAL, TARGET_TYPE_BYTE_STATEMENT,
@@ -601,10 +602,11 @@ struct PgWireExtendedState {
     portals: BTreeMap<String, PgWireBoundPortal>,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 struct PgWireBoundPortal {
     id: PortalId,
     statement: PreparedStatementId,
+    fields: Arc<Vec<FieldInfo>>,
 }
 
 /// Protocol-owned state for one PostgreSQL connection.
@@ -1048,9 +1050,20 @@ fn simple_query_response(
     behavior: StatementBehavior,
     execution: PreparedExecution,
 ) -> PgWireResult<Response> {
+    execution_response(behavior, execution, None)
+}
+
+fn execution_response(
+    behavior: StatementBehavior,
+    execution: PreparedExecution,
+    fields: Option<Arc<Vec<FieldInfo>>>,
+) -> PgWireResult<Response> {
     match execution {
         PreparedExecution::Rows(result) if matches!(behavior, StatementBehavior::Read) => {
-            result_set_response(result)
+            match fields {
+                Some(fields) => result_set_response_with_fields(result, fields),
+                None => result_set_response(result),
+            }
         }
         PreparedExecution::AffectedRows(rows) => {
             Ok(Response::Execution(write_tag(behavior, rows)?))
@@ -1091,30 +1104,53 @@ fn result_set_response(result: ResultSet) -> PgWireResult<Response> {
             })
             .collect::<Vec<_>>(),
     );
+    encode_query_response(rows, fields)
+}
+
+fn result_set_response_with_fields(
+    result: ResultSet,
+    fields: Arc<Vec<FieldInfo>>,
+) -> PgWireResult<Response> {
+    let (columns, rows) = result.into_parts();
+    if columns.len() != fields.len() {
+        return Err(internal_query_error());
+    }
+    encode_query_response(rows, fields)
+}
+
+fn encode_query_response(
+    rows: Vec<crate::core::Row>,
+    fields: Arc<Vec<FieldInfo>>,
+) -> PgWireResult<Response> {
     let encoded = rows
         .into_iter()
         .map(|row| encode_data_row(Arc::clone(&fields), row.into_values()))
-        .collect::<Vec<_>>();
-    if encoded.iter().any(Result::is_err) {
-        return Err(internal_query_error());
-    }
+        .collect::<PgWireResult<Vec<_>>>()?;
     Ok(Response::Query(QueryResponse::new(
         fields,
-        stream::iter(encoded),
+        stream::iter(encoded.into_iter().map(Ok)),
     )))
 }
 
 fn description_fields(description: &PreparedStatementDescription) -> Vec<FieldInfo> {
+    description_fields_with(description, |_| FieldFormat::Text)
+}
+
+fn description_fields_with(
+    description: &PreparedStatementDescription,
+    format_for: impl Fn(usize) -> FieldFormat,
+) -> Vec<FieldInfo> {
     description
         .columns()
         .iter()
-        .map(|column| {
+        .enumerate()
+        .map(|(index, column)| {
             FieldInfo::new(
                 column.name.clone(),
                 None,
                 None,
                 postgres_type(column.data_type),
-                FieldFormat::Text,
+                format_for(index),
             )
         })
         .collect()
@@ -1131,25 +1167,632 @@ fn postgres_type(data_type: DataType) -> Type {
     }
 }
 
-fn encode_data_row(
-    fields: Arc<Vec<FieldInfo>>,
-    values: Vec<Value>,
-) -> PgWireResult<pgwire::messages::data::DataRow> {
-    let mut encoder = DataRowEncoder::new(fields);
-    for value in values {
-        match value {
-            Value::Null => encoder.encode_field(&None::<String>)?,
-            Value::Boolean(value) => encoder.encode_field(&value)?,
-            Value::Int64(value) => encoder.encode_field(&value)?,
-            Value::UInt64(value) => encoder.encode_field(&value.to_string())?,
-            Value::Float64(value) => encoder.encode_field(&value)?,
-            Value::Decimal(value) => encoder.encode_field(&value.into_string())?,
-            Value::Text(value) => encoder.encode_field(&value)?,
-            Value::InvalidText(_) => return Err(invalid_text_query_error()),
-            Value::Binary(value) => encoder.encode_field(&value)?,
+fn supported_parameter_type(data_type: &Type) -> bool {
+    matches!(
+        data_type,
+        &Type::BOOL
+            | &Type::INT2
+            | &Type::INT4
+            | &Type::INT8
+            | &Type::OID
+            | &Type::FLOAT4
+            | &Type::FLOAT8
+            | &Type::NUMERIC
+            | &Type::BYTEA
+            | &Type::TEXT
+            | &Type::VARCHAR
+            | &Type::BPCHAR
+            | &Type::NAME
+            | &Type::UNKNOWN
+            | &Type::JSON
+            | &Type::JSONB
+    )
+}
+
+fn decode_bound_parameters(
+    portal: &Portal<PgWirePrepared>,
+    parameter_types: &[Type],
+) -> PgWireResult<Vec<Value>> {
+    if portal.parameters.len() != parameter_types.len() {
+        return Err(query_wire_error(
+            "08P01",
+            "the PostgreSQL bound parameter count does not match the statement",
+        ));
+    }
+    portal
+        .parameters
+        .iter()
+        .zip(parameter_types)
+        .enumerate()
+        .map(|(index, (parameter, data_type))| match parameter {
+            None => Ok(Value::Null),
+            Some(parameter) => match portal.parameter_format.format_for(index) {
+                FieldFormat::Text => decode_text_parameter(parameter, data_type),
+                FieldFormat::Binary => decode_binary_parameter(parameter, data_type),
+            },
+        })
+        .collect()
+}
+
+fn decode_text_parameter(parameter: &[u8], data_type: &Type) -> PgWireResult<Value> {
+    if data_type == &Type::BYTEA {
+        return decode_bytea_text(parameter).map(Value::Binary);
+    }
+    let parameter = std::str::from_utf8(parameter).map_err(|_| invalid_parameter_utf8_error())?;
+    if data_type == &Type::BOOL {
+        if ["t", "true", "y", "yes", "on", "1"]
+            .iter()
+            .any(|accepted| parameter.eq_ignore_ascii_case(accepted))
+        {
+            Ok(Value::Boolean(true))
+        } else if ["f", "false", "n", "no", "off", "0"]
+            .iter()
+            .any(|accepted| parameter.eq_ignore_ascii_case(accepted))
+        {
+            Ok(Value::Boolean(false))
+        } else {
+            Err(invalid_parameter_value_error())
+        }
+    } else if data_type == &Type::INT2 {
+        parameter
+            .parse::<i16>()
+            .map(|value| Value::Int64(i64::from(value)))
+            .map_err(|_| invalid_parameter_value_error())
+    } else if data_type == &Type::INT4 {
+        parameter
+            .parse::<i32>()
+            .map(|value| Value::Int64(i64::from(value)))
+            .map_err(|_| invalid_parameter_value_error())
+    } else if data_type == &Type::INT8 {
+        parameter
+            .parse::<i64>()
+            .map(Value::Int64)
+            .map_err(|_| invalid_parameter_value_error())
+    } else if data_type == &Type::OID {
+        parameter
+            .parse::<u32>()
+            .map(|value| Value::UInt64(u64::from(value)))
+            .map_err(|_| invalid_parameter_value_error())
+    } else if data_type == &Type::FLOAT4 {
+        parse_postgres_float(parameter)
+            .and_then(|value| {
+                let narrowed = value as f32;
+                if narrowed.is_finite() || value.is_nan() || value.is_infinite() {
+                    Some(Value::Float64(f64::from(narrowed)))
+                } else {
+                    None
+                }
+            })
+            .ok_or_else(invalid_parameter_value_error)
+    } else if data_type == &Type::FLOAT8 {
+        parse_postgres_float(parameter)
+            .map(Value::Float64)
+            .ok_or_else(invalid_parameter_value_error)
+    } else if data_type == &Type::NUMERIC {
+        Value::decimal(parameter).map_err(|_| invalid_parameter_value_error())
+    } else if is_postgres_text_type(data_type) || matches!(data_type, &Type::JSON | &Type::JSONB) {
+        Ok(Value::Text(parameter.to_owned()))
+    } else {
+        Err(unsupported_parameter_type_error())
+    }
+}
+
+fn decode_binary_parameter(parameter: &[u8], data_type: &Type) -> PgWireResult<Value> {
+    if data_type == &Type::BOOL {
+        return match parameter {
+            [0] => Ok(Value::Boolean(false)),
+            [1] => Ok(Value::Boolean(true)),
+            _ => Err(invalid_parameter_value_error()),
+        };
+    }
+    if data_type == &Type::INT2 {
+        return parameter
+            .try_into()
+            .map(i16::from_be_bytes)
+            .map(|value| Value::Int64(i64::from(value)))
+            .map_err(|_| invalid_parameter_value_error());
+    }
+    if data_type == &Type::INT4 {
+        return parameter
+            .try_into()
+            .map(i32::from_be_bytes)
+            .map(|value| Value::Int64(i64::from(value)))
+            .map_err(|_| invalid_parameter_value_error());
+    }
+    if data_type == &Type::INT8 {
+        return parameter
+            .try_into()
+            .map(i64::from_be_bytes)
+            .map(Value::Int64)
+            .map_err(|_| invalid_parameter_value_error());
+    }
+    if data_type == &Type::OID {
+        return parameter
+            .try_into()
+            .map(u32::from_be_bytes)
+            .map(|value| Value::UInt64(u64::from(value)))
+            .map_err(|_| invalid_parameter_value_error());
+    }
+    if data_type == &Type::FLOAT4 {
+        return parameter
+            .try_into()
+            .map(f32::from_be_bytes)
+            .map(|value| Value::Float64(f64::from(value)))
+            .map_err(|_| invalid_parameter_value_error());
+    }
+    if data_type == &Type::FLOAT8 {
+        return parameter
+            .try_into()
+            .map(f64::from_be_bytes)
+            .map(Value::Float64)
+            .map_err(|_| invalid_parameter_value_error());
+    }
+    if data_type == &Type::NUMERIC {
+        return decode_numeric_binary(parameter);
+    }
+    if data_type == &Type::BYTEA {
+        return Ok(Value::Binary(parameter.to_vec()));
+    }
+    if data_type == &Type::JSONB {
+        let Some((1, json)) = parameter.split_first() else {
+            return Err(invalid_parameter_value_error());
+        };
+        return std::str::from_utf8(json)
+            .map(|json| Value::Text(json.to_owned()))
+            .map_err(|_| invalid_parameter_utf8_error());
+    }
+    if is_postgres_text_type(data_type) || data_type == &Type::JSON {
+        return std::str::from_utf8(parameter)
+            .map(|value| Value::Text(value.to_owned()))
+            .map_err(|_| invalid_parameter_utf8_error());
+    }
+    Err(unsupported_parameter_type_error())
+}
+
+fn parse_postgres_float(value: &str) -> Option<f64> {
+    if value.eq_ignore_ascii_case("nan") {
+        Some(f64::NAN)
+    } else if value.eq_ignore_ascii_case("infinity") || value.eq_ignore_ascii_case("inf") {
+        Some(f64::INFINITY)
+    } else if value.eq_ignore_ascii_case("-infinity") || value.eq_ignore_ascii_case("-inf") {
+        Some(f64::NEG_INFINITY)
+    } else {
+        value.parse().ok()
+    }
+}
+
+fn decode_bytea_text(value: &[u8]) -> PgWireResult<Vec<u8>> {
+    if let Some(hex) = value.strip_prefix(br"\x") {
+        if hex.len() % 2 != 0 {
+            return Err(invalid_parameter_value_error());
+        }
+        return hex
+            .chunks_exact(2)
+            .map(|pair| {
+                let high = decode_hex(pair[0]).ok_or_else(invalid_parameter_value_error)?;
+                let low = decode_hex(pair[1]).ok_or_else(invalid_parameter_value_error)?;
+                Ok((high << 4) | low)
+            })
+            .collect();
+    }
+
+    let mut decoded = Vec::with_capacity(value.len());
+    let mut index = 0;
+    while index < value.len() {
+        if value[index] != b'\\' {
+            decoded.push(value[index]);
+            index += 1;
+        } else if value.get(index + 1) == Some(&b'\\') {
+            decoded.push(b'\\');
+            index += 2;
+        } else {
+            let octal = value
+                .get(index + 1..index + 4)
+                .filter(|digits| digits.iter().all(|digit| matches!(digit, b'0'..=b'7')))
+                .ok_or_else(invalid_parameter_value_error)?;
+            let value = u16::from(octal[0] - b'0') * 64
+                + u16::from(octal[1] - b'0') * 8
+                + u16::from(octal[2] - b'0');
+            decoded.push(u8::try_from(value).map_err(|_| invalid_parameter_value_error())?);
+            index += 4;
         }
     }
-    encoder.finish()
+    Ok(decoded)
+}
+
+fn decode_hex(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        b'A'..=b'F' => Some(value - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn decode_numeric_binary(value: &[u8]) -> PgWireResult<Value> {
+    if value.len() < 8 || (value.len() - 8) % 2 != 0 {
+        return Err(invalid_parameter_value_error());
+    }
+    let ndigits = i16::from_be_bytes(value[0..2].try_into().unwrap());
+    let weight = i16::from_be_bytes(value[2..4].try_into().unwrap());
+    let sign = u16::from_be_bytes(value[4..6].try_into().unwrap());
+    let dscale = i16::from_be_bytes(value[6..8].try_into().unwrap());
+    if ndigits < 0
+        || !(0..=16_383).contains(&dscale)
+        || usize::try_from(ndigits).ok() != Some((value.len() - 8) / 2)
+        || !matches!(sign, 0x0000 | 0x4000)
+    {
+        return Err(invalid_parameter_value_error());
+    }
+    let groups = value[8..]
+        .chunks_exact(2)
+        .map(|bytes| i16::from_be_bytes(bytes.try_into().unwrap()))
+        .collect::<Vec<_>>();
+    if groups.iter().any(|group| !(0..=9999).contains(group)) {
+        return Err(invalid_parameter_value_error());
+    }
+
+    let mut integer = String::new();
+    if weight >= 0 {
+        for position in (0..=weight).rev() {
+            let index = i32::from(weight) - i32::from(position);
+            let group = usize::try_from(index)
+                .ok()
+                .and_then(|index| groups.get(index))
+                .copied()
+                .unwrap_or(0);
+            if integer.is_empty() {
+                integer.push_str(&group.to_string());
+            } else {
+                integer.push_str(&format!("{group:04}"));
+            }
+        }
+    } else {
+        integer.push('0');
+    }
+    if integer.is_empty() {
+        integer.push('0');
+    }
+
+    let mut fraction = String::new();
+    let fraction_groups = usize::from(u16::try_from(dscale).unwrap()).div_ceil(4);
+    for offset in 0..fraction_groups {
+        let position =
+            -1_i32 - i32::try_from(offset).map_err(|_| invalid_parameter_value_error())?;
+        let index = i32::from(weight) - position;
+        let group = usize::try_from(index)
+            .ok()
+            .and_then(|index| groups.get(index))
+            .copied()
+            .unwrap_or(0);
+        fraction.push_str(&format!("{group:04}"));
+    }
+    fraction.truncate(usize::from(u16::try_from(dscale).unwrap()));
+
+    let mut decoded = String::new();
+    if sign == 0x4000 {
+        decoded.push('-');
+    }
+    decoded.push_str(&integer);
+    if dscale > 0 {
+        decoded.push('.');
+        decoded.push_str(&fraction);
+    }
+    Value::decimal(decoded).map_err(|_| invalid_parameter_value_error())
+}
+
+fn unsupported_parameter_type_error() -> PgWireError {
+    query_wire_error("0A000", "the PostgreSQL parameter type is unsupported")
+}
+
+fn invalid_parameter_value_error() -> PgWireError {
+    query_wire_error("22P02", "the PostgreSQL parameter value is invalid")
+}
+
+fn invalid_parameter_utf8_error() -> PgWireError {
+    query_wire_error("22021", "the PostgreSQL text parameter is not valid UTF8")
+}
+
+fn encode_data_row(fields: Arc<Vec<FieldInfo>>, values: Vec<Value>) -> PgWireResult<DataRow> {
+    if fields.len() != values.len() {
+        return Err(internal_query_error());
+    }
+    let field_count = i16::try_from(fields.len()).map_err(|_| internal_query_error())?;
+    let mut data = BytesMut::new();
+    for (field, value) in fields.iter().zip(values) {
+        let Some(encoded) = encode_postgres_value(value, field.datatype(), field.format())? else {
+            data.put_i32(-1);
+            continue;
+        };
+        data.put_i32(i32::try_from(encoded.len()).map_err(|_| internal_query_error())?);
+        data.extend_from_slice(&encoded);
+    }
+    Ok(DataRow::new(data, field_count))
+}
+
+fn encode_postgres_value(
+    value: Value,
+    data_type: &Type,
+    format: FieldFormat,
+) -> PgWireResult<Option<Vec<u8>>> {
+    if matches!(value, Value::Null) {
+        return Ok(None);
+    }
+
+    let text = || postgres_scalar_text(&value);
+    let encoded = if data_type == &Type::BOOL {
+        let value = postgres_bool(&value)?;
+        match format {
+            FieldFormat::Text => vec![if value { b't' } else { b'f' }],
+            FieldFormat::Binary => vec![u8::from(value)],
+        }
+    } else if data_type == &Type::INT8 {
+        let value = postgres_i64(&value)?;
+        match format {
+            FieldFormat::Text => value.to_string().into_bytes(),
+            FieldFormat::Binary => value.to_be_bytes().to_vec(),
+        }
+    } else if data_type == &Type::FLOAT8 {
+        let Value::Float64(value) = value else {
+            return Err(result_type_mismatch_error());
+        };
+        match format {
+            FieldFormat::Text => postgres_float_text(value).into_bytes(),
+            FieldFormat::Binary => value.to_be_bytes().to_vec(),
+        }
+    } else if data_type == &Type::NUMERIC {
+        let text = postgres_numeric_text(&value)?;
+        match format {
+            FieldFormat::Text => text.into_bytes(),
+            FieldFormat::Binary => encode_numeric_binary(&text)?,
+        }
+    } else if data_type == &Type::BYTEA {
+        let Value::Binary(value) = value else {
+            return Err(result_type_mismatch_error());
+        };
+        match format {
+            FieldFormat::Text => postgres_bytea_text(&value),
+            FieldFormat::Binary => value,
+        }
+    } else if is_postgres_text_type(data_type) {
+        text()?.into_bytes()
+    } else {
+        return Err(result_type_mismatch_error());
+    };
+    Ok(Some(encoded))
+}
+
+fn postgres_bool(value: &Value) -> PgWireResult<bool> {
+    match value {
+        Value::Boolean(value) => Ok(*value),
+        Value::Int64(0) => Ok(false),
+        Value::Int64(1) => Ok(true),
+        _ => Err(result_type_mismatch_error()),
+    }
+}
+
+fn postgres_i64(value: &Value) -> PgWireResult<i64> {
+    match value {
+        Value::Int64(value) => Ok(*value),
+        Value::UInt64(value) => i64::try_from(*value).map_err(|_| result_type_mismatch_error()),
+        _ => Err(result_type_mismatch_error()),
+    }
+}
+
+fn postgres_numeric_text(value: &Value) -> PgWireResult<String> {
+    match value {
+        Value::Int64(value) => Ok(value.to_string()),
+        Value::UInt64(value) => Ok(value.to_string()),
+        Value::Float64(value) => Ok(postgres_float_text(*value)),
+        Value::Decimal(value) => Ok(value.as_str().to_owned()),
+        _ => Err(result_type_mismatch_error()),
+    }
+}
+
+fn postgres_scalar_text(value: &Value) -> PgWireResult<String> {
+    match value {
+        Value::Null => unreachable!("NULL is handled before scalar encoding"),
+        Value::Boolean(value) => Ok(if *value { "t" } else { "f" }.to_owned()),
+        Value::Int64(value) => Ok(value.to_string()),
+        Value::UInt64(value) => Ok(value.to_string()),
+        Value::Float64(value) => Ok(postgres_float_text(*value)),
+        Value::Decimal(value) => Ok(value.as_str().to_owned()),
+        Value::Text(value) => Ok(value.clone()),
+        Value::InvalidText(_) => Err(invalid_text_query_error()),
+        Value::Binary(value) => {
+            String::from_utf8(postgres_bytea_text(value)).map_err(|_| internal_query_error())
+        }
+    }
+}
+
+fn postgres_float_text(value: f64) -> String {
+    if value.is_nan() {
+        "NaN".to_owned()
+    } else if value == f64::INFINITY {
+        "Infinity".to_owned()
+    } else if value == f64::NEG_INFINITY {
+        "-Infinity".to_owned()
+    } else {
+        value.to_string()
+    }
+}
+
+fn postgres_bytea_text(value: &[u8]) -> Vec<u8> {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = Vec::with_capacity(2 + value.len().saturating_mul(2));
+    encoded.extend_from_slice(br"\x");
+    for byte in value {
+        encoded.push(HEX[usize::from(byte >> 4)]);
+        encoded.push(HEX[usize::from(byte & 0x0f)]);
+    }
+    encoded
+}
+
+fn is_postgres_text_type(data_type: &Type) -> bool {
+    matches!(
+        data_type,
+        &Type::TEXT | &Type::VARCHAR | &Type::BPCHAR | &Type::NAME | &Type::UNKNOWN
+    )
+}
+
+fn encode_numeric_binary(value: &str) -> PgWireResult<Vec<u8>> {
+    let special_sign = match value {
+        "NaN" => Some(0xc000_u16),
+        "Infinity" => Some(0xd000),
+        "-Infinity" => Some(0xf000),
+        _ => None,
+    };
+    if let Some(sign) = special_sign {
+        let mut encoded = Vec::with_capacity(8);
+        encoded.extend_from_slice(&0_i16.to_be_bytes());
+        encoded.extend_from_slice(&0_i16.to_be_bytes());
+        encoded.extend_from_slice(&sign.to_be_bytes());
+        encoded.extend_from_slice(&0_i16.to_be_bytes());
+        return Ok(encoded);
+    }
+
+    let (negative, unsigned) = value
+        .strip_prefix('-')
+        .map(|value| (true, value))
+        .or_else(|| value.strip_prefix('+').map(|value| (false, value)))
+        .unwrap_or((false, value));
+    let (mantissa, exponent) = unsigned
+        .split_once(['e', 'E'])
+        .map(|(mantissa, exponent)| {
+            exponent
+                .parse::<i32>()
+                .map(|exponent| (mantissa, exponent))
+                .map_err(|_| result_type_mismatch_error())
+        })
+        .transpose()?
+        .unwrap_or((unsigned, 0));
+    let (integer, fraction) = mantissa.split_once('.').unwrap_or((mantissa, ""));
+    if integer.is_empty() && fraction.is_empty() {
+        return Err(result_type_mismatch_error());
+    }
+    if !integer
+        .bytes()
+        .chain(fraction.bytes())
+        .all(|byte| byte.is_ascii_digit())
+    {
+        return Err(result_type_mismatch_error());
+    }
+
+    let mut digits = String::with_capacity(integer.len() + fraction.len());
+    digits.push_str(integer);
+    digits.push_str(fraction);
+    let decimal_index = i64::try_from(integer.len())
+        .ok()
+        .and_then(|length| length.checked_add(i64::from(exponent)))
+        .ok_or_else(numeric_out_of_range_error)?;
+    let digit_count = i64::try_from(digits.len()).map_err(|_| numeric_out_of_range_error())?;
+    let dscale = digit_count.checked_sub(decimal_index).unwrap_or(0).max(0);
+    if dscale > 16_383 {
+        return Err(numeric_out_of_range_error());
+    }
+    let dscale = i16::try_from(dscale).map_err(|_| numeric_out_of_range_error())?;
+
+    let mut whole = String::new();
+    if decimal_index <= 0 {
+        whole.push('0');
+    } else {
+        let integer_digits =
+            usize::try_from(decimal_index).map_err(|_| numeric_out_of_range_error())?;
+        let available = integer_digits.min(digits.len());
+        whole.push_str(&digits[..available]);
+        whole.extend(std::iter::repeat_n('0', integer_digits - available));
+        if whole.is_empty() {
+            whole.push('0');
+        }
+    }
+
+    let mut fractional = String::new();
+    if dscale > 0 {
+        if decimal_index < 0 {
+            fractional.extend(std::iter::repeat_n(
+                '0',
+                usize::try_from(-decimal_index).map_err(|_| numeric_out_of_range_error())?,
+            ));
+            fractional.push_str(&digits);
+        } else {
+            let start = usize::try_from(decimal_index)
+                .map_err(|_| numeric_out_of_range_error())?
+                .min(digits.len());
+            fractional.push_str(&digits[start..]);
+        }
+        fractional.truncate(usize::try_from(dscale).expect("positive i16 fits usize"));
+        fractional.extend(std::iter::repeat_n(
+            '0',
+            usize::try_from(dscale).expect("positive i16 fits usize") - fractional.len(),
+        ));
+    }
+
+    let integer_groups = whole.len().div_ceil(4);
+    let left_padding = integer_groups * 4 - whole.len();
+    let fractional_groups = fractional.len().div_ceil(4);
+    let mut grouped = String::with_capacity((integer_groups + fractional_groups) * 4);
+    grouped.extend(std::iter::repeat_n('0', left_padding));
+    grouped.push_str(&whole);
+    grouped.push_str(&fractional);
+    grouped.extend(std::iter::repeat_n(
+        '0',
+        fractional_groups * 4 - fractional.len(),
+    ));
+    let groups = grouped
+        .as_bytes()
+        .chunks_exact(4)
+        .map(|chunk| {
+            std::str::from_utf8(chunk)
+                .ok()
+                .and_then(|chunk| chunk.parse::<i16>().ok())
+                .ok_or_else(result_type_mismatch_error)
+        })
+        .collect::<PgWireResult<Vec<_>>>()?;
+    let leading_zeroes = groups.iter().take_while(|group| **group == 0).count();
+    let trailing_zeroes = groups.iter().rev().take_while(|group| **group == 0).count();
+    let retained_end = groups
+        .len()
+        .saturating_sub(trailing_zeroes)
+        .max(leading_zeroes);
+    let groups = &groups[leading_zeroes..retained_end];
+    let mut weight = i32::try_from(integer_groups).map_err(|_| numeric_out_of_range_error())?
+        - 1
+        - i32::try_from(leading_zeroes).map_err(|_| numeric_out_of_range_error())?;
+    if groups.is_empty() {
+        weight = 0;
+    }
+
+    let mut encoded = Vec::with_capacity(8 + groups.len() * 2);
+    encoded.extend_from_slice(
+        &i16::try_from(groups.len())
+            .map_err(|_| numeric_out_of_range_error())?
+            .to_be_bytes(),
+    );
+    encoded.extend_from_slice(
+        &i16::try_from(weight)
+            .map_err(|_| numeric_out_of_range_error())?
+            .to_be_bytes(),
+    );
+    encoded.extend_from_slice(&(if negative { 0x4000_u16 } else { 0 }).to_be_bytes());
+    encoded.extend_from_slice(&dscale.to_be_bytes());
+    for group in groups {
+        encoded.extend_from_slice(&group.to_be_bytes());
+    }
+    Ok(encoded)
+}
+
+fn result_type_mismatch_error() -> PgWireError {
+    engine_error_to_pgwire(EngineError::new(
+        crate::core::EngineErrorKind::TypeMismatch,
+        "a PostgreSQL result value does not match its advertised type",
+    ))
+}
+
+fn numeric_out_of_range_error() -> PgWireError {
+    engine_error_to_pgwire(EngineError::new(
+        crate::core::EngineErrorKind::NumericOutOfRange,
+        "a PostgreSQL numeric value exceeds the supported wire range",
+    ))
 }
 
 fn internal_query_error() -> PgWireError {
@@ -1200,29 +1843,31 @@ impl ExtendedQueryHandler for WireHandlers {
             self.remove_statement(client, name).await?;
         }
 
-        if !message.type_oids.is_empty() {
-            return Err(query_wire_error(
-                "0A000",
-                "PostgreSQL parameter OID lists are deferred to type mapping",
-            ));
+        for oid in &message.type_oids {
+            if *oid != 0
+                && !Type::from_oid(*oid)
+                    .as_ref()
+                    .is_some_and(supported_parameter_type)
+            {
+                return Err(unsupported_parameter_type_error());
+            }
         }
+        let parameter_types = message
+            .type_oids
+            .iter()
+            .map(|oid| Type::from_oid(*oid))
+            .collect::<Vec<_>>();
         let statement = self
             .query_parser()
-            .parse_sql(client, &message.query, &[])
+            .parse_sql(client, &message.query, &parameter_types)
             .await?;
-        if !statement.description.parameter_types().is_empty() {
-            let connection = self.connection.installed()?;
-            let _ = connection
-                .state
-                .engine
-                .close_prepared_statement(&connection.state.session, statement.id)
-                .await;
-            return Err(query_wire_error(
-                "0A000",
-                "PostgreSQL bound parameters are deferred to type mapping",
-            ));
-        }
-        let statement = StoredStatement::new(name.to_owned(), statement, Vec::new());
+        let stored_parameter_types = statement
+            .parameter_types
+            .iter()
+            .cloned()
+            .map(Some)
+            .collect();
+        let statement = StoredStatement::new(name.to_owned(), statement, stored_parameter_types);
         client.portal_store().put_statement(Arc::new(statement));
         client
             .send(PgWireBackendMessage::ParseComplete(ParseComplete::new()))
@@ -1244,21 +1889,22 @@ impl ExtendedQueryHandler for WireHandlers {
             .get_statement(statement_name)
             .ok_or_else(|| PgWireError::StatementNotFound(statement_name.to_owned()))?;
 
-        if !message.parameters.is_empty()
-            || !matches!(message.parameter_format_codes.as_slice(), [] | [0])
+        let parameter_count = statement.statement.parameter_types.len();
+        if message.parameters.len() != parameter_count {
+            return Err(query_wire_error(
+                "08P01",
+                "the PostgreSQL bound parameter count does not match the statement",
+            ));
+        }
+        if !matches!(message.parameter_format_codes.len(), 0 | 1)
+            && message.parameter_format_codes.len() != parameter_count
         {
             return Err(query_wire_error(
-                "0A000",
-                "PostgreSQL bound parameters are deferred to type mapping",
+                "08P01",
+                "the PostgreSQL parameter format count does not match the parameters",
             ));
         }
         let result_formats = message.result_column_format_codes.as_slice();
-        if !result_formats.iter().all(|format| *format == 0) {
-            return Err(query_wire_error(
-                "0A000",
-                "PostgreSQL binary result formats are deferred to type mapping",
-            ));
-        }
         if portal_name != DEFAULT_NAME && client.portal_store().get_portal(portal_name).is_some() {
             return Err(query_wire_error(
                 "42P03",
@@ -1288,33 +1934,29 @@ impl ExtendedQueryHandler for WireHandlers {
             self.remove_portal(client, portal_name).await?;
         }
 
+        let portal = Portal::try_new(&message, Arc::clone(&statement))?;
+        let parameters = decode_bound_parameters(&portal, &statement.statement.parameter_types)?;
+        let fields = Arc::new(description_fields_with(&description, |index| {
+            portal.result_column_format.format_for(index)
+        }));
+
         let portal_id = connection
             .state
             .engine
             .bind_statement(
                 &connection.state.session,
                 statement.statement.id,
-                Vec::new(),
+                parameters,
             )
             .await
             .map_err(engine_error_to_pgwire)?;
-        let portal = match Portal::try_new(&message, Arc::clone(&statement)) {
-            Ok(portal) => portal,
-            Err(error) => {
-                let _ = connection
-                    .state
-                    .engine
-                    .close_portal(&connection.state.session, portal_id)
-                    .await;
-                return Err(error);
-            }
-        };
         if let Err(error) = insert_bound_portal(
             &connection.state,
             portal_name,
             PgWireBoundPortal {
                 id: portal_id,
                 statement: statement.statement.id,
+                fields,
             },
         ) {
             let _ = connection
@@ -1431,12 +2073,7 @@ impl ExtendedQueryHandler for WireHandlers {
             .await
             .map_err(engine_error_to_pgwire)?;
         Ok(DescribeStatementResponse::new(
-            description
-                .parameter_types()
-                .iter()
-                .copied()
-                .map(postgres_type)
-                .collect(),
+            target.statement.parameter_types.iter().cloned().collect(),
             description_fields(&description),
         ))
     }
@@ -1454,16 +2091,7 @@ impl ExtendedQueryHandler for WireHandlers {
     {
         let portal = bound_portal(&self.connection.installed()?.state, target.name.as_str())?
             .ok_or_else(|| PgWireError::PortalNotFound(target.name.clone()))?;
-        let connection = self.connection.installed()?;
-        let description = connection
-            .state
-            .engine
-            .describe_prepared(&connection.state.session, DescribeTarget::Portal(portal.id))
-            .await
-            .map_err(engine_error_to_pgwire)?;
-        Ok(DescribePortalResponse::new(description_fields(
-            &description,
-        )))
+        Ok(DescribePortalResponse::new(portal.fields.as_ref().clone()))
     }
 
     async fn do_query<C>(
@@ -1494,7 +2122,7 @@ impl ExtendedQueryHandler for WireHandlers {
             .execute_portal_logical(&connection.state.session, bound.id)
             .await
             .map_err(engine_error_to_pgwire)?;
-        simple_query_response(behavior, execution.value)
+        execution_response(behavior, execution.value, Some(Arc::clone(&bound.fields)))
     }
 }
 
@@ -1739,7 +2367,7 @@ fn lock_extended_state(
 }
 
 fn bound_portal(state: &ConnectionState, name: &str) -> PgWireResult<Option<PgWireBoundPortal>> {
-    Ok(lock_extended_state(state)?.portals.get(name).copied())
+    Ok(lock_extended_state(state)?.portals.get(name).cloned())
 }
 
 fn insert_bound_portal(
@@ -1802,6 +2430,7 @@ fn valid_application_name(name: &str) -> bool {
 struct PgWirePrepared {
     id: PreparedStatementId,
     description: PreparedStatementDescription,
+    parameter_types: Arc<Vec<Type>>,
 }
 
 impl fmt::Debug for PgWirePrepared {
@@ -1810,6 +2439,7 @@ impl fmt::Debug for PgWirePrepared {
             .debug_struct("PgWirePrepared")
             .field("id", &self.id)
             .field("description", &self.description)
+            .field("parameter_types", &self.parameter_types)
             .finish()
     }
 }
@@ -1840,16 +2470,14 @@ impl QueryParser for PgWireQueryParser {
     where
         C: ClientInfo + Unpin + Send + Sync,
     {
-        // pgwire has already converted raw OIDs by this point. Both the
-        // inference marker (OID 0) and an unknown/custom OID arrive as `None`,
-        // so this boundary cannot safely distinguish them. Reject every
-        // nonempty type list until BriskDB owns raw Parse-message validation.
-        if !types.is_empty() {
-            return Err(engine_error_to_pgwire(EngineError::new(
-                crate::core::EngineErrorKind::Unsupported,
-                "PostgreSQL parameter OID lists are deferred to type mapping",
-            )));
-        }
+        let supplied_types = types
+            .iter()
+            .map(|data_type| match data_type {
+                Some(data_type) if supported_parameter_type(data_type) => Ok(data_type.clone()),
+                Some(_) => Err(unsupported_parameter_type_error()),
+                None => Ok(Type::TEXT),
+            })
+            .collect::<PgWireResult<Vec<_>>>()?;
 
         let request = PrepareRequest::new(
             self.state.database,
@@ -1880,7 +2508,25 @@ impl QueryParser for PgWireQueryParser {
             }
         };
 
-        Ok(PgWirePrepared { id, description })
+        if supplied_types.len() > description.parameter_types().len() {
+            let _ = self
+                .state
+                .engine
+                .close_prepared_statement(&self.state.session, id)
+                .await;
+            return Err(query_wire_error(
+                "08P01",
+                "the PostgreSQL parameter type count exceeds the statement parameters",
+            ));
+        }
+        let mut parameter_types = supplied_types;
+        parameter_types.resize(description.parameter_types().len(), Type::TEXT);
+
+        Ok(PgWirePrepared {
+            id,
+            description,
+            parameter_types: Arc::new(parameter_types),
+        })
     }
 }
 
@@ -2032,20 +2678,56 @@ mod tests {
     }
 
     fn parse_packet(name: &str, query: &str) -> Vec<u8> {
+        parse_packet_with_oids(name, query, &[])
+    }
+
+    fn parse_packet_with_oids(name: &str, query: &str, type_oids: &[u32]) -> Vec<u8> {
         let mut body = Vec::new();
         push_cstring(&mut body, name);
         push_cstring(&mut body, query);
-        body.extend_from_slice(&0_u16.to_be_bytes());
+        body.extend_from_slice(&u16::try_from(type_oids.len()).unwrap().to_be_bytes());
+        for oid in type_oids {
+            body.extend_from_slice(&oid.to_be_bytes());
+        }
         typed_packet(b'P', &body)
     }
 
     fn bind_packet(portal: &str, statement: &str) -> Vec<u8> {
+        bind_packet_with(portal, statement, &[], &[], &[])
+    }
+
+    fn bind_packet_with(
+        portal: &str,
+        statement: &str,
+        parameter_formats: &[i16],
+        parameters: &[Option<&[u8]>],
+        result_formats: &[i16],
+    ) -> Vec<u8> {
         let mut body = Vec::new();
         push_cstring(&mut body, portal);
         push_cstring(&mut body, statement);
-        body.extend_from_slice(&0_u16.to_be_bytes());
-        body.extend_from_slice(&0_u16.to_be_bytes());
-        body.extend_from_slice(&0_i16.to_be_bytes());
+        body.extend_from_slice(
+            &u16::try_from(parameter_formats.len())
+                .unwrap()
+                .to_be_bytes(),
+        );
+        for format in parameter_formats {
+            body.extend_from_slice(&format.to_be_bytes());
+        }
+        body.extend_from_slice(&u16::try_from(parameters.len()).unwrap().to_be_bytes());
+        for parameter in parameters {
+            match parameter {
+                Some(parameter) => {
+                    body.extend_from_slice(&i32::try_from(parameter.len()).unwrap().to_be_bytes());
+                    body.extend_from_slice(parameter);
+                }
+                None => body.extend_from_slice(&(-1_i32).to_be_bytes()),
+            }
+        }
+        body.extend_from_slice(&i16::try_from(result_formats.len()).unwrap().to_be_bytes());
+        for format in result_formats {
+            body.extend_from_slice(&format.to_be_bytes());
+        }
         typed_packet(b'B', &body)
     }
 
@@ -2172,6 +2854,13 @@ mod tests {
     }
 
     fn row_description(body: &[u8]) -> Vec<(String, u32)> {
+        row_description_fields(body)
+            .into_iter()
+            .map(|(name, oid, _)| (name, oid))
+            .collect()
+    }
+
+    fn row_description_fields(body: &[u8]) -> Vec<(String, u32, i16)> {
         let count = usize::from(u16::from_be_bytes(body[..2].try_into().unwrap()));
         let mut fields = Vec::with_capacity(count);
         let mut offset = 2;
@@ -2185,11 +2874,22 @@ mod tests {
             offset = end + 1;
             offset += 4 + 2;
             let oid = u32::from_be_bytes(body[offset..offset + 4].try_into().unwrap());
-            offset += 4 + 2 + 4 + 2;
-            fields.push((name, oid));
+            offset += 4 + 2 + 4;
+            let format = i16::from_be_bytes(body[offset..offset + 2].try_into().unwrap());
+            offset += 2;
+            fields.push((name, oid, format));
         }
         assert_eq!(offset, body.len());
         fields
+    }
+
+    fn parameter_description(body: &[u8]) -> Vec<u32> {
+        let count = usize::from(u16::from_be_bytes(body[..2].try_into().unwrap()));
+        assert_eq!(body.len(), 2 + count * 4);
+        body[2..]
+            .chunks_exact(4)
+            .map(|bytes| u32::from_be_bytes(bytes.try_into().unwrap()))
+            .collect()
     }
 
     #[test]
@@ -2283,6 +2983,152 @@ mod tests {
             info.message,
             postgres_error(EngineErrorKind::InvalidTextEncoding).message
         );
+
+        let invalid_result = ResultSet::new(
+            vec![crate::core::Column::new("invalid", DataType::Text)],
+            vec![crate::core::Row::new(vec![Value::InvalidText(vec![0x80])])],
+        )
+        .unwrap();
+        let Err(PgWireError::UserError(info)) = result_set_response(invalid_result) else {
+            panic!("result response encoding must preserve the fixed invalid-text error")
+        };
+        assert_eq!(info.code, "22021");
+
+        let mismatched_result = ResultSet::new(
+            vec![crate::core::Column::new("count", DataType::Int64)],
+            vec![crate::core::Row::new(vec![Value::Text(
+                "not an integer".to_owned(),
+            )])],
+        )
+        .unwrap();
+        let Err(PgWireError::UserError(info)) = result_set_response(mismatched_result) else {
+            panic!("result response encoding must preserve the fixed type-mismatch error")
+        };
+        assert_eq!(info.code, "42804");
+    }
+
+    #[test]
+    fn postgres_binary_values_and_numeric_groups_are_exact() {
+        let fields = Arc::new(vec![
+            FieldInfo::new(
+                "bool".to_owned(),
+                None,
+                None,
+                Type::BOOL,
+                FieldFormat::Binary,
+            ),
+            FieldInfo::new(
+                "int".to_owned(),
+                None,
+                None,
+                Type::INT8,
+                FieldFormat::Binary,
+            ),
+            FieldInfo::new(
+                "numeric".to_owned(),
+                None,
+                None,
+                Type::NUMERIC,
+                FieldFormat::Binary,
+            ),
+            FieldInfo::new(
+                "float".to_owned(),
+                None,
+                None,
+                Type::FLOAT8,
+                FieldFormat::Binary,
+            ),
+            FieldInfo::new(
+                "text".to_owned(),
+                None,
+                None,
+                Type::TEXT,
+                FieldFormat::Binary,
+            ),
+            FieldInfo::new(
+                "bytea".to_owned(),
+                None,
+                None,
+                Type::BYTEA,
+                FieldFormat::Binary,
+            ),
+        ]);
+        let row = encode_data_row(
+            fields,
+            vec![
+                Value::Int64(1),
+                Value::Int64(-42),
+                Value::decimal("12.3400").unwrap(),
+                Value::Float64(1.5),
+                Value::Text("hello".to_owned()),
+                Value::Binary(vec![0, 255]),
+            ],
+        )
+        .unwrap();
+        let mut body = row.field_count.to_be_bytes().to_vec();
+        body.extend_from_slice(&row.data);
+        let numeric = [
+            0, 2, // two base-10000 digits
+            0, 0, // weight zero
+            0, 0, // positive
+            0, 4, // four decimal places
+            0, 12, // 12
+            13, 72, // 3400
+        ];
+        assert_eq!(
+            data_row(&body),
+            [
+                Some(vec![1]),
+                Some((-42_i64).to_be_bytes().to_vec()),
+                Some(numeric.to_vec()),
+                Some(1.5_f64.to_be_bytes().to_vec()),
+                Some(b"hello".to_vec()),
+                Some(vec![0, 255]),
+            ]
+        );
+        assert_eq!(
+            decode_numeric_binary(&numeric).unwrap(),
+            Value::decimal("12.3400").unwrap()
+        );
+        for value in ["0", "-0.0012", "10000", ".5", "1e3", "1e-3"] {
+            let encoded = encode_numeric_binary(value).unwrap();
+            let Value::Decimal(decoded) = decode_numeric_binary(&encoded).unwrap() else {
+                panic!("finite PostgreSQL numeric decoded as another BriskDB type")
+            };
+            let expected = match value {
+                ".5" => "0.5",
+                "1e3" => "1000",
+                "1e-3" => "0.001",
+                value => value,
+            };
+            assert_eq!(decoded.as_str(), expected);
+        }
+        let invalid_bytea = decode_bytea_text(br"\777").unwrap_err();
+        let PgWireError::UserError(info) = invalid_bytea else {
+            panic!("invalid bytea must use the fixed parameter error")
+        };
+        assert_eq!(info.code, "22P02");
+    }
+
+    #[test]
+    fn generated_insert_uses_the_standard_command_tag_without_unsolicited_rows() {
+        let execution =
+            PreparedExecution::GeneratedWrite(crate::core::WriteResult::with_generated_key(
+                1,
+                crate::core::GeneratedKey::new("id", Value::Int64(4_620_693_217_682_128_897)),
+            ));
+        let response = execution_response(
+            StatementBehavior::Write(WriteBehavior::Insert),
+            execution,
+            None,
+        )
+        .unwrap();
+        let Response::Execution(tag) = response else {
+            panic!("PostgreSQL must not invent a result row without RETURNING")
+        };
+        let complete: pgwire::messages::response::CommandComplete = tag.into();
+        assert_eq!(complete.tag, "INSERT 0 1");
+        assert!(!complete.tag.contains("4620693217682128897"));
     }
 
     async fn assert_eof(stream: &mut TcpStream) {
@@ -3018,6 +3864,166 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn extended_parameters_and_binary_results_use_declared_postgres_types() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut database = crate::core::Database::open(temp.path(), 2).unwrap();
+        database
+            .broadcast(
+                "CREATE TABLE typed_records (
+                    tenant_id TEXT NOT NULL PRIMARY KEY,
+                    enabled BOOLEAN NOT NULL,
+                    count_value INTEGER NOT NULL,
+                    ratio REAL NOT NULL,
+                    payload BLOB NOT NULL
+                 )",
+            )
+            .unwrap();
+        let logical_database = database.catalog().default_database().id();
+        database
+            .register_tables(vec![
+                crate::core::TableDeclaration::sharded(
+                    logical_database,
+                    "typed_records",
+                    crate::core::ShardKeyMetadata::new(
+                        "tenant_id",
+                        crate::core::ShardKeyType::Text,
+                    )
+                    .unwrap(),
+                )
+                .unwrap(),
+            ])
+            .unwrap();
+        let engine = Engine::from_database(Arc::new(database));
+        let adapter = Adapter::new(engine.clone());
+        let (address, wire, server) = spawn_wire_server(&adapter).await;
+        let mut client = TcpStream::connect(address).await.unwrap();
+        client.write_all(&startup_packet()).await.unwrap();
+        read_until_ready(&mut client).await;
+
+        let insert_types = [
+            Type::TEXT.oid(),
+            Type::BOOL.oid(),
+            Type::INT8.oid(),
+            Type::FLOAT8.oid(),
+            Type::BYTEA.oid(),
+        ];
+        let ratio = 1.5_f64.to_be_bytes();
+        let insert = [
+            parse_packet_with_oids(
+                "insert_typed",
+                "INSERT INTO typed_records
+                 (tenant_id, enabled, count_value, ratio, payload)
+                 VALUES ($1, $2, $3, $4, $5)",
+                &insert_types,
+            ),
+            bind_packet_with(
+                "insert_portal",
+                "insert_typed",
+                &[0, 1, 0, 1, 1],
+                &[
+                    Some(b"tenant-b"),
+                    Some(&[1]),
+                    Some(b"42"),
+                    Some(&ratio),
+                    Some(&[0, 255]),
+                ],
+                &[],
+            ),
+            execute_packet("insert_portal", 0),
+            typed_packet(b'S', &[]),
+        ]
+        .concat();
+        client.write_all(&insert).await.unwrap();
+        let frames = read_until_ready(&mut client).await;
+        assert_eq!(
+            frames.iter().map(|frame| frame.0).collect::<Vec<_>>(),
+            [b'1', b'2', b'C', b'Z']
+        );
+        assert_eq!(command_tag(&frames[2].1), "INSERT 0 1");
+
+        client
+            .write_all(
+                &[
+                    parse_packet_with_oids(
+                        "select_typed",
+                        "SELECT tenant_id, enabled, count_value, ratio, payload
+                         FROM typed_records WHERE tenant_id = $1",
+                        &[Type::TEXT.oid()],
+                    ),
+                    describe_packet(TARGET_TYPE_BYTE_STATEMENT, "select_typed"),
+                ]
+                .concat(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(read_frame(&mut client).await, (b'1', vec![]));
+        let parameter_frame = read_frame(&mut client).await;
+        assert_eq!(parameter_frame.0, b't');
+        assert_eq!(
+            parameter_description(&parameter_frame.1),
+            [Type::TEXT.oid()]
+        );
+        let statement_fields = read_frame(&mut client).await;
+        assert_eq!(statement_fields.0, b'T');
+        assert_eq!(
+            row_description_fields(&statement_fields.1),
+            [
+                ("tenant_id".to_owned(), Type::TEXT.oid(), 0),
+                ("enabled".to_owned(), Type::BOOL.oid(), 0),
+                ("count_value".to_owned(), Type::INT8.oid(), 0),
+                ("ratio".to_owned(), Type::FLOAT8.oid(), 0),
+                ("payload".to_owned(), Type::BYTEA.oid(), 0),
+            ]
+        );
+
+        let read = [
+            bind_packet_with(
+                "select_portal",
+                "select_typed",
+                &[1],
+                &[Some(b"tenant-b")],
+                &[1],
+            ),
+            describe_packet(TARGET_TYPE_BYTE_PORTAL, "select_portal"),
+            execute_packet("select_portal", 0),
+            typed_packet(b'S', &[]),
+        ]
+        .concat();
+        client.write_all(&read).await.unwrap();
+        let frames = read_until_ready(&mut client).await;
+        assert_eq!(
+            frames.iter().map(|frame| frame.0).collect::<Vec<_>>(),
+            [b'2', b'T', b'D', b'C', b'Z']
+        );
+        assert_eq!(
+            row_description_fields(&frames[1].1),
+            [
+                ("tenant_id".to_owned(), Type::TEXT.oid(), 1),
+                ("enabled".to_owned(), Type::BOOL.oid(), 1),
+                ("count_value".to_owned(), Type::INT8.oid(), 1),
+                ("ratio".to_owned(), Type::FLOAT8.oid(), 1),
+                ("payload".to_owned(), Type::BYTEA.oid(), 1),
+            ]
+        );
+        assert_eq!(
+            data_row(&frames[2].1),
+            [
+                Some(b"tenant-b".to_vec()),
+                Some(vec![1]),
+                Some(42_i64.to_be_bytes().to_vec()),
+                Some(1.5_f64.to_be_bytes().to_vec()),
+                Some(vec![0, 255]),
+            ]
+        );
+        assert_eq!(command_tag(&frames[3].1), "SELECT 1");
+
+        let core = Arc::clone(wire.connection().unwrap());
+        finish_wire_server(&mut client, server).await;
+        assert_eq!(core.state().await, SessionState::Closed);
+        engine.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
     async fn extended_query_errors_resync_and_unnamed_replacement_cleans_up_portals() {
         let (_temp, engine) = engine(2).await;
         let adapter = Adapter::new(engine.clone());
@@ -3027,19 +4033,21 @@ mod tests {
         read_until_ready(&mut client).await;
         let core = Arc::clone(wire.connection().unwrap());
 
-        let mut parse = Vec::new();
-        push_cstring(&mut parse, "private_statement");
-        push_cstring(&mut parse, "SELECT 'private extended text'");
-        parse.extend_from_slice(&1_u16.to_be_bytes());
-        parse.extend_from_slice(&Type::INT4.oid().to_be_bytes());
-        client.write_all(&typed_packet(b'P', &parse)).await.unwrap();
+        client
+            .write_all(&parse_packet_with_oids(
+                "private_statement",
+                "SELECT $1 || 'private extended text'",
+                &[Type::DATE.oid()],
+            ))
+            .await
+            .unwrap();
         let error = read_frame(&mut client).await;
         assert_eq!(error.0, b'E');
         let fields = message_fields(&error.1);
         assert_eq!(fields.get(&b'C').map(String::as_str), Some("0A000"));
         assert_eq!(
             fields.get(&b'M').map(String::as_str),
-            Some("PostgreSQL parameter OID lists are deferred to type mapping")
+            Some("the PostgreSQL parameter type is unsupported")
         );
         assert!(!fields.get(&b'M').unwrap().contains("private extended text"));
 
@@ -3047,15 +4055,52 @@ mod tests {
         assert_eq!(read_frame(&mut client).await, (b'Z', vec![b'I']));
 
         client
-            .write_all(&parse_packet("parameterized", "SELECT $1"))
+            .write_all(&parse_packet_with_oids(
+                "too_many_types",
+                "SELECT $1",
+                &[Type::INT8.oid(), Type::BOOL.oid()],
+            ))
+            .await
+            .unwrap();
+        let error = read_frame(&mut client).await;
+        assert_eq!(error.0, b'E');
+        assert_eq!(
+            message_fields(&error.1).get(&b'C').map(String::as_str),
+            Some("08P01")
+        );
+        client.write_all(&typed_packet(b'S', &[])).await.unwrap();
+        assert_eq!(read_frame(&mut client).await, (b'Z', vec![b'I']));
+
+        client
+            .write_all(&parse_packet_with_oids(
+                "parameterized",
+                "SELECT $1",
+                &[Type::INT8.oid()],
+            ))
+            .await
+            .unwrap();
+        assert_eq!(read_frame(&mut client).await, (b'1', vec![]));
+        client
+            .write_all(&bind_packet_with(
+                "invalid_parameter_portal",
+                "parameterized",
+                &[1],
+                &[Some(&1_i32.to_be_bytes())],
+                &[],
+            ))
             .await
             .unwrap();
         let error = read_frame(&mut client).await;
         assert_eq!(error.0, b'E');
         let fields = message_fields(&error.1);
-        assert_eq!(fields.get(&b'C').map(String::as_str), Some("0A000"));
+        assert_eq!(fields.get(&b'C').map(String::as_str), Some("22P02"));
         client.write_all(&typed_packet(b'S', &[])).await.unwrap();
         assert_eq!(read_frame(&mut client).await, (b'Z', vec![b'I']));
+        assert!(
+            bound_portal(&core.state, "invalid_parameter_portal")
+                .unwrap()
+                .is_none()
+        );
 
         client
             .write_all(&parse_packet(
@@ -3573,7 +4618,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn selected_query_parser_prepares_through_core_and_rejects_all_oid_lists() {
+    async fn selected_query_parser_prepares_through_core_and_owns_parameter_types() {
         let (_temp, engine) = engine(2).await;
         let adapter = Adapter::new(engine.clone());
         let connection = adapter.open_connection();
@@ -3599,29 +4644,52 @@ mod tests {
             .wire_parser
             .parse_sql(&client, "SELECT $1", &[None])
             .await
-            .unwrap_err();
-        let PgWireError::UserError(info) = inferred_or_unknown else {
-            panic!("expected a BriskDB-owned PostgreSQL error")
-        };
-        assert_eq!(info.code, "0A000");
-        assert_eq!(
-            info.message,
-            postgres_error(EngineErrorKind::Unsupported).message
+            .unwrap();
+        assert_eq!(inferred_or_unknown.parameter_types.as_ref(), &[Type::TEXT]);
+        assert!(
+            connection
+                .state
+                .engine
+                .close_prepared_statement(&connection.state.session, inferred_or_unknown.id)
+                .await
+                .unwrap()
         );
 
         let recognized = connection
             .wire_parser
             .parse_sql(&client, "SELECT $1", &[Some(Type::INT8)])
             .await
+            .unwrap();
+        assert_eq!(recognized.parameter_types.as_ref(), &[Type::INT8]);
+        assert!(
+            connection
+                .state
+                .engine
+                .close_prepared_statement(&connection.state.session, recognized.id)
+                .await
+                .unwrap()
+        );
+
+        let unsupported = connection
+            .wire_parser
+            .parse_sql(&client, "SELECT $1", &[Some(Type::DATE)])
+            .await
             .unwrap_err();
-        let PgWireError::UserError(info) = recognized else {
+        let PgWireError::UserError(info) = unsupported else {
             panic!("expected a BriskDB-owned PostgreSQL error")
         };
         assert_eq!(info.code, "0A000");
-        assert_eq!(
-            info.message,
-            postgres_error(EngineErrorKind::Unsupported).message
-        );
+        assert_eq!(info.message, "the PostgreSQL parameter type is unsupported");
+
+        let too_many = connection
+            .wire_parser
+            .parse_sql(&client, "SELECT $1", &[Some(Type::INT8), Some(Type::BOOL)])
+            .await
+            .unwrap_err();
+        let PgWireError::UserError(info) = too_many else {
+            panic!("expected a BriskDB-owned PostgreSQL error")
+        };
+        assert_eq!(info.code, "08P01");
 
         let invalid = connection
             .wire_parser

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -276,11 +276,44 @@ fn statement_metadata(statement: &SqlStatement<'_>) -> StatementMetadata {
     StatementMetadata {
         parameter_count: statement.parameter_count(),
         columns: statement
-            .column_names()
+            .columns()
             .into_iter()
-            .map(|name| Column::new(name, DataType::Unknown))
+            .map(|column| {
+                Column::new(
+                    column.name(),
+                    column
+                        .decl_type()
+                        .map(declared_data_type)
+                        .unwrap_or(DataType::Unknown),
+                )
+            })
             .collect(),
         readonly: statement.readonly(),
+    }
+}
+
+fn declared_data_type(declaration: &str) -> DataType {
+    let declaration = declaration.trim().to_ascii_uppercase();
+    if matches!(declaration.as_str(), "BOOL" | "BOOLEAN") {
+        DataType::Boolean
+    } else if declaration.contains("INT") {
+        DataType::Int64
+    } else if declaration.contains("CHAR")
+        || declaration.contains("CLOB")
+        || declaration.contains("TEXT")
+    {
+        DataType::Text
+    } else if declaration.contains("BLOB") {
+        DataType::Binary
+    } else if declaration.contains("REAL")
+        || declaration.contains("FLOA")
+        || declaration.contains("DOUB")
+    {
+        DataType::Float64
+    } else if declaration.contains("DECIMAL") || declaration.contains("NUMERIC") {
+        DataType::Decimal
+    } else {
+        DataType::Unknown
     }
 }
 
@@ -615,12 +648,39 @@ mod tests {
         assert_eq!(
             returning.columns(),
             [
-                Column::new("id", DataType::Unknown),
-                Column::new("value", DataType::Unknown),
+                Column::new("id", DataType::Int64),
+                Column::new("value", DataType::Text),
             ]
         );
         assert!(!returning.readonly());
         assert!(returning.produces_columns());
+
+        let selected =
+            describe_statement(&connection, "SELECT id, value FROM metadata_test").unwrap();
+        assert_eq!(
+            selected.columns(),
+            [
+                Column::new("id", DataType::Int64),
+                Column::new("value", DataType::Text),
+            ]
+        );
+        assert!(selected.readonly());
+    }
+
+    #[test]
+    fn sqlite_declarations_map_to_conservative_protocol_neutral_types() {
+        for (declaration, expected) in [
+            ("BOOLEAN", DataType::Boolean),
+            ("unsigned big int", DataType::Int64),
+            ("VARCHAR(255)", DataType::Text),
+            ("BLOB", DataType::Binary),
+            ("DOUBLE PRECISION", DataType::Float64),
+            ("DECIMAL(20, 4)", DataType::Decimal),
+            ("DATE", DataType::Unknown),
+            ("", DataType::Unknown),
+        ] {
+            assert_eq!(declared_data_type(declaration), expected, "{declaration}");
+        }
     }
 
     #[test]
@@ -1471,12 +1531,12 @@ mod tests {
         assert_eq!(
             result.columns(),
             vec![
-                Column::new("id", DataType::Unknown),
-                Column::new("enabled", DataType::Unknown),
-                Column::new("ratio", DataType::Unknown),
-                Column::new("text_value", DataType::Unknown),
-                Column::new("blob_value", DataType::Unknown),
-                Column::new("optional_value", DataType::Unknown),
+                Column::new("id", DataType::Int64),
+                Column::new("enabled", DataType::Int64),
+                Column::new("ratio", DataType::Float64),
+                Column::new("text_value", DataType::Text),
+                Column::new("blob_value", DataType::Binary),
+                Column::new("optional_value", DataType::Text),
             ]
         );
         assert_eq!(

--- a/tests/benchmark_workloads.rs
+++ b/tests/benchmark_workloads.rs
@@ -15,9 +15,9 @@ fn point_read_returns_the_seeded_row() {
     assert_eq!(
         result.columns(),
         vec![
-            Column::new("id", DataType::Unknown),
-            Column::new("writes", DataType::Unknown),
-            Column::new("payload", DataType::Unknown),
+            Column::new("id", DataType::Text),
+            Column::new("writes", DataType::Int64),
+            Column::new("payload", DataType::Text),
         ]
     );
     assert_eq!(
@@ -73,9 +73,9 @@ fn engine_point_read_returns_the_seeded_row_through_the_default_pool() {
     assert_eq!(
         result.columns(),
         vec![
-            Column::new("id", DataType::Unknown),
-            Column::new("writes", DataType::Unknown),
-            Column::new("payload", DataType::Unknown),
+            Column::new("id", DataType::Text),
+            Column::new("writes", DataType::Int64),
+            Column::new("payload", DataType::Text),
         ]
     );
     assert_eq!(

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -1280,8 +1280,8 @@ async fn prepared_lifecycle_is_public_owned_and_protocol_neutral() {
     assert_eq!(
         description.columns(),
         [
-            core::Column::new("tenant_id", core::DataType::Unknown),
-            core::Column::new("payload", core::DataType::Unknown),
+            core::Column::new("tenant_id", core::DataType::Int64),
+            core::Column::new("payload", core::DataType::Text),
         ]
     );
     assert!(description.returns_rows());


### PR DESCRIPTION
Closes #33.

## What changed
- map conservative SQLite declared types to protocol-neutral BriskDB types and PostgreSQL OIDs
- decode supported PostgreSQL text/binary parameters before engine binding and routing
- encode text/binary result rows with immutable portal format metadata
- preserve standard generated-write command tags and fixed SQLSTATE failures
- update README, roadmap, compatibility docs, and affected API metadata tests

## Verification
- `cargo fmt --all --check`
- feature-surface checks for core, default, embedded, listeners, HTTP, PostgreSQL, and SQLite import
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo package --locked --allow-dirty`
- `cargo test --locked --all-targets --all-features`
- `cargo test --locked --doc --all-features`
- native macOS arm64 wheel build/install and 24 Python tests under Python 3.13
- `cargo test --locked -p briskdb-python`
- Python extension Clippy