### PR TITLE
Stream PostgreSQL rows with backpressure

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ experimental and opt-in; the exact contract lives in
 | Durable virtual-bucket routing over independent SQLite WAL files | Working |
 | Exact-key routing and bounded scatter/gather reads | Working |
 | HTTP query/write API and admin data browser | Working, loopback-only |
-| PostgreSQL wire protocol | TLS/SCRAM, text/binary CRUD, cancellation, real single-shard transactions, and a live psql/tokio-postgres/psycopg/SQLAlchemy matrix |
+| PostgreSQL wire protocol | TLS/SCRAM, backpressured row streaming, SQLite-interrupt cancellation, text/binary CRUD, real single-shard transactions, and a live psql/tokio-postgres/psycopg/SQLAlchemy matrix |
 | Offline import from a standard SQLite database | Working |
 | Native-range and hi/lo generated IDs | Experimental, opt-in |
 | Ubuntu/macOS x86-64 and ARM64 release artifacts | Published |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -265,7 +265,7 @@ the engine regardless of its eventual wire protocol.
   and only the catalog queries needed by explicitly tested clients.
 - [x] Test with `psql`, `tokio-postgres`, `psycopg`, and SQLAlchemy ORM through
   a live, release-gating client matrix.
-- [ ] Stream rows with backpressure while preserving the PostgreSQL
+- [x] Stream rows with backpressure while preserving the PostgreSQL
   `CancelRequest` to SQLite interrupt path.
 
 Deferred: `COPY`, replication, `LISTEN/NOTIFY`, large objects, PostgreSQL
@@ -396,7 +396,7 @@ requires an earlier dependency:
    SQLite WAL files, version the allocation policies, support native shard
    ranges and durable hi/lo leases, and retain the general virtual-table path
    behind its measured rollout gate.
-2. [ ] **Complete PostgreSQL support.** Finish the simple and extended query
+2. [x] **Complete PostgreSQL support.** Finish the simple and extended query
    lifecycle, type mapping, transactions, cancellation, compatibility shims,
    and real-client conformance tests.
 3. [ ] **Implement global indexes, uniqueness, and value allocation.** Add the

--- a/docs/POSTGRES_ADAPTER.md
+++ b/docs/POSTGRES_ADAPTER.md
@@ -178,8 +178,8 @@ particular:
   names, raw parameters, prepared objects, or rows. Those values and connection
   tasks still require their BriskDB-owned finite limits.
 - Portal suspension cannot cause a BriskDB portal to execute twice. The adapter
-  retains and resumes the already produced bounded materialized response;
-  issue #39 owns a separately reviewed streaming contract.
+  retains and resumes the same bounded Engine row stream. The stream keeps the
+  request cancellation key active until completion or close.
 
 These are adapter requirements, not reasons to move protocol state into core.
 The library remains replaceable as long as the BriskDB seam and conformance
@@ -216,8 +216,9 @@ retains product identity, and no general PostgreSQL 14 compatibility is
 claimed. Issue #38 adds the release-gating psql, tokio-postgres, psycopg, and
 SQLAlchemy ORM matrix plus the exact bare `START TRANSACTION` and bind-only
 `::VARCHAR` adapters those tested clients require.
-The remaining roadmap issue retains row-streaming scope. The exact live
-contract and user workflow are in the
+Issue #39 adds protocol-neutral bounded row streaming and carries an exact
+`CancelRequest` through portal suspension to the leased SQLite interrupt
+handle. The exact live contract and user workflow are in the
 [PostgreSQL listener document](POSTGRES_LISTENER.md) and
 [query quickstart](POSTGRES_QUICKSTART.md).
 

--- a/docs/POSTGRES_CLIENTS.md
+++ b/docs/POSTGRES_CLIENTS.md
@@ -13,7 +13,9 @@ these exact client lines; it is not a claim of general PostgreSQL compatibility.
 
 All data work runs through the same protocol-neutral Engine, catalog, routing,
 limits, and fixed-error boundary used by BriskDB's other frontends. The first
-data statement pins each transaction to one physical shard.
+data statement pins each transaction to one physical shard. Query rows cross a
+bounded 16-row Engine handoff; a slow client therefore stops SQLite stepping,
+and PostgreSQL cancellation interrupts the exact leased SQLite handle.
 
 ## Bounded client adaptations
 

--- a/docs/POSTGRES_LISTENER.md
+++ b/docs/POSTGRES_LISTENER.md
@@ -147,12 +147,14 @@ request currently running on that backend; an unknown, stale, or mismatched key
 does nothing. Each command receives a fresh core cancellation token so a token
 for completed command A cannot interrupt later command B.
 
-Cancellation can interrupt a SQLite lock wait or active SQLite statement. It
-returns SQLSTATE `57014`. Inside an explicit transaction, the transaction then
-reports failed status (`E`) until `ROLLBACK`; the same connection can continue
-after rollback. Clients must wait for the cancelled command's response before
-starting another command on that connection. Disconnect and server shutdown
-unregister the key and cancel any active work.
+Cancellation can interrupt a SQLite lock wait, active SQLite statement, or a
+producer paused behind a slow client. It returns SQLSTATE `57014`. A suspended
+portal keeps the same request key and SQLite operation, so cancellation between
+`Execute` messages is also effective. Inside an explicit transaction, the
+transaction then reports failed status (`E`) until `ROLLBACK`; the same
+connection can continue after rollback. Clients must wait for the cancelled
+command's response before starting another command on that connection.
+Disconnect and server shutdown unregister the key and cancel active work.
 
 ## Startup errors
 
@@ -230,8 +232,10 @@ fixed Engine-to-SQLSTATE mapping, appends the session's exact `ReadyForQuery`
 status, never includes query text, and leaves an idle connection reusable. An
 error in a transaction reports `E` and requires rollback.
 
-Rows are bounded and materialized by the Engine, then returned in PostgreSQL
-text format. Declared SQLite columns map `BOOL`/`BOOLEAN` to `bool`, names
+Rows are decoded into a protocol-neutral Engine stream and returned in
+PostgreSQL text format. A bounded 16-row handoff applies backpressure before
+SQLite steps farther; the existing operation-wide row and logical-byte limits
+still apply. Declared SQLite columns map `BOOL`/`BOOLEAN` to `bool`, names
 containing `INT` to `int8`, `REAL`/`FLOA`/`DOUB` to `float8`,
 `DECIMAL`/`NUMERIC` to `numeric`, `CHAR`/`CLOB`/`TEXT` to `text`, and `BLOB` to
 `bytea`. Unknown declarations and expressions remain conservative `text`.
@@ -259,8 +263,9 @@ The parameterized text/binary extended flow uses the same Engine lifecycle:
   fields, or the bound portal's immutable requested result formats, without
   execution.
 - `Execute` returns rows or a command tag. A positive row limit suspends and
-  resumes the already materialized bounded response without rerunning the core
-  portal; a completed portal cannot replay a write.
+  resumes the same bounded Engine stream without rerunning the core portal; a
+  completed portal cannot replay a write. Closing a suspended portal cancels
+  its stream before releasing its core handle.
 - `Close` releases a portal or cascades statement closure to its portals;
   `Flush` flushes pending output; `Sync` reports the current `I`, `T`, or `E`
   status and causes skipped extended messages to be accepted again.

--- a/docs/REQUEST_CONTROLS.md
+++ b/docs/REQUEST_CONTROLS.md
@@ -90,13 +90,14 @@ request deadlines wins. Deadline failures use the distinct
 `DeadlineExceeded` kind. The server flag `--request-timeout-ms 0` disables the
 engine default.
 
-## Materialized result budgets
+## Query result budgets
 
 Every query has a finite row and logical-byte budget. Defaults are 10,000 rows
 and 16 MiB; the configurable hard caps are 1,000,000 rows and 1 GiB. A request
 context may narrow but never widen its engine's configured budget. Equality at
-the limit succeeds. Exceeding either limit returns `LimitExceeded` without a
-partial `ResultSet`.
+the limit succeeds. Exceeding either limit returns `LimitExceeded`. Materialized
+Engine APIs return no partial `ResultSet`; a streaming frontend may already
+have delivered the bounded prefix that preceded a later limit failure.
 
 Logical bytes use a stable protocol-neutral model rather than JSON or future
 wire-protocol encoding:
@@ -123,6 +124,14 @@ results, and schema migration do not materialize a `ResultSet` and are
 unaffected by query result budgets. A logical scatter applies one budget to the
 combined result, including one result envelope and one set of column metadata;
 it does not grant every shard a fresh row or byte allowance.
+
+PostgreSQL reads use a protocol-neutral stream with a 16-row handoff. SQLite
+stops stepping when that handoff is full and resumes only as the client drains
+rows. Scatter streams visit physical shards in ascending order to retain the
+same deterministic concatenation while holding one shard connection at a time.
+Dropping or closing a stream cancels its operation; request cancellation,
+deadline expiry, and shutdown interrupt the currently leased SQLite handle and
+discard already-buffered rows.
 
 Logical scatter/gather schedules at most eight shard tasks concurrently. All
 children inherit the operation's one absolute deadline and sticky cancellation

--- a/docs/SQL_PREPARED_STATEMENTS.md
+++ b/docs/SQL_PREPARED_STATEMENTS.md
@@ -209,8 +209,10 @@ or routing bytes.
 
 Portals are reusable and are not consumed by execution. Multiple portals may
 refer to one prepared statement, subject to the per-session limits. Portal row
-suspension and protocol cursor semantics are not implemented; each execution
-materializes one complete bounded result or returns an error.
+suspension remains a frontend concern. PostgreSQL resumes the same bounded
+protocol-neutral `RowStream`; other Engine execution methods continue to
+materialize one complete bounded `ResultSet`. A completed stream does not
+consume its core portal, so a later execution can intentionally rerun it.
 
 ## Cache limits and exact byte accounting
 

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use tokio::{
-    sync::OwnedMutexGuard,
+    sync::{OwnedMutexGuard, oneshot},
     task::{JoinHandle, JoinSet},
 };
 
@@ -21,8 +21,9 @@ use super::{
     EngineState, Executed, Lifecycle, LogicalDatabaseId, OperationControl, OperationLease,
     PortalId, PrepareRequest, PreparedExecution, PreparedStatementDescription, PreparedStatementId,
     PreparedStatementLimits, RawDataOperation, RawDataTarget, RequestContext, ResultLimits,
-    ResultSet, Routed, Session, SessionInner, ShutdownReport, TablePlacement, TransactionExecution,
-    Value, merge_scatter_results, wait_for_cancellation, wait_pending,
+    ResultSet, Routed, RowProducer, RowStream, Session, SessionInner, ShutdownReport,
+    TablePlacement, TransactionExecution, Value, merge_scatter_results, wait_for_cancellation,
+    wait_pending,
 };
 use crate::{
     sql,
@@ -292,6 +293,55 @@ struct Operation {
     deadline: Option<Instant>,
     result_limits: ResultLimits,
     cancel_on_drop: CancelOnDrop,
+}
+
+struct StreamReadiness {
+    sender: std::sync::Mutex<Option<oneshot::Sender<EngineResult<Vec<super::Column>>>>>,
+}
+
+impl StreamReadiness {
+    fn new(sender: oneshot::Sender<EngineResult<Vec<super::Column>>>) -> Arc<Self> {
+        Arc::new(Self {
+            sender: std::sync::Mutex::new(Some(sender)),
+        })
+    }
+
+    fn publish(&self, columns: &[super::Column]) -> EngineResult<()> {
+        let sender = self
+            .sender
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+        if let Some(sender) = sender {
+            sender.send(Ok(columns.to_vec())).map_err(|_| {
+                EngineError::new(
+                    EngineErrorKind::Cancelled,
+                    "the streamed query caller stopped before receiving metadata",
+                )
+            })?;
+        }
+        Ok(())
+    }
+
+    fn finish(&self, result: EngineResult<()>, producer: &RowProducer) {
+        let sender = self
+            .sender
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+        match (sender, result) {
+            (Some(sender), Err(error)) => {
+                let _ = sender.send(Err(error));
+            }
+            (Some(sender), Ok(())) => {
+                let _ = sender.send(Err(EngineError::new(
+                    EngineErrorKind::Internal,
+                    "a streamed query completed without publishing column metadata",
+                )));
+            }
+            (None, result) => producer.finish(result),
+        }
+    }
 }
 
 impl Operation {
@@ -1554,6 +1604,322 @@ impl Engine {
             .await;
         let value = operation.finish_started(result)?;
         Ok(Executed { shards, value })
+    }
+
+    /// Execute one immutable read portal as a bounded protocol-neutral row
+    /// stream with default request controls.
+    pub async fn stream_portal_logical(
+        &self,
+        session: &Session,
+        portal: PortalId,
+    ) -> EngineResult<Executed<RowStream>> {
+        self.stream_portal_logical_with_context(session, portal, RequestContext::new())
+            .await
+    }
+
+    /// Execute one immutable read portal as a bounded protocol-neutral row
+    /// stream across every metadata-selected physical shard.
+    ///
+    /// Column metadata is available before this method returns. SQLite steps at
+    /// most [`super::DEFAULT_STREAM_BUFFER_ROWS`] rows ahead of the consumer,
+    /// and dropping the returned stream cancels the complete logical query.
+    pub async fn stream_portal_logical_with_context(
+        &self,
+        session: &Session,
+        portal: PortalId,
+        context: RequestContext,
+    ) -> EngineResult<Executed<RowStream>> {
+        let mut operation = self.operation(context)?;
+        let (schema_operation, mut guard) =
+            match self.session_with_schema(&operation, session).await {
+                Ok(admission) => admission,
+                Err(error) => return operation.finish(Err(error)),
+            };
+        let portal_snapshot = match guard.prepared().portal(portal) {
+            Ok(portal) => portal.clone(),
+            Err(error) => {
+                guard.fail_transaction();
+                return operation.finish(Err(error));
+            }
+        };
+        let template = match guard.prepared().statement(portal_snapshot.statement()) {
+            Ok(template) => template,
+            Err(error) => {
+                guard.fail_transaction();
+                return operation.finish(Err(error));
+            }
+        };
+        if !matches!(
+            template.description().behavior(),
+            sql::StatementBehavior::Read
+        ) {
+            return operation.finish(Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "only read portals can produce a row stream",
+            )));
+        }
+        if guard.state() == super::SessionState::FailedTransaction {
+            return operation.finish(Err(transaction_aborted()));
+        }
+        let plan = match self.plan_bound_statement_admitted(
+            template.database(),
+            template.translated().normalized_sql(),
+            0,
+            portal_snapshot.parameters(),
+            None,
+        ) {
+            Ok(plan) => plan,
+            Err(error) => {
+                guard.fail_transaction();
+                return operation.finish(Err(error));
+            }
+        };
+        let shards = match prepared_execution_shards(&plan, self.catalog(), self.shard_count()) {
+            Ok(shards) => shards,
+            Err(error) => {
+                guard.fail_transaction();
+                return operation.finish(Err(error));
+            }
+        };
+        if shards.len() > 1 {
+            if let Err(error) = sql::validate_scatter_safe(template.translated()) {
+                return operation.finish(Err(error));
+            }
+        }
+        if guard.state() == super::SessionState::InTransaction
+            && (shards.len() != 1
+                || guard
+                    .transaction_shard()
+                    .is_some_and(|pinned| pinned != shards[0]))
+        {
+            guard.fail_transaction();
+            return operation.finish(Err(cross_shard_transaction()));
+        }
+
+        let owner = ConnectionOwner::new(session.id().get());
+        let sqlite_sql: Arc<str> = Arc::from(template.translated().sqlite_sql());
+        let parameters: Arc<[Value]> = Arc::from(portal_snapshot.parameters().to_vec());
+        let result_limits = operation.result_limits;
+        let control = Arc::clone(&operation.control);
+        let (mut stream, producer) = RowStream::channel(
+            control,
+            operation.cancellation.clone(),
+            operation.shutdown_cancel.clone(),
+            operation.deadline,
+        );
+        let (ready_tx, ready_rx) = oneshot::channel();
+        let readiness = StreamReadiness::new(ready_tx);
+        let engine = self.clone();
+        let task_shards = shards.clone();
+        tokio::spawn(async move {
+            let result = if guard.state() == super::SessionState::InTransaction {
+                engine
+                    .produce_transaction_stream(
+                        &mut operation,
+                        task_shards[0],
+                        owner,
+                        schema_operation,
+                        guard,
+                        sqlite_sql,
+                        parameters,
+                        result_limits,
+                        Arc::clone(&readiness),
+                        producer.clone(),
+                    )
+                    .await
+            } else {
+                engine
+                    .produce_stream(
+                        &mut operation,
+                        owner,
+                        schema_operation,
+                        guard,
+                        task_shards,
+                        sqlite_sql,
+                        parameters,
+                        result_limits,
+                        Arc::clone(&readiness),
+                        producer.clone(),
+                    )
+                    .await
+            };
+            let result = operation.finish(result);
+            readiness.finish(result, &producer);
+        });
+
+        let columns = ready_rx.await.map_err(|error| {
+            EngineError::from_source(
+                EngineErrorKind::Internal,
+                "the streamed query worker stopped before publishing metadata",
+                error,
+            )
+        })??;
+        stream.set_columns(columns);
+        Ok(Executed {
+            shards,
+            value: stream,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn produce_stream(
+        &self,
+        operation: &mut Operation,
+        owner: ConnectionOwner,
+        _schema_operation: SchemaOperationGuard,
+        _session: OwnedMutexGuard<SessionInner>,
+        shards: Vec<u16>,
+        sqlite_sql: Arc<str>,
+        parameters: Arc<[Value]>,
+        result_limits: ResultLimits,
+        readiness: Arc<StreamReadiness>,
+        producer: RowProducer,
+    ) -> EngineResult<()> {
+        let budget = sql::ScatterResultBudget::new(result_limits);
+        for shard in shards {
+            let permit = operation
+                .wait_pending(self.inner.connections.acquire_for_owner(shard, owner))
+                .await?;
+            let worker = operation.wait_pending(self.inner.workers.acquire()).await?;
+            operation.check_before_start()?;
+            let control = Arc::clone(&operation.control);
+            let worker_control = Arc::clone(&control);
+            let storage = self.inner.database.storage.clone();
+            let sqlite_sql = Arc::clone(&sqlite_sql);
+            let parameters = Arc::clone(&parameters);
+            let readiness = Arc::clone(&readiness);
+            let producer = producer.clone();
+            let budget = budget.clone();
+            let join = worker.spawn(move || {
+                let result = permit
+                    .checkout_controlled(Arc::clone(&worker_control))
+                    .and_then(|mut connection| {
+                        let result = connection
+                            .isolate_foreign_sql_controlled(
+                                Arc::clone(&worker_control),
+                                &sqlite_sql,
+                            )
+                            .and_then(|_| {
+                                connection.run_controlled(worker_control, |connection| {
+                                    sql::stream_query_with_budget(
+                                        connection,
+                                        &sqlite_sql,
+                                        &parameters,
+                                        &budget,
+                                        |columns| readiness.publish(columns),
+                                        |row| producer.send(row),
+                                    )
+                                })
+                            });
+                        retire_if_broken(&mut connection, &result);
+                        result
+                    });
+                if result
+                    .as_ref()
+                    .is_err_and(|error| error.kind() == EngineErrorKind::DataCorruption)
+                {
+                    storage.record_schema_degraded();
+                }
+                result
+            });
+            operation.wait_started(join).await?;
+        }
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn produce_transaction_stream(
+        &self,
+        operation: &mut Operation,
+        shard: u16,
+        owner: ConnectionOwner,
+        schema_operation: SchemaOperationGuard,
+        mut session: OwnedMutexGuard<SessionInner>,
+        sqlite_sql: Arc<str>,
+        parameters: Arc<[Value]>,
+        result_limits: ResultLimits,
+        readiness: Arc<StreamReadiness>,
+        producer: RowProducer,
+    ) -> EngineResult<()> {
+        let needs_connection = session
+            .transaction_mut()
+            .is_some_and(|transaction| transaction.connection.is_none());
+        let permit = if needs_connection {
+            Some(
+                operation
+                    .wait_pending(self.inner.connections.acquire_for_owner(shard, owner))
+                    .await?,
+            )
+        } else {
+            None
+        };
+        let worker = operation.wait_pending(self.inner.workers.acquire()).await?;
+        operation.check_before_start()?;
+        let worker_control = Arc::clone(&operation.control);
+        let storage = self.inner.database.storage.clone();
+        let budget = sql::ScatterResultBudget::new(result_limits);
+        let join = worker.spawn(move || {
+            let _schema_operation = schema_operation;
+            let result = (|| {
+                let transaction = session.transaction_mut().ok_or_else(|| {
+                    EngineError::new(
+                        EngineErrorKind::Internal,
+                        "active session transaction state is missing",
+                    )
+                })?;
+                let first_statement = transaction.pinned_shard.is_none();
+                let mut connection = match transaction.connection.take() {
+                    Some(connection) => connection,
+                    None => permit
+                        .ok_or_else(|| {
+                            EngineError::new(
+                                EngineErrorKind::Internal,
+                                "a pinned transaction lost its SQLite connection",
+                            )
+                        })?
+                        .checkout_controlled(Arc::clone(&worker_control))?,
+                };
+                let result = (|| {
+                    if first_statement {
+                        connection.isolate_foreign_sql_controlled(
+                            Arc::clone(&worker_control),
+                            &sqlite_sql,
+                        )?;
+                        connection.run_controlled(Arc::clone(&worker_control), |connection| {
+                            connection.execute_batch("BEGIN DEFERRED").map_err(|error| {
+                                crate::sqlite_error::storage(error)
+                                    .context("failed to begin the pinned SQLite transaction")
+                            })
+                        })?;
+                        transaction.pinned_shard = Some(shard);
+                    }
+                    connection.run_controlled(Arc::clone(&worker_control), |connection| {
+                        sql::stream_query_with_budget(
+                            connection,
+                            &sqlite_sql,
+                            &parameters,
+                            &budget,
+                            |columns| readiness.publish(columns),
+                            |row| producer.send(row),
+                        )
+                    })
+                })();
+                retire_if_broken(&mut connection, &result);
+                transaction.connection = Some(connection);
+                result
+            })();
+            if result.is_err() {
+                session.fail_transaction();
+            }
+            if result
+                .as_ref()
+                .is_err_and(|error| error.kind() == EngineErrorKind::DataCorruption)
+            {
+                storage.record_schema_degraded();
+            }
+            result
+        });
+        operation.wait_started(join).await
     }
 
     /// Close a prepared statement and every portal bound from it.
@@ -5298,6 +5664,236 @@ mod tests {
                     && result.rows()[0].get(0) == Some(&Value::from(1_i64))
                     && result.rows()[1].get(0) == Some(&Value::from(2_i64))
         ));
+    }
+
+    #[tokio::test]
+    async fn portal_row_stream_applies_backpressure_and_drop_releases_engine_ownership() {
+        let options = EngineOptions::new(1, 1)
+            .unwrap()
+            .with_request_timeout(None)
+            .unwrap();
+        let (temp, engine, database) = engine_with_prepared_catalog(options);
+        let connection =
+            rusqlite::Connection::open(temp.path().join("shards/0000.sqlite")).unwrap();
+        let mut insert = connection
+            .prepare("INSERT INTO global_events (code) VALUES (?1)")
+            .unwrap();
+        for value in 0..(super::super::DEFAULT_STREAM_BUFFER_ROWS + 8) {
+            insert.execute([value as i64]).unwrap();
+        }
+        drop(insert);
+        drop(connection);
+
+        let session = engine.session();
+        let statement = engine
+            .prepare_statement(
+                &session,
+                PrepareRequest::new(
+                    database,
+                    sql::SqlDialect::Sqlite,
+                    sql::SqlTranslationMode::StrictSqlite,
+                    "SELECT code FROM global_events ORDER BY code",
+                ),
+            )
+            .await
+            .unwrap();
+        let portal = engine
+            .bind_statement(&session, statement, vec![])
+            .await
+            .unwrap();
+        let available_workers = engine.inner.workers.available_permits();
+        let mut stream = engine
+            .stream_portal_logical_with_context(&session, portal, RequestContext::new())
+            .await
+            .unwrap()
+            .value;
+        assert_eq!(stream.columns().len(), 1);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(engine.inner.lifecycle.active(), 1);
+        assert_eq!(
+            engine.inner.workers.available_permits(),
+            available_workers - 1
+        );
+        assert_eq!(
+            stream.next_row().await.unwrap().unwrap().get(0),
+            Some(&Value::Int64(0))
+        );
+
+        drop(stream);
+        timeout(Duration::from_secs(2), async {
+            while engine.inner.lifecycle.active() != 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        assert_eq!(engine.inner.workers.available_permits(), available_workers);
+        assert_eq!(engine.status(&session).await.unwrap().shard_count(), 4);
+    }
+
+    #[tokio::test]
+    async fn cancelling_a_portal_row_stream_discards_buffered_rows_and_recovers() {
+        let (temp, engine, database) = engine_with_prepared_catalog(EngineOptions::default());
+        let connection =
+            rusqlite::Connection::open(temp.path().join("shards/0000.sqlite")).unwrap();
+        for value in 0..64_i64 {
+            connection
+                .execute("INSERT INTO global_events (code) VALUES (?1)", [value])
+                .unwrap();
+        }
+        drop(connection);
+        let session = engine.session();
+        let statement = engine
+            .prepare_statement(
+                &session,
+                PrepareRequest::new(
+                    database,
+                    sql::SqlDialect::Sqlite,
+                    sql::SqlTranslationMode::StrictSqlite,
+                    "SELECT code FROM global_events",
+                ),
+            )
+            .await
+            .unwrap();
+        let portal = engine
+            .bind_statement(&session, statement, vec![])
+            .await
+            .unwrap();
+        let cancellation = CancellationToken::new();
+        let mut stream = engine
+            .stream_portal_logical_with_context(
+                &session,
+                portal,
+                RequestContext::new().with_cancellation_token(cancellation.clone()),
+            )
+            .await
+            .unwrap()
+            .value;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        cancellation.cancel();
+        let error = stream.next_row().await.unwrap().unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Cancelled);
+        drop(stream);
+        timeout(Duration::from_secs(2), async {
+            while engine.inner.lifecycle.active() != 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+
+        let rows = engine.execute_portal(&session, portal).await.unwrap();
+        assert!(matches!(
+            rows.value,
+            PreparedExecution::Rows(result) if result.rows().len() == 64
+        ));
+    }
+
+    #[tokio::test]
+    async fn portal_row_stream_reports_a_late_result_limit_and_remains_retryable() {
+        let (temp, engine, database) = engine_with_prepared_catalog(EngineOptions::default());
+        let connection =
+            rusqlite::Connection::open(temp.path().join("shards/0000.sqlite")).unwrap();
+        connection
+            .execute_batch("INSERT INTO global_events (code) VALUES (1), (2), (3)")
+            .unwrap();
+        drop(connection);
+        let session = engine.session();
+        let statement = engine
+            .prepare_statement(
+                &session,
+                PrepareRequest::new(
+                    database,
+                    sql::SqlDialect::Sqlite,
+                    sql::SqlTranslationMode::StrictSqlite,
+                    "SELECT code FROM global_events ORDER BY code",
+                ),
+            )
+            .await
+            .unwrap();
+        let portal = engine
+            .bind_statement(&session, statement, vec![])
+            .await
+            .unwrap();
+        let limits = ResultLimits::new(1, 1_024).unwrap();
+        let mut stream = engine
+            .stream_portal_logical_with_context(
+                &session,
+                portal,
+                RequestContext::new().with_result_limits(limits),
+            )
+            .await
+            .unwrap()
+            .value;
+        assert_eq!(
+            stream.next_row().await.unwrap().unwrap().get(0),
+            Some(&Value::Int64(1))
+        );
+        assert_eq!(
+            stream.next_row().await.unwrap().unwrap_err().kind(),
+            EngineErrorKind::LimitExceeded
+        );
+        assert!(stream.next_row().await.is_none());
+
+        let retried = engine.execute_portal(&session, portal).await.unwrap();
+        assert!(matches!(
+            retried.value,
+            PreparedExecution::Rows(result) if result.rows().len() == 3
+        ));
+    }
+
+    #[tokio::test]
+    async fn portal_row_stream_reuses_and_releases_a_pinned_transaction_connection() {
+        let (_temp, engine, database) = engine_with_prepared_catalog(EngineOptions::default());
+        let session = engine.session();
+        let key = integer_key_for_shard(&engine, 0, None);
+        execute_prepared_sql(
+            &engine,
+            &session,
+            database,
+            "INSERT INTO events (tenant_id, payload) VALUES (?, ?)",
+            vec![Value::from(key), Value::from("streamed")],
+        )
+        .await
+        .unwrap();
+        execute_prepared_sql(&engine, &session, database, "BEGIN", vec![])
+            .await
+            .unwrap();
+        let statement = engine
+            .prepare_statement(
+                &session,
+                PrepareRequest::new(
+                    database,
+                    sql::SqlDialect::Sqlite,
+                    sql::SqlTranslationMode::StrictSqlite,
+                    "SELECT payload FROM events WHERE tenant_id = ?",
+                ),
+            )
+            .await
+            .unwrap();
+        let portal = engine
+            .bind_statement(&session, statement, vec![Value::from(key)])
+            .await
+            .unwrap();
+        let mut stream = engine
+            .stream_portal_logical(&session, portal)
+            .await
+            .unwrap()
+            .value;
+        assert_eq!(
+            stream.next_row().await.unwrap().unwrap().get(0),
+            Some(&Value::from("streamed"))
+        );
+        assert!(stream.next_row().await.is_none());
+        assert_eq!(session.state().await, SessionState::InTransaction);
+        assert_eq!(
+            execute_prepared_sql(&engine, &session, database, "COMMIT", vec![])
+                .await
+                .unwrap()
+                .value,
+            PreparedExecution::Transaction(TransactionExecution::Committed)
+        );
+        assert_eq!(session.state().await, SessionState::Ready);
     }
 
     #[tokio::test]

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -15,6 +15,7 @@ mod prepared;
 mod routing;
 mod scatter;
 mod session;
+mod stream;
 mod types;
 pub(crate) mod worker;
 
@@ -58,6 +59,8 @@ pub(crate) use routing::{
 };
 pub(crate) use scatter::merge_scatter_results;
 pub use session::{Session, SessionId, SessionState};
+pub(crate) use stream::RowProducer;
+pub use stream::{DEFAULT_STREAM_BUFFER_ROWS, RowStream};
 pub use types::{
     Column, DataType, Decimal, GeneratedKey, ParseDecimalError, ResultSet, ResultSetShapeError,
     Row, Value, WriteResult,

--- a/src/core/options.rs
+++ b/src/core/options.rs
@@ -10,10 +10,10 @@ pub const DEFAULT_CONNECTIONS_PER_SHARD: usize = 4;
 /// Default number of operations admitted to each shard's pending queue.
 pub const DEFAULT_QUEUE_CAPACITY_PER_SHARD: usize = 32;
 
-/// Default maximum number of rows materialized by one query.
+/// Default maximum number of rows produced by one query.
 pub const DEFAULT_MAX_RESULT_ROWS: u64 = 10_000;
 
-/// Default maximum logical size of one materialized query result (16 MiB).
+/// Default maximum logical size of one query result (16 MiB).
 pub const DEFAULT_MAX_RESULT_BYTES: u64 = 16 * 1024 * 1024;
 
 /// Default engine-enforced request deadline in milliseconds.
@@ -37,10 +37,10 @@ pub const MAX_CONNECTIONS_PER_SHARD: usize = 16;
 /// Maximum configurable pending operations per shard.
 pub const MAX_QUEUE_CAPACITY_PER_SHARD: usize = 1_024;
 
-/// Maximum configurable rows in one materialized query result.
+/// Maximum configurable rows in one query result.
 pub const MAX_RESULT_ROWS: u64 = 1_000_000;
 
-/// Maximum configurable logical size of one materialized query result (1 GiB).
+/// Maximum configurable logical size of one query result (1 GiB).
 pub const MAX_RESULT_BYTES: u64 = 1024 * 1024 * 1024;
 
 /// Maximum configured request timeout (24 hours).
@@ -60,7 +60,7 @@ pub const MAX_RETAINED_BOUND_VALUE_BYTES: u64 = 1024 * 1024 * 1024;
 
 const MAX_TOTAL_ACTIVE_CONNECTIONS: usize = 512;
 
-/// Validated finite limits for a materialized query result.
+/// Validated finite limits for a materialized or streamed query result.
 ///
 /// BriskDB accounts a result independently of any wire protocol: 16 bytes for
 /// the result envelope, one type byte plus an eight-byte length and the UTF-8
@@ -96,7 +96,7 @@ impl ResultLimits {
         })
     }
 
-    /// Return the maximum number of rows materialized by one query.
+    /// Return the maximum number of rows produced by one query.
     pub const fn max_rows(self) -> u64 {
         self.max_rows
     }
@@ -122,7 +122,7 @@ impl Default for ResultLimits {
 /// by all portals in a session. The same ceiling conservatively bounds one
 /// bind's planning expansion by charging the captured route once and every
 /// normalized marker occurrence twice, once for typed inference and once for
-/// canonical routing. It is independent of the materialized query-result byte
+/// canonical routing. It is independent of the query-result byte
 /// limit.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PreparedStatementLimits {
@@ -260,12 +260,12 @@ impl EngineOptions {
         self.queue_capacity_per_shard
     }
 
-    /// Return the finite limits applied to each materialized query result.
+    /// Return the finite limits applied to each query result.
     pub const fn result_limits(&self) -> ResultLimits {
         self.result_limits
     }
 
-    /// Replace the finite limits applied to each materialized query result.
+    /// Replace the finite limits applied to each query result.
     #[must_use]
     pub const fn with_result_limits(mut self, result_limits: ResultLimits) -> Self {
         self.result_limits = result_limits;

--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -1,0 +1,287 @@
+//! Bounded protocol-neutral row streaming.
+
+use std::{
+    collections::VecDeque,
+    fmt,
+    sync::{Arc, Condvar, Mutex, MutexGuard},
+    time::{Duration, Instant},
+};
+
+use tokio::sync::Notify;
+
+use super::{CancellationReason, Column, EngineResult, OperationControl, Row};
+
+/// The maximum number of decoded rows retained between SQLite and a frontend.
+pub const DEFAULT_STREAM_BUFFER_ROWS: usize = 16;
+
+struct StreamState {
+    rows: VecDeque<Row>,
+    terminal: Option<EngineResult<()>>,
+    receiver_alive: bool,
+}
+
+struct Shared {
+    capacity: usize,
+    state: Mutex<StreamState>,
+    not_full: Condvar,
+    not_empty: Notify,
+    control: Arc<OperationControl>,
+    request_cancellation: super::CancellationToken,
+    shutdown_cancellation: super::CancellationToken,
+    deadline: Option<Instant>,
+}
+
+impl Shared {
+    fn lock(&self) -> MutexGuard<'_, StreamState> {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+/// The engine side of one bounded row stream.
+pub(crate) struct RowProducer {
+    shared: Arc<Shared>,
+}
+
+impl RowProducer {
+    pub(crate) fn send(&self, row: Row) -> EngineResult<()> {
+        let mut row = Some(row);
+        let mut state = self.shared.lock();
+        loop {
+            if !state.receiver_alive {
+                return Err(CancellationReason::Cancelled.error());
+            }
+            if self.shared.control.should_stop() {
+                return Err(self
+                    .shared
+                    .control
+                    .reason()
+                    .unwrap_or(CancellationReason::Cancelled)
+                    .error());
+            }
+            if state.rows.len() < self.shared.capacity {
+                state
+                    .rows
+                    .push_back(row.take().expect("a streamed row is queued once"));
+                drop(state);
+                self.shared.not_empty.notify_one();
+                return Ok(());
+            }
+            let waited = self
+                .shared
+                .not_full
+                .wait_timeout(state, Duration::from_millis(25));
+            state = match waited {
+                Ok((state, _)) => state,
+                Err(poisoned) => poisoned.into_inner().0,
+            };
+        }
+    }
+
+    pub(crate) fn finish(&self, result: EngineResult<()>) {
+        let mut state = self.shared.lock();
+        if state.terminal.is_none() {
+            state.terminal = Some(result);
+        }
+        drop(state);
+        self.shared.not_empty.notify_waiters();
+    }
+}
+
+impl Clone for RowProducer {
+    fn clone(&self) -> Self {
+        Self {
+            shared: Arc::clone(&self.shared),
+        }
+    }
+}
+
+/// A bounded, asynchronous stream of protocol-neutral rows.
+///
+/// SQLite only steps ahead by [`DEFAULT_STREAM_BUFFER_ROWS`] rows. Dropping the
+/// stream cancels the operation and interrupts its currently leased SQLite
+/// connection before that connection can be reused.
+#[must_use = "dropping a row stream cancels its unfinished query"]
+pub struct RowStream {
+    columns: Vec<Column>,
+    shared: Arc<Shared>,
+    complete: bool,
+}
+
+impl RowStream {
+    pub(crate) fn channel(
+        control: Arc<OperationControl>,
+        request_cancellation: super::CancellationToken,
+        shutdown_cancellation: super::CancellationToken,
+        deadline: Option<Instant>,
+    ) -> (Self, RowProducer) {
+        let shared = Arc::new(Shared {
+            capacity: DEFAULT_STREAM_BUFFER_ROWS,
+            state: Mutex::new(StreamState {
+                rows: VecDeque::new(),
+                terminal: None,
+                receiver_alive: true,
+            }),
+            not_full: Condvar::new(),
+            not_empty: Notify::new(),
+            control,
+            request_cancellation,
+            shutdown_cancellation,
+            deadline,
+        });
+        (
+            Self {
+                columns: Vec::new(),
+                shared: Arc::clone(&shared),
+                complete: false,
+            },
+            RowProducer { shared },
+        )
+    }
+
+    pub(crate) fn set_columns(&mut self, columns: Vec<Column>) {
+        self.columns = columns;
+    }
+
+    /// Return the stable column metadata published before the first row.
+    pub fn columns(&self) -> &[Column] {
+        &self.columns
+    }
+
+    /// Wait for the next row, terminal query error, or clean end of stream.
+    pub async fn next_row(&mut self) -> Option<EngineResult<Row>> {
+        if self.complete {
+            return None;
+        }
+        loop {
+            let notified = self.shared.not_empty.notified();
+            {
+                let mut state = self.shared.lock();
+                let pending_reason = if self.shared.request_cancellation.is_cancelled()
+                    || self.shared.shutdown_cancellation.is_cancelled()
+                {
+                    Some(CancellationReason::Cancelled)
+                } else if self
+                    .shared
+                    .deadline
+                    .is_some_and(|deadline| Instant::now() >= deadline)
+                {
+                    Some(CancellationReason::DeadlineExceeded)
+                } else {
+                    self.shared.control.reason()
+                };
+                if let Some(reason) = pending_reason {
+                    self.shared.control.request_cancel(reason);
+                    state.receiver_alive = false;
+                    state.rows.clear();
+                    self.complete = true;
+                    self.shared.not_full.notify_all();
+                    return Some(Err(reason.error()));
+                }
+                if let Some(row) = state.rows.pop_front() {
+                    self.shared.not_full.notify_one();
+                    return Some(Ok(row));
+                }
+                if let Some(result) = state.terminal.take() {
+                    state.receiver_alive = false;
+                    self.complete = true;
+                    return result.err().map(Err);
+                }
+            }
+            notified.await;
+        }
+    }
+}
+
+impl Drop for RowStream {
+    fn drop(&mut self) {
+        let mut state = self.shared.lock();
+        state.receiver_alive = false;
+        state.rows.clear();
+        drop(state);
+        self.shared.not_full.notify_all();
+        if !self.complete {
+            self.shared
+                .control
+                .request_cancel(CancellationReason::Cancelled);
+        }
+    }
+}
+
+impl fmt::Debug for RowStream {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let state = self.shared.lock();
+        formatter
+            .debug_struct("RowStream")
+            .field("columns", &self.columns)
+            .field("buffered_rows", &state.rows.len())
+            .field("capacity", &self.shared.capacity)
+            .field("complete", &self.complete)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Instant;
+
+    use tokio::time::{Duration, timeout};
+
+    use super::*;
+    use crate::core::{CancellationToken, EngineError, EngineErrorKind, Value};
+
+    fn row(value: i64) -> Row {
+        Row::new(vec![Value::Int64(value)])
+    }
+
+    #[tokio::test]
+    async fn producer_waits_for_bounded_capacity() {
+        let control = OperationControl::new(None);
+        let (mut stream, producer) = RowStream::channel(
+            control,
+            CancellationToken::new(),
+            CancellationToken::new(),
+            None,
+        );
+        for value in 0..DEFAULT_STREAM_BUFFER_ROWS {
+            producer.send(row(value as i64)).unwrap();
+        }
+        let blocked = tokio::task::spawn_blocking(move || {
+            producer.send(row(99))?;
+            producer.finish(Ok(()));
+            Ok::<_, EngineError>(())
+        });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(!blocked.is_finished());
+        assert_eq!(stream.next_row().await.unwrap().unwrap(), row(0));
+        timeout(Duration::from_secs(2), blocked)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn dropping_consumer_cancels_a_blocked_producer() {
+        let control = OperationControl::new(Some(Instant::now() + Duration::from_secs(10)));
+        let (stream, producer) = RowStream::channel(
+            Arc::clone(&control),
+            CancellationToken::new(),
+            CancellationToken::new(),
+            None,
+        );
+        for value in 0..DEFAULT_STREAM_BUFFER_ROWS {
+            producer.send(row(value as i64)).unwrap();
+        }
+        let blocked = tokio::task::spawn_blocking(move || producer.send(row(99)));
+        drop(stream);
+        let error = timeout(Duration::from_secs(2), blocked)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Cancelled);
+        assert_eq!(control.reason(), Some(CancellationReason::Cancelled));
+    }
+}

--- a/src/protocol/postgres.rs
+++ b/src/protocol/postgres.rs
@@ -84,8 +84,8 @@ use crate::{
     core::{
         CancellationToken, DataType, DescribeTarget, Engine, EngineError, EngineResult,
         EngineStatus, LogicalDatabaseId, PortalId, PrepareRequest, PreparedExecution,
-        PreparedStatementDescription, PreparedStatementId, RequestContext, ResultSet, Session,
-        SessionId, TransactionExecution, Value,
+        PreparedStatementDescription, PreparedStatementId, RequestContext, ResultSet, RowStream,
+        Session, SessionId, TransactionExecution, Value,
     },
     protocol::error::postgres_error,
     sql::{MAX_PARSED_SQL_BYTES, SqlDialect, SqlTranslationMode, StatementBehavior, WriteBehavior},
@@ -1453,6 +1453,7 @@ impl Connection {
         self.state.engine.status(&self.state.session).await
     }
 
+    #[cfg(test)]
     async fn execute_simple_query(
         &self,
         sql: &str,
@@ -1487,6 +1488,102 @@ impl Connection {
         }
     }
 
+    async fn execute_simple_query_streaming(
+        &self,
+        sql: &str,
+        context: RequestContext,
+    ) -> EngineResult<(StatementBehavior, SimpleWireExecution)> {
+        let sql = postgres_compatibility_sql(&self.state, sql);
+        let statement = self
+            .state
+            .engine
+            .prepare_statement_with_context(
+                &self.state.session,
+                PrepareRequest::new(
+                    self.state.database,
+                    SqlDialect::PostgreSql,
+                    SqlTranslationMode::Compatibility,
+                    sql.as_ref(),
+                ),
+                context.clone(),
+            )
+            .await?;
+        let result = self
+            .execute_prepared_simple_query_streaming(statement, context)
+            .await;
+        if result.is_err() {
+            let _ = self
+                .state
+                .engine
+                .close_prepared_statement(&self.state.session, statement)
+                .await;
+        }
+        result
+    }
+
+    async fn execute_prepared_simple_query_streaming(
+        &self,
+        statement: PreparedStatementId,
+        context: RequestContext,
+    ) -> EngineResult<(StatementBehavior, SimpleWireExecution)> {
+        let description = self
+            .state
+            .engine
+            .describe_prepared_with_context(
+                &self.state.session,
+                DescribeTarget::Statement(statement),
+                context.clone(),
+            )
+            .await?;
+        let behavior = description.behavior();
+        let portal = self
+            .state
+            .engine
+            .bind_statement_with_context(
+                &self.state.session,
+                statement,
+                Vec::new(),
+                context.clone(),
+            )
+            .await?;
+        if matches!(behavior, StatementBehavior::Read) {
+            let stream = self
+                .state
+                .engine
+                .stream_portal_logical_with_context(&self.state.session, portal, context)
+                .await?
+                .value;
+            return Ok((
+                behavior,
+                SimpleWireExecution::Stream {
+                    stream,
+                    cleanup: SimpleQueryCleanup {
+                        state: Arc::clone(&self.state),
+                        statement: Some(statement),
+                    },
+                },
+            ));
+        }
+
+        let result = self
+            .state
+            .engine
+            .execute_portal_logical_with_context(&self.state.session, portal, context)
+            .await
+            .map(|executed| executed.value);
+        let cleanup = self
+            .state
+            .engine
+            .close_prepared_statement(&self.state.session, statement)
+            .await;
+        match (result, cleanup) {
+            (Err(error), _) => Err(error),
+            (Ok(_), Err(error)) => Err(error),
+            (Ok(execution), Ok(_)) => Ok((behavior, SimpleWireExecution::Materialized(execution))),
+        }
+    }
+
+    #[cfg(test)]
     async fn execute_prepared_simple_query(
         &self,
         statement: PreparedStatementId,
@@ -1536,6 +1633,48 @@ impl Connection {
     /// this on ordinary termination, EOF, error, shutdown, and forced cleanup.
     pub async fn close(&self) -> EngineResult<()> {
         self.state.session.close().await
+    }
+}
+
+enum SimpleWireExecution {
+    Materialized(PreparedExecution),
+    Stream {
+        stream: RowStream,
+        cleanup: SimpleQueryCleanup,
+    },
+}
+
+struct SimpleQueryCleanup {
+    state: Arc<ConnectionState>,
+    statement: Option<PreparedStatementId>,
+}
+
+impl SimpleQueryCleanup {
+    async fn finish(&mut self) {
+        if let Some(statement) = self.statement.take() {
+            let _ = self
+                .state
+                .engine
+                .close_prepared_statement(&self.state.session, statement)
+                .await;
+        }
+    }
+}
+
+impl Drop for SimpleQueryCleanup {
+    fn drop(&mut self) {
+        let Some(statement) = self.statement.take() else {
+            return;
+        };
+        let state = Arc::clone(&self.state);
+        if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+            runtime.spawn(async move {
+                let _ = state
+                    .engine
+                    .close_prepared_statement(&state.session, statement)
+                    .await;
+            });
+        }
     }
 }
 
@@ -1753,17 +1892,20 @@ impl WireHandlers {
             return Ok(());
         };
         let connection = self.connection.installed()?;
+        let portals =
+            remove_bound_portals_for_statement(&connection.state, statement.statement.id)?;
+        for portal_name in &portals {
+            if let Some(portal) = client.portal_store().get_portal(portal_name) {
+                *portal.state().lock().await = PortalExecutionState::Finished;
+            }
+            client.portal_store().rm_portal(portal_name);
+        }
         connection
             .state
             .engine
             .close_prepared_statement(&connection.state.session, statement.statement.id)
             .await
             .map_err(engine_error_to_pgwire)?;
-        let portals =
-            remove_bound_portals_for_statement(&connection.state, statement.statement.id)?;
-        for portal in portals {
-            client.portal_store().rm_portal(&portal);
-        }
         client.portal_store().rm_statement(name);
         Ok(())
     }
@@ -1777,13 +1919,17 @@ impl WireHandlers {
     {
         let connection = self.connection.installed()?;
         if let Some(portal) = bound_portal(&connection.state, name)? {
+            if let Some(wire_portal) = client.portal_store().get_portal(name) {
+                *wire_portal.state().lock().await = PortalExecutionState::Finished;
+            }
+            client.portal_store().rm_portal(name);
+            remove_bound_portal(&connection.state, name)?;
             connection
                 .state
                 .engine
                 .close_portal(&connection.state.session, portal.id)
                 .await
                 .map_err(engine_error_to_pgwire)?;
-            remove_bound_portal(&connection.state, name)?;
         }
         client.portal_store().rm_portal(name);
         Ok(())
@@ -1793,7 +1939,7 @@ impl WireHandlers {
         &self,
         _client: &mut C,
         portal: &Portal<PgWirePrepared>,
-        context: RequestContext,
+        request: ActiveRequest,
     ) -> PgWireResult<Response>
     where
         C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
@@ -1804,6 +1950,7 @@ impl WireHandlers {
         let connection = self.connection.installed()?;
         let bound = bound_portal(&connection.state, portal.name.as_str())?
             .ok_or_else(|| PgWireError::PortalNotFound(portal.name.clone()))?;
+        let context = request.context();
         let behavior = connection
             .state
             .engine
@@ -1815,13 +1962,24 @@ impl WireHandlers {
             .await
             .map_err(engine_error_to_pgwire)?
             .behavior();
-        let execution = connection
-            .state
-            .engine
-            .execute_portal_logical_with_context(&connection.state.session, bound.id, context)
-            .await
-            .map_err(engine_error_to_pgwire)?;
-        execution_response(behavior, execution.value, Some(Arc::clone(&bound.fields)))
+        if matches!(behavior, StatementBehavior::Read) {
+            let stream = connection
+                .state
+                .engine
+                .stream_portal_logical_with_context(&connection.state.session, bound.id, context)
+                .await
+                .map_err(engine_error_to_pgwire)?
+                .value;
+            row_stream_response(stream, Arc::clone(&bound.fields), request, None)
+        } else {
+            let execution = connection
+                .state
+                .engine
+                .execute_portal_logical_with_context(&connection.state.session, bound.id, context)
+                .await
+                .map_err(engine_error_to_pgwire)?;
+            execution_response(behavior, execution.value, Some(Arc::clone(&bound.fields)))
+        }
     }
 }
 
@@ -2103,10 +2261,19 @@ impl SimpleQueryHandler for WireHandlers {
         let (behavior, execution) = self
             .connection
             .installed()?
-            .execute_simple_query(query, request.context())
+            .execute_simple_query_streaming(query, request.context())
             .await
             .map_err(engine_error_to_pgwire)?;
-        Ok(vec![simple_query_response(behavior, execution)?])
+        let response = match execution {
+            SimpleWireExecution::Materialized(execution) => {
+                simple_query_response(behavior, execution)?
+            }
+            SimpleWireExecution::Stream { stream, cleanup } => {
+                let fields = result_columns_to_fields(stream.columns());
+                row_stream_response(stream, fields, request, Some(cleanup))?
+            }
+        };
+        Ok(vec![response])
     }
 }
 
@@ -2163,12 +2330,17 @@ fn write_tag(behavior: StatementBehavior, rows: usize) -> PgWireResult<Tag> {
 
 fn result_set_response(result: ResultSet) -> PgWireResult<Response> {
     let (columns, rows) = result.into_parts();
-    let fields = Arc::new(
+    let fields = result_columns_to_fields(&columns);
+    encode_query_response(rows, fields)
+}
+
+fn result_columns_to_fields(columns: &[crate::core::Column]) -> Arc<Vec<FieldInfo>> {
+    Arc::new(
         columns
-            .into_iter()
+            .iter()
             .map(|column| {
                 FieldInfo::new(
-                    column.name,
+                    column.name.clone(),
                     None,
                     None,
                     postgres_type(column.data_type),
@@ -2176,8 +2348,7 @@ fn result_set_response(result: ResultSet) -> PgWireResult<Response> {
                 )
             })
             .collect::<Vec<_>>(),
-    );
-    encode_query_response(rows, fields)
+    )
 }
 
 fn result_set_response_with_fields(
@@ -2203,6 +2374,63 @@ fn encode_query_response(
         fields,
         stream::iter(encoded.into_iter().map(Ok)),
     )))
+}
+
+struct PgRowStreamState {
+    stream: RowStream,
+    fields: Arc<Vec<FieldInfo>>,
+    _request: ActiveRequest,
+    cleanup: Option<SimpleQueryCleanup>,
+    finished: bool,
+}
+
+fn row_stream_response(
+    stream: RowStream,
+    fields: Arc<Vec<FieldInfo>>,
+    request: ActiveRequest,
+    cleanup: Option<SimpleQueryCleanup>,
+) -> PgWireResult<Response> {
+    if stream.columns().len() != fields.len() {
+        return Err(internal_query_error());
+    }
+    let state = PgRowStreamState {
+        stream,
+        fields: Arc::clone(&fields),
+        _request: request,
+        cleanup,
+        finished: false,
+    };
+    let rows = stream::unfold(state, |mut state| async move {
+        if state.finished {
+            return None;
+        }
+        match state.stream.next_row().await {
+            Some(Ok(row)) => {
+                let encoded = encode_data_row(Arc::clone(&state.fields), row.into_values());
+                if encoded.is_err() {
+                    state.finished = true;
+                    if let Some(cleanup) = &mut state.cleanup {
+                        cleanup.finish().await;
+                    }
+                }
+                Some((encoded, state))
+            }
+            Some(Err(error)) => {
+                state.finished = true;
+                if let Some(cleanup) = &mut state.cleanup {
+                    cleanup.finish().await;
+                }
+                Some((Err(engine_error_to_pgwire(error)), state))
+            }
+            None => {
+                if let Some(cleanup) = &mut state.cleanup {
+                    cleanup.finish().await;
+                }
+                None
+            }
+        }
+    });
+    Ok(Response::Query(QueryResponse::new(fields, rows)))
 }
 
 fn description_fields(description: &PreparedStatementDescription) -> Vec<FieldInfo> {
@@ -3060,7 +3288,6 @@ impl ExtendedQueryHandler for WireHandlers {
         PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
     {
         self.sync_failed_transaction(client).await?;
-        let request = self.connection.begin_request()?;
         if !matches!(client.state(), PgWireConnectionState::ReadyForQuery) {
             return Err(PgWireError::NotReadyForQuery);
         }
@@ -3078,10 +3305,8 @@ impl ExtendedQueryHandler for WireHandlers {
         let mut portal_state = portal_state_lock.lock().await;
         match &mut *portal_state {
             PortalExecutionState::Initial => {
-                match self
-                    .execute_bound_portal(client, &portal, request.context())
-                    .await?
-                {
+                let request = self.connection.begin_request()?;
+                match self.execute_bound_portal(client, &portal, request).await? {
                     Response::Query(mut response) if max_rows > 0 => {
                         if send_partial_query_response(client, &mut response, max_rows).await? {
                             *portal_state = PortalExecutionState::Suspended(response);
@@ -3111,8 +3336,13 @@ impl ExtendedQueryHandler for WireHandlers {
                 }
             }
             PortalExecutionState::Suspended(response) => {
-                if !send_partial_query_response(client, response, max_rows).await? {
-                    *portal_state = PortalExecutionState::Finished;
+                match send_partial_query_response(client, response, max_rows).await {
+                    Ok(true) => {}
+                    Ok(false) => *portal_state = PortalExecutionState::Finished,
+                    Err(error) => {
+                        *portal_state = PortalExecutionState::Finished;
+                        return Err(error);
+                    }
                 }
             }
             PortalExecutionState::Finished => {
@@ -3207,8 +3437,7 @@ impl ExtendedQueryHandler for WireHandlers {
     {
         self.sync_failed_transaction(client).await?;
         let request = self.connection.begin_request()?;
-        self.execute_bound_portal(client, portal, request.context())
-            .await
+        self.execute_bound_portal(client, portal, request).await
     }
 }
 
@@ -5895,6 +6124,122 @@ mod tests {
         assert_eq!(total_rows, 1, "a finished write portal must not re-execute");
 
         finish_wire_server(&mut client, server).await;
+        assert_eq!(
+            wire.connection().unwrap().state().await,
+            SessionState::Closed
+        );
+        engine.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn cancel_request_interrupts_a_suspended_stream_and_the_connection_recovers() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut database = crate::core::Database::open(temp.path(), 2).unwrap();
+        database
+            .broadcast("CREATE TABLE global_records (value INTEGER NOT NULL)")
+            .unwrap();
+        let logical_database = database.catalog().default_database().id();
+        database
+            .register_tables(vec![
+                crate::core::TableDeclaration::global(logical_database, "global_records").unwrap(),
+            ])
+            .unwrap();
+        let connection =
+            rusqlite::Connection::open(temp.path().join("shards/0000.sqlite")).unwrap();
+        for value in 0..64_i64 {
+            connection
+                .execute("INSERT INTO global_records (value) VALUES (?1)", [value])
+                .unwrap();
+        }
+        drop(connection);
+
+        let engine = Engine::from_database(Arc::new(database));
+        let adapter = Adapter::new(engine.clone());
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let wire = adapter.wire_connection();
+        let served = wire.clone();
+        let cancellation_adapter = adapter.clone();
+        let (main_tx, main_rx) = tokio::sync::oneshot::channel();
+        let cancellation_server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let main =
+                tokio::spawn(async move { served.serve(stream, std::future::pending()).await });
+            main_tx.send(main).unwrap();
+            let (stream, _) = listener.accept().await.unwrap();
+            cancellation_adapter
+                .wire_connection()
+                .serve(stream, std::future::pending())
+                .await
+        });
+
+        let mut client = TcpStream::connect(address).await.unwrap();
+        let main_server = main_rx.await.unwrap();
+        client.write_all(&startup_packet()).await.unwrap();
+        let startup = read_until_ready(&mut client).await;
+        let key = startup
+            .iter()
+            .find(|frame| frame.0 == b'K')
+            .map(|frame| backend_key(&frame.1))
+            .unwrap();
+        let start_stream = [
+            parse_packet("stream", "SELECT value FROM global_records ORDER BY value"),
+            bind_packet("stream_portal", "stream"),
+            execute_packet("stream_portal", 1),
+            typed_packet(b'H', &[]),
+        ]
+        .concat();
+        client.write_all(&start_stream).await.unwrap();
+        let mut frames = Vec::new();
+        for _ in 0..4 {
+            frames.push(read_frame(&mut client).await);
+        }
+        assert_eq!(
+            frames.iter().map(|frame| frame.0).collect::<Vec<_>>(),
+            [b'1', b'2', b'D', b's']
+        );
+        assert_eq!(adapter.cancellations.active_len(), 1);
+
+        let mut cancellation = TcpStream::connect(address).await.unwrap();
+        cancellation
+            .write_all(&cancel_packet(key.pid, key.secret))
+            .await
+            .unwrap();
+        assert_eof(&mut cancellation).await;
+        cancellation_server.abort();
+        let _ = cancellation_server.await;
+
+        client
+            .write_all(&[execute_packet("stream_portal", 1), typed_packet(b'S', &[])].concat())
+            .await
+            .unwrap();
+        let cancelled = read_until_ready(&mut client).await;
+        assert_eq!(cancelled[0].0, b'E');
+        assert_eq!(
+            message_fields(&cancelled[0].1)
+                .get(&b'C')
+                .map(String::as_str),
+            Some("57014")
+        );
+        assert_eq!(adapter.cancellations.active_len(), 0);
+
+        client
+            .write_all(&typed_packet(b'Q', b"SELECT 1\0"))
+            .await
+            .unwrap();
+        let recovered = read_until_ready(&mut client).await;
+        assert_eq!(
+            recovered.iter().map(|frame| frame.0).collect::<Vec<_>>(),
+            [b'T', b'D', b'C', b'Z']
+        );
+
+        client.write_all(&typed_packet(b'X', &[])).await.unwrap();
+        assert_eof(&mut client).await;
+        tokio::time::timeout(Duration::from_secs(2), main_server)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
         assert_eq!(
             wire.connection().unwrap().state().await,
             SessionState::Closed

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -384,6 +384,50 @@ pub(crate) fn query_with_scatter_budget(
     materialize_rows_with_scatter_budget(&mut statement, metadata.columns, params, budget)
 }
 
+/// Step one read-only SQLite statement and publish each owned row through a
+/// bounded protocol-neutral sink.
+///
+/// `publish_columns` runs after successful prepare and budget validation but
+/// before SQLite is stepped. Scatter callers share one budget and invoke this
+/// once per shard, which also verifies identical column metadata.
+pub(crate) fn stream_query_with_budget(
+    connection: &Connection,
+    statement: &str,
+    params: &[Value],
+    budget: &ScatterResultBudget,
+    publish_columns: impl FnOnce(&[Column]) -> EngineResult<()>,
+    mut publish_row: impl FnMut(Row) -> EngineResult<()>,
+) -> EngineResult<()> {
+    let params = sqlite_parameters(params)?;
+    let mut statement = connection
+        .prepare(statement)
+        .map_err(sqlite_error::statement)?;
+    if !statement.readonly() {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidQuery,
+            "streamed query statements must be read-only",
+        ));
+    }
+
+    let metadata = statement_metadata(&statement);
+    budget.register_columns(&metadata.columns)?;
+    publish_columns(&metadata.columns)?;
+    let mut sqlite_rows = statement
+        .query(params_from_iter(params))
+        .map_err(sqlite_error::statement)?;
+    while let Some(sqlite_row) = sqlite_rows.next().map_err(sqlite_error::statement)? {
+        budget.reserve_sqlite_row(sqlite_row, metadata.columns.len())?;
+        let mut values = Vec::with_capacity(metadata.columns.len());
+        for index in 0..metadata.columns.len() {
+            values.push(sql_to_value(
+                sqlite_row.get_ref(index).map_err(sqlite_error::statement)?,
+            ));
+        }
+        publish_row(Row::new(values))?;
+    }
+    Ok(())
+}
+
 fn materialize_rows(
     statement: &mut SqlStatement<'_>,
     columns: Vec<Column>,

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -1210,6 +1210,8 @@ async fn prepared_lifecycle_is_public_owned_and_protocol_neutral() {
     assert_owned::<core::DescribeTarget>();
     assert_owned::<core::PreparedStatementDescription>();
     assert_owned::<core::PreparedExecution>();
+    assert_owned::<core::RowStream>();
+    assert_eq!(core::DEFAULT_STREAM_BUFFER_ROWS, 16);
 
     let temp = tempfile::tempdir().unwrap();
     let mut database = core::Database::open(temp.path(), 4).unwrap();
@@ -1305,6 +1307,21 @@ async fn prepared_lifecycle_is_public_owned_and_protocol_neutral() {
             core::Value::from("private-literal")
         ]
     );
+
+    let mut streamed = engine
+        .stream_portal_logical(&session, select_portal)
+        .await
+        .unwrap()
+        .value;
+    assert_eq!(streamed.columns(), description.columns());
+    assert_eq!(
+        streamed.next_row().await.unwrap().unwrap().values(),
+        [
+            core::Value::from(42_i64),
+            core::Value::from("private-literal")
+        ]
+    );
+    assert!(streamed.next_row().await.is_none());
 
     assert!(engine.close_portal(&session, select_portal).await.unwrap());
     assert!(


### PR DESCRIPTION
Closes #39

## Summary
- add a protocol-neutral bounded `RowStream` that stops SQLite stepping after a 16-row handoff
- stream simple and extended PostgreSQL reads, including suspended portals and single-shard transactions
- keep backend cancellation active for the stream lifetime and interrupt/retire the exact leased SQLite handle
- document streamed limits, cancellation, client behavior, and complete the PostgreSQL roadmap effort

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (stable and Rust 1.85)
- `cargo test --locked --doc --all-features` (stable and Rust 1.85)
- feature-surface checks and `cargo package --locked --allow-dirty`
- live psql/tokio-postgres/psycopg/SQLAlchemy matrix