### PR TITLE
Add global-index performance baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,13 @@ jobs:
       - name: Run documentation tests
         run: cargo test --locked --doc --all-features
 
+      - name: Run global-index benchmark correctness smoke
+        if: matrix.rust == 'stable'
+        run: >-
+          cargo test --locked --test global_index_baseline
+          global_index_baseline_smoke --
+          --ignored --exact --test-threads=1
+
   python:
     name: Python source build (${{ matrix.python }})
     runs-on: ubuntu-24.04

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -402,6 +402,22 @@ requires an earlier dependency:
 3. [ ] **Implement global indexes, uniqueness, and value allocation.** Add the
    protocol-neutral authority and routing metadata needed for cross-shard
    constraints, collision-free allocation, and exact indexed shard targeting.
+   Track the rollout in [#225](https://github.com/schapman1974/briskdb/issues/225):
+
+   - [x] [#226](https://github.com/schapman1974/briskdb/issues/226) — baseline and regression suite
+   - [ ] [#227](https://github.com/schapman1974/briskdb/issues/227) — canonical key encoding
+   - [ ] [#228](https://github.com/schapman1974/briskdb/issues/228) — catalog lifecycle and compatibility fencing
+   - [ ] [#229](https://github.com/schapman1974/briskdb/issues/229) — storage-topology prototype
+   - [ ] [#230](https://github.com/schapman1974/briskdb/issues/230) — offline index construction
+   - [ ] [#231](https://github.com/schapman1974/briskdb/issues/231) — validation, repair, and rebuild
+   - [ ] [#232](https://github.com/schapman1974/briskdb/issues/232) — unique reservations and global allocation
+   - [ ] [#233](https://github.com/schapman1974/briskdb/issues/233) — authoritative write maintenance
+   - [ ] [#234](https://github.com/schapman1974/briskdb/issues/234) — exact indexed routing
+   - [ ] [#235](https://github.com/schapman1974/briskdb/issues/235) — candidate verification and repair
+   - [ ] [#236](https://github.com/schapman1974/briskdb/issues/236) — transactional shard outboxes
+   - [ ] [#237](https://github.com/schapman1974/briskdb/issues/237) — asynchronous indexing and watermarks
+   - [ ] [#238](https://github.com/schapman1974/briskdb/issues/238) — Bloom/min-max shard summaries
+   - [ ] [#239](https://github.com/schapman1974/briskdb/issues/239) — production/release gates
 4. [ ] **Finish the embedded Rust API.** Make sessions, transactions,
    cancellation, concurrency, document commands, and shutdown safe for a host
    process.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -4,6 +4,72 @@ BriskDB's Criterion suite establishes repeatable controls for the synchronous
 storage path and the bounded asynchronous engine. It is a measurement tool, not
 a claim about production capacity or a timing threshold for shared CI runners.
 
+## Global-index before/after gate
+
+Issue [#226](https://github.com/schapman1974/briskdb/issues/226) freezes the
+protocol-neutral Engine baseline that every global-index phase must compare
+against. The matrix covers 2, 4, 10, and 64 shards in both one-process and
+four-process modes. Each case uses deterministic data and validates returned
+rows, affected rows, shard targets, constraint outcomes, and every SQLite
+file's `PRAGMA quick_check` before accepting timing data.
+
+| Workload | Current routing | Purpose |
+| --- | --- | --- |
+| `point_read` | One shard | Preserve exact shard-key routing cost |
+| `scatter_read` | Every shard | Measure bounded logical fan-out |
+| `indexed_hit` / `indexed_miss` | Every shard, using a shard-local SQLite index | Freeze the cost that global index routing should remove |
+| `insert` / `update` / `delete` | One shard | Quantify foreground write cost before index maintenance |
+| `contended_unique_insert` | One authoritative shard today | Quantify unique-conflict and multi-process contention cost before global reservations |
+
+Every result is a tab-separated record with attempts, successes, constraint
+failures, returned rows, visited shards, throughput, p50/p95/p99 latency,
+process CPU, peak RSS, operating-system-reported physical write bytes, peak WAL
+growth, and SQLite durability mode. `physical_write_bytes` comes from
+`getrusage`; a platform/filesystem may report zero. The harness does not invent
+an fsync count when portable syscall accounting is unavailable. It records the
+production `WAL` plus `synchronous=FULL` policy explicitly, while WAL growth
+provides a portable storage-cost signal.
+
+Run the parser/budget unit test and the same short correctness smoke used by CI:
+
+```bash
+cargo test --locked --test global_index_baseline \
+  report_parser_and_regression_budgets_are_deterministic -- --exact
+cargo test --locked --test global_index_baseline \
+  global_index_baseline_smoke -- --ignored --exact --test-threads=1
+```
+
+One command runs the complete optimized matrix locally:
+
+```bash
+cargo test --release --locked --test global_index_baseline \
+  release_global_index_baseline -- \
+  --ignored --exact --nocapture --test-threads=1
+```
+
+Use a quiet machine, the same local filesystem, toolchain, power policy, and
+warm-cache policy for before/after comparisons. Set `BRISKDB_BENCH_COMPARE` to
+the committed TSV baseline to enforce the deliberately broad stable-host
+budgets: at least 50% of baseline throughput; p99 no greater than the broader
+of 3x baseline or 5 ms of host-scheduling jitter; at most 2x CPU, physical
+writes, or WAL growth per attempt; and at most 64 MiB additional peak RSS.
+Shared CI runs correctness smoke and synthetic budget tests, not cross-host
+timing thresholds.
+
+```bash
+BRISKDB_BENCH_COMPARE=docs/benchmarks/global-index-before-2026-08-14.tsv \
+  cargo test --release --locked --test global_index_baseline \
+  release_global_index_baseline -- \
+  --ignored --exact --nocapture --test-threads=1
+```
+
+The frozen pre-index artifact is
+[`global-index-before-2026-08-14.tsv`](benchmarks/global-index-before-2026-08-14.tsv).
+It records the exact engine revision, host, compiler, controls, and all 64
+results. The local SQLite secondary index makes individual child lookups cheap,
+but `indexed_hit` and `indexed_miss` still visit 2/4/10/64 shards respectively;
+future gains therefore cannot be mistaken for cache-only improvements.
+
 ## Workload contract
 
 Every benchmark creates a fresh temporary BriskDB database with exactly four

--- a/docs/benchmarks/global-index-before-2026-08-14.tsv
+++ b/docs/benchmarks/global-index-before-2026-08-14.tsv
@@ -1,0 +1,84 @@
+metadata	captured_at	2026-08-14
+metadata	engine_revision	51c84212839632ecbf27fddb56d5c792cf56207f
+metadata	rustc	rustc 1.94.1 (e408947bf 2026-03-25); binary: rustc; commit-hash: e408947bfd200af42db322daf0fadfe7e26d3bd1; commit-date: 2026-03-25; host: aarch64-apple-darwin; release: 1.94.1; LLVM version: 21.1.8
+metadata	uname	Darwin MacBook-Pro-2.local 25.2.0 Darwin Kernel Version 25.2.0: Tue Nov 18 21:09:40 PST 2025; root:xnu-12377.61.12~1/RELEASE_ARM64_T6000 arm64
+metadata	cpu	Apple M1 Pro
+metadata	memory_bytes	17179869184
+metadata	filesystem	APFS; internal Apple Fabric storage
+metadata	power_cache_policy	AC power; normal warm operating-system cache
+metadata	command	cargo test --release --locked --test global_index_baseline release_global_index_baseline -- --ignored --exact --nocapture --test-threads=1
+metadata	os	macos
+metadata	arch	aarch64
+control	rows_per_shard	16
+control	operations_per_worker	256
+control	warmup_operations	16
+control	process_workers	4
+control	cache_policy	warm
+control	sqlite_journal_mode	WAL
+control	sqlite_synchronous	FULL
+control	fsync_observation	SQLite FULL durability policy; syscall counts are not portable and are not inferred
+record	mode	shards	workload	workers	operations_per_worker	attempts	successes	constraints	returned_rows	visited_shards	elapsed_us	throughput_ops_s	p50_us	p95_us	p99_us	cpu_us	peak_rss_bytes	physical_write_bytes	peak_wal_growth_bytes	expected_shards_per_operation	sqlite_synchronous
+result	single_process	2	point_read	1	256	256	256	0	256	256	6799	37652.60	24	32	68	7420	14057472	0	0	1	FULL
+result	single_process	2	scatter_read	1	256	256	256	0	2048	512	14866	17220.50	53	88	106	25454	14286848	0	0	2	FULL
+result	single_process	2	indexed_hit	1	256	256	256	0	256	512	10965	23347.01	39	69	89	17331	14385152	0	0	2	FULL
+result	single_process	2	indexed_miss	1	256	256	256	0	0	512	11126	23009.17	38	71	93	17588	14401536	0	0	2	FULL
+result	single_process	2	insert	1	256	256	256	0	256	256	32465	7885.42	124	164	235	29162	14401536	0	4128272	1	FULL
+result	single_process	2	update	1	256	256	256	0	256	256	22093	11587.38	83	109	143	20090	14450688	0	1120672	1	FULL
+result	single_process	2	delete	1	256	256	256	0	256	256	40988	6245.73	159	234	307	37771	14467072	0	4128272	1	FULL
+result	single_process	2	contended_unique_insert	1	256	256	256	0	256	256	39595	6465.46	156	224	294	35203	14467072	0	4132392	1	FULL
+result	multi_process	2	point_read	4	256	1024	1024	0	1024	1024	12327	83069.68	47	61	75	49809	54542336	0	0	1	FULL
+result	multi_process	2	scatter_read	4	256	1024	1024	0	8192	2048	32608	31403.34	121	170	209	202798	54935552	0	0	2	FULL
+result	multi_process	2	indexed_hit	4	256	1024	1024	0	1024	2048	53403	19174.95	141	558	1079	153142	54919168	0	0	2	FULL
+result	multi_process	2	indexed_miss	4	256	1024	1024	0	0	2048	26166	39134.76	97	134	166	156189	55001088	0	0	2	FULL
+result	multi_process	2	insert	4	256	1024	1024	0	1024	1024	83717	12231.69	104	336	2672	132149	54951936	0	7057560	1	FULL
+result	multi_process	2	update	4	256	1024	1024	0	1024	1024	57808	17713.81	100	182	4007	96875	54411264	0	4124120	1	FULL
+result	multi_process	2	delete	4	256	1024	1024	0	1024	1024	60180	17015.62	96	260	2988	97938	54214656	0	7172920	1	FULL
+result	multi_process	2	contended_unique_insert	4	256	1024	256	768	256	1024	49382	20736.30	31	153	2828	52803	54755328	0	3872800	1	FULL
+result	single_process	4	point_read	1	256	256	256	0	256	256	6719	38100.91	24	37	47	7244	14696448	0	0	1	FULL
+result	single_process	4	scatter_read	1	256	256	256	0	4096	1024	23078	11092.82	88	123	136	50165	14860288	0	0	4	FULL
+result	single_process	4	indexed_hit	1	256	256	256	0	256	1024	16599	15422.62	61	101	119	35834	14860288	0	0	4	FULL
+result	single_process	4	indexed_miss	1	256	256	256	0	0	1024	17709	14455.93	65	104	119	36643	14860288	0	0	4	FULL
+result	single_process	4	insert	1	256	256	256	0	256	256	32790	7807.26	133	161	221	31077	14860288	0	4132392	1	FULL
+result	single_process	4	update	1	256	256	256	0	256	256	21879	11700.72	74	141	215	20505	14860288	0	1120672	1	FULL
+result	single_process	4	delete	1	256	256	256	0	256	256	36759	6964.28	148	184	224	34278	14860288	0	4132392	1	FULL
+result	single_process	4	contended_unique_insert	1	256	256	256	0	256	256	36292	7053.90	153	197	225	33749	14860288	0	4128272	1	FULL
+result	multi_process	4	point_read	4	256	1024	1024	0	1024	1024	11706	87476.51	45	56	74	48224	55328768	0	0	1	FULL
+result	multi_process	4	scatter_read	4	256	1024	1024	0	16384	4096	43107	23754.84	161	220	257	323524	56115200	0	0	4	FULL
+result	multi_process	4	indexed_hit	4	256	1024	1024	0	1024	4096	37039	27646.53	139	196	219	274208	56459264	0	0	4	FULL
+result	multi_process	4	indexed_miss	4	256	1024	1024	0	0	4096	37207	27521.70	138	194	230	269329	56147968	0	0	4	FULL
+result	multi_process	4	insert	4	256	1024	1024	0	1024	1024	73680	13897.94	272	470	633	222694	55427072	0	15322280	1	FULL
+result	multi_process	4	update	4	256	1024	1024	0	1024	1024	44914	22799.13	165	232	269	146793	55230464	0	4078824	1	FULL
+result	multi_process	4	delete	4	256	1024	1024	0	1024	1024	112853	9073.75	436	729	864	266313	54935552	0	15474720	1	FULL
+result	multi_process	4	contended_unique_insert	4	256	1024	256	768	256	1024	66207	15466.64	29	255	2915	68121	55508992	0	3835720	1	FULL
+result	single_process	10	point_read	1	256	256	256	0	256	256	6769	37819.47	23	39	73	7490	15368192	0	0	1	FULL
+result	single_process	10	scatter_read	1	256	256	256	0	10240	2560	36183	7075.15	139	172	194	129582	15712256	0	0	10	FULL
+result	single_process	10	indexed_hit	1	256	256	256	0	256	2560	32843	7794.66	126	160	190	107011	15728640	0	0	10	FULL
+result	single_process	10	indexed_miss	1	256	256	256	0	0	2560	32222	7944.88	123	157	170	104662	15810560	0	0	10	FULL
+result	single_process	10	insert	1	256	256	256	0	256	256	31941	8014.78	113	183	225	30652	15810560	0	4132392	1	FULL
+result	single_process	10	update	1	256	256	256	0	256	256	21999	11636.89	81	122	145	20671	15810560	0	1116552	1	FULL
+result	single_process	10	delete	1	256	256	256	0	256	256	32493	7878.62	130	154	205	30982	15810560	0	4132392	1	FULL
+result	single_process	10	contended_unique_insert	1	256	256	256	0	256	256	32351	7913.20	119	181	219	30786	15810560	0	4128272	1	FULL
+result	multi_process	10	point_read	4	256	1024	1024	0	1024	1024	12362	82834.49	47	60	77	50390	56885248	0	0	1	FULL
+result	multi_process	10	scatter_read	4	256	1024	1024	0	40960	10240	72951	14036.82	275	361	418	556314	59244544	0	0	10	FULL
+result	multi_process	10	indexed_hit	4	256	1024	1024	0	1024	10240	67119	15256.48	255	357	414	528198	59080704	0	0	10	FULL
+result	multi_process	10	indexed_miss	4	256	1024	1024	0	0	10240	67437	15184.54	255	340	381	526996	59785216	0	0	10	FULL
+result	multi_process	10	insert	4	256	1024	1024	0	1024	1024	106505	9614.57	424	645	778	271368	57573376	0	15309920	1	FULL
+result	multi_process	10	update	4	256	1024	1024	0	1024	1024	45122	22694.03	175	233	255	156031	56901632	0	4161200	1	FULL
+result	multi_process	10	delete	4	256	1024	1024	0	1024	1024	83209	12306.36	316	491	613	236083	56590336	0	15474720	1	FULL
+result	multi_process	10	contended_unique_insert	4	256	1024	256	768	256	1024	62417	16405.79	33	238	4380	63853	57196544	0	3839840	1	FULL
+result	single_process	64	point_read	1	256	256	256	0	256	256	6681	38317.62	24	33	47	8896	21217280	0	0	1	FULL
+result	single_process	64	scatter_read	1	256	256	256	0	65536	16384	164935	1552.13	642	730	776	821480	23232512	0	0	64	FULL
+result	single_process	64	indexed_hit	1	256	256	256	0	256	16384	155651	1644.71	603	697	729	759559	23396352	0	0	64	FULL
+result	single_process	64	indexed_miss	1	256	256	256	0	0	16384	157247	1628.01	614	702	737	763407	23592960	0	0	64	FULL
+result	single_process	64	insert	1	256	256	256	0	256	256	55813	4586.75	244	301	334	66460	23592960	0	4132392	1	FULL
+result	single_process	64	update	1	256	256	256	0	256	256	20755	12334.38	77	118	128	24348	23740416	0	1120672	1	FULL
+result	single_process	64	delete	1	256	256	256	0	256	256	28716	8914.89	108	159	230	33065	23756800	0	4132392	1	FULL
+result	single_process	64	contended_unique_insert	1	256	256	256	0	256	256	41618	6151.18	163	257	379	49681	23756800	0	4128272	1	FULL
+result	multi_process	64	point_read	4	256	1024	1024	0	1024	1024	12164	84182.83	46	61	78	49559	76890112	0	0	1	FULL
+result	multi_process	64	scatter_read	4	256	1024	1024	0	262144	65536	346070	2958.94	1188	2103	3210	2900320	84656128	0	0	64	FULL
+result	multi_process	64	indexed_hit	4	256	1024	1024	0	1024	65536	295886	3460.79	1126	1457	1777	2451473	84410368	0	0	64	FULL
+result	multi_process	64	indexed_miss	4	256	1024	1024	0	0	65536	359844	2845.68	1179	1772	7820	2381590	84000768	0	0	64	FULL
+result	multi_process	64	insert	4	256	1024	1024	0	1024	1024	128498	7969.00	495	797	947	311009	76906496	0	15309920	1	FULL
+result	multi_process	64	update	4	256	1024	1024	0	1024	1024	43372	23609.70	164	228	253	149456	77152256	0	4041720	1	FULL
+result	multi_process	64	delete	4	256	1024	1024	0	1024	1024	129909	7882.44	515	812	1009	295327	77070336	0	15474720	1	FULL
+result	multi_process	64	contended_unique_insert	4	256	1024	256	768	256	1024	64352	15912.48	27	216	1564	62097	76742656	0	3839840	1	FULL

--- a/tests/global_index_baseline.rs
+++ b/tests/global_index_baseline.rs
@@ -1,0 +1,1431 @@
+//! Frozen before/after workload for the global-index rollout (issue #226).
+//!
+//! Timing is deliberately opt-in. Ordinary test runs validate the report and
+//! regression-budget machinery; CI invokes the ignored smoke matrix explicitly.
+
+use std::{
+    collections::BTreeMap,
+    env, fs,
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    str::FromStr,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread,
+    time::{Duration, Instant},
+};
+
+use briskdb::core::{
+    Database, Engine, EngineErrorKind, Session, ShardKeyMetadata, ShardKeyType, Statement,
+    TableDeclaration, Value,
+};
+use rusqlite::{Connection, params};
+use tempfile::TempDir;
+use tokio::runtime::{Builder, Runtime};
+
+const FORMAT_VERSION: &str = "global-index-baseline-v1";
+const TABLE: &str = "global_index_baseline";
+const SHARD_MATRIX: [u16; 4] = [2, 4, 10, 64];
+const FULL_ROWS_PER_SHARD: usize = 16;
+const FULL_OPERATIONS_PER_WORKER: usize = 256;
+const FULL_WARMUP_OPERATIONS: usize = 16;
+const FULL_PROCESS_WORKERS: usize = 4;
+const SMOKE_ROWS_PER_SHARD: usize = 4;
+const SMOKE_OPERATIONS_PER_WORKER: usize = 2;
+const SMOKE_WARMUP_OPERATIONS: usize = 1;
+const SMOKE_PROCESS_WORKERS: usize = 2;
+const INSERT_ROW_BASE: i64 = 1_000_000;
+const DELETE_ROW_BASE: i64 = 2_000_000;
+const CONTENDED_ROW_BASE: i64 = 3_000_000;
+const CHILD_TIMEOUT: Duration = Duration::from_secs(30);
+const TELEMETRY_INTERVAL: Duration = Duration::from_micros(200);
+
+const CREATE_SCHEMA: &str = "
+    CREATE TABLE global_index_baseline (
+        tenant_id INTEGER NOT NULL,
+        row_id INTEGER NOT NULL,
+        lookup_value TEXT NOT NULL,
+        unique_value TEXT NOT NULL,
+        payload INTEGER NOT NULL,
+        PRIMARY KEY (tenant_id, row_id),
+        UNIQUE (tenant_id, unique_value)
+    ) STRICT;
+    CREATE INDEX global_index_baseline_lookup
+        ON global_index_baseline (lookup_value);
+";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum Workload {
+    PointRead,
+    ScatterRead,
+    IndexedHit,
+    IndexedMiss,
+    Insert,
+    Update,
+    Delete,
+    ContendedUniqueInsert,
+}
+
+impl Workload {
+    const ALL: [Self; 8] = [
+        Self::PointRead,
+        Self::ScatterRead,
+        Self::IndexedHit,
+        Self::IndexedMiss,
+        Self::Insert,
+        Self::Update,
+        Self::Delete,
+        Self::ContendedUniqueInsert,
+    ];
+
+    const fn name(self) -> &'static str {
+        match self {
+            Self::PointRead => "point_read",
+            Self::ScatterRead => "scatter_read",
+            Self::IndexedHit => "indexed_hit",
+            Self::IndexedMiss => "indexed_miss",
+            Self::Insert => "insert",
+            Self::Update => "update",
+            Self::Delete => "delete",
+            Self::ContendedUniqueInsert => "contended_unique_insert",
+        }
+    }
+
+    const fn is_read(self) -> bool {
+        matches!(
+            self,
+            Self::PointRead | Self::ScatterRead | Self::IndexedHit | Self::IndexedMiss
+        )
+    }
+
+    const fn expected_shards(self, shard_count: u16) -> usize {
+        if matches!(self, Self::PointRead) {
+            1
+        } else if self.is_read() {
+            shard_count as usize
+        } else {
+            1
+        }
+    }
+}
+
+impl FromStr for Workload {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .into_iter()
+            .find(|workload| workload.name() == value)
+            .ok_or_else(|| format!("unknown global-index benchmark workload {value:?}"))
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum RunMode {
+    SingleProcess,
+    MultiProcess,
+}
+
+impl RunMode {
+    const ALL: [Self; 2] = [Self::SingleProcess, Self::MultiProcess];
+
+    const fn name(self) -> &'static str {
+        match self {
+            Self::SingleProcess => "single_process",
+            Self::MultiProcess => "multi_process",
+        }
+    }
+}
+
+impl FromStr for RunMode {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .into_iter()
+            .find(|mode| mode.name() == value)
+            .ok_or_else(|| format!("unknown global-index benchmark mode {value:?}"))
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct MatrixControls {
+    rows_per_shard: usize,
+    operations_per_worker: usize,
+    warmup_operations: usize,
+    process_workers: usize,
+}
+
+impl MatrixControls {
+    const fn smoke() -> Self {
+        Self {
+            rows_per_shard: SMOKE_ROWS_PER_SHARD,
+            operations_per_worker: SMOKE_OPERATIONS_PER_WORKER,
+            warmup_operations: SMOKE_WARMUP_OPERATIONS,
+            process_workers: SMOKE_PROCESS_WORKERS,
+        }
+    }
+
+    const fn full() -> Self {
+        Self {
+            rows_per_shard: FULL_ROWS_PER_SHARD,
+            operations_per_worker: FULL_OPERATIONS_PER_WORKER,
+            warmup_operations: FULL_WARMUP_OPERATIONS,
+            process_workers: FULL_PROCESS_WORKERS,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct WorkerSpec {
+    workload: Workload,
+    shard_count: u16,
+    rows_per_shard: usize,
+    operations: usize,
+    warmups: usize,
+    worker: usize,
+    workers: usize,
+}
+
+impl WorkerSpec {
+    const fn total_operations(self) -> usize {
+        self.operations + self.warmups
+    }
+}
+
+struct BenchmarkFixture {
+    root: TempDir,
+    tenant_keys: Vec<i64>,
+}
+
+impl BenchmarkFixture {
+    fn new(shard_count: u16, controls: MatrixControls) -> Self {
+        let root = tempfile::tempdir().expect("create global-index benchmark directory");
+        let mut database =
+            Database::open(root.path(), shard_count).expect("open global-index benchmark database");
+        let completed = database
+            .broadcast(CREATE_SCHEMA)
+            .expect("create global-index benchmark schema");
+        assert_eq!(completed, (0..shard_count).collect::<Vec<_>>());
+
+        let logical_database = database.catalog().default_database().id();
+        database
+            .register_tables(vec![
+                TableDeclaration::sharded(
+                    logical_database,
+                    TABLE,
+                    ShardKeyMetadata::new("tenant_id", ShardKeyType::Int64)
+                        .expect("declare benchmark shard key"),
+                )
+                .expect("declare benchmark table"),
+            ])
+            .expect("register global-index benchmark table");
+        let tenant_keys = (0..shard_count)
+            .map(|shard| integer_key_for_shard(&database, shard))
+            .collect::<Vec<_>>();
+        drop(database);
+
+        seed_fixture(root.path(), &tenant_keys, controls);
+        Self { root, tenant_keys }
+    }
+
+    fn path(&self) -> &Path {
+        self.root.path()
+    }
+}
+
+fn integer_key_for_shard(database: &Database, expected: u16) -> i64 {
+    (1_i64..)
+        .find(|value| database.shard_for_key(value.to_string().as_bytes()) == expected)
+        .expect("the finite shard map has an integer benchmark key for every shard")
+}
+
+fn seed_fixture(root: &Path, tenant_keys: &[i64], controls: MatrixControls) {
+    for (shard, tenant_key) in tenant_keys.iter().copied().enumerate() {
+        let mut connection = Connection::open(shard_path(root, shard as u16))
+            .expect("open physical shard for benchmark seeding");
+        let transaction = connection
+            .transaction()
+            .expect("start global-index benchmark seed transaction");
+        {
+            let mut insert = transaction
+                .prepare(
+                    "INSERT INTO global_index_baseline
+                     (tenant_id, row_id, lookup_value, unique_value, payload)
+                     VALUES (?1, ?2, ?3, ?4, ?5)",
+                )
+                .expect("prepare global-index benchmark seed insert");
+
+            for row in 0..controls.rows_per_shard {
+                insert
+                    .execute(params![
+                        tenant_key,
+                        row as i64,
+                        format!("lookup-{shard}-{row}"),
+                        format!("base-{shard}-{row}"),
+                        (row % 4) as i64,
+                    ])
+                    .expect("seed global-index benchmark base row");
+            }
+
+            let total_per_worker = controls.operations_per_worker + controls.warmup_operations;
+            for worker in 0..controls.process_workers {
+                if worker % tenant_keys.len() != shard {
+                    continue;
+                }
+                for operation in 0..total_per_worker {
+                    let row_id = delete_row_id(worker, operation, total_per_worker);
+                    insert
+                        .execute(params![
+                            tenant_key,
+                            row_id,
+                            format!("delete-lookup-{worker}-{operation}"),
+                            format!("delete-unique-{worker}-{operation}"),
+                            -1_i64,
+                        ])
+                        .expect("seed global-index benchmark delete row");
+                }
+            }
+        }
+        transaction
+            .commit()
+            .expect("commit global-index benchmark seed transaction");
+        connection
+            .execute_batch("PRAGMA wal_checkpoint(TRUNCATE)")
+            .expect("checkpoint global-index benchmark seed WAL");
+    }
+}
+
+fn shard_path(root: &Path, shard: u16) -> PathBuf {
+    root.join("shards").join(format!("{shard:04}.sqlite"))
+}
+
+fn insert_row_id(worker: usize, operation: usize, total_per_worker: usize) -> i64 {
+    indexed_row_id(INSERT_ROW_BASE, worker, operation, total_per_worker)
+}
+
+fn delete_row_id(worker: usize, operation: usize, total_per_worker: usize) -> i64 {
+    indexed_row_id(DELETE_ROW_BASE, worker, operation, total_per_worker)
+}
+
+fn contended_row_id(worker: usize, operation: usize, total_per_worker: usize) -> i64 {
+    indexed_row_id(CONTENDED_ROW_BASE, worker, operation, total_per_worker)
+}
+
+fn indexed_row_id(base: i64, worker: usize, operation: usize, total_per_worker: usize) -> i64 {
+    let offset = worker
+        .checked_mul(total_per_worker)
+        .and_then(|value| value.checked_add(operation))
+        .and_then(|value| i64::try_from(value).ok())
+        .expect("benchmark row offset fits i64");
+    base.checked_add(offset).expect("benchmark row ID fits i64")
+}
+
+#[derive(Clone, Debug, Default)]
+struct OperationTotals {
+    attempts: u64,
+    successes: u64,
+    constraints: u64,
+    returned_rows: u64,
+    visited_shards: u64,
+    latency_micros: Vec<u64>,
+}
+
+impl OperationTotals {
+    fn merge(&mut self, other: Self) {
+        self.attempts += other.attempts;
+        self.successes += other.successes;
+        self.constraints += other.constraints;
+        self.returned_rows += other.returned_rows;
+        self.visited_shards += other.visited_shards;
+        self.latency_micros.extend(other.latency_micros);
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct ProcessUsage {
+    cpu_micros: u64,
+    peak_rss_bytes: u64,
+    physical_write_bytes: u64,
+}
+
+impl ProcessUsage {
+    fn delta(self, before: Self) -> Self {
+        Self {
+            cpu_micros: self.cpu_micros.saturating_sub(before.cpu_micros),
+            peak_rss_bytes: self.peak_rss_bytes,
+            physical_write_bytes: self
+                .physical_write_bytes
+                .saturating_sub(before.physical_write_bytes),
+        }
+    }
+}
+
+#[cfg(unix)]
+fn current_process_usage() -> ProcessUsage {
+    let mut usage = std::mem::MaybeUninit::<libc::rusage>::uninit();
+    // SAFETY: getrusage initializes the provided rusage on success.
+    let result = unsafe { libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr()) };
+    assert_eq!(result, 0, "getrusage must succeed for benchmark telemetry");
+    // SAFETY: the successful call above initialized the value.
+    let usage = unsafe { usage.assume_init() };
+    let user_micros = timeval_micros(usage.ru_utime);
+    let system_micros = timeval_micros(usage.ru_stime);
+    #[cfg(target_os = "macos")]
+    let peak_rss_bytes = u64::try_from(usage.ru_maxrss).unwrap_or_default();
+    #[cfg(not(target_os = "macos"))]
+    let peak_rss_bytes = u64::try_from(usage.ru_maxrss)
+        .unwrap_or_default()
+        .saturating_mul(1024);
+    let output_blocks = u64::try_from(usage.ru_oublock).unwrap_or_default();
+    ProcessUsage {
+        cpu_micros: user_micros.saturating_add(system_micros),
+        peak_rss_bytes,
+        physical_write_bytes: output_blocks.saturating_mul(512),
+    }
+}
+
+#[cfg(unix)]
+fn timeval_micros(value: libc::timeval) -> u64 {
+    let seconds = u64::try_from(value.tv_sec).unwrap_or_default();
+    let micros = u64::try_from(value.tv_usec).unwrap_or_default();
+    seconds.saturating_mul(1_000_000).saturating_add(micros)
+}
+
+#[cfg(not(unix))]
+fn current_process_usage() -> ProcessUsage {
+    ProcessUsage::default()
+}
+
+#[derive(Clone, Debug)]
+struct WorkerMeasurement {
+    totals: OperationTotals,
+    elapsed_micros: u64,
+    usage: ProcessUsage,
+}
+
+fn runtime() -> Runtime {
+    Builder::new_multi_thread()
+        .worker_threads(2)
+        .max_blocking_threads(8)
+        .enable_all()
+        .build()
+        .expect("create global-index benchmark runtime")
+}
+
+fn run_worker(root: &Path, tenant_keys: &[i64], spec: WorkerSpec) -> WorkerMeasurement {
+    let runtime = runtime();
+    let engine = runtime
+        .block_on(Engine::open(root, spec.shard_count))
+        .expect("open global-index benchmark Engine");
+    let session = engine.session();
+    if !spec.workload.is_read() {
+        let routed_worker = if matches!(spec.workload, Workload::ContendedUniqueInsert) {
+            0
+        } else {
+            spec.worker
+        };
+        runtime
+            .block_on(
+                session.set_routing_key(tenant_keys[routed_worker % tenant_keys.len()].to_string()),
+            )
+            .expect("set global-index benchmark routing key");
+    }
+
+    for operation in spec.operations..spec.total_operations() {
+        let _ = runtime.block_on(perform_operation(
+            &engine,
+            &session,
+            tenant_keys,
+            spec,
+            operation,
+        ));
+    }
+
+    wait_for_parent_start_if_requested();
+    let before = current_process_usage();
+    let started = Instant::now();
+    let mut totals = OperationTotals::default();
+    for operation in 0..spec.operations {
+        let operation_started = Instant::now();
+        let outcome = runtime.block_on(perform_operation(
+            &engine,
+            &session,
+            tenant_keys,
+            spec,
+            operation,
+        ));
+        let latency = operation_started.elapsed();
+        totals.attempts += 1;
+        totals.latency_micros.push(duration_micros(latency));
+        match outcome {
+            Ok((rows, shards)) => {
+                totals.successes += 1;
+                totals.returned_rows += rows;
+                totals.visited_shards += shards;
+            }
+            Err(kind)
+                if matches!(spec.workload, Workload::ContendedUniqueInsert)
+                    && matches!(
+                        kind,
+                        EngineErrorKind::ConstraintViolation | EngineErrorKind::UniqueViolation
+                    ) =>
+            {
+                totals.constraints += 1;
+                totals.visited_shards += 1;
+            }
+            Err(kind) => panic!(
+                "global-index benchmark {} worker {} failed with {kind:?}",
+                spec.workload.name(),
+                spec.worker
+            ),
+        }
+    }
+    let elapsed_micros = duration_micros(started.elapsed());
+    let usage = current_process_usage().delta(before);
+
+    runtime
+        .block_on(session.close())
+        .expect("close global-index benchmark session");
+    runtime
+        .block_on(engine.shutdown())
+        .expect("shut down global-index benchmark Engine");
+    WorkerMeasurement {
+        totals,
+        elapsed_micros,
+        usage,
+    }
+}
+
+async fn perform_operation(
+    engine: &Engine,
+    session: &Session,
+    tenant_keys: &[i64],
+    spec: WorkerSpec,
+    operation: usize,
+) -> Result<(u64, u64), EngineErrorKind> {
+    let worker_key = tenant_keys[spec.worker % tenant_keys.len()];
+    let result = match spec.workload {
+        Workload::PointRead => engine
+            .query_logical(
+                session,
+                Statement::new(
+                    "SELECT tenant_id, row_id, payload
+                     FROM global_index_baseline
+                     WHERE tenant_id = ?1 AND row_id = ?2",
+                    vec![Value::from(worker_key), Value::from(0_i64)],
+                ),
+            )
+            .await
+            .map(|result| {
+                assert_eq!(result.shards, [spec.worker as u16 % spec.shard_count]);
+                assert_eq!(result.value.len(), 1);
+                (1, result.shards.len() as u64)
+            }),
+        Workload::ScatterRead => engine
+            .query_logical(
+                session,
+                Statement::new(
+                    "SELECT tenant_id, row_id, payload
+                     FROM global_index_baseline
+                     WHERE payload = ?1",
+                    vec![Value::from(1_i64)],
+                ),
+            )
+            .await
+            .map(|result| {
+                let expected_per_shard =
+                    (0..spec.rows_per_shard).filter(|row| row % 4 == 1).count();
+                assert_eq!(result.shards.len(), spec.shard_count as usize);
+                assert_eq!(
+                    result.value.len(),
+                    expected_per_shard * spec.shard_count as usize
+                );
+                (result.value.len() as u64, result.shards.len() as u64)
+            }),
+        Workload::IndexedHit => engine
+            .query_logical(
+                session,
+                Statement::new(
+                    "SELECT tenant_id, row_id, payload
+                     FROM global_index_baseline
+                     WHERE lookup_value = ?1",
+                    vec![Value::from(format!(
+                        "lookup-{}-0",
+                        spec.worker % spec.shard_count as usize
+                    ))],
+                ),
+            )
+            .await
+            .map(|result| {
+                assert_eq!(result.shards.len(), spec.shard_count as usize);
+                assert_eq!(result.value.len(), 1);
+                (1, result.shards.len() as u64)
+            }),
+        Workload::IndexedMiss => engine
+            .query_logical(
+                session,
+                Statement::new(
+                    "SELECT tenant_id, row_id, payload
+                     FROM global_index_baseline
+                     WHERE lookup_value = ?1",
+                    vec![Value::from("missing-global-index-key")],
+                ),
+            )
+            .await
+            .map(|result| {
+                assert_eq!(result.shards.len(), spec.shard_count as usize);
+                assert!(result.value.is_empty());
+                (0, result.shards.len() as u64)
+            }),
+        Workload::Insert => engine
+            .execute(
+                session,
+                Statement::new(
+                    "INSERT INTO global_index_baseline
+                     (tenant_id, row_id, lookup_value, unique_value, payload)
+                     VALUES (?1, ?2, ?3, ?4, ?5)",
+                    vec![
+                        Value::from(worker_key),
+                        Value::from(insert_row_id(
+                            spec.worker,
+                            operation,
+                            spec.total_operations(),
+                        )),
+                        Value::from(format!("insert-lookup-{}-{operation}", spec.worker)),
+                        Value::from(format!("insert-unique-{}-{operation}", spec.worker)),
+                        Value::from(7_i64),
+                    ],
+                ),
+            )
+            .await
+            .map(|result| {
+                assert_eq!(result.shard, (spec.worker % tenant_keys.len()) as u16);
+                assert_eq!(result.value, 1);
+                (1, 1)
+            }),
+        Workload::Update => engine
+            .execute(
+                session,
+                Statement::new(
+                    "UPDATE global_index_baseline
+                     SET payload = payload + 1
+                     WHERE tenant_id = ?1 AND row_id = ?2",
+                    vec![
+                        Value::from(worker_key),
+                        Value::from((operation % spec.rows_per_shard) as i64),
+                    ],
+                ),
+            )
+            .await
+            .map(|result| {
+                assert_eq!(result.shard, (spec.worker % tenant_keys.len()) as u16);
+                assert_eq!(result.value, 1);
+                (1, 1)
+            }),
+        Workload::Delete => engine
+            .execute(
+                session,
+                Statement::new(
+                    "DELETE FROM global_index_baseline
+                     WHERE tenant_id = ?1 AND row_id = ?2",
+                    vec![
+                        Value::from(worker_key),
+                        Value::from(delete_row_id(
+                            spec.worker,
+                            operation,
+                            spec.total_operations(),
+                        )),
+                    ],
+                ),
+            )
+            .await
+            .map(|result| {
+                assert_eq!(result.shard, (spec.worker % tenant_keys.len()) as u16);
+                assert_eq!(result.value, 1);
+                (1, 1)
+            }),
+        Workload::ContendedUniqueInsert => {
+            let tenant_key = tenant_keys[0];
+            engine
+                .execute(
+                    session,
+                    Statement::new(
+                        "INSERT INTO global_index_baseline
+                         (tenant_id, row_id, lookup_value, unique_value, payload)
+                         VALUES (?1, ?2, ?3, ?4, ?5)",
+                        vec![
+                            Value::from(tenant_key),
+                            Value::from(contended_row_id(
+                                spec.worker,
+                                operation,
+                                spec.total_operations(),
+                            )),
+                            Value::from(format!("contended-lookup-{}-{operation}", spec.worker)),
+                            Value::from(format!("contended-{operation}")),
+                            Value::from(9_i64),
+                        ],
+                    ),
+                )
+                .await
+                .map(|result| {
+                    assert_eq!(result.shard, 0);
+                    assert_eq!(result.value, 1);
+                    (1, 1)
+                })
+        }
+    };
+    result.map_err(|error| error.kind())
+}
+
+fn duration_micros(duration: Duration) -> u64 {
+    u64::try_from(duration.as_micros())
+        .unwrap_or(u64::MAX)
+        .max(1)
+}
+
+fn wait_for_parent_start_if_requested() {
+    let Ok(ready_path) = env::var("BRISKDB_BENCH_READY_PATH") else {
+        return;
+    };
+    let start_path = PathBuf::from(
+        env::var("BRISKDB_BENCH_START_PATH").expect("child benchmark start path is configured"),
+    );
+    fs::write(&ready_path, b"ready\n").expect("publish child benchmark readiness");
+    let deadline = Instant::now() + CHILD_TIMEOUT;
+    while !start_path.exists() {
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for parent benchmark start"
+        );
+        thread::sleep(Duration::from_millis(1));
+    }
+}
+
+#[derive(Clone, Debug)]
+struct MatrixRecord {
+    mode: RunMode,
+    shard_count: u16,
+    workload: Workload,
+    workers: usize,
+    operations_per_worker: usize,
+    totals: OperationTotals,
+    elapsed_micros: u64,
+    cpu_micros: u64,
+    peak_rss_bytes: u64,
+    physical_write_bytes: u64,
+    peak_wal_growth_bytes: u64,
+}
+
+impl MatrixRecord {
+    fn throughput_per_second(&self) -> f64 {
+        self.totals.attempts as f64 * 1_000_000.0 / self.elapsed_micros.max(1) as f64
+    }
+
+    fn percentile_micros(&self, percentile: usize) -> u64 {
+        let mut latencies = self.totals.latency_micros.clone();
+        latencies.sort_unstable();
+        assert!(!latencies.is_empty());
+        let numerator = percentile
+            .saturating_mul(latencies.len())
+            .saturating_add(99);
+        let rank = numerator / 100;
+        latencies[rank.saturating_sub(1).min(latencies.len() - 1)]
+    }
+
+    fn to_tsv(&self) -> String {
+        format!(
+            "result\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:.2}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\tFULL",
+            self.mode.name(),
+            self.shard_count,
+            self.workload.name(),
+            self.workers,
+            self.operations_per_worker,
+            self.totals.attempts,
+            self.totals.successes,
+            self.totals.constraints,
+            self.totals.returned_rows,
+            self.totals.visited_shards,
+            self.elapsed_micros,
+            self.throughput_per_second(),
+            self.percentile_micros(50),
+            self.percentile_micros(95),
+            self.percentile_micros(99),
+            self.cpu_micros,
+            self.peak_rss_bytes,
+            self.physical_write_bytes,
+            self.peak_wal_growth_bytes,
+            self.workload.expected_shards(self.shard_count),
+        )
+    }
+}
+
+fn run_single_process_case(
+    shard_count: u16,
+    workload: Workload,
+    controls: MatrixControls,
+) -> MatrixRecord {
+    let fixture = BenchmarkFixture::new(shard_count, controls);
+    let initial_wal = total_wal_bytes(fixture.path(), shard_count);
+    let telemetry = WalTelemetry::start(fixture.path().to_path_buf(), shard_count, initial_wal);
+    let measurement = run_worker(
+        fixture.path(),
+        &fixture.tenant_keys,
+        WorkerSpec {
+            workload,
+            shard_count,
+            rows_per_shard: controls.rows_per_shard,
+            operations: controls.operations_per_worker,
+            warmups: controls.warmup_operations,
+            worker: 0,
+            workers: 1,
+        },
+    );
+    let peak_wal_growth_bytes = telemetry.stop();
+    validate_case(
+        fixture.path(),
+        &fixture.tenant_keys,
+        workload,
+        controls,
+        1,
+        &measurement.totals,
+    );
+    MatrixRecord {
+        mode: RunMode::SingleProcess,
+        shard_count,
+        workload,
+        workers: 1,
+        operations_per_worker: controls.operations_per_worker,
+        totals: measurement.totals,
+        elapsed_micros: measurement.elapsed_micros,
+        cpu_micros: measurement.usage.cpu_micros,
+        peak_rss_bytes: measurement.usage.peak_rss_bytes,
+        physical_write_bytes: measurement.usage.physical_write_bytes,
+        peak_wal_growth_bytes,
+    }
+}
+
+fn run_multi_process_case(
+    shard_count: u16,
+    workload: Workload,
+    controls: MatrixControls,
+) -> MatrixRecord {
+    let fixture = BenchmarkFixture::new(shard_count, controls);
+    let coordination =
+        tempfile::tempdir().expect("create benchmark process coordination directory");
+    let start_path = coordination.path().join("start");
+    let executable = env::current_exe().expect("resolve global-index benchmark test executable");
+    let tenant_keys = fixture
+        .tenant_keys
+        .iter()
+        .map(i64::to_string)
+        .collect::<Vec<_>>()
+        .join(",");
+    let mut children = Vec::with_capacity(controls.process_workers);
+    let mut result_paths = Vec::with_capacity(controls.process_workers);
+
+    for worker in 0..controls.process_workers {
+        let ready_path = coordination.path().join(format!("ready-{worker}"));
+        let result_path = coordination.path().join(format!("result-{worker}.tsv"));
+        let child = Command::new(&executable)
+            .args(["--ignored", "--exact", "global_index_baseline_worker"])
+            .env("BRISKDB_BENCH_CHILD", "1")
+            .env("BRISKDB_BENCH_ROOT", fixture.path())
+            .env("BRISKDB_BENCH_SHARDS", shard_count.to_string())
+            .env("BRISKDB_BENCH_ROWS", controls.rows_per_shard.to_string())
+            .env(
+                "BRISKDB_BENCH_OPERATIONS",
+                controls.operations_per_worker.to_string(),
+            )
+            .env(
+                "BRISKDB_BENCH_WARMUPS",
+                controls.warmup_operations.to_string(),
+            )
+            .env("BRISKDB_BENCH_WORKER", worker.to_string())
+            .env(
+                "BRISKDB_BENCH_WORKERS",
+                controls.process_workers.to_string(),
+            )
+            .env("BRISKDB_BENCH_WORKLOAD", workload.name())
+            .env("BRISKDB_BENCH_TENANT_KEYS", &tenant_keys)
+            .env("BRISKDB_BENCH_READY_PATH", &ready_path)
+            .env("BRISKDB_BENCH_START_PATH", &start_path)
+            .env("BRISKDB_BENCH_RESULT_PATH", &result_path)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn global-index benchmark child");
+        children.push((child, ready_path));
+        result_paths.push(result_path);
+    }
+
+    let ready_deadline = Instant::now() + CHILD_TIMEOUT;
+    while children.iter().any(|(_, ready)| !ready.exists()) {
+        assert!(
+            Instant::now() < ready_deadline,
+            "timed out waiting for global-index benchmark children"
+        );
+        thread::sleep(Duration::from_millis(1));
+    }
+
+    let initial_wal = total_wal_bytes(fixture.path(), shard_count);
+    let telemetry = WalTelemetry::start(fixture.path().to_path_buf(), shard_count, initial_wal);
+    fs::write(&start_path, b"start\n").expect("release global-index benchmark children");
+
+    for (child, _) in children {
+        let output = child
+            .wait_with_output()
+            .expect("wait for global-index benchmark child");
+        assert!(
+            output.status.success(),
+            "global-index benchmark child failed:\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    let peak_wal_growth_bytes = telemetry.stop();
+
+    let mut totals = OperationTotals::default();
+    let mut elapsed_micros = 0_u64;
+    let mut cpu_micros = 0_u64;
+    let mut peak_rss_bytes = 0_u64;
+    let mut physical_write_bytes = 0_u64;
+    for path in result_paths {
+        let measurement = parse_worker_measurement(
+            &fs::read_to_string(path).expect("read global-index benchmark child result"),
+        );
+        elapsed_micros = elapsed_micros.max(measurement.elapsed_micros);
+        totals.merge(measurement.totals);
+        cpu_micros = cpu_micros.saturating_add(measurement.usage.cpu_micros);
+        peak_rss_bytes = peak_rss_bytes.saturating_add(measurement.usage.peak_rss_bytes);
+        physical_write_bytes =
+            physical_write_bytes.saturating_add(measurement.usage.physical_write_bytes);
+    }
+    validate_case(
+        fixture.path(),
+        &fixture.tenant_keys,
+        workload,
+        controls,
+        controls.process_workers,
+        &totals,
+    );
+    MatrixRecord {
+        mode: RunMode::MultiProcess,
+        shard_count,
+        workload,
+        workers: controls.process_workers,
+        operations_per_worker: controls.operations_per_worker,
+        totals,
+        elapsed_micros,
+        cpu_micros,
+        peak_rss_bytes,
+        physical_write_bytes,
+        peak_wal_growth_bytes,
+    }
+}
+
+struct WalTelemetry {
+    stop: Arc<AtomicBool>,
+    handle: thread::JoinHandle<u64>,
+}
+
+impl WalTelemetry {
+    fn start(root: PathBuf, shard_count: u16, initial_bytes: u64) -> Self {
+        let stop = Arc::new(AtomicBool::new(false));
+        let worker_stop = Arc::clone(&stop);
+        let handle = thread::spawn(move || {
+            let mut peak = initial_bytes;
+            while !worker_stop.load(Ordering::Acquire) {
+                peak = peak.max(total_wal_bytes(&root, shard_count));
+                thread::sleep(TELEMETRY_INTERVAL);
+            }
+            peak.max(total_wal_bytes(&root, shard_count))
+                .saturating_sub(initial_bytes)
+        });
+        Self { stop, handle }
+    }
+
+    fn stop(self) -> u64 {
+        self.stop.store(true, Ordering::Release);
+        self.handle.join().expect("join WAL telemetry thread")
+    }
+}
+
+fn total_wal_bytes(root: &Path, shard_count: u16) -> u64 {
+    let manifest = fs::metadata(root.join("manifest.sqlite-wal"))
+        .map(|metadata| metadata.len())
+        .unwrap_or_default();
+    (0..shard_count).fold(manifest, |total, shard| {
+        total.saturating_add(
+            fs::metadata(format!("{}-wal", shard_path(root, shard).display()))
+                .map(|metadata| metadata.len())
+                .unwrap_or_default(),
+        )
+    })
+}
+
+fn validate_case(
+    root: &Path,
+    tenant_keys: &[i64],
+    workload: Workload,
+    controls: MatrixControls,
+    workers: usize,
+    totals: &OperationTotals,
+) {
+    let attempts = (workers * controls.operations_per_worker) as u64;
+    assert_eq!(totals.attempts, attempts);
+    assert_eq!(totals.latency_micros.len() as u64, attempts);
+    assert_eq!(
+        totals.visited_shards,
+        attempts * workload.expected_shards(tenant_keys.len() as u16) as u64
+    );
+    if matches!(workload, Workload::ContendedUniqueInsert) {
+        assert_eq!(totals.successes, controls.operations_per_worker as u64);
+        assert_eq!(totals.successes + totals.constraints, attempts);
+        let connection =
+            Connection::open(shard_path(root, 0)).expect("open unique benchmark shard");
+        let count: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM global_index_baseline
+                 WHERE unique_value LIKE 'contended-%'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count contended benchmark rows");
+        let expected = controls.operations_per_worker + controls.warmup_operations;
+        assert_eq!(count, expected as i64);
+    } else {
+        assert_eq!(totals.successes, attempts);
+        assert_eq!(totals.constraints, 0);
+    }
+
+    match workload {
+        Workload::Insert => {
+            assert_eq!(
+                count_rows_with_prefix(root, tenant_keys, "insert-unique-%"),
+                workers * (controls.operations_per_worker + controls.warmup_operations)
+            );
+        }
+        Workload::Delete => {
+            let seeded_per_worker = controls.operations_per_worker + controls.warmup_operations;
+            assert_eq!(
+                count_rows_with_prefix(root, tenant_keys, "delete-unique-%"),
+                (controls.process_workers - workers) * seeded_per_worker
+            );
+        }
+        _ => {}
+    }
+    validate_sqlite_files(root, tenant_keys.len() as u16);
+}
+
+fn count_rows_with_prefix(root: &Path, tenant_keys: &[i64], pattern: &str) -> usize {
+    (0..tenant_keys.len())
+        .map(|shard| {
+            let connection = Connection::open(shard_path(root, shard as u16))
+                .expect("open benchmark shard for row count");
+            connection
+                .query_row(
+                    "SELECT COUNT(*) FROM global_index_baseline WHERE unique_value LIKE ?1",
+                    [pattern],
+                    |row| row.get::<_, i64>(0),
+                )
+                .expect("count benchmark rows") as usize
+        })
+        .sum()
+}
+
+fn validate_sqlite_files(root: &Path, shard_count: u16) {
+    for shard in 0..shard_count {
+        let connection = Connection::open(shard_path(root, shard))
+            .expect("open benchmark shard for integrity check");
+        let quick_check: String = connection
+            .query_row("PRAGMA quick_check", [], |row| row.get(0))
+            .expect("run benchmark shard quick_check");
+        assert_eq!(quick_check, "ok");
+    }
+}
+
+fn worker_measurement_tsv(measurement: &WorkerMeasurement) -> String {
+    format!(
+        "worker\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\n",
+        measurement.elapsed_micros,
+        measurement.usage.cpu_micros,
+        measurement.usage.peak_rss_bytes,
+        measurement.usage.physical_write_bytes,
+        measurement.totals.attempts,
+        measurement.totals.successes,
+        measurement.totals.constraints,
+        measurement.totals.returned_rows,
+        measurement.totals.visited_shards,
+        join_u64(&measurement.totals.latency_micros),
+    )
+}
+
+fn parse_worker_measurement(value: &str) -> WorkerMeasurement {
+    let fields = value.trim_end().split('\t').collect::<Vec<_>>();
+    assert_eq!(fields.len(), 11, "worker result has a fixed field count");
+    assert_eq!(fields[0], "worker");
+    WorkerMeasurement {
+        elapsed_micros: parse_field(fields[1], "elapsed micros"),
+        usage: ProcessUsage {
+            cpu_micros: parse_field(fields[2], "CPU micros"),
+            peak_rss_bytes: parse_field(fields[3], "peak RSS"),
+            physical_write_bytes: parse_field(fields[4], "physical write bytes"),
+        },
+        totals: OperationTotals {
+            attempts: parse_field(fields[5], "attempts"),
+            successes: parse_field(fields[6], "successes"),
+            constraints: parse_field(fields[7], "constraints"),
+            returned_rows: parse_field(fields[8], "returned rows"),
+            visited_shards: parse_field(fields[9], "visited shards"),
+            latency_micros: fields[10]
+                .split(',')
+                .map(|field| parse_field(field, "latency"))
+                .collect(),
+        },
+    }
+}
+
+fn join_u64(values: &[u64]) -> String {
+    values
+        .iter()
+        .map(u64::to_string)
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn parse_field<T>(value: &str, name: &str) -> T
+where
+    T: FromStr,
+    T::Err: std::fmt::Display,
+{
+    value
+        .parse()
+        .unwrap_or_else(|error| panic!("invalid {name} {value:?}: {error}"))
+}
+
+fn run_matrix(shards: &[u16], controls: MatrixControls) -> Vec<MatrixRecord> {
+    let mut records = Vec::new();
+    for shard_count in shards.iter().copied() {
+        for mode in RunMode::ALL {
+            for workload in Workload::ALL {
+                let record = match mode {
+                    RunMode::SingleProcess => {
+                        run_single_process_case(shard_count, workload, controls)
+                    }
+                    RunMode::MultiProcess => {
+                        run_multi_process_case(shard_count, workload, controls)
+                    }
+                };
+                println!("{}", record.to_tsv());
+                records.push(record);
+            }
+        }
+    }
+    records
+}
+
+const RESULT_HEADER: &str = "record\tmode\tshards\tworkload\tworkers\toperations_per_worker\tattempts\tsuccesses\tconstraints\treturned_rows\tvisited_shards\telapsed_us\tthroughput_ops_s\tp50_us\tp95_us\tp99_us\tcpu_us\tpeak_rss_bytes\tphysical_write_bytes\tpeak_wal_growth_bytes\texpected_shards_per_operation\tsqlite_synchronous";
+
+fn print_report_header(controls: MatrixControls) {
+    println!("metadata\tformat\t{FORMAT_VERSION}");
+    println!("metadata\tos\t{}", env::consts::OS);
+    println!("metadata\tarch\t{}", env::consts::ARCH);
+    println!("control\trows_per_shard\t{}", controls.rows_per_shard);
+    println!(
+        "control\toperations_per_worker\t{}",
+        controls.operations_per_worker
+    );
+    println!("control\twarmup_operations\t{}", controls.warmup_operations);
+    println!("control\tprocess_workers\t{}", controls.process_workers);
+    println!("control\tcache_policy\twarm");
+    println!("control\tsqlite_journal_mode\tWAL");
+    println!("control\tsqlite_synchronous\tFULL");
+    println!(
+        "control\tfsync_observation\tSQLite FULL durability policy; syscall counts are not portable and are not inferred"
+    );
+    println!("{RESULT_HEADER}");
+}
+
+#[derive(Clone, Debug)]
+struct ParsedBaseline {
+    mode: RunMode,
+    shards: u16,
+    workload: Workload,
+    throughput: f64,
+    p99_micros: u64,
+    cpu_micros: u64,
+    peak_rss_bytes: u64,
+    physical_write_bytes: u64,
+    peak_wal_growth_bytes: u64,
+    attempts: u64,
+}
+
+impl ParsedBaseline {
+    fn parse(line: &str) -> Result<Self, String> {
+        let fields = line.split('\t').collect::<Vec<_>>();
+        if fields.len() != 22 || fields[0] != "result" {
+            return Err(format!("invalid result record field count: {line}"));
+        }
+        Ok(Self {
+            mode: fields[1].parse()?,
+            shards: fields[2]
+                .parse()
+                .map_err(|error| format!("invalid shard count: {error}"))?,
+            workload: fields[3].parse()?,
+            attempts: fields[6]
+                .parse()
+                .map_err(|error| format!("invalid attempt count: {error}"))?,
+            throughput: fields[12]
+                .parse()
+                .map_err(|error| format!("invalid throughput: {error}"))?,
+            p99_micros: fields[15]
+                .parse()
+                .map_err(|error| format!("invalid p99: {error}"))?,
+            cpu_micros: fields[16]
+                .parse()
+                .map_err(|error| format!("invalid CPU time: {error}"))?,
+            peak_rss_bytes: fields[17]
+                .parse()
+                .map_err(|error| format!("invalid RSS: {error}"))?,
+            physical_write_bytes: fields[18]
+                .parse()
+                .map_err(|error| format!("invalid write bytes: {error}"))?,
+            peak_wal_growth_bytes: fields[19]
+                .parse()
+                .map_err(|error| format!("invalid WAL bytes: {error}"))?,
+        })
+    }
+
+    fn key(&self) -> (RunMode, u16, Workload) {
+        (self.mode, self.shards, self.workload)
+    }
+}
+
+fn parse_report(
+    report: &str,
+) -> Result<BTreeMap<(RunMode, u16, Workload), ParsedBaseline>, String> {
+    let mut records = BTreeMap::new();
+    for line in report.lines().filter(|line| line.starts_with("result\t")) {
+        let record = ParsedBaseline::parse(line)?;
+        if records.insert(record.key(), record).is_some() {
+            return Err(format!("duplicate result record: {line}"));
+        }
+    }
+    if records.is_empty() {
+        return Err("report contains no result records".to_owned());
+    }
+    Ok(records)
+}
+
+#[derive(Clone, Copy)]
+struct RegressionBudget {
+    minimum_throughput_ratio: f64,
+    maximum_p99_ratio: f64,
+    maximum_p99_jitter_micros: u64,
+    maximum_cpu_per_attempt_ratio: f64,
+    maximum_write_bytes_per_attempt_ratio: f64,
+    maximum_wal_bytes_per_attempt_ratio: f64,
+    maximum_rss_growth_bytes: u64,
+}
+
+impl RegressionBudget {
+    const STABLE_HOST: Self = Self {
+        minimum_throughput_ratio: 0.50,
+        maximum_p99_ratio: 3.0,
+        maximum_p99_jitter_micros: 5_000,
+        maximum_cpu_per_attempt_ratio: 2.0,
+        maximum_write_bytes_per_attempt_ratio: 2.0,
+        maximum_wal_bytes_per_attempt_ratio: 2.0,
+        maximum_rss_growth_bytes: 64 * 1024 * 1024,
+    };
+
+    fn compare(self, baseline: &ParsedBaseline, candidate: &ParsedBaseline) -> Vec<String> {
+        let mut failures = Vec::new();
+        if candidate.throughput < baseline.throughput * self.minimum_throughput_ratio {
+            failures.push("throughput".to_owned());
+        }
+        let p99_limit = (baseline.p99_micros.max(1) as f64 * self.maximum_p99_ratio).max(
+            baseline
+                .p99_micros
+                .saturating_add(self.maximum_p99_jitter_micros) as f64,
+        );
+        if candidate.p99_micros as f64 > p99_limit {
+            failures.push("p99 latency".to_owned());
+        }
+        if per_attempt(candidate.cpu_micros, candidate.attempts)
+            > per_attempt(baseline.cpu_micros, baseline.attempts)
+                * self.maximum_cpu_per_attempt_ratio
+        {
+            failures.push("CPU per attempt".to_owned());
+        }
+        if per_attempt(candidate.physical_write_bytes, candidate.attempts)
+            > per_attempt(baseline.physical_write_bytes, baseline.attempts)
+                * self.maximum_write_bytes_per_attempt_ratio
+        {
+            failures.push("physical write bytes per attempt".to_owned());
+        }
+        if per_attempt(candidate.peak_wal_growth_bytes, candidate.attempts)
+            > per_attempt(baseline.peak_wal_growth_bytes, baseline.attempts)
+                * self.maximum_wal_bytes_per_attempt_ratio
+        {
+            failures.push("WAL bytes per attempt".to_owned());
+        }
+        if candidate.peak_rss_bytes
+            > baseline
+                .peak_rss_bytes
+                .saturating_add(self.maximum_rss_growth_bytes)
+        {
+            failures.push("peak RSS".to_owned());
+        }
+        failures
+    }
+}
+
+fn per_attempt(value: u64, attempts: u64) -> f64 {
+    value as f64 / attempts.max(1) as f64
+}
+
+fn compare_reports(baseline: &str, candidate: &str) -> Result<(), String> {
+    let baseline = parse_report(baseline)?;
+    let candidate = parse_report(candidate)?;
+    if baseline.keys().collect::<Vec<_>>() != candidate.keys().collect::<Vec<_>>() {
+        return Err("baseline and candidate matrices do not contain identical cases".to_owned());
+    }
+    let mut failures = Vec::new();
+    for (key, before) in &baseline {
+        let after = &candidate[key];
+        for metric in RegressionBudget::STABLE_HOST.compare(before, after) {
+            failures.push(format!(
+                "{} shards {} {} regressed: {metric}",
+                key.1,
+                key.0.name(),
+                key.2.name()
+            ));
+        }
+    }
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(failures.join("; "))
+    }
+}
+
+#[test]
+fn report_parser_and_regression_budgets_are_deterministic() {
+    let line = "result\tsingle_process\t2\tpoint_read\t1\t32\t32\t32\t0\t32\t32\t1000\t32000.00\t20\t30\t40\t500\t1000\t2000\t3000\t1\tFULL";
+    let parsed = ParsedBaseline::parse(line).unwrap();
+    assert_eq!(
+        parsed.key(),
+        (RunMode::SingleProcess, 2, Workload::PointRead)
+    );
+    assert_eq!(parse_report(line).unwrap().len(), 1);
+    assert!(compare_reports(line, line).is_ok());
+
+    let slow = line.replacen("32000.00", "1000.00", 1);
+    let failure = compare_reports(line, &slow).unwrap_err();
+    assert!(failure.contains("throughput"));
+
+    let high_tail = line.replacen("\t40\t500\t", "\t6000\t500\t", 1);
+    assert!(
+        compare_reports(line, &high_tail)
+            .unwrap_err()
+            .contains("p99 latency")
+    );
+
+    let duplicate = format!("{line}\n{line}\n");
+    assert!(parse_report(&duplicate).unwrap_err().contains("duplicate"));
+}
+
+#[test]
+fn frozen_baseline_contains_every_ordered_matrix_case() {
+    let report = include_str!("../docs/benchmarks/global-index-before-2026-08-14.tsv");
+    let records = parse_report(report).unwrap();
+    assert_eq!(
+        records.len(),
+        SHARD_MATRIX.len() * RunMode::ALL.len() * Workload::ALL.len()
+    );
+    for shard_count in SHARD_MATRIX {
+        for mode in RunMode::ALL {
+            for workload in Workload::ALL {
+                let record = &records[&(mode, shard_count, workload)];
+                assert!(record.attempts > 0);
+                assert!(record.throughput > 0.0);
+                assert!(record.p99_micros > 0);
+            }
+        }
+    }
+}
+
+#[test]
+#[ignore = "dedicated stable Linux correctness smoke for issue #226"]
+fn global_index_baseline_smoke() {
+    let controls = MatrixControls::smoke();
+    print_report_header(controls);
+    let records = run_matrix(&[2], controls);
+    assert_eq!(records.len(), RunMode::ALL.len() * Workload::ALL.len());
+}
+
+#[test]
+#[ignore = "manual release-mode global-index baseline matrix for issue #226"]
+fn release_global_index_baseline() {
+    if cfg!(debug_assertions) {
+        panic!("run the full matrix with --release");
+    }
+    let controls = MatrixControls::full();
+    print_report_header(controls);
+    let records = run_matrix(&SHARD_MATRIX, controls);
+    assert_eq!(
+        records.len(),
+        SHARD_MATRIX.len() * RunMode::ALL.len() * Workload::ALL.len()
+    );
+    if let Ok(path) = env::var("BRISKDB_BENCH_COMPARE") {
+        let baseline = fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("read comparison baseline {path}: {error}"));
+        let candidate = records
+            .iter()
+            .map(MatrixRecord::to_tsv)
+            .collect::<Vec<_>>()
+            .join("\n");
+        compare_reports(&baseline, &candidate)
+            .unwrap_or_else(|error| panic!("global-index benchmark regression: {error}"));
+    }
+}
+
+#[test]
+#[ignore = "internal subprocess entrypoint for the issue #226 benchmark"]
+fn global_index_baseline_worker() {
+    if env::var("BRISKDB_BENCH_CHILD").as_deref() != Ok("1") {
+        return;
+    }
+    let root = PathBuf::from(required_env("BRISKDB_BENCH_ROOT"));
+    let tenant_keys = required_env("BRISKDB_BENCH_TENANT_KEYS")
+        .split(',')
+        .map(|value| parse_field(value, "tenant key"))
+        .collect::<Vec<i64>>();
+    let spec = WorkerSpec {
+        workload: required_env("BRISKDB_BENCH_WORKLOAD")
+            .parse()
+            .expect("parse child workload"),
+        shard_count: parse_field(&required_env("BRISKDB_BENCH_SHARDS"), "shard count"),
+        rows_per_shard: parse_field(&required_env("BRISKDB_BENCH_ROWS"), "rows per shard"),
+        operations: parse_field(&required_env("BRISKDB_BENCH_OPERATIONS"), "operations"),
+        warmups: parse_field(&required_env("BRISKDB_BENCH_WARMUPS"), "warmups"),
+        worker: parse_field(&required_env("BRISKDB_BENCH_WORKER"), "worker"),
+        workers: parse_field(&required_env("BRISKDB_BENCH_WORKERS"), "workers"),
+    };
+    assert_eq!(tenant_keys.len(), spec.shard_count as usize);
+    assert!(spec.worker < spec.workers);
+    let measurement = run_worker(&root, &tenant_keys, spec);
+    fs::write(
+        required_env("BRISKDB_BENCH_RESULT_PATH"),
+        worker_measurement_tsv(&measurement),
+    )
+    .expect("write global-index benchmark child result");
+}
+
+fn required_env(name: &str) -> String {
+    env::var(name).unwrap_or_else(|_| panic!("required benchmark environment {name} is missing"))
+}


### PR DESCRIPTION
## What changed

- add a deterministic global-index before/after harness over the public Engine
- cover point/scatter/indexed hit/indexed miss/insert/update/delete/unique contention at 2, 4, 10, and 64 shards
- exercise both single-process and four-process readers and writers
- record throughput, p50/p95/p99, CPU, RSS, physical-write accounting, WAL growth, shard visits, and durability controls
- commit a complete 64-case pre-index TSV baseline and stable-host regression budgets
- add an explicit Linux x86-64 CI correctness smoke and roadmap tracking

## Why

Global-index work will change read routing and write cost. This freezes the current behavior before those changes so later phases can quantify shard-pruning gains and reject material regressions without using flaky cross-host timing gates.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features`
- `cargo +1.85.0 test --locked --all-targets --all-features`
- stable and Rust 1.85 documentation tests
- `cargo package --locked --allow-dirty`
- dedicated multi-process benchmark correctness smoke
- full optimized 64-case matrix
- full rerun against the committed regression budgets

Closes #226
