### PR TITLE
Global indexes: add catalog lifecycle and compatibility fencing

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -406,7 +406,7 @@ requires an earlier dependency:
 
    - [x] [#226](https://github.com/schapman1974/briskdb/issues/226) — baseline and regression suite
    - [x] [#227](https://github.com/schapman1974/briskdb/issues/227) — canonical key encoding
-   - [ ] [#228](https://github.com/schapman1974/briskdb/issues/228) — catalog lifecycle and compatibility fencing
+   - [x] [#228](https://github.com/schapman1974/briskdb/issues/228) — catalog lifecycle and compatibility fencing
    - [ ] [#229](https://github.com/schapman1974/briskdb/issues/229) — storage-topology prototype
    - [ ] [#230](https://github.com/schapman1974/briskdb/issues/230) — offline index construction
    - [ ] [#231](https://github.com/schapman1974/briskdb/issues/231) — validation, repair, and rebuild

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,7 +30,7 @@ server ---------> protocol::http
 | Module | Responsibility | Must not own |
 | --- | --- | --- |
 | `core` | Protocol-neutral `Engine`, `Session`, statements, immutable bound portals, values, results, errors, read-only catalog views and initialization declarations, generated-ID policy and codec types, canonical global-index keys, synchronous bound-value-aware plans, prepared lifecycle, explicit-shard read-only inspection, logical Sharded read target selection and scatter/gather, and sharded routing policy; stable key routing; bounded per-session and per-shard admission; routed execution and journaled schema migration | JSON/HTTP types, listeners, or Axum handlers |
-| `storage` | Versioned routing and authoritative logical manifest, persisted generated-ID policy/activation, stable active/retired allocation-owner slots, durable per-table hi/lo block leases, recoverable one-time table provisioning, shard layout, migration journals and recovery, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
+| `storage` | Versioned routing and authoritative logical/global-index manifest, persisted generated-ID policy/activation, stable active/retired allocation-owner slots, durable per-table hi/lo block leases, recoverable one-time table provisioning, shard layout, migration journals and recovery, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
 | `import` | Offline source-schema preflight, explicit placement and generated-ID plan validation, exact-value row routing into private staging, independent verification, durable receipt creation, and atomic publication | Network handlers, live/incremental migration, generated-ID inference, implicit Global placement, or protocol-specific behavior |
 | `sql` | Dialect-explicit SQL syntax parsing, recursive common-subset validation, protocol-neutral statement/batch classification, source-preserving placeholder normalization, explicit strict/compatibility translation, catalog-aware typed shard-key inference, and narrow crate-private DML-shape inspection behind BriskDB-owned boundaries; exact source retention; SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, key hashing or shard selection, mutable session state, physical write-routing policy, filesystem layout, protocol responses, protocol-buffer ownership, or protocol-specific support policy |
 | `protocol::http` | Existing HTTP request extraction, shared JSON/BriskDB value and RFC 9457 problem-detail encoding, and the embedded admin shell/assets, temporary browser sessions, metadata-driven logical discovery, exact logical counts, and bounded shard-major page handlers | BLAKE3 routing, shard files, direct SQLite access, or rusqlite calls |
@@ -324,9 +324,10 @@ this core boundary after converting to protocol-neutral values. The exact
 format and compatibility rules are in [canonical global-index
 keys](INDEX_KEY_ENCODING.md).
 
-Issue #227 introduces only this public codec. It adds no manifest record or
-global-index file; the catalog lifecycle in issue #228 is the first consumer
-that may persist its version.
+Version 13 persists this codec version with each global-index definition. The
+catalog records stable identity, owning table, key parts, uniqueness and NULL
+semantics, predicate, schema generation, lifecycle, and selected topology; it
+does not yet create a global-index file or route a query through one.
 
 ### Bound statement-planning boundary
 
@@ -527,6 +528,20 @@ infer authority. The v11-to-v12 migration itself is manifest-only: it adds an
 empty bridge table, raises the downgrade fence, advances the semantic root to
 version 5, and changes no shard or application row.
 
+Version 13 adds `briskdb_global_indexes` and
+`briskdb_global_index_parts` plus manifest digest version 6. Definitions retain
+stable identity, owning table, ordered key parts, uniqueness/NULL semantics,
+predicate, schema generation, canonical key encoding, lifecycle, and selected
+topology. Create, lifecycle transition, and removal each replace the validated
+catalog snapshot only after one checksummed `BEGIN IMMEDIATE` commit. The
+durable states are `Creating`, `Ready`, `Invalid`, `Rebuilding`, and
+`Dropping`; ready/rebuilding definitions require a versioned topology and the
+current schema generation. Schema migration is fenced while any definition
+exists. Read-only inspection validates without initializing or upgrading.
+Writers use the existing sole-process mutation fence, while concurrent readers
+see only complete SQLite snapshots. The v12-to-v13 migration creates empty
+catalog tables and changes no shard; physical construction starts in #229/#230.
+
 Each manifest version retains an intentionally incompatible
 `briskdb_metadata` definition and row as a downgrade fence. The v3-to-v4
 migration remains manifest-atomic. The v4-to-v5 step first validates the v4
@@ -554,6 +569,8 @@ The v10-to-v11 step is likewise manifest-only: it creates the empty durable
 hi/lo allocation table, raises the fence, and installs checksum version 4.
 The v11-to-v12 step adds the empty durable generated-table DDL bridge, raises
 the fence, and installs checksum version 5 without changing a shard.
+The v12-to-v13 step adds the empty durable global-index catalog, raises the
+fence, and installs checksum version 6 without changing a shard.
 There is no automatic downgrade; an older binary requires a backup from before
 the newer format.
 
@@ -582,7 +599,7 @@ lock through independently durable per-shard work and `Ready` publication. A
 lagging opener re-reads `Ready` and strictly validates instead of provisioning
 from a stale `Creating` observation. Only a locked, durable `Creating` state
 permits missing canonical shard files to be created and WAL to be enabled. The
-validated v12 manifest may also retain one generated-table DDL bridge and one
+validated v13 manifest may also retain one generated-table DDL bridge and one
 matching active table-provisioning record. Startup first resumes any
 `Applying` physical migration under its ordinary exact-prefix rules. It then
 keeps admission `Pending`, advances the bridge from `ApplyingPhysical` to

--- a/docs/MULTIPROCESS.md
+++ b/docs/MULTIPROCESS.md
@@ -11,7 +11,9 @@ Python wheel use the same locks and SQLite WAL files.
 | Reads and autocommit writes | Supported; normal SQLite writer contention can return retryable `Busy` |
 | Generated IDs | Supported; native ranges and manifest-leased hi/lo blocks remain unique |
 | Passive checkpoints | Supported; a competing checkpoint can report `busy` with unavailable frame counts |
+| Read-only global-index catalog inspection | Supported; readers observe one complete old or new checksummed snapshot |
 | Opening a current `Ready`/`Degraded` root | Supported; startup inspection is serialized |
+| Global-index create/lifecycle/remove | Requires sole-process ownership; each checksummed transition is one manifest transaction |
 | Schema migration, catalog registration, generated-table DDL, initialization, upgrade, or recovery | Requires sole-process ownership; retryable `Busy` is returned before mutation when a peer is open |
 | Offline import or backup/restore | Stop every server and embedder first |
 
@@ -97,6 +99,7 @@ directory. See [offline backup](OFFLINE_BACKUP.md) and the
 
 `tests/multiprocess_shared_root.rs` covers overlapping same- and cross-shard
 traffic, pooled handles, checkpoints, generated IDs, retryable contention,
-abrupt termination, reopen/integrity validation, and one service plus one
-embedder. `python/tests/test_multiprocess.py` repeats the public wheel contract
-with independently spawned interpreters.
+global-index writer fencing and atomic read-only catalog snapshots, abrupt
+termination, reopen/integrity validation, and one service plus one embedder.
+`python/tests/test_multiprocess.py` repeats the public wheel contract with
+independently spawned interpreters.

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -20,26 +20,26 @@ kernel releases their advisory locks when the process exits. They must not be
 replaced while a process is live. See the
 [multi-process contract](MULTIPROCESS.md).
 
-## Current format: version 12
+## Current format: version 13
 
 SQLite header fields identify the file and its format:
 
 | Header field | Value | Meaning |
 | --- | --- | --- |
 | `PRAGMA application_id` | `0x42524442` (`BRDB`) | Permanent BriskDB manifest-family marker |
-| `PRAGMA user_version` | `12` | Authoritative manifest schema version |
+| `PRAGMA user_version` | `13` | Authoritative manifest schema version |
 
 The application ID prevents an accidental foreign SQLite file from being
 adopted as a manifest. It is not authentication or tamper protection: a process
 that can write the data directory can forge it and the unkeyed checksums
 described below.
 
-Version 12 has seventeen strict manifest tables plus the partial unique
-allocation-owner index shown below. It retains the v11 routing,
+Version 13 has nineteen strict manifest tables plus the partial unique
+allocation-owner index shown below. It retains the v12 routing,
 authoritative logical catalog, physical layout, application-schema migration,
 integrity, generated-ID activation, allocation-owner lifecycle, and recoverable
 table-provisioning and hi/lo leasing tables; replaces the downgrade fence; adds
-the durable generated-table DDL bridge; and changes no shard-file format.
+the durable global-index catalog and lifecycle; and changes no shard-file format.
 
 ```sql
 CREATE TABLE briskdb_manifest (
@@ -49,7 +49,7 @@ CREATE TABLE briskdb_manifest (
 
 CREATE TABLE briskdb_metadata (
     requires_manifest_version INTEGER NOT NULL
-        CHECK (requires_manifest_version >= 12)
+        CHECK (requires_manifest_version >= 13)
 ) STRICT;
 
 CREATE TABLE briskdb_routing (
@@ -330,6 +330,62 @@ CREATE TABLE briskdb_generated_table_ddl (
     )
 ) STRICT;
 
+CREATE TABLE briskdb_global_indexes (
+    index_id INTEGER PRIMARY KEY CHECK (index_id > 0),
+    table_id INTEGER NOT NULL,
+    index_name TEXT NOT NULL COLLATE BINARY
+        CHECK (
+            length(index_name) BETWEEN 1 AND 63
+            AND instr(index_name, char(0)) = 0
+            AND index_name NOT GLOB '*[^a-z0-9_]*'
+            AND substr(index_name, 1, 1) GLOB '[a-z_]'
+            AND index_name <> 'briskdb'
+            AND index_name NOT GLOB 'briskdb_*'
+            AND index_name NOT GLOB 'sqlite_*'
+        ),
+    is_unique INTEGER NOT NULL CHECK (is_unique IN (0, 1)),
+    null_semantics INTEGER NOT NULL CHECK (null_semantics > 0),
+    predicate_sql TEXT
+        CHECK (
+            predicate_sql IS NULL
+            OR (
+                typeof(predicate_sql) = 'text'
+                AND length(CAST(predicate_sql AS BLOB)) BETWEEN 1 AND 4096
+                AND instr(predicate_sql, char(0)) = 0
+            )
+        ),
+    lifecycle_state INTEGER NOT NULL CHECK (lifecycle_state > 0),
+    key_encoding_version INTEGER NOT NULL CHECK (key_encoding_version > 0),
+    schema_generation INTEGER NOT NULL
+        CHECK (schema_generation BETWEEN 0 AND 2147483647),
+    topology_kind INTEGER NOT NULL CHECK (topology_kind >= 0),
+    topology_version INTEGER NOT NULL CHECK (topology_version >= 0),
+    partition_count INTEGER NOT NULL CHECK (partition_count BETWEEN 0 AND 256),
+    UNIQUE (table_id, index_name),
+    FOREIGN KEY (table_id) REFERENCES briskdb_tables (table_id) ON DELETE RESTRICT,
+    CHECK (is_unique = 1 OR null_semantics = 1)
+) STRICT;
+
+CREATE TABLE briskdb_global_index_parts (
+    index_id INTEGER NOT NULL,
+    ordinal INTEGER NOT NULL CHECK (ordinal BETWEEN 0 AND 15),
+    source_kind INTEGER NOT NULL CHECK (source_kind > 0),
+    source_text TEXT NOT NULL COLLATE BINARY
+        CHECK (
+            typeof(source_text) = 'text'
+            AND length(CAST(source_text AS BLOB)) BETWEEN 1 AND 4096
+            AND instr(source_text, char(0)) = 0
+        ),
+    key_type INTEGER NOT NULL CHECK (key_type > 0),
+    sort_order INTEGER NOT NULL CHECK (sort_order > 0),
+    null_order INTEGER NOT NULL CHECK (null_order > 0),
+    collation_version INTEGER NOT NULL CHECK (collation_version > 0),
+    PRIMARY KEY (index_id, ordinal),
+    FOREIGN KEY (index_id)
+        REFERENCES briskdb_global_indexes (index_id)
+        ON DELETE CASCADE
+) STRICT;
+
 CREATE TABLE briskdb_table_provisioning (
     singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
     provisioning_id BLOB NOT NULL
@@ -482,32 +538,32 @@ CREATE TABLE briskdb_integrity (
 ```
 
 The manifest, metadata, routing, schema-catalog, shard-layout, and integrity
-tables each contain exactly one row. The v12 downgrade-fence row is exactly
-`12`. `briskdb_generated_table_ddl` and `briskdb_table_provisioning` each
+tables each contain exactly one row. The v13 downgrade-fence row is exactly
+`13`. `briskdb_generated_table_ddl` and `briskdb_table_provisioning` each
 contain zero or one row. A completed generated-table bridge is retained;
 table-provisioning declaration rows exist only while their transient parent row
 exists.
 The two integrity-version columns deliberately accept any positive integer so
 a future digest encoding can remain structurally readable long enough for an
-older binary to reject it as `FailedPrecondition`; v12 writers emit manifest
-digest version `5` and schema digest version `1`.
+older binary to reject it as `FailedPrecondition`; v13 writers emit manifest
+digest version `6` and schema digest version `1`.
 Zero or negative versions are malformed and are `DataCorruption`.
 `briskdb_manifest.shard_count` is immutable and is the initial routing modulus;
 it is also the live physical-shard count. Physical IDs are exactly
 `0..shard_count - 1`. Filenames remain derived by trusted code as
 `shards/{shard_id:04}.sqlite` and are never read from catalog-controlled paths.
-Version 12 supports only the `active` physical-shard lifecycle state. Adding
+Version 13 supports only the `active` physical-shard lifecycle state. Adding
 provisioning, draining, or retirement states to the routing catalog requires a
 later format and state-machine change. The separate shard-layout state governs
 only startup identity reconciliation.
 
 ### Logical catalog
 
-Every fresh or upgraded v12 manifest contains logical database ID `1` named
+Every fresh or upgraded v13 manifest contains logical database ID `1` named
 `default`. A fresh or pre-v6 upgrade begins at application-schema
 generation `0`; each completed journal row advances it by exactly one, through
 a maximum of `2,147,483,647`. The schema-catalog singleton also contains
-identifier encoding version `1` and default database ID `1`. Version 12 permits
+identifier encoding version `1` and default database ID `1`. Version 13 permits
 at most 64 logical databases and 4,096 table rows. Database and table IDs are
 positive; table names are unique within their owning database, and every table
 references an existing database.
@@ -522,6 +578,33 @@ logical-database names, table names, and shard-key column names:
 
 Names use binary comparison. There is no case folding, quoting transform, or
 Unicode normalization; a caller must supply the canonical lowercase name.
+
+### Global-index catalog and lifecycle
+
+Version 13 adds up to 4,096 durable global-index definitions with at most 16
+ordered key parts each. A definition records its stable ID, owning Sharded
+table, canonical name, column/expression parts and types, uniqueness and NULL
+semantics, optional predicate, schema generation, canonical key-encoding
+version, and selected storage topology. Unsupported positive encoding,
+lifecycle, topology, type, ordering, or collation versions return an actionable
+`FailedPrecondition`; malformed values are `DataCorruption`.
+
+Lifecycle transitions are explicit: `Creating` may become `Ready`, `Invalid`,
+or `Dropping`; `Ready` may become `Invalid`, `Rebuilding`, or `Dropping`;
+`Invalid` may become `Rebuilding` or `Dropping`; and `Rebuilding` may become
+`Ready`, `Invalid`, or `Dropping`. Removal is legal only from `Dropping`.
+`Ready` and `Rebuilding` require an assigned versioned topology and the current
+schema generation. Application-schema migration is fenced while any definition
+exists, avoiding a catalog/schema split until later coordinated rebuild work.
+
+Each create, transition, and removal is one `BEGIN IMMEDIATE` transaction that
+reseals the semantic root before commit. The existing process mutation fence
+requires sole-process ownership for writers. `Database::inspect_global_indexes`
+opens the manifest read-only, performs full version/checksum/catalog validation,
+and neither initializes nor upgrades storage; concurrent readers therefore see
+only the complete old or complete new snapshot. This issue stores metadata
+only—physical index files, construction, maintenance, and query routing begin
+in issues #229 and later.
 
 Table placement and shard-key type use stable numeric codes:
 
@@ -601,10 +684,10 @@ shard. SQLite never lowers an `AUTOINCREMENT` high-water mark, even after the
 row which established it is deleted, so a lower replacement could otherwise
 continue allocating values in a retired owner's encoded range.
 
-Fresh version 12 storage seeds active `owner_slot = physical_shard_id`, so the
+Fresh version 13 storage seeds active `owner_slot = physical_shard_id`, so the
 initial slots are the contiguous range `0..shard_count - 1`. A slot is an
 immutable ID namespace, not a value that may be recomputed from a later shard
-count or bucket map. Version 12 has no public owner-map mutation operation, but
+count or bucket map. Version 13 has no public owner-map mutation operation, but
 its format preserves the state required by a later resharding workflow: retire
 the old slot without deleting it and explicitly add a never-used replacement
 whose slot is greater than every prior owner of that physical shard.
@@ -736,7 +819,7 @@ the data root. An exact complete repeat is a read-only idempotent success;
 empty, partial, different, duplicate, nonempty, or physically mismatched
 declarations fail without replacing the catalog. Once populated, the catalog
 cannot be edited in place. The one exception is an exact declaration repeat for
-a v9 catalog migrated with an inactive native policy: v12 may provision that
+a v9 catalog migrated with an inactive native policy: v13 may provision that
 unchanged policy if all declared physical tables are still empty, but it may
 not alter a declaration or catalog ID. A later journaled schema migration must preserve the
 exact registered physical table set on every shard and retain every sharded
@@ -907,9 +990,9 @@ acknowledged or replayed shard, resumes in ascending order, and publishes
 digests, owner ranges, or nonempty tables fail closed; BriskDB never infers a
 different request from partial shard state.
 
-Fresh v12 initialization leaves `briskdb_tables`, `briskdb_generated_ids`,
-`briskdb_hilo_leases`, `briskdb_generated_table_ddl`, and both provisioning
-tables empty. The v7-to-v8 migration
+Fresh v13 initialization leaves `briskdb_tables`, `briskdb_generated_ids`,
+`briskdb_hilo_leases`, `briskdb_generated_table_ddl`, both global-index tables,
+and both provisioning tables empty. The v7-to-v8 migration
 also clears all v7 table rows because those rows were advisory and were never
 proved against the physical schema; silently promoting them would create false
 routing authority. The upgrade preserves logical databases, routing, schema
@@ -954,7 +1037,7 @@ additional `Applying` row may exist, and it must target
 `schema_generation + 1`. Its stored source generation, shard count, SQL text,
 digest, state, and progress are validated on every manifest open. Any journal
 history requires the physical layout to be `Ready`; `Creating` and `Adopting`
-manifests have an empty journal. Fresh v12 initialization and pre-v6 upgrades
+manifests have an empty journal. Fresh v13 initialization and pre-v6 upgrades
 begin with an empty journal at generation 0.
 
 The retained journal proves which exact batches BriskDB coordinated; it does
@@ -998,8 +1081,8 @@ restart as repair after any reported `DataCorruption`; whole-shard corruption
 drills and failure handling remain issue #68. Those storage failures retain
 their own error kinds and do not themselves justify rebaselining data.
 
-Manifest digest version 5 is a full 32-byte, unkeyed BLAKE3 digest. The stream
-begins with `briskdb.manifest.semantic-root.v5` plus its terminating NUL. It
+Manifest digest version 6 is a full 32-byte, unkeyed BLAKE3 digest. The stream
+begins with `briskdb.manifest.semantic-root.v6` plus its terminating NUL. It
 then encodes the length-prefixed name `application_id` and its tagged integer,
 followed by the length-prefixed name `user_version` and its tagged integer.
 These tables and columns follow in fixed order:
@@ -1017,6 +1100,8 @@ These tables and columns follow in fixed order:
 | `briskdb_tables` | `table_id`, `database_id`, `table_name`, `placement`, `shard_key_column`, `shard_key_type` |
 | `briskdb_generated_ids` | `table_id`, `policy`, `generated_column`, `encoding_version`, `activation_state` |
 | `briskdb_generated_table_ddl` | `singleton`, `logical_id`, `logical_digest_version`, `source_dialect`, `translation_version`, `source_sql`, `physical_migration_id`, `physical_sql`, `database_id`, `table_name`, `generated_column`, `generated_policy`, `generated_encoding_version`, `lifecycle_state`, `provisioning_id`, `provisioning_schema_digest`, `table_id` |
+| `briskdb_global_indexes` | `index_id`, `table_id`, `index_name`, `is_unique`, `null_semantics`, `predicate_sql`, `lifecycle_state`, `key_encoding_version`, `schema_generation`, `topology_kind`, `topology_version`, `partition_count` |
+| `briskdb_global_index_parts` | `index_id`, `ordinal`, `source_kind`, `source_text`, `key_type`, `sort_order`, `null_order`, `collation_version` |
 | `briskdb_hilo_leases` | `table_id`, `block_size`, `next_sequence`, `fence_token`, `last_owner_id`, `last_first_sequence`, `last_last_sequence` |
 | `briskdb_table_provisioning` | `singleton`, `provisioning_id`, `digest_version`, `schema_digest_version`, `committed_schema_digest`, `shard_count`, `declaration_count`, `next_shard` |
 | `briskdb_table_provisioning_declarations` | `provisioning_singleton`, `ordinal`, `database_id`, `table_name`, `placement`, `shard_key_column`, `shard_key_type`, `generated_policy`, `generated_column`, `generated_encoding_version` |
@@ -1037,7 +1122,7 @@ self-reference; its version, database state, and schema digest fields are
 covered. Frozen SQL definitions, STRICT flags, indexes, and foreign keys are
 validated separately rather than encoded as semantic rows.
 
-Every BriskDB-owned v12 manifest mutation recalculates the root after its row
+Every BriskDB-owned v13 manifest mutation recalculates the root after its row
 changes and before the same transaction commits. Progress acknowledgement,
 migration publication/finalization, provisioning intent/progress/finalization,
 generated-table bridge transitions, layout publication, owner/activation state
@@ -1047,7 +1132,10 @@ semantic values instead of the raw SQLite file makes the root stable across WAL
 checkpoints, page relocation, and `VACUUM`; it deliberately does not cover
 SQLite page bytes, rollback journals, WAL, or shared memory.
 
-Digest version 4 remains frozen solely to verify and migrate version-11
+Digest version 5 remains frozen solely to verify and migrate version-12
+manifests. It uses the `briskdb.manifest.semantic-root.v5` domain and the same
+encoding but omits both global-index tables. Digest version 4 remains frozen
+solely to verify and migrate version-11
 manifests. It uses the `briskdb.manifest.semantic-root.v4` domain and the same
 encoding, covers `briskdb_hilo_leases`, but omits
 `briskdb_generated_table_ddl`. Digest version 3 remains frozen solely to verify
@@ -1061,8 +1149,8 @@ encoding, covers generated-ID policy and the owner-to-shard mapping, but omits
 activation, owner lifecycle, and both provisioning tables. Digest version 1
 remains frozen for version-7 and version-8 manifests. It uses the
 `briskdb.manifest.semantic-root.v1` domain and the same encoding, but omits the
-two version-9 tables. A v12 manifest must store version 5; storing an older
-digest in an otherwise v12 shape is corruption, and an unsupported future
+two version-9 tables. A v13 manifest must store version 6; storing an older
+digest in an otherwise v13 shape is corruption, and an unsupported future
 positive digest version is a failed precondition.
 
 The frozen four-shard v8/version-1 fixture with layout ID
@@ -1197,7 +1285,7 @@ The routing singleton contains exactly these generation-1 values:
 | `key_encoding_version` | `1` | Canonical bytes defined below for raw, explicit, and typed inferred routing keys |
 | `bucket_algorithm_version` | `1` | Compatibility-preserving range algorithm below |
 | `virtual_bucket_count` | `4096` | Fixed virtual bucket space `0..4095` |
-| `map_generation` | `1` | Initial committed bucket map and the only generation version 12 can interpret |
+| `map_generation` | `1` | Initial committed bucket map and the only generation version 13 can interpret |
 
 Every bucket ID exists exactly once and references an active physical shard.
 Every physical shard owns at least one bucket. The generation-1 map partitions
@@ -1220,10 +1308,9 @@ planning and policy contract is in [bound statement
 planning](SQL_PLANNING.md).
 
 This routing format is intentionally distinct from the tagged, order-preserving
-[canonical global-index key format](INDEX_KEY_ENCODING.md). Issue #227 adds the
-global-index codec without persisting it, changing this manifest schema, or
-changing shard placement. A later manifest version must record the index codec
-version before any global-index bytes become durable.
+[canonical global-index key format](INDEX_KEY_ENCODING.md). Version 13 records
+the codec version in every global-index definition but does not persist physical
+index entries or change shard placement.
 
 Bucket algorithm version 1 deliberately preserves legacy placement even when
 `N` does not divide 4,096. Given the version-1 64-bit hash `H`:
@@ -1245,7 +1332,7 @@ vectors freeze the exact key bytes, BLAKE3 prefix, little-endian hash integer,
 bucket ID, and persisted physical shard.
 
 `map_generation` is separate from manifest `user_version` and from
-`schema_generation`. Version 12 accepts only routing generation 1 and validates
+`schema_generation`. Version 13 accepts only routing generation 1 and validates
 its exact deterministic assignment; no public map-mutation operation exists
 yet. A future format that can commit a changed map must bump `user_version` and
 its downgrade fence as well as `map_generation`. That requirement makes this
@@ -1256,12 +1343,27 @@ At each open, BriskDB validates the exact objects, columns, strict flags, frozen
 schema SQL, singleton rows, logical identifiers and limits, metadata codes,
 supported algorithm values, contiguous physical and bucket IDs, active
 lifecycle states, assignments, coverage, and foreign keys. A recognized
-version-12 manifest that violates any invariant is `DataCorruption` and is
+version-13 manifest that violates any invariant is `DataCorruption` and is
 rejected before shard connections are opened. The same locked transaction
 returns routing and logical rows as one coherent shared snapshot. Request
 routing performs no manifest query and cannot fall back to modulo after a failed
 validation; only successful migration finalization publishes a newer logical
 schema generation into the snapshot.
+
+## Previous version 12
+
+Version 12 has seventeen strict manifest tables and semantic manifest digest
+version 5. It includes the retained generated-table DDL bridge but has no
+global-index catalog. Its downgrade fence requires 12 and its header stores
+`user_version = 12`.
+
+The atomic v12-to-v13 transaction creates both empty global-index tables,
+replaces the downgrade fence with 13, changes the integrity row to manifest
+digest version 6, stamps `user_version = 13`, and reseals the version-6 root.
+It preserves routing, logical tables, generated-ID and DDL state, migration
+history, schema generations, layout, integrity, shard files, schemas, and rows.
+The migration never opens or mutates a shard. A version-12 reader rejects the
+version-13 header and fence before it could ignore global-index authority.
 
 ## Previous version 11
 
@@ -1474,7 +1576,7 @@ CREATE TABLE briskdb_metadata (
 
 The fence contains exactly `2`. A current opener validates this complete format
 before applying the numbered v2-to-v3, v3-to-v4, v4-to-v5, v5-to-v6,
-v6-to-v7, v7-to-v8, v8-to-v9, v9-to-v10, v10-to-v11, and v11-to-v12
+v6-to-v7, v7-to-v8, v8-to-v9, v9-to-v10, v10-to-v11, v11-to-v12, and v12-to-v13
 transactions.
 
 ## Legacy version 1
@@ -1534,12 +1636,13 @@ returning:
    2; and v9-to-v10 installs activation/lifecycle state, the provisioning
    journal, and semantic digest version 3. The v10-to-v11 step adds durable
    hi/lo allocation heads and semantic digest version 4. The v11-to-v12 step
-   adds the retained generated-table DDL bridge and semantic digest version 5.
+   adds the retained generated-table DDL bridge and semantic digest version 5;
+   v12-to-v13 adds the global-index catalog and semantic digest version 6.
    Older formats therefore cannot be mistaken for checksummed,
    authoritative-catalog, allocator-authority, recoverable provisioning, or
    durable logical-to-physical DDL identity.
 6. Fresh initialization is allowed only beside an otherwise empty physical
-   layout and commits v12 physical state `Creating`, integrity state
+   layout and commits v13 physical state `Creating`, integrity state
    `Verifying`, generation 0, and empty application-schema and provisioning
    journals. An existing
    v1/v2/v3 manifest first advances through v4; the v4-to-v5 transaction commits
@@ -1549,9 +1652,10 @@ returning:
    table catalog. The v8-to-v9 step adds the empty generated-policy catalog and
    immutable owner map; v9-to-v10 adds inactive activation fields, active owner
    states, and empty provisioning tables; v10-to-v11 adds the empty hi/lo lease
-   table; and v11-to-v12 adds the empty generated-table DDL bridge.
+   table; v11-to-v12 adds the empty generated-table DDL bridge; and v12-to-v13
+   adds the empty global-index catalog.
 7. If the validated integrity state is `Degraded`, fail startup without
-   changing it. Otherwise, if a validated v12 manifest contains one `Applying`
+   changing it. Otherwise, if a validated v13 manifest contains one `Applying`
    migration, require state `Migrating`, validate every shard against the
    trusted source/target fingerprint for its exact journal-prefix position,
    and resume it in ascending order. The final transaction publishes the
@@ -1629,6 +1733,8 @@ The v11-to-v12 step also changes no shard: it creates the empty retained
 generated-table DDL bridge and moves the checksum to version 5. Existing
 policies, allocator state, provisioning progress, migration history, schema,
 and application rows are unchanged.
+The v12-to-v13 step likewise changes no shard: it creates the empty global-index
+catalog, raises the downgrade fence, and moves the checksum to version 6.
 
 A new application-schema migration follows a separate durable protocol:
 
@@ -1767,7 +1873,7 @@ header value, format version, digest input, routing metadata, schema
 fingerprint, journal record, or recovery step. Listener settings are not
 persisted. Because engine open and its existing recovery precede listener
 binding, a later bind failure does not undo a migration or recovery transaction
-that already committed; a subsequent startup revalidates the same version-12
+that already committed; a subsequent startup revalidates the same version-13
 layout normally.
 
 Issue #29's pinned `pgwire` dependency and issue #30's production startup,
@@ -1814,8 +1920,8 @@ requires a backup from before the unsupported format.
 
 ## Verification contract
 
-Tests cover fresh creation and every v1/v2/v3/v4/v5/v6/v7/v8/v9/v10/v11
-upgrade path to v12, every
+Tests cover fresh creation and every v1/v2/v3/v4/v5/v6/v7/v8/v9/v10/v11/v12
+upgrade path to v13, every
 manifest layout and integrity state, the exact shard header and metadata row,
 dynamic schema generations, retained migration history, checksum golden
 vectors, and no-op ready reopen. Failure

--- a/src/core/catalog.rs
+++ b/src/core/catalog.rs
@@ -5,7 +5,10 @@ use std::{
     sync::atomic::{AtomicU64, Ordering},
 };
 
-use super::{AllocationOwnerMap, EngineError, EngineErrorKind, EngineResult, RoutingCatalog};
+use super::{
+    AllocationOwnerMap, EngineError, EngineErrorKind, EngineResult, GlobalIndexId,
+    GlobalIndexMetadata, RoutingCatalog,
+};
 
 pub(crate) const IDENTIFIER_ENCODING_VERSION: u32 = 1;
 pub(crate) const DEFAULT_LOGICAL_DATABASE_ID: u64 = 1;
@@ -508,6 +511,7 @@ pub struct Catalog {
     default_database_id: LogicalDatabaseId,
     databases: Box<[LogicalDatabaseMetadata]>,
     tables: Box<[TableMetadata]>,
+    global_indexes: Box<[GlobalIndexMetadata]>,
 }
 
 impl fmt::Debug for Catalog {
@@ -522,6 +526,7 @@ impl fmt::Debug for Catalog {
             .field("default_database_id", &self.default_database_id)
             .field("databases", &self.databases)
             .field("tables", &self.tables)
+            .field("global_indexes", &self.global_indexes)
             .finish()
     }
 }
@@ -537,6 +542,7 @@ impl Clone for Catalog {
             default_database_id: self.default_database_id,
             databases: self.databases.clone(),
             tables: self.tables.clone(),
+            global_indexes: self.global_indexes.clone(),
         }
     }
 }
@@ -551,6 +557,7 @@ impl PartialEq for Catalog {
             && self.default_database_id == other.default_database_id
             && self.databases == other.databases
             && self.tables == other.tables
+            && self.global_indexes == other.global_indexes
     }
 }
 
@@ -588,7 +595,19 @@ impl Catalog {
             default_database_id: LogicalDatabaseId::from_validated(default_database_id),
             databases,
             tables,
+            global_indexes: Box::new([]),
         }
+    }
+
+    pub(crate) fn with_global_indexes(mut self, indexes: Box<[GlobalIndexMetadata]>) -> Self {
+        debug_assert!(indexes.windows(2).all(|rows| rows[0].id() < rows[1].id()));
+        debug_assert!(
+            indexes
+                .iter()
+                .all(|index| self.table_by_id(index.table_id()).is_some())
+        );
+        self.global_indexes = indexes;
+        self
     }
 
     /// Return the persisted identifier-encoding version.
@@ -652,6 +671,19 @@ impl Catalog {
     /// Return tables in logical-database-ID then canonical-name order.
     pub fn tables(&self) -> &[TableMetadata] {
         &self.tables
+    }
+
+    /// Return durable global-index definitions in stable numeric-ID order.
+    pub fn global_indexes(&self) -> &[GlobalIndexMetadata] {
+        &self.global_indexes
+    }
+
+    /// Look up a durable global index by stable ID.
+    pub fn global_index_by_id(&self, id: GlobalIndexId) -> Option<&GlobalIndexMetadata> {
+        self.global_indexes
+            .binary_search_by_key(&id, GlobalIndexMetadata::id)
+            .ok()
+            .map(|index| &self.global_indexes[index])
     }
 
     /// Look up a logical database by stable ID.

--- a/src/core/global_index.rs
+++ b/src/core/global_index.rs
@@ -1,0 +1,517 @@
+//! Durable, protocol-neutral global-index catalog metadata.
+
+use std::fmt;
+
+use super::{
+    EngineError, EngineErrorKind, EngineResult, INDEX_KEY_ENCODING_VERSION, IndexKeyCollation,
+    IndexKeyOrder, IndexNullOrder, TableId, UniqueNullSemantics, validate_catalog_identifier,
+};
+
+pub(crate) const MAX_GLOBAL_INDEXES: usize = 4_096;
+pub(crate) const MAX_GLOBAL_INDEX_PARTS: usize = 16;
+pub(crate) const MAX_GLOBAL_INDEX_SQL_BYTES: usize = 4_096;
+
+/// Stable identity of one durable global index.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct GlobalIndexId(u64);
+
+impl GlobalIndexId {
+    /// Construct a positive stable global-index identity.
+    pub fn new(value: u64) -> EngineResult<Self> {
+        if value == 0 {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "global-index IDs must be positive",
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    pub(crate) const fn from_validated(value: u64) -> Self {
+        debug_assert!(value > 0);
+        Self(value)
+    }
+
+    /// Return the persisted numeric identity.
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+impl fmt::Display for GlobalIndexId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+/// Durable lifecycle of a global-index definition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum GlobalIndexLifecycle {
+    /// Metadata exists, but index data must not be used by queries.
+    Creating,
+    /// Index data is complete and eligible for its documented use.
+    Ready,
+    /// Validation failed or compatibility was lost; the index is fenced.
+    Invalid,
+    /// Replacement index data is being constructed and is not yet published.
+    Rebuilding,
+    /// The definition and any physical artifacts are being removed.
+    Dropping,
+}
+
+impl GlobalIndexLifecycle {
+    /// Return whether one durable lifecycle transition is legal.
+    pub fn can_transition_to(self, target: Self) -> bool {
+        if self == target {
+            return true;
+        }
+        matches!(
+            (self, target),
+            (Self::Creating, Self::Ready | Self::Invalid | Self::Dropping)
+                | (
+                    Self::Ready,
+                    Self::Invalid | Self::Rebuilding | Self::Dropping
+                )
+                | (Self::Invalid, Self::Rebuilding | Self::Dropping)
+                | (
+                    Self::Rebuilding,
+                    Self::Ready | Self::Invalid | Self::Dropping
+                )
+        )
+    }
+}
+
+/// Durable physical-layout choice for global-index data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum GlobalIndexStorageTopology {
+    /// No physical layout has been selected yet.
+    Unassigned,
+    /// One shared global-index SQLite file.
+    SharedSqliteV1,
+    /// Canonical keys are hash-partitioned across multiple SQLite files.
+    HashPartitionedSqliteV1 { partitions: u16 },
+}
+
+impl GlobalIndexStorageTopology {
+    /// Construct a validated version-1 hash-partitioned topology.
+    pub fn hash_partitioned_sqlite_v1(partitions: u16) -> EngineResult<Self> {
+        if !(2..=256).contains(&partitions) || !partitions.is_power_of_two() {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "global-index partition count must be a power of two between 2 and 256",
+            ));
+        }
+        Ok(Self::HashPartitionedSqliteV1 { partitions })
+    }
+
+    pub(crate) fn from_validated_parts(kind: i64, version: i64, partitions: i64) -> Self {
+        match (kind, version, partitions) {
+            (0, 0, 0) => Self::Unassigned,
+            (1, 1, 1) => Self::SharedSqliteV1,
+            (2, 1, partitions) => Self::HashPartitionedSqliteV1 {
+                partitions: partitions as u16,
+            },
+            _ => unreachable!("validated global-index topology"),
+        }
+    }
+
+    pub(crate) const fn persisted_parts(self) -> (i64, i64, i64) {
+        match self {
+            Self::Unassigned => (0, 0, 0),
+            Self::SharedSqliteV1 => (1, 1, 1),
+            Self::HashPartitionedSqliteV1 { partitions } => (2, 1, partitions as i64),
+        }
+    }
+}
+
+/// Declared logical type of one encoded global-index key component.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum GlobalIndexKeyType {
+    Boolean,
+    Int64,
+    UInt64,
+    Float64,
+    Date,
+    Timestamp,
+    Text,
+    Binary,
+}
+
+/// Source expression for one global-index key component.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum GlobalIndexKeySource {
+    /// A canonical catalog column name.
+    Column(String),
+    /// Exact canonical SQLite expression text retained for later evaluation.
+    Expression(String),
+}
+
+impl GlobalIndexKeySource {
+    /// Construct a validated column source.
+    pub fn column(name: impl Into<String>) -> EngineResult<Self> {
+        let name = name.into();
+        ensure_identifier(&name, "global-index column")?;
+        Ok(Self::Column(name))
+    }
+
+    /// Construct a bounded, NUL-free expression source.
+    pub fn expression(sql: impl Into<String>) -> EngineResult<Self> {
+        let sql = sql.into();
+        ensure_sql_fragment(&sql, "global-index expression")?;
+        Ok(Self::Expression(sql))
+    }
+
+    pub(crate) fn from_validated(kind: i64, source: String) -> Self {
+        match kind {
+            1 => Self::Column(source),
+            2 => Self::Expression(source),
+            _ => unreachable!("validated global-index key source"),
+        }
+    }
+
+    pub(crate) const fn kind_code(&self) -> i64 {
+        match self {
+            Self::Column(_) => 1,
+            Self::Expression(_) => 2,
+        }
+    }
+
+    /// Return the canonical column name or exact expression text.
+    pub fn source(&self) -> &str {
+        match self {
+            Self::Column(source) | Self::Expression(source) => source,
+        }
+    }
+}
+
+/// Frozen definition of one component in a compound global-index key.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct GlobalIndexKeyPart {
+    source: GlobalIndexKeySource,
+    key_type: GlobalIndexKeyType,
+    order: IndexKeyOrder,
+    null_order: IndexNullOrder,
+    collation: IndexKeyCollation,
+}
+
+impl GlobalIndexKeyPart {
+    /// Construct an ascending, NULLS FIRST, BINARY key component.
+    pub const fn new(source: GlobalIndexKeySource, key_type: GlobalIndexKeyType) -> Self {
+        Self {
+            source,
+            key_type,
+            order: IndexKeyOrder::Ascending,
+            null_order: IndexNullOrder::First,
+            collation: IndexKeyCollation::Binary,
+        }
+    }
+
+    pub const fn with_order(mut self, order: IndexKeyOrder) -> Self {
+        self.order = order;
+        self
+    }
+
+    pub const fn with_null_order(mut self, null_order: IndexNullOrder) -> Self {
+        self.null_order = null_order;
+        self
+    }
+
+    pub const fn with_collation(mut self, collation: IndexKeyCollation) -> Self {
+        self.collation = collation;
+        self
+    }
+
+    pub const fn source(&self) -> &GlobalIndexKeySource {
+        &self.source
+    }
+
+    pub const fn key_type(&self) -> GlobalIndexKeyType {
+        self.key_type
+    }
+
+    pub const fn order(&self) -> IndexKeyOrder {
+        self.order
+    }
+
+    pub const fn null_order(&self) -> IndexNullOrder {
+        self.null_order
+    }
+
+    pub const fn collation(&self) -> IndexKeyCollation {
+        self.collation
+    }
+
+    pub(crate) const fn from_validated(
+        source: GlobalIndexKeySource,
+        key_type: GlobalIndexKeyType,
+        order: IndexKeyOrder,
+        null_order: IndexNullOrder,
+        collation: IndexKeyCollation,
+    ) -> Self {
+        Self {
+            source,
+            key_type,
+            order,
+            null_order,
+            collation,
+        }
+    }
+}
+
+/// Validated request to add one durable global-index definition.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GlobalIndexDeclaration {
+    table_id: TableId,
+    name: String,
+    key_parts: Box<[GlobalIndexKeyPart]>,
+    unique: bool,
+    null_semantics: UniqueNullSemantics,
+    predicate: Option<String>,
+    topology: GlobalIndexStorageTopology,
+}
+
+impl GlobalIndexDeclaration {
+    /// Define a non-unique global index in the unassigned topology.
+    pub fn new(
+        table_id: TableId,
+        name: impl Into<String>,
+        key_parts: Vec<GlobalIndexKeyPart>,
+    ) -> EngineResult<Self> {
+        let name = name.into();
+        ensure_identifier(&name, "global-index name")?;
+        ensure_key_parts(&key_parts)?;
+        Ok(Self {
+            table_id,
+            name,
+            key_parts: key_parts.into_boxed_slice(),
+            unique: false,
+            null_semantics: UniqueNullSemantics::Distinct,
+            predicate: None,
+            topology: GlobalIndexStorageTopology::Unassigned,
+        })
+    }
+
+    /// Mark this definition unique and freeze its NULL semantics.
+    pub const fn unique(mut self, null_semantics: UniqueNullSemantics) -> Self {
+        self.unique = true;
+        self.null_semantics = null_semantics;
+        self
+    }
+
+    /// Attach an exact bounded predicate used for a partial index.
+    pub fn with_predicate(mut self, predicate: impl Into<String>) -> EngineResult<Self> {
+        let predicate = predicate.into();
+        ensure_sql_fragment(&predicate, "global-index predicate")?;
+        self.predicate = Some(predicate);
+        Ok(self)
+    }
+
+    /// Select the durable storage topology. `Ready` publication remains a
+    /// separate lifecycle transition.
+    pub const fn with_topology(mut self, topology: GlobalIndexStorageTopology) -> Self {
+        self.topology = topology;
+        self
+    }
+
+    pub const fn table_id(&self) -> TableId {
+        self.table_id
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn key_parts(&self) -> &[GlobalIndexKeyPart] {
+        &self.key_parts
+    }
+
+    pub const fn is_unique(&self) -> bool {
+        self.unique
+    }
+
+    pub const fn null_semantics(&self) -> UniqueNullSemantics {
+        self.null_semantics
+    }
+
+    pub fn predicate(&self) -> Option<&str> {
+        self.predicate.as_deref()
+    }
+
+    pub const fn topology(&self) -> GlobalIndexStorageTopology {
+        self.topology
+    }
+}
+
+/// Fully validated read-only global-index metadata loaded from the manifest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GlobalIndexMetadata {
+    id: GlobalIndexId,
+    table_id: TableId,
+    name: String,
+    key_parts: Box<[GlobalIndexKeyPart]>,
+    unique: bool,
+    null_semantics: UniqueNullSemantics,
+    predicate: Option<String>,
+    lifecycle: GlobalIndexLifecycle,
+    key_encoding_version: u32,
+    schema_generation: u64,
+    topology: GlobalIndexStorageTopology,
+}
+
+impl GlobalIndexMetadata {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn from_validated(
+        id: u64,
+        table_id: u64,
+        name: String,
+        key_parts: Box<[GlobalIndexKeyPart]>,
+        unique: bool,
+        null_semantics: UniqueNullSemantics,
+        predicate: Option<String>,
+        lifecycle: GlobalIndexLifecycle,
+        schema_generation: u64,
+        topology: GlobalIndexStorageTopology,
+    ) -> Self {
+        Self {
+            id: GlobalIndexId::from_validated(id),
+            table_id: TableId::from_validated(table_id),
+            name,
+            key_parts,
+            unique,
+            null_semantics,
+            predicate,
+            lifecycle,
+            key_encoding_version: INDEX_KEY_ENCODING_VERSION,
+            schema_generation,
+            topology,
+        }
+    }
+
+    pub const fn id(&self) -> GlobalIndexId {
+        self.id
+    }
+
+    pub const fn table_id(&self) -> TableId {
+        self.table_id
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn key_parts(&self) -> &[GlobalIndexKeyPart] {
+        &self.key_parts
+    }
+
+    pub const fn is_unique(&self) -> bool {
+        self.unique
+    }
+
+    pub const fn null_semantics(&self) -> UniqueNullSemantics {
+        self.null_semantics
+    }
+
+    pub fn predicate(&self) -> Option<&str> {
+        self.predicate.as_deref()
+    }
+
+    pub const fn lifecycle(&self) -> GlobalIndexLifecycle {
+        self.lifecycle
+    }
+
+    pub const fn key_encoding_version(&self) -> u32 {
+        self.key_encoding_version
+    }
+
+    pub const fn schema_generation(&self) -> u64 {
+        self.schema_generation
+    }
+
+    pub const fn topology(&self) -> GlobalIndexStorageTopology {
+        self.topology
+    }
+}
+
+fn ensure_identifier(value: &str, description: &str) -> EngineResult<()> {
+    if validate_catalog_identifier(value) {
+        Ok(())
+    } else {
+        Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            format!("{description} must use canonical catalog spelling"),
+        ))
+    }
+}
+
+fn ensure_sql_fragment(value: &str, description: &str) -> EngineResult<()> {
+    if value.is_empty() || value.len() > MAX_GLOBAL_INDEX_SQL_BYTES || value.as_bytes().contains(&0)
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            format!(
+                "{description} must contain 1 through {MAX_GLOBAL_INDEX_SQL_BYTES} UTF-8 bytes without NUL"
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_key_parts(parts: &[GlobalIndexKeyPart]) -> EngineResult<()> {
+    if parts.is_empty() || parts.len() > MAX_GLOBAL_INDEX_PARTS {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            format!("a global index requires 1 through {MAX_GLOBAL_INDEX_PARTS} key components"),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn table_id() -> TableId {
+        TableId::new(7).unwrap()
+    }
+
+    fn part() -> GlobalIndexKeyPart {
+        GlobalIndexKeyPart::new(
+            GlobalIndexKeySource::column("email").unwrap(),
+            GlobalIndexKeyType::Text,
+        )
+    }
+
+    #[test]
+    fn lifecycle_transitions_are_explicit_and_idempotent() {
+        use GlobalIndexLifecycle as State;
+        assert!(State::Creating.can_transition_to(State::Ready));
+        assert!(State::Ready.can_transition_to(State::Rebuilding));
+        assert!(State::Rebuilding.can_transition_to(State::Invalid));
+        assert!(State::Invalid.can_transition_to(State::Dropping));
+        assert!(State::Dropping.can_transition_to(State::Dropping));
+        assert!(!State::Dropping.can_transition_to(State::Ready));
+        assert!(!State::Invalid.can_transition_to(State::Ready));
+    }
+
+    #[test]
+    fn declarations_validate_identifiers_sql_and_compound_limits() {
+        let declaration = GlobalIndexDeclaration::new(table_id(), "users_email", vec![part()])
+            .unwrap()
+            .unique(UniqueNullSemantics::NotDistinct)
+            .with_predicate("active = 1")
+            .unwrap()
+            .with_topology(GlobalIndexStorageTopology::SharedSqliteV1);
+        assert!(declaration.is_unique());
+        assert_eq!(declaration.predicate(), Some("active = 1"));
+
+        assert!(GlobalIndexDeclaration::new(table_id(), "Bad Name", vec![part()]).is_err());
+        assert!(GlobalIndexDeclaration::new(table_id(), "empty", vec![]).is_err());
+        assert!(GlobalIndexKeySource::expression("\0").is_err());
+        assert!(GlobalIndexStorageTopology::hash_partitioned_sqlite_v1(3).is_err());
+        assert!(GlobalIndexStorageTopology::hash_partitioned_sqlite_v1(16).is_ok());
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -8,6 +8,7 @@ mod control;
 mod engine;
 mod error;
 pub(crate) mod generated_id;
+mod global_index;
 mod index_key;
 mod lifecycle;
 mod options;
@@ -35,6 +36,13 @@ pub use control::{CancellationToken, RequestContext};
 pub use engine::{CheckpointReport, CheckpointShardReport, Engine, EngineStatus, Statement};
 pub use error::{EngineError, EngineErrorKind, EngineResult};
 pub(crate) use generated_id::AllocationOwnerMap;
+pub use global_index::{
+    GlobalIndexDeclaration, GlobalIndexId, GlobalIndexKeyPart, GlobalIndexKeySource,
+    GlobalIndexKeyType, GlobalIndexLifecycle, GlobalIndexMetadata, GlobalIndexStorageTopology,
+};
+pub(crate) use global_index::{
+    MAX_GLOBAL_INDEX_PARTS, MAX_GLOBAL_INDEX_SQL_BYTES, MAX_GLOBAL_INDEXES,
+};
 pub use index_key::{
     CanonicalIndexKey, DecodedIndexKeyPart, INDEX_KEY_ENCODING_VERSION, IndexKeyCollation,
     IndexKeyOrder, IndexKeyPart, IndexKeyValue, IndexKeyValueRef, IndexNullOrder,
@@ -188,6 +196,14 @@ impl Database {
         crate::storage::detect_shard_count(root)
     }
 
+    /// Validate and inspect global-index definitions without creating or
+    /// upgrading storage.
+    pub fn inspect_global_indexes(
+        root: impl AsRef<Path>,
+    ) -> EngineResult<Box<[GlobalIndexMetadata]>> {
+        crate::storage::inspect_global_indexes(root)
+    }
+
     pub fn shard_count(&self) -> u16 {
         self.storage.shard_count()
     }
@@ -205,6 +221,34 @@ impl Database {
     /// schema-and-catalog migration.
     pub fn register_tables(&mut self, declarations: Vec<TableDeclaration>) -> EngineResult<()> {
         self.storage.register_tables(declarations)
+    }
+
+    /// Atomically add one durable global-index definition in `Creating` state.
+    ///
+    /// This lifecycle API publishes metadata only. Physical index construction
+    /// and query use are implemented by the later global-index build stages.
+    pub fn create_global_index(
+        &mut self,
+        declaration: GlobalIndexDeclaration,
+    ) -> EngineResult<GlobalIndexId> {
+        self.storage.create_global_index(declaration)
+    }
+
+    /// Atomically apply one legal global-index lifecycle transition.
+    ///
+    /// Callers must not publish `Ready` until the declared physical topology is
+    /// complete and validated.
+    pub fn transition_global_index(
+        &mut self,
+        index_id: GlobalIndexId,
+        target: GlobalIndexLifecycle,
+    ) -> EngineResult<()> {
+        self.storage.transition_global_index(index_id, target)
+    }
+
+    /// Remove a global-index definition after it reaches `Dropping`.
+    pub fn remove_global_index(&mut self, index_id: GlobalIndexId) -> EngineResult<()> {
+        self.storage.remove_global_index(index_id)
     }
 
     /// Create and durably register one generated-ID Sharded table from a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,8 @@ pub use core::{
     CancellationToken, CanonicalIndexKey, CheckpointReport, CheckpointShardReport, Column,
     DataType, Decimal, DecodedIndexKeyPart, DescribeTarget, EngineError, EngineErrorKind,
     EngineOptions, EngineResult, EngineState, EngineStatus, Executed, GeneratedKey,
+    GlobalIndexDeclaration, GlobalIndexId, GlobalIndexKeyPart, GlobalIndexKeySource,
+    GlobalIndexKeyType, GlobalIndexLifecycle, GlobalIndexMetadata, GlobalIndexStorageTopology,
     INDEX_KEY_ENCODING_VERSION, IndexKeyCollation, IndexKeyOrder, IndexKeyPart, IndexKeyValue,
     IndexKeyValueRef, IndexNullOrder, ParseDecimalError, PortalId, PrepareRequest,
     PreparedExecution, PreparedStatementDescription, PreparedStatementId, PreparedStatementLimits,

--- a/src/storage/manifest.rs
+++ b/src/storage/manifest.rs
@@ -12,11 +12,15 @@ use crate::{
     core::{
         AllocationOwnerMap, BUCKET_ALGORITHM_VERSION, Catalog, CatalogSnapshot,
         DEFAULT_LOGICAL_DATABASE_ID, DEFAULT_LOGICAL_DATABASE_NAME, EngineError, EngineErrorKind,
-        EngineResult, GeneratedIdPolicy, HASH_VERSION, IDENTIFIER_ENCODING_VERSION,
-        INITIAL_MAP_GENERATION, KEY_ENCODING_VERSION, LogicalDatabaseId, LogicalDatabaseMetadata,
+        EngineResult, GeneratedIdPolicy, GlobalIndexDeclaration, GlobalIndexId, GlobalIndexKeyPart,
+        GlobalIndexKeySource, GlobalIndexKeyType, GlobalIndexLifecycle, GlobalIndexMetadata,
+        GlobalIndexStorageTopology, HASH_VERSION, IDENTIFIER_ENCODING_VERSION,
+        INDEX_KEY_ENCODING_VERSION, INITIAL_MAP_GENERATION, IndexKeyCollation, IndexKeyOrder,
+        IndexNullOrder, KEY_ENCODING_VERSION, LogicalDatabaseId, LogicalDatabaseMetadata,
+        MAX_GLOBAL_INDEX_PARTS, MAX_GLOBAL_INDEX_SQL_BYTES, MAX_GLOBAL_INDEXES,
         MAX_LOGICAL_DATABASES, MAX_TABLES, RoutingCatalog, ShardKeyMetadata, ShardKeyType,
-        TableDeclaration, TableId, TableMetadata, TablePlacement, VIRTUAL_BUCKET_COUNT,
-        initial_physical_shard, validate_catalog_identifier,
+        TableDeclaration, TableId, TableMetadata, TablePlacement, UniqueNullSemantics,
+        VIRTUAL_BUCKET_COUNT, initial_physical_shard, validate_catalog_identifier,
     },
     sql::SqlDialect,
     sqlite_error,
@@ -41,7 +45,8 @@ const V9_SCHEMA_VERSION: u32 = 9;
 const V10_SCHEMA_VERSION: u32 = 10;
 const V11_SCHEMA_VERSION: u32 = 11;
 const V12_SCHEMA_VERSION: u32 = 12;
-pub(super) const CURRENT_SCHEMA_VERSION: u32 = V12_SCHEMA_VERSION;
+const V13_SCHEMA_VERSION: u32 = 13;
+pub(super) const CURRENT_SCHEMA_VERSION: u32 = V13_SCHEMA_VERSION;
 const MAX_TABLE_SQL_BYTES: i64 = 4_096;
 
 pub(super) const MAX_SCHEMA_MIGRATION_SQL_BYTES: usize = 65_536;
@@ -55,12 +60,14 @@ const V2_MANIFEST_DIGEST_VERSION: u32 = 2;
 const V3_MANIFEST_DIGEST_VERSION: u32 = 3;
 const V4_MANIFEST_DIGEST_VERSION: u32 = 4;
 const V5_MANIFEST_DIGEST_VERSION: u32 = 5;
+const V6_MANIFEST_DIGEST_VERSION: u32 = 6;
 pub(super) const SCHEMA_DIGEST_VERSION: u32 = 1;
 const V1_MANIFEST_DIGEST_DOMAIN: &[u8] = b"briskdb.manifest.semantic-root.v1\0";
 const V2_MANIFEST_DIGEST_DOMAIN: &[u8] = b"briskdb.manifest.semantic-root.v2\0";
 const V3_MANIFEST_DIGEST_DOMAIN: &[u8] = b"briskdb.manifest.semantic-root.v3\0";
 const V4_MANIFEST_DIGEST_DOMAIN: &[u8] = b"briskdb.manifest.semantic-root.v4\0";
 const V5_MANIFEST_DIGEST_DOMAIN: &[u8] = b"briskdb.manifest.semantic-root.v5\0";
+const V6_MANIFEST_DIGEST_DOMAIN: &[u8] = b"briskdb.manifest.semantic-root.v6\0";
 const TABLE_PROVISIONING_DIGEST_DOMAIN: &[u8] = b"briskdb.table-provisioning.v1\0";
 const GENERATED_TABLE_DDL_DIGEST_DOMAIN: &[u8] = b"briskdb.generated-table-ddl.v1\0";
 
@@ -99,6 +106,34 @@ const MAX_ALLOCATION_OWNER_SLOT: i64 = 1_023;
 const ALLOCATION_OWNER_ACTIVE: i64 = 1;
 const ALLOCATION_OWNER_RETIRED: i64 = 2;
 
+const GLOBAL_INDEX_CREATING: i64 = 1;
+const GLOBAL_INDEX_READY: i64 = 2;
+const GLOBAL_INDEX_INVALID: i64 = 3;
+const GLOBAL_INDEX_REBUILDING: i64 = 4;
+const GLOBAL_INDEX_DROPPING: i64 = 5;
+const GLOBAL_INDEX_NON_UNIQUE: i64 = 0;
+const GLOBAL_INDEX_UNIQUE: i64 = 1;
+const GLOBAL_INDEX_NULLS_DISTINCT: i64 = 1;
+const GLOBAL_INDEX_NULLS_NOT_DISTINCT: i64 = 2;
+const GLOBAL_INDEX_TOPOLOGY_UNASSIGNED: i64 = 0;
+const GLOBAL_INDEX_TOPOLOGY_SHARED_SQLITE: i64 = 1;
+const GLOBAL_INDEX_TOPOLOGY_HASH_PARTITIONED_SQLITE: i64 = 2;
+const GLOBAL_INDEX_SOURCE_COLUMN: i64 = 1;
+const GLOBAL_INDEX_SOURCE_EXPRESSION: i64 = 2;
+const GLOBAL_INDEX_KEY_BOOLEAN: i64 = 1;
+const GLOBAL_INDEX_KEY_INT64: i64 = 2;
+const GLOBAL_INDEX_KEY_UINT64: i64 = 3;
+const GLOBAL_INDEX_KEY_FLOAT64: i64 = 4;
+const GLOBAL_INDEX_KEY_DATE: i64 = 5;
+const GLOBAL_INDEX_KEY_TIMESTAMP: i64 = 6;
+const GLOBAL_INDEX_KEY_TEXT: i64 = 7;
+const GLOBAL_INDEX_KEY_BINARY: i64 = 8;
+const GLOBAL_INDEX_ASCENDING: i64 = 1;
+const GLOBAL_INDEX_DESCENDING: i64 = 2;
+const GLOBAL_INDEX_NULLS_FIRST: i64 = 1;
+const GLOBAL_INDEX_NULLS_LAST: i64 = 2;
+const GLOBAL_INDEX_BINARY_COLLATION: i64 = 1;
+
 const ACTIVE_LIFECYCLE_STATE: &str = "active";
 
 #[cfg(test)]
@@ -121,6 +156,13 @@ fn abort_table_registration_at_test_boundary(boundary: &str) {
 #[cfg(test)]
 fn abort_hilo_lease_at_test_boundary(boundary: &str) {
     if std::env::var("BRISKDB_HILO_LEASE_ABORT_POINT").as_deref() == Ok(boundary) {
+        std::process::abort();
+    }
+}
+
+#[cfg(test)]
+fn abort_global_index_at_test_boundary(boundary: &str) {
+    if std::env::var("BRISKDB_GLOBAL_INDEX_ABORT_POINT").as_deref() == Ok(boundary) {
         std::process::abort();
     }
 }
@@ -176,6 +218,10 @@ const V11_DOWNGRADE_FENCE_SQL: &str = "CREATE TABLE briskdb_metadata (
 const V12_DOWNGRADE_FENCE_SQL: &str = "CREATE TABLE briskdb_metadata (
     requires_manifest_version INTEGER NOT NULL
         CHECK (requires_manifest_version >= 12)
+) STRICT";
+const V13_DOWNGRADE_FENCE_SQL: &str = "CREATE TABLE briskdb_metadata (
+    requires_manifest_version INTEGER NOT NULL
+        CHECK (requires_manifest_version >= 13)
 ) STRICT";
 const V3_ROUTING_TABLE_SQL: &str = "CREATE TABLE briskdb_routing (
     singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
@@ -574,6 +620,62 @@ const V12_GENERATED_TABLE_DDL_TABLE_SQL: &str = "CREATE TABLE briskdb_generated_
             AND table_id IS NOT NULL
         )
     )
+) STRICT";
+const V13_GLOBAL_INDEXES_TABLE_SQL: &str = "CREATE TABLE briskdb_global_indexes (
+    index_id INTEGER PRIMARY KEY CHECK (index_id > 0),
+    table_id INTEGER NOT NULL,
+    index_name TEXT NOT NULL COLLATE BINARY
+        CHECK (
+            length(index_name) BETWEEN 1 AND 63
+            AND instr(index_name, char(0)) = 0
+            AND index_name NOT GLOB '*[^a-z0-9_]*'
+            AND substr(index_name, 1, 1) GLOB '[a-z_]'
+            AND index_name <> 'briskdb'
+            AND index_name NOT GLOB 'briskdb_*'
+            AND index_name NOT GLOB 'sqlite_*'
+        ),
+    is_unique INTEGER NOT NULL CHECK (is_unique IN (0, 1)),
+    null_semantics INTEGER NOT NULL CHECK (null_semantics > 0),
+    predicate_sql TEXT
+        CHECK (
+            predicate_sql IS NULL
+            OR (
+                typeof(predicate_sql) = 'text'
+                AND length(CAST(predicate_sql AS BLOB)) BETWEEN 1 AND 4096
+                AND instr(predicate_sql, char(0)) = 0
+            )
+        ),
+    lifecycle_state INTEGER NOT NULL CHECK (lifecycle_state > 0),
+    key_encoding_version INTEGER NOT NULL CHECK (key_encoding_version > 0),
+    schema_generation INTEGER NOT NULL
+        CHECK (schema_generation BETWEEN 0 AND 2147483647),
+    topology_kind INTEGER NOT NULL CHECK (topology_kind >= 0),
+    topology_version INTEGER NOT NULL CHECK (topology_version >= 0),
+    partition_count INTEGER NOT NULL CHECK (partition_count BETWEEN 0 AND 256),
+    UNIQUE (table_id, index_name),
+    FOREIGN KEY (table_id)
+        REFERENCES briskdb_tables (table_id)
+        ON DELETE RESTRICT,
+    CHECK (is_unique = 1 OR null_semantics = 1)
+) STRICT";
+const V13_GLOBAL_INDEX_PARTS_TABLE_SQL: &str = "CREATE TABLE briskdb_global_index_parts (
+    index_id INTEGER NOT NULL,
+    ordinal INTEGER NOT NULL CHECK (ordinal BETWEEN 0 AND 15),
+    source_kind INTEGER NOT NULL CHECK (source_kind > 0),
+    source_text TEXT NOT NULL COLLATE BINARY
+        CHECK (
+            typeof(source_text) = 'text'
+            AND length(CAST(source_text AS BLOB)) BETWEEN 1 AND 4096
+            AND instr(source_text, char(0)) = 0
+        ),
+    key_type INTEGER NOT NULL CHECK (key_type > 0),
+    sort_order INTEGER NOT NULL CHECK (sort_order > 0),
+    null_order INTEGER NOT NULL CHECK (null_order > 0),
+    collation_version INTEGER NOT NULL CHECK (collation_version > 0),
+    PRIMARY KEY (index_id, ordinal),
+    FOREIGN KEY (index_id)
+        REFERENCES briskdb_global_indexes (index_id)
+        ON DELETE CASCADE
 ) STRICT";
 const V5_SHARD_LAYOUT_TABLE_SQL: &str = "CREATE TABLE briskdb_shard_layout (
     singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
@@ -1129,6 +1231,13 @@ const MIGRATIONS: &[Migration] = &[
         apply: migrate_v11_to_v12,
         validate: validate_v12,
     },
+    Migration {
+        from: V12_SCHEMA_VERSION,
+        to: V13_SCHEMA_VERSION,
+        name: "global_index_catalog_and_lifecycle",
+        apply: migrate_v12_to_v13,
+        validate: validate_v13,
+    },
 ];
 
 #[derive(Clone, Copy)]
@@ -1142,8 +1251,8 @@ struct MigrationPlan<'a> {
 const CURRENT_PLAN: MigrationPlan<'static> = MigrationPlan {
     current_version: CURRENT_SCHEMA_VERSION,
     migrations: MIGRATIONS,
-    initialize_current: create_v12_schema,
-    initialize_interrupted_legacy: migrate_interrupted_legacy_to_v12,
+    initialize_current: create_v13_schema,
+    initialize_interrupted_legacy: migrate_interrupted_legacy_to_v13,
 };
 
 // Startup uses this frozen plan only to finish an already-active v6 journal
@@ -2756,7 +2865,9 @@ pub(super) fn inspect_with_v9_plan_for_test(
 fn downgrade_v10_manifest_to_v9_for_test(connection: &Connection) -> EngineResult<()> {
     connection
         .execute_batch(
-            "DROP TABLE IF EXISTS briskdb_hilo_leases;
+            "DROP TABLE IF EXISTS briskdb_global_index_parts;
+             DROP TABLE IF EXISTS briskdb_global_indexes;
+             DROP TABLE IF EXISTS briskdb_hilo_leases;
              DROP TABLE IF EXISTS briskdb_generated_table_ddl;
              DROP TABLE briskdb_table_provisioning_declarations;
              DROP TABLE briskdb_table_provisioning;
@@ -2817,9 +2928,12 @@ fn downgrade_v11_manifest_to_v10_for_test(
     connection: &Connection,
     shard_count: u16,
 ) -> EngineResult<()> {
+    if read_identity(connection)?.1 >= i64::from(V12_SCHEMA_VERSION) {
+        downgrade_v12_manifest_to_v11_for_test(connection, shard_count)?;
+    }
     connection
         .execute_batch(
-            "DROP TABLE briskdb_generated_table_ddl;
+            "DROP TABLE IF EXISTS briskdb_generated_table_ddl;
              DROP TABLE briskdb_hilo_leases;
              DROP TABLE briskdb_metadata;",
         )
@@ -2850,6 +2964,9 @@ fn downgrade_v12_manifest_to_v11_for_test(
     connection: &Connection,
     shard_count: u16,
 ) -> EngineResult<()> {
+    if read_identity(connection)?.1 == i64::from(V13_SCHEMA_VERSION) {
+        downgrade_v13_manifest_to_v12_for_test(connection, shard_count)?;
+    }
     connection
         .execute_batch(
             "DROP TABLE briskdb_generated_table_ddl;
@@ -2874,6 +2991,39 @@ fn downgrade_v12_manifest_to_v11_for_test(
     set_identity(connection, V11_SCHEMA_VERSION)?;
     refresh_manifest_digest(connection)?;
     validate_v11(connection, shard_count, &schema_objects(connection)?)?;
+    Ok(())
+}
+
+#[cfg(test)]
+fn downgrade_v13_manifest_to_v12_for_test(
+    connection: &Connection,
+    shard_count: u16,
+) -> EngineResult<()> {
+    connection
+        .execute_batch(
+            "DROP TABLE briskdb_global_index_parts;
+             DROP TABLE briskdb_global_indexes;
+             DROP TABLE briskdb_metadata;",
+        )
+        .map_err(sqlite_error::storage)?;
+    connection
+        .execute_batch(V12_DOWNGRADE_FENCE_SQL)
+        .map_err(sqlite_error::storage)?;
+    connection
+        .execute(
+            "INSERT INTO briskdb_metadata (requires_manifest_version) VALUES (?1)",
+            [V12_SCHEMA_VERSION],
+        )
+        .map_err(sqlite_error::storage)?;
+    connection
+        .execute(
+            "UPDATE briskdb_integrity SET manifest_digest_version = ?1 WHERE singleton = 1",
+            [V5_MANIFEST_DIGEST_VERSION],
+        )
+        .map_err(sqlite_error::storage)?;
+    set_identity(connection, V12_SCHEMA_VERSION)?;
+    refresh_manifest_digest(connection)?;
+    validate_v12(connection, shard_count, &schema_objects(connection)?)?;
     Ok(())
 }
 
@@ -3524,6 +3674,418 @@ where
         ));
     }
     Ok(replacement)
+}
+
+/// Atomically add one checksummed global-index definition in `Creating` state.
+pub(super) fn create_global_index<F>(
+    connection: &mut Connection,
+    requested_shards: u16,
+    declaration: &GlobalIndexDeclaration,
+    on_commit_attempted: F,
+) -> EngineResult<(CatalogSnapshot, GlobalIndexId)>
+where
+    F: FnOnce(),
+{
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    let current = current_manifest_snapshot(&transaction, requested_shards)?;
+    ensure_global_index_catalog_ready(&current)?;
+    let catalog = current.logical_catalog.as_ref().ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::Internal,
+            "global-index creation omitted the logical catalog",
+        )
+    })?;
+    let Some(table) = catalog.table_by_id(declaration.table_id()) else {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            format!(
+                "global index {} references unknown table {}",
+                declaration.name(),
+                declaration.table_id()
+            ),
+        ));
+    };
+    if !matches!(table.placement(), TablePlacement::Sharded(_)) {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            "global indexes currently require Sharded table placement",
+        ));
+    }
+    if catalog.global_indexes().len() >= MAX_GLOBAL_INDEXES {
+        return Err(EngineError::new(
+            EngineErrorKind::LimitExceeded,
+            format!("global-index catalog has reached its {MAX_GLOBAL_INDEXES}-entry limit"),
+        ));
+    }
+    if let Some(existing) = catalog.global_indexes().iter().find(|index| {
+        index.table_id() == declaration.table_id() && index.name() == declaration.name()
+    }) {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!(
+                "global index {} already exists with ID {} and lifecycle {:?}",
+                declaration.name(),
+                existing.id(),
+                existing.lifecycle()
+            ),
+        ));
+    }
+
+    let index_id = transaction
+        .query_row(
+            "SELECT COALESCE(MAX(index_id), 0) FROM briskdb_global_indexes",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .map_err(|error| manifest_read_error(error, "failed to allocate a global-index ID"))?
+        .checked_add(1)
+        .ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::NumericOutOfRange,
+                "global-index ID space is exhausted",
+            )
+        })?;
+    let table_id = i64::try_from(declaration.table_id().get()).map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::NumericOutOfRange,
+            "global-index table ID does not fit in SQLite",
+            error,
+        )
+    })?;
+    let (topology_kind, topology_version, partition_count) =
+        declaration.topology().persisted_parts();
+    transaction
+        .execute(
+            "INSERT INTO briskdb_global_indexes (
+                index_id, table_id, index_name, is_unique, null_semantics,
+                predicate_sql, lifecycle_state, key_encoding_version,
+                schema_generation, topology_kind, topology_version, partition_count
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+            rusqlite::params![
+                index_id,
+                table_id,
+                declaration.name(),
+                if declaration.is_unique() {
+                    GLOBAL_INDEX_UNIQUE
+                } else {
+                    GLOBAL_INDEX_NON_UNIQUE
+                },
+                encode_unique_null_semantics(declaration.null_semantics()),
+                declaration.predicate(),
+                GLOBAL_INDEX_CREATING,
+                INDEX_KEY_ENCODING_VERSION,
+                i64::try_from(catalog.schema_generation()).expect("schema generation fits SQLite"),
+                topology_kind,
+                topology_version,
+                partition_count,
+            ],
+        )
+        .map_err(sqlite_error::storage)?;
+    {
+        let mut insert = transaction
+            .prepare(
+                "INSERT INTO briskdb_global_index_parts (
+                    index_id, ordinal, source_kind, source_text, key_type,
+                    sort_order, null_order, collation_version
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            )
+            .map_err(sqlite_error::storage)?;
+        for (ordinal, part) in declaration.key_parts().iter().enumerate() {
+            insert
+                .execute(rusqlite::params![
+                    index_id,
+                    i64::try_from(ordinal).expect("global-index ordinal fits SQLite"),
+                    part.source().kind_code(),
+                    part.source().source(),
+                    encode_global_index_key_type(part.key_type()),
+                    encode_global_index_order(part.order()),
+                    encode_global_index_null_order(part.null_order()),
+                    encode_global_index_collation(part.collation()),
+                ])
+                .map_err(sqlite_error::storage)?;
+        }
+    }
+    refresh_manifest_digest(&transaction)?;
+    let replacement = current_manifest_snapshot(&transaction, requested_shards)?;
+    let persisted_id = GlobalIndexId::from_validated(
+        u64::try_from(index_id).expect("positive global-index ID fits u64"),
+    );
+    if replacement
+        .logical_catalog
+        .as_ref()
+        .and_then(|catalog| catalog.global_index_by_id(persisted_id))
+        .is_none_or(|index| index.lifecycle() != GlobalIndexLifecycle::Creating)
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::Internal,
+            "global-index creation did not persist its complete Creating definition",
+        ));
+    }
+    let replacement = catalog_snapshot_from_manifest(replacement)?;
+    on_commit_attempted();
+    #[cfg(test)]
+    abort_global_index_at_test_boundary("create-before-commit");
+    transaction.commit().map_err(sqlite_error::storage)?;
+    #[cfg(test)]
+    abort_global_index_at_test_boundary("create-after-commit");
+    Ok((replacement, persisted_id))
+}
+
+/// Atomically apply one validated lifecycle transition.
+pub(super) fn transition_global_index<F>(
+    connection: &mut Connection,
+    requested_shards: u16,
+    index_id: GlobalIndexId,
+    target: GlobalIndexLifecycle,
+    on_commit_attempted: F,
+) -> EngineResult<CatalogSnapshot>
+where
+    F: FnOnce(),
+{
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    let current = current_manifest_snapshot(&transaction, requested_shards)?;
+    ensure_global_index_catalog_ready(&current)?;
+    let catalog = current.logical_catalog.as_ref().ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::Internal,
+            "global-index transition omitted the logical catalog",
+        )
+    })?;
+    let existing = catalog.global_index_by_id(index_id).ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            format!("global index {index_id} does not exist"),
+        )
+    })?;
+    if !existing.lifecycle().can_transition_to(target) {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!(
+                "global index {index_id} cannot transition from {:?} to {target:?}",
+                existing.lifecycle()
+            ),
+        ));
+    }
+    if matches!(
+        target,
+        GlobalIndexLifecycle::Ready | GlobalIndexLifecycle::Rebuilding
+    ) && existing.topology() == GlobalIndexStorageTopology::Unassigned
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!("global index {index_id} cannot become {target:?} without a storage topology"),
+        ));
+    }
+    if matches!(
+        target,
+        GlobalIndexLifecycle::Ready | GlobalIndexLifecycle::Rebuilding
+    ) && existing.schema_generation() != catalog.schema_generation()
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!(
+                "global index {index_id} belongs to schema generation {}, not current generation {}",
+                existing.schema_generation(),
+                catalog.schema_generation()
+            ),
+        ));
+    }
+    let changed = transaction
+        .execute(
+            "UPDATE briskdb_global_indexes
+             SET lifecycle_state = ?1
+             WHERE index_id = ?2 AND lifecycle_state = ?3",
+            rusqlite::params![
+                encode_global_index_lifecycle(target),
+                i64::try_from(index_id.get()).map_err(|error| {
+                    EngineError::from_source(
+                        EngineErrorKind::NumericOutOfRange,
+                        "global-index ID does not fit in SQLite",
+                        error,
+                    )
+                })?,
+                encode_global_index_lifecycle(existing.lifecycle()),
+            ],
+        )
+        .map_err(sqlite_error::storage)?;
+    if changed != 1 {
+        return Err(EngineError::new(
+            EngineErrorKind::Busy,
+            format!("global index {index_id} changed concurrently; reload the catalog and retry"),
+        ));
+    }
+    refresh_manifest_digest(&transaction)?;
+    let replacement = current_manifest_snapshot(&transaction, requested_shards)?;
+    if replacement
+        .logical_catalog
+        .as_ref()
+        .and_then(|catalog| catalog.global_index_by_id(index_id))
+        .is_none_or(|index| index.lifecycle() != target)
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::Internal,
+            "global-index lifecycle transition did not persist",
+        ));
+    }
+    let replacement = catalog_snapshot_from_manifest(replacement)?;
+    on_commit_attempted();
+    #[cfg(test)]
+    abort_global_index_at_test_boundary("transition-before-commit");
+    transaction.commit().map_err(sqlite_error::storage)?;
+    #[cfg(test)]
+    abort_global_index_at_test_boundary("transition-after-commit");
+    Ok(replacement)
+}
+
+/// Remove a definition only after its durable `Dropping` phase is visible.
+pub(super) fn remove_global_index<F>(
+    connection: &mut Connection,
+    requested_shards: u16,
+    index_id: GlobalIndexId,
+    on_commit_attempted: F,
+) -> EngineResult<CatalogSnapshot>
+where
+    F: FnOnce(),
+{
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    let current = current_manifest_snapshot(&transaction, requested_shards)?;
+    ensure_global_index_catalog_ready(&current)?;
+    let existing = current
+        .logical_catalog
+        .as_ref()
+        .and_then(|catalog| catalog.global_index_by_id(index_id))
+        .ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                format!("global index {index_id} does not exist"),
+            )
+        })?;
+    if existing.lifecycle() != GlobalIndexLifecycle::Dropping {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!("global index {index_id} must enter Dropping before removal"),
+        ));
+    }
+    let changed = transaction
+        .execute(
+            "DELETE FROM briskdb_global_indexes
+             WHERE index_id = ?1 AND lifecycle_state = ?2",
+            rusqlite::params![
+                i64::try_from(index_id.get()).map_err(|error| {
+                    EngineError::from_source(
+                        EngineErrorKind::NumericOutOfRange,
+                        "global-index ID does not fit in SQLite",
+                        error,
+                    )
+                })?,
+                GLOBAL_INDEX_DROPPING,
+            ],
+        )
+        .map_err(sqlite_error::storage)?;
+    if changed != 1 {
+        return Err(EngineError::new(
+            EngineErrorKind::Busy,
+            format!("global index {index_id} changed concurrently; reload the catalog and retry"),
+        ));
+    }
+    refresh_manifest_digest(&transaction)?;
+    let replacement = current_manifest_snapshot(&transaction, requested_shards)?;
+    if replacement
+        .logical_catalog
+        .as_ref()
+        .and_then(|catalog| catalog.global_index_by_id(index_id))
+        .is_some()
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::Internal,
+            "global-index removal did not remove its catalog definition",
+        ));
+    }
+    let replacement = catalog_snapshot_from_manifest(replacement)?;
+    on_commit_attempted();
+    #[cfg(test)]
+    abort_global_index_at_test_boundary("remove-before-commit");
+    transaction.commit().map_err(sqlite_error::storage)?;
+    #[cfg(test)]
+    abort_global_index_at_test_boundary("remove-after-commit");
+    Ok(replacement)
+}
+
+fn ensure_global_index_catalog_ready(snapshot: &ManifestSnapshot) -> EngineResult<()> {
+    ensure_table_registration_ready(snapshot)?;
+    if snapshot.active_table_provisioning.is_some() {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "global-index catalog mutation cannot overlap table provisioning",
+        ));
+    }
+    if snapshot
+        .generated_table_ddl
+        .as_ref()
+        .is_some_and(|ddl| ddl.lifecycle() != GeneratedTableDdlLifecycle::Complete)
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "global-index catalog mutation cannot overlap generated-table DDL",
+        ));
+    }
+    Ok(())
+}
+
+const fn encode_unique_null_semantics(value: UniqueNullSemantics) -> i64 {
+    match value {
+        UniqueNullSemantics::Distinct => GLOBAL_INDEX_NULLS_DISTINCT,
+        UniqueNullSemantics::NotDistinct => GLOBAL_INDEX_NULLS_NOT_DISTINCT,
+    }
+}
+
+const fn encode_global_index_lifecycle(value: GlobalIndexLifecycle) -> i64 {
+    match value {
+        GlobalIndexLifecycle::Creating => GLOBAL_INDEX_CREATING,
+        GlobalIndexLifecycle::Ready => GLOBAL_INDEX_READY,
+        GlobalIndexLifecycle::Invalid => GLOBAL_INDEX_INVALID,
+        GlobalIndexLifecycle::Rebuilding => GLOBAL_INDEX_REBUILDING,
+        GlobalIndexLifecycle::Dropping => GLOBAL_INDEX_DROPPING,
+    }
+}
+
+const fn encode_global_index_key_type(value: GlobalIndexKeyType) -> i64 {
+    match value {
+        GlobalIndexKeyType::Boolean => GLOBAL_INDEX_KEY_BOOLEAN,
+        GlobalIndexKeyType::Int64 => GLOBAL_INDEX_KEY_INT64,
+        GlobalIndexKeyType::UInt64 => GLOBAL_INDEX_KEY_UINT64,
+        GlobalIndexKeyType::Float64 => GLOBAL_INDEX_KEY_FLOAT64,
+        GlobalIndexKeyType::Date => GLOBAL_INDEX_KEY_DATE,
+        GlobalIndexKeyType::Timestamp => GLOBAL_INDEX_KEY_TIMESTAMP,
+        GlobalIndexKeyType::Text => GLOBAL_INDEX_KEY_TEXT,
+        GlobalIndexKeyType::Binary => GLOBAL_INDEX_KEY_BINARY,
+    }
+}
+
+const fn encode_global_index_order(value: IndexKeyOrder) -> i64 {
+    match value {
+        IndexKeyOrder::Ascending => GLOBAL_INDEX_ASCENDING,
+        IndexKeyOrder::Descending => GLOBAL_INDEX_DESCENDING,
+    }
+}
+
+const fn encode_global_index_null_order(value: IndexNullOrder) -> i64 {
+    match value {
+        IndexNullOrder::First => GLOBAL_INDEX_NULLS_FIRST,
+        IndexNullOrder::Last => GLOBAL_INDEX_NULLS_LAST,
+    }
+}
+
+const fn encode_global_index_collation(value: IndexKeyCollation) -> i64 {
+    match value {
+        IndexKeyCollation::Binary => GLOBAL_INDEX_BINARY_COLLATION,
+    }
 }
 
 fn insert_authoritative_table_catalog(
@@ -4257,6 +4819,11 @@ fn create_v12_schema(transaction: &Transaction<'_>, shard_count: u16) -> EngineR
     migrate_v11_to_v12(transaction, shard_count)
 }
 
+fn create_v13_schema(transaction: &Transaction<'_>, shard_count: u16) -> EngineResult<()> {
+    create_v12_schema(transaction, shard_count)?;
+    migrate_v12_to_v13(transaction, shard_count)
+}
+
 fn migrate_interrupted_legacy_to_v6(
     transaction: &Transaction<'_>,
     shard_count: u16,
@@ -4324,6 +4891,7 @@ fn migrate_interrupted_legacy_to_v11(
     create_v11_schema(transaction, shard_count)
 }
 
+#[cfg(test)]
 fn migrate_interrupted_legacy_to_v12(
     transaction: &Transaction<'_>,
     shard_count: u16,
@@ -4332,6 +4900,16 @@ fn migrate_interrupted_legacy_to_v12(
         .execute_batch("DROP TABLE briskdb_metadata;")
         .map_err(sqlite_error::storage)?;
     create_v12_schema(transaction, shard_count)
+}
+
+fn migrate_interrupted_legacy_to_v13(
+    transaction: &Transaction<'_>,
+    shard_count: u16,
+) -> EngineResult<()> {
+    transaction
+        .execute_batch("DROP TABLE briskdb_metadata;")
+        .map_err(sqlite_error::storage)?;
+    create_v13_schema(transaction, shard_count)
 }
 
 #[cfg(test)]
@@ -4810,6 +5388,36 @@ fn migrate_v11_to_v12(transaction: &Transaction<'_>, _shard_count: u16) -> Engin
     Ok(())
 }
 
+fn migrate_v12_to_v13(transaction: &Transaction<'_>, _shard_count: u16) -> EngineResult<()> {
+    transaction
+        .execute_batch(V13_GLOBAL_INDEXES_TABLE_SQL)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch(V13_GLOBAL_INDEX_PARTS_TABLE_SQL)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch("DROP TABLE briskdb_metadata;")
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch(V13_DOWNGRADE_FENCE_SQL)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "INSERT INTO briskdb_metadata (requires_manifest_version) VALUES (?1)",
+            [V13_SCHEMA_VERSION],
+        )
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "UPDATE briskdb_integrity
+             SET manifest_digest_version = ?1
+             WHERE singleton = 1",
+            [V6_MANIFEST_DIGEST_VERSION],
+        )
+        .map_err(sqlite_error::storage)?;
+    Ok(())
+}
+
 fn add_v5_schema(transaction: &Transaction<'_>, state: ShardLayoutState) -> EngineResult<()> {
     transaction
         .execute_batch("DROP TABLE briskdb_metadata;")
@@ -5158,6 +5766,20 @@ fn v12_objects() -> Vec<SchemaObject> {
     objects
 }
 
+fn v13_objects() -> Vec<SchemaObject> {
+    let mut objects = v12_objects();
+    for name in ["briskdb_global_index_parts", "briskdb_global_indexes"] {
+        objects.push(SchemaObject {
+            object_type: "table".to_owned(),
+            name: name.to_owned(),
+        });
+    }
+    objects.sort_by(|left, right| {
+        (&left.object_type, &left.name).cmp(&(&right.object_type, &right.name))
+    });
+    objects
+}
+
 fn schema_objects(connection: &Connection) -> EngineResult<Vec<SchemaObject>> {
     let mut statement = connection
         .prepare(
@@ -5290,6 +5912,14 @@ fn validate_table(
         "briskdb_generated_table_ddl" => {
             "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden
              FROM pragma_table_xinfo('briskdb_generated_table_ddl') LIMIT ?1"
+        }
+        "briskdb_global_indexes" => {
+            "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden
+             FROM pragma_table_xinfo('briskdb_global_indexes') LIMIT ?1"
+        }
+        "briskdb_global_index_parts" => {
+            "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden
+             FROM pragma_table_xinfo('briskdb_global_index_parts') LIMIT ?1"
         }
         _ => {
             return Err(EngineError::new(
@@ -5892,7 +6522,7 @@ fn validate_v12(
     requested_shards: u16,
     objects: &[SchemaObject],
 ) -> EngineResult<ManifestSnapshot> {
-    let mut snapshot = validate_integrity_manifest_with_definition(
+    validate_v12_features(
         connection,
         requested_shards,
         objects,
@@ -5903,6 +6533,48 @@ fn validate_v12(
             expected_manifest_digest_version: V5_MANIFEST_DIGEST_VERSION,
             generated_ids: true,
         },
+    )
+}
+
+fn validate_v13(
+    connection: &Connection,
+    requested_shards: u16,
+    objects: &[SchemaObject],
+) -> EngineResult<ManifestSnapshot> {
+    let mut snapshot = validate_v12_features(
+        connection,
+        requested_shards,
+        objects,
+        IntegrityManifestDefinition {
+            version: V13_SCHEMA_VERSION,
+            downgrade_fence_sql: V13_DOWNGRADE_FENCE_SQL,
+            expected_objects: &v13_objects(),
+            expected_manifest_digest_version: V6_MANIFEST_DIGEST_VERSION,
+            generated_ids: true,
+        },
+    )?;
+    let catalog = snapshot.logical_catalog.take().ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::Internal,
+            "global-index validation omitted the logical table catalog",
+        )
+    })?;
+    let indexes = validate_global_indexes(connection, &catalog)?;
+    snapshot.logical_catalog = Some(catalog.with_global_indexes(indexes));
+    Ok(snapshot)
+}
+
+fn validate_v12_features(
+    connection: &Connection,
+    requested_shards: u16,
+    objects: &[SchemaObject],
+    definition: IntegrityManifestDefinition<'_>,
+) -> EngineResult<ManifestSnapshot> {
+    let mut snapshot = validate_integrity_manifest_with_definition(
+        connection,
+        requested_shards,
+        objects,
+        definition,
     )?;
     snapshot.allocation_owners = Some(validate_allocation_owners(
         connection,
@@ -5919,7 +6591,7 @@ fn validate_v12(
     )?;
     snapshot.active_table_provisioning = validate_table_provisioning(
         connection,
-        V12_SCHEMA_VERSION,
+        definition.version,
         snapshot.shard_count,
         snapshot.logical_catalog.as_ref(),
         snapshot.active_migration.as_ref(),
@@ -5956,6 +6628,488 @@ fn validate_v12(
     )?;
     snapshot.generated_table_ddl = validate_generated_table_ddl(connection, &snapshot)?;
     Ok(snapshot)
+}
+
+#[derive(Debug)]
+struct ValidatedGlobalIndexRow {
+    id: u64,
+    table_id: u64,
+    name: String,
+    unique: bool,
+    null_semantics: UniqueNullSemantics,
+    predicate: Option<String>,
+    lifecycle: GlobalIndexLifecycle,
+    schema_generation: u64,
+    topology: GlobalIndexStorageTopology,
+}
+
+#[allow(clippy::type_complexity)]
+fn validate_global_indexes(
+    connection: &Connection,
+    catalog: &Catalog,
+) -> EngineResult<Box<[GlobalIndexMetadata]>> {
+    validate_table(
+        connection,
+        "briskdb_global_indexes",
+        &[
+            TableColumn::expected(0, "index_id", "INTEGER", false, 1),
+            TableColumn::expected(1, "table_id", "INTEGER", true, 0),
+            TableColumn::expected(2, "index_name", "TEXT", true, 0),
+            TableColumn::expected(3, "is_unique", "INTEGER", true, 0),
+            TableColumn::expected(4, "null_semantics", "INTEGER", true, 0),
+            TableColumn::expected(5, "predicate_sql", "TEXT", false, 0),
+            TableColumn::expected(6, "lifecycle_state", "INTEGER", true, 0),
+            TableColumn::expected(7, "key_encoding_version", "INTEGER", true, 0),
+            TableColumn::expected(8, "schema_generation", "INTEGER", true, 0),
+            TableColumn::expected(9, "topology_kind", "INTEGER", true, 0),
+            TableColumn::expected(10, "topology_version", "INTEGER", true, 0),
+            TableColumn::expected(11, "partition_count", "INTEGER", true, 0),
+        ],
+        true,
+    )?;
+    validate_table_sql(
+        connection,
+        "briskdb_global_indexes",
+        V13_GLOBAL_INDEXES_TABLE_SQL,
+    )?;
+    validate_table(
+        connection,
+        "briskdb_global_index_parts",
+        &[
+            TableColumn::expected(0, "index_id", "INTEGER", true, 1),
+            TableColumn::expected(1, "ordinal", "INTEGER", true, 2),
+            TableColumn::expected(2, "source_kind", "INTEGER", true, 0),
+            TableColumn::expected(3, "source_text", "TEXT", true, 0),
+            TableColumn::expected(4, "key_type", "INTEGER", true, 0),
+            TableColumn::expected(5, "sort_order", "INTEGER", true, 0),
+            TableColumn::expected(6, "null_order", "INTEGER", true, 0),
+            TableColumn::expected(7, "collation_version", "INTEGER", true, 0),
+        ],
+        true,
+    )?;
+    validate_table_sql(
+        connection,
+        "briskdb_global_index_parts",
+        V13_GLOBAL_INDEX_PARTS_TABLE_SQL,
+    )?;
+
+    let rows = connection
+        .prepare(
+            "SELECT index_id, table_id, index_name, is_unique, null_semantics,
+                    predicate_sql, lifecycle_state, key_encoding_version,
+                    schema_generation, topology_kind, topology_version, partition_count
+             FROM briskdb_global_indexes
+             ORDER BY index_id
+             LIMIT 4097",
+        )
+        .and_then(|mut statement| {
+            statement
+                .query_map([], |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, String>(2)?,
+                        row.get::<_, i64>(3)?,
+                        row.get::<_, i64>(4)?,
+                        row.get::<_, Option<String>>(5)?,
+                        row.get::<_, i64>(6)?,
+                        row.get::<_, i64>(7)?,
+                        row.get::<_, i64>(8)?,
+                        row.get::<_, i64>(9)?,
+                        row.get::<_, i64>(10)?,
+                        row.get::<_, i64>(11)?,
+                    ))
+                })?
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .map_err(|error| manifest_read_error(error, "failed to read global-index catalog"))?;
+    if rows.len() > MAX_GLOBAL_INDEXES {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "global-index catalog exceeds its supported entry limit",
+        ));
+    }
+
+    let mut validated_rows = Vec::with_capacity(rows.len());
+    for row in rows {
+        let (
+            id,
+            table_id,
+            name,
+            unique,
+            null_semantics,
+            predicate,
+            lifecycle,
+            key_encoding_version,
+            schema_generation,
+            topology_kind,
+            topology_version,
+            partition_count,
+        ) = row;
+        let id = positive_catalog_id(id, "global index")?;
+        let table_id = positive_catalog_id(table_id, "table")?;
+        if !validate_catalog_identifier(&name) {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!("global index {id} has an invalid canonical name"),
+            ));
+        }
+        if predicate.as_ref().is_some_and(|predicate| {
+            predicate.is_empty()
+                || predicate.len() > MAX_GLOBAL_INDEX_SQL_BYTES
+                || predicate.as_bytes().contains(&0)
+        }) {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!("global index {id} has an invalid predicate"),
+            ));
+        }
+        let Some(table) = catalog.table_by_id(TableId::from_validated(table_id)) else {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!("global index {id} references a missing table"),
+            ));
+        };
+        if !matches!(table.placement(), TablePlacement::Sharded(_)) {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!("global index {id} must reference a Sharded table"),
+            ));
+        }
+        let unique = match unique {
+            GLOBAL_INDEX_NON_UNIQUE => false,
+            GLOBAL_INDEX_UNIQUE => true,
+            _ => {
+                return Err(EngineError::new(
+                    EngineErrorKind::DataCorruption,
+                    format!("global index {id} has invalid uniqueness metadata"),
+                ));
+            }
+        };
+        let null_semantics = match null_semantics {
+            GLOBAL_INDEX_NULLS_DISTINCT => UniqueNullSemantics::Distinct,
+            GLOBAL_INDEX_NULLS_NOT_DISTINCT if unique => UniqueNullSemantics::NotDistinct,
+            value if value > GLOBAL_INDEX_NULLS_NOT_DISTINCT => {
+                return Err(unsupported_global_index(
+                    id,
+                    "NULL-semantics version",
+                    value,
+                ));
+            }
+            _ => {
+                return Err(EngineError::new(
+                    EngineErrorKind::DataCorruption,
+                    format!("global index {id} has inconsistent NULL semantics"),
+                ));
+            }
+        };
+        let lifecycle = decode_global_index_lifecycle(id, lifecycle)?;
+        if key_encoding_version > i64::from(INDEX_KEY_ENCODING_VERSION) {
+            return Err(unsupported_global_index(
+                id,
+                "key encoding version",
+                key_encoding_version,
+            ));
+        }
+        if key_encoding_version != i64::from(INDEX_KEY_ENCODING_VERSION) {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!("global index {id} has an invalid key encoding version"),
+            ));
+        }
+        let schema_generation = u64::try_from(schema_generation).map_err(|error| {
+            EngineError::from_source(
+                EngineErrorKind::DataCorruption,
+                format!("global index {id} has an invalid schema generation"),
+                error,
+            )
+        })?;
+        let topology =
+            decode_global_index_topology(id, topology_kind, topology_version, partition_count)?;
+        if matches!(
+            lifecycle,
+            GlobalIndexLifecycle::Creating
+                | GlobalIndexLifecycle::Ready
+                | GlobalIndexLifecycle::Rebuilding
+        ) && schema_generation != catalog.schema_generation()
+        {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "global index {id} targets schema generation {schema_generation}, but the catalog is at generation {}; mark, rebuild, or drop the index before opening",
+                    catalog.schema_generation()
+                ),
+            ));
+        }
+        if matches!(
+            lifecycle,
+            GlobalIndexLifecycle::Ready | GlobalIndexLifecycle::Rebuilding
+        ) && topology == GlobalIndexStorageTopology::Unassigned
+        {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!("global index {id} is active without a storage topology"),
+            ));
+        }
+        validated_rows.push(ValidatedGlobalIndexRow {
+            id,
+            table_id,
+            name,
+            unique,
+            null_semantics,
+            predicate,
+            lifecycle,
+            schema_generation,
+            topology,
+        });
+    }
+
+    let part_limit = i64::try_from(MAX_GLOBAL_INDEXES * MAX_GLOBAL_INDEX_PARTS + 1)
+        .expect("global-index part limit fits SQLite");
+    let parts = connection
+        .prepare(
+            "SELECT index_id, ordinal, source_kind, source_text, key_type,
+                    sort_order, null_order, collation_version
+             FROM briskdb_global_index_parts
+             ORDER BY index_id, ordinal
+             LIMIT ?1",
+        )
+        .and_then(|mut statement| {
+            statement
+                .query_map([part_limit], |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, i64>(2)?,
+                        row.get::<_, String>(3)?,
+                        row.get::<_, i64>(4)?,
+                        row.get::<_, i64>(5)?,
+                        row.get::<_, i64>(6)?,
+                        row.get::<_, i64>(7)?,
+                    ))
+                })?
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .map_err(|error| manifest_read_error(error, "failed to read global-index key parts"))?;
+    if parts.len() > MAX_GLOBAL_INDEXES * MAX_GLOBAL_INDEX_PARTS {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "global-index key-part catalog exceeds its supported limit",
+        ));
+    }
+
+    let mut part_cursor = 0;
+    let mut indexes = Vec::with_capacity(validated_rows.len());
+    for row in validated_rows {
+        let mut key_parts = Vec::new();
+        while let Some(part) = parts.get(part_cursor) {
+            let part_index_id = positive_catalog_id(part.0, "global index")?;
+            if part_index_id != row.id {
+                break;
+            }
+            let expected_ordinal =
+                i64::try_from(key_parts.len()).expect("key-part ordinal fits i64");
+            if part.1 != expected_ordinal || key_parts.len() >= MAX_GLOBAL_INDEX_PARTS {
+                return Err(EngineError::new(
+                    EngineErrorKind::DataCorruption,
+                    format!(
+                        "global index {} has non-contiguous or excessive key parts",
+                        row.id
+                    ),
+                ));
+            }
+            key_parts.push(decode_global_index_key_part(row.id, part)?);
+            part_cursor += 1;
+        }
+        if key_parts.is_empty() {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!("global index {} has no key parts", row.id),
+            ));
+        }
+        indexes.push(GlobalIndexMetadata::from_validated(
+            row.id,
+            row.table_id,
+            row.name,
+            key_parts.into_boxed_slice(),
+            row.unique,
+            row.null_semantics,
+            row.predicate,
+            row.lifecycle,
+            row.schema_generation,
+            row.topology,
+        ));
+    }
+    if part_cursor != parts.len() {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "global-index key parts do not match their catalog entries",
+        ));
+    }
+    Ok(indexes.into_boxed_slice())
+}
+
+fn decode_global_index_lifecycle(id: u64, value: i64) -> EngineResult<GlobalIndexLifecycle> {
+    match value {
+        GLOBAL_INDEX_CREATING => Ok(GlobalIndexLifecycle::Creating),
+        GLOBAL_INDEX_READY => Ok(GlobalIndexLifecycle::Ready),
+        GLOBAL_INDEX_INVALID => Ok(GlobalIndexLifecycle::Invalid),
+        GLOBAL_INDEX_REBUILDING => Ok(GlobalIndexLifecycle::Rebuilding),
+        GLOBAL_INDEX_DROPPING => Ok(GlobalIndexLifecycle::Dropping),
+        value if value > GLOBAL_INDEX_DROPPING => {
+            Err(unsupported_global_index(id, "lifecycle state", value))
+        }
+        _ => Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!("global index {id} has an invalid lifecycle state"),
+        )),
+    }
+}
+
+fn decode_global_index_topology(
+    id: u64,
+    kind: i64,
+    version: i64,
+    partitions: i64,
+) -> EngineResult<GlobalIndexStorageTopology> {
+    let supported = match (kind, version, partitions) {
+        (GLOBAL_INDEX_TOPOLOGY_UNASSIGNED, 0, 0) | (GLOBAL_INDEX_TOPOLOGY_SHARED_SQLITE, 1, 1) => {
+            true
+        }
+        (GLOBAL_INDEX_TOPOLOGY_HASH_PARTITIONED_SQLITE, 1, partitions) => {
+            (2..=256).contains(&partitions) && partitions & (partitions - 1) == 0
+        }
+        _ => false,
+    };
+    if supported {
+        return Ok(GlobalIndexStorageTopology::from_validated_parts(
+            kind, version, partitions,
+        ));
+    }
+    if kind > GLOBAL_INDEX_TOPOLOGY_HASH_PARTITIONED_SQLITE || version > 1 {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!(
+                "global index {id} uses unsupported storage topology kind {kind} version {version}"
+            ),
+        ));
+    }
+    Err(EngineError::new(
+        EngineErrorKind::DataCorruption,
+        format!("global index {id} has inconsistent storage topology metadata"),
+    ))
+}
+
+fn decode_global_index_key_part(
+    index_id: u64,
+    part: &(i64, i64, i64, String, i64, i64, i64, i64),
+) -> EngineResult<GlobalIndexKeyPart> {
+    let source = match part.2 {
+        GLOBAL_INDEX_SOURCE_COLUMN if validate_catalog_identifier(&part.3) => {
+            GlobalIndexKeySource::from_validated(part.2, part.3.clone())
+        }
+        GLOBAL_INDEX_SOURCE_EXPRESSION
+            if !part.3.is_empty()
+                && part.3.len() <= MAX_GLOBAL_INDEX_SQL_BYTES
+                && !part.3.as_bytes().contains(&0) =>
+        {
+            GlobalIndexKeySource::from_validated(part.2, part.3.clone())
+        }
+        value if value > GLOBAL_INDEX_SOURCE_EXPRESSION => {
+            return Err(unsupported_global_index(
+                index_id,
+                "key-source version",
+                value,
+            ));
+        }
+        _ => {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!("global index {index_id} has an invalid key source"),
+            ));
+        }
+    };
+    let key_type = match part.4 {
+        GLOBAL_INDEX_KEY_BOOLEAN => GlobalIndexKeyType::Boolean,
+        GLOBAL_INDEX_KEY_INT64 => GlobalIndexKeyType::Int64,
+        GLOBAL_INDEX_KEY_UINT64 => GlobalIndexKeyType::UInt64,
+        GLOBAL_INDEX_KEY_FLOAT64 => GlobalIndexKeyType::Float64,
+        GLOBAL_INDEX_KEY_DATE => GlobalIndexKeyType::Date,
+        GLOBAL_INDEX_KEY_TIMESTAMP => GlobalIndexKeyType::Timestamp,
+        GLOBAL_INDEX_KEY_TEXT => GlobalIndexKeyType::Text,
+        GLOBAL_INDEX_KEY_BINARY => GlobalIndexKeyType::Binary,
+        value if value > GLOBAL_INDEX_KEY_BINARY => {
+            return Err(unsupported_global_index(index_id, "key type", value));
+        }
+        _ => {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!("global index {index_id} has an invalid key type"),
+            ));
+        }
+    };
+    let order = match part.5 {
+        GLOBAL_INDEX_ASCENDING => IndexKeyOrder::Ascending,
+        GLOBAL_INDEX_DESCENDING => IndexKeyOrder::Descending,
+        value if value > GLOBAL_INDEX_DESCENDING => {
+            return Err(unsupported_global_index(
+                index_id,
+                "sort-order version",
+                value,
+            ));
+        }
+        _ => {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!("global index {index_id} has an invalid sort order"),
+            ));
+        }
+    };
+    let null_order = match part.6 {
+        GLOBAL_INDEX_NULLS_FIRST => IndexNullOrder::First,
+        GLOBAL_INDEX_NULLS_LAST => IndexNullOrder::Last,
+        value if value > GLOBAL_INDEX_NULLS_LAST => {
+            return Err(unsupported_global_index(
+                index_id,
+                "NULL-order version",
+                value,
+            ));
+        }
+        _ => {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!("global index {index_id} has an invalid NULL order"),
+            ));
+        }
+    };
+    let collation = match part.7 {
+        GLOBAL_INDEX_BINARY_COLLATION => IndexKeyCollation::Binary,
+        value if value > GLOBAL_INDEX_BINARY_COLLATION => {
+            return Err(unsupported_global_index(
+                index_id,
+                "collation version",
+                value,
+            ));
+        }
+        _ => {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!("global index {index_id} has an invalid collation version"),
+            ));
+        }
+    };
+    Ok(GlobalIndexKeyPart::from_validated(
+        source, key_type, order, null_order, collation,
+    ))
+}
+
+fn unsupported_global_index(id: u64, field: &str, value: i64) -> EngineError {
+    EngineError::new(
+        EngineErrorKind::FailedPrecondition,
+        format!(
+            "global index {id} requires unsupported {field} {value}; upgrade BriskDB before opening this data"
+        ),
+    )
 }
 
 #[allow(clippy::type_complexity)]
@@ -6423,7 +7577,7 @@ fn validate_manifest_semantic_root(
             "manifest checksum version must be positive",
         ));
     }
-    if *version > i64::from(V5_MANIFEST_DIGEST_VERSION) {
+    if *version > i64::from(V6_MANIFEST_DIGEST_VERSION) {
         return Err(EngineError::new(
             EngineErrorKind::FailedPrecondition,
             "manifest checksum version is newer than this BriskDB build supports",
@@ -6644,6 +7798,38 @@ const V5_GENERATED_TABLE_DDL_DIGEST_QUERY: ManifestDigestQuery = ManifestDigestQ
     ],
     sql: "SELECT singleton, logical_id, logical_digest_version, source_dialect, translation_version, source_sql, physical_migration_id, physical_sql, database_id, table_name, generated_column, generated_policy, generated_encoding_version, lifecycle_state, provisioning_id, provisioning_schema_digest, table_id FROM briskdb_generated_table_ddl ORDER BY singleton",
 };
+const V6_GLOBAL_INDEXES_DIGEST_QUERY: ManifestDigestQuery = ManifestDigestQuery {
+    table: "briskdb_global_indexes",
+    columns: &[
+        "index_id",
+        "table_id",
+        "index_name",
+        "is_unique",
+        "null_semantics",
+        "predicate_sql",
+        "lifecycle_state",
+        "key_encoding_version",
+        "schema_generation",
+        "topology_kind",
+        "topology_version",
+        "partition_count",
+    ],
+    sql: "SELECT index_id, table_id, index_name, is_unique, null_semantics, predicate_sql, lifecycle_state, key_encoding_version, schema_generation, topology_kind, topology_version, partition_count FROM briskdb_global_indexes ORDER BY index_id",
+};
+const V6_GLOBAL_INDEX_PARTS_DIGEST_QUERY: ManifestDigestQuery = ManifestDigestQuery {
+    table: "briskdb_global_index_parts",
+    columns: &[
+        "index_id",
+        "ordinal",
+        "source_kind",
+        "source_text",
+        "key_type",
+        "sort_order",
+        "null_order",
+        "collation_version",
+    ],
+    sql: "SELECT index_id, ordinal, source_kind, source_text, key_type, sort_order, null_order, collation_version FROM briskdb_global_index_parts ORDER BY index_id, ordinal",
+};
 
 fn manifest_semantic_digest_for_version(
     connection: &Connection,
@@ -6714,6 +7900,25 @@ fn manifest_semantic_digest_for_version(
                 }
             }
             (V5_MANIFEST_DIGEST_DOMAIN, queries)
+        }
+        V6_MANIFEST_DIGEST_VERSION => {
+            let mut queries = Vec::with_capacity(V1_MANIFEST_DIGEST_QUERIES.len() + 8);
+            for query in V1_MANIFEST_DIGEST_QUERIES {
+                queries.push(query);
+                if query.table == "briskdb_physical_shards" {
+                    queries.push(&V3_ALLOCATION_OWNERS_DIGEST_QUERY);
+                }
+                if query.table == "briskdb_tables" {
+                    queries.push(&V3_GENERATED_IDS_DIGEST_QUERY);
+                    queries.push(&V5_GENERATED_TABLE_DDL_DIGEST_QUERY);
+                    queries.push(&V6_GLOBAL_INDEXES_DIGEST_QUERY);
+                    queries.push(&V6_GLOBAL_INDEX_PARTS_DIGEST_QUERY);
+                    queries.push(&V4_HILO_LEASES_DIGEST_QUERY);
+                    queries.push(&V3_TABLE_PROVISIONING_DIGEST_QUERY);
+                    queries.push(&V3_TABLE_PROVISIONING_DECLARATIONS_DIGEST_QUERY);
+                }
+            }
+            (V6_MANIFEST_DIGEST_DOMAIN, queries)
         }
         0 => {
             return Err(EngineError::new(
@@ -6854,7 +8059,8 @@ fn refresh_manifest_digest_if_checksummed(connection: &Connection) -> EngineResu
                 | V9_SCHEMA_VERSION
                 | V10_SCHEMA_VERSION
                 | V11_SCHEMA_VERSION
-                | V12_SCHEMA_VERSION)
+                | V12_SCHEMA_VERSION
+                | V13_SCHEMA_VERSION)
         )
     {
         let _ = refresh_manifest_digest(connection)?;
@@ -6918,7 +8124,7 @@ fn validate_manifest_integrity(
             "manifest checksum version must be positive",
         ));
     }
-    if *manifest_version > i64::from(V5_MANIFEST_DIGEST_VERSION) {
+    if *manifest_version > i64::from(V6_MANIFEST_DIGEST_VERSION) {
         return Err(EngineError::new(
             EngineErrorKind::FailedPrecondition,
             "manifest checksum version is newer than this BriskDB build supports",
@@ -8688,6 +9894,23 @@ pub(super) fn detect_shard_count(connection: &Connection) -> EngineResult<u16> {
     }
 }
 
+/// Validate and return the durable global-index catalog without upgrading the
+/// manifest. Formats before v13 have no global-index definitions.
+pub(super) fn inspect_global_indexes(
+    connection: &Connection,
+) -> EngineResult<Box<[GlobalIndexMetadata]>> {
+    let shard_count = detect_shard_count(connection)?;
+    match inspect_with_plan(connection, shard_count, CURRENT_PLAN)? {
+        ManifestState::Versioned { snapshot, .. } => Ok(snapshot
+            .logical_catalog
+            .as_ref()
+            .map_or_else(Vec::new, |catalog| catalog.global_indexes().to_vec())
+            .into_boxed_slice()),
+        ManifestState::LegacyV1 { .. } => Ok(Box::new([])),
+        ManifestState::Empty | ManifestState::LegacyUninitialized => Err(shard_count_required()),
+    }
+}
+
 fn shard_count_required() -> EngineError {
     EngineError::new(
         EngineErrorKind::FailedPrecondition,
@@ -9468,7 +10691,7 @@ mod tests {
             identity(connection),
             (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
         );
-        assert_eq!(schema_objects(connection).unwrap(), v12_objects());
+        assert_eq!(schema_objects(connection).unwrap(), v13_objects());
         assert_eq!(
             connection
                 .query_row(
@@ -9535,7 +10758,7 @@ mod tests {
                     |row| row.get::<_, i64>(0),
                 )
                 .unwrap(),
-            i64::from(V5_MANIFEST_DIGEST_VERSION)
+            i64::from(V6_MANIFEST_DIGEST_VERSION)
         );
         let (layout_id, application_id, metadata_version, state) = shard_layout_row(connection);
         assert_eq!(layout_id.len(), 16);
@@ -9654,6 +10877,7 @@ mod tests {
                 (9, 10),
                 (10, 11),
                 (11, 12),
+                (12, 13),
             ]
         );
         assert_generation_one_catalog(&connection, 4);
@@ -9724,7 +10948,7 @@ mod tests {
 
                 load_or_create_manifest(&mut connection, 4).unwrap();
                 assert_eq!(identity(&connection).1, i64::from(CURRENT_SCHEMA_VERSION));
-                assert_eq!(schema_objects(&connection).unwrap(), v12_objects());
+                assert_eq!(schema_objects(&connection).unwrap(), v13_objects());
                 assert_eq!(
                     connection
                         .query_row(
@@ -9733,7 +10957,7 @@ mod tests {
                             |row| row.get::<_, i64>(0),
                         )
                         .unwrap(),
-                    i64::from(V5_MANIFEST_DIGEST_VERSION)
+                    i64::from(V6_MANIFEST_DIGEST_VERSION)
                 );
                 assert_eq!(
                     connection
@@ -10274,7 +11498,7 @@ mod tests {
             identity(&connection),
             (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
         );
-        assert_eq!(schema_objects(&connection).unwrap(), v12_objects());
+        assert_eq!(schema_objects(&connection).unwrap(), v13_objects());
         assert_eq!(table_metadata_rows(&connection), tables_before);
         assert_eq!(logical_databases(&connection), databases_before);
         assert_eq!(routing_configuration(&connection), routing_before);
@@ -10317,7 +11541,7 @@ mod tests {
                     |row| row.get::<_, i64>(0),
                 )
                 .unwrap(),
-            i64::from(V5_MANIFEST_DIGEST_VERSION)
+            i64::from(V6_MANIFEST_DIGEST_VERSION)
         );
         assert_eq!(
             manifest_semantic_digest(&connection).unwrap(),
@@ -10379,7 +11603,9 @@ mod tests {
             .unwrap();
         connection
             .execute_batch(
-                "DROP TABLE briskdb_generated_table_ddl;
+                "DROP TABLE briskdb_global_index_parts;
+                 DROP TABLE briskdb_global_indexes;
+                 DROP TABLE briskdb_generated_table_ddl;
                  DROP TABLE briskdb_hilo_leases;
                  DROP TABLE briskdb_table_provisioning_declarations;
                  DROP TABLE briskdb_table_provisioning;
@@ -10851,7 +12077,7 @@ mod tests {
                     identity(&connection),
                     (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
                 );
-                assert_eq!(schema_objects(&connection).unwrap(), v12_objects());
+                assert_eq!(schema_objects(&connection).unwrap(), v13_objects());
                 assert_eq!(
                     manifest_semantic_digest(&connection).unwrap(),
                     stored_manifest_digest(&connection)
@@ -11217,7 +12443,7 @@ mod tests {
     fn semantic_root_covers_every_authoritative_manifest_table_and_integrity_state() {
         let mutations = [
             "UPDATE briskdb_manifest SET singleton = 2 WHERE singleton = 1",
-            "UPDATE briskdb_metadata SET requires_manifest_version = 13",
+            "UPDATE briskdb_metadata SET requires_manifest_version = 14",
             "UPDATE briskdb_routing SET hash_version = 2 WHERE singleton = 1",
             "UPDATE briskdb_physical_shards SET lifecycle_state = 'retired' WHERE shard_id = 0",
             "UPDATE briskdb_allocation_owners SET owner_slot = 100 WHERE owner_slot = 0",
@@ -11227,6 +12453,11 @@ mod tests {
             "INSERT INTO briskdb_tables VALUES (1, 1, 'widgets', 2, NULL, NULL)",
             "INSERT INTO briskdb_generated_ids VALUES (1, 0, NULL, NULL, 0)",
             "INSERT INTO briskdb_generated_table_ddl VALUES (1, zeroblob(32), 1, 1, 1, 'x', zeroblob(32), 'x', 1, 'events', 'id', 1, 1, 1, NULL, NULL, NULL)",
+            "INSERT INTO briskdb_tables VALUES (1, 1, 'events', 1, 'tenant_id', 2);
+             INSERT INTO briskdb_global_indexes VALUES (1, 1, 'events_email', 0, 1, NULL, 1, 1, 0, 0, 0, 0)",
+            "INSERT INTO briskdb_tables VALUES (1, 1, 'events', 1, 'tenant_id', 2);
+             INSERT INTO briskdb_global_indexes VALUES (1, 1, 'events_email', 0, 1, NULL, 1, 1, 0, 0, 0, 0);
+             INSERT INTO briskdb_global_index_parts VALUES (1, 0, 1, 'email', 7, 1, 1, 1)",
             "INSERT INTO briskdb_hilo_leases VALUES (1, 4096, 1, 0, NULL, NULL, NULL)",
             "UPDATE briskdb_shard_layout SET layout_id = randomblob(16) WHERE singleton = 1",
             "INSERT INTO briskdb_schema_migrations VALUES (1, 0, randomblob(32), 1, 'SELECT 1', 4, 2, 4)",
@@ -11265,6 +12496,54 @@ mod tests {
                 "{mutation}"
             );
             assert_eq!(stored_manifest_digest(&connection), trusted, "{mutation}");
+        }
+    }
+
+    #[test]
+    fn global_index_future_formats_are_actionable_after_checksum_validation() {
+        for (mutation, diagnostic) in [
+            (
+                "UPDATE briskdb_global_indexes SET key_encoding_version = 2",
+                "key encoding version",
+            ),
+            (
+                "UPDATE briskdb_global_indexes SET lifecycle_state = 6",
+                "lifecycle state",
+            ),
+            (
+                "UPDATE briskdb_global_indexes
+                 SET topology_kind = 1, topology_version = 2, partition_count = 1",
+                "storage topology",
+            ),
+            (
+                "UPDATE briskdb_global_index_parts SET source_kind = 3",
+                "key-source version",
+            ),
+        ] {
+            let mut connection = Connection::open_in_memory().unwrap();
+            create_ready_current_manifest(&mut connection, 4);
+            insert_valid_table_catalog(&connection);
+            let declaration = GlobalIndexDeclaration::new(
+                TableId::new(3).unwrap(),
+                "accounts_email",
+                vec![GlobalIndexKeyPart::new(
+                    GlobalIndexKeySource::column("email").unwrap(),
+                    GlobalIndexKeyType::Text,
+                )],
+            )
+            .unwrap()
+            .with_topology(GlobalIndexStorageTopology::SharedSqliteV1);
+            create_global_index(&mut connection, 4, &declaration, || {}).unwrap();
+            connection.execute_batch(mutation).unwrap();
+            refresh_manifest_digest(&connection).unwrap();
+
+            let error = load_or_create_manifest(&mut connection, 4).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+            assert!(
+                error.diagnostic().contains(diagnostic),
+                "unexpected diagnostic for {mutation}: {}",
+                error.diagnostic()
+            );
         }
     }
 
@@ -11384,7 +12663,7 @@ mod tests {
     #[test]
     fn integrity_versions_lengths_and_forged_state_invariants_fail_closed() {
         for (version_column, unsupported_version) in
-            [("manifest_digest_version", 6), ("schema_digest_version", 2)]
+            [("manifest_digest_version", 7), ("schema_digest_version", 2)]
         {
             let mut unsupported = Connection::open_in_memory().unwrap();
             create_ready_current_manifest(&mut unsupported, 4);
@@ -11612,7 +12891,7 @@ mod tests {
             identity(&connection),
             (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
         );
-        assert_eq!(schema_objects(&connection).unwrap(), v12_objects());
+        assert_eq!(schema_objects(&connection).unwrap(), v13_objects());
         assert_eq!(
             shard_layout_row(&connection).3,
             ShardLayoutState::Adopting.code()
@@ -11636,7 +12915,7 @@ mod tests {
             identity(&connection),
             (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
         );
-        assert_eq!(schema_objects(&connection).unwrap(), v12_objects());
+        assert_eq!(schema_objects(&connection).unwrap(), v13_objects());
         assert_eq!(layout.state(), ShardLayoutState::Ready);
         assert_eq!(shard_layout_row(&connection), layout_before);
         assert_eq!(catalog.logical().schema_generation(), 0);
@@ -11728,7 +13007,7 @@ mod tests {
                 identity(&connection),
                 (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
             );
-            assert_eq!(schema_objects(&connection).unwrap(), v12_objects());
+            assert_eq!(schema_objects(&connection).unwrap(), v13_objects());
         }
 
         let mut connection = Connection::open_in_memory().unwrap();
@@ -13665,6 +14944,43 @@ mod tests {
                 migration_state INTEGER NOT NULL,
                 next_shard INTEGER NOT NULL
              ) STRICT;",
+            "DROP TABLE briskdb_global_index_parts;
+             CREATE TABLE briskdb_global_index_parts (
+                index_id INTEGER NOT NULL,
+                ordinal INTEGER NOT NULL,
+                source_kind INTEGER NOT NULL,
+                source_text TEXT NOT NULL,
+                key_type INTEGER NOT NULL,
+                sort_order INTEGER NOT NULL,
+                null_order INTEGER NOT NULL,
+                collation_version INTEGER NOT NULL
+             ) STRICT;",
+            "DROP TABLE briskdb_global_index_parts;
+             DROP TABLE briskdb_global_indexes;
+             CREATE TABLE briskdb_global_indexes (
+                index_id INTEGER PRIMARY KEY,
+                table_id INTEGER NOT NULL,
+                index_name TEXT NOT NULL,
+                is_unique INTEGER NOT NULL,
+                null_semantics INTEGER NOT NULL,
+                predicate_sql TEXT,
+                lifecycle_state INTEGER NOT NULL,
+                key_encoding_version INTEGER NOT NULL,
+                schema_generation INTEGER NOT NULL,
+                topology_kind INTEGER NOT NULL,
+                topology_version INTEGER NOT NULL,
+                partition_count INTEGER NOT NULL
+             ) STRICT;
+             CREATE TABLE briskdb_global_index_parts (
+                index_id INTEGER NOT NULL,
+                ordinal INTEGER NOT NULL,
+                source_kind INTEGER NOT NULL,
+                source_text TEXT NOT NULL,
+                key_type INTEGER NOT NULL,
+                sort_order INTEGER NOT NULL,
+                null_order INTEGER NOT NULL,
+                collation_version INTEGER NOT NULL
+             ) STRICT;",
         ] {
             let mut connection = Connection::open_in_memory().unwrap();
             load_or_create(&mut connection, 4).unwrap();
@@ -13736,6 +15052,12 @@ mod tests {
             initialize_current: create_v11_schema,
             initialize_interrupted_legacy: migrate_interrupted_legacy_to_v11,
         };
+        const V12_PLAN: MigrationPlan<'static> = MigrationPlan {
+            current_version: V12_SCHEMA_VERSION,
+            migrations: MIGRATIONS,
+            initialize_current: create_v12_schema,
+            initialize_interrupted_legacy: migrate_interrupted_legacy_to_v12,
+        };
         for phase in [
             MigrationPhase::AfterSchemaChange,
             MigrationPhase::AfterVersionStamp,
@@ -13762,7 +15084,9 @@ mod tests {
 
         let mut connection = Connection::open_in_memory().unwrap();
         create_ready_v11_manifest(&mut connection, 4);
-        load_or_create_manifest(&mut connection, 4).unwrap();
+        let mut no_hook = |_| Ok(());
+        load_or_create_snapshot_with_plan(&mut connection, 4, V12_PLAN, true, &mut no_hook)
+            .unwrap();
         assert_eq!(identity(&connection).1, i64::from(V12_SCHEMA_VERSION));
         assert_eq!(schema_objects(&connection).unwrap(), v12_objects());
         assert_eq!(
@@ -13794,6 +15118,73 @@ mod tests {
                 .unwrap_err()
                 .kind(),
             EngineErrorKind::FailedPrecondition
+        );
+    }
+
+    #[test]
+    fn v12_to_v13_upgrade_is_atomic_read_only_discoverable_and_downgrade_fenced() {
+        const V12_PLAN: MigrationPlan<'static> = MigrationPlan {
+            current_version: V12_SCHEMA_VERSION,
+            migrations: MIGRATIONS,
+            initialize_current: create_v12_schema,
+            initialize_interrupted_legacy: migrate_interrupted_legacy_to_v12,
+        };
+        for phase in [
+            MigrationPhase::AfterSchemaChange,
+            MigrationPhase::AfterVersionStamp,
+        ] {
+            let mut interrupted = Connection::open_in_memory().unwrap();
+            create_ready_current_manifest(&mut interrupted, 4);
+            downgrade_v13_manifest_to_v12_for_test(&interrupted, 4).unwrap();
+            let root = stored_manifest_digest(&interrupted);
+            let error = load_or_create_with_hook(&mut interrupted, 4, |point| {
+                if point.from == V12_SCHEMA_VERSION && point.phase == phase {
+                    Err(EngineError::new(
+                        EngineErrorKind::Internal,
+                        "injected v12 to v13 failure",
+                    ))
+                } else {
+                    Ok(())
+                }
+            })
+            .unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::Internal);
+            assert_eq!(identity(&interrupted).1, i64::from(V12_SCHEMA_VERSION));
+            assert_eq!(schema_objects(&interrupted).unwrap(), v12_objects());
+            assert_eq!(stored_manifest_digest(&interrupted), root);
+        }
+
+        let mut connection = Connection::open_in_memory().unwrap();
+        create_ready_current_manifest(&mut connection, 4);
+        downgrade_v13_manifest_to_v12_for_test(&connection, 4).unwrap();
+        let root = stored_manifest_digest(&connection);
+        assert!(inspect_global_indexes(&connection).unwrap().is_empty());
+        assert_eq!(identity(&connection).1, i64::from(V12_SCHEMA_VERSION));
+        assert_eq!(stored_manifest_digest(&connection), root);
+
+        load_or_create_manifest(&mut connection, 4).unwrap();
+        assert_eq!(identity(&connection).1, i64::from(V13_SCHEMA_VERSION));
+        assert_eq!(schema_objects(&connection).unwrap(), v13_objects());
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT requires_manifest_version, manifest_digest_version
+                     FROM briskdb_metadata
+                     JOIN briskdb_integrity ON briskdb_integrity.singleton = 1",
+                    [],
+                    |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+                )
+                .unwrap(),
+            (
+                i64::from(V13_SCHEMA_VERSION),
+                i64::from(V6_MANIFEST_DIGEST_VERSION)
+            )
+        );
+        assert!(
+            load_or_create_snapshot_with_plan(&mut connection, 4, V12_PLAN, true, &mut |_| Ok(()))
+                .unwrap_err()
+                .kind()
+                == EngineErrorKind::FailedPrecondition
         );
     }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -44,7 +44,8 @@ use crate::core::TableId;
 use crate::{
     core::{
         Catalog, CatalogSnapshot, EngineError, EngineErrorKind, EngineResult, GeneratedIdPolicy,
-        GeneratedTableDdlReceipt, MAX_TABLES, ShardKeyType, TableDeclaration, TablePlacement,
+        GeneratedTableDdlReceipt, GlobalIndexDeclaration, GlobalIndexId, GlobalIndexLifecycle,
+        GlobalIndexMetadata, MAX_TABLES, ShardKeyType, TableDeclaration, TablePlacement,
         generated_id::{
             NATIVE_RANGE_V1_FORMAT_MARKER, native_range_v1_sequence_ceiling,
             native_range_v1_sequence_floor,
@@ -178,7 +179,7 @@ impl RootSchemaCoordination {
         {
             return Err(EngineError::new(
                 EngineErrorKind::FailedPrecondition,
-                "the committed table catalog conflicts with a live database handle; close stale handles before reopening",
+                "the committed catalog conflicts with a live database handle; close stale handles before reopening",
             ));
         }
         let loaded = Arc::new(loaded);
@@ -193,7 +194,7 @@ impl RootSchemaCoordination {
         if Arc::strong_count(current) != 1 {
             return Err(EngineError::new(
                 EngineErrorKind::FailedPrecondition,
-                "table registration requires one exclusively owned database handle",
+                "catalog mutation requires one exclusively owned database handle",
             ));
         }
         let mut catalogs = self.catalogs.lock().map_err(|error| {
@@ -210,7 +211,7 @@ impl RootSchemaCoordination {
         if live.next().is_none_or(|catalog| !catalog.ptr_eq(&current)) || live.next().is_some() {
             return Err(EngineError::new(
                 EngineErrorKind::FailedPrecondition,
-                "table registration requires every other database handle to be closed",
+                "catalog mutation requires every other database handle to be closed",
             ));
         }
         Ok(CatalogReplacementGuard { catalogs })
@@ -288,7 +289,7 @@ impl RootSchemaCoordination {
         {
             return Err(EngineError::new(
                 EngineErrorKind::FailedPrecondition,
-                "the validated table catalog conflicts with a live database handle",
+                "the validated catalog conflicts with a live database handle",
             ));
         }
 
@@ -339,6 +340,7 @@ fn immutable_catalog_metadata_matches(left: &CatalogSnapshot, right: &CatalogSna
         && left_logical.default_database().id() == right_logical.default_database().id()
         && left_logical.logical_databases() == right_logical.logical_databases()
         && left_logical.tables() == right_logical.tables()
+        && left_logical.global_indexes() == right_logical.global_indexes()
 }
 
 static ROOT_SCHEMA_COORDINATIONS: OnceLock<Mutex<HashMap<PathBuf, Weak<RootSchemaCoordination>>>> =
@@ -1265,6 +1267,97 @@ impl Storage {
         migration.publish_ready()
     }
 
+    pub(crate) fn create_global_index(
+        &mut self,
+        declaration: GlobalIndexDeclaration,
+    ) -> EngineResult<GlobalIndexId> {
+        let result = self.create_global_index_inner(declaration);
+        self.fail_closed_on_corruption(result)
+    }
+
+    fn create_global_index_inner(
+        &mut self,
+        declaration: GlobalIndexDeclaration,
+    ) -> EngineResult<GlobalIndexId> {
+        let mut mutation =
+            SchemaMigrationGuard::new(self.schema_coordination.gate.begin_new_migration()?);
+        mutation.wait_for_quiescence_blocking();
+        mutation.acquire_process_ownership(&self.schema_coordination.process_lease)?;
+        let replacement_guard = self
+            .schema_coordination
+            .reserve_catalog_replacement(&self.catalog)?;
+        let mut manifest_connection = open_existing_manifest(&self.root.join("manifest.sqlite"))?;
+        configure_manifest_connection(&manifest_connection)?;
+        let (replacement, index_id) = manifest::create_global_index(
+            &mut manifest_connection,
+            self.shard_count(),
+            &declaration,
+            || mutation.mark_pending_on_drop(),
+        )?;
+        self.catalog = replacement_guard.publish(&self.catalog, replacement)?;
+        mutation.publish_ready()?;
+        Ok(index_id)
+    }
+
+    pub(crate) fn transition_global_index(
+        &mut self,
+        index_id: GlobalIndexId,
+        target: GlobalIndexLifecycle,
+    ) -> EngineResult<()> {
+        let result = self.transition_global_index_inner(index_id, target);
+        self.fail_closed_on_corruption(result)
+    }
+
+    fn transition_global_index_inner(
+        &mut self,
+        index_id: GlobalIndexId,
+        target: GlobalIndexLifecycle,
+    ) -> EngineResult<()> {
+        let mut mutation =
+            SchemaMigrationGuard::new(self.schema_coordination.gate.begin_new_migration()?);
+        mutation.wait_for_quiescence_blocking();
+        mutation.acquire_process_ownership(&self.schema_coordination.process_lease)?;
+        let replacement_guard = self
+            .schema_coordination
+            .reserve_catalog_replacement(&self.catalog)?;
+        let mut manifest_connection = open_existing_manifest(&self.root.join("manifest.sqlite"))?;
+        configure_manifest_connection(&manifest_connection)?;
+        let replacement = manifest::transition_global_index(
+            &mut manifest_connection,
+            self.shard_count(),
+            index_id,
+            target,
+            || mutation.mark_pending_on_drop(),
+        )?;
+        self.catalog = replacement_guard.publish(&self.catalog, replacement)?;
+        mutation.publish_ready()
+    }
+
+    pub(crate) fn remove_global_index(&mut self, index_id: GlobalIndexId) -> EngineResult<()> {
+        let result = self.remove_global_index_inner(index_id);
+        self.fail_closed_on_corruption(result)
+    }
+
+    fn remove_global_index_inner(&mut self, index_id: GlobalIndexId) -> EngineResult<()> {
+        let mut mutation =
+            SchemaMigrationGuard::new(self.schema_coordination.gate.begin_new_migration()?);
+        mutation.wait_for_quiescence_blocking();
+        mutation.acquire_process_ownership(&self.schema_coordination.process_lease)?;
+        let replacement_guard = self
+            .schema_coordination
+            .reserve_catalog_replacement(&self.catalog)?;
+        let mut manifest_connection = open_existing_manifest(&self.root.join("manifest.sqlite"))?;
+        configure_manifest_connection(&manifest_connection)?;
+        let replacement = manifest::remove_global_index(
+            &mut manifest_connection,
+            self.shard_count(),
+            index_id,
+            || mutation.mark_pending_on_drop(),
+        )?;
+        self.catalog = replacement_guard.publish(&self.catalog, replacement)?;
+        mutation.publish_ready()
+    }
+
     fn validate_table_declaration_request(
         &self,
         declarations: &[TableDeclaration],
@@ -1689,6 +1782,12 @@ impl Storage {
         guard: &mut SchemaMigrationGuard,
         control: Option<Arc<crate::core::OperationControl>>,
     ) -> EngineResult<Vec<u16>> {
+        if !self.catalog.logical().global_indexes().is_empty() {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "application-schema migration is fenced while global-index definitions exist; drop them before migrating",
+            ));
+        }
         guard.acquire_process_ownership(&self.schema_coordination.process_lease)?;
         migration::apply_schema_migration(self, sql, guard, control)
     }
@@ -2044,7 +2143,42 @@ impl Storage {
 /// Detect the immutable physical shard count without creating or upgrading
 /// any database files.
 pub(crate) fn detect_shard_count(root: impl AsRef<Path>) -> EngineResult<u16> {
-    let root = root.as_ref();
+    inspect_manifest_snapshot(root.as_ref(), manifest::detect_shard_count)
+}
+
+/// Validate and inspect durable global-index definitions without creating or
+/// upgrading any database files.
+pub(crate) fn inspect_global_indexes(
+    root: impl AsRef<Path>,
+) -> EngineResult<Box<[GlobalIndexMetadata]>> {
+    inspect_manifest_snapshot(root.as_ref(), manifest::inspect_global_indexes)
+}
+
+fn inspect_manifest_snapshot<T>(
+    root: &Path,
+    inspect: impl FnOnce(&Connection) -> EngineResult<T>,
+) -> EngineResult<T> {
+    let connection = open_manifest_for_read_only_inspection(root)?;
+    connection
+        .execute_batch("BEGIN DEFERRED TRANSACTION")
+        .map_err(sqlite_error::storage)?;
+    match inspect(&connection) {
+        Ok(value) => {
+            connection
+                .execute_batch("COMMIT")
+                .map_err(sqlite_error::storage)?;
+            Ok(value)
+        }
+        Err(error) => {
+            // Preserve the validation error. A read-only rollback is best-effort
+            // cleanup and cannot make the original manifest diagnosis clearer.
+            let _ = connection.execute_batch("ROLLBACK");
+            Err(error)
+        }
+    }
+}
+
+fn open_manifest_for_read_only_inspection(root: &Path) -> EngineResult<Connection> {
     let metadata = fs::symlink_metadata(root).map_err(|error| {
         if error.kind() == std::io::ErrorKind::NotFound {
             EngineError::from_source(
@@ -2094,7 +2228,7 @@ pub(crate) fn detect_shard_count(root: impl AsRef<Path>) -> EngineResult<u16> {
     }
     let connection = open_existing_manifest_read_only(&manifest_path)?;
     configure_manifest_connection(&connection)?;
-    manifest::detect_shard_count(&connection)
+    Ok(connection)
 }
 
 fn declarations_match_catalog(catalog: &Catalog, declarations: &[TableDeclaration]) -> bool {
@@ -3211,6 +3345,8 @@ mod tests {
             manifest
                 .execute_batch(
                     "BEGIN IMMEDIATE;
+                     DROP TABLE briskdb_global_index_parts;
+                     DROP TABLE briskdb_global_indexes;
                      DROP TABLE briskdb_generated_table_ddl;
                      DROP TABLE briskdb_hilo_leases;
                      DROP TABLE briskdb_table_provisioning_declarations;
@@ -3315,6 +3451,8 @@ mod tests {
             .unwrap()
             .execute_batch(
                 "BEGIN IMMEDIATE;
+                 DROP TABLE briskdb_global_index_parts;
+                 DROP TABLE briskdb_global_indexes;
                  DROP TABLE briskdb_generated_table_ddl;
                  DROP TABLE briskdb_hilo_leases;
                  DROP TABLE briskdb_table_provisioning_declarations;
@@ -3413,6 +3551,8 @@ mod tests {
             .unwrap()
             .execute_batch(
                 "BEGIN IMMEDIATE;
+                 DROP TABLE briskdb_global_index_parts;
+                 DROP TABLE briskdb_global_indexes;
                  DROP TABLE briskdb_generated_table_ddl;
                  DROP TABLE briskdb_hilo_leases;
                  DROP TABLE briskdb_table_provisioning_declarations;
@@ -5723,6 +5863,145 @@ mod tests {
             let declarations = registered_table_declarations(&reopened);
             reopened.register_tables(declarations).unwrap();
             assert_eq!(reopened.catalog().tables().len(), 2);
+        }
+    }
+
+    fn global_index_test_declaration(database: &Database) -> GlobalIndexDeclaration {
+        let table_id = database
+            .catalog()
+            .table("default", "events")
+            .unwrap()
+            .unwrap()
+            .id();
+        GlobalIndexDeclaration::new(
+            table_id,
+            "events_payload_global",
+            vec![crate::core::GlobalIndexKeyPart::new(
+                crate::core::GlobalIndexKeySource::column("payload").unwrap(),
+                crate::core::GlobalIndexKeyType::Binary,
+            )],
+        )
+        .unwrap()
+        .with_topology(crate::core::GlobalIndexStorageTopology::SharedSqliteV1)
+    }
+
+    fn setup_global_index_root(root: &Path) -> Database {
+        let mut database = Database::open(root, 2).unwrap();
+        create_registered_table_schema(&database);
+        database
+            .register_tables(registered_table_declarations(&database))
+            .unwrap();
+        database
+    }
+
+    #[test]
+    fn global_index_catalog_crash_child() {
+        let Ok(root) = std::env::var("BRISKDB_GLOBAL_INDEX_ABORT_ROOT") else {
+            return;
+        };
+        let mode = std::env::var("BRISKDB_GLOBAL_INDEX_ABORT_MODE").unwrap();
+        let mut database = Database::open(root, 2).unwrap();
+        let result = match mode.as_str() {
+            "create" => {
+                let declaration = global_index_test_declaration(&database);
+                database.create_global_index(declaration).map(|_| ())
+            }
+            "transition" => {
+                let id = GlobalIndexId::new(
+                    std::env::var("BRISKDB_GLOBAL_INDEX_ABORT_ID")
+                        .unwrap()
+                        .parse()
+                        .unwrap(),
+                )
+                .unwrap();
+                database.transition_global_index(id, GlobalIndexLifecycle::Ready)
+            }
+            "remove" => {
+                let id = GlobalIndexId::new(
+                    std::env::var("BRISKDB_GLOBAL_INDEX_ABORT_ID")
+                        .unwrap()
+                        .parse()
+                        .unwrap(),
+                )
+                .unwrap();
+                database.remove_global_index(id)
+            }
+            unexpected => panic!("unexpected global-index crash mode: {unexpected}"),
+        };
+        panic!("child did not reach requested global-index boundary: {result:?}");
+    }
+
+    fn abort_global_index_child(
+        root: &Path,
+        mode: &str,
+        boundary: &str,
+        id: Option<GlobalIndexId>,
+    ) {
+        let mut command = Command::new(std::env::current_exe().unwrap());
+        command
+            .arg("--exact")
+            .arg("storage::tests::global_index_catalog_crash_child")
+            .arg("--nocapture")
+            .env("BRISKDB_GLOBAL_INDEX_ABORT_ROOT", root)
+            .env("BRISKDB_GLOBAL_INDEX_ABORT_MODE", mode)
+            .env("BRISKDB_GLOBAL_INDEX_ABORT_POINT", boundary);
+        if let Some(id) = id {
+            command.env("BRISKDB_GLOBAL_INDEX_ABORT_ID", id.get().to_string());
+        }
+        let status = command.status().unwrap();
+        assert!(!status.success(), "child did not abort at {boundary}");
+    }
+
+    #[test]
+    fn global_index_catalog_recovers_at_every_transaction_boundary() {
+        for (boundary, expected_count) in [("create-before-commit", 0), ("create-after-commit", 1)]
+        {
+            let temp = tempfile::tempdir().unwrap();
+            drop(setup_global_index_root(temp.path()));
+            abort_global_index_child(temp.path(), "create", boundary, None);
+            assert_eq!(
+                Database::inspect_global_indexes(temp.path()).unwrap().len(),
+                expected_count,
+                "boundary {boundary}"
+            );
+            drop(Database::open(temp.path(), 2).unwrap());
+        }
+
+        for (boundary, expected) in [
+            ("transition-before-commit", GlobalIndexLifecycle::Creating),
+            ("transition-after-commit", GlobalIndexLifecycle::Ready),
+        ] {
+            let temp = tempfile::tempdir().unwrap();
+            let mut database = setup_global_index_root(temp.path());
+            let declaration = global_index_test_declaration(&database);
+            let id = database.create_global_index(declaration).unwrap();
+            drop(database);
+            abort_global_index_child(temp.path(), "transition", boundary, Some(id));
+            assert_eq!(
+                Database::inspect_global_indexes(temp.path()).unwrap()[0].lifecycle(),
+                expected,
+                "boundary {boundary}"
+            );
+            drop(Database::open(temp.path(), 2).unwrap());
+        }
+
+        for (boundary, expected_count) in [("remove-before-commit", 1), ("remove-after-commit", 0)]
+        {
+            let temp = tempfile::tempdir().unwrap();
+            let mut database = setup_global_index_root(temp.path());
+            let declaration = global_index_test_declaration(&database);
+            let id = database.create_global_index(declaration).unwrap();
+            database
+                .transition_global_index(id, GlobalIndexLifecycle::Dropping)
+                .unwrap();
+            drop(database);
+            abort_global_index_child(temp.path(), "remove", boundary, Some(id));
+            assert_eq!(
+                Database::inspect_global_indexes(temp.path()).unwrap().len(),
+                expected_count,
+                "boundary {boundary}"
+            );
+            drop(Database::open(temp.path(), 2).unwrap());
         }
     }
 

--- a/tests/multiprocess_shared_root.rs
+++ b/tests/multiprocess_shared_root.rs
@@ -12,7 +12,11 @@ use std::{
 use briskdb::core::GeneratedIdPolicy;
 use briskdb::{
     BriskDb, EngineError, EngineErrorKind, EngineOptions, Statement, Value,
-    core::{Database, ShardKeyMetadata, ShardKeyType, TableDeclaration},
+    core::{
+        Database, GlobalIndexDeclaration, GlobalIndexKeyPart, GlobalIndexKeySource,
+        GlobalIndexKeyType, GlobalIndexStorageTopology, ShardKeyMetadata, ShardKeyType,
+        TableDeclaration,
+    },
 };
 #[cfg(feature = "experimental-vtab")]
 use std::collections::BTreeSet;
@@ -306,6 +310,30 @@ fn shared_root_process_child() {
                 database.close().await.expect("close lock-holder database");
             });
         }
+        "index-holder" => {
+            let _database = Database::open(&root, SHARDS).expect("open catalog holder");
+            fs::write(&ready, b"ready").expect("publish catalog-holder readiness");
+            wait_for_path(&go);
+            let count = Database::inspect_global_indexes(&root)
+                .expect("inspect catalog while holding root")
+                .len();
+            fs::write(&output, count.to_string()).expect("publish held catalog count");
+        }
+        "index-reader" => {
+            fs::write(&ready, b"ready").expect("publish catalog-reader readiness");
+            wait_for_path(&go);
+            let observations = (0..128)
+                .map(|_| {
+                    let count = Database::inspect_global_indexes(&root)
+                        .expect("inspect concurrent global-index catalog")
+                        .len();
+                    thread::yield_now();
+                    count.to_string()
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            fs::write(&output, observations).expect("publish catalog observations");
+        }
         #[cfg(feature = "experimental-vtab")]
         "hilo" => {
             runtime.block_on(run_hilo_writer(
@@ -352,6 +380,25 @@ fn setup_events(root: &Path) -> (String, String) {
         .find(|candidate| database.shard_for_key(candidate.as_bytes()) != same_shard)
         .expect("find a route on another shard");
     (same_route, different_route)
+}
+
+fn global_index_declaration(database: &Database, name: &str) -> GlobalIndexDeclaration {
+    let table_id = database
+        .catalog()
+        .table("default", "events")
+        .unwrap()
+        .unwrap()
+        .id();
+    GlobalIndexDeclaration::new(
+        table_id,
+        name,
+        vec![GlobalIndexKeyPart::new(
+            GlobalIndexKeySource::column("payload").unwrap(),
+            GlobalIndexKeyType::Text,
+        )],
+    )
+    .unwrap()
+    .with_topology(GlobalIndexStorageTopology::SharedSqliteV1)
 }
 
 #[cfg(feature = "experimental-vtab")]
@@ -545,6 +592,78 @@ fn cross_process_sqlite_contention_is_retryable_and_the_exact_retry_succeeds() {
     });
 
     assert_eq!(total_rows(temp.path(), "events"), 1);
+    assert_root_integrity(temp.path());
+}
+
+#[test]
+fn global_index_catalog_serializes_writers_and_readers_see_only_complete_snapshots() {
+    let temp = tempfile::tempdir().expect("create global-index root");
+    setup_events(temp.path());
+
+    let holder_ready = temp.path().join("index-holder-ready");
+    let holder_go = temp.path().join("index-holder-go");
+    let holder_output = temp.path().join("index-holder-output");
+    let mut holder = spawn_test_child(
+        temp.path(),
+        "index-holder",
+        0,
+        None,
+        &holder_ready,
+        &holder_go,
+        &holder_output,
+    );
+    wait_for_path(&holder_ready);
+
+    let mut database = Database::open(temp.path(), SHARDS).expect("open catalog writer");
+    let declaration = global_index_declaration(&database, "events_payload_global");
+    let error = database
+        .create_global_index(declaration.clone())
+        .expect_err("a live peer must fence catalog mutation");
+    assert_eq!(error.kind(), EngineErrorKind::Busy);
+    assert!(error.is_retryable());
+    assert!(
+        Database::inspect_global_indexes(temp.path())
+            .unwrap()
+            .is_empty()
+    );
+
+    fs::write(&holder_go, b"release").expect("release catalog holder");
+    holder.wait_success();
+    assert_eq!(fs::read_to_string(&holder_output).unwrap(), "0");
+    database
+        .create_global_index(declaration)
+        .expect("retry catalog mutation after peer closes");
+
+    let reader_ready = temp.path().join("index-reader-ready");
+    let reader_go = temp.path().join("index-reader-go");
+    let reader_output = temp.path().join("index-reader-output");
+    let mut reader = spawn_test_child(
+        temp.path(),
+        "index-reader",
+        1,
+        None,
+        &reader_ready,
+        &reader_go,
+        &reader_output,
+    );
+    wait_for_path(&reader_ready);
+    fs::write(&reader_go, b"race").expect("release catalog reader");
+    let second_declaration = global_index_declaration(&database, "events_payload_global_2");
+    database
+        .create_global_index(second_declaration)
+        .expect("commit catalog mutation beside read-only inspector");
+    reader.wait_success();
+
+    let observations = fs::read_to_string(&reader_output).unwrap();
+    assert!(
+        observations.lines().all(|count| matches!(count, "1" | "2")),
+        "reader observed a partial catalog: {observations}"
+    );
+    assert_eq!(
+        Database::inspect_global_indexes(temp.path()).unwrap().len(),
+        2
+    );
+    drop(database);
     assert_root_integrity(temp.path());
 }
 

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -127,6 +127,127 @@ fn assert_catalog_fixture(catalog: &core::Catalog) {
     );
 }
 
+fn global_email_index(table_id: core::TableId) -> core::GlobalIndexDeclaration {
+    core::GlobalIndexDeclaration::new(
+        table_id,
+        "accounts_email",
+        vec![core::GlobalIndexKeyPart::new(
+            core::GlobalIndexKeySource::column("payload").unwrap(),
+            core::GlobalIndexKeyType::Text,
+        )],
+    )
+    .unwrap()
+    .unique(core::UniqueNullSemantics::Distinct)
+    .with_predicate("payload IS NOT NULL")
+    .unwrap()
+    .with_topology(core::GlobalIndexStorageTopology::SharedSqliteV1)
+}
+
+#[test]
+fn global_index_catalog_is_read_only_reopenable_and_lifecycle_fenced() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut database = core::Database::open(temp.path(), 2).unwrap();
+    register_catalog_fixture(&mut database);
+    let accounts = database
+        .catalog()
+        .table("default", "accounts")
+        .unwrap()
+        .unwrap();
+    let declaration = global_email_index(accounts.id());
+    drop(database);
+
+    let manifest = temp.path().join("manifest.sqlite");
+    let before = std::fs::read(&manifest).unwrap();
+    assert!(
+        core::Database::inspect_global_indexes(temp.path())
+            .unwrap()
+            .is_empty()
+    );
+    assert_eq!(std::fs::read(&manifest).unwrap(), before);
+
+    let mut database = core::Database::open(temp.path(), 2).unwrap();
+    let index_id = database.create_global_index(declaration).unwrap();
+    assert_eq!(database.catalog().global_indexes().len(), 1);
+    assert_eq!(
+        database.remove_global_index(index_id).unwrap_err().kind(),
+        core::EngineErrorKind::FailedPrecondition
+    );
+    assert_eq!(
+        database
+            .broadcast("CREATE INDEX accounts_payload ON accounts(payload)")
+            .unwrap_err()
+            .kind(),
+        core::EngineErrorKind::FailedPrecondition
+    );
+    drop(database);
+
+    let inspected = core::Database::inspect_global_indexes(temp.path()).unwrap();
+    assert_eq!(inspected.len(), 1);
+    assert_eq!(inspected[0].id(), index_id);
+    assert_eq!(inspected[0].name(), "accounts_email");
+    assert_eq!(
+        inspected[0].lifecycle(),
+        core::GlobalIndexLifecycle::Creating
+    );
+    assert_eq!(
+        inspected[0].topology(),
+        core::GlobalIndexStorageTopology::SharedSqliteV1
+    );
+    assert_eq!(
+        inspected[0].key_encoding_version(),
+        core::INDEX_KEY_ENCODING_VERSION
+    );
+    assert_eq!(
+        core::Database::open(temp.path(), 4).unwrap_err().kind(),
+        core::EngineErrorKind::FailedPrecondition
+    );
+    assert_eq!(
+        core::Database::inspect_global_indexes(temp.path())
+            .unwrap()
+            .len(),
+        1
+    );
+
+    let mut database = core::Database::open(temp.path(), 2).unwrap();
+    database
+        .transition_global_index(index_id, core::GlobalIndexLifecycle::Ready)
+        .unwrap();
+    assert_eq!(
+        database
+            .transition_global_index(index_id, core::GlobalIndexLifecycle::Creating)
+            .unwrap_err()
+            .kind(),
+        core::EngineErrorKind::FailedPrecondition
+    );
+    database
+        .transition_global_index(index_id, core::GlobalIndexLifecycle::Rebuilding)
+        .unwrap();
+    database
+        .transition_global_index(index_id, core::GlobalIndexLifecycle::Ready)
+        .unwrap();
+    database
+        .transition_global_index(index_id, core::GlobalIndexLifecycle::Dropping)
+        .unwrap();
+    drop(database);
+    assert_eq!(
+        core::Database::inspect_global_indexes(temp.path()).unwrap()[0].lifecycle(),
+        core::GlobalIndexLifecycle::Dropping
+    );
+
+    let mut database = core::Database::open(temp.path(), 2).unwrap();
+    database.remove_global_index(index_id).unwrap();
+    assert!(database.catalog().global_indexes().is_empty());
+    database
+        .broadcast("CREATE INDEX accounts_payload ON accounts(payload)")
+        .unwrap();
+    drop(database);
+    assert!(
+        core::Database::inspect_global_indexes(temp.path())
+            .unwrap()
+            .is_empty()
+    );
+}
+
 #[test]
 fn legacy_and_explicit_module_paths_are_both_available() {
     fn assert_owned_public<T: Clone + Send + Sync + 'static>() {}


### PR DESCRIPTION
Closes #228

## Summary
- add a versioned, checksummed global-index catalog and v12-to-v13 migration
- expose protocol-neutral metadata, lifecycle mutation, and read-only inspection APIs
- serialize catalog writers, fence incompatible layouts/schema generations, and keep readers on one SQLite snapshot
- document the storage and multi-process contracts

This PR intentionally covers metadata and lifecycle only. Physical index storage and construction continue in #229 and #230.

## Verification
- cargo test --locked --all-targets --all-features
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --doc --all-features
- cargo package --locked --allow-dirty
- Rust 1.85 checks for core, embedded, listeners, HTTP, PostgreSQL, SQLite import, and default surfaces
- cargo test/clippy for briskdb-python
- global-index multi-process reader/writer race repeated 10 times