### PR TITLE
Global indexes: maintain authority on SQL writes

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -131,6 +131,7 @@ jobs:
           rust-toolchain: 1.85.0
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux }}
+          before-script-linux: dnf install --assumeyes clang-devel
           args: >-
             --release
             --locked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex 1.3.0",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,6 +309,7 @@ version = "0.1.0-alpha.5"
 dependencies = [
  "briskdb",
  "pyo3",
+ "tempfile",
  "tokio",
 ]
 
@@ -325,7 +344,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9066c49992464636f92905fa096ec58baaa4d57ec19a5c096c68d3e25ef3d136"
 dependencies = [
  "find-msvc-tools",
- "shlex",
+ "shlex 2.0.1",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -381,6 +409,17 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -747,6 +786,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -977,6 +1022,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -991,6 +1046,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
+ "bindgen",
  "cc",
  "pkg-config",
  "vcpkg",
@@ -1061,6 +1117,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,6 +1131,16 @@ dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1566,6 +1638,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1746,6 +1824,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shlex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ categories = ["database-implementations"]
 default = ["server-cli", "sqlite-import-cli"]
 # Host-controlled Rust API with no networking by default. SQL execution,
 # routing, and the bundled SQLite storage engine are the embedded surface.
-embedded = []
+embedded = ["experimental-vtab"]
 # Network adapters can be selected independently by downstream applications.
 http = [
     "dep:axum",
@@ -98,7 +98,7 @@ libc = "0.2"
 # pulling in the dependency's defaults.
 pgwire = { version = "=0.36.3", default-features = false, features = ["server-api"], optional = true }
 rustls-pemfile = { version = "2.2", optional = true }
-rusqlite = { version = "0.39.0", features = ["bundled", "column_decltype", "column_metadata", "hooks", "limits"] }
+rusqlite = { version = "0.39.0", features = ["bundled", "column_decltype", "column_metadata", "hooks", "limits", "preupdate_hook"] }
 same-file = "1.0"
 serde = { version = "1.0.229", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ HTTP and PostgreSQL. Native MongoDB, MySQL, and serverless use are on the roadma
   blocks and route them through the normal shard map.
 - **A real cross-shard constraint authority.** Durable operation-ID
   reservations can choose one global unique-key owner, while fenced range
-  leases allocate collision-free values across processes. SQL write-path
-  integration is the next rollout stage.
+  leases allocate collision-free values across processes. Successful
+  single-shard `INSERT`, `UPDATE`, and `DELETE` statements now maintain ready
+  global unique indexes automatically.
 - **Bring the client you already have.** HTTP and PostgreSQL are available now;
   MongoDB and MySQL wire compatibility are being built over the same engine.
 - **Files remain files.** The layout is a manifest plus normal SQLite databases,
@@ -115,7 +116,7 @@ experimental and opt-in; the exact contract lives in
 | PostgreSQL wire protocol | TLS/SCRAM, backpressured row streaming, SQLite-interrupt cancellation, text/binary CRUD, real single-shard transactions, and a live psql/tokio-postgres/psycopg/SQLAlchemy matrix |
 | Offline import from a standard SQLite database | Working |
 | Native-range and hi/lo generated IDs | Experimental, opt-in |
-| Cross-shard unique reservations and global value leases | Rust authority API working; automatic SQL maintenance is [next](https://github.com/schapman1974/briskdb/issues/233) |
+| Cross-shard unique reservations and global value leases | Automatic autocommit maintenance works across Rust, Python, HTTP, and PostgreSQL; indexed query routing is [next](https://github.com/schapman1974/briskdb/issues/234) |
 | Ubuntu/macOS x86-64 and ARM64 release artifacts | Published |
 | Debian package and hardened systemd service | Published |
 | Rust library entrypoint with optional attached listeners | Working |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -411,7 +411,7 @@ requires an earlier dependency:
    - [x] [#230](https://github.com/schapman1974/briskdb/issues/230) — offline index construction
    - [x] [#231](https://github.com/schapman1974/briskdb/issues/231) — validation, repair, and rebuild
    - [x] [#232](https://github.com/schapman1974/briskdb/issues/232) — unique reservations and global allocation
-   - [ ] [#233](https://github.com/schapman1974/briskdb/issues/233) — authoritative write maintenance
+   - [x] [#233](https://github.com/schapman1974/briskdb/issues/233) — authoritative write maintenance
    - [ ] [#234](https://github.com/schapman1974/briskdb/issues/234) — exact indexed routing
    - [ ] [#235](https://github.com/schapman1974/briskdb/issues/235) — candidate verification and repair
    - [ ] [#236](https://github.com/schapman1974/briskdb/issues/236) — transactional shard outboxes

--- a/docs/GLOBAL_INDEX_AUTHORITY.md
+++ b/docs/GLOBAL_INDEX_AUTHORITY.md
@@ -4,9 +4,43 @@ BriskDB now has protocol-neutral primitives for enforcing a unique key across
 all SQLite shards and leasing collision-free global integer values. They are
 safe across service, Rust, and Python processes sharing one local data root.
 
-> Automatic `INSERT`/`UPDATE`/`DELETE` maintenance is the next rollout stage,
-> [#233](https://github.com/schapman1974/briskdb/issues/233). Until that lands,
-> SQL statements do not call these primitives automatically.
+Ready unique indexes are maintained automatically for successful autocommit
+`INSERT`, `UPDATE`, and `DELETE` statements through the shared Rust engine. The
+same path serves the Rust and Python libraries, HTTP, and PostgreSQL.
+
+## Coordinated SQL writes
+
+```mermaid
+flowchart LR
+    SQL[SQL mutation] --> CAPTURE[SQLite pre-update hook\ncaptures old + new rows]
+    CAPTURE --> PLAN[Evaluate predicate, expressions,\ncompound key, and NULL policy]
+    PLAN --> RESERVE[Reserve old/new canonical keys\nin global.sqlite]
+    RESERVE --> COMMIT[Commit one physical shard]
+    COMMIT --> FINALIZE[Publish ownership +\nrefresh shard snapshot]
+    COMMIT -. process exit .-> RECOVER[Next writer probes the row\nand finalizes or rolls back]
+    RECOVER --> FINALIZE
+```
+
+The hook is part of BriskDB's bundled SQLite build; it is not a loadable SQLite
+extension. Cascades and `REPLACE` side effects are captured at the physical-row
+boundary, so authority follows what SQLite actually changed. A durable
+per-operation marker and file lock distinguish a live coordinator from an
+orphaned write across independent processes.
+
+The alpha path deliberately accepts only mutations whose atomicity it can
+prove. One statement may change at most one authoritative row per global index,
+and the write must stay on one physical shard. Explicit transactions on indexed
+tables, `ON CONFLICT DO UPDATE`, and cross-shard `INSERT OR REPLACE` conflicts
+return `Unsupported` before commit. `INSERT OR IGNORE` returns zero affected
+rows on a global conflict. These restrictions avoid silently partial writes.
+
+Maintenance is synchronous and currently refreshes the affected index/shard
+snapshot before acknowledging the write. This favors correctness over write
+throughput in the alpha; the outbox and asynchronous-index stages tracked by
+[#236](https://github.com/schapman1974/briskdb/issues/236) and
+[#237](https://github.com/schapman1974/briskdb/issues/237) are the planned
+throughput path. Global-index query routing begins in
+[#234](https://github.com/schapman1974/briskdb/issues/234).
 
 ## Unique-key state machine
 
@@ -47,11 +81,12 @@ commit returns `Cancelled` without changing state.
 
 ## Recovery and maintenance
 
-An active operation survives a process exit. The write coordinator in #233 can
-retry the shard step with the same operation ID, then finalize or roll it back;
-there is no scan-then-insert race. Offline validation reports
-`active_unique_reservation`. A unique-index rebuild rolls active reservations
-back before reconstructing ownership from the authoritative shard rows.
+An active operation survives a process exit. The write coordinator probes the
+recorded physical row identity, then finalizes a committed mutation or rolls
+back an uncommitted one; there is no scan-then-insert race. Offline validation
+reports `active_unique_reservation`. A unique-index rebuild rolls active
+reservations back before reconstructing ownership from the authoritative shard
+rows.
 
 Physical global-index storage version 2 adds the operation, reservation,
 sequence, and lease tables to `global-indexes/global.sqlite`. Startup upgrades
@@ -60,10 +95,12 @@ retryable `Busy` before any format mutation.
 
 ## Verification and benchmarks
 
-The test suite covers deterministic transitions, exact retry mismatches,
-cancellation, replacement locking, serial-model property histories,
-four-process hot-key contention, four-process range leasing, every durable
-process-abort boundary, format-upgrade crashes, and peer fencing.
+The test suite covers deterministic transitions, old/new mutation planning,
+partial/compound/NULL key derivation, constraint outcomes, competing-process
+insert/update/delete races and exact retries, Python and PostgreSQL clients,
+replacement locking, serial-model property histories, four-process hot-key
+contention, four-process range leasing, durable process-abort boundaries,
+format-upgrade crashes, and peer fencing.
 
 Criterion includes three focused measurements:
 

--- a/docs/GLOBAL_INDEX_BUILD.md
+++ b/docs/GLOBAL_INDEX_BUILD.md
@@ -104,5 +104,6 @@ predicates instead of publishing an index that cannot be reproduced.
 [Global-index recovery](GLOBAL_INDEX_RECOVERY.md) adds full or sampled
 validation, bounded machine-readable findings, targeted non-unique repair, and
 resumable replacement builds. Unique authority is never repaired by inference;
-it must be rebuilt. All construction and recovery remain offline. Write
-maintenance and query routing are later rollout stages.
+it must be rebuilt. All construction and recovery remain offline. Ready unique
+indexes receive synchronous single-shard SQL write maintenance; indexed query
+routing remains a later rollout stage.

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -16,3 +16,6 @@ crate-type = ["cdylib", "rlib"]
 briskdb = { path = "..", default-features = false, features = ["listeners"] }
 pyo3 = { version = "=0.29.2", features = ["abi3-py39"] }
 tokio = { version = "1.53.1", features = ["rt-multi-thread", "sync", "time"] }
+
+[dev-dependencies]
+tempfile = "3.23"

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1164,7 +1164,13 @@ fn _briskdb(module: &Bound<'_, PyModule>) -> PyResult<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::python_distribution_version;
+    use briskdb::core::{
+        Database as CoreDatabase, GlobalIndexDeclaration, GlobalIndexKeyPart, GlobalIndexKeySource,
+        GlobalIndexKeyType, GlobalIndexStorageTopology, ShardKeyMetadata, ShardKeyType,
+        TableDeclaration, UniqueNullSemantics,
+    };
+
+    use super::{Config, Database, error::UniqueViolationError, python_distribution_version};
 
     #[test]
     fn cargo_prereleases_match_python_distribution_versions() {
@@ -1172,5 +1178,88 @@ mod tests {
         assert_eq!(python_distribution_version("1.2.3-alpha.4"), "1.2.3a4");
         assert_eq!(python_distribution_version("1.2.3-beta.5"), "1.2.3b5");
         assert_eq!(python_distribution_version("1.2.3-rc.6"), "1.2.3rc6");
+    }
+
+    #[test]
+    fn python_session_writes_use_global_unique_authority() {
+        let root = tempfile::tempdir().unwrap();
+        let mut core = CoreDatabase::open(root.path(), 2).unwrap();
+        core.broadcast(
+            "CREATE TABLE accounts (
+                tenant_id TEXT PRIMARY KEY NOT NULL,
+                email TEXT NOT NULL
+             )",
+        )
+        .unwrap();
+        let logical = core.catalog().default_database().id();
+        core.register_tables(vec![
+            TableDeclaration::sharded(
+                logical,
+                "accounts",
+                ShardKeyMetadata::new("tenant_id", ShardKeyType::Text).unwrap(),
+            )
+            .unwrap(),
+        ])
+        .unwrap();
+        let table_id = core
+            .catalog()
+            .table("default", "accounts")
+            .unwrap()
+            .unwrap()
+            .id();
+        let declaration = GlobalIndexDeclaration::new(
+            table_id,
+            "accounts_email_unique",
+            vec![GlobalIndexKeyPart::new(
+                GlobalIndexKeySource::column("email").unwrap(),
+                GlobalIndexKeyType::Text,
+            )],
+        )
+        .unwrap()
+        .unique(UniqueNullSemantics::Distinct)
+        .with_topology(GlobalIndexStorageTopology::selected_v1());
+        let index_id = core.create_global_index(declaration).unwrap();
+        core.build_global_index(index_id).unwrap();
+        drop(core);
+
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
+            let database = Database::create(py, root.path().to_path_buf(), Config::default())
+                .expect("open Python database wrapper");
+            let first = database
+                .session(py, Some("python-index-a".to_owned()))
+                .unwrap();
+            first
+                .execute(
+                    py,
+                    "INSERT INTO accounts (tenant_id, email) VALUES ('python-index-a', 'python-global@example.test')"
+                        .to_owned(),
+                    None,
+                    None,
+                    None,
+                )
+                .unwrap();
+            first.close(py).unwrap();
+
+            let duplicate = database
+                .session(py, Some("python-index-b".to_owned()))
+                .unwrap();
+            let error = duplicate
+                .execute(
+                    py,
+                    "INSERT INTO accounts (tenant_id, email) VALUES ('python-index-b', 'python-global@example.test')"
+                        .to_owned(),
+                    None,
+                    None,
+                    None,
+                )
+                .unwrap_err();
+            assert!(error.is_instance_of::<UniqueViolationError>(py));
+            duplicate.close(py).unwrap();
+            database.close(py).unwrap();
+        });
+
+        let mut core = CoreDatabase::open(root.path(), 2).unwrap();
+        assert!(core.validate_global_index(index_id).unwrap().is_valid());
     }
 }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -553,6 +553,21 @@ impl Engine {
     }
 
     #[cfg(feature = "experimental-vtab")]
+    fn table_requires_global_unique_maintenance(&self, table: Option<super::TableId>) -> bool {
+        let Some(table) = table else {
+            return false;
+        };
+        self.catalog().global_indexes().iter().any(|index| {
+            index.table_id() == table
+                && index.is_unique()
+                && matches!(
+                    index.lifecycle(),
+                    super::GlobalIndexLifecycle::Ready | super::GlobalIndexLifecycle::Invalid
+                )
+        })
+    }
+
+    #[cfg(feature = "experimental-vtab")]
     fn generated_write_target_for_table(
         &self,
         table: super::TableId,
@@ -1272,6 +1287,12 @@ impl Engine {
                 return operation.finish(Err(error));
             }
         };
+        #[cfg(feature = "experimental-vtab")]
+        let global_unique_maintenance = matches!(
+            template.description().behavior(),
+            sql::StatementBehavior::Write(_)
+        ) && self
+            .table_requires_global_unique_maintenance(plan.inference().table_id());
         let sqlite_sql = template.translated().sqlite_sql().to_owned();
         let owner = ConnectionOwner::new(session.id().get());
         if guard.state() == super::SessionState::InTransaction && plan.generated_insert().is_some()
@@ -1331,6 +1352,31 @@ impl Engine {
         };
         let behavior = plan.behavior();
         let result_limits = operation.result_limits;
+        #[cfg(feature = "experimental-vtab")]
+        if global_unique_maintenance {
+            if guard.state() == super::SessionState::InTransaction {
+                let mut guard = guard;
+                guard.fail_transaction();
+                return operation.finish(Err(indexed_explicit_transaction_unsupported()));
+            }
+            let result = self
+                .run_coordinator_write(
+                    &mut operation,
+                    shard,
+                    owner,
+                    schema_operation,
+                    guard,
+                    sqlite_sql,
+                    portal_snapshot.parameters().to_vec(),
+                    None,
+                )
+                .await
+                .map(|routed| Routed {
+                    shard: routed.shard,
+                    value: PreparedExecution::AffectedRows(routed.value.rows_affected),
+                });
+            return operation.finish_started(result);
+        }
         if guard.state() == super::SessionState::InTransaction {
             let result = self
                 .run_transaction_statement(
@@ -1458,6 +1504,12 @@ impl Engine {
                 return operation.finish(Err(error));
             }
         };
+        #[cfg(feature = "experimental-vtab")]
+        let global_unique_maintenance = matches!(
+            template.description().behavior(),
+            sql::StatementBehavior::Write(_)
+        ) && self
+            .table_requires_global_unique_maintenance(plan.inference().table_id());
         let sqlite_sql = template.translated().sqlite_sql().to_owned();
         let owner = ConnectionOwner::new(session.id().get());
         if guard.state() == super::SessionState::InTransaction && plan.generated_insert().is_some()
@@ -1517,6 +1569,38 @@ impl Engine {
         };
         let behavior = plan.behavior();
         let result_limits = operation.result_limits;
+        #[cfg(feature = "experimental-vtab")]
+        if global_unique_maintenance {
+            if guard.state() == super::SessionState::InTransaction {
+                let mut guard = guard;
+                guard.fail_transaction();
+                return operation.finish(Err(indexed_explicit_transaction_unsupported()));
+            }
+            if shards.len() != 1 {
+                return operation.finish(Err(EngineError::new(
+                    EngineErrorKind::Unsupported,
+                    "authoritative global-index writes require one planned physical shard",
+                )));
+            }
+            let shard = shards[0];
+            let result = self
+                .run_coordinator_write(
+                    &mut operation,
+                    shard,
+                    owner,
+                    schema_operation,
+                    guard,
+                    sqlite_sql,
+                    portal_snapshot.parameters().to_vec(),
+                    None,
+                )
+                .await
+                .map(|routed| Executed {
+                    shards: vec![routed.shard],
+                    value: PreparedExecution::AffectedRows(routed.value.rows_affected),
+                });
+            return operation.finish_started(result);
+        }
         if guard.state() == super::SessionState::InTransaction {
             if shards.len() != 1 {
                 let mut guard = guard;
@@ -2177,6 +2261,10 @@ impl Engine {
             Err(error) => return operation.finish(Err(error)),
         };
         let catalog_authoritative = plan.is_some();
+        #[cfg(feature = "experimental-vtab")]
+        let global_unique_maintenance = plan
+            .as_ref()
+            .is_some_and(|plan| self.table_requires_global_unique_maintenance(plan.table_id));
         let owner = match (owner_policy, plan.is_some()) {
             (ExecuteOwnerPolicy::ReuseValidatedCatalogWrite, true) => {
                 ConnectionOwner::stateless_catalog_write()
@@ -2242,7 +2330,9 @@ impl Engine {
         };
 
         #[cfg(feature = "experimental-vtab")]
-        if catalog_authoritative && self.inner.options.experimental_vtab_writes() {
+        if catalog_authoritative
+            && (self.inner.options.experimental_vtab_writes() || global_unique_maintenance)
+        {
             let value = self
                 .run_coordinator_write(
                     &mut operation,
@@ -3914,6 +4004,14 @@ fn explicit_generated_write_unsupported() -> EngineError {
     EngineError::new(
         EngineErrorKind::Unsupported,
         "generated-key writes are not supported inside an explicit transaction",
+    )
+}
+
+#[cfg(feature = "experimental-vtab")]
+fn indexed_explicit_transaction_unsupported() -> EngineError {
+    EngineError::new(
+        EngineErrorKind::Unsupported,
+        "explicit transactions on a table with an authoritative global unique index are not yet supported",
     )
 }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -102,6 +102,7 @@ pub(crate) enum RawDataOperation {
 #[derive(Debug)]
 pub(crate) struct RawDataPlan {
     pub(crate) target: RawDataTarget,
+    pub(crate) table_id: Option<TableId>,
     pub(crate) sqlite_sql: String,
 }
 
@@ -582,6 +583,7 @@ impl Database {
         let target = raw_data_execution_target(&plan, catalog, operation)?;
         Ok(Some(RawDataPlan {
             target,
+            table_id: plan.inference().table_id(),
             sqlite_sql: translated.sqlite_sql().to_owned(),
         }))
     }

--- a/src/sql/subset.rs
+++ b/src/sql/subset.rs
@@ -161,7 +161,7 @@ fn validate_statement(
         AstStatement::CreateTable(table) => validate_create_table(table, dialect, statement_index),
         AstStatement::CreateIndex(index) => validate_create_index(index),
         AstStatement::Query(query) => validate_query(query, validation),
-        AstStatement::Insert(insert) => validate_insert(insert, validation),
+        AstStatement::Insert(insert) => validate_insert(insert, dialect, validation),
         AstStatement::Update(update) => validate_update(update, validation),
         AstStatement::Delete(delete) => validate_delete(delete, validation),
         AstStatement::StartTransaction {
@@ -684,7 +684,11 @@ fn validate_limit_clause(
     Ok(())
 }
 
-fn validate_insert(insert: &Insert, validation: &mut ValidationState) -> SubsetResult {
+fn validate_insert(
+    insert: &Insert,
+    dialect: SqlDialect,
+    validation: &mut ValidationState,
+) -> SubsetResult {
     let Insert {
         insert_token: _,
         optimizer_hints,
@@ -714,8 +718,9 @@ fn validate_insert(insert: &Insert, validation: &mut ValidationState) -> SubsetR
         multi_table_else_clause,
     } = insert;
 
+    let sqlite_conflict_clause = dialect == SqlDialect::Sqlite && or.is_some();
     if !optimizer_hints.is_empty()
-        || or.is_some()
+        || (or.is_some() && !sqlite_conflict_clause)
         || *ignore
         || !into
         || table_alias.is_some()
@@ -1476,7 +1481,7 @@ mod tests {
     }
 
     #[test]
-    fn insert_requires_explicit_equal_width_values_without_modifiers() {
+    fn insert_requires_explicit_equal_width_values_and_bounded_sqlite_conflicts() {
         assert_supported(
             SqlDialect::PostgreSql,
             "INSERT INTO widgets(id, tenant_id) VALUES ($1, 1), (2, $2)",
@@ -1494,6 +1499,10 @@ mod tests {
         assert_unsupported(
             SqlDialect::Sqlite,
             "INSERT INTO widgets(id) VALUES (1) ON CONFLICT(id) DO NOTHING",
+        );
+        assert_supported(
+            SqlDialect::Sqlite,
+            "INSERT OR IGNORE INTO widgets(id) VALUES (1)",
         );
         assert_unsupported(
             SqlDialect::MySql,

--- a/src/storage/global_index.rs
+++ b/src/storage/global_index.rs
@@ -9,14 +9,14 @@ use std::{
 
 use rusqlite::{
     Connection, OpenFlags, OptionalExtension, Transaction, TransactionBehavior, params,
-    types::ValueRef,
+    types::{Value as SqliteValue, ValueRef},
 };
 
 use crate::{
     core::{
         CancellationToken, CanonicalIndexKey, EngineError, EngineErrorKind, EngineResult,
         GlobalIndexBuildReport, GlobalIndexId, GlobalIndexKeySource, GlobalIndexKeyType,
-        GlobalIndexLifecycle, GlobalIndexMetadata, GlobalIndexStorageTopology,
+        GlobalIndexLifecycle, GlobalIndexMetadata, GlobalIndexOwner, GlobalIndexStorageTopology,
         GlobalIndexValidationIssue, GlobalIndexValidationIssueKind, GlobalIndexValidationMode,
         GlobalIndexValidationOptions, GlobalIndexValidationReport, GlobalOperationId,
         GlobalOperationState, GlobalUniqueMutation, GlobalUniqueReservation, GlobalValueLease,
@@ -228,6 +228,18 @@ impl SourceLocator {
                 .iter()
                 .map(|column| quote_identifier(column))
                 .collect(),
+        }
+    }
+
+    fn predicate_sql(&self) -> String {
+        match self {
+            Self::RowId(name) => format!("{} = ?1", quote_identifier(name)),
+            Self::PrimaryKey(columns) => columns
+                .iter()
+                .enumerate()
+                .map(|(offset, column)| format!("{} IS ?{}", quote_identifier(column), offset + 1))
+                .collect::<Vec<_>>()
+                .join(" AND "),
         }
     }
 }
@@ -496,6 +508,221 @@ pub(super) fn rollback_unique(
     transition_unique_operation(root, operation_id, OPERATION_ROLLED_BACK, cancellation)
 }
 
+/// Return active unique mutations. The storage coordinator filters this list
+/// through its durable operation-lock markers before attempting recovery, so
+/// lower-level callers retain ownership of their manually managed operations.
+pub(super) fn active_unique_mutations(
+    root: &Path,
+) -> EngineResult<Vec<(GlobalOperationId, GlobalUniqueMutation)>> {
+    let Some((connection, _)) = open_existing(root)? else {
+        return Ok(Vec::new());
+    };
+    let mut statement = connection
+        .prepare(
+            "SELECT operation_id FROM briskdb_global_operations
+             WHERE operation_kind = ?1 AND operation_state = ?2
+             ORDER BY operation_id",
+        )
+        .map_err(sqlite_error::storage)?;
+    let operation_ids = statement
+        .query_map(params![UNIQUE_OPERATION, OPERATION_ACTIVE], |row| {
+            row.get::<_, Vec<u8>>(0)
+        })
+        .map_err(sqlite_error::storage)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(sqlite_error::storage)?;
+    drop(statement);
+    operation_ids
+        .into_iter()
+        .map(|bytes| {
+            let bytes: [u8; 16] = bytes
+                .try_into()
+                .map_err(|_| corrupt("global operation has an invalid identifier"))?;
+            let operation_id = GlobalOperationId::new(bytes)
+                .map_err(|_| corrupt("global operation has an invalid identifier"))?;
+            let transaction = connection
+                .unchecked_transaction()
+                .map_err(sqlite_error::storage)?;
+            let stored = load_stored_unique_mutation(&transaction, operation_id)?;
+            transaction.commit().map_err(sqlite_error::storage)?;
+            Ok((operation_id, public_unique_mutation(stored)?))
+        })
+        .collect()
+}
+
+/// Finalize one coordinator-owned reservation and refresh every affected
+/// unique-index source-shard snapshot in the same global SQLite transaction.
+/// The physical shard commit happens first; an active durable reservation
+/// remains conservative until this transaction succeeds or recovery retries.
+pub(super) fn finalize_unique_write(
+    storage: &Storage,
+    operation_id: GlobalOperationId,
+    cancellation: &CancellationToken,
+) -> EngineResult<GlobalUniqueReservation> {
+    ensure_authority_not_cancelled(cancellation, "before finalizing an indexed write")?;
+    let (mut connection, _) = open_existing(&storage.root)?
+        .ok_or_else(|| corrupt("global uniqueness operation has no physical authority"))?;
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    let (kind, current) = load_operation_kind_and_state(&transaction, operation_id)?
+        .ok_or_else(|| unknown_operation(operation_id))?;
+    if kind != UNIQUE_OPERATION {
+        return Err(operation_reuse_error(operation_id));
+    }
+    let mutation = load_stored_unique_mutation(&transaction, operation_id)?;
+    if current == OPERATION_FINALIZED {
+        transaction.commit().map_err(sqlite_error::storage)?;
+        return Ok(GlobalUniqueReservation::from_validated(
+            operation_id,
+            mutation.index_id,
+            GlobalOperationState::Finalized,
+        ));
+    }
+    if current != OPERATION_ACTIVE {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!(
+                "global unique operation {:?} is already {}",
+                operation_id,
+                operation_state(current)?.code()
+            ),
+        ));
+    }
+    let index = storage
+        .catalog
+        .logical()
+        .global_index_by_id(mutation.index_id)
+        .ok_or_else(|| corrupt("global unique operation references a missing index"))?;
+    if !index.is_unique() || index.lifecycle() != GlobalIndexLifecycle::Ready {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!(
+                "global index {} is not ready for authoritative write finalization",
+                index.id()
+            ),
+        ));
+    }
+    validate_physical_authority(&transaction, index, storage.shard_count())?;
+
+    let affected_shards = [&mutation.previous, &mutation.new]
+        .into_iter()
+        .flatten()
+        .map(|entry| entry.1 as u16)
+        .collect::<BTreeSet<_>>();
+    for shard in affected_shards {
+        refresh_unique_shard_snapshot(storage, &transaction, index, shard, cancellation)?;
+    }
+    finalize_stored_unique_mutation(&transaction, &mutation)?;
+    complete_unique_transition(&transaction, operation_id, &mutation, OPERATION_FINALIZED)?;
+    ensure_authority_not_cancelled(cancellation, "before committing an indexed write authority")?;
+    abort_at_authority_test_boundary("unique-write-finalize-before-commit");
+    transaction.commit().map_err(sqlite_error::storage)?;
+    abort_at_authority_test_boundary("unique-write-finalize-after-commit");
+    Ok(GlobalUniqueReservation::from_validated(
+        operation_id,
+        mutation.index_id,
+        GlobalOperationState::Finalized,
+    ))
+}
+
+/// Refresh authoritative unique-index entries and source checkpoints after a
+/// committed physical write, including partial or NULL-distinct rows that do
+/// not require a key reservation.
+pub(super) fn refresh_unique_write_indexes(
+    storage: &Storage,
+    index_ids: &[GlobalIndexId],
+    shard: u16,
+    cancellation: &CancellationToken,
+) -> EngineResult<()> {
+    if index_ids.is_empty() {
+        return Ok(());
+    }
+    ensure_authority_not_cancelled(cancellation, "before refreshing indexed write snapshots")?;
+    let (mut connection, _) = open_existing(&storage.root)?
+        .ok_or_else(|| corrupt("ready global index has no physical storage"))?;
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    for index_id in index_ids {
+        let index = storage
+            .catalog
+            .logical()
+            .global_index_by_id(*index_id)
+            .ok_or_else(|| corrupt("indexed write references a missing global index"))?;
+        if !index.is_unique() || index.lifecycle() != GlobalIndexLifecycle::Ready {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "global index {} is not ready for authoritative snapshot maintenance",
+                    index.id()
+                ),
+            ));
+        }
+        validate_physical_authority(&transaction, index, storage.shard_count())?;
+        refresh_unique_shard_snapshot(storage, &transaction, index, shard, cancellation)?;
+    }
+    ensure_authority_not_cancelled(cancellation, "before committing indexed write snapshots")?;
+    transaction.commit().map_err(sqlite_error::storage)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum OrphanedUniqueWriteDecision {
+    Finalize,
+    RollBack,
+}
+
+/// Resolve whether the physical half of an orphaned coordinator operation
+/// committed. Active key reservations prevent another indexed write from
+/// changing either affected owner until this decision is made.
+pub(super) fn decide_orphaned_unique_write(
+    storage: &Storage,
+    mutation: &GlobalUniqueMutation,
+    cancellation: &CancellationToken,
+) -> EngineResult<OrphanedUniqueWriteDecision> {
+    ensure_authority_not_cancelled(cancellation, "before recovering an indexed write")?;
+    let index = storage
+        .catalog
+        .logical()
+        .global_index_by_id(mutation.index_id())
+        .ok_or_else(|| corrupt("global unique operation references a missing index"))?;
+    let new_matches = mutation
+        .new_entry()
+        .map(|(key, owner)| {
+            probe_unique_owner(storage, index, owner, cancellation)
+                .map(|observed| observed.as_ref() == Some(key))
+        })
+        .transpose()?;
+    let previous_matches = mutation
+        .previous_entry()
+        .map(|(key, owner)| {
+            probe_unique_owner(storage, index, owner, cancellation)
+                .map(|observed| observed.as_ref() == Some(key))
+        })
+        .transpose()?;
+    match (mutation.previous_entry(), mutation.new_entry()) {
+        (None, Some(_)) => Ok(if new_matches == Some(true) {
+            OrphanedUniqueWriteDecision::Finalize
+        } else {
+            OrphanedUniqueWriteDecision::RollBack
+        }),
+        (Some(_), None) => Ok(if previous_matches == Some(true) {
+            OrphanedUniqueWriteDecision::RollBack
+        } else {
+            OrphanedUniqueWriteDecision::Finalize
+        }),
+        (Some(previous), Some(new)) if previous == new => Ok(OrphanedUniqueWriteDecision::Finalize),
+        (Some(_), Some(_)) => match (previous_matches, new_matches) {
+            (Some(true), Some(false)) => Ok(OrphanedUniqueWriteDecision::RollBack),
+            (Some(false), Some(true)) => Ok(OrphanedUniqueWriteDecision::Finalize),
+            _ => Err(corrupt(
+                "orphaned global unique write has an ambiguous physical outcome",
+            )),
+        },
+        (None, None) => Err(corrupt("global unique operation has no affected key")),
+    }
+}
+
 fn transition_unique_operation(
     root: &Path,
     operation_id: GlobalOperationId,
@@ -536,6 +763,34 @@ fn transition_unique_operation(
     if target == OPERATION_FINALIZED {
         finalize_stored_unique_mutation(&transaction, &mutation)?;
     }
+    complete_unique_transition(&transaction, operation_id, &mutation, target)?;
+    ensure_authority_not_cancelled(cancellation, "before committing a unique transition")?;
+    let boundary = if target == OPERATION_FINALIZED {
+        "unique-finalize-before-commit"
+    } else {
+        "unique-rollback-before-commit"
+    };
+    abort_at_authority_test_boundary(boundary);
+    transaction.commit().map_err(sqlite_error::storage)?;
+    let boundary = if target == OPERATION_FINALIZED {
+        "unique-finalize-after-commit"
+    } else {
+        "unique-rollback-after-commit"
+    };
+    abort_at_authority_test_boundary(boundary);
+    Ok(GlobalUniqueReservation::from_validated(
+        operation_id,
+        mutation.index_id,
+        operation_state(target)?,
+    ))
+}
+
+fn complete_unique_transition(
+    transaction: &Transaction<'_>,
+    operation_id: GlobalOperationId,
+    mutation: &StoredUniqueMutation,
+    target: i64,
+) -> EngineResult<()> {
     let deleted = transaction
         .execute(
             "DELETE FROM briskdb_global_unique_reservations WHERE operation_id = ?1",
@@ -559,25 +814,7 @@ fn transition_unique_operation(
             "global unique operation state changed unexpectedly",
         ));
     }
-    ensure_authority_not_cancelled(cancellation, "before committing a unique transition")?;
-    let boundary = if target == OPERATION_FINALIZED {
-        "unique-finalize-before-commit"
-    } else {
-        "unique-rollback-before-commit"
-    };
-    abort_at_authority_test_boundary(boundary);
-    transaction.commit().map_err(sqlite_error::storage)?;
-    let boundary = if target == OPERATION_FINALIZED {
-        "unique-finalize-after-commit"
-    } else {
-        "unique-rollback-after-commit"
-    };
-    abort_at_authority_test_boundary(boundary);
-    Ok(GlobalUniqueReservation::from_validated(
-        operation_id,
-        mutation.index_id,
-        operation_state(target)?,
-    ))
+    Ok(())
 }
 
 pub(super) fn lease_values(
@@ -915,6 +1152,37 @@ fn load_stored_unique_mutation(
         new,
         previous,
     })
+}
+
+fn public_unique_mutation(stored: StoredUniqueMutation) -> EngineResult<GlobalUniqueMutation> {
+    let decode_entry = |entry: StoredUniqueEntry| {
+        Ok((
+            CanonicalIndexKey::from_bytes(&entry.0)?,
+            GlobalIndexOwner::new(entry.1 as u16, entry.2)?,
+        ))
+    };
+    match (stored.previous, stored.new) {
+        (None, Some(new)) => {
+            let (key, owner) = decode_entry(new)?;
+            Ok(GlobalUniqueMutation::claim(stored.index_id, key, owner))
+        }
+        (Some(previous), None) => {
+            let (key, owner) = decode_entry(previous)?;
+            Ok(GlobalUniqueMutation::release(stored.index_id, key, owner))
+        }
+        (Some(previous), Some(new)) => {
+            let (previous_key, previous_owner) = decode_entry(previous)?;
+            let (new_key, new_owner) = decode_entry(new)?;
+            Ok(GlobalUniqueMutation::replace(
+                stored.index_id,
+                previous_key,
+                previous_owner,
+                new_key,
+                new_owner,
+            ))
+        }
+        (None, None) => Err(corrupt("global unique operation has no affected key")),
+    }
 }
 
 fn stored_optional_entry(
@@ -2983,6 +3251,26 @@ fn read_source_entry(
     shard: u16,
     locator_count: usize,
 ) -> EngineResult<SourceEntry> {
+    let (encoded_key, reserves_unique_key) = read_source_key(row, index, shard)?;
+    let locator_values = (0..locator_count)
+        .map(|offset| {
+            row.get_ref(index.key_parts().len() + offset)
+                .map_err(sqlite_error::statement)
+        })
+        .collect::<EngineResult<Vec<_>>>()?;
+    let encoded_locator = encode_locator(&locator_values)?;
+    Ok(SourceEntry {
+        encoded_key,
+        encoded_locator,
+        reserves_unique_key,
+    })
+}
+
+fn read_source_key(
+    row: &rusqlite::Row<'_>,
+    index: &GlobalIndexMetadata,
+    shard: u16,
+) -> EngineResult<(CanonicalIndexKey, bool)> {
     let values = index
         .key_parts()
         .iter()
@@ -3010,20 +3298,21 @@ fn read_source_entry(
         })
         .collect::<Vec<_>>();
     let encoded_key = CanonicalIndexKey::encode(&parts)?;
-    let locator_values = (0..locator_count)
-        .map(|offset| {
-            row.get_ref(index.key_parts().len() + offset)
-                .map_err(sqlite_error::statement)
-        })
-        .collect::<EngineResult<Vec<_>>>()?;
-    let encoded_locator = encode_locator(&locator_values)?;
     let reserves_unique_key = index.is_unique()
         && CanonicalIndexKey::encode_unique(&parts, index.null_semantics())?.is_some();
-    Ok(SourceEntry {
-        encoded_key,
-        encoded_locator,
-        reserves_unique_key,
-    })
+    Ok((encoded_key, reserves_unique_key))
+}
+
+/// Encode one qualifying captured source row with the exact key semantics used
+/// by offline builds. Rows excluded by a partial predicate never reach this
+/// helper; unique NULL-distinct rows return `None`.
+pub(super) fn read_captured_unique_key(
+    row: &rusqlite::Row<'_>,
+    index: &GlobalIndexMetadata,
+    shard: u16,
+) -> EngineResult<Option<CanonicalIndexKey>> {
+    let (key, reserves) = read_source_key(row, index, shard)?;
+    Ok(reserves.then_some(key))
 }
 
 fn insert_entry(
@@ -3088,6 +3377,79 @@ fn insert_entry(
             locator_label(&entry.encoded_locator),
         ),
     ))
+}
+
+fn insert_snapshot_entry(
+    transaction: &Transaction<'_>,
+    index: &GlobalIndexMetadata,
+    shard: u16,
+    source_ordinal: u64,
+    entry: &SourceEntry,
+) -> EngineResult<()> {
+    transaction
+        .execute(
+            "INSERT INTO briskdb_global_index_entries (
+                 index_id, encoded_key, source_shard, source_ordinal, source_locator
+             ) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                to_sqlite_id(index.id())?,
+                entry.encoded_key.as_bytes(),
+                i64::from(shard),
+                to_sqlite_u64(source_ordinal, "source row ordinal")?,
+                &entry.encoded_locator,
+            ],
+        )
+        .map_err(sqlite_error::storage)?;
+    Ok(())
+}
+
+fn refresh_unique_shard_snapshot(
+    storage: &Storage,
+    transaction: &Transaction<'_>,
+    index: &GlobalIndexMetadata,
+    shard: u16,
+    cancellation: &CancellationToken,
+) -> EngineResult<()> {
+    transaction
+        .execute(
+            "DELETE FROM briskdb_global_index_entries
+             WHERE index_id = ?1 AND source_shard = ?2",
+            params![to_sqlite_id(index.id())?, i64::from(shard)],
+        )
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "DELETE FROM briskdb_global_index_checkpoints
+             WHERE index_id = ?1 AND source_shard = ?2",
+            params![to_sqlite_id(index.id())?, i64::from(shard)],
+        )
+        .map_err(sqlite_error::storage)?;
+    let outcome = scan_source_shard_with_visitor(
+        storage,
+        index,
+        shard,
+        cancellation,
+        |source_ordinal, entry| {
+            insert_snapshot_entry(transaction, index, shard, source_ordinal, entry)
+        },
+    )?;
+    write_checkpoint(transaction, index.id(), shard, &outcome)?;
+    let indexed_rows = transaction
+        .query_row(
+            "SELECT COALESCE(SUM(indexed_rows), 0)
+             FROM briskdb_global_index_checkpoints WHERE index_id = ?1",
+            [to_sqlite_id(index.id())?],
+            |row| row.get::<_, i64>(0),
+        )
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "UPDATE briskdb_global_index_builds SET indexed_rows = ?1
+             WHERE index_id = ?2 AND build_state = ?3",
+            params![indexed_rows, to_sqlite_id(index.id())?, COMPLETE],
+        )
+        .map_err(sqlite_error::storage)?;
+    Ok(())
 }
 
 fn delete_shard_rows(
@@ -3395,6 +3757,64 @@ fn scan_sql(index: &GlobalIndexMetadata, table: &str, locator: &SourceLocator) -
     sql
 }
 
+fn probe_unique_owner(
+    storage: &Storage,
+    index: &GlobalIndexMetadata,
+    owner: &GlobalIndexOwner,
+    cancellation: &CancellationToken,
+) -> EngineResult<Option<CanonicalIndexKey>> {
+    ensure_authority_not_cancelled(cancellation, "while probing an indexed write owner")?;
+    if owner.source_shard() >= storage.shard_count() {
+        return Err(corrupt(
+            "global unique owner points outside the shard layout",
+        ));
+    }
+    let source = storage.open_shard(owner.source_shard())?;
+    let table = storage
+        .catalog
+        .logical()
+        .table_by_id(index.table_id())
+        .ok_or_else(|| corrupt("global index references a missing table"))?;
+    let locator = inspect_source_locator(&source, table.name())?;
+    let parameters = decode_locator(owner.locator(), locator.expressions().len())?;
+    let expressions = index
+        .key_parts()
+        .iter()
+        .map(|part| match part.source() {
+            GlobalIndexKeySource::Column(column) => quote_identifier(column),
+            GlobalIndexKeySource::Expression(expression) => format!("({expression})"),
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    let mut sql = format!(
+        "SELECT {expressions} FROM main.{} WHERE ({})",
+        quote_identifier(table.name()),
+        locator.predicate_sql()
+    );
+    if let Some(predicate) = index.predicate() {
+        sql.push_str(" AND (");
+        sql.push_str(predicate);
+        sql.push(')');
+    }
+    let mut statement = source.prepare(&sql).map_err(sqlite_error::statement)?;
+    let mut rows = statement
+        .query(rusqlite::params_from_iter(parameters))
+        .map_err(sqlite_error::statement)?;
+    let result = match rows.next().map_err(sqlite_error::statement)? {
+        Some(row) => {
+            let (key, reserves) = read_source_key(row, index, owner.source_shard())?;
+            if rows.next().map_err(sqlite_error::statement)?.is_some() {
+                return Err(corrupt(
+                    "global unique owner locator identifies multiple physical rows",
+                ));
+            }
+            reserves.then_some(key)
+        }
+        None => None,
+    };
+    Ok(result)
+}
+
 fn read_key_value(
     value: ValueRef<'_>,
     key_type: GlobalIndexKeyType,
@@ -3453,7 +3873,7 @@ fn read_key_value(
     }
 }
 
-fn encode_locator(values: &[ValueRef<'_>]) -> EngineResult<Vec<u8>> {
+pub(super) fn encode_locator(values: &[ValueRef<'_>]) -> EngineResult<Vec<u8>> {
     let count = u16::try_from(values.len()).map_err(|_| {
         EngineError::new(
             EngineErrorKind::LimitExceeded,
@@ -3486,6 +3906,101 @@ fn encode_locator(values: &[ValueRef<'_>]) -> EngineResult<Vec<u8>> {
         }
     }
     Ok(output)
+}
+
+fn decode_locator(input: &[u8], expected_count: usize) -> EngineResult<Vec<SqliteValue>> {
+    if input.len() < 10 || &input[..4] != LOCATOR_MAGIC {
+        return Err(corrupt(
+            "global-index owner has an invalid locator encoding",
+        ));
+    }
+    let version = u32::from_be_bytes(
+        input[4..8]
+            .try_into()
+            .map_err(|_| corrupt("global-index owner has a truncated locator version"))?,
+    );
+    if version != LOCATOR_VERSION {
+        return Err(corrupt(
+            "global-index owner has an incompatible locator version",
+        ));
+    }
+    let count =
+        usize::from(u16::from_be_bytes(input[8..10].try_into().map_err(
+            |_| corrupt("global-index owner has a truncated locator count"),
+        )?));
+    if count != expected_count {
+        return Err(corrupt(
+            "global-index owner locator does not match the physical table",
+        ));
+    }
+    let mut cursor = 10_usize;
+    let mut values = Vec::with_capacity(count);
+    for _ in 0..count {
+        let tag = *input
+            .get(cursor)
+            .ok_or_else(|| corrupt("global-index owner has a truncated locator"))?;
+        cursor += 1;
+        let value = match tag {
+            0 => SqliteValue::Null,
+            1 => {
+                let end = cursor
+                    .checked_add(8)
+                    .ok_or_else(|| corrupt("global-index locator length overflowed"))?;
+                let bytes = input
+                    .get(cursor..end)
+                    .ok_or_else(|| corrupt("global-index owner has a truncated integer locator"))?;
+                cursor = end;
+                SqliteValue::Integer(i64::from_be_bytes(
+                    bytes.try_into().expect("checked integer locator length"),
+                ))
+            }
+            2 => {
+                let end = cursor
+                    .checked_add(8)
+                    .ok_or_else(|| corrupt("global-index locator length overflowed"))?;
+                let bytes = input
+                    .get(cursor..end)
+                    .ok_or_else(|| corrupt("global-index owner has a truncated real locator"))?;
+                cursor = end;
+                SqliteValue::Real(f64::from_bits(u64::from_be_bytes(
+                    bytes.try_into().expect("checked real locator length"),
+                )))
+            }
+            3 | 4 => {
+                let length_end = cursor
+                    .checked_add(4)
+                    .ok_or_else(|| corrupt("global-index locator length overflowed"))?;
+                let length_bytes = input
+                    .get(cursor..length_end)
+                    .ok_or_else(|| corrupt("global-index owner has a truncated locator length"))?;
+                let length = u32::from_be_bytes(
+                    length_bytes
+                        .try_into()
+                        .expect("checked locator length prefix"),
+                ) as usize;
+                let end = length_end
+                    .checked_add(length)
+                    .ok_or_else(|| corrupt("global-index locator length overflowed"))?;
+                let bytes = input
+                    .get(length_end..end)
+                    .ok_or_else(|| corrupt("global-index owner has a truncated locator value"))?;
+                cursor = end;
+                if tag == 3 {
+                    SqliteValue::Text(String::from_utf8(bytes.to_vec()).map_err(|_| {
+                        corrupt("global-index owner has an invalid UTF-8 text locator")
+                    })?)
+                } else {
+                    SqliteValue::Blob(bytes.to_vec())
+                }
+            }
+            _ => return Err(corrupt("global-index owner has an unknown locator tag")),
+        };
+        values.push(value);
+    }
+    if cursor != input.len() {
+        return Err(corrupt("global-index owner locator has trailing bytes"));
+    }
+    Ok(values)
 }
 
 fn valid_locator_encoding(input: &[u8]) -> bool {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -529,6 +529,12 @@ pub(crate) struct Storage {
     schema_coordination: Arc<RootSchemaCoordination>,
 }
 
+#[derive(Debug)]
+pub(crate) struct GlobalWriteReservationGuard {
+    operation_id: GlobalOperationId,
+    _lease: process_lock::GlobalWriteOperationLease,
+}
+
 impl Storage {
     pub(crate) fn open(root: impl AsRef<Path>, requested_shards: u16) -> EngineResult<Self> {
         validate_shard_count(requested_shards)?;
@@ -1574,6 +1580,109 @@ impl Storage {
                 self.shard_count(),
                 cancellation,
             )
+        })();
+        self.fail_closed_on_corruption(result)
+    }
+
+    /// Reserve one coordinator-owned unique mutation while holding an exact
+    /// process-liveness lease used by crash recovery.
+    pub(crate) fn reserve_global_unique_write(
+        &self,
+        mutation: &GlobalUniqueMutation,
+        cancellation: &crate::core::CancellationToken,
+    ) -> EngineResult<GlobalWriteReservationGuard> {
+        let mut bytes = [0_u8; 16];
+        getrandom::fill(&mut bytes).map_err(|error| {
+            EngineError::from_source(
+                EngineErrorKind::StorageUnavailable,
+                "could not generate a global-index write operation ID",
+                error,
+            )
+        })?;
+        if bytes == [0; 16] {
+            bytes[0] = 1;
+        }
+        let operation_id = GlobalOperationId::new(bytes)?;
+        let lease = process_lock::GlobalWriteOperationLease::acquire(&self.root, operation_id)?;
+        if let Err(error) = self.reserve_global_unique(operation_id, mutation, cancellation) {
+            process_lock::remove_global_write_marker(&self.root, operation_id);
+            return Err(error);
+        }
+        Ok(GlobalWriteReservationGuard {
+            operation_id,
+            _lease: lease,
+        })
+    }
+
+    pub(crate) fn finalize_global_unique_write(
+        &self,
+        reservation: &GlobalWriteReservationGuard,
+        cancellation: &crate::core::CancellationToken,
+    ) -> EngineResult<GlobalUniqueReservation> {
+        let result =
+            global_index::finalize_unique_write(self, reservation.operation_id, cancellation);
+        if result.is_ok() {
+            process_lock::remove_global_write_marker(&self.root, reservation.operation_id);
+        }
+        self.fail_closed_on_corruption(result)
+    }
+
+    pub(crate) fn rollback_global_unique_write(
+        &self,
+        reservation: &GlobalWriteReservationGuard,
+        cancellation: &crate::core::CancellationToken,
+    ) -> EngineResult<GlobalUniqueReservation> {
+        let result = self.rollback_global_unique(reservation.operation_id, cancellation);
+        if result.is_ok() {
+            process_lock::remove_global_write_marker(&self.root, reservation.operation_id);
+        }
+        result
+    }
+
+    pub(crate) fn refresh_global_unique_write_indexes(
+        &self,
+        index_ids: &[GlobalIndexId],
+        shard: u16,
+        cancellation: &crate::core::CancellationToken,
+    ) -> EngineResult<()> {
+        let result =
+            global_index::refresh_unique_write_indexes(self, index_ids, shard, cancellation);
+        self.fail_closed_on_corruption(result)
+    }
+
+    /// Recover only coordinator-owned active reservations whose OS lease is
+    /// no longer held by a live writer.
+    pub(crate) fn recover_global_unique_writes(
+        &self,
+        cancellation: &crate::core::CancellationToken,
+    ) -> EngineResult<usize> {
+        let result = (|| {
+            let mut recovered = 0_usize;
+            for (operation_id, mutation) in global_index::active_unique_mutations(&self.root)? {
+                let Some(_lease) = process_lock::GlobalWriteOperationLease::try_acquire_orphan(
+                    &self.root,
+                    operation_id,
+                )?
+                else {
+                    continue;
+                };
+                match global_index::decide_orphaned_unique_write(self, &mutation, cancellation)? {
+                    global_index::OrphanedUniqueWriteDecision::Finalize => {
+                        global_index::finalize_unique_write(self, operation_id, cancellation)?;
+                    }
+                    global_index::OrphanedUniqueWriteDecision::RollBack => {
+                        global_index::rollback_unique(&self.root, operation_id, cancellation)?;
+                    }
+                }
+                process_lock::remove_global_write_marker(&self.root, operation_id);
+                recovered = recovered.checked_add(1).ok_or_else(|| {
+                    EngineError::new(
+                        EngineErrorKind::LimitExceeded,
+                        "global-index recovered operation count overflowed",
+                    )
+                })?;
+            }
+            Ok(recovered)
         })();
         self.fail_closed_on_corruption(result)
     }
@@ -6415,7 +6524,7 @@ mod tests {
         let Ok(root) = std::env::var("BRISKDB_TABLE_REGISTRATION_ABORT_ROOT") else {
             return;
         };
-        let mut database = Database::open(root, 2).unwrap();
+        let mut database = Database::open(&root, 2).unwrap();
         create_registered_table_schema(&database);
         let declarations = registered_table_declarations(&database);
         let result = database.register_tables(declarations);
@@ -6478,7 +6587,7 @@ mod tests {
             return;
         };
         let mode = std::env::var("BRISKDB_GLOBAL_INDEX_ABORT_MODE").unwrap();
-        let mut database = Database::open(root, 2).unwrap();
+        let mut database = Database::open(&root, 2).unwrap();
         let result = match mode.as_str() {
             "create" => {
                 let declaration = global_index_test_declaration(&database);
@@ -6558,6 +6667,71 @@ mod tests {
             "authority-rollback" => {
                 let (_, operation, _) = authority_crash_request();
                 database.rollback_global_unique(operation).map(|_| ())
+            }
+            "authority-write-finalize" => {
+                let id = GlobalIndexId::new(
+                    std::env::var("BRISKDB_GLOBAL_INDEX_ABORT_ID")
+                        .unwrap()
+                        .parse()
+                        .unwrap(),
+                )
+                .unwrap();
+                let shard = database.shard_for_key(&crate::core::canonical_shard_key_bytes(
+                    crate::core::CanonicalShardKeyRef::Text("crash-writer"),
+                ));
+                let locator =
+                    global_index::encode_locator(&[rusqlite::types::ValueRef::Integer(1)]).unwrap();
+                let mutation = crate::core::GlobalUniqueMutation::claim(
+                    id,
+                    crate::core::CanonicalIndexKey::encode_values(&[crate::core::Value::from(
+                        vec![1_u8, 2, 3],
+                    )])
+                    .unwrap(),
+                    crate::core::GlobalIndexOwner::new(shard, locator).unwrap(),
+                );
+                let cancellation = crate::core::CancellationToken::new();
+                let storage = Storage::open(&root, 2).unwrap();
+                let reservation = storage
+                    .reserve_global_unique_write(&mutation, &cancellation)
+                    .unwrap();
+                database
+                    .execute(
+                        "crash-writer",
+                        "INSERT INTO events (id, tenant_id, payload) VALUES (1, ?1, ?2)",
+                        &[
+                            crate::core::Value::from("crash-writer"),
+                            crate::core::Value::from(vec![1_u8, 2, 3]),
+                        ],
+                    )
+                    .unwrap();
+                storage
+                    .finalize_global_unique_write(&reservation, &cancellation)
+                    .map(|_| ())
+            }
+            "authority-coordinator-write" => {
+                drop(database);
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                runtime.block_on(async {
+                    let brisk = crate::BriskDb::open(&root).await?;
+                    let session = brisk.session();
+                    session.set_routing_key("crash-writer").await?;
+                    brisk
+                        .execute_write(
+                            &session,
+                            crate::Statement::new(
+                                "INSERT INTO events (id, tenant_id, payload) VALUES (1, ?1, ?2)",
+                                vec![
+                                    crate::core::Value::from("crash-writer"),
+                                    crate::core::Value::from(vec![1_u8, 2, 3]),
+                                ],
+                            ),
+                        )
+                        .await?;
+                    Ok(())
+                })
             }
             "authority-lease" => {
                 let (id, operation, _) = authority_crash_request();
@@ -6787,6 +6961,92 @@ mod tests {
                 };
                 assert_eq!(lease.state(), target);
             }
+        }
+    }
+
+    #[test]
+    fn indexed_write_recovery_converges_after_real_process_abort() {
+        for (boundary, expected_recovered) in [
+            ("unique-write-finalize-before-commit", 1_usize),
+            ("unique-write-finalize-after-commit", 0_usize),
+        ] {
+            let temp = tempfile::tempdir().unwrap();
+            let mut database = setup_global_index_root(temp.path());
+            let declaration = global_index_test_declaration(&database)
+                .unique(crate::core::UniqueNullSemantics::Distinct);
+            let index_id = database.create_global_index(declaration).unwrap();
+            database.build_global_index(index_id).unwrap();
+            drop(database);
+
+            abort_global_index_child(
+                temp.path(),
+                "authority-write-finalize",
+                boundary,
+                Some(index_id),
+            );
+            let storage = Storage::open(temp.path(), 2).unwrap();
+            assert_eq!(
+                storage
+                    .recover_global_unique_writes(&crate::core::CancellationToken::new())
+                    .unwrap(),
+                expected_recovered
+            );
+            drop(storage);
+            let mut database = Database::open(temp.path(), 2).unwrap();
+            let report = database.validate_global_index(index_id).unwrap();
+            assert!(report.is_valid(), "{report:?}");
+        }
+    }
+
+    #[test]
+    fn indexed_write_recovers_across_the_physical_commit_boundary() {
+        for boundary in [
+            "unique-write-physical-before-commit",
+            "unique-write-physical-after-commit",
+        ] {
+            let temp = tempfile::tempdir().unwrap();
+            let mut database = setup_global_index_root(temp.path());
+            let declaration = global_index_test_declaration(&database)
+                .unique(crate::core::UniqueNullSemantics::Distinct);
+            let index_id = database.create_global_index(declaration).unwrap();
+            database.build_global_index(index_id).unwrap();
+            drop(database);
+
+            abort_global_index_child(
+                temp.path(),
+                "authority-coordinator-write",
+                boundary,
+                Some(index_id),
+            );
+            let storage = Storage::open(temp.path(), 2).unwrap();
+            assert_eq!(
+                storage
+                    .recover_global_unique_writes(&crate::core::CancellationToken::new())
+                    .unwrap(),
+                1
+            );
+            drop(storage);
+            let mut database = Database::open(temp.path(), 2).unwrap();
+            let report = database.validate_global_index(index_id).unwrap();
+            assert!(report.is_valid(), "{report:?}");
+            assert_eq!(
+                database
+                    .query(
+                        "crash-writer",
+                        "SELECT COUNT(*) FROM events WHERE id = 1 AND tenant_id = ?1",
+                        &[crate::core::Value::from("crash-writer")],
+                    )
+                    .unwrap()
+                    .rows()[0]
+                    .get(0)
+                    .unwrap()
+                    .as_i64(),
+                Some(if boundary.ends_with("after-commit") {
+                    1
+                } else {
+                    0
+                })
+            );
         }
     }
 

--- a/src/storage/process_lock.rs
+++ b/src/storage/process_lock.rs
@@ -1,6 +1,7 @@
 //! Local-filesystem advisory locks shared by independent BriskDB processes.
 
 use std::{
+    fmt::Write,
     fs::{File, OpenOptions},
     io,
     path::{Path, PathBuf},
@@ -9,12 +10,13 @@ use std::{
 };
 
 use crate::{
-    core::{EngineError, EngineErrorKind, EngineResult},
+    core::{EngineError, EngineErrorKind, EngineResult, GlobalOperationId},
     sqlite_error,
 };
 
 pub(super) const PROCESS_LEASE_FILE_NAME: &str = ".briskdb-process.lock";
 pub(super) const STARTUP_LOCK_FILE_NAME: &str = ".briskdb-startup.lock";
+const GLOBAL_WRITE_LOCK_PREFIX: &str = ".briskdb-global-write-";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum LeaseMode {
@@ -162,6 +164,70 @@ pub(super) struct RootStartupGuard {
     _file: File,
 }
 
+/// One exact cross-process lease for an integrated global-index write.
+///
+/// The file intentionally remains after the lock is released. Its presence
+/// durably distinguishes coordinator-owned operations from callers using the
+/// lower-level public reservation API, while `flock` distinguishes a live
+/// writer from an orphan left by process termination.
+#[derive(Debug)]
+pub(super) struct GlobalWriteOperationLease {
+    _file: File,
+}
+
+impl GlobalWriteOperationLease {
+    pub(super) fn acquire(root: &Path, operation_id: GlobalOperationId) -> EngineResult<Self> {
+        let path = global_write_lock_path(root, operation_id);
+        let file = open_regular_lock_file(&path)?;
+        lock_nonblocking(&file, LockRequest::Exclusive).map_err(|error| {
+            map_lock_error(
+                error,
+                &path,
+                "another process owns this global-index write operation",
+            )
+        })?;
+        Ok(Self { _file: file })
+    }
+
+    /// Acquire an existing coordinator marker only when its writer is gone.
+    pub(super) fn try_acquire_orphan(
+        root: &Path,
+        operation_id: GlobalOperationId,
+    ) -> EngineResult<Option<Self>> {
+        let path = global_write_lock_path(root, operation_id);
+        let file = match open_existing_regular_lock_file(&path)? {
+            Some(file) => file,
+            None => return Ok(None),
+        };
+        match lock_nonblocking(&file, LockRequest::Exclusive) {
+            Ok(()) => Ok(Some(Self { _file: file })),
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => Ok(None),
+            Err(error) => Err(map_lock_error(
+                error,
+                &path,
+                "another process owns this global-index write operation",
+            )),
+        }
+    }
+}
+
+fn global_write_lock_path(root: &Path, operation_id: GlobalOperationId) -> PathBuf {
+    let mut name = String::with_capacity(GLOBAL_WRITE_LOCK_PREFIX.len() + 32 + 5);
+    name.push_str(GLOBAL_WRITE_LOCK_PREFIX);
+    for byte in operation_id.as_bytes() {
+        write!(&mut name, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    name.push_str(".lock");
+    root.join(name)
+}
+
+pub(super) fn remove_global_write_marker(root: &Path, operation_id: GlobalOperationId) {
+    let path = global_write_lock_path(root, operation_id);
+    // A stale marker is harmless once the durable operation is no longer
+    // active; recovery filters by operation state first.
+    let _ = std::fs::remove_file(path);
+}
+
 impl RootStartupGuard {
     #[allow(dead_code)]
     pub(super) fn acquire(root: &Path, timeout: Duration) -> EngineResult<Self> {
@@ -223,6 +289,42 @@ fn open_regular_lock_file(path: &Path) -> EngineResult<File> {
     Ok(file)
 }
 
+fn open_existing_regular_lock_file(path: &Path) -> EngineResult<Option<File>> {
+    let file = match open_existing_lock_file(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) if error.raw_os_error() == Some(libc::ELOOP) => {
+            return Err(EngineError::from_source(
+                EngineErrorKind::FailedPrecondition,
+                format!(
+                    "BriskDB lock {} must not be a symbolic link",
+                    path.display()
+                ),
+                error,
+            ));
+        }
+        Err(error) => {
+            return Err(sqlite_error::storage_io(
+                error,
+                format!("failed to open BriskDB lock {}", path.display()),
+            ));
+        }
+    };
+    let metadata = file.metadata().map_err(|error| {
+        sqlite_error::storage_io(
+            error,
+            format!("failed to inspect BriskDB lock {}", path.display()),
+        )
+    })?;
+    if !metadata.is_file() {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!("BriskDB lock {} is not a regular file", path.display()),
+        ));
+    }
+    Ok(Some(file))
+}
+
 #[cfg(unix)]
 fn open_lock_file(path: &Path) -> io::Result<File> {
     use std::os::unix::fs::OpenOptionsExt;
@@ -237,11 +339,30 @@ fn open_lock_file(path: &Path) -> io::Result<File> {
         .open(path)
 }
 
+#[cfg(unix)]
+fn open_existing_lock_file(path: &Path) -> io::Result<File> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    OpenOptions::new()
+        .read(true)
+        .write(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(path)
+}
+
 #[cfg(not(unix))]
 fn open_lock_file(_path: &Path) -> io::Result<File> {
     Err(io::Error::new(
         io::ErrorKind::Unsupported,
         "cross-process BriskDB root leases require a supported Unix host",
+    ))
+}
+
+#[cfg(not(unix))]
+fn open_existing_lock_file(_path: &Path) -> io::Result<File> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "cross-process BriskDB operation leases require a supported Unix host",
     ))
 }
 

--- a/src/storage/sharded_vtab.rs
+++ b/src/storage/sharded_vtab.rs
@@ -36,8 +36,8 @@ use crate::{
     },
     core::{
         AllocationOwnerMap, CanonicalShardKeyRef, EngineError, EngineErrorKind, EngineResult,
-        GeneratedIdPolicy, OperationControl, ShardKeyType, TableMetadata, TablePlacement,
-        canonical_shard_key_bytes,
+        GeneratedIdPolicy, GlobalIndexKeySource, GlobalIndexLifecycle, GlobalIndexMetadata,
+        OperationControl, ShardKeyType, TableMetadata, TablePlacement, canonical_shard_key_bytes,
     },
     sqlite_error,
 };
@@ -313,6 +313,7 @@ impl CoordinatorCancellation {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         self.epoch.fetch_add(1, Ordering::AcqRel);
         if let Some(write_state) = &self.write_state {
+            write_state.cancel_authority();
             write_state.interrupt_child();
         }
         self.interrupt.interrupt();
@@ -772,6 +773,7 @@ impl Registry {
             let spec = TableSpec::from_physical_table(
                 shard,
                 table,
+                storage.logical_catalog().global_indexes(),
                 storage.generated_id_policy_is_active(table.id()),
                 allocation_owners.cloned(),
                 targets.into_boxed_slice(),
@@ -783,6 +785,10 @@ impl Registry {
 
     fn table(&self, id: u64) -> Option<Arc<TableSpec>> {
         self.tables.get(&id).cloned()
+    }
+
+    fn table_named(&self, name: &str) -> Option<&Arc<TableSpec>> {
+        self.tables.values().find(|spec| spec.name == name)
     }
 
     fn write_state(&self) -> &Arc<write::WriteState> {
@@ -1264,6 +1270,7 @@ struct TableSpec {
     locator_point_select_sql: Option<String>,
     columns: Box<[PhysicalColumnSpec]>,
     locator: Option<PhysicalLocatorSpec>,
+    global_unique_indexes: Box<[GlobalUniqueIndexSpec]>,
     write_unsupported: Option<String>,
     column_count: usize,
     targets: Box<[u16]>,
@@ -1277,34 +1284,47 @@ struct TableSpec {
 #[derive(Debug, Clone)]
 struct PhysicalColumnSpec {
     name: String,
+    affinity: SqliteAffinity,
+    collation: String,
     generated: bool,
 }
 
 #[derive(Debug, Clone)]
+struct GlobalUniqueIndexSpec {
+    metadata: GlobalIndexMetadata,
+    evaluation_sql: String,
+}
+
+#[derive(Debug, Clone)]
 enum PhysicalLocatorSpec {
-    Rowid { expression: String },
-    PrimaryKey { columns: Box<[String]> },
+    Rowid {
+        expression: String,
+    },
+    PrimaryKey {
+        columns: Box<[String]>,
+        column_indices: Box<[usize]>,
+    },
 }
 
 impl PhysicalLocatorSpec {
     fn expressions(&self) -> Box<[String]> {
         match self {
             Self::Rowid { expression } => vec![expression.clone()].into_boxed_slice(),
-            Self::PrimaryKey { columns } => columns.clone(),
+            Self::PrimaryKey { columns, .. } => columns.clone(),
         }
     }
 
     fn value_count(&self) -> usize {
         match self {
             Self::Rowid { .. } => 1,
-            Self::PrimaryKey { columns } => columns.len(),
+            Self::PrimaryKey { columns, .. } => columns.len(),
         }
     }
 
     fn predicate_sql(&self) -> String {
         match self {
             Self::Rowid { expression } => format!("{expression} = ?"),
-            Self::PrimaryKey { columns } => columns
+            Self::PrimaryKey { columns, .. } => columns
                 .iter()
                 .map(|column| format!("{} IS ?", quote_identifier(column)))
                 .collect::<Vec<_>>()
@@ -1323,6 +1343,7 @@ impl TableSpec {
     fn from_physical_table(
         connection: &Connection,
         table: &TableMetadata,
+        global_indexes: &[GlobalIndexMetadata],
         generated_id_policy_active: bool,
         allocation_owners: Option<Arc<AllocationOwnerMap>>,
         targets: Box<[u16]>,
@@ -1372,7 +1393,7 @@ impl TableSpec {
             ));
         }
 
-        let declared_columns = columns
+        let physical_columns = columns
             .iter()
             .map(|(column, declared_type, not_null, default_sql, _, _)| {
                 let (_, collation, _, _, _) = connection
@@ -1416,9 +1437,21 @@ impl TableSpec {
                     declaration.push_str(default_sql);
                     declaration.push(')');
                 }
-                Ok(declaration)
+                Ok((
+                    PhysicalColumnSpec {
+                        name: column.clone(),
+                        affinity,
+                        collation: collation.to_owned(),
+                        generated: false,
+                    },
+                    declaration,
+                ))
             })
             .collect::<EngineResult<Vec<_>>>()?;
+        let declared_columns = physical_columns
+            .iter()
+            .map(|(_, declaration)| declaration.as_str())
+            .collect::<Vec<_>>();
         let read_declared_schema = format!("CREATE TABLE x({})", declared_columns.join(", "));
         let write_declared_schema = format!(
             "CREATE TABLE x({}, {} BLOB HIDDEN PRIMARY KEY NOT NULL) WITHOUT ROWID",
@@ -1476,11 +1509,12 @@ impl TableSpec {
             _ => None,
         };
 
-        let physical_columns = columns
-            .iter()
-            .map(|(column, _, _, _, _, hidden)| PhysicalColumnSpec {
-                name: column.clone(),
-                generated: matches!(*hidden, 2 | 3),
+        let physical_columns = physical_columns
+            .into_iter()
+            .zip(columns.iter())
+            .map(|((mut column, _), (_, _, _, _, _, hidden))| {
+                column.generated = matches!(*hidden, 2 | 3);
+                column
             })
             .collect::<Vec<_>>()
             .into_boxed_slice();
@@ -1492,12 +1526,24 @@ impl TableSpec {
                 .map(|(column, _, _, _, primary_key, _)| (*primary_key, column.clone()))
                 .collect::<Vec<_>>();
             primary_key.sort_unstable_by_key(|(position, _)| *position);
-            (!primary_key.is_empty()).then(|| PhysicalLocatorSpec::PrimaryKey {
-                columns: primary_key
+            (!primary_key.is_empty()).then(|| {
+                let primary_key = primary_key
                     .into_iter()
                     .map(|(_, column)| column)
-                    .collect::<Vec<_>>()
-                    .into_boxed_slice(),
+                    .collect::<Vec<_>>();
+                let column_indices = primary_key
+                    .iter()
+                    .map(|primary| {
+                        physical_columns
+                            .iter()
+                            .position(|column| column.name == *primary)
+                            .expect("primary-key column was discovered from this schema")
+                    })
+                    .collect::<Vec<_>>();
+                PhysicalLocatorSpec::PrimaryKey {
+                    columns: primary_key.into_boxed_slice(),
+                    column_indices: column_indices.into_boxed_slice(),
+                }
             })
         } else {
             let physical_names = columns
@@ -1520,9 +1566,31 @@ impl TableSpec {
             Some(format!(
                 "registered table {name} is not Sharded; the writable facade does not mutate replicated or catalog placement"
             ))
+        } else if global_indexes.iter().any(|index| {
+            index.table_id() == table.id()
+                && index.is_unique()
+                && index.lifecycle() == GlobalIndexLifecycle::Invalid
+        }) {
+            Some(format!(
+                "registered table {name} has an invalid authoritative global index; rebuild it before writing"
+            ))
         } else {
             shard::writable_table_unsupported_reason(connection, name)?
         };
+
+        let global_unique_indexes = global_indexes
+            .iter()
+            .filter(|index| {
+                index.table_id() == table.id()
+                    && index.is_unique()
+                    && index.lifecycle() == GlobalIndexLifecycle::Ready
+            })
+            .map(|metadata| GlobalUniqueIndexSpec {
+                evaluation_sql: global_unique_evaluation_sql(metadata, &physical_columns),
+                metadata: metadata.clone(),
+            })
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
 
         let (locator_select_sql, locator_point_select_sql) = locator
             .as_ref()
@@ -1558,6 +1626,7 @@ impl TableSpec {
             locator_point_select_sql,
             columns: physical_columns,
             locator,
+            global_unique_indexes,
             write_unsupported,
             column_count: columns.len(),
             targets,
@@ -1933,6 +2002,46 @@ const fn affinity_name(affinity: SqliteAffinity) -> &'static str {
         SqliteAffinity::Real => "REAL",
         SqliteAffinity::Numeric => "NUMERIC",
     }
+}
+
+fn global_unique_evaluation_sql(
+    index: &GlobalIndexMetadata,
+    columns: &[PhysicalColumnSpec],
+) -> String {
+    let input = columns
+        .iter()
+        .enumerate()
+        .map(|(ordinal, column)| {
+            let parameter = ordinal + 1;
+            let value = if column.affinity == SqliteAffinity::Blob {
+                format!("?{parameter}")
+            } else {
+                format!("CAST(?{parameter} AS {})", affinity_name(column.affinity))
+            };
+            format!(
+                "({value} COLLATE {}) AS {}",
+                quote_identifier(&column.collation),
+                quote_identifier(&column.name)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    let keys = index
+        .key_parts()
+        .iter()
+        .map(|part| match part.source() {
+            GlobalIndexKeySource::Column(column) => quote_identifier(column),
+            GlobalIndexKeySource::Expression(expression) => format!("({expression})"),
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    let mut sql = format!("SELECT {keys} FROM (SELECT {input})");
+    if let Some(predicate) = index.predicate() {
+        sql.push_str(" WHERE (");
+        sql.push_str(predicate);
+        sql.push(')');
+    }
+    sql
 }
 
 #[derive(Default)]
@@ -2503,7 +2612,7 @@ impl Drop for BriskShardCursor {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum RawCell {
     Null,
     Integer(i64),
@@ -2532,6 +2641,16 @@ impl RawCell {
             }
         }
     }
+
+    fn as_value_ref(&self) -> ValueRef<'_> {
+        match self {
+            Self::Null => ValueRef::Null,
+            Self::Integer(value) => ValueRef::Integer(*value),
+            Self::Real(value) => ValueRef::Real(*value),
+            Self::Text(value) => ValueRef::Text(value),
+            Self::Blob(value) => ValueRef::Blob(value),
+        }
+    }
 }
 
 fn copy_bytes(bytes: &[u8]) -> EngineResult<Vec<u8>> {
@@ -2552,13 +2671,7 @@ fn allocation_error(error: std::collections::TryReserveError) -> EngineError {
 
 impl ToSql for RawCell {
     fn to_sql(&self) -> SqliteResult<ToSqlOutput<'_>> {
-        Ok(ToSqlOutput::Borrowed(match self {
-            Self::Null => ValueRef::Null,
-            Self::Integer(value) => ValueRef::Integer(*value),
-            Self::Real(value) => ValueRef::Real(*value),
-            Self::Text(value) => ValueRef::Text(value),
-            Self::Blob(value) => ValueRef::Blob(value),
-        }))
+        Ok(ToSqlOutput::Borrowed(self.as_value_ref()))
     }
 }
 
@@ -2584,6 +2697,9 @@ fn vtab_error(error: EngineError) -> SqliteError {
             Some(ffi::SQLITE_INTERRUPT)
         }
         EngineErrorKind::LimitExceeded => Some(ffi::SQLITE_TOOBIG),
+        EngineErrorKind::Unsupported if write::is_global_index_write_unsupported(&error) => {
+            Some(ffi::SQLITE_NOLFS)
+        }
         EngineErrorKind::ShuttingDown => Some(ffi::SQLITE_ABORT),
         EngineErrorKind::StorageFull => Some(ffi::SQLITE_FULL),
         EngineErrorKind::OutOfMemory => Some(ffi::SQLITE_NOMEM),
@@ -6695,7 +6811,12 @@ mod tests {
         gate.release();
 
         let (mut coordinator, result) = worker.join().unwrap();
-        assert_eq!(result.unwrap_err().kind(), EngineErrorKind::Cancelled);
+        let error = result.unwrap_err();
+        assert_eq!(
+            error.kind(),
+            EngineErrorKind::Cancelled,
+            "unexpected cancellation error: {error}"
+        );
         assert_eq!(fixture.row_count(), 0);
 
         let after = coordinator

--- a/src/storage/sharded_vtab/write.rs
+++ b/src/storage/sharded_vtab/write.rs
@@ -1,6 +1,7 @@
 //! Writable coordinator execution and one-shard transaction state.
 
 use std::{
+    collections::{BTreeMap, BTreeSet},
     sync::{
         Arc, Mutex, MutexGuard, TryLockError,
         atomic::{AtomicBool, Ordering},
@@ -9,32 +10,438 @@ use std::{
 };
 
 use rusqlite::{
-    Connection, InterruptHandle, Params, Result as SqliteResult, types::ValueRef,
-    vtab::ConflictMode,
+    Connection, InterruptHandle, Params, Result as SqliteResult, hooks::PreUpdateCase,
+    types::ValueRef, vtab::ConflictMode,
 };
 
 use super::{
-    ALLOCATION_OVERHEAD_BYTES, CoordinatorCancellation, CursorLimits, ROW_ACCOUNTING_BYTES,
-    RawCell, Registry, RegistrySchemaCache, TableSpec, VALUE_ACCOUNTING_BYTES, allocation_error,
-    attach_writable_coordinator_authorizer, bootstrap_coordinator_schema, cancelled_error,
-    limit_error, locator, module_v2,
+    ALLOCATION_OVERHEAD_BYTES, CoordinatorCancellation, CursorLimits, PhysicalLocatorSpec,
+    ROW_ACCOUNTING_BYTES, RawCell, Registry, RegistrySchemaCache, TableSpec,
+    VALUE_ACCOUNTING_BYTES, allocation_error, attach_writable_coordinator_authorizer,
+    bootstrap_coordinator_schema, cancelled_error, limit_error, locator, module_v2,
 };
 #[cfg(test)]
 use super::{TestChildScanControl, TestChildScanGate};
 use crate::{
     core::{
-        CanonicalShardKeyRef, EngineError, EngineErrorKind, EngineResult, GeneratedIdPolicy,
-        GeneratedKey, OperationControl, TableId, Value, canonical_shard_key_bytes,
+        CancellationToken, CanonicalIndexKey, CanonicalShardKeyRef, EngineError, EngineErrorKind,
+        EngineResult, GeneratedIdPolicy, GeneratedKey, GlobalIndexId, GlobalIndexOwner,
+        GlobalUniqueMutation, OperationControl, TableId, Value, canonical_shard_key_bytes,
         generated_id::{
             AllocationOwnerSlot, GeneratedIdClassification, classify_generated_id,
             native_range_v1_sequence_ceiling, native_range_v1_sequence_floor,
         },
     },
     sqlite_error,
-    storage::{CONNECTION_BUSY_TIMEOUT, SchemaOperationGuard, Storage, hilo::HiloAllocation},
+    storage::{
+        CONNECTION_BUSY_TIMEOUT, GlobalWriteReservationGuard, SchemaOperationGuard, Storage,
+        global_index, hilo::HiloAllocation,
+    },
 };
 
 const CANCELLABLE_BUSY_SLICE: Duration = Duration::from_millis(25);
+
+#[derive(Debug)]
+struct GlobalIndexWriteUnsupported;
+
+impl std::fmt::Display for GlobalIndexWriteUnsupported {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("authoritative global-index write is unsupported")
+    }
+}
+
+impl std::error::Error for GlobalIndexWriteUnsupported {}
+
+fn global_index_write_unsupported(diagnostic: impl Into<String>) -> EngineError {
+    EngineError::from_source(
+        EngineErrorKind::Unsupported,
+        diagnostic,
+        GlobalIndexWriteUnsupported,
+    )
+}
+
+pub(super) fn is_global_index_write_unsupported(error: &EngineError) -> bool {
+    std::error::Error::source(error)
+        .and_then(|source| source.downcast_ref::<GlobalIndexWriteUnsupported>())
+        .is_some()
+}
+
+#[cfg(test)]
+fn abort_at_global_write_test_boundary(boundary: &str) {
+    if std::env::var("BRISKDB_GLOBAL_INDEX_AUTHORITY_ABORT_POINT").as_deref() == Ok(boundary) {
+        std::process::abort();
+    }
+}
+
+#[cfg(not(test))]
+fn abort_at_global_write_test_boundary(_boundary: &str) {}
+
+#[derive(Debug, Clone)]
+struct CapturedPhysicalRow {
+    rowid: i64,
+    values: Vec<RawCell>,
+}
+
+#[derive(Debug, Clone)]
+struct CapturedPhysicalChange {
+    table: String,
+    old: Option<CapturedPhysicalRow>,
+    new: Option<CapturedPhysicalRow>,
+}
+
+#[derive(Debug, Default)]
+struct GlobalMutationCapture {
+    changes: Vec<CapturedPhysicalChange>,
+    error: Option<String>,
+}
+
+impl GlobalMutationCapture {
+    fn record(&mut self, table: &str, case: &PreUpdateCase) -> EngineResult<()> {
+        let (old, new) = match case {
+            PreUpdateCase::Insert(accessor) => (
+                None,
+                Some(capture_new_row(
+                    accessor.get_new_row_id(),
+                    accessor.get_column_count(),
+                    |column| accessor.get_new_column_value(column),
+                )?),
+            ),
+            PreUpdateCase::Delete(accessor) => (
+                Some(capture_old_row(
+                    accessor.get_old_row_id(),
+                    accessor.get_column_count(),
+                    |column| accessor.get_old_column_value(column),
+                )?),
+                None,
+            ),
+            PreUpdateCase::Update {
+                old_value_accessor,
+                new_value_accessor,
+            } => (
+                Some(capture_old_row(
+                    old_value_accessor.get_old_row_id(),
+                    old_value_accessor.get_column_count(),
+                    |column| old_value_accessor.get_old_column_value(column),
+                )?),
+                Some(capture_new_row(
+                    new_value_accessor.get_new_row_id(),
+                    new_value_accessor.get_column_count(),
+                    |column| new_value_accessor.get_new_column_value(column),
+                )?),
+            ),
+            PreUpdateCase::Unknown => {
+                return Err(EngineError::new(
+                    EngineErrorKind::Unsupported,
+                    "SQLite reported an unknown physical change to global-index maintenance",
+                ));
+            }
+        };
+        self.changes.push(CapturedPhysicalChange {
+            table: table.to_owned(),
+            old,
+            new,
+        });
+        Ok(())
+    }
+}
+
+fn capture_old_row<'value>(
+    rowid: i64,
+    count: i32,
+    mut value: impl FnMut(i32) -> rusqlite::Result<ValueRef<'value>>,
+) -> EngineResult<CapturedPhysicalRow> {
+    capture_physical_row(rowid, count, &mut value)
+}
+
+fn capture_new_row<'value>(
+    rowid: i64,
+    count: i32,
+    mut value: impl FnMut(i32) -> rusqlite::Result<ValueRef<'value>>,
+) -> EngineResult<CapturedPhysicalRow> {
+    capture_physical_row(rowid, count, &mut value)
+}
+
+fn capture_physical_row<'value>(
+    rowid: i64,
+    count: i32,
+    value: &mut impl FnMut(i32) -> rusqlite::Result<ValueRef<'value>>,
+) -> EngineResult<CapturedPhysicalRow> {
+    let count = usize::try_from(count).map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::DataCorruption,
+            "SQLite pre-update hook reported a negative column count",
+            error,
+        )
+    })?;
+    let mut values = Vec::new();
+    values.try_reserve_exact(count).map_err(allocation_error)?;
+    for column in 0..count {
+        let column = i32::try_from(column).map_err(|error| {
+            EngineError::from_source(
+                EngineErrorKind::LimitExceeded,
+                "physical row has too many columns for global-index capture",
+                error,
+            )
+        })?;
+        values.push(RawCell::try_copy_from(
+            value(column).map_err(sqlite_error::statement)?,
+        )?);
+    }
+    Ok(CapturedPhysicalRow { rowid, values })
+}
+
+#[derive(Debug)]
+struct CapturedOwnerState {
+    owner: GlobalIndexOwner,
+    initial: Option<CanonicalIndexKey>,
+    current: Option<CanonicalIndexKey>,
+}
+
+fn touched_global_unique_indexes(
+    registry: &Registry,
+    changes: &[CapturedPhysicalChange],
+) -> EngineResult<Vec<GlobalIndexId>> {
+    let mut touched = BTreeSet::new();
+    for change in changes {
+        let spec = registry.table_named(&change.table).ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!(
+                    "global-index capture references unregistered physical table {}",
+                    change.table
+                ),
+            )
+        })?;
+        touched.extend(
+            spec.global_unique_indexes
+                .iter()
+                .map(|index| index.metadata.id()),
+        );
+    }
+    Ok(touched.into_iter().collect())
+}
+
+fn plan_global_unique_mutations(
+    registry: &Registry,
+    shard: u16,
+    connection: &Connection,
+    changes: &[CapturedPhysicalChange],
+) -> EngineResult<Vec<GlobalUniqueMutation>> {
+    let mut by_index = BTreeMap::<GlobalIndexId, BTreeMap<Vec<u8>, CapturedOwnerState>>::new();
+    for change in changes {
+        let spec = registry.table_named(&change.table).ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!(
+                    "global-index capture references unregistered physical table {}",
+                    change.table
+                ),
+            )
+        })?;
+        if change
+            .old
+            .iter()
+            .chain(change.new.iter())
+            .any(|row| row.values.len() != spec.columns.len())
+        {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!(
+                    "physical table {} changed column count during global-index capture",
+                    spec.name
+                ),
+            ));
+        }
+        for index in &spec.global_unique_indexes {
+            let states = by_index.entry(index.metadata.id()).or_default();
+            if let Some(old) = &change.old {
+                let owner = captured_global_owner(spec, shard, old)?;
+                let key = evaluate_captured_unique_key(connection, index, shard, old)?;
+                apply_captured_old(states, owner, key)?;
+            }
+            if let Some(new) = &change.new {
+                let owner = captured_global_owner(spec, shard, new)?;
+                let key = evaluate_captured_unique_key(connection, index, shard, new)?;
+                apply_captured_new(states, owner, key)?;
+            }
+        }
+    }
+
+    collapse_global_unique_mutations(by_index)
+}
+
+fn collapse_global_unique_mutations(
+    by_index: BTreeMap<GlobalIndexId, BTreeMap<Vec<u8>, CapturedOwnerState>>,
+) -> EngineResult<Vec<GlobalUniqueMutation>> {
+    let mut mutations = Vec::new();
+    for (index_id, states) in by_index {
+        let mut previous = Vec::new();
+        let mut new = Vec::new();
+        for state in states.into_values() {
+            if state.initial == state.current {
+                continue;
+            }
+            if let Some(key) = state.initial {
+                previous.push((key, state.owner.clone()));
+            }
+            if let Some(key) = state.current {
+                new.push((key, state.owner));
+            }
+        }
+        for left in 0..new.len() {
+            if new[left + 1..]
+                .iter()
+                .any(|(right, _)| *right == new[left].0)
+            {
+                return Err(EngineError::new(
+                    EngineErrorKind::UniqueViolation,
+                    format!(
+                        "one statement produced duplicate keys for global index {index_id}; key bytes are redacted"
+                    ),
+                ));
+            }
+        }
+        if previous.len() > 1 || new.len() > 1 {
+            return Err(global_index_write_unsupported(format!(
+                "global index {index_id} does not yet support one transaction changing more than one authoritative row"
+            )));
+        }
+        match (previous.pop(), new.pop()) {
+            (None, None) => {}
+            (None, Some((key, owner))) => {
+                mutations.push(GlobalUniqueMutation::claim(index_id, key, owner));
+            }
+            (Some((key, owner)), None) => {
+                mutations.push(GlobalUniqueMutation::release(index_id, key, owner));
+            }
+            (Some((previous_key, previous_owner)), Some((new_key, new_owner))) => {
+                mutations.push(GlobalUniqueMutation::replace(
+                    index_id,
+                    previous_key,
+                    previous_owner,
+                    new_key,
+                    new_owner,
+                ));
+            }
+        }
+    }
+    Ok(mutations)
+}
+
+fn apply_captured_old(
+    states: &mut BTreeMap<Vec<u8>, CapturedOwnerState>,
+    owner: GlobalIndexOwner,
+    key: Option<CanonicalIndexKey>,
+) -> EngineResult<()> {
+    if key.is_none() && !states.contains_key(owner.locator()) {
+        return Ok(());
+    }
+    let state = states
+        .entry(owner.locator().to_vec())
+        .or_insert_with(|| CapturedOwnerState {
+            owner,
+            initial: key.clone(),
+            current: key.clone(),
+        });
+    if state.current != key {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "global-index physical change history has a discontinuous old row",
+        ));
+    }
+    state.current = None;
+    Ok(())
+}
+
+fn apply_captured_new(
+    states: &mut BTreeMap<Vec<u8>, CapturedOwnerState>,
+    owner: GlobalIndexOwner,
+    key: Option<CanonicalIndexKey>,
+) -> EngineResult<()> {
+    if key.is_none() && !states.contains_key(owner.locator()) {
+        return Ok(());
+    }
+    let state = states
+        .entry(owner.locator().to_vec())
+        .or_insert_with(|| CapturedOwnerState {
+            owner,
+            initial: None,
+            current: None,
+        });
+    if state.current.is_some() {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "global-index physical change history inserted over a live row identity",
+        ));
+    }
+    state.current = key;
+    Ok(())
+}
+
+fn captured_global_owner(
+    spec: &TableSpec,
+    shard: u16,
+    row: &CapturedPhysicalRow,
+) -> EngineResult<GlobalIndexOwner> {
+    let locator = spec.locator.as_ref().ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::Unsupported,
+            format!(
+                "registered table {} has no stable global-index row identity",
+                spec.name
+            ),
+        )
+    })?;
+    let rowid;
+    let values = match locator {
+        PhysicalLocatorSpec::Rowid { .. } => {
+            rowid = RawCell::Integer(row.rowid);
+            vec![rowid.as_value_ref()]
+        }
+        PhysicalLocatorSpec::PrimaryKey { column_indices, .. } => column_indices
+            .iter()
+            .map(|index| {
+                row.values
+                    .get(*index)
+                    .map(RawCell::as_value_ref)
+                    .ok_or_else(|| {
+                        EngineError::new(
+                            EngineErrorKind::DataCorruption,
+                            "global-index primary-key locator is outside the captured row",
+                        )
+                    })
+            })
+            .collect::<EngineResult<Vec<_>>>()?,
+    };
+    GlobalIndexOwner::new(shard, global_index::encode_locator(&values)?)
+}
+
+fn evaluate_captured_unique_key(
+    connection: &Connection,
+    index: &super::GlobalUniqueIndexSpec,
+    shard: u16,
+    row: &CapturedPhysicalRow,
+) -> EngineResult<Option<CanonicalIndexKey>> {
+    let mut statement = connection
+        .prepare_cached(&index.evaluation_sql)
+        .map_err(sqlite_error::statement)?;
+    let mut rows = statement
+        .query(rusqlite::params_from_iter(&row.values))
+        .map_err(sqlite_error::statement)?;
+    let key = rows
+        .next()
+        .map_err(sqlite_error::statement)?
+        .map(|row| global_index::read_captured_unique_key(row, &index.metadata, shard))
+        .transpose()?
+        .flatten();
+    if rows.next().map_err(sqlite_error::statement)?.is_some() {
+        return Err(EngineError::new(
+            EngineErrorKind::Internal,
+            "captured global-index expression returned more than one row",
+        ));
+    }
+    Ok(key)
+}
 
 fn validate_allocation_sequence_capacity(
     connection: &Connection,
@@ -889,6 +1296,7 @@ pub(super) struct WriteState {
     armed_statement_epoch: Mutex<Option<u64>>,
     generated_insert: Mutex<Option<GeneratedInsertIntent>>,
     active_interrupt: Mutex<Option<Arc<InterruptHandle>>>,
+    active_authority_cancellation: Mutex<Option<CancellationToken>>,
     commit_linearization: Mutex<()>,
     nonblocking_cancel_requested: AtomicBool,
     #[cfg(test)]
@@ -923,6 +1331,7 @@ impl WriteState {
             armed_statement_epoch: Mutex::new(None),
             generated_insert: Mutex::new(None),
             active_interrupt: Mutex::new(None),
+            active_authority_cancellation: Mutex::new(None),
             commit_linearization: Mutex::new(()),
             nonblocking_cancel_requested: AtomicBool::new(false),
             #[cfg(test)]
@@ -1195,6 +1604,24 @@ impl WriteState {
         }
     }
 
+    pub(super) fn cancel_authority(&self) {
+        if let Some(cancellation) = self
+            .active_authority_cancellation
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .as_ref()
+        {
+            cancellation.cancel();
+        }
+    }
+
+    fn clear_authority_cancellation(&self) {
+        *self
+            .active_authority_cancellation
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+    }
+
     #[cfg(test)]
     pub(super) fn has_active_child(&self) -> bool {
         self.active_interrupt
@@ -1299,8 +1726,8 @@ impl WriteState {
     }
 
     pub(super) fn sync(&self, registry: &Registry) -> EngineResult<()> {
-        let state = self.lock();
-        match &*state {
+        let mut state = self.lock();
+        match &mut *state {
             WriteTransactionState::Idle => Ok(()),
             WriteTransactionState::Active(transaction) => {
                 transaction.ensure_healthy(registry)?;
@@ -1314,6 +1741,7 @@ impl WriteState {
                         "brisk_shard child transaction ended before coordinator sync",
                     ));
                 }
+                transaction.prepare_global_authority(registry)?;
                 Ok(())
             }
             WriteTransactionState::PendingCommit(_) | WriteTransactionState::PendingRollback(_) => {
@@ -1404,6 +1832,7 @@ impl WriteState {
                 })
             }
         };
+        self.clear_authority_cancellation();
         self.clear_active_interrupt();
         registry.storage.fail_closed_on_corruption(result)
     }
@@ -1420,6 +1849,7 @@ impl WriteState {
             | WriteTransactionState::PendingCommit(mut transaction)
             | WriteTransactionState::PendingRollback(mut transaction) => transaction.rollback(),
         };
+        self.clear_authority_cancellation();
         self.clear_active_interrupt();
         registry.storage.fail_closed_on_corruption(result)
     }
@@ -1433,6 +1863,7 @@ impl WriteState {
                 transaction.statement_shard = None;
                 transaction.explicit_key = None;
                 transaction.generated_key = None;
+                transaction.statement_ignores_conflicts = false;
                 Ok(())
             }
             WriteTransactionState::PendingCommit(_) | WriteTransactionState::PendingRollback(_) => {
@@ -1489,6 +1920,7 @@ impl WriteState {
         conflict: ConflictMode,
     ) -> EngineResult<i64> {
         self.with_active(registry, |transaction| {
+            transaction.record_statement_conflict(&conflict);
             let shard_key = spec.write_shard_key(values)?;
             let generated_shard = self.generated_insert_target(
                 registry,
@@ -1532,6 +1964,7 @@ impl WriteState {
     ) -> EngineResult<()> {
         self.reject_generated_non_insert()?;
         self.with_active(registry, |transaction| {
+            transaction.record_statement_conflict(&conflict);
             transaction.update(
                 registry,
                 spec,
@@ -1615,7 +2048,18 @@ impl WriteState {
                 ));
             }
             let epoch = self.statement_epoch(registry)?;
-            *state = WriteTransactionState::Active(WriteTransaction::new(operation, epoch));
+            let authority_cancellation = CancellationToken::new();
+            *self
+                .active_authority_cancellation
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) =
+                Some(authority_cancellation.clone());
+            *state = WriteTransactionState::Active(WriteTransaction::new(
+                operation,
+                epoch,
+                registry.storage.clone(),
+                authority_cancellation,
+            ));
         }
         match state {
             WriteTransactionState::Active(transaction) => Ok(transaction),
@@ -1734,6 +2178,7 @@ impl CoordinatorCancellation {
             .nonblocking_cancel_requested
             .store(true, Ordering::Release);
         self.epoch.fetch_add(1, Ordering::AcqRel);
+        write_state.cancel_authority();
         write_state.interrupt_child();
         self.interrupt.interrupt();
     }
@@ -2062,6 +2507,7 @@ enum WriteTransactionState {
 
 struct WriteTransaction {
     _operation: Option<SchemaOperationGuard>,
+    authority_storage: Storage,
     epoch: u64,
     child: Option<WriteChild>,
     savepoints: Vec<SavepointMark>,
@@ -2070,6 +2516,12 @@ struct WriteTransaction {
     statement_shard: Option<u16>,
     explicit_key: Option<Value>,
     generated_key: Option<GeneratedKey>,
+    statement_ignores_conflicts: bool,
+    authority_cancellation: CancellationToken,
+    global_reservations: Vec<GlobalWriteReservationGuard>,
+    global_reserved_indexes: Vec<GlobalIndexId>,
+    global_snapshot_indexes: Vec<GlobalIndexId>,
+    global_authority_prepared: bool,
 }
 
 struct SavepointMark {
@@ -2078,12 +2530,19 @@ struct SavepointMark {
     statement_shard: Option<u16>,
     explicit_key: Option<Value>,
     generated_key: Option<GeneratedKey>,
+    captured_changes: usize,
 }
 
 impl WriteTransaction {
-    fn new(operation: Option<SchemaOperationGuard>, epoch: u64) -> Self {
+    fn new(
+        operation: Option<SchemaOperationGuard>,
+        epoch: u64,
+        authority_storage: Storage,
+        authority_cancellation: CancellationToken,
+    ) -> Self {
         Self {
             _operation: operation,
+            authority_storage,
             epoch,
             child: None,
             savepoints: Vec::new(),
@@ -2092,6 +2551,12 @@ impl WriteTransaction {
             statement_shard: None,
             explicit_key: None,
             generated_key: None,
+            statement_ignores_conflicts: false,
+            authority_cancellation,
+            global_reservations: Vec::new(),
+            global_reserved_indexes: Vec::new(),
+            global_snapshot_indexes: Vec::new(),
+            global_authority_prepared: false,
         }
     }
 
@@ -2114,10 +2579,86 @@ impl WriteTransaction {
         Ok(())
     }
 
+    fn prepare_global_authority(&mut self, registry: &Registry) -> EngineResult<()> {
+        if self.global_authority_prepared {
+            return Ok(());
+        }
+        let Some(child) = &self.child else {
+            self.global_authority_prepared = true;
+            return Ok(());
+        };
+        let changes = child.captured_changes()?;
+        if changes.is_empty() {
+            self.global_authority_prepared = true;
+            return Ok(());
+        }
+        if self.authority_cancellation.is_cancelled() {
+            return Err(cancelled_error());
+        }
+
+        registry
+            .storage
+            .recover_global_unique_writes(&self.authority_cancellation)?;
+        self.global_snapshot_indexes = touched_global_unique_indexes(registry, &changes)?;
+        let mutations =
+            plan_global_unique_mutations(registry, child.shard, &child.connection, &changes)?;
+        let mut reservations = Vec::new();
+        reservations
+            .try_reserve_exact(mutations.len())
+            .map_err(allocation_error)?;
+        for mutation in &mutations {
+            match registry
+                .storage
+                .reserve_global_unique_write(mutation, &self.authority_cancellation)
+            {
+                Ok(reservation) => reservations.push(reservation),
+                Err(error) => {
+                    let cleanup = CancellationToken::new();
+                    for reservation in reservations.iter().rev() {
+                        let _ = registry
+                            .storage
+                            .rollback_global_unique_write(reservation, &cleanup);
+                    }
+                    if error.kind() == EngineErrorKind::UniqueViolation
+                        && self.statement_ignores_conflicts
+                    {
+                        if let Some(child) = self.child.take() {
+                            if !child.connection.is_autocommit() {
+                                child
+                                    .connection
+                                    .execute_batch("ROLLBACK")
+                                    .map_err(sqlite_error::statement)?;
+                            }
+                        }
+                        self.affected_rows = 0;
+                        self.statement_shard = None;
+                        self.explicit_key = None;
+                        self.generated_key = None;
+                        self.global_snapshot_indexes.clear();
+                        self.global_authority_prepared = true;
+                        return Ok(());
+                    }
+                    return Err(error);
+                }
+            }
+        }
+        self.global_reserved_indexes = mutations
+            .iter()
+            .map(GlobalUniqueMutation::index_id)
+            .collect();
+        self.global_reservations = reservations;
+        self.global_authority_prepared = true;
+        Ok(())
+    }
+
     fn poison(&mut self, reason: impl Into<String>) {
         if self.poison.is_none() {
             self.poison = Some(reason.into());
         }
+    }
+
+    fn record_statement_conflict(&mut self, conflict: &ConflictMode) {
+        self.statement_ignores_conflicts = matches!(conflict, ConflictMode::Ignore);
     }
 
     fn record_physical_changes(&mut self, changed: usize) -> EngineResult<()> {
@@ -2265,6 +2806,32 @@ impl WriteTransaction {
                     "SQLite foreign-key enforcement is not enabled on a writable shard child",
                 ));
             }
+            let indexed_tables = registry
+                .tables
+                .values()
+                .filter(|spec| !spec.global_unique_indexes.is_empty())
+                .map(|spec| spec.name.clone())
+                .collect::<BTreeSet<_>>();
+            let mutation_capture = Arc::new(Mutex::new(GlobalMutationCapture::default()));
+            let hook_capture = Arc::clone(&mutation_capture);
+            connection
+                .preupdate_hook(Some(
+                    move |_action, database: &str, table: &str, case: &PreUpdateCase| {
+                        if database != "main" || !indexed_tables.contains(table) {
+                            return;
+                        }
+                        let mut capture = hook_capture
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner);
+                        if capture.error.is_some() {
+                            return;
+                        }
+                        if let Err(error) = capture.record(table, case) {
+                            capture.error = Some(error.to_string());
+                        }
+                    },
+                ))
+                .map_err(sqlite_error::storage)?;
             for savepoint in &self.savepoints {
                 if let Err(error) = connection
                     .execute_batch(&format!("SAVEPOINT brisk_vtab_{}", savepoint.number))
@@ -2288,6 +2855,7 @@ impl WriteTransaction {
             self.child = Some(WriteChild {
                 shard,
                 connection,
+                mutation_capture,
                 _interrupt: interrupt,
             });
         }
@@ -2370,6 +2938,7 @@ impl WriteTransaction {
         let statement_shard = self.statement_shard;
         let explicit_key = self.explicit_key.clone();
         let generated_key = self.generated_key.clone();
+        let captured_changes = self.child.as_ref().map_or(0, |child| child.capture_len());
         for missing in first_missing..=number {
             if let Some(child) = &self.child {
                 child
@@ -2383,6 +2952,7 @@ impl WriteTransaction {
                 statement_shard,
                 explicit_key: explicit_key.clone(),
                 generated_key: generated_key.clone(),
+                captured_changes,
             });
         }
         Ok(())
@@ -2425,6 +2995,9 @@ impl WriteTransaction {
         self.statement_shard = self.savepoints[position].statement_shard;
         self.explicit_key = self.savepoints[position].explicit_key.clone();
         self.generated_key = self.savepoints[position].generated_key.clone();
+        if let Some(child) = &self.child {
+            child.truncate_capture(self.savepoints[position].captured_changes);
+        }
         self.savepoints.truncate(position + 1);
         Ok(())
     }
@@ -3056,7 +3629,16 @@ impl WriteTransaction {
     }
 
     fn commit(&mut self) -> EngineResult<WriteOutcome> {
+        if self.child.is_some() && !self.global_authority_prepared {
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                "brisk_shard reached physical commit before preparing global-index authority",
+            ));
+        }
         if let Some(child) = self.child.take() {
+            if !self.global_snapshot_indexes.is_empty() {
+                abort_at_global_write_test_boundary("unique-write-physical-before-commit");
+            }
             if let Err(error) = child
                 .connection
                 .execute_batch("COMMIT")
@@ -3065,9 +3647,34 @@ impl WriteTransaction {
                 if !child.connection.is_autocommit() {
                     let _ = child.connection.execute_batch("ROLLBACK");
                 }
+                self.rollback_global_reservations();
                 return Err(error);
             }
+            if !self.global_snapshot_indexes.is_empty() {
+                abort_at_global_write_test_boundary("unique-write-physical-after-commit");
+            }
         }
+        // Once the physical shard commits, cancellation can no longer roll
+        // the row back. Complete authority with a fresh token so a deadline
+        // racing this boundary cannot leave a live process holding an active
+        // reservation solely because its client stopped waiting.
+        let completion = CancellationToken::new();
+        for reservation in &self.global_reservations {
+            self.authority_storage
+                .finalize_global_unique_write(reservation, &completion)?;
+        }
+        self.global_reservations.clear();
+        self.global_snapshot_indexes
+            .retain(|index| !self.global_reserved_indexes.contains(index));
+        self.global_reserved_indexes.clear();
+        if let Some(shard) = self.statement_shard {
+            self.authority_storage.refresh_global_unique_write_indexes(
+                &self.global_snapshot_indexes,
+                shard,
+                &completion,
+            )?;
+        }
+        self.global_snapshot_indexes.clear();
         Ok(WriteOutcome {
             affected_rows: std::mem::take(&mut self.affected_rows),
             shard: self.statement_shard.take(),
@@ -3077,22 +3684,69 @@ impl WriteTransaction {
     }
 
     fn rollback(&mut self) -> EngineResult<()> {
+        let mut physical_error = None;
         if let Some(child) = self.child.take() {
             if !child.connection.is_autocommit() {
-                child
+                if let Err(error) = child
                     .connection
                     .execute_batch("ROLLBACK")
-                    .map_err(sqlite_error::statement)?;
+                    .map_err(sqlite_error::statement)
+                {
+                    physical_error = Some(error);
+                }
             }
         }
-        Ok(())
+        self.rollback_global_reservations();
+        physical_error.map_or(Ok(()), Err)
+    }
+
+    fn rollback_global_reservations(&mut self) {
+        let cleanup = CancellationToken::new();
+        for reservation in self.global_reservations.drain(..).rev() {
+            let _ = self
+                .authority_storage
+                .rollback_global_unique_write(&reservation, &cleanup);
+        }
     }
 }
 
 struct WriteChild {
     shard: u16,
     connection: Connection,
+    mutation_capture: Arc<Mutex<GlobalMutationCapture>>,
     _interrupt: Arc<InterruptHandle>,
+}
+
+impl WriteChild {
+    fn capture_len(&self) -> usize {
+        self.mutation_capture
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .changes
+            .len()
+    }
+
+    fn truncate_capture(&self, len: usize) {
+        self.mutation_capture
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .changes
+            .truncate(len);
+    }
+
+    fn captured_changes(&self) -> EngineResult<Vec<CapturedPhysicalChange>> {
+        let capture = self
+            .mutation_capture
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(error) = &capture.error {
+            return Err(EngineError::new(
+                EngineErrorKind::StorageUnavailable,
+                format!("could not capture a physical row for global-index maintenance: {error}"),
+            ));
+        }
+        Ok(capture.changes.clone())
+    }
 }
 
 #[derive(Debug, Default)]
@@ -3237,6 +3891,70 @@ mod tests {
                 .unwrap(),
             captured
         );
+    }
+
+    #[test]
+    fn captured_old_and_new_rows_collapse_into_claim_release_and_replace_plans() {
+        let index_id = GlobalIndexId::new(7).unwrap();
+        let old_key = CanonicalIndexKey::encode_values(&[Value::from("old")]).unwrap();
+        let new_key = CanonicalIndexKey::encode_values(&[Value::from("new")]).unwrap();
+        let claimed_key = CanonicalIndexKey::encode_values(&[Value::from("claimed")]).unwrap();
+        let released_key = CanonicalIndexKey::encode_values(&[Value::from("released")]).unwrap();
+        let replaced_owner = GlobalIndexOwner::new(1, b"replaced".to_vec()).unwrap();
+        let claimed_owner = GlobalIndexOwner::new(2, b"claimed".to_vec()).unwrap();
+        let released_owner = GlobalIndexOwner::new(3, b"released".to_vec()).unwrap();
+
+        let mut replace_states = BTreeMap::new();
+        apply_captured_old(
+            &mut replace_states,
+            replaced_owner.clone(),
+            Some(old_key.clone()),
+        )
+        .unwrap();
+        apply_captured_new(
+            &mut replace_states,
+            replaced_owner.clone(),
+            Some(new_key.clone()),
+        )
+        .unwrap();
+        let mut by_index = BTreeMap::new();
+        by_index.insert(index_id, replace_states);
+        let planned = collapse_global_unique_mutations(by_index).unwrap();
+        assert_eq!(planned.len(), 1);
+        assert_eq!(
+            planned[0].previous_entry(),
+            Some((&old_key, &replaced_owner))
+        );
+        assert_eq!(planned[0].new_entry(), Some((&new_key, &replaced_owner)));
+
+        let mut claim_states = BTreeMap::new();
+        apply_captured_new(
+            &mut claim_states,
+            claimed_owner.clone(),
+            Some(claimed_key.clone()),
+        )
+        .unwrap();
+        let mut by_index = BTreeMap::new();
+        by_index.insert(index_id, claim_states);
+        let planned = collapse_global_unique_mutations(by_index).unwrap();
+        assert_eq!(planned[0].previous_entry(), None);
+        assert_eq!(planned[0].new_entry(), Some((&claimed_key, &claimed_owner)));
+
+        let mut release_states = BTreeMap::new();
+        apply_captured_old(
+            &mut release_states,
+            released_owner.clone(),
+            Some(released_key.clone()),
+        )
+        .unwrap();
+        let mut by_index = BTreeMap::new();
+        by_index.insert(index_id, release_states);
+        let planned = collapse_global_unique_mutations(by_index).unwrap();
+        assert_eq!(
+            planned[0].previous_entry(),
+            Some((&released_key, &released_owner))
+        );
+        assert_eq!(planned[0].new_entry(), None);
     }
 
     #[test]

--- a/tests/global_index_write_maintenance.rs
+++ b/tests/global_index_write_maintenance.rs
@@ -1,0 +1,759 @@
+use std::path::Path;
+
+#[cfg(unix)]
+use std::{
+    env, fs,
+    path::PathBuf,
+    process::{Command, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+
+use briskdb::{
+    BriskDb, EngineErrorKind, Statement, Value,
+    core::{
+        Database, Engine, GlobalIndexDeclaration, GlobalIndexId, GlobalIndexKeyPart,
+        GlobalIndexKeySource, GlobalIndexKeyType, GlobalIndexStorageTopology, PrepareRequest,
+        ShardKeyMetadata, ShardKeyType, TableDeclaration, UniqueNullSemantics,
+    },
+    sql,
+};
+use rusqlite::Connection;
+
+const SHARDS: u16 = 4;
+
+#[cfg(unix)]
+const PROCESS_WAIT: Duration = Duration::from_secs(20);
+
+fn setup(root: &Path) -> GlobalIndexId {
+    let mut database = Database::open(root, SHARDS).unwrap();
+    database
+        .broadcast(
+            "CREATE TABLE accounts (
+                tenant_id TEXT PRIMARY KEY NOT NULL,
+                email TEXT,
+                active INTEGER NOT NULL
+             )",
+        )
+        .unwrap();
+    let logical = database.catalog().default_database().id();
+    database
+        .register_tables(vec![
+            TableDeclaration::sharded(
+                logical,
+                "accounts",
+                ShardKeyMetadata::new("tenant_id", ShardKeyType::Text).unwrap(),
+            )
+            .unwrap(),
+        ])
+        .unwrap();
+    let table_id = database
+        .catalog()
+        .table("default", "accounts")
+        .unwrap()
+        .unwrap()
+        .id();
+    let declaration = GlobalIndexDeclaration::new(
+        table_id,
+        "accounts_email_unique",
+        vec![GlobalIndexKeyPart::new(
+            GlobalIndexKeySource::column("email").unwrap(),
+            GlobalIndexKeyType::Text,
+        )],
+    )
+    .unwrap()
+    .unique(UniqueNullSemantics::Distinct)
+    .with_topology(GlobalIndexStorageTopology::selected_v1());
+    let index_id = database.create_global_index(declaration).unwrap();
+    database.build_global_index(index_id).unwrap();
+    index_id
+}
+
+async fn write(db: &BriskDb, route: &str, sql: &str, values: Vec<Value>) {
+    let session = db.session();
+    session.set_routing_key(route).await.unwrap();
+    db.execute_write(&session, Statement::new(sql, values))
+        .await
+        .unwrap();
+    session.close().await.unwrap();
+}
+
+async fn write_error(
+    db: &BriskDb,
+    route: &str,
+    sql: &str,
+    values: Vec<Value>,
+) -> briskdb::EngineError {
+    let session = db.session();
+    session.set_routing_key(route).await.unwrap();
+    let error = db
+        .execute_write(&session, Statement::new(sql, values))
+        .await
+        .unwrap_err();
+    session.close().await.unwrap();
+    error
+}
+
+#[tokio::test]
+async fn engine_writes_keep_global_unique_ownership_in_sync() {
+    let root = tempfile::tempdir().unwrap();
+    let index_id = setup(root.path());
+    let db = BriskDb::open(root.path()).await.unwrap();
+
+    write(
+        &db,
+        "tenant-a",
+        "INSERT INTO accounts (tenant_id, email, active) VALUES (?1, ?2, 1)",
+        vec!["tenant-a".into(), "first@example.test".into()],
+    )
+    .await;
+    let authority = Connection::open(root.path().join("global-indexes/global.sqlite")).unwrap();
+    assert_eq!(
+        authority
+            .query_row(
+                "SELECT COUNT(*) FROM briskdb_global_index_unique_keys WHERE index_id = ?1",
+                [i64::try_from(index_id.get()).unwrap()],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+        1
+    );
+    drop(authority);
+
+    let session = db.session();
+    session.set_routing_key("tenant-b").await.unwrap();
+    let duplicate = db
+        .execute_write(
+            &session,
+            Statement::new(
+                "INSERT INTO accounts (tenant_id, email, active) VALUES (?1, ?2, 1)",
+                vec!["tenant-b".into(), "first@example.test".into()],
+            ),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(duplicate.kind(), EngineErrorKind::UniqueViolation);
+    session.close().await.unwrap();
+
+    let session = db.session();
+    session.set_routing_key("tenant-ignore").await.unwrap();
+    let ignored = db
+        .execute_write(
+            &session,
+            Statement::new(
+                "INSERT OR IGNORE INTO accounts (tenant_id, email, active) VALUES (?1, ?2, 1)",
+                vec!["tenant-ignore".into(), "first@example.test".into()],
+            ),
+        )
+        .await
+        .unwrap();
+    assert_eq!(ignored.value.rows_affected, 0);
+    session.close().await.unwrap();
+
+    let replaced = write_error(
+        &db,
+        "tenant-replace",
+        "INSERT OR REPLACE INTO accounts (tenant_id, email, active) VALUES (?1, ?2, 1)",
+        vec!["tenant-replace".into(), "first@example.test".into()],
+    )
+    .await;
+    assert_eq!(replaced.kind(), EngineErrorKind::UniqueViolation);
+
+    let upsert = write_error(
+        &db,
+        "tenant-upsert",
+        "INSERT INTO accounts (tenant_id, email, active) VALUES (?1, ?2, 1)
+         ON CONFLICT (tenant_id) DO UPDATE SET email = excluded.email",
+        vec!["tenant-upsert".into(), "upsert@example.test".into()],
+    )
+    .await;
+    assert_eq!(upsert.kind(), EngineErrorKind::Unsupported);
+
+    write(
+        &db,
+        "tenant-a",
+        "UPDATE accounts SET email = ?1 WHERE tenant_id = ?2",
+        vec!["second@example.test".into(), "tenant-a".into()],
+    )
+    .await;
+    write(
+        &db,
+        "tenant-b",
+        "INSERT INTO accounts (tenant_id, email, active) VALUES (?1, ?2, 1)",
+        vec!["tenant-b".into(), "first@example.test".into()],
+    )
+    .await;
+    write(
+        &db,
+        "tenant-a",
+        "DELETE FROM accounts WHERE tenant_id = ?1",
+        vec!["tenant-a".into()],
+    )
+    .await;
+    write(
+        &db,
+        "tenant-c",
+        "INSERT INTO accounts (tenant_id, email, active) VALUES (?1, ?2, 1)",
+        vec!["tenant-c".into(), "second@example.test".into()],
+    )
+    .await;
+
+    db.close().await.unwrap();
+    drop(db);
+    let mut database = Database::open(root.path(), SHARDS).unwrap();
+    let ignored = database
+        .query(
+            "tenant-ignore",
+            "SELECT COUNT(*) FROM accounts WHERE tenant_id = ?1",
+            &["tenant-ignore".into()],
+        )
+        .unwrap();
+    assert_eq!(ignored.rows()[0].get(0).and_then(Value::as_i64), Some(0));
+    let validation = database.validate_global_index(index_id).unwrap();
+    assert!(validation.is_valid(), "{validation:?}");
+}
+
+#[tokio::test]
+async fn null_distinct_rows_do_not_take_global_reservations() {
+    let root = tempfile::tempdir().unwrap();
+    let index_id = setup(root.path());
+    let db = BriskDb::open(root.path()).await.unwrap();
+    for tenant in ["null-a", "null-b"] {
+        write(
+            &db,
+            tenant,
+            "INSERT INTO accounts (tenant_id, email, active) VALUES (?1, NULL, 1)",
+            vec![tenant.into()],
+        )
+        .await;
+    }
+    db.close().await.unwrap();
+    drop(db);
+
+    let mut database = Database::open(root.path(), SHARDS).unwrap();
+    let validation = database.validate_global_index(index_id).unwrap();
+    assert!(validation.is_valid(), "{validation:?}");
+}
+
+#[tokio::test]
+async fn partial_compound_updates_reserve_only_qualifying_keys() {
+    let root = tempfile::tempdir().unwrap();
+    let mut database = Database::open(root.path(), SHARDS).unwrap();
+    database
+        .broadcast(
+            "CREATE TABLE memberships (
+                tenant_id TEXT NOT NULL,
+                local_id INTEGER NOT NULL,
+                namespace TEXT NOT NULL,
+                external_id INTEGER NOT NULL,
+                active INTEGER NOT NULL,
+                PRIMARY KEY (tenant_id, local_id)
+             ) WITHOUT ROWID",
+        )
+        .unwrap();
+    let logical = database.catalog().default_database().id();
+    database
+        .register_tables(vec![
+            TableDeclaration::sharded(
+                logical,
+                "memberships",
+                ShardKeyMetadata::new("tenant_id", ShardKeyType::Text).unwrap(),
+            )
+            .unwrap(),
+        ])
+        .unwrap();
+    let table_id = database
+        .catalog()
+        .table("default", "memberships")
+        .unwrap()
+        .unwrap()
+        .id();
+    let declaration = GlobalIndexDeclaration::new(
+        table_id,
+        "memberships_external_unique",
+        vec![
+            GlobalIndexKeyPart::new(
+                GlobalIndexKeySource::column("namespace").unwrap(),
+                GlobalIndexKeyType::Text,
+            ),
+            GlobalIndexKeyPart::new(
+                GlobalIndexKeySource::expression("external_id * 2").unwrap(),
+                GlobalIndexKeyType::Int64,
+            ),
+        ],
+    )
+    .unwrap()
+    .unique(UniqueNullSemantics::Distinct)
+    .with_predicate("active = 1")
+    .unwrap()
+    .with_topology(GlobalIndexStorageTopology::selected_v1());
+    let index_id = database.create_global_index(declaration).unwrap();
+    database.build_global_index(index_id).unwrap();
+    drop(database);
+
+    let db = BriskDb::open(root.path()).await.unwrap();
+    for tenant in ["partial-a", "partial-b"] {
+        write(
+            &db,
+            tenant,
+            "INSERT INTO memberships (
+                 tenant_id, local_id, namespace, external_id, active
+             ) VALUES (?1, 1, 'github', 7, 0)",
+            vec![tenant.into()],
+        )
+        .await;
+    }
+    write(
+        &db,
+        "partial-a",
+        "UPDATE memberships SET active = 1 WHERE tenant_id = ?1 AND local_id = 1",
+        vec!["partial-a".into()],
+    )
+    .await;
+    let duplicate = write_error(
+        &db,
+        "partial-b",
+        "UPDATE memberships SET active = 1 WHERE tenant_id = ?1 AND local_id = 1",
+        vec!["partial-b".into()],
+    )
+    .await;
+    assert_eq!(duplicate.kind(), EngineErrorKind::UniqueViolation);
+    write(
+        &db,
+        "partial-a",
+        "UPDATE memberships SET external_id = 8 WHERE tenant_id = ?1 AND local_id = 1",
+        vec!["partial-a".into()],
+    )
+    .await;
+    write(
+        &db,
+        "partial-b",
+        "UPDATE memberships SET active = 1 WHERE tenant_id = ?1 AND local_id = 1",
+        vec!["partial-b".into()],
+    )
+    .await;
+    db.close().await.unwrap();
+    drop(db);
+
+    let mut database = Database::open(root.path(), SHARDS).unwrap();
+    let validation = database.validate_global_index(index_id).unwrap();
+    assert!(validation.is_valid(), "{validation:?}");
+}
+
+#[tokio::test]
+async fn null_not_distinct_is_enforced_globally() {
+    let root = tempfile::tempdir().unwrap();
+    let mut database = Database::open(root.path(), SHARDS).unwrap();
+    database
+        .broadcast(
+            "CREATE TABLE aliases (
+                tenant_id TEXT PRIMARY KEY NOT NULL,
+                alias TEXT
+             )",
+        )
+        .unwrap();
+    let logical = database.catalog().default_database().id();
+    database
+        .register_tables(vec![
+            TableDeclaration::sharded(
+                logical,
+                "aliases",
+                ShardKeyMetadata::new("tenant_id", ShardKeyType::Text).unwrap(),
+            )
+            .unwrap(),
+        ])
+        .unwrap();
+    let table_id = database
+        .catalog()
+        .table("default", "aliases")
+        .unwrap()
+        .unwrap()
+        .id();
+    let declaration = GlobalIndexDeclaration::new(
+        table_id,
+        "aliases_unique",
+        vec![GlobalIndexKeyPart::new(
+            GlobalIndexKeySource::column("alias").unwrap(),
+            GlobalIndexKeyType::Text,
+        )],
+    )
+    .unwrap()
+    .unique(UniqueNullSemantics::NotDistinct)
+    .with_topology(GlobalIndexStorageTopology::selected_v1());
+    let index_id = database.create_global_index(declaration).unwrap();
+    database.build_global_index(index_id).unwrap();
+    drop(database);
+
+    let db = BriskDb::open(root.path()).await.unwrap();
+    write(
+        &db,
+        "alias-a",
+        "INSERT INTO aliases (tenant_id, alias) VALUES (?1, NULL)",
+        vec!["alias-a".into()],
+    )
+    .await;
+    let duplicate = write_error(
+        &db,
+        "alias-b",
+        "INSERT INTO aliases (tenant_id, alias) VALUES (?1, NULL)",
+        vec!["alias-b".into()],
+    )
+    .await;
+    assert_eq!(duplicate.kind(), EngineErrorKind::UniqueViolation);
+    db.close().await.unwrap();
+    drop(db);
+
+    let mut database = Database::open(root.path(), SHARDS).unwrap();
+    let validation = database.validate_global_index(index_id).unwrap();
+    assert!(validation.is_valid(), "{validation:?}");
+}
+
+#[tokio::test]
+async fn multirow_authoritative_changes_are_rejected_before_commit() {
+    let root = tempfile::tempdir().unwrap();
+    let mut database = Database::open(root.path(), SHARDS).unwrap();
+    database
+        .broadcast(
+            "CREATE TABLE contacts (
+                tenant_id TEXT NOT NULL,
+                local_id INTEGER NOT NULL,
+                email TEXT NOT NULL,
+                PRIMARY KEY (tenant_id, local_id)
+             ) WITHOUT ROWID",
+        )
+        .unwrap();
+    let logical = database.catalog().default_database().id();
+    database
+        .register_tables(vec![
+            TableDeclaration::sharded(
+                logical,
+                "contacts",
+                ShardKeyMetadata::new("tenant_id", ShardKeyType::Text).unwrap(),
+            )
+            .unwrap(),
+        ])
+        .unwrap();
+    let table_id = database
+        .catalog()
+        .table("default", "contacts")
+        .unwrap()
+        .unwrap()
+        .id();
+    let declaration = GlobalIndexDeclaration::new(
+        table_id,
+        "contacts_email_unique",
+        vec![GlobalIndexKeyPart::new(
+            GlobalIndexKeySource::column("email").unwrap(),
+            GlobalIndexKeyType::Text,
+        )],
+    )
+    .unwrap()
+    .unique(UniqueNullSemantics::Distinct)
+    .with_topology(GlobalIndexStorageTopology::selected_v1());
+    let index_id = database.create_global_index(declaration).unwrap();
+    database.build_global_index(index_id).unwrap();
+    drop(database);
+
+    let db = BriskDb::open(root.path()).await.unwrap();
+    let error = write_error(
+        &db,
+        "batch",
+        "INSERT INTO contacts (tenant_id, local_id, email) VALUES
+             (?1, 1, 'one@example.test'),
+             (?1, 2, 'two@example.test')",
+        vec!["batch".into()],
+    )
+    .await;
+    assert_eq!(error.kind(), EngineErrorKind::Unsupported);
+    db.close().await.unwrap();
+    drop(db);
+
+    let mut database = Database::open(root.path(), SHARDS).unwrap();
+    let validation = database.validate_global_index(index_id).unwrap();
+    assert!(validation.is_valid(), "{validation:?}");
+    assert_eq!(validation.source_rows_examined(), 0);
+}
+
+#[tokio::test]
+async fn prepared_postgres_dialect_writes_use_the_same_authority() {
+    let root = tempfile::tempdir().unwrap();
+    let index_id = setup(root.path());
+    let engine = Engine::open(root.path(), SHARDS).await.unwrap();
+    let session = engine.session();
+    let logical = engine.catalog().default_database().id();
+    let statement = engine
+        .prepare_statement(
+            &session,
+            PrepareRequest::new(
+                logical,
+                sql::SqlDialect::PostgreSql,
+                sql::SqlTranslationMode::Compatibility,
+                "INSERT INTO accounts (tenant_id, email, active) VALUES ($1, $2, 1)",
+            ),
+        )
+        .await
+        .unwrap();
+    for (tenant, expected) in [
+        ("prepared-a", None),
+        ("prepared-b", Some(EngineErrorKind::UniqueViolation)),
+    ] {
+        let portal = engine
+            .bind_statement(
+                &session,
+                statement,
+                vec![tenant.into(), "prepared@example.test".into()],
+            )
+            .await
+            .unwrap();
+        let result = engine.execute_portal(&session, portal).await;
+        match expected {
+            None => assert!(result.is_ok(), "{result:?}"),
+            Some(kind) => assert_eq!(result.unwrap_err().kind(), kind),
+        }
+    }
+    session.close().await.unwrap();
+    engine.shutdown().await.unwrap();
+    drop(engine);
+
+    let mut database = Database::open(root.path(), SHARDS).unwrap();
+    let validation = database.validate_global_index(index_id).unwrap();
+    assert!(validation.is_valid(), "{validation:?}");
+}
+
+#[cfg(unix)]
+fn wait_for_process_paths(paths: &[PathBuf]) {
+    let deadline = Instant::now() + PROCESS_WAIT;
+    while paths.iter().any(|path| !path.exists()) && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(5));
+    }
+    assert!(
+        paths.iter().all(|path| path.exists()),
+        "timed out waiting for global-index race barrier: {paths:?}"
+    );
+}
+
+#[cfg(unix)]
+fn run_process_race(root: &Path, mode: &str, routes: &[&str]) -> Vec<String> {
+    let go = root.join(format!("{mode}-go"));
+    let mut children = Vec::new();
+    let mut ready = Vec::new();
+    let mut outputs = Vec::new();
+    for (worker, route) in routes.iter().enumerate() {
+        let ready_path = root.join(format!("{mode}-ready-{worker}"));
+        let output_path = root.join(format!("{mode}-output-{worker}"));
+        let child = Command::new(env::current_exe().unwrap())
+            .args(["--exact", "global_index_write_process_child", "--nocapture"])
+            .env("BRISKDB_INDEX_WRITE_ROOT", root)
+            .env("BRISKDB_INDEX_WRITE_MODE", mode)
+            .env("BRISKDB_INDEX_WRITE_WORKER", worker.to_string())
+            .env("BRISKDB_INDEX_WRITE_ROUTE", route)
+            .env("BRISKDB_INDEX_WRITE_READY", &ready_path)
+            .env("BRISKDB_INDEX_WRITE_GO", &go)
+            .env("BRISKDB_INDEX_WRITE_OUTPUT", &output_path)
+            .stdout(Stdio::null())
+            .spawn()
+            .unwrap();
+        children.push(child);
+        ready.push(ready_path);
+        outputs.push(output_path);
+    }
+    wait_for_process_paths(&ready);
+    fs::write(&go, b"go").unwrap();
+    for mut child in children {
+        let status = child.wait().unwrap();
+        assert!(status.success(), "global-index race child failed: {status}");
+    }
+    outputs
+        .iter()
+        .map(|path| fs::read_to_string(path).unwrap())
+        .collect()
+}
+
+#[cfg(unix)]
+async fn run_process_write(root: &Path, mode: &str, worker: usize, route: &str) -> String {
+    let db = BriskDb::open(root).await.unwrap();
+    let session = db.session();
+    session.set_routing_key(route).await.unwrap();
+    let statement = match (mode, worker) {
+        ("insert", _) => Statement::new(
+            "INSERT INTO accounts (tenant_id, email, active) VALUES (?1, ?2, 1)",
+            vec![route.into(), "process-race@example.test".into()],
+        ),
+        ("update", _) => Statement::new(
+            "UPDATE accounts SET email = ?1 WHERE tenant_id = ?2",
+            vec!["process-update@example.test".into(), route.into()],
+        ),
+        ("update-delete", 0) => Statement::new(
+            "UPDATE accounts SET email = ?1 WHERE tenant_id = ?2",
+            vec!["process-final@example.test".into(), route.into()],
+        ),
+        ("update-delete", 1) => Statement::new(
+            "DELETE FROM accounts WHERE tenant_id = ?1",
+            vec![route.into()],
+        ),
+        _ => panic!("unknown indexed-write process mode {mode}/{worker}"),
+    };
+    let deadline = Instant::now() + PROCESS_WAIT;
+    let result = loop {
+        match db.execute_write(&session, statement.clone()).await {
+            Err(error) if error.kind() == EngineErrorKind::Busy && Instant::now() < deadline => {
+                tokio::time::sleep(Duration::from_millis(2)).await;
+            }
+            result => break result,
+        }
+    };
+    let output = match result {
+        Ok(result) => format!("ok:{}", result.value.rows_affected),
+        Err(error) if error.kind() == EngineErrorKind::UniqueViolation => {
+            "unique_violation".to_owned()
+        }
+        Err(error) => panic!("unexpected indexed-write race error: {error}"),
+    };
+    session.close().await.unwrap();
+    db.close().await.unwrap();
+    output
+}
+
+#[cfg(unix)]
+#[test]
+fn global_index_write_process_child() {
+    let Ok(root) = env::var("BRISKDB_INDEX_WRITE_ROOT") else {
+        return;
+    };
+    let mode = env::var("BRISKDB_INDEX_WRITE_MODE").unwrap();
+    let worker = env::var("BRISKDB_INDEX_WRITE_WORKER")
+        .unwrap()
+        .parse::<usize>()
+        .unwrap();
+    let route = env::var("BRISKDB_INDEX_WRITE_ROUTE").unwrap();
+    let ready = PathBuf::from(env::var("BRISKDB_INDEX_WRITE_READY").unwrap());
+    let go = PathBuf::from(env::var("BRISKDB_INDEX_WRITE_GO").unwrap());
+    let output = PathBuf::from(env::var("BRISKDB_INDEX_WRITE_OUTPUT").unwrap());
+    fs::write(&ready, b"ready").unwrap();
+    wait_for_process_paths(&[go]);
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let result = runtime.block_on(run_process_write(Path::new(&root), &mode, worker, &route));
+    fs::write(output, result).unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn process_races_and_exact_retries_preserve_global_unique_authority() {
+    let insert_root = tempfile::tempdir().unwrap();
+    let insert_index = setup(insert_root.path());
+    let mut insert_results = run_process_race(
+        insert_root.path(),
+        "insert",
+        &["process-insert-a", "process-insert-b"],
+    );
+    insert_results.sort();
+    assert_eq!(insert_results, ["ok:1", "unique_violation"]);
+    let mut database = Database::open(insert_root.path(), SHARDS).unwrap();
+    assert!(
+        database
+            .validate_global_index(insert_index)
+            .unwrap()
+            .is_valid()
+    );
+    drop(database);
+
+    let update_root = tempfile::tempdir().unwrap();
+    let update_index = setup(update_root.path());
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        let db = BriskDb::open(update_root.path()).await.unwrap();
+        for (route, email) in [
+            ("process-update-a", "before-a@example.test"),
+            ("process-update-b", "before-b@example.test"),
+        ] {
+            write(
+                &db,
+                route,
+                "INSERT INTO accounts (tenant_id, email, active) VALUES (?1, ?2, 1)",
+                vec![route.into(), email.into()],
+            )
+            .await;
+        }
+        db.close().await.unwrap();
+    });
+    let update_results = run_process_race(
+        update_root.path(),
+        "update",
+        &["process-update-a", "process-update-b"],
+    );
+    let mut sorted_update_results = update_results.clone();
+    sorted_update_results.sort();
+    assert_eq!(sorted_update_results, ["ok:1", "unique_violation"]);
+    let retry_route = if update_results[0] == "unique_violation" {
+        "process-update-a"
+    } else {
+        "process-update-b"
+    };
+    runtime.block_on(async {
+        let db = BriskDb::open(update_root.path()).await.unwrap();
+        let retry = write_error(
+            &db,
+            retry_route,
+            "UPDATE accounts SET email = ?1 WHERE tenant_id = ?2",
+            vec!["process-update@example.test".into(), retry_route.into()],
+        )
+        .await;
+        assert_eq!(retry.kind(), EngineErrorKind::UniqueViolation);
+        write(
+            &db,
+            retry_route,
+            "UPDATE accounts SET email = ?1 WHERE tenant_id = ?2",
+            vec!["retry-safe@example.test".into(), retry_route.into()],
+        )
+        .await;
+        db.close().await.unwrap();
+    });
+    let mut database = Database::open(update_root.path(), SHARDS).unwrap();
+    assert!(
+        database
+            .validate_global_index(update_index)
+            .unwrap()
+            .is_valid()
+    );
+    drop(database);
+
+    let delete_root = tempfile::tempdir().unwrap();
+    let delete_index = setup(delete_root.path());
+    runtime.block_on(async {
+        let db = BriskDb::open(delete_root.path()).await.unwrap();
+        write(
+            &db,
+            "process-delete",
+            "INSERT INTO accounts (tenant_id, email, active) VALUES (?1, ?2, 1)",
+            vec![
+                "process-delete".into(),
+                "process-before@example.test".into(),
+            ],
+        )
+        .await;
+        db.close().await.unwrap();
+    });
+    let delete_results = run_process_race(
+        delete_root.path(),
+        "update-delete",
+        &["process-delete", "process-delete"],
+    );
+    assert!(
+        delete_results
+            .iter()
+            .all(|result| result.starts_with("ok:"))
+    );
+    let mut database = Database::open(delete_root.path(), SHARDS).unwrap();
+    assert!(
+        database
+            .validate_global_index(delete_index)
+            .unwrap()
+            .is_valid()
+    );
+}

--- a/tests/postgres_client_matrix.py
+++ b/tests/postgres_client_matrix.py
@@ -24,6 +24,20 @@ class Record(Base):
 
 
 class PostgreSQLClientMatrix(unittest.TestCase):
+    def test_psycopg_autocommit_enforces_global_unique_index(self) -> None:
+        dsn = os.environ[DSN_ENV]
+        with psycopg.connect(dsn, autocommit=True) as connection:
+            connection.execute(
+                "INSERT INTO indexed_records (tenant_id, payload) VALUES (%s, %s)",
+                ("psycopg-index-a", "psycopg-global-key"),
+            )
+            with self.assertRaises(psycopg.errors.UniqueViolation):
+                connection.execute(
+                    "INSERT INTO indexed_records (tenant_id, payload) VALUES (%s, %s)",
+                    ("psycopg-index-b", "psycopg-global-key"),
+                )
+            self.assertEqual(connection.execute("SELECT 1").fetchone(), ("1",))
+
     def test_psycopg_transaction_error_recovery_and_reconnect(self) -> None:
         dsn = os.environ[DSN_ENV]
         with psycopg.connect(dsn) as connection:

--- a/tests/postgres_client_matrix.rs
+++ b/tests/postgres_client_matrix.rs
@@ -1,8 +1,39 @@
 use std::{env, error::Error, time::Duration};
 
+use briskdb::core::{
+    Database, GlobalIndexDeclaration, GlobalIndexKeyPart, GlobalIndexKeySource, GlobalIndexKeyType,
+    GlobalIndexStorageTopology, UniqueNullSemantics,
+};
 use tokio_postgres::{NoTls, SimpleQueryMessage, error::SqlState};
 
 const MATRIX_DSN_ENV: &str = "BRISKDB_POSTGRES_MATRIX_DSN";
+const MATRIX_ROOT_ENV: &str = "BRISKDB_POSTGRES_MATRIX_ROOT";
+
+#[test]
+#[ignore = "requires the imported matrix root prepared by tests/postgres_client_matrix.sh"]
+fn prepare_postgres_client_global_index() {
+    let root = env::var(MATRIX_ROOT_ENV).expect("matrix root");
+    let mut database = Database::open(root, 2).unwrap();
+    let table_id = database
+        .catalog()
+        .table("default", "indexed_records")
+        .unwrap()
+        .unwrap()
+        .id();
+    let declaration = GlobalIndexDeclaration::new(
+        table_id,
+        "indexed_records_payload_unique",
+        vec![GlobalIndexKeyPart::new(
+            GlobalIndexKeySource::column("payload").unwrap(),
+            GlobalIndexKeyType::Text,
+        )],
+    )
+    .unwrap()
+    .unique(UniqueNullSemantics::Distinct)
+    .with_topology(GlobalIndexStorageTopology::selected_v1());
+    let index_id = database.create_global_index(declaration).unwrap();
+    database.build_global_index(index_id).unwrap();
+}
 
 async fn connect(
     dsn: &str,
@@ -34,6 +65,29 @@ async fn tokio_postgres_client_matrix() -> Result<(), Box<dyn Error>> {
     let dsn = env::var(MATRIX_DSN_ENV)
         .map_err(|_| format!("{MATRIX_DSN_ENV} must name the live BriskDB listener"))?;
     let (mut client, connection) = connect(&dsn).await?;
+
+    eprintln!("tokio-postgres: indexed autocommit write");
+    assert_eq!(
+        client
+            .execute(
+                "INSERT INTO indexed_records (tenant_id, payload) VALUES ($1, $2)",
+                &[&"tokio-index-a", &"tokio-global-key"],
+            )
+            .await?,
+        1
+    );
+    let duplicate = client
+        .execute(
+            "INSERT INTO indexed_records (tenant_id, payload) VALUES ($1, $2)",
+            &[&"tokio-index-b", &"tokio-global-key"],
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(duplicate.code(), Some(&SqlState::UNIQUE_VIOLATION));
+    assert_eq!(
+        client.query_one("SELECT 1", &[]).await?.get::<_, String>(0),
+        "1"
+    );
 
     eprintln!("tokio-postgres: begin CRUD transaction");
     let transaction = client.transaction().await?;

--- a/tests/postgres_client_matrix.sh
+++ b/tests/postgres_client_matrix.sh
@@ -38,6 +38,11 @@ with sqlite3.connect(sys.argv[1]) as connection:
         "tenant_id TEXT NOT NULL PRIMARY KEY, "
         "payload TEXT NOT NULL)"
     )
+    connection.execute(
+        "CREATE TABLE indexed_records ("
+        "tenant_id TEXT NOT NULL PRIMARY KEY, "
+        "payload TEXT NOT NULL)"
+    )
 PY
 
 "${python_command}" - "${plan}" <<'PY'
@@ -55,7 +60,16 @@ plan = {
                 "column": "tenant_id",
                 "key_type": "text",
             },
-        }
+        },
+        {
+            "name": "indexed_records",
+            "placement": "sharded",
+            "shard_key": {
+                "strategy": "column",
+                "column": "tenant_id",
+                "key_type": "text",
+            },
+        },
     ],
 }
 with open(sys.argv[1], "w", encoding="utf-8") as output:
@@ -68,6 +82,10 @@ target/debug/briskdb-import \
   --data-dir "${data_dir}" \
   --plan "${plan}" \
   --shards 2
+
+BRISKDB_POSTGRES_MATRIX_ROOT="${data_dir}" \
+  cargo test --locked --test postgres_client_matrix \
+  prepare_postgres_client_global_index -- --exact --ignored
 
 target/debug/briskdb \
   --data-dir "${data_dir}" \
@@ -91,6 +109,17 @@ curl --fail --silent "http://127.0.0.1:${http_port}/health" >/dev/null
 
 matrix_dsn="host=127.0.0.1 port=${postgres_port} user=briskdb dbname=default sslmode=disable"
 matrix_url="postgresql+psycopg://briskdb@127.0.0.1:${postgres_port}/default"
+
+"${psql_command}" "${matrix_dsn}" -X --set ON_ERROR_STOP=1 --command \
+  "INSERT INTO indexed_records (tenant_id, payload) VALUES ('psql-index-a', 'psql-global-key')" \
+  >/dev/null
+if "${psql_command}" "${matrix_dsn}" -X --set ON_ERROR_STOP=1 --command \
+  "INSERT INTO indexed_records (tenant_id, payload) VALUES ('psql-index-b', 'psql-global-key')" \
+  >/dev/null 2>&1; then
+  exit 1
+fi
+indexed_recovered="$("${psql_command}" "${matrix_dsn}" -X --tuples-only --no-align --command "SELECT 1")"
+test "${indexed_recovered}" = "1"
 
 "${psql_command}" "${matrix_dsn}" -X --set ON_ERROR_STOP=1 >/dev/null <<'SQL'
 BEGIN;


### PR DESCRIPTION
Closes #233

## What changed

- route ready global-unique `INSERT`, `UPDATE`, and `DELETE` statements through the shared writable coordinator across Rust, Python, HTTP, and PostgreSQL
- capture SQLite's physical old/new rows with the bundled pre-update hook, including partial predicates, expressions, compound keys, cascades, and configured NULL semantics
- reserve authoritative keys before the physical commit, then finalize or roll back with durable cross-process operation markers and orphan recovery
- preserve SQLite conflict behavior for `OR IGNORE`; reject unsafe global replace/upsert, multi-authoritative-row, cross-shard, and explicit-transaction shapes before commit
- refresh affected unique-index snapshots synchronously and fail closed for invalid authoritative indexes
- keep cancellation live while reserving, but finish authority with a non-cancelled token once the physical commit wins
- install libclang in Linux wheel containers for the bundled SQLite pre-update bindings
- update README, roadmap, and global-index architecture documentation

## Verification

- `cargo +1.85.0 check --locked --lib --no-default-features`
- `cargo +1.85.0 check --locked --lib --all-features`
- `cargo test --locked --all-targets --all-features`
- `cargo test --locked --doc --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked -p briskdb-python`
- `cargo clippy --locked -p briskdb-python --all-targets --no-deps -- -D warnings`
- local abi3 macOS wheel build/install and all 25 Python tests
- live PostgreSQL client matrix with psql, tokio-postgres, psycopg, and SQLAlchemy
- competing-process insert/insert, update/update, update/delete, retry, and physical-commit crash recovery tests
