### PR TITLE
Build global indexes offline across all shards

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -408,7 +408,7 @@ requires an earlier dependency:
    - [x] [#227](https://github.com/schapman1974/briskdb/issues/227) — canonical key encoding
    - [x] [#228](https://github.com/schapman1974/briskdb/issues/228) — catalog lifecycle and compatibility fencing
    - [x] [#229](https://github.com/schapman1974/briskdb/issues/229) — storage-topology prototype
-   - [ ] [#230](https://github.com/schapman1974/briskdb/issues/230) — offline index construction
+   - [x] [#230](https://github.com/schapman1974/briskdb/issues/230) — offline index construction
    - [ ] [#231](https://github.com/schapman1974/briskdb/issues/231) — validation, repair, and rebuild
    - [ ] [#232](https://github.com/schapman1974/briskdb/issues/232) — unique reservations and global allocation
    - [ ] [#233](https://github.com/schapman1974/briskdb/issues/233) — authoritative write maintenance

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -330,8 +330,16 @@ semantics, predicate, schema generation, lifecycle, and selected topology.
 The measured initial topology is one shared WAL-mode SQLite database: every key
 routes to partition zero. A domain-separated `(index ID, canonical key)` BLAKE3
 mapping remains frozen for a possible 16-file rebuild, but is not the initial
-default. See the [topology decision](GLOBAL_INDEX_TOPOLOGY.md). Physical files
-are first created by the offline builder in #230.
+default. See the [topology decision](GLOBAL_INDEX_TOPOLOGY.md).
+
+The [offline builder](GLOBAL_INDEX_BUILD.md) materializes `SharedSqliteV1` in
+`global-indexes/global.sqlite`. It holds sole-process maintenance ownership,
+scans every shard in physical-locator order, checkpoints a canonical-key/source
+digest per completed shard, and revalidates resumable checkpoints before use.
+Unique definitions reserve one canonical key across every shard. The physical
+file is fully checked, checkpointed, and synchronized before the checksummed
+manifest alone publishes `Creating` to `Ready`; the public lifecycle API cannot
+bypass this boundary.
 
 ### Bound statement-planning boundary
 
@@ -546,7 +554,11 @@ Writers use the existing sole-process mutation fence, while concurrent readers
 see only complete SQLite snapshots. The v12-to-v13 migration creates empty
 catalog tables and changes no shard. Issue #229 selects the one-file
 `SharedSqliteV1` layout after comparing it with 16 hash-partitioned files;
-physical construction starts in #230.
+issue #230 adds its offline, resumable physical construction. The builder uses
+the same local schema gate and sole-process lease as schema mutation, so another
+service or embedded process receives retryable `Busy`. Cancellation restores
+ordinary admission while retaining only complete shard checkpoints. Online and
+replacement construction remain later work.
 
 Each manifest version retains an intentionally incompatible
 `briskdb_metadata` definition and row as a downgrade fence. The v3-to-v4

--- a/docs/GLOBAL_INDEX_BUILD.md
+++ b/docs/GLOBAL_INDEX_BUILD.md
@@ -1,0 +1,98 @@
+# Offline global-index construction
+
+BriskDB builds the first physical global-index format through the Rust library:
+
+```rust
+let declaration = declaration
+    .with_topology(GlobalIndexStorageTopology::selected_v1());
+let index_id = database.create_global_index(declaration)?;
+let report = database.build_global_index(index_id)?;
+assert_eq!(report.shard_count(), database.shard_count());
+```
+
+`build_global_index_with_cancellation` accepts the same sticky
+`CancellationToken` used by the rest of the core API. Cancellation never makes
+partial data visible; call the builder again to resume.
+
+## Maintenance-mode boundary
+
+The initial builder is deliberately offline. It closes admission to new local
+operations, drains admitted work, and upgrades the data-directory process lease
+to sole-process ownership before reading a source row. If another BriskDB
+process has the root open, the build returns retryable `Busy` without changing
+physical index data.
+
+Direct writes to shard SQLite files outside BriskDB are unsupported. Operators
+must stop every service and embedded process using the root, open one exclusive
+`Database` handle, run the build, and only then restart normal traffic.
+
+## Physical format
+
+`SharedSqliteV1` is stored at:
+
+```text
+<data-root>/global-indexes/global.sqlite
+```
+
+It is a separate, application-identified, storage-version-1 SQLite database in
+WAL mode with `synchronous=FULL`. It contains five BriskDB-owned tables:
+
+| Table | Authority |
+| --- | --- |
+| `briskdb_global_index_storage` | Physical format and canonical-key codec versions |
+| `briskdb_global_index_builds` | Definition digest, schema generation, state, and final row count |
+| `briskdb_global_index_checkpoints` | One digest and row count for each completed source shard |
+| `briskdb_global_index_entries` | Canonical key to source shard, scan ordinal, and typed physical row locator |
+| `briskdb_global_index_unique_keys` | One reservation per key when the definition is unique |
+
+Rowid tables retain an unshadowed physical rowid locator. `WITHOUT ROWID`
+tables retain the complete ordered primary key. The locator is a typed,
+length-framed version-1 blob; it is not an application key and never changes a
+source shard.
+
+## Checkpoints and publication
+
+Each source shard is scanned in ascending shard order through a read
+transaction. Its entries, unique reservations, BLAKE3 source digest, and
+checkpoint commit atomically in the physical index database. A unique
+per-shard scan ordinal lets validation reproduce digest order without treating
+locator bytes as an ordering codec. An interrupted
+shard transaction rolls back and is retried. On restart, completed checkpoint
+digests are recomputed from a stable, locator-ordered source scan:
+
+- unchanged prefix shards are reused;
+- any changed prefix restarts that index from shard zero; and
+- missing, duplicate, or out-of-order checkpoints fail as corruption.
+
+After all shards complete, BriskDB revalidates every source digest and exact
+physical row count, marks the build complete, checkpoints the WAL, synchronizes
+the file and directory, and only then commits the checksummed manifest
+transition from `Creating` to `Ready`. The public lifecycle method cannot set
+`Ready`; only the builder owns that publication boundary. A process exit before
+the manifest commit leaves `Creating`, while an exit after it leaves `Ready`.
+
+Removing a `Dropping` definition also removes its physical rows. A later build
+opportunistically deletes records whose definition no longer exists.
+
+## Keys, predicates, and uniqueness
+
+Column and expression parts are evaluated by bundled SQLite on every source
+shard. BriskDB converts the result to the declared logical type and then uses
+the protocol-neutral canonical-key codec, including compound order, explicit
+NULL placement, and binary collation. A partial-index predicate is evaluated by
+SQLite before key conversion.
+
+Unique builds reserve the canonical key across all shards. `NULLS DISTINCT`
+does not reserve a key containing NULL; `NULLS NOT DISTINCT` does. A collision
+returns `UniqueViolation` with both source shards and redacted locator labels,
+while the catalog remains `Creating` for an exact retry after the data is fixed.
+
+The repeated source-digest pass also rejects nondeterministic expressions or
+predicates instead of publishing an index that cannot be reproduced.
+
+## Current limit
+
+Issue #230 builds only new `Creating` indexes in `SharedSqliteV1`. Online
+construction is not supported. Validation, repair, and replacement builds from
+`Invalid`/`Rebuilding` state belong to issue #231; write maintenance and query
+routing remain later rollout stages.

--- a/docs/OFFLINE_BACKUP.md
+++ b/docs/OFFLINE_BACKUP.md
@@ -3,7 +3,8 @@
 BriskDB's supported alpha backup is a complete copy made while every BriskDB
 process using the data directory is stopped. This procedure preserves one
 consistent manifest, shard set, schema generation, routing map, generated-ID
-allocator state, and any SQLite sidecar files as a unit.
+allocator state, physical global-index storage, and any SQLite sidecar files as
+a unit.
 
 This is not an online backup. Do not copy a live data directory, even when no
 application writes are expected. Coordinated online backup remains tracked by
@@ -17,11 +18,12 @@ issue #67.
    to exit. A service manager must report its service stopped before copying.
 3. Verify that no other BriskDB process or embedder is using the directory.
 4. Copy the complete data directory into a new backup directory. Include
-   `manifest.sqlite`, the entire `shards` directory, the import receipt when
-   present, `.briskdb-process.lock`, `.briskdb-startup.lock`, and every SQLite
-   `-wal`, `-shm`, or journal sidecar that exists. The lock files contain no
-   persistent ownership, but a complete-directory copy includes them. Do not
-   select individual database files.
+   `manifest.sqlite`, the entire `shards` directory, the entire
+   `global-indexes` directory when present, the import receipt when present,
+   `.briskdb-process.lock`, `.briskdb-startup.lock`, and every SQLite `-wal`,
+   `-shm`, or journal sidecar that exists. The lock files contain no persistent
+   ownership, but a complete-directory copy includes them. Do not select
+   individual database files.
 5. Make the backup durable using the snapshot, archive, or copy tool's normal
    completion and sync guarantees. Retain the recorded BriskDB version and
    shard count with the backup.
@@ -70,8 +72,9 @@ For release upgrades and rollback, follow the additional requirements in the
 ## Automated evidence
 
 `tests/offline_backup.rs` creates schema and one routed row on every shard,
-performs explicit engine shutdown, copies the complete layout through a backup
-directory into a new root, reopens it, and verifies the schema generation,
-physical route, and row value for every shard. The test freezes the stopped-copy
-contract but does not claim online snapshot safety or certify a particular
-third-party backup product.
+builds and validates a global index, performs explicit engine shutdown, copies
+the complete layout through a backup directory into a new root, reopens it, and
+verifies the schema generation, global-index authority, physical route, and row
+value for every shard. The test freezes the stopped-copy contract but does not
+claim online snapshot safety or certify a particular third-party backup
+product.

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -594,8 +594,10 @@ or `Dropping`; `Ready` may become `Invalid`, `Rebuilding`, or `Dropping`;
 `Invalid` may become `Rebuilding` or `Dropping`; and `Rebuilding` may become
 `Ready`, `Invalid`, or `Dropping`. Removal is legal only from `Dropping`.
 `Ready` and `Rebuilding` require an assigned versioned topology and the current
-schema generation. Application-schema migration is fenced while any definition
-exists, avoiding a catalog/schema split until later coordinated rebuild work.
+schema generation. Public callers cannot transition an index to `Ready`; the
+offline builder owns that transition after validating durable physical state.
+Application-schema migration is fenced while any definition exists, avoiding a
+catalog/schema split until later coordinated rebuild work.
 
 Each create, transition, and removal is one `BEGIN IMMEDIATE` transaction that
 reseals the semantic root before commit. The existing process mutation fence
@@ -606,7 +608,9 @@ only the complete old or complete new snapshot. Version 13 stores metadata
 only. The measured initial physical choice is `SharedSqliteV1`, with one
 partition and every key routed to partition zero; the exact comparison and
 migration option are documented in the [topology decision](GLOBAL_INDEX_TOPOLOGY.md).
-Physical index files and construction begin in issue #230.
+Issue #230 adds the separate physical format and offline construction described
+in [offline global-index construction](GLOBAL_INDEX_BUILD.md); it does not
+change the version-13 manifest or any shard-file format.
 
 Table placement and shard-key type use stable numeric codes:
 
@@ -1312,7 +1316,34 @@ planning](SQL_PLANNING.md).
 This routing format is intentionally distinct from the tagged, order-preserving
 [canonical global-index key format](INDEX_KEY_ENCODING.md). Version 13 records
 the codec version in every global-index definition but does not persist physical
-index entries or change shard placement.
+index entries or change shard placement. Physical entries live in the separate
+storage-version-1 `global-indexes/global.sqlite` authority, never in a shard.
+
+### Physical global-index storage version 1
+
+The selected `SharedSqliteV1` layout is one real regular file at
+`global-indexes/global.sqlite`. Its `application_id` is `0x42524749`, its
+`user_version` is `1`, its journal mode is `WAL`, and writers use
+`synchronous=FULL`. The exact five-table schema and ownership rules are listed
+in [offline global-index construction](GLOBAL_INDEX_BUILD.md).
+
+One build row binds the index ID to a BLAKE3 digest of its complete manifest
+definition, schema generation, shard count, and build state. Checkpoints form
+exactly one contiguous source-shard prefix. Each checkpoint contains the
+qualifying row count, unique-reservation count, and a domain-separated digest
+of canonical key plus versioned physical locator in locator order. Entries use
+`(index_id, encoded_key, source_shard, source_locator)` as their primary key and
+retain a unique per-shard scan ordinal so validation can replay digest order;
+unique reservations use `(index_id, encoded_key)`.
+
+Source-shard entries and their checkpoint commit together. Resume re-hashes
+every completed prefix shard and restarts from zero if application data changed.
+After a second full digest pass and exact count validation, the builder commits
+physical `Complete`, truncates the WAL, synchronizes the file and parent
+directory, and then publishes manifest lifecycle `Ready` in its existing
+checksummed transaction. Thus physical completion always precedes visibility.
+Removal is legal only after `Dropping` and deletes physical rows before removing
+the unavailable manifest definition.
 
 Bucket algorithm version 1 deliberately preserves legacy placement even when
 `N` does not divide 4,096. Given the version-1 64-bit hash `H`:

--- a/src/core/global_index.rs
+++ b/src/core/global_index.rs
@@ -414,6 +414,54 @@ pub struct GlobalIndexMetadata {
     topology: GlobalIndexStorageTopology,
 }
 
+/// Durable outcome of an offline global-index build.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GlobalIndexBuildReport {
+    index_id: GlobalIndexId,
+    shard_count: u16,
+    resumed_from_shard: u16,
+    indexed_rows: u64,
+}
+
+impl GlobalIndexBuildReport {
+    pub(crate) const fn from_validated(
+        index_id: GlobalIndexId,
+        shard_count: u16,
+        resumed_from_shard: u16,
+        indexed_rows: u64,
+    ) -> Self {
+        Self {
+            index_id,
+            shard_count,
+            resumed_from_shard,
+            indexed_rows,
+        }
+    }
+
+    /// Return the durable index identity that was built or revalidated.
+    pub const fn index_id(self) -> GlobalIndexId {
+        self.index_id
+    }
+
+    /// Return the number of source shards represented by the completed index.
+    pub const fn shard_count(self) -> u16 {
+        self.shard_count
+    }
+
+    /// Return the first shard that did not already have a reusable checkpoint.
+    ///
+    /// This equals [`Self::shard_count`] when every shard checkpoint could be
+    /// revalidated and only final publication remained.
+    pub const fn resumed_from_shard(self) -> u16 {
+        self.resumed_from_shard
+    }
+
+    /// Return the exact number of qualifying physical source rows indexed.
+    pub const fn indexed_rows(self) -> u64 {
+        self.indexed_rows
+    }
+}
+
 impl GlobalIndexMetadata {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn from_validated(

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -37,9 +37,9 @@ pub use engine::{CheckpointReport, CheckpointShardReport, Engine, EngineStatus, 
 pub use error::{EngineError, EngineErrorKind, EngineResult};
 pub(crate) use generated_id::AllocationOwnerMap;
 pub use global_index::{
-    GlobalIndexDeclaration, GlobalIndexId, GlobalIndexKeyPart, GlobalIndexKeySource,
-    GlobalIndexKeyType, GlobalIndexLifecycle, GlobalIndexMetadata, GlobalIndexStorageTopology,
-    HASH_PARTITIONED_GLOBAL_INDEX_PARTITIONS_V1,
+    GlobalIndexBuildReport, GlobalIndexDeclaration, GlobalIndexId, GlobalIndexKeyPart,
+    GlobalIndexKeySource, GlobalIndexKeyType, GlobalIndexLifecycle, GlobalIndexMetadata,
+    GlobalIndexStorageTopology, HASH_PARTITIONED_GLOBAL_INDEX_PARTITIONS_V1,
 };
 pub(crate) use global_index::{
     MAX_GLOBAL_INDEX_PARTS, MAX_GLOBAL_INDEX_SQL_BYTES, MAX_GLOBAL_INDEXES,
@@ -235,10 +235,36 @@ impl Database {
         self.storage.create_global_index(declaration)
     }
 
-    /// Atomically apply one legal global-index lifecycle transition.
+    /// Build one declared global index while holding exclusive maintenance-mode
+    /// ownership of the data directory.
     ///
-    /// Callers must not publish `Ready` until the declared physical topology is
-    /// complete and validated.
+    /// Construction scans every physical shard, checkpoints only complete
+    /// shard transactions, revalidates resumed checkpoints against the source,
+    /// and publishes `Ready` only after the physical SQLite authority is fully
+    /// durable. A cancelled build remains in `Creating` and can be resumed by
+    /// calling this method again.
+    pub fn build_global_index(
+        &mut self,
+        index_id: GlobalIndexId,
+    ) -> EngineResult<GlobalIndexBuildReport> {
+        self.storage
+            .build_global_index(index_id, &CancellationToken::new())
+    }
+
+    /// Build one declared global index with a caller-owned sticky cancellation
+    /// signal.
+    pub fn build_global_index_with_cancellation(
+        &mut self,
+        index_id: GlobalIndexId,
+        cancellation: &CancellationToken,
+    ) -> EngineResult<GlobalIndexBuildReport> {
+        self.storage.build_global_index(index_id, cancellation)
+    }
+
+    /// Atomically apply one legal non-publication global-index lifecycle transition.
+    ///
+    /// `Ready` is reserved for [`Self::build_global_index`], which proves that
+    /// physical storage is complete before atomically publishing the catalog.
     pub fn transition_global_index(
         &mut self,
         index_id: GlobalIndexId,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,14 +20,14 @@ pub use core::{
     CancellationToken, CanonicalIndexKey, CheckpointReport, CheckpointShardReport, Column,
     DataType, Decimal, DecodedIndexKeyPart, DescribeTarget, EngineError, EngineErrorKind,
     EngineOptions, EngineResult, EngineState, EngineStatus, Executed, GeneratedKey,
-    GlobalIndexDeclaration, GlobalIndexId, GlobalIndexKeyPart, GlobalIndexKeySource,
-    GlobalIndexKeyType, GlobalIndexLifecycle, GlobalIndexMetadata, GlobalIndexStorageTopology,
-    HASH_PARTITIONED_GLOBAL_INDEX_PARTITIONS_V1, INDEX_KEY_ENCODING_VERSION, IndexKeyCollation,
-    IndexKeyOrder, IndexKeyPart, IndexKeyValue, IndexKeyValueRef, IndexNullOrder,
-    ParseDecimalError, PortalId, PrepareRequest, PreparedExecution, PreparedStatementDescription,
-    PreparedStatementId, PreparedStatementLimits, RequestContext, ResultLimits, ResultSet,
-    ResultSetShapeError, Routed, Row, Session, SessionId, SessionState, ShutdownReport, Statement,
-    UniqueNullSemantics, Value, WriteResult,
+    GlobalIndexBuildReport, GlobalIndexDeclaration, GlobalIndexId, GlobalIndexKeyPart,
+    GlobalIndexKeySource, GlobalIndexKeyType, GlobalIndexLifecycle, GlobalIndexMetadata,
+    GlobalIndexStorageTopology, HASH_PARTITIONED_GLOBAL_INDEX_PARTITIONS_V1,
+    INDEX_KEY_ENCODING_VERSION, IndexKeyCollation, IndexKeyOrder, IndexKeyPart, IndexKeyValue,
+    IndexKeyValueRef, IndexNullOrder, ParseDecimalError, PortalId, PrepareRequest,
+    PreparedExecution, PreparedStatementDescription, PreparedStatementId, PreparedStatementLimits,
+    RequestContext, ResultLimits, ResultSet, ResultSetShapeError, Routed, Row, Session, SessionId,
+    SessionState, ShutdownReport, Statement, UniqueNullSemantics, Value, WriteResult,
 };
 #[cfg(feature = "embedded")]
 pub use embedded::{

--- a/src/storage/global_index.rs
+++ b/src/storage/global_index.rs
@@ -1,0 +1,1661 @@
+//! Offline construction and durable storage for global indexes.
+
+use std::{
+    collections::BTreeSet,
+    fs::{self, File},
+    path::{Path, PathBuf},
+    str,
+};
+
+use rusqlite::{
+    Connection, OpenFlags, OptionalExtension, Transaction, TransactionBehavior, params,
+    types::ValueRef,
+};
+
+use crate::{
+    core::{
+        CancellationToken, CanonicalIndexKey, EngineError, EngineErrorKind, EngineResult,
+        GlobalIndexBuildReport, GlobalIndexId, GlobalIndexKeySource, GlobalIndexKeyType,
+        GlobalIndexLifecycle, GlobalIndexMetadata, GlobalIndexStorageTopology,
+        INDEX_KEY_ENCODING_VERSION, IndexKeyOrder, IndexKeyPart, IndexKeyValue,
+        UniqueNullSemantics,
+    },
+    sqlite_error,
+};
+
+use super::{CONNECTION_BUSY_TIMEOUT, Storage};
+
+const DIRECTORY_NAME: &str = "global-indexes";
+const SHARED_FILE_NAME: &str = "global.sqlite";
+const APPLICATION_ID: i32 = 0x4252_4749;
+const STORAGE_VERSION: u32 = 1;
+const BUILDING: i64 = 1;
+const COMPLETE: i64 = 2;
+const DEFINITION_DIGEST_DOMAIN: &[u8] = b"briskdb.global-index.definition.v1\0";
+const SOURCE_DIGEST_DOMAIN: &[u8] = b"briskdb.global-index.source-shard.v1\0";
+const LOCATOR_MAGIC: &[u8; 4] = b"BRIL";
+const LOCATOR_VERSION: u32 = 1;
+
+const SCHEMA_SQL: &str = "
+CREATE TABLE briskdb_global_index_storage (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    storage_version INTEGER NOT NULL CHECK (storage_version = 1),
+    key_encoding_version INTEGER NOT NULL CHECK (key_encoding_version = 1)
+) STRICT;
+
+CREATE TABLE briskdb_global_index_builds (
+    index_id INTEGER PRIMARY KEY CHECK (index_id > 0),
+    definition_digest BLOB NOT NULL CHECK (length(definition_digest) = 32),
+    schema_generation INTEGER NOT NULL CHECK (schema_generation >= 0),
+    shard_count INTEGER NOT NULL CHECK (shard_count BETWEEN 2 AND 64),
+    build_state INTEGER NOT NULL CHECK (build_state IN (1, 2)),
+    indexed_rows INTEGER NOT NULL CHECK (indexed_rows >= 0)
+) STRICT;
+
+CREATE TABLE briskdb_global_index_checkpoints (
+    index_id INTEGER NOT NULL,
+    source_shard INTEGER NOT NULL CHECK (source_shard BETWEEN 0 AND 63),
+    source_digest BLOB NOT NULL CHECK (length(source_digest) = 32),
+    indexed_rows INTEGER NOT NULL CHECK (indexed_rows >= 0),
+    unique_rows INTEGER NOT NULL CHECK (unique_rows >= 0),
+    PRIMARY KEY (index_id, source_shard),
+    FOREIGN KEY (index_id) REFERENCES briskdb_global_index_builds (index_id)
+        ON DELETE CASCADE
+) STRICT, WITHOUT ROWID;
+
+CREATE TABLE briskdb_global_index_entries (
+    index_id INTEGER NOT NULL,
+    encoded_key BLOB NOT NULL,
+    source_shard INTEGER NOT NULL CHECK (source_shard BETWEEN 0 AND 63),
+    source_ordinal INTEGER NOT NULL CHECK (source_ordinal >= 0),
+    source_locator BLOB NOT NULL,
+    PRIMARY KEY (index_id, encoded_key, source_shard, source_locator),
+    UNIQUE (index_id, source_shard, source_ordinal),
+    FOREIGN KEY (index_id) REFERENCES briskdb_global_index_builds (index_id)
+        ON DELETE CASCADE
+) STRICT, WITHOUT ROWID;
+
+CREATE TABLE briskdb_global_index_unique_keys (
+    index_id INTEGER NOT NULL,
+    encoded_key BLOB NOT NULL,
+    source_shard INTEGER NOT NULL CHECK (source_shard BETWEEN 0 AND 63),
+    source_locator BLOB NOT NULL,
+    PRIMARY KEY (index_id, encoded_key),
+    FOREIGN KEY (index_id) REFERENCES briskdb_global_index_builds (index_id)
+        ON DELETE CASCADE
+) STRICT, WITHOUT ROWID;
+
+INSERT INTO briskdb_global_index_storage (
+    singleton, storage_version, key_encoding_version
+) VALUES (1, 1, 1);
+";
+
+const EXPECTED_OBJECTS: &[&str] = &[
+    "briskdb_global_index_builds",
+    "briskdb_global_index_checkpoints",
+    "briskdb_global_index_entries",
+    "briskdb_global_index_storage",
+    "briskdb_global_index_unique_keys",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Checkpoint {
+    source_shard: u16,
+    source_digest: [u8; 32],
+    indexed_rows: u64,
+    unique_rows: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct BuildState {
+    state: i64,
+    indexed_rows: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SourceLocator {
+    RowId(String),
+    PrimaryKey(Vec<String>),
+}
+
+impl SourceLocator {
+    fn expressions(&self) -> Vec<String> {
+        match self {
+            Self::RowId(name) => vec![quote_identifier(name)],
+            Self::PrimaryKey(columns) => columns
+                .iter()
+                .map(|column| quote_identifier(column))
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ScanOutcome {
+    source_digest: [u8; 32],
+    indexed_rows: u64,
+    unique_rows: u64,
+}
+
+pub(super) fn build(
+    storage: &Storage,
+    index: &GlobalIndexMetadata,
+    cancellation: &CancellationToken,
+) -> EngineResult<GlobalIndexBuildReport> {
+    ensure_not_cancelled(cancellation, "before global-index construction")?;
+    if index.topology() != GlobalIndexStorageTopology::SharedSqliteV1 {
+        return Err(EngineError::new(
+            EngineErrorKind::Unsupported,
+            format!(
+                "global index {} cannot be built with {:?}; the initial builder supports only SharedSqliteV1",
+                index.id(),
+                index.topology()
+            ),
+        ));
+    }
+    match index.lifecycle() {
+        GlobalIndexLifecycle::Creating | GlobalIndexLifecycle::Ready => {}
+        GlobalIndexLifecycle::Rebuilding => {
+            return Err(EngineError::new(
+                EngineErrorKind::Unsupported,
+                format!(
+                    "global index {} replacement construction belongs to the validation and rebuild workflow",
+                    index.id()
+                ),
+            ));
+        }
+        lifecycle => {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "global index {} cannot be built while its lifecycle is {lifecycle:?}",
+                    index.id()
+                ),
+            ));
+        }
+    }
+
+    let (mut connection, path) = open_or_create(&storage.root)?;
+    cleanup_abandoned(&mut connection, storage.catalog.logical().global_indexes())?;
+    let definition_digest = definition_digest(index);
+    prepare_build(
+        &mut connection,
+        index,
+        storage.shard_count(),
+        &definition_digest,
+    )?;
+    abort_at_test_boundary("initialized");
+
+    let checkpoints = load_checkpoints(&connection, index.id(), storage.shard_count())?;
+    let mut resumed_from_shard = checkpoints.len() as u16;
+    for checkpoint in &checkpoints {
+        ensure_not_cancelled(cancellation, "while revalidating a build checkpoint")?;
+        let observed =
+            scan_source_shard(storage, index, checkpoint.source_shard, cancellation, None)?;
+        if observed.source_digest != checkpoint.source_digest
+            || observed.indexed_rows != checkpoint.indexed_rows
+            || observed.unique_rows != checkpoint.unique_rows
+        {
+            reset_build(
+                &mut connection,
+                index,
+                storage.shard_count(),
+                &definition_digest,
+            )?;
+            resumed_from_shard = 0;
+            break;
+        }
+    }
+
+    for shard in resumed_from_shard..storage.shard_count() {
+        ensure_not_cancelled(cancellation, "before scanning a source shard")?;
+        let transaction = connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(sqlite_error::storage)?;
+        delete_shard_rows(&transaction, index.id(), shard)?;
+        let outcome = scan_source_shard(storage, index, shard, cancellation, Some(&transaction))?;
+        write_checkpoint(&transaction, index.id(), shard, &outcome)?;
+        ensure_not_cancelled(cancellation, "before committing a source-shard checkpoint")?;
+        abort_at_test_boundary(&format!("shard-{shard}-before-commit"));
+        transaction.commit().map_err(sqlite_error::storage)?;
+        abort_at_test_boundary(&format!("shard-{shard}-after-commit"));
+    }
+
+    let checkpoints = load_checkpoints(&connection, index.id(), storage.shard_count())?;
+    verify_checkpoint_sources(storage, index, cancellation, &checkpoints)?;
+    let indexed_rows = checkpoints.iter().try_fold(0_u64, |total, checkpoint| {
+        total.checked_add(checkpoint.indexed_rows).ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::NumericOutOfRange,
+                "global-index row count overflowed",
+            )
+        })
+    })?;
+    let unique_rows = checkpoints.iter().try_fold(0_u64, |total, checkpoint| {
+        total.checked_add(checkpoint.unique_rows).ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::NumericOutOfRange,
+                "global-index unique reservation count overflowed",
+            )
+        })
+    })?;
+    validate_physical_contents(&connection, index, &checkpoints, indexed_rows, unique_rows)?;
+
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "UPDATE briskdb_global_index_builds
+             SET build_state = ?1, indexed_rows = ?2
+             WHERE index_id = ?3",
+            params![
+                COMPLETE,
+                to_sqlite_u64(indexed_rows, "global-index row count")?,
+                to_sqlite_id(index.id())?,
+            ],
+        )
+        .map_err(sqlite_error::storage)?;
+    ensure_not_cancelled(
+        cancellation,
+        "before completing physical global-index storage",
+    )?;
+    abort_at_test_boundary("complete-before-commit");
+    transaction.commit().map_err(sqlite_error::storage)?;
+    abort_at_test_boundary("complete-after-commit");
+
+    checkpoint_and_sync(&connection, &path)?;
+    Ok(GlobalIndexBuildReport::from_validated(
+        index.id(),
+        storage.shard_count(),
+        resumed_from_shard,
+        indexed_rows,
+    ))
+}
+
+pub(super) fn validate_ready(
+    storage: &Storage,
+    index: &GlobalIndexMetadata,
+    cancellation: &CancellationToken,
+) -> EngineResult<GlobalIndexBuildReport> {
+    let (connection, _) = open_existing(&storage.root)?.ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!(
+                "ready global index {} has no physical storage file",
+                index.id()
+            ),
+        )
+    })?;
+    let digest = definition_digest(index);
+    let state = load_build_state(&connection, index.id(), storage.shard_count(), &digest)?
+        .ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!(
+                    "ready global index {} has no physical build record",
+                    index.id()
+                ),
+            )
+        })?;
+    if state.state != COMPLETE {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            format!(
+                "ready global index {} is not physically complete",
+                index.id()
+            ),
+        ));
+    }
+    let checkpoints = load_checkpoints(&connection, index.id(), storage.shard_count())?;
+    verify_checkpoint_sources(storage, index, cancellation, &checkpoints)?;
+    let unique_rows = checkpoints
+        .iter()
+        .map(|checkpoint| checkpoint.unique_rows)
+        .sum();
+    validate_physical_contents(
+        &connection,
+        index,
+        &checkpoints,
+        state.indexed_rows,
+        unique_rows,
+    )?;
+    Ok(GlobalIndexBuildReport::from_validated(
+        index.id(),
+        storage.shard_count(),
+        storage.shard_count(),
+        state.indexed_rows,
+    ))
+}
+
+pub(super) fn remove_artifacts(root: &Path, index_id: GlobalIndexId) -> EngineResult<()> {
+    let Some((mut connection, path)) = open_existing(root)? else {
+        return Ok(());
+    };
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "DELETE FROM briskdb_global_index_builds WHERE index_id = ?1",
+            [to_sqlite_id(index_id)?],
+        )
+        .map_err(sqlite_error::storage)?;
+    transaction.commit().map_err(sqlite_error::storage)?;
+    checkpoint_and_sync(&connection, &path)
+}
+
+fn prepare_build(
+    connection: &mut Connection,
+    index: &GlobalIndexMetadata,
+    shard_count: u16,
+    definition_digest: &[u8; 32],
+) -> EngineResult<()> {
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    let existing = transaction
+        .query_row(
+            "SELECT definition_digest, schema_generation, shard_count
+             FROM briskdb_global_index_builds WHERE index_id = ?1",
+            [to_sqlite_id(index.id())?],
+            |row| {
+                Ok((
+                    row.get::<_, Vec<u8>>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, i64>(2)?,
+                ))
+            },
+        )
+        .optional()
+        .map_err(sqlite_error::storage)?;
+    let expected_generation = to_sqlite_u64(index.schema_generation(), "schema generation")?;
+    if existing
+        .as_ref()
+        .is_some_and(|(digest, generation, shards)| {
+            digest.as_slice() != definition_digest
+                || *generation != expected_generation
+                || *shards != i64::from(shard_count)
+        })
+    {
+        transaction
+            .execute(
+                "DELETE FROM briskdb_global_index_builds WHERE index_id = ?1",
+                [to_sqlite_id(index.id())?],
+            )
+            .map_err(sqlite_error::storage)?;
+    }
+    transaction
+        .execute(
+            "INSERT OR IGNORE INTO briskdb_global_index_builds (
+                 index_id, definition_digest, schema_generation, shard_count,
+                 build_state, indexed_rows
+             ) VALUES (?1, ?2, ?3, ?4, ?5, 0)",
+            params![
+                to_sqlite_id(index.id())?,
+                definition_digest.as_slice(),
+                expected_generation,
+                i64::from(shard_count),
+                BUILDING,
+            ],
+        )
+        .map_err(sqlite_error::storage)?;
+    transaction.commit().map_err(sqlite_error::storage)
+}
+
+fn reset_build(
+    connection: &mut Connection,
+    index: &GlobalIndexMetadata,
+    shard_count: u16,
+    definition_digest: &[u8; 32],
+) -> EngineResult<()> {
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "DELETE FROM briskdb_global_index_builds WHERE index_id = ?1",
+            [to_sqlite_id(index.id())?],
+        )
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "INSERT INTO briskdb_global_index_builds (
+                 index_id, definition_digest, schema_generation, shard_count,
+                 build_state, indexed_rows
+             ) VALUES (?1, ?2, ?3, ?4, ?5, 0)",
+            params![
+                to_sqlite_id(index.id())?,
+                definition_digest.as_slice(),
+                to_sqlite_u64(index.schema_generation(), "schema generation")?,
+                i64::from(shard_count),
+                BUILDING,
+            ],
+        )
+        .map_err(sqlite_error::storage)?;
+    transaction.commit().map_err(sqlite_error::storage)
+}
+
+fn cleanup_abandoned(
+    connection: &mut Connection,
+    indexes: &[GlobalIndexMetadata],
+) -> EngineResult<()> {
+    let live = indexes
+        .iter()
+        .map(|index| to_sqlite_id(index.id()))
+        .collect::<EngineResult<BTreeSet<_>>>()?;
+    let stored = {
+        let mut statement = connection
+            .prepare("SELECT index_id FROM briskdb_global_index_builds ORDER BY index_id")
+            .map_err(sqlite_error::storage)?;
+        statement
+            .query_map([], |row| row.get::<_, i64>(0))
+            .map_err(sqlite_error::storage)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(sqlite_error::storage)?
+    };
+    let abandoned = stored
+        .into_iter()
+        .filter(|index_id| !live.contains(index_id))
+        .collect::<Vec<_>>();
+    if abandoned.is_empty() {
+        return Ok(());
+    }
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    for index_id in abandoned {
+        transaction
+            .execute(
+                "DELETE FROM briskdb_global_index_builds WHERE index_id = ?1",
+                [index_id],
+            )
+            .map_err(sqlite_error::storage)?;
+    }
+    transaction.commit().map_err(sqlite_error::storage)
+}
+
+fn load_build_state(
+    connection: &Connection,
+    index_id: GlobalIndexId,
+    shard_count: u16,
+    definition_digest: &[u8; 32],
+) -> EngineResult<Option<BuildState>> {
+    connection
+        .query_row(
+            "SELECT build_state, indexed_rows
+             FROM briskdb_global_index_builds
+             WHERE index_id = ?1 AND definition_digest = ?2 AND shard_count = ?3",
+            params![
+                to_sqlite_id(index_id)?,
+                definition_digest.as_slice(),
+                i64::from(shard_count),
+            ],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+        )
+        .optional()
+        .map_err(sqlite_error::storage)?
+        .map(|(state, rows)| {
+            Ok(BuildState {
+                state,
+                indexed_rows: from_sqlite_u64(rows, "global-index row count")?,
+            })
+        })
+        .transpose()
+}
+
+fn load_checkpoints(
+    connection: &Connection,
+    index_id: GlobalIndexId,
+    shard_count: u16,
+) -> EngineResult<Vec<Checkpoint>> {
+    let mut statement = connection
+        .prepare(
+            "SELECT source_shard, source_digest, indexed_rows, unique_rows
+             FROM briskdb_global_index_checkpoints
+             WHERE index_id = ?1 ORDER BY source_shard",
+        )
+        .map_err(sqlite_error::storage)?;
+    let rows = statement
+        .query_map([to_sqlite_id(index_id)?], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, Vec<u8>>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, i64>(3)?,
+            ))
+        })
+        .map_err(sqlite_error::storage)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(sqlite_error::storage)?;
+    if rows.len() > usize::from(shard_count) {
+        return Err(corrupt(format!(
+            "global index {index_id} has more checkpoints than source shards"
+        )));
+    }
+    rows.into_iter()
+        .enumerate()
+        .map(
+            |(expected, (source_shard, digest, indexed_rows, unique_rows))| {
+                let source_shard = u16::try_from(source_shard).map_err(|_| {
+                    corrupt(format!(
+                        "global index {index_id} has an invalid source-shard checkpoint"
+                    ))
+                })?;
+                if usize::from(source_shard) != expected || source_shard >= shard_count {
+                    return Err(corrupt(format!(
+                        "global index {index_id} checkpoints are not a contiguous shard prefix"
+                    )));
+                }
+                let source_digest: [u8; 32] = digest.try_into().map_err(|_| {
+                    corrupt(format!(
+                        "global index {index_id} has an invalid checkpoint digest"
+                    ))
+                })?;
+                Ok(Checkpoint {
+                    source_shard,
+                    source_digest,
+                    indexed_rows: from_sqlite_u64(indexed_rows, "checkpoint row count")?,
+                    unique_rows: from_sqlite_u64(unique_rows, "checkpoint unique row count")?,
+                })
+            },
+        )
+        .collect()
+}
+
+fn verify_checkpoint_sources(
+    storage: &Storage,
+    index: &GlobalIndexMetadata,
+    cancellation: &CancellationToken,
+    checkpoints: &[Checkpoint],
+) -> EngineResult<()> {
+    if checkpoints.len() != usize::from(storage.shard_count()) {
+        return Err(corrupt(format!(
+            "global index {} has an incomplete checkpoint set",
+            index.id()
+        )));
+    }
+    for checkpoint in checkpoints {
+        ensure_not_cancelled(cancellation, "while validating completed source shards")?;
+        let observed =
+            scan_source_shard(storage, index, checkpoint.source_shard, cancellation, None)?;
+        if observed.source_digest != checkpoint.source_digest
+            || observed.indexed_rows != checkpoint.indexed_rows
+            || observed.unique_rows != checkpoint.unique_rows
+        {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "global index {} source shard {} changed or uses a nondeterministic expression during its offline build",
+                    index.id(),
+                    checkpoint.source_shard
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn scan_source_shard(
+    storage: &Storage,
+    index: &GlobalIndexMetadata,
+    shard: u16,
+    cancellation: &CancellationToken,
+    target: Option<&Transaction<'_>>,
+) -> EngineResult<ScanOutcome> {
+    let source = storage.open_shard(shard)?;
+    let progress_cancellation = cancellation.clone();
+    source
+        .progress_handler(1_000, Some(move || progress_cancellation.is_cancelled()))
+        .map_err(sqlite_error::storage)?;
+    source
+        .execute_batch("BEGIN DEFERRED TRANSACTION")
+        .map_err(sqlite_error::storage)?;
+    let table = storage
+        .catalog
+        .logical()
+        .table_by_id(index.table_id())
+        .ok_or_else(|| {
+            corrupt(format!(
+                "global index {} references a missing table",
+                index.id()
+            ))
+        })?;
+    let locator = inspect_source_locator(&source, table.name())?;
+    let sql = scan_sql(index, table.name(), &locator);
+    let mut statement = source.prepare(&sql).map_err(sqlite_error::statement)?;
+    let locator_count = locator.expressions().len();
+    let mut rows = statement.query([]).map_err(sqlite_error::statement)?;
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(SOURCE_DIGEST_DOMAIN);
+    hasher.update(&index.id().get().to_le_bytes());
+    hasher.update(&shard.to_le_bytes());
+    let mut indexed_rows = 0_u64;
+    let mut unique_rows = 0_u64;
+    while let Some(row) = rows.next().map_err(sqlite_error::statement)? {
+        ensure_not_cancelled(cancellation, "while scanning a source shard")?;
+        let values = index
+            .key_parts()
+            .iter()
+            .enumerate()
+            .map(|(ordinal, part)| {
+                read_key_value(
+                    row.get_ref(ordinal).map_err(sqlite_error::statement)?,
+                    part.key_type(),
+                    index,
+                    shard,
+                    ordinal,
+                )
+            })
+            .collect::<EngineResult<Vec<_>>>()?;
+        let parts = values
+            .iter()
+            .zip(index.key_parts())
+            .map(|(value, metadata)| {
+                let part = match metadata.order() {
+                    IndexKeyOrder::Ascending => IndexKeyPart::ascending(value.as_ref()),
+                    IndexKeyOrder::Descending => IndexKeyPart::descending(value.as_ref()),
+                };
+                part.with_null_order(metadata.null_order())
+                    .with_collation(metadata.collation())
+            })
+            .collect::<Vec<_>>();
+        let encoded_key = CanonicalIndexKey::encode(&parts)?;
+        let locator_values = (0..locator_count)
+            .map(|offset| {
+                row.get_ref(index.key_parts().len() + offset)
+                    .map_err(sqlite_error::statement)
+            })
+            .collect::<EngineResult<Vec<_>>>()?;
+        let encoded_locator = encode_locator(&locator_values)?;
+        update_framed(&mut hasher, encoded_key.as_bytes());
+        update_framed(&mut hasher, &encoded_locator);
+
+        if let Some(target) = target {
+            insert_entry(
+                target,
+                index,
+                shard,
+                indexed_rows,
+                &encoded_key,
+                &encoded_locator,
+                &parts,
+            )?;
+        }
+        indexed_rows = indexed_rows.checked_add(1).ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::NumericOutOfRange,
+                "global-index row count overflowed",
+            )
+        })?;
+        if index.is_unique()
+            && !(index.null_semantics() == UniqueNullSemantics::Distinct
+                && values
+                    .iter()
+                    .any(|value| matches!(value, IndexKeyValue::Null)))
+        {
+            unique_rows = unique_rows.checked_add(1).ok_or_else(|| {
+                EngineError::new(
+                    EngineErrorKind::NumericOutOfRange,
+                    "global-index unique reservation count overflowed",
+                )
+            })?;
+        }
+    }
+    source
+        .execute_batch("COMMIT")
+        .map_err(sqlite_error::storage)?;
+    Ok(ScanOutcome {
+        source_digest: *hasher.finalize().as_bytes(),
+        indexed_rows,
+        unique_rows,
+    })
+}
+
+fn insert_entry(
+    transaction: &Transaction<'_>,
+    index: &GlobalIndexMetadata,
+    shard: u16,
+    source_ordinal: u64,
+    encoded_key: &CanonicalIndexKey,
+    encoded_locator: &[u8],
+    parts: &[IndexKeyPart<'_>],
+) -> EngineResult<()> {
+    let index_id = to_sqlite_id(index.id())?;
+    transaction
+        .execute(
+            "INSERT INTO briskdb_global_index_entries (
+                 index_id, encoded_key, source_shard, source_ordinal, source_locator
+             ) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                index_id,
+                encoded_key.as_bytes(),
+                i64::from(shard),
+                to_sqlite_u64(source_ordinal, "source row ordinal")?,
+                encoded_locator,
+            ],
+        )
+        .map_err(sqlite_error::storage)?;
+    if !index.is_unique()
+        || CanonicalIndexKey::encode_unique(parts, index.null_semantics())?.is_none()
+    {
+        return Ok(());
+    }
+    let inserted = transaction
+        .execute(
+            "INSERT OR IGNORE INTO briskdb_global_index_unique_keys (
+                 index_id, encoded_key, source_shard, source_locator
+             ) VALUES (?1, ?2, ?3, ?4)",
+            params![
+                index_id,
+                encoded_key.as_bytes(),
+                i64::from(shard),
+                encoded_locator,
+            ],
+        )
+        .map_err(sqlite_error::storage)?;
+    if inserted == 1 {
+        return Ok(());
+    }
+    let (existing_shard, existing_locator) = transaction
+        .query_row(
+            "SELECT source_shard, source_locator
+             FROM briskdb_global_index_unique_keys
+             WHERE index_id = ?1 AND encoded_key = ?2",
+            params![index_id, encoded_key.as_bytes()],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, Vec<u8>>(1)?)),
+        )
+        .map_err(sqlite_error::storage)?;
+    Err(EngineError::new(
+        EngineErrorKind::UniqueViolation,
+        format!(
+            "global index {} ({}) found a duplicate unique key at shard {} row {} and shard {} row {}; key bytes are redacted",
+            index.id(),
+            index.name(),
+            existing_shard,
+            locator_label(&existing_locator),
+            shard,
+            locator_label(encoded_locator),
+        ),
+    ))
+}
+
+fn delete_shard_rows(
+    transaction: &Transaction<'_>,
+    index_id: GlobalIndexId,
+    shard: u16,
+) -> EngineResult<()> {
+    for table in [
+        "briskdb_global_index_unique_keys",
+        "briskdb_global_index_entries",
+        "briskdb_global_index_checkpoints",
+    ] {
+        transaction
+            .execute(
+                &format!("DELETE FROM {table} WHERE index_id = ?1 AND source_shard = ?2"),
+                params![to_sqlite_id(index_id)?, i64::from(shard)],
+            )
+            .map_err(sqlite_error::storage)?;
+    }
+    transaction
+        .execute(
+            "UPDATE briskdb_global_index_builds
+             SET build_state = ?1, indexed_rows = 0 WHERE index_id = ?2",
+            params![BUILDING, to_sqlite_id(index_id)?],
+        )
+        .map_err(sqlite_error::storage)?;
+    Ok(())
+}
+
+fn write_checkpoint(
+    transaction: &Transaction<'_>,
+    index_id: GlobalIndexId,
+    shard: u16,
+    outcome: &ScanOutcome,
+) -> EngineResult<()> {
+    transaction
+        .execute(
+            "INSERT INTO briskdb_global_index_checkpoints (
+                 index_id, source_shard, source_digest, indexed_rows, unique_rows
+             ) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                to_sqlite_id(index_id)?,
+                i64::from(shard),
+                outcome.source_digest.as_slice(),
+                to_sqlite_u64(outcome.indexed_rows, "checkpoint row count")?,
+                to_sqlite_u64(outcome.unique_rows, "checkpoint unique row count")?,
+            ],
+        )
+        .map_err(sqlite_error::storage)?;
+    Ok(())
+}
+
+fn validate_physical_contents(
+    connection: &Connection,
+    index: &GlobalIndexMetadata,
+    checkpoints: &[Checkpoint],
+    indexed_rows: u64,
+    unique_rows: u64,
+) -> EngineResult<()> {
+    let index_id = to_sqlite_id(index.id())?;
+    let entries = connection
+        .query_row(
+            "SELECT COUNT(*) FROM briskdb_global_index_entries WHERE index_id = ?1",
+            [index_id],
+            |row| row.get::<_, i64>(0),
+        )
+        .map_err(sqlite_error::storage)?;
+    let reservations = connection
+        .query_row(
+            "SELECT COUNT(*) FROM briskdb_global_index_unique_keys WHERE index_id = ?1",
+            [index_id],
+            |row| row.get::<_, i64>(0),
+        )
+        .map_err(sqlite_error::storage)?;
+    if from_sqlite_u64(entries, "physical global-index entry count")? != indexed_rows
+        || from_sqlite_u64(reservations, "physical unique reservation count")? != unique_rows
+    {
+        return Err(corrupt(format!(
+            "global index {} physical row counts do not match its checkpoints",
+            index.id()
+        )));
+    }
+    for checkpoint in checkpoints {
+        let mut statement = connection
+            .prepare(
+                "SELECT encoded_key, source_locator
+                 FROM briskdb_global_index_entries
+                 WHERE index_id = ?1 AND source_shard = ?2
+                 ORDER BY source_ordinal",
+            )
+            .map_err(sqlite_error::storage)?;
+        let mut rows = statement
+            .query(params![index_id, i64::from(checkpoint.source_shard)])
+            .map_err(sqlite_error::storage)?;
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(SOURCE_DIGEST_DOMAIN);
+        hasher.update(&index.id().get().to_le_bytes());
+        hasher.update(&checkpoint.source_shard.to_le_bytes());
+        let mut physical_rows = 0_u64;
+        while let Some(row) = rows.next().map_err(sqlite_error::storage)? {
+            let key = row.get_ref(0).map_err(sqlite_error::storage)?;
+            let locator = row.get_ref(1).map_err(sqlite_error::storage)?;
+            let (ValueRef::Blob(key), ValueRef::Blob(locator)) = (key, locator) else {
+                return Err(corrupt(format!(
+                    "global index {} contains a non-blob physical entry",
+                    index.id()
+                )));
+            };
+            CanonicalIndexKey::from_bytes(key)?;
+            update_framed(&mut hasher, key);
+            update_framed(&mut hasher, locator);
+            physical_rows = physical_rows.checked_add(1).ok_or_else(|| {
+                EngineError::new(
+                    EngineErrorKind::NumericOutOfRange,
+                    "physical global-index row count overflowed",
+                )
+            })?;
+        }
+        if physical_rows != checkpoint.indexed_rows
+            || hasher.finalize().as_bytes() != &checkpoint.source_digest
+        {
+            return Err(corrupt(format!(
+                "global index {} physical entries do not match source-shard checkpoint {}",
+                index.id(),
+                checkpoint.source_shard
+            )));
+        }
+    }
+    validate_unique_reservations(connection, index)?;
+    Ok(())
+}
+
+fn validate_unique_reservations(
+    connection: &Connection,
+    index: &GlobalIndexMetadata,
+) -> EngineResult<()> {
+    if !index.is_unique() {
+        return Ok(());
+    }
+    let index_id = to_sqlite_id(index.id())?;
+    let mut entry_statement = connection
+        .prepare(
+            "SELECT encoded_key, source_shard, source_locator
+             FROM briskdb_global_index_entries
+             WHERE index_id = ?1
+             ORDER BY encoded_key, source_shard, source_locator",
+        )
+        .map_err(sqlite_error::storage)?;
+    let mut reservation_statement = connection
+        .prepare(
+            "SELECT encoded_key, source_shard, source_locator
+             FROM briskdb_global_index_unique_keys
+             WHERE index_id = ?1 ORDER BY encoded_key",
+        )
+        .map_err(sqlite_error::storage)?;
+    let mut entries = entry_statement
+        .query([index_id])
+        .map_err(sqlite_error::storage)?;
+    let mut reservations = reservation_statement
+        .query([index_id])
+        .map_err(sqlite_error::storage)?;
+    let mut previous_reserved_key: Option<Vec<u8>> = None;
+    while let Some(entry) = entries.next().map_err(sqlite_error::storage)? {
+        let key = entry.get::<_, Vec<u8>>(0).map_err(sqlite_error::storage)?;
+        let canonical = CanonicalIndexKey::from_bytes(&key)?;
+        let contains_null = canonical
+            .decode()?
+            .iter()
+            .any(|part| matches!(part.value(), IndexKeyValue::Null));
+        if index.null_semantics() == UniqueNullSemantics::Distinct && contains_null {
+            continue;
+        }
+        if previous_reserved_key.as_deref() == Some(key.as_slice()) {
+            return Err(corrupt(format!(
+                "global index {} contains duplicate physically reserved keys",
+                index.id()
+            )));
+        }
+        previous_reserved_key = Some(key.clone());
+        let source_shard = entry.get::<_, i64>(1).map_err(sqlite_error::storage)?;
+        let source_locator = entry.get::<_, Vec<u8>>(2).map_err(sqlite_error::storage)?;
+        let reservation = reservations
+            .next()
+            .map_err(sqlite_error::storage)?
+            .ok_or_else(|| {
+                corrupt(format!(
+                    "global index {} is missing a unique reservation",
+                    index.id()
+                ))
+            })?;
+        if reservation
+            .get::<_, Vec<u8>>(0)
+            .map_err(sqlite_error::storage)?
+            != key
+            || reservation
+                .get::<_, i64>(1)
+                .map_err(sqlite_error::storage)?
+                != source_shard
+            || reservation
+                .get::<_, Vec<u8>>(2)
+                .map_err(sqlite_error::storage)?
+                != source_locator
+        {
+            return Err(corrupt(format!(
+                "global index {} unique reservation does not match its source entry",
+                index.id()
+            )));
+        }
+    }
+    if reservations
+        .next()
+        .map_err(sqlite_error::storage)?
+        .is_some()
+    {
+        return Err(corrupt(format!(
+            "global index {} contains an extra unique reservation",
+            index.id()
+        )));
+    }
+    Ok(())
+}
+
+fn inspect_source_locator(connection: &Connection, table: &str) -> EngineResult<SourceLocator> {
+    let without_rowid = connection
+        .query_row(
+            "SELECT wr FROM pragma_table_list
+             WHERE schema = 'main' AND name = ?1 COLLATE BINARY AND type = 'table'",
+            [table],
+            |row| row.get::<_, bool>(0),
+        )
+        .optional()
+        .map_err(sqlite_error::storage)?
+        .ok_or_else(|| {
+            corrupt(format!(
+                "registered global-index source table {table} is missing"
+            ))
+        })?;
+    let columns = {
+        let mut statement = connection
+            .prepare(
+                "SELECT name, pk
+                 FROM pragma_table_xinfo(?1)
+                 ORDER BY CASE WHEN pk = 0 THEN 2147483647 ELSE pk END, cid",
+            )
+            .map_err(sqlite_error::storage)?;
+        statement
+            .query_map([table], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+            })
+            .map_err(sqlite_error::storage)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(sqlite_error::storage)?
+    };
+    if without_rowid {
+        let primary_key = columns
+            .iter()
+            .filter(|(_, ordinal)| *ordinal > 0)
+            .map(|(name, _)| name.clone())
+            .collect::<Vec<_>>();
+        if primary_key.is_empty() {
+            return Err(corrupt(format!(
+                "WITHOUT ROWID source table {table} has no primary-key locator"
+            )));
+        }
+        return Ok(SourceLocator::PrimaryKey(primary_key));
+    }
+    ["rowid", "_rowid_", "oid"]
+        .into_iter()
+        .find(|candidate| {
+            columns
+                .iter()
+                .all(|(column, _)| !column.eq_ignore_ascii_case(candidate))
+        })
+        .map(|candidate| SourceLocator::RowId(candidate.to_owned()))
+        .ok_or_else(|| {
+            corrupt(format!(
+                "rowid source table {table} has no unshadowed physical row locator"
+            ))
+        })
+}
+
+fn scan_sql(index: &GlobalIndexMetadata, table: &str, locator: &SourceLocator) -> String {
+    let mut expressions = index
+        .key_parts()
+        .iter()
+        .map(|part| match part.source() {
+            GlobalIndexKeySource::Column(column) => quote_identifier(column),
+            GlobalIndexKeySource::Expression(expression) => format!("({expression})"),
+        })
+        .collect::<Vec<_>>();
+    let locator_expressions = locator.expressions();
+    expressions.extend(locator_expressions.iter().cloned());
+    let mut sql = format!(
+        "SELECT {} FROM {}",
+        expressions.join(", "),
+        quote_identifier(table)
+    );
+    if let Some(predicate) = index.predicate() {
+        sql.push_str(" WHERE (");
+        sql.push_str(predicate);
+        sql.push(')');
+    }
+    sql.push_str(" ORDER BY ");
+    sql.push_str(&locator_expressions.join(", "));
+    sql
+}
+
+fn read_key_value(
+    value: ValueRef<'_>,
+    key_type: GlobalIndexKeyType,
+    index: &GlobalIndexMetadata,
+    shard: u16,
+    ordinal: usize,
+) -> EngineResult<IndexKeyValue> {
+    if matches!(value, ValueRef::Null) {
+        return Ok(IndexKeyValue::Null);
+    }
+    let mismatch = || {
+        EngineError::new(
+            EngineErrorKind::TypeMismatch,
+            format!(
+                "global index {} ({}) key part {} has an incompatible SQLite value on source shard {shard}",
+                index.id(),
+                index.name(),
+                ordinal
+            ),
+        )
+    };
+    match (key_type, value) {
+        (GlobalIndexKeyType::Boolean, ValueRef::Integer(0)) => Ok(IndexKeyValue::Boolean(false)),
+        (GlobalIndexKeyType::Boolean, ValueRef::Integer(1)) => Ok(IndexKeyValue::Boolean(true)),
+        (GlobalIndexKeyType::Int64, ValueRef::Integer(value)) => Ok(IndexKeyValue::Int64(value)),
+        (GlobalIndexKeyType::UInt64, ValueRef::Integer(value)) => u64::try_from(value)
+            .map(IndexKeyValue::UInt64)
+            .map_err(|_| mismatch()),
+        (GlobalIndexKeyType::Float64, ValueRef::Integer(value)) => {
+            Ok(IndexKeyValue::Float64(value as f64))
+        }
+        (GlobalIndexKeyType::Float64, ValueRef::Real(value)) => Ok(IndexKeyValue::Float64(value)),
+        (GlobalIndexKeyType::Date, ValueRef::Integer(value)) => i32::try_from(value)
+            .map(IndexKeyValue::Date)
+            .map_err(|_| mismatch()),
+        (GlobalIndexKeyType::Timestamp, ValueRef::Integer(value)) => {
+            Ok(IndexKeyValue::Timestamp(value))
+        }
+        (GlobalIndexKeyType::Text, ValueRef::Text(value)) => str::from_utf8(value)
+            .map(|value| IndexKeyValue::Text(value.to_owned()))
+            .map_err(|_| {
+                EngineError::new(
+                    EngineErrorKind::InvalidTextEncoding,
+                    format!(
+                        "global index {} ({}) key part {} contains invalid UTF-8 on source shard {shard}",
+                        index.id(),
+                        index.name(),
+                        ordinal
+                    ),
+                )
+            }),
+        (GlobalIndexKeyType::Binary, ValueRef::Blob(value)) => {
+            Ok(IndexKeyValue::Binary(value.to_vec()))
+        }
+        _ => Err(mismatch()),
+    }
+}
+
+fn encode_locator(values: &[ValueRef<'_>]) -> EngineResult<Vec<u8>> {
+    let count = u16::try_from(values.len()).map_err(|_| {
+        EngineError::new(
+            EngineErrorKind::LimitExceeded,
+            "source row locator has too many components",
+        )
+    })?;
+    let mut output = Vec::with_capacity(16 + values.len() * 9);
+    output.extend_from_slice(LOCATOR_MAGIC);
+    output.extend_from_slice(&LOCATOR_VERSION.to_be_bytes());
+    output.extend_from_slice(&count.to_be_bytes());
+    for value in values {
+        match value {
+            ValueRef::Null => output.push(0),
+            ValueRef::Integer(value) => {
+                output.push(1);
+                output.extend_from_slice(&value.to_be_bytes());
+            }
+            ValueRef::Real(value) => {
+                output.push(2);
+                output.extend_from_slice(&value.to_bits().to_be_bytes());
+            }
+            ValueRef::Text(value) => {
+                output.push(3);
+                append_locator_bytes(&mut output, value)?;
+            }
+            ValueRef::Blob(value) => {
+                output.push(4);
+                append_locator_bytes(&mut output, value)?;
+            }
+        }
+    }
+    Ok(output)
+}
+
+fn append_locator_bytes(output: &mut Vec<u8>, value: &[u8]) -> EngineResult<()> {
+    let length = u32::try_from(value.len()).map_err(|_| {
+        EngineError::new(
+            EngineErrorKind::LimitExceeded,
+            "source row locator component exceeds the version-1 size limit",
+        )
+    })?;
+    output.extend_from_slice(&length.to_be_bytes());
+    output.extend_from_slice(value);
+    Ok(())
+}
+
+fn definition_digest(index: &GlobalIndexMetadata) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(DEFINITION_DIGEST_DOMAIN);
+    hasher.update(&index.id().get().to_le_bytes());
+    hasher.update(&index.table_id().get().to_le_bytes());
+    update_framed(&mut hasher, index.name().as_bytes());
+    hasher.update(&[u8::from(index.is_unique())]);
+    hasher.update(&[match index.null_semantics() {
+        UniqueNullSemantics::Distinct => 1,
+        UniqueNullSemantics::NotDistinct => 2,
+    }]);
+    match index.predicate() {
+        Some(predicate) => {
+            hasher.update(&[1]);
+            update_framed(&mut hasher, predicate.as_bytes());
+        }
+        None => {
+            hasher.update(&[0]);
+        }
+    }
+    hasher.update(&index.schema_generation().to_le_bytes());
+    hasher.update(&index.key_encoding_version().to_le_bytes());
+    let (topology_kind, topology_version, partition_count) = index.topology().persisted_parts();
+    hasher.update(&topology_kind.to_le_bytes());
+    hasher.update(&topology_version.to_le_bytes());
+    hasher.update(&partition_count.to_le_bytes());
+    hasher.update(&(index.key_parts().len() as u64).to_le_bytes());
+    for part in index.key_parts() {
+        hasher.update(&part.source().kind_code().to_le_bytes());
+        update_framed(&mut hasher, part.source().source().as_bytes());
+        hasher.update(&[key_type_code(part.key_type())]);
+        hasher.update(&[match part.order() {
+            IndexKeyOrder::Ascending => 1,
+            IndexKeyOrder::Descending => 2,
+        }]);
+        hasher.update(&[match part.null_order() {
+            crate::core::IndexNullOrder::First => 1,
+            crate::core::IndexNullOrder::Last => 2,
+        }]);
+        hasher.update(&[match part.collation() {
+            crate::core::IndexKeyCollation::Binary => 1,
+        }]);
+    }
+    *hasher.finalize().as_bytes()
+}
+
+fn key_type_code(key_type: GlobalIndexKeyType) -> u8 {
+    match key_type {
+        GlobalIndexKeyType::Boolean => 1,
+        GlobalIndexKeyType::Int64 => 2,
+        GlobalIndexKeyType::UInt64 => 3,
+        GlobalIndexKeyType::Float64 => 4,
+        GlobalIndexKeyType::Date => 5,
+        GlobalIndexKeyType::Timestamp => 6,
+        GlobalIndexKeyType::Text => 7,
+        GlobalIndexKeyType::Binary => 8,
+    }
+}
+
+fn update_framed(hasher: &mut blake3::Hasher, value: &[u8]) {
+    hasher.update(&(value.len() as u64).to_le_bytes());
+    hasher.update(value);
+}
+
+fn open_or_create(root: &Path) -> EngineResult<(Connection, PathBuf)> {
+    let directory = root.join(DIRECTORY_NAME);
+    ensure_real_directory(&directory)?;
+    let path = directory.join(SHARED_FILE_NAME);
+    let exists = ensure_regular_file_or_absent(&path)?;
+    let flags = OpenFlags::SQLITE_OPEN_READ_WRITE
+        | OpenFlags::SQLITE_OPEN_NO_MUTEX
+        | OpenFlags::SQLITE_OPEN_NOFOLLOW
+        | if exists {
+            OpenFlags::empty()
+        } else {
+            OpenFlags::SQLITE_OPEN_CREATE
+        };
+    let connection = Connection::open_with_flags(&path, flags).map_err(sqlite_error::storage)?;
+    configure(&connection)?;
+    if exists {
+        validate(&connection)?;
+    } else {
+        initialize(&connection)?;
+        sync_directory(&directory)?;
+    }
+    Ok((connection, path))
+}
+
+fn open_existing(root: &Path) -> EngineResult<Option<(Connection, PathBuf)>> {
+    let directory = root.join(DIRECTORY_NAME);
+    match fs::symlink_metadata(&directory) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(sqlite_error::storage_io(
+                error,
+                format!("failed to inspect {}", directory.display()),
+            ));
+        }
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "global-index path {} is not a real directory",
+                    directory.display()
+                ),
+            ));
+        }
+        Ok(_) => {}
+    }
+    let path = directory.join(SHARED_FILE_NAME);
+    if !ensure_regular_file_or_absent(&path)? {
+        return Ok(None);
+    }
+    let connection = Connection::open_with_flags(
+        &path,
+        OpenFlags::SQLITE_OPEN_READ_WRITE
+            | OpenFlags::SQLITE_OPEN_NO_MUTEX
+            | OpenFlags::SQLITE_OPEN_NOFOLLOW,
+    )
+    .map_err(sqlite_error::storage)?;
+    configure(&connection)?;
+    validate(&connection)?;
+    Ok(Some((connection, path)))
+}
+
+fn configure(connection: &Connection) -> EngineResult<()> {
+    connection
+        .busy_timeout(CONNECTION_BUSY_TIMEOUT)
+        .map_err(sqlite_error::storage)?;
+    connection
+        .pragma_update(None, "foreign_keys", "ON")
+        .map_err(sqlite_error::storage)?;
+    connection
+        .pragma_update(None, "synchronous", "FULL")
+        .map_err(sqlite_error::storage)?;
+    Ok(())
+}
+
+fn initialize(connection: &Connection) -> EngineResult<()> {
+    connection
+        .pragma_update(None, "application_id", APPLICATION_ID)
+        .map_err(sqlite_error::storage)?;
+    connection
+        .pragma_update(None, "user_version", STORAGE_VERSION)
+        .map_err(sqlite_error::storage)?;
+    let mode: String = connection
+        .pragma_query_value(None, "journal_mode", |row| row.get(0))
+        .map_err(sqlite_error::storage)?;
+    if !mode.eq_ignore_ascii_case("wal") {
+        let mode: String = connection
+            .pragma_update_and_check(None, "journal_mode", "WAL", |row| row.get(0))
+            .map_err(sqlite_error::storage)?;
+        if !mode.eq_ignore_ascii_case("wal") {
+            return Err(EngineError::new(
+                EngineErrorKind::StorageUnavailable,
+                "global-index storage did not enter WAL mode",
+            ));
+        }
+    }
+    connection
+        .execute_batch(SCHEMA_SQL)
+        .map_err(sqlite_error::storage)?;
+    validate(connection)
+}
+
+fn validate(connection: &Connection) -> EngineResult<()> {
+    let application_id: i32 = connection
+        .pragma_query_value(None, "application_id", |row| row.get(0))
+        .map_err(sqlite_error::storage)?;
+    let storage_version: u32 = connection
+        .pragma_query_value(None, "user_version", |row| row.get(0))
+        .map_err(sqlite_error::storage)?;
+    if application_id != APPLICATION_ID {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "global-index SQLite file has a foreign application identity",
+        ));
+    }
+    if storage_version != STORAGE_VERSION {
+        return Err(EngineError::new(
+            if storage_version > STORAGE_VERSION {
+                EngineErrorKind::FailedPrecondition
+            } else {
+                EngineErrorKind::DataCorruption
+            },
+            format!(
+                "global-index storage version {storage_version} is not supported by this build"
+            ),
+        ));
+    }
+    let mode: String = connection
+        .pragma_query_value(None, "journal_mode", |row| row.get(0))
+        .map_err(sqlite_error::storage)?;
+    if !mode.eq_ignore_ascii_case("wal") {
+        return Err(corrupt("global-index storage is not in WAL mode"));
+    }
+    let quick_check: String = connection
+        .query_row("PRAGMA quick_check", [], |row| row.get(0))
+        .map_err(sqlite_error::storage)?;
+    if quick_check != "ok" {
+        return Err(corrupt("global-index storage failed SQLite quick_check"));
+    }
+    let objects = {
+        let mut statement = connection
+            .prepare(
+                "SELECT name FROM sqlite_schema
+                 WHERE name NOT GLOB 'sqlite_*'
+                 ORDER BY name COLLATE BINARY",
+            )
+            .map_err(sqlite_error::storage)?;
+        statement
+            .query_map([], |row| row.get::<_, String>(0))
+            .map_err(sqlite_error::storage)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(sqlite_error::storage)?
+    };
+    if objects != EXPECTED_OBJECTS {
+        return Err(corrupt("global-index storage schema is not canonical"));
+    }
+    let metadata = connection
+        .query_row(
+            "SELECT storage_version, key_encoding_version
+             FROM briskdb_global_index_storage WHERE singleton = 1",
+            [],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+        )
+        .optional()
+        .map_err(sqlite_error::storage)?;
+    if metadata
+        != Some((
+            i64::from(STORAGE_VERSION),
+            i64::from(INDEX_KEY_ENCODING_VERSION),
+        ))
+    {
+        return Err(corrupt("global-index storage metadata is invalid"));
+    }
+    Ok(())
+}
+
+fn ensure_real_directory(path: &Path) -> EngineResult<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "global-index path {} is not a real directory",
+                    path.display()
+                ),
+            ));
+        }
+        Ok(_) => return Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(sqlite_error::storage_io(
+                error,
+                format!("failed to inspect {}", path.display()),
+            ));
+        }
+    }
+    fs::create_dir(path).map_err(|error| {
+        sqlite_error::storage_io(error, format!("failed to create {}", path.display()))
+    })?;
+    Ok(())
+}
+
+fn ensure_regular_file_or_absent(path: &Path) -> EngineResult<bool> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
+            Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "global-index storage {} is not a regular file",
+                    path.display()
+                ),
+            ))
+        }
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(sqlite_error::storage_io(
+            error,
+            format!("failed to inspect {}", path.display()),
+        )),
+    }
+}
+
+fn checkpoint_and_sync(connection: &Connection, path: &Path) -> EngineResult<()> {
+    let (_, remaining): (i64, i64) = connection
+        .query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| {
+            Ok((row.get(0)?, row.get(1)?))
+        })
+        .map_err(sqlite_error::storage)?;
+    if remaining != 0 {
+        return Err(EngineError::new(
+            EngineErrorKind::Busy,
+            "global-index WAL could not be fully checkpointed before publication",
+        ));
+    }
+    File::open(path)
+        .and_then(|file| file.sync_all())
+        .map_err(|error| {
+            sqlite_error::storage_io(error, format!("failed to synchronize {}", path.display()))
+        })?;
+    sync_directory(path.parent().expect("global-index file has a parent"))
+}
+
+fn sync_directory(path: &Path) -> EngineResult<()> {
+    File::open(path)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|error| {
+            sqlite_error::storage_io(error, format!("failed to synchronize {}", path.display()))
+        })
+}
+
+fn ensure_not_cancelled(cancellation: &CancellationToken, context: &str) -> EngineResult<()> {
+    if cancellation.is_cancelled() {
+        Err(EngineError::new(
+            EngineErrorKind::Cancelled,
+            format!("global-index build was cancelled {context}"),
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn to_sqlite_id(index_id: GlobalIndexId) -> EngineResult<i64> {
+    i64::try_from(index_id.get()).map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::NumericOutOfRange,
+            "global-index ID does not fit in SQLite",
+            error,
+        )
+    })
+}
+
+fn to_sqlite_u64(value: u64, description: &str) -> EngineResult<i64> {
+    i64::try_from(value).map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::NumericOutOfRange,
+            format!("{description} does not fit in SQLite"),
+            error,
+        )
+    })
+}
+
+fn from_sqlite_u64(value: i64, description: &str) -> EngineResult<u64> {
+    u64::try_from(value).map_err(|_| corrupt(format!("{description} is negative")))
+}
+
+fn locator_label(locator: &[u8]) -> String {
+    let digest = blake3::hash(locator);
+    digest.as_bytes()[..8]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn quote_identifier(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
+}
+
+fn corrupt(diagnostic: impl Into<String>) -> EngineError {
+    EngineError::new(EngineErrorKind::DataCorruption, diagnostic)
+}
+
+#[cfg(test)]
+fn abort_at_test_boundary(boundary: &str) {
+    if std::env::var("BRISKDB_GLOBAL_INDEX_BUILD_ABORT_POINT").as_deref() == Ok(boundary) {
+        std::process::abort();
+    }
+}
+
+#[cfg(not(test))]
+fn abort_at_test_boundary(_boundary: &str) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unique_metadata() -> GlobalIndexMetadata {
+        GlobalIndexMetadata::from_validated(
+            1,
+            1,
+            "events_email".to_owned(),
+            vec![crate::core::GlobalIndexKeyPart::new(
+                GlobalIndexKeySource::column("email").unwrap(),
+                GlobalIndexKeyType::Text,
+            )]
+            .into_boxed_slice(),
+            true,
+            UniqueNullSemantics::Distinct,
+            None,
+            GlobalIndexLifecycle::Creating,
+            1,
+            GlobalIndexStorageTopology::SharedSqliteV1,
+        )
+    }
+
+    #[test]
+    fn source_locator_encoding_is_typed_framed_and_stable() {
+        let encoded = encode_locator(&[
+            ValueRef::Integer(-1),
+            ValueRef::Text(b"a"),
+            ValueRef::Blob(&[0, 255]),
+        ])
+        .unwrap();
+        let mut expected = Vec::new();
+        expected.extend_from_slice(b"BRIL");
+        expected.extend_from_slice(&1_u32.to_be_bytes());
+        expected.extend_from_slice(&3_u16.to_be_bytes());
+        expected.push(1);
+        expected.extend_from_slice(&(-1_i64).to_be_bytes());
+        expected.push(3);
+        expected.extend_from_slice(&1_u32.to_be_bytes());
+        expected.push(b'a');
+        expected.push(4);
+        expected.extend_from_slice(&2_u32.to_be_bytes());
+        expected.extend_from_slice(&[0, 255]);
+        assert_eq!(encoded, expected);
+    }
+
+    #[test]
+    fn checkpoints_must_form_one_contiguous_source_shard_prefix() {
+        let connection = Connection::open_in_memory().unwrap();
+        connection.execute_batch(SCHEMA_SQL).unwrap();
+        connection
+            .execute(
+                "INSERT INTO briskdb_global_index_builds VALUES (1, ?1, 0, 4, 1, 0)",
+                [&[0_u8; 32][..]],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO briskdb_global_index_checkpoints
+                 VALUES (1, 1, ?1, 0, 0)",
+                [&[0_u8; 32][..]],
+            )
+            .unwrap();
+        let error = load_checkpoints(&connection, GlobalIndexId::new(1).unwrap(), 4).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+        assert!(error.diagnostic().contains("contiguous shard prefix"));
+    }
+
+    #[test]
+    fn duplicate_reservations_report_both_redacted_source_locations() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        connection.execute_batch(SCHEMA_SQL).unwrap();
+        connection
+            .execute(
+                "INSERT INTO briskdb_global_index_builds VALUES (1, ?1, 1, 2, 1, 0)",
+                [&[0_u8; 32][..]],
+            )
+            .unwrap();
+        let index = unique_metadata();
+        let value = IndexKeyValue::Text("duplicate@example.test".to_owned());
+        let parts = [IndexKeyPart::ascending(value.as_ref())];
+        let key = CanonicalIndexKey::encode(&parts).unwrap();
+        let first_locator = encode_locator(&[ValueRef::Integer(1)]).unwrap();
+        let second_locator = encode_locator(&[ValueRef::Integer(2)]).unwrap();
+        let transaction = connection.transaction().unwrap();
+        insert_entry(&transaction, &index, 0, 0, &key, &first_locator, &parts).unwrap();
+        let error =
+            insert_entry(&transaction, &index, 1, 0, &key, &second_locator, &parts).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::UniqueViolation);
+        assert!(error.diagnostic().contains("shard 0"));
+        assert!(error.diagnostic().contains("shard 1"));
+        assert!(error.diagnostic().contains("key bytes are redacted"));
+        assert!(!error.diagnostic().contains("duplicate@example.test"));
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,5 +1,6 @@
 //! SQLite file layout, versioned manifest management, and connection configuration.
 
+mod global_index;
 mod hilo;
 mod manifest;
 mod migration;
@@ -44,8 +45,9 @@ use crate::core::TableId;
 use crate::{
     core::{
         Catalog, CatalogSnapshot, EngineError, EngineErrorKind, EngineResult, GeneratedIdPolicy,
-        GeneratedTableDdlReceipt, GlobalIndexDeclaration, GlobalIndexId, GlobalIndexLifecycle,
-        GlobalIndexMetadata, MAX_TABLES, ShardKeyType, TableDeclaration, TablePlacement,
+        GeneratedTableDdlReceipt, GlobalIndexBuildReport, GlobalIndexDeclaration, GlobalIndexId,
+        GlobalIndexLifecycle, GlobalIndexMetadata, MAX_TABLES, ShardKeyType, TableDeclaration,
+        TablePlacement,
         generated_id::{
             NATIVE_RANGE_V1_FORMAT_MARKER, native_range_v1_sequence_ceiling,
             native_range_v1_sequence_floor,
@@ -1304,8 +1306,74 @@ impl Storage {
         index_id: GlobalIndexId,
         target: GlobalIndexLifecycle,
     ) -> EngineResult<()> {
+        if target == GlobalIndexLifecycle::Ready {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!("global index {index_id} can become Ready only through build_global_index"),
+            ));
+        }
         let result = self.transition_global_index_inner(index_id, target);
         self.fail_closed_on_corruption(result)
+    }
+
+    pub(crate) fn build_global_index(
+        &mut self,
+        index_id: GlobalIndexId,
+        cancellation: &crate::core::CancellationToken,
+    ) -> EngineResult<GlobalIndexBuildReport> {
+        let result = self.build_global_index_inner(index_id, cancellation);
+        self.fail_closed_on_corruption(result)
+    }
+
+    fn build_global_index_inner(
+        &mut self,
+        index_id: GlobalIndexId,
+        cancellation: &crate::core::CancellationToken,
+    ) -> EngineResult<GlobalIndexBuildReport> {
+        let mut mutation =
+            SchemaMigrationGuard::new(self.schema_coordination.gate.begin_new_migration()?);
+        mutation.wait_for_quiescence_blocking();
+        mutation.acquire_process_ownership(&self.schema_coordination.process_lease)?;
+        let index = self
+            .catalog
+            .logical()
+            .global_index_by_id(index_id)
+            .cloned()
+            .ok_or_else(|| {
+                EngineError::new(
+                    EngineErrorKind::InvalidArgument,
+                    format!("global index {index_id} does not exist"),
+                )
+            })?;
+
+        if index.lifecycle() == GlobalIndexLifecycle::Ready {
+            let report = global_index::validate_ready(self, &index, cancellation)?;
+            mutation.publish_ready()?;
+            return Ok(report);
+        }
+
+        let replacement_guard = self
+            .schema_coordination
+            .reserve_catalog_replacement(&self.catalog)?;
+        let report = global_index::build(self, &index, cancellation)?;
+        if cancellation.is_cancelled() {
+            return Err(EngineError::new(
+                EngineErrorKind::Cancelled,
+                format!("global-index build {index_id} was cancelled before publication"),
+            ));
+        }
+        let mut manifest_connection = open_existing_manifest(&self.root.join("manifest.sqlite"))?;
+        configure_manifest_connection(&manifest_connection)?;
+        let replacement = manifest::transition_global_index(
+            &mut manifest_connection,
+            self.shard_count(),
+            index_id,
+            GlobalIndexLifecycle::Ready,
+            || mutation.mark_pending_on_drop(),
+        )?;
+        self.catalog = replacement_guard.publish(&self.catalog, replacement)?;
+        mutation.publish_ready()?;
+        Ok(report)
     }
 
     fn transition_global_index_inner(
@@ -1346,6 +1414,23 @@ impl Storage {
         let replacement_guard = self
             .schema_coordination
             .reserve_catalog_replacement(&self.catalog)?;
+        let index = self
+            .catalog
+            .logical()
+            .global_index_by_id(index_id)
+            .ok_or_else(|| {
+                EngineError::new(
+                    EngineErrorKind::InvalidArgument,
+                    format!("global index {index_id} does not exist"),
+                )
+            })?;
+        if index.lifecycle() != GlobalIndexLifecycle::Dropping {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!("global index {index_id} must enter Dropping before removal"),
+            ));
+        }
+        global_index::remove_artifacts(&self.root, index_id)?;
         let mut manifest_connection = open_existing_manifest(&self.root.join("manifest.sqlite"))?;
         configure_manifest_connection(&manifest_connection)?;
         let replacement = manifest::remove_global_index(
@@ -5914,7 +5999,7 @@ mod tests {
                         .unwrap(),
                 )
                 .unwrap();
-                database.transition_global_index(id, GlobalIndexLifecycle::Ready)
+                database.transition_global_index(id, GlobalIndexLifecycle::Invalid)
             }
             "remove" => {
                 let id = GlobalIndexId::new(
@@ -5925,6 +6010,16 @@ mod tests {
                 )
                 .unwrap();
                 database.remove_global_index(id)
+            }
+            "build" => {
+                let id = GlobalIndexId::new(
+                    std::env::var("BRISKDB_GLOBAL_INDEX_ABORT_ID")
+                        .unwrap()
+                        .parse()
+                        .unwrap(),
+                )
+                .unwrap();
+                database.build_global_index(id).map(|_| ())
             }
             unexpected => panic!("unexpected global-index crash mode: {unexpected}"),
         };
@@ -5969,7 +6064,7 @@ mod tests {
 
         for (boundary, expected) in [
             ("transition-before-commit", GlobalIndexLifecycle::Creating),
-            ("transition-after-commit", GlobalIndexLifecycle::Ready),
+            ("transition-after-commit", GlobalIndexLifecycle::Invalid),
         ] {
             let temp = tempfile::tempdir().unwrap();
             let mut database = setup_global_index_root(temp.path());
@@ -6003,6 +6098,160 @@ mod tests {
             );
             drop(Database::open(temp.path(), 2).unwrap());
         }
+    }
+
+    #[test]
+    fn global_index_build_resumes_after_real_process_abort_at_every_durable_phase() {
+        let boundaries = [
+            ("initialized", 0_u16, false),
+            ("shard-0-before-commit", 0, false),
+            ("shard-0-after-commit", 1, false),
+            ("shard-1-before-commit", 1, false),
+            ("shard-1-after-commit", 2, false),
+            ("complete-before-commit", 2, false),
+            ("complete-after-commit", 2, false),
+            ("transition-before-commit", 2, true),
+            ("transition-after-commit", 2, true),
+        ];
+        for (boundary, expected_resume, manifest_boundary) in boundaries {
+            let temp = tempfile::tempdir().unwrap();
+            let mut database = setup_global_index_root(temp.path());
+            for shard in 0..2_u16 {
+                for row in 0..2_i64 {
+                    let tenant = (0..10_000)
+                        .map(|candidate| format!("tenant-{shard}-{candidate}"))
+                        .find(|candidate| database.shard_for_key(candidate.as_bytes()) == shard)
+                        .unwrap();
+                    database
+                        .execute(
+                            &tenant,
+                            "INSERT INTO events (id, tenant_id, payload)
+                             VALUES (?1, ?2, ?3)",
+                            &[
+                                crate::core::Value::from(i64::from(shard) * 10 + row),
+                                crate::core::Value::from(tenant.as_str()),
+                                crate::core::Value::from(
+                                    format!("payload-{shard}-{row}").into_bytes(),
+                                ),
+                            ],
+                        )
+                        .unwrap();
+                }
+            }
+            let declaration = global_index_test_declaration(&database);
+            let id = database.create_global_index(declaration).unwrap();
+            drop(database);
+
+            let mut command = Command::new(std::env::current_exe().unwrap());
+            command
+                .arg("--exact")
+                .arg("storage::tests::global_index_catalog_crash_child")
+                .arg("--nocapture")
+                .env("BRISKDB_GLOBAL_INDEX_ABORT_ROOT", temp.path())
+                .env("BRISKDB_GLOBAL_INDEX_ABORT_MODE", "build")
+                .env("BRISKDB_GLOBAL_INDEX_ABORT_ID", id.get().to_string());
+            if manifest_boundary {
+                command.env("BRISKDB_GLOBAL_INDEX_ABORT_POINT", boundary);
+            } else {
+                command.env("BRISKDB_GLOBAL_INDEX_BUILD_ABORT_POINT", boundary);
+            }
+            let status = command.status().unwrap();
+            assert!(!status.success(), "child did not abort at {boundary}");
+
+            let mut reopened = Database::open(temp.path(), 2).unwrap();
+            let report = reopened.build_global_index(id).unwrap();
+            assert_eq!(
+                report.resumed_from_shard(),
+                expected_resume,
+                "boundary {boundary}"
+            );
+            assert_eq!(report.indexed_rows(), 4, "boundary {boundary}");
+            assert_eq!(
+                reopened
+                    .catalog()
+                    .global_index_by_id(id)
+                    .unwrap()
+                    .lifecycle(),
+                GlobalIndexLifecycle::Ready,
+                "boundary {boundary}"
+            );
+            let physical =
+                Connection::open(temp.path().join("global-indexes").join("global.sqlite")).unwrap();
+            assert_eq!(
+                physical
+                    .query_row(
+                        "SELECT COUNT(*) FROM briskdb_global_index_entries
+                         WHERE index_id = ?1",
+                        [i64::try_from(id.get()).unwrap()],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .unwrap(),
+                4,
+                "boundary {boundary}"
+            );
+            assert_eq!(
+                physical
+                    .query_row("PRAGMA quick_check", [], |row| row.get::<_, String>(0))
+                    .unwrap(),
+                "ok",
+                "boundary {boundary}"
+            );
+        }
+    }
+
+    #[test]
+    fn global_index_resume_restarts_if_a_checkpointed_source_shard_changed() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut database = setup_global_index_root(temp.path());
+        let tenant = (0..10_000)
+            .map(|candidate| format!("checkpoint-tenant-{candidate}"))
+            .find(|candidate| database.shard_for_key(candidate.as_bytes()) == 0)
+            .unwrap();
+        database
+            .execute(
+                &tenant,
+                "INSERT INTO events (id, tenant_id, payload) VALUES (?1, ?2, ?3)",
+                &[
+                    crate::core::Value::from(1_i64),
+                    crate::core::Value::from(tenant.as_str()),
+                    crate::core::Value::from(b"old".to_vec()),
+                ],
+            )
+            .unwrap();
+        let declaration = global_index_test_declaration(&database);
+        let id = database.create_global_index(declaration).unwrap();
+        drop(database);
+
+        let status = Command::new(std::env::current_exe().unwrap())
+            .arg("--exact")
+            .arg("storage::tests::global_index_catalog_crash_child")
+            .arg("--nocapture")
+            .env("BRISKDB_GLOBAL_INDEX_ABORT_ROOT", temp.path())
+            .env("BRISKDB_GLOBAL_INDEX_ABORT_MODE", "build")
+            .env("BRISKDB_GLOBAL_INDEX_ABORT_ID", id.get().to_string())
+            .env(
+                "BRISKDB_GLOBAL_INDEX_BUILD_ABORT_POINT",
+                "shard-0-after-commit",
+            )
+            .status()
+            .unwrap();
+        assert!(!status.success());
+
+        let mut reopened = Database::open(temp.path(), 2).unwrap();
+        reopened
+            .execute(
+                &tenant,
+                "INSERT INTO events (id, tenant_id, payload) VALUES (?1, ?2, ?3)",
+                &[
+                    crate::core::Value::from(2_i64),
+                    crate::core::Value::from(tenant.as_str()),
+                    crate::core::Value::from(b"new".to_vec()),
+                ],
+            )
+            .unwrap();
+        let report = reopened.build_global_index(id).unwrap();
+        assert_eq!(report.resumed_from_shard(), 0);
+        assert_eq!(report.indexed_rows(), 2);
     }
 
     const GENERATED_DDL_CRASH_SOURCE: &str =

--- a/tests/global_index_build.rs
+++ b/tests/global_index_build.rs
@@ -1,0 +1,375 @@
+use std::{
+    env, fs,
+    path::Path,
+    process::{Command, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+
+use briskdb::core::{
+    CancellationToken, Database, EngineErrorKind, GlobalIndexDeclaration, GlobalIndexKeyPart,
+    GlobalIndexKeySource, GlobalIndexKeyType, GlobalIndexLifecycle, GlobalIndexStorageTopology,
+    IndexKeyOrder, ShardKeyMetadata, ShardKeyType, TableDeclaration, TableId, UniqueNullSemantics,
+    Value,
+};
+use rusqlite::Connection;
+
+const SHARDS: u16 = 4;
+const CHILD_ROOT: &str = "BRISKDB_GLOBAL_INDEX_BUILD_CHILD_ROOT";
+const CHILD_READY: &str = "BRISKDB_GLOBAL_INDEX_BUILD_CHILD_READY";
+const CHILD_RELEASE: &str = "BRISKDB_GLOBAL_INDEX_BUILD_CHILD_RELEASE";
+
+fn setup(root: &Path, without_rowid: bool) -> Database {
+    let mut database = Database::open(root, SHARDS).unwrap();
+    let suffix = if without_rowid { " WITHOUT ROWID" } else { "" };
+    database
+        .broadcast(&format!(
+            "CREATE TABLE events (
+                tenant_id TEXT NOT NULL,
+                local_id INTEGER NOT NULL,
+                email TEXT,
+                category TEXT NOT NULL,
+                score INTEGER NOT NULL,
+                active INTEGER NOT NULL,
+                PRIMARY KEY (tenant_id, local_id)
+             ){suffix}"
+        ))
+        .unwrap();
+    let logical = database.catalog().default_database().id();
+    database
+        .register_tables(vec![
+            TableDeclaration::sharded(
+                logical,
+                "events",
+                ShardKeyMetadata::new("tenant_id", ShardKeyType::Text).unwrap(),
+            )
+            .unwrap(),
+        ])
+        .unwrap();
+    database
+}
+
+fn table_id(database: &Database) -> TableId {
+    database
+        .catalog()
+        .table("default", "events")
+        .unwrap()
+        .unwrap()
+        .id()
+}
+
+fn declaration(
+    database: &Database,
+    name: &str,
+    parts: Vec<GlobalIndexKeyPart>,
+) -> GlobalIndexDeclaration {
+    GlobalIndexDeclaration::new(table_id(database), name, parts)
+        .unwrap()
+        .with_topology(GlobalIndexStorageTopology::selected_v1())
+}
+
+fn seed(database: &Database, rows: usize) {
+    for ordinal in 0..rows {
+        let tenant = format!("tenant-{}", ordinal % 29);
+        let email = format!("user-{ordinal}@example.test");
+        let category = format!("category-{}", ordinal % 7);
+        database
+            .execute(
+                &tenant,
+                "INSERT INTO events (
+                    tenant_id, local_id, email, category, score, active
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                &[
+                    Value::from(tenant.as_str()),
+                    Value::from(ordinal as i64),
+                    Value::from(email),
+                    Value::from(category),
+                    Value::from((ordinal % 101) as i64),
+                    Value::from(if ordinal % 3 == 0 { 1_i64 } else { 0_i64 }),
+                ],
+            )
+            .unwrap();
+    }
+}
+
+fn physical_count(root: &Path, table: &str, index_id: briskdb::GlobalIndexId) -> i64 {
+    let connection = Connection::open(root.join("global-indexes/global.sqlite")).unwrap();
+    connection
+        .query_row(
+            &format!("SELECT COUNT(*) FROM {table} WHERE index_id = ?1"),
+            [i64::try_from(index_id.get()).unwrap()],
+            |row| row.get(0),
+        )
+        .unwrap()
+}
+
+#[test]
+fn offline_builder_covers_empty_large_compound_sparse_and_without_rowid_sources() {
+    for without_rowid in [false, true] {
+        let temp = tempfile::tempdir().unwrap();
+        let mut database = setup(temp.path(), without_rowid);
+
+        let empty = declaration(
+            &database,
+            "events_empty",
+            vec![GlobalIndexKeyPart::new(
+                GlobalIndexKeySource::column("email").unwrap(),
+                GlobalIndexKeyType::Text,
+            )],
+        );
+        let empty_id = database.create_global_index(empty).unwrap();
+        let report = database.build_global_index(empty_id).unwrap();
+        assert_eq!(report.index_id(), empty_id);
+        assert_eq!(report.shard_count(), SHARDS);
+        assert_eq!(report.indexed_rows(), 0);
+        assert_eq!(
+            database
+                .catalog()
+                .global_index_by_id(empty_id)
+                .unwrap()
+                .lifecycle(),
+            GlobalIndexLifecycle::Ready
+        );
+
+        seed(&database, 2_000);
+        let compound = declaration(
+            &database,
+            "events_compound_sparse",
+            vec![
+                GlobalIndexKeyPart::new(
+                    GlobalIndexKeySource::column("category").unwrap(),
+                    GlobalIndexKeyType::Text,
+                ),
+                GlobalIndexKeyPart::new(
+                    GlobalIndexKeySource::expression("score * 2").unwrap(),
+                    GlobalIndexKeyType::Int64,
+                )
+                .with_order(IndexKeyOrder::Descending),
+            ],
+        )
+        .with_predicate("active = 1")
+        .unwrap();
+        let compound_id = database.create_global_index(compound).unwrap();
+        let report = database.build_global_index(compound_id).unwrap();
+        assert_eq!(report.indexed_rows(), 667);
+        assert_eq!(
+            physical_count(temp.path(), "briskdb_global_index_entries", compound_id),
+            667
+        );
+        assert_eq!(
+            physical_count(temp.path(), "briskdb_global_index_unique_keys", compound_id),
+            0
+        );
+        let revalidated = database.build_global_index(compound_id).unwrap();
+        assert_eq!(revalidated.resumed_from_shard(), SHARDS);
+        assert_eq!(revalidated.indexed_rows(), 667);
+    }
+}
+
+#[test]
+fn unique_build_reports_both_sources_and_restarts_after_the_data_is_fixed() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut database = setup(temp.path(), false);
+    for (tenant, local_id) in [("tenant-a", 1_i64), ("tenant-b", 2_i64)] {
+        database
+            .execute(
+                tenant,
+                "INSERT INTO events (
+                    tenant_id, local_id, email, category, score, active
+                 ) VALUES (?1, ?2, 'duplicate@example.test', 'same', 1, 1)",
+                &[Value::from(tenant), Value::from(local_id)],
+            )
+            .unwrap();
+    }
+    let unique = declaration(
+        &database,
+        "events_email_unique",
+        vec![GlobalIndexKeyPart::new(
+            GlobalIndexKeySource::column("email").unwrap(),
+            GlobalIndexKeyType::Text,
+        )],
+    )
+    .unique(UniqueNullSemantics::Distinct);
+    let index_id = database.create_global_index(unique).unwrap();
+    let error = database.build_global_index(index_id).unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::UniqueViolation);
+    assert!(error.diagnostic().contains("shard"));
+    assert!(error.diagnostic().contains("key bytes are redacted"));
+    assert_eq!(
+        database
+            .catalog()
+            .global_index_by_id(index_id)
+            .unwrap()
+            .lifecycle(),
+        GlobalIndexLifecycle::Creating
+    );
+
+    database
+        .execute(
+            "tenant-b",
+            "DELETE FROM events WHERE tenant_id = ?1 AND local_id = ?2",
+            &[Value::from("tenant-b"), Value::from(2_i64)],
+        )
+        .unwrap();
+    let report = database.build_global_index(index_id).unwrap();
+    assert_eq!(report.indexed_rows(), 1);
+    assert_eq!(
+        physical_count(temp.path(), "briskdb_global_index_unique_keys", index_id),
+        1
+    );
+}
+
+#[test]
+fn ready_revalidation_rejects_semantically_tampered_physical_entries() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut database = setup(temp.path(), false);
+    seed(&database, 4);
+    let index = declaration(
+        &database,
+        "events_email_tamper",
+        vec![GlobalIndexKeyPart::new(
+            GlobalIndexKeySource::column("email").unwrap(),
+            GlobalIndexKeyType::Text,
+        )],
+    );
+    let index_id = database.create_global_index(index).unwrap();
+    database.build_global_index(index_id).unwrap();
+    Connection::open(temp.path().join("global-indexes/global.sqlite"))
+        .unwrap()
+        .execute(
+            "UPDATE briskdb_global_index_entries
+             SET encoded_key = x'00'
+             WHERE index_id = ?1 AND source_ordinal = 0",
+            [i64::try_from(index_id.get()).unwrap()],
+        )
+        .unwrap();
+    let error = database.build_global_index(index_id).unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+    assert_eq!(
+        database
+            .query("tenant-0", "SELECT 1", &[])
+            .unwrap_err()
+            .kind(),
+        EngineErrorKind::DataCorruption
+    );
+}
+
+#[test]
+fn cancellation_and_manual_ready_publication_leave_the_database_usable() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut database = setup(temp.path(), false);
+    seed(&database, 20);
+    let index = declaration(
+        &database,
+        "events_email_cancelled",
+        vec![GlobalIndexKeyPart::new(
+            GlobalIndexKeySource::column("email").unwrap(),
+            GlobalIndexKeyType::Text,
+        )],
+    );
+    let index_id = database.create_global_index(index).unwrap();
+    assert_eq!(
+        database
+            .transition_global_index(index_id, GlobalIndexLifecycle::Ready)
+            .unwrap_err()
+            .kind(),
+        EngineErrorKind::FailedPrecondition
+    );
+    let cancellation = CancellationToken::new();
+    assert!(cancellation.cancel());
+    assert_eq!(
+        database
+            .build_global_index_with_cancellation(index_id, &cancellation)
+            .unwrap_err()
+            .kind(),
+        EngineErrorKind::Cancelled
+    );
+    assert_eq!(
+        database
+            .query(
+                "tenant-0",
+                "SELECT COUNT(*) FROM events WHERE tenant_id = ?1",
+                &[Value::from("tenant-0")],
+            )
+            .unwrap()
+            .rows()[0]
+            .values()[0],
+        Value::from(1_i64)
+    );
+    assert_eq!(
+        database
+            .build_global_index(index_id)
+            .unwrap()
+            .indexed_rows(),
+        20
+    );
+    database
+        .transition_global_index(index_id, GlobalIndexLifecycle::Dropping)
+        .unwrap();
+    database.remove_global_index(index_id).unwrap();
+    assert_eq!(
+        physical_count(temp.path(), "briskdb_global_index_builds", index_id),
+        0
+    );
+}
+
+#[test]
+fn global_index_build_peer_child() {
+    let Ok(root) = env::var(CHILD_ROOT) else {
+        return;
+    };
+    let ready = env::var(CHILD_READY).unwrap();
+    let release = env::var(CHILD_RELEASE).unwrap();
+    let database = Database::open(root, SHARDS).unwrap();
+    fs::write(&ready, b"ready").unwrap();
+    let deadline = Instant::now() + Duration::from_secs(20);
+    while !Path::new(&release).exists() {
+        assert!(Instant::now() < deadline, "timed out waiting for release");
+        thread::sleep(Duration::from_millis(5));
+    }
+    drop(database);
+}
+
+#[test]
+fn offline_builder_requires_sole_process_ownership() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut database = setup(temp.path(), false);
+    seed(&database, 10);
+    let index = declaration(
+        &database,
+        "events_email_fenced",
+        vec![GlobalIndexKeyPart::new(
+            GlobalIndexKeySource::column("email").unwrap(),
+            GlobalIndexKeyType::Text,
+        )],
+    );
+    let index_id = database.create_global_index(index).unwrap();
+    let ready = temp.path().join("peer-ready");
+    let release = temp.path().join("peer-release");
+    let mut child = Command::new(env::current_exe().unwrap())
+        .args(["--exact", "global_index_build_peer_child", "--nocapture"])
+        .env(CHILD_ROOT, temp.path())
+        .env(CHILD_READY, &ready)
+        .env(CHILD_RELEASE, &release)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    let deadline = Instant::now() + Duration::from_secs(20);
+    while !ready.exists() {
+        assert!(Instant::now() < deadline, "timed out waiting for peer");
+        thread::sleep(Duration::from_millis(5));
+    }
+    let error = database.build_global_index(index_id).unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::Busy);
+    assert!(error.is_retryable());
+    fs::write(&release, b"release").unwrap();
+    assert!(child.wait().unwrap().success());
+    assert_eq!(
+        database
+            .build_global_index(index_id)
+            .unwrap()
+            .indexed_rows(),
+        10
+    );
+}

--- a/tests/offline_backup.rs
+++ b/tests/offline_backup.rs
@@ -1,6 +1,10 @@
 use std::{fs, path::Path};
 
-use briskdb::core::{Database, Engine, Statement, Value};
+use briskdb::core::{
+    Database, Engine, GlobalIndexDeclaration, GlobalIndexKeyPart, GlobalIndexKeySource,
+    GlobalIndexKeyType, GlobalIndexStorageTopology, ShardKeyMetadata, ShardKeyType, Statement,
+    TableDeclaration, Value,
+};
 
 const SHARDS: u16 = 4;
 
@@ -38,14 +42,25 @@ async fn stopped_server_backup_restores_schema_and_rows_from_every_shard() {
     let backup = directory.path().join("backup");
     let restored = directory.path().join("restored");
 
-    let database = Database::open(&live, SHARDS).unwrap();
+    let mut database = Database::open(&live, SHARDS).unwrap();
     database
         .broadcast(
             "CREATE TABLE backup_items (
-                id TEXT PRIMARY KEY,
+                id TEXT NOT NULL PRIMARY KEY,
                 shard_number INTEGER NOT NULL
              )",
         )
+        .unwrap();
+    let logical = database.catalog().default_database().id();
+    database
+        .register_tables(vec![
+            TableDeclaration::sharded(
+                logical,
+                "backup_items",
+                ShardKeyMetadata::new("id", ShardKeyType::Text).unwrap(),
+            )
+            .unwrap(),
+        ])
         .unwrap();
     let keys = one_key_per_shard(&database);
     drop(database);
@@ -70,9 +85,45 @@ async fn stopped_server_backup_restores_schema_and_rows_from_every_shard() {
     engine.shutdown().await.unwrap();
     drop(engine);
 
+    let mut database = Database::open(&live, SHARDS).unwrap();
+    let table_id = database
+        .catalog()
+        .table("default", "backup_items")
+        .unwrap()
+        .unwrap()
+        .id();
+    let declaration = GlobalIndexDeclaration::new(
+        table_id,
+        "backup_items_id_global",
+        vec![GlobalIndexKeyPart::new(
+            GlobalIndexKeySource::column("id").unwrap(),
+            GlobalIndexKeyType::Text,
+        )],
+    )
+    .unwrap()
+    .with_topology(GlobalIndexStorageTopology::selected_v1());
+    let index_id = database.create_global_index(declaration).unwrap();
+    assert_eq!(
+        database
+            .build_global_index(index_id)
+            .unwrap()
+            .indexed_rows(),
+        u64::from(SHARDS)
+    );
+    drop(database);
+
     copy_directory(&live, &backup);
     copy_directory(&backup, &restored);
 
+    let mut restored_database = Database::open(&restored, SHARDS).unwrap();
+    assert_eq!(
+        restored_database
+            .build_global_index(index_id)
+            .unwrap()
+            .indexed_rows(),
+        u64::from(SHARDS)
+    );
+    drop(restored_database);
     let restored_engine = Engine::open(&restored, SHARDS).await.unwrap();
     assert_eq!(restored_engine.catalog().schema_generation(), 1);
     for (expected_shard, key) in keys.iter().enumerate() {

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -209,9 +209,14 @@ fn global_index_catalog_is_read_only_reopenable_and_lifecycle_fenced() {
     );
 
     let mut database = core::Database::open(temp.path(), 2).unwrap();
-    database
-        .transition_global_index(index_id, core::GlobalIndexLifecycle::Ready)
-        .unwrap();
+    assert_eq!(
+        database
+            .transition_global_index(index_id, core::GlobalIndexLifecycle::Ready)
+            .unwrap_err()
+            .kind(),
+        core::EngineErrorKind::FailedPrecondition
+    );
+    database.build_global_index(index_id).unwrap();
     assert_eq!(
         database
             .transition_global_index(index_id, core::GlobalIndexLifecycle::Creating)
@@ -222,8 +227,12 @@ fn global_index_catalog_is_read_only_reopenable_and_lifecycle_fenced() {
     database
         .transition_global_index(index_id, core::GlobalIndexLifecycle::Rebuilding)
         .unwrap();
+    assert_eq!(
+        database.build_global_index(index_id).unwrap_err().kind(),
+        core::EngineErrorKind::Unsupported
+    );
     database
-        .transition_global_index(index_id, core::GlobalIndexLifecycle::Ready)
+        .transition_global_index(index_id, core::GlobalIndexLifecycle::Invalid)
         .unwrap();
     database
         .transition_global_index(index_id, core::GlobalIndexLifecycle::Dropping)


### PR DESCRIPTION
Closes #230\n\n## Summary\n\n- add the SharedSqliteV1 physical global-index database and a public offline build API\n- scan every source shard in stable locator order with resumable, source-validated checkpoints\n- enforce cross-shard uniqueness, validate physical contents, and publish Ready only after durable completion\n- fence other BriskDB processes during construction and clean up Dropping or abandoned artifacts\n- document construction, storage format, and complete-directory backup requirements\n\n## Validation\n\n- cargo test --locked --all-targets --all-features\n- cargo clippy --locked --all-targets --all-features -- -D warnings\n- cargo fmt --all -- --check\n- cargo test --locked --doc --all-features\n- cargo package --locked --allow-dirty\n- cargo test --locked -p briskdb-python\n- cargo clippy --locked -p briskdb-python --all-targets --no-deps -- -D warnings\n- Rust 1.85 feature matrix: core, embedded, listeners, http, postgres, sqlite-import, default\n- git diff --check