### PR TITLE
Global indexes: verify and repair read candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ HTTP and PostgreSQL. Native MongoDB, MySQL, and serverless use are on the roadma
   leases allocate collision-free values across processes. Successful
   single-shard `INSERT`, `UPDATE`, and `DELETE` statements now maintain ready
   global unique indexes automatically, and exact indexed reads skip shards
-  that cannot own a match.
+  that cannot own a match. Non-unique index hits are physically rechecked and
+  stale entries are repaired without trusting them as authority.
 - **Bring the client you already have.** HTTP and PostgreSQL are available now;
   MongoDB and MySQL wire compatibility are being built over the same engine.
 - **Files remain files.** The layout is a manifest plus normal SQLite databases,
@@ -117,7 +118,7 @@ experimental and opt-in; the exact contract lives in
 | PostgreSQL wire protocol | TLS/SCRAM, backpressured row streaming, SQLite-interrupt cancellation, text/binary CRUD, real single-shard transactions, and a live psql/tokio-postgres/psycopg/SQLAlchemy matrix |
 | Offline import from a standard SQLite database | Working |
 | Native-range and hi/lo generated IDs | Experimental, opt-in |
-| Cross-shard unique indexes and global value leases | Automatic autocommit maintenance plus equality/`IN` shard pruning works across the shared engine; candidate verification and richer index shapes are next |
+| Cross-shard indexes and global value leases | Unique equality/`IN` reads prune shards; non-unique candidates are physically verified with bounded durable repair, then safely scatter until freshness watermarks land |
 | Ubuntu/macOS x86-64 and ARM64 release artifacts | Published |
 | Debian package and hardened systemd service | Published |
 | Rust library entrypoint with optional attached listeners | Working |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -413,7 +413,7 @@ requires an earlier dependency:
    - [x] [#232](https://github.com/schapman1974/briskdb/issues/232) — unique reservations and global allocation
    - [x] [#233](https://github.com/schapman1974/briskdb/issues/233) — authoritative write maintenance
    - [x] [#234](https://github.com/schapman1974/briskdb/issues/234) — exact indexed routing
-   - [ ] [#235](https://github.com/schapman1974/briskdb/issues/235) — candidate verification and repair
+   - [x] [#235](https://github.com/schapman1974/briskdb/issues/235) — candidate verification and repair
    - [ ] [#236](https://github.com/schapman1974/briskdb/issues/236) — transactional shard outboxes
    - [ ] [#237](https://github.com/schapman1974/briskdb/issues/237) — asynchronous indexing and watermarks
    - [ ] [#238](https://github.com/schapman1974/briskdb/issues/238) — Bloom/min-max shard summaries

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -355,6 +355,14 @@ across retries and process loss. Key locks and finalized owners change in single
 SQLite transactions, so no protocol needs an unsafe scan-then-insert check.
 Automatic DML coordination remains the separate #233 write-path stage.
 
+Storage version 3 adds bounded non-unique candidate repair. A candidate is
+looked up by its stable row locator, its canonical key is recomputed, and the
+complete bound predicate is evaluated by SQLite on the owning shard. Stale
+observations become idempotent tombstones without changing unique authority or
+the immutable build snapshot. Until freshness watermarks prove completeness,
+verified candidate shards remain explain data and execution keeps the safe
+ordinary scatter target.
+
 ### Bound statement-planning boundary
 
 Synchronous `Engine::plan_bound_statement` accepts a `NormalizedSql` batch, one
@@ -970,16 +978,17 @@ therefore reject generated-key writes before allocation. HTTP still creates a
 fresh Session per request; PostgreSQL sessions support retained single-shard
 transactions through the ordinary prepared execution path.
 
-Ready unique global indexes also participate in protocol-neutral read
-planning. The structural analyzer recognizes exact equality and non-negated
+Ready global indexes also participate in protocol-neutral read planning. The
+structural analyzer recognizes exact equality and non-negated
 `IN` constraints on column key parts, constructs bounded canonical compound
-keys, and asks storage for both finalized entries and the old/new owners of
-active mutations in one SQLite snapshot. It deduplicates those owners and
-intersects them with any shard-key inference before the unchanged query runs on
-the remaining children. The public bound plan carries redaction-safe explain
-metadata. Any partial/expression definition, non-exact predicate, invalid
-lifecycle, excessive expansion, or authority-open/read failure retains the
-ordinary correct shard route or scatter path.
+keys, and asks storage for candidate owners. Unique indexes include both
+finalized entries and old/new active-mutation owners in one snapshot, then
+authoritatively prune shards. Non-unique candidates are physically rechecked
+against their row locator, canonical key, and complete predicate; bounded stale
+entries are tombstoned, but execution still scatters until freshness is proven.
+The public bound plan carries redaction-safe explain metadata. Any unsupported
+definition or predicate, excessive expansion/candidates, invalid lifecycle, or
+authority/verification failure retains the ordinary correct route.
 
 Each PostgreSQL connection also owns a random, in-memory backend PID/secret pair.
 The adapter registers a fresh core cancellation token only for the command that

--- a/docs/GLOBAL_INDEX_AUTHORITY.md
+++ b/docs/GLOBAL_INDEX_AUTHORITY.md
@@ -61,13 +61,24 @@ flowchart LR
     AUTH -. unavailable .-> SCATTER
 ```
 
-Only synchronously maintained, ready unique indexes are eligible today.
-Partial indexes, expression keys, non-unique indexes, unsupported predicate
-shapes/types, oversized key sets, invalid lifecycle state, and unavailable
-index storage fall back without omitting a shard. Active old and new mutation
-owners are included so the physical-commit/finalization window is conservative.
-`BoundStatementPlan::global_index_routing()` exposes the selected index,
-redaction-safe counts, exact target shards, and a stable fallback reason.
+Ready non-unique column indexes can also supply candidates. BriskDB reads at
+most 4,096 candidates, fetches each by its stable physical locator, recomputes
+the canonical key, and evaluates the complete original predicate on that
+shard. Deleted, moved, malformed, and no-longer-matching candidates are never
+returned as index evidence. Up to 64 stale observations per plan become
+idempotent durable tombstones; applied tombstones are skipped on later reads.
+
+Non-unique candidates cannot yet prove that another shard has no newer match,
+so these plans retain the ordinary safe scatter route with the stable
+`freshness_unproven` reason. Issue
+[#237](https://github.com/schapman1974/briskdb/issues/237) adds the watermarks
+needed for exclusion. Partial indexes, expression keys, unsupported predicate
+shapes/types, oversized key/candidate sets, invalid lifecycle state, and
+unavailable index storage also fall back without omitting a shard. Active old
+and new unique-mutation owners remain included through the physical-commit
+window. `BoundStatementPlan::global_index_routing()` exposes authoritative
+status, candidates, verified/rejected/stale counts, repairs, diagnostic
+candidate shards, exact execution targets, and a stable fallback reason.
 
 ## Unique-key state machine
 
@@ -115,10 +126,11 @@ reports `active_unique_reservation`. A unique-index rebuild rolls active
 reservations back before reconstructing ownership from the authoritative shard
 rows.
 
-Physical global-index storage version 2 adds the operation, reservation,
-sequence, and lease tables to `global-indexes/global.sqlite`. Startup upgrades
-version 1 atomically and requires sole-process ownership; a live peer receives
-retryable `Busy` before any format mutation.
+Physical global-index storage version 2 added the operation, reservation,
+sequence, and lease tables to `global-indexes/global.sqlite`. Version 3 adds
+bounded non-unique read-repair tombstones. Startup upgrades versions 1 and 2
+atomically and requires sole-process ownership; a live peer receives retryable
+`Busy` before any format mutation.
 
 ## Verification and benchmarks
 
@@ -127,7 +139,8 @@ partial/compound/NULL key derivation, constraint outcomes, competing-process
 insert/update/delete races and exact retries, Python and PostgreSQL clients,
 replacement locking, serial-model property histories, four-process hot-key
 contention, four-process range leasing, durable process-abort boundaries,
-format-upgrade crashes, and peer fencing.
+format-upgrade crashes, peer fencing, stale-candidate differential properties,
+cancellation/deadlines, and process exits around repair enqueue/application.
 
 Criterion includes three focused measurements:
 

--- a/docs/GLOBAL_INDEX_BUILD.md
+++ b/docs/GLOBAL_INDEX_BUILD.md
@@ -34,8 +34,8 @@ must stop every service and embedded process using the root, open one exclusive
 <data-root>/global-indexes/global.sqlite
 ```
 
-It is a separate, application-identified, storage-version-2 SQLite database in
-WAL mode with `synchronous=FULL`. It contains ten BriskDB-owned tables:
+It is a separate, application-identified, storage-version-3 SQLite database in
+WAL mode with `synchronous=FULL`. It contains eleven BriskDB-owned tables:
 
 | Table | Authority |
 | --- | --- |
@@ -43,6 +43,7 @@ WAL mode with `synchronous=FULL`. It contains ten BriskDB-owned tables:
 | `briskdb_global_index_builds` | Definition digest, schema generation, state, and final row count |
 | `briskdb_global_index_checkpoints` | One digest and row count for each completed source shard |
 | `briskdb_global_index_entries` | Canonical key to source shard, scan ordinal, and typed physical row locator |
+| `briskdb_global_index_read_repairs` | Bounded, idempotent non-unique stale-candidate tombstones |
 | `briskdb_global_index_unique_keys` | One reservation per key when the definition is unique |
 | `briskdb_global_operations` | Idempotent uniqueness/value operation state and request digest |
 | `briskdb_global_unique_mutations` | Old/new owner intent for a unique operation |
@@ -50,7 +51,7 @@ WAL mode with `synchronous=FULL`. It contains ten BriskDB-owned tables:
 | `briskdb_global_value_sequences` | Per-index positive integer head and fence token |
 | `briskdb_global_value_leases` | Irrevocable operation-bound value ranges |
 
-Storage version 1 is upgraded atomically during sole-process startup. The
+Storage versions 1 and 2 are upgraded atomically during sole-process startup. The
 online state machines are documented in [global uniqueness and value
 authority](GLOBAL_INDEX_AUTHORITY.md).
 

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -1317,13 +1317,13 @@ This routing format is intentionally distinct from the tagged, order-preserving
 [canonical global-index key format](INDEX_KEY_ENCODING.md). Version 13 records
 the codec version in every global-index definition but does not persist physical
 index entries or change shard placement. Physical entries live in the separate
-storage-version-2 `global-indexes/global.sqlite` authority, never in a shard.
+storage-version-3 `global-indexes/global.sqlite` authority, never in a shard.
 
-### Physical global-index storage version 2
+### Physical global-index storage version 3
 
 The selected `SharedSqliteV1` layout is one real regular file at
 `global-indexes/global.sqlite`. Its `application_id` is `0x42524749`, its
-`user_version` is `2`, its journal mode is `WAL`, and writers use
+`user_version` is `3`, its journal mode is `WAL`, and writers use
 `synchronous=FULL`. The build tables and ownership rules are listed
 in [offline global-index construction](GLOBAL_INDEX_BUILD.md).
 
@@ -1343,6 +1343,16 @@ Unique reserve/finalize/rollback transactions and value lease state transitions
 are described in [global uniqueness and value authority](GLOBAL_INDEX_AUTHORITY.md).
 Startup upgrades version 1 in one transaction only after acquiring sole-process
 ownership.
+
+Version 3 adds `briskdb_global_index_read_repairs`. Its tuple identity is the
+index ID, canonical key, source shard, and stable source locator. Repair kind
+distinguishes missing rows, changed keys, and malformed locators; state moves
+idempotently from queued to applied, while a saturating observation count makes
+repeated staleness observable without growing one record per read. Applied
+tombstones hide only matching non-unique candidate entries. They never alter
+unique-key ownership or the base build/checkpoint digest. One plan reads at
+most 4,096 candidates and queues at most 64 repairs. Startup upgrades either
+version 1 or 2 under the same sole-process fence.
 
 Source-shard entries and their checkpoint commit together. Resume re-hashes
 every completed prefix shard and restarts from zero if application data changed.

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -632,12 +632,14 @@ impl Engine {
         explicit_routing_key: Option<&[u8]>,
     ) -> EngineResult<BoundStatementPlan> {
         let _schema_operation = self.inner.database.storage.enter_schema_operation()?;
+        let cancellation = CancellationToken::new();
         self.plan_bound_statement_admitted(
             database,
             normalized,
             statement_index,
             parameters,
             explicit_routing_key,
+            (&cancellation, None),
         )
     }
 
@@ -648,6 +650,7 @@ impl Engine {
         statement_index: usize,
         parameters: &[Value],
         explicit_routing_key: Option<&[u8]>,
+        read_control: (&CancellationToken, Option<Instant>),
     ) -> EngineResult<BoundStatementPlan> {
         let (hash_version, key_encoding_version, bucket_algorithm_version, map_generation) =
             self.inner.database.routing_provenance();
@@ -675,11 +678,15 @@ impl Engine {
             normalized,
             parameters,
             self.shard_count(),
-            |index_id, keys| {
-                self.inner
-                    .database
-                    .storage
-                    .global_index_read_candidates(index_id, keys)
+            |index_id, keys, predicate, alias, parameters| {
+                self.inner.database.storage.global_index_read_resolution(
+                    index_id,
+                    keys,
+                    predicate,
+                    alias,
+                    parameters,
+                    read_control,
+                )
             },
         )?;
         Ok(plan)
@@ -689,6 +696,8 @@ impl Engine {
         &self,
         statement: &str,
         parameters: &[Value],
+        cancellation: &CancellationToken,
+        deadline: Option<Instant>,
     ) -> EngineResult<(Vec<u16>, String)> {
         let parsed = sql::parse(sql::SqlDialect::Sqlite, statement)?;
         if parsed.statement_count() != 1 {
@@ -706,6 +715,7 @@ impl Engine {
             0,
             parameters,
             None,
+            (cancellation, deadline),
         )?;
         if !matches!(plan.behavior(), sql::StatementBehavior::Read) {
             return Err(EngineError::new(
@@ -1151,6 +1161,7 @@ impl Engine {
                 0,
                 &parameters,
                 routing_key,
+                (&operation.cancellation, operation.deadline),
             )?;
             operation.check_before_start()?;
             let routing_key = routing_key.map(<[u8]>::to_vec);
@@ -1296,6 +1307,7 @@ impl Engine {
             0,
             portal_snapshot.parameters(),
             portal_snapshot.routing_key(),
+            (&operation.cancellation, operation.deadline),
         ) {
             Ok(plan) => plan,
             Err(error) => {
@@ -1513,6 +1525,7 @@ impl Engine {
             0,
             portal_snapshot.parameters(),
             explicit_routing_key,
+            (&operation.cancellation, operation.deadline),
         ) {
             Ok(plan) => plan,
             Err(error) => {
@@ -1767,6 +1780,7 @@ impl Engine {
             0,
             portal_snapshot.parameters(),
             None,
+            (&operation.cancellation, operation.deadline),
         ) {
             Ok(plan) => plan,
             Err(error) => {
@@ -2745,7 +2759,12 @@ impl Engine {
             Err(error) => return operation.finish(Err(error)),
         };
         let (sql, params) = statement.into_parts();
-        let (shards, sql) = match self.logical_raw_query_plan(&sql, &params) {
+        let (shards, sql) = match self.logical_raw_query_plan(
+            &sql,
+            &params,
+            &operation.cancellation,
+            operation.deadline,
+        ) {
             Ok(plan) => plan,
             Err(error) => return operation.finish(Err(error)),
         };

--- a/src/core/global_index.rs
+++ b/src/core/global_index.rs
@@ -12,6 +12,8 @@ pub(crate) const MAX_GLOBAL_INDEXES: usize = 4_096;
 pub(crate) const MAX_GLOBAL_INDEX_PARTS: usize = 16;
 pub(crate) const MAX_GLOBAL_INDEX_SQL_BYTES: usize = 4_096;
 pub(crate) const MAX_GLOBAL_OWNER_LOCATOR_BYTES: usize = 4_096;
+pub(crate) const MAX_GLOBAL_INDEX_READ_CANDIDATES: usize = 4_096;
+pub(crate) const MAX_GLOBAL_INDEX_READ_REPAIRS: usize = 64;
 pub(crate) const MAX_GLOBAL_VALUE_LEASE_COUNT: u32 = 65_536;
 const DEFAULT_MAX_REPORTED_VALIDATION_ISSUES: u16 = 128;
 const MAX_REPORTED_VALIDATION_ISSUES: u16 = 1_024;
@@ -132,6 +134,121 @@ impl fmt::Debug for GlobalIndexOwner {
             .field("source_shard", &self.source_shard)
             .field("locator", &"<redacted>")
             .finish()
+    }
+}
+
+/// Storage result consumed by protocol-neutral global-index read planning.
+/// Non-unique results remain incomplete until asynchronous freshness
+/// watermarks prove which source shards may be excluded.
+#[derive(Debug)]
+pub(crate) struct GlobalIndexReadResolution {
+    owners: Vec<GlobalIndexOwner>,
+    candidate_count: usize,
+    verified_count: usize,
+    rejected_count: usize,
+    stale_count: usize,
+    repairs_queued: usize,
+    repairs_applied: usize,
+    repairs_deferred: usize,
+    complete: bool,
+    candidate_limit_exceeded: bool,
+}
+
+impl GlobalIndexReadResolution {
+    pub(crate) fn authoritative(owners: Vec<GlobalIndexOwner>) -> Self {
+        let candidate_count = owners.len();
+        Self {
+            owners,
+            candidate_count,
+            verified_count: 0,
+            rejected_count: 0,
+            stale_count: 0,
+            repairs_queued: 0,
+            repairs_applied: 0,
+            repairs_deferred: 0,
+            complete: true,
+            candidate_limit_exceeded: false,
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn candidates(
+        owners: Vec<GlobalIndexOwner>,
+        candidate_count: usize,
+        verified_count: usize,
+        rejected_count: usize,
+        stale_count: usize,
+        repairs_queued: usize,
+        repairs_applied: usize,
+        repairs_deferred: usize,
+    ) -> Self {
+        Self {
+            owners,
+            candidate_count,
+            verified_count,
+            rejected_count,
+            stale_count,
+            repairs_queued,
+            repairs_applied,
+            repairs_deferred,
+            complete: false,
+            candidate_limit_exceeded: false,
+        }
+    }
+
+    pub(crate) const fn candidate_limit_exceeded(candidate_count: usize) -> Self {
+        Self {
+            owners: Vec::new(),
+            candidate_count,
+            verified_count: 0,
+            rejected_count: 0,
+            stale_count: 0,
+            repairs_queued: 0,
+            repairs_applied: 0,
+            repairs_deferred: 0,
+            complete: false,
+            candidate_limit_exceeded: true,
+        }
+    }
+
+    pub(crate) fn owners(&self) -> &[GlobalIndexOwner] {
+        &self.owners
+    }
+
+    pub(crate) const fn candidate_count(&self) -> usize {
+        self.candidate_count
+    }
+
+    pub(crate) const fn verified_count(&self) -> usize {
+        self.verified_count
+    }
+
+    pub(crate) const fn rejected_count(&self) -> usize {
+        self.rejected_count
+    }
+
+    pub(crate) const fn stale_count(&self) -> usize {
+        self.stale_count
+    }
+
+    pub(crate) const fn repairs_queued(&self) -> usize {
+        self.repairs_queued
+    }
+
+    pub(crate) const fn repairs_applied(&self) -> usize {
+        self.repairs_applied
+    }
+
+    pub(crate) const fn repairs_deferred(&self) -> usize {
+        self.repairs_deferred
+    }
+
+    pub(crate) const fn is_complete(&self) -> bool {
+        self.complete
+    }
+
+    pub(crate) const fn is_candidate_limit_exceeded(&self) -> bool {
+        self.candidate_limit_exceeded
     }
 }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -46,7 +46,8 @@ pub use global_index::{
     HASH_PARTITIONED_GLOBAL_INDEX_PARTITIONS_V1,
 };
 pub(crate) use global_index::{
-    MAX_GLOBAL_INDEX_PARTS, MAX_GLOBAL_INDEX_SQL_BYTES, MAX_GLOBAL_INDEXES,
+    GlobalIndexReadResolution, MAX_GLOBAL_INDEX_PARTS, MAX_GLOBAL_INDEX_READ_CANDIDATES,
+    MAX_GLOBAL_INDEX_READ_REPAIRS, MAX_GLOBAL_INDEX_SQL_BYTES, MAX_GLOBAL_INDEXES,
     MAX_GLOBAL_VALUE_LEASE_COUNT,
 };
 pub use index_key::{
@@ -583,13 +584,23 @@ impl Database {
             ),
             |key| self.shard_for_key(key),
         )?;
+        let cancellation = CancellationToken::new();
         planner::apply_global_index_routing(
             &mut plan,
             catalog,
             translated.normalized_sql(),
             params,
             self.shard_count(),
-            |index_id, keys| self.storage.global_index_read_candidates(index_id, keys),
+            |index_id, keys, predicate, alias, parameters| {
+                self.storage.global_index_read_resolution(
+                    index_id,
+                    keys,
+                    predicate,
+                    alias,
+                    parameters,
+                    (&cancellation, None),
+                )
+            },
         )?;
         let target = raw_data_execution_target(&plan, catalog, operation)?;
         Ok(Some(RawDataPlan {

--- a/src/core/planner.rs
+++ b/src/core/planner.rs
@@ -10,8 +10,8 @@ use crate::sql::{
 
 use super::{
     AllocationOwnerMap, CanonicalIndexKey, Catalog, EngineError, EngineErrorKind, EngineResult,
-    GeneratedIdPolicy, GlobalIndexId, GlobalIndexOwner, LogicalDatabaseId, TableId, TableMetadata,
-    TablePlacement, Value,
+    GeneratedIdPolicy, GlobalIndexId, GlobalIndexOwner, GlobalIndexReadResolution,
+    LogicalDatabaseId, TableId, TableMetadata, TablePlacement, Value,
     generated_id::{
         GeneratedIdClassification, HILO_V1_FORMAT_MARKER, classify_caller_generated_id,
     },
@@ -92,7 +92,7 @@ pub enum GlobalIndexRoutingKind {
     Fallback,
 }
 
-/// Stable reason an authoritative index was not used.
+/// Stable reason a global index was not used to exclude every other shard.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum GlobalIndexRoutingFallback {
@@ -100,7 +100,10 @@ pub enum GlobalIndexRoutingFallback {
     UnsupportedIndexDefinition,
     PredicateNotExact,
     TooManyKeys,
+    TooManyCandidates,
     IndexUnavailable,
+    CandidateVerificationFailed,
+    FreshnessUnproven,
 }
 
 impl GlobalIndexRoutingFallback {
@@ -111,7 +114,10 @@ impl GlobalIndexRoutingFallback {
             Self::UnsupportedIndexDefinition => "unsupported_index_definition",
             Self::PredicateNotExact => "predicate_not_exact",
             Self::TooManyKeys => "too_many_exact_keys",
+            Self::TooManyCandidates => "too_many_index_candidates",
             Self::IndexUnavailable => "index_unavailable",
+            Self::CandidateVerificationFailed => "candidate_verification_failed",
+            Self::FreshnessUnproven => "freshness_unproven",
         }
     }
 }
@@ -122,8 +128,16 @@ pub struct GlobalIndexRoutingPlan {
     kind: GlobalIndexRoutingKind,
     index_id: Option<GlobalIndexId>,
     index_name: Option<Arc<str>>,
+    authoritative: bool,
     lookup_key_count: usize,
     candidate_count: usize,
+    verified_candidate_count: usize,
+    rejected_candidate_count: usize,
+    stale_candidate_count: usize,
+    repairs_queued: usize,
+    repairs_applied: usize,
+    repairs_deferred: usize,
+    candidate_shards: Vec<u16>,
     target_shards: Vec<u16>,
     fallback: Option<GlobalIndexRoutingFallback>,
 }
@@ -134,8 +148,16 @@ impl GlobalIndexRoutingPlan {
             kind: GlobalIndexRoutingKind::NotApplicable,
             index_id: None,
             index_name: None,
+            authoritative: false,
             lookup_key_count: 0,
             candidate_count: 0,
+            verified_candidate_count: 0,
+            rejected_candidate_count: 0,
+            stale_candidate_count: 0,
+            repairs_queued: 0,
+            repairs_applied: 0,
+            repairs_deferred: 0,
+            candidate_shards: Vec::new(),
             target_shards: Vec::new(),
             fallback: None,
         }
@@ -165,6 +187,11 @@ impl GlobalIndexRoutingPlan {
         self.index_name.as_deref()
     }
 
+    /// Return whether the selected index is synchronously authoritative.
+    pub const fn authoritative(&self) -> bool {
+        self.authoritative
+    }
+
     /// Return the number of distinct canonical keys probed.
     pub const fn lookup_key_count(&self) -> usize {
         self.lookup_key_count
@@ -173,6 +200,42 @@ impl GlobalIndexRoutingPlan {
     /// Return the owner candidates read before shard deduplication/intersection.
     pub const fn candidate_count(&self) -> usize {
         self.candidate_count
+    }
+
+    /// Return how many non-unique candidates still matched the bound query.
+    pub const fn verified_candidate_count(&self) -> usize {
+        self.verified_candidate_count
+    }
+
+    /// Return how many healthy index candidates failed another query filter.
+    pub const fn rejected_candidate_count(&self) -> usize {
+        self.rejected_candidate_count
+    }
+
+    /// Return how many candidate entries were stale at verification time.
+    pub const fn stale_candidate_count(&self) -> usize {
+        self.stale_candidate_count
+    }
+
+    /// Return the number of bounded repair tombstones queued by this plan.
+    pub const fn repairs_queued(&self) -> usize {
+        self.repairs_queued
+    }
+
+    /// Return the number of queued repair tombstones durably applied.
+    pub const fn repairs_applied(&self) -> usize {
+        self.repairs_applied
+    }
+
+    /// Return repair observations left for a later retry.
+    pub const fn repairs_deferred(&self) -> usize {
+        self.repairs_deferred
+    }
+
+    /// Return shards containing physically verified query candidates. These
+    /// are diagnostic until freshness watermarks can prove completeness.
+    pub fn candidate_shards(&self) -> &[u16] {
+        &self.candidate_shards
     }
 
     /// Return the exact logical shard target set. An empty set is executed on
@@ -194,8 +257,16 @@ impl fmt::Debug for GlobalIndexRoutingPlan {
             .field("kind", &self.kind)
             .field("index_id", &self.index_id)
             .field("index_name", &self.index_name)
+            .field("authoritative", &self.authoritative)
             .field("lookup_key_count", &self.lookup_key_count)
             .field("candidate_count", &self.candidate_count)
+            .field("verified_candidate_count", &self.verified_candidate_count)
+            .field("rejected_candidate_count", &self.rejected_candidate_count)
+            .field("stale_candidate_count", &self.stale_candidate_count)
+            .field("repairs_queued", &self.repairs_queued)
+            .field("repairs_applied", &self.repairs_applied)
+            .field("repairs_deferred", &self.repairs_deferred)
+            .field("candidate_shards", &self.candidate_shards)
             .field("target_shards", &self.target_shards)
             .field("fallback", &self.fallback)
             .finish()
@@ -547,7 +618,13 @@ pub(super) fn apply_global_index_routing<F>(
     mut resolve: F,
 ) -> EngineResult<()>
 where
-    F: FnMut(GlobalIndexId, &[CanonicalIndexKey]) -> EngineResult<Vec<GlobalIndexOwner>>,
+    F: FnMut(
+        GlobalIndexId,
+        &[CanonicalIndexKey],
+        &str,
+        Option<&str>,
+        &[Value],
+    ) -> EngineResult<GlobalIndexReadResolution>,
 {
     if plan.behavior != StatementBehavior::Read {
         return Ok(());
@@ -601,36 +678,64 @@ where
             kind: GlobalIndexRoutingKind::Empty,
             index_id: Some(index_id),
             index_name: Some(index_name),
+            authoritative: candidate.is_unique(),
             lookup_key_count,
             candidate_count: 0,
+            verified_candidate_count: 0,
+            rejected_candidate_count: 0,
+            stale_candidate_count: 0,
+            repairs_queued: 0,
+            repairs_applied: 0,
+            repairs_deferred: 0,
+            candidate_shards: Vec::new(),
             target_shards: Vec::new(),
             fallback: None,
         };
         return Ok(());
     }
 
-    let owners = match resolve(index_id, candidate.keys()) {
-        Ok(owners) => owners,
+    let resolution = match resolve(
+        index_id,
+        candidate.keys(),
+        candidate.query_predicate_sql(),
+        candidate.query_table_alias(),
+        parameters,
+    ) {
+        Ok(resolution) => resolution,
+        Err(error)
+            if matches!(
+                error.kind(),
+                EngineErrorKind::Cancelled | EngineErrorKind::DeadlineExceeded
+            ) =>
+        {
+            return Err(error);
+        }
         Err(_) => {
             plan.global_index_routing = GlobalIndexRoutingPlan {
                 index_id: Some(index_id),
                 index_name: Some(index_name),
+                authoritative: candidate.is_unique(),
                 lookup_key_count,
                 ..GlobalIndexRoutingPlan::fallback(
-                    GlobalIndexRoutingFallback::IndexUnavailable,
+                    if candidate.is_unique() {
+                        GlobalIndexRoutingFallback::IndexUnavailable
+                    } else {
+                        GlobalIndexRoutingFallback::CandidateVerificationFailed
+                    },
                     fallback_targets,
                 )
             };
             return Ok(());
         }
     };
-    let candidate_count = owners.len();
-    let mut target_shards = owners
+    let candidate_count = resolution.candidate_count();
+    let mut candidate_shards = resolution
+        .owners()
         .iter()
         .map(GlobalIndexOwner::source_shard)
         .collect::<Vec<_>>();
-    target_shards.sort_unstable();
-    target_shards.dedup();
+    candidate_shards.sort_unstable();
+    candidate_shards.dedup();
 
     match plan.inference.kind() {
         ShardKeyInferenceKind::Exact | ShardKeyInferenceKind::Multiple => {
@@ -641,26 +746,48 @@ where
                 .collect::<Vec<_>>();
             routed.sort_unstable();
             routed.dedup();
-            target_shards.retain(|shard| routed.binary_search(shard).is_ok());
+            candidate_shards.retain(|shard| routed.binary_search(shard).is_ok());
         }
-        ShardKeyInferenceKind::Contradiction => target_shards.clear(),
+        ShardKeyInferenceKind::Contradiction => candidate_shards.clear(),
         ShardKeyInferenceKind::Unconstrained => {}
         ShardKeyInferenceKind::NotApplicable | ShardKeyInferenceKind::NotSharded => {
             return Err(planning_invariant());
         }
     }
+    let fallback = if resolution.is_candidate_limit_exceeded() {
+        Some(GlobalIndexRoutingFallback::TooManyCandidates)
+    } else if resolution.is_complete() {
+        None
+    } else {
+        Some(GlobalIndexRoutingFallback::FreshnessUnproven)
+    };
+    let target_shards = if fallback.is_some() {
+        fallback_targets
+    } else {
+        candidate_shards.clone()
+    };
     plan.global_index_routing = GlobalIndexRoutingPlan {
-        kind: if target_shards.is_empty() {
+        kind: if fallback.is_some() {
+            GlobalIndexRoutingKind::Fallback
+        } else if target_shards.is_empty() {
             GlobalIndexRoutingKind::Empty
         } else {
             GlobalIndexRoutingKind::Routed
         },
         index_id: Some(index_id),
         index_name: Some(index_name),
+        authoritative: candidate.is_unique(),
         lookup_key_count,
         candidate_count,
+        verified_candidate_count: resolution.verified_count(),
+        rejected_candidate_count: resolution.rejected_count(),
+        stale_candidate_count: resolution.stale_count(),
+        repairs_queued: resolution.repairs_queued(),
+        repairs_applied: resolution.repairs_applied(),
+        repairs_deferred: resolution.repairs_deferred(),
+        candidate_shards,
         target_shards,
-        fallback: None,
+        fallback,
     };
     Ok(())
 }

--- a/src/sql/global_index.rs
+++ b/src/sql/global_index.rs
@@ -22,7 +22,10 @@ use crate::core::{
 pub(crate) struct GlobalIndexLookupCandidate {
     index_id: GlobalIndexId,
     index_name: String,
+    unique: bool,
     keys: Vec<CanonicalIndexKey>,
+    query_predicate_sql: String,
+    query_table_alias: Option<String>,
 }
 
 impl GlobalIndexLookupCandidate {
@@ -34,8 +37,20 @@ impl GlobalIndexLookupCandidate {
         &self.index_name
     }
 
+    pub(crate) const fn is_unique(&self) -> bool {
+        self.unique
+    }
+
     pub(crate) fn keys(&self) -> &[CanonicalIndexKey] {
         &self.keys
+    }
+
+    pub(crate) fn query_predicate_sql(&self) -> &str {
+        &self.query_predicate_sql
+    }
+
+    pub(crate) fn query_table_alias(&self) -> Option<&str> {
+        self.query_table_alias.as_deref()
     }
 }
 
@@ -135,7 +150,7 @@ pub(crate) fn infer_global_index_lookup(
         .iter()
         .filter(|index| index.table_id() == table_id)
     {
-        if index.lifecycle() != GlobalIndexLifecycle::Ready || !index.is_unique() {
+        if index.lifecycle() != GlobalIndexLifecycle::Ready {
             continue;
         }
         saw_ready = true;
@@ -154,7 +169,12 @@ pub(crate) fn infer_global_index_lookup(
             IndexKeys::Finite(keys) => candidates.push(GlobalIndexLookupCandidate {
                 index_id: index.id(),
                 index_name: index.name().to_owned(),
+                unique: index.is_unique(),
                 keys,
+                query_predicate_sql: String::new(),
+                query_table_alias: alias
+                    .as_ref()
+                    .map(|alias| reference_identifier(&alias.name)),
             }),
         }
     }
@@ -166,12 +186,15 @@ pub(crate) fn infer_global_index_lookup(
             .global_index_by_id(candidate.index_id)
             .map_or(0, |index| index.key_parts().len());
         (
+            !candidate.unique,
             candidate.keys.len(),
             usize::MAX - parts,
             candidate.index_id.get(),
         )
     });
-    if let Some(candidate) = candidates.into_iter().next() {
+    if let Some(mut candidate) = candidates.into_iter().next() {
+        candidate.query_predicate_sql =
+            super::translator::translated_query_predicate(normalized, statement_index)?;
         return Ok(Ok(candidate));
     }
     Ok(Err(if saw_too_many {
@@ -755,7 +778,7 @@ mod tests {
     }
 
     #[test]
-    fn partial_expression_nonunique_and_invalid_indexes_do_not_claim_routes() {
+    fn nonunique_indexes_produce_candidates_while_unsupported_and_invalid_indexes_fall_back() {
         let expression = GlobalIndexKeyPart::new(
             GlobalIndexKeySource::expression("lower(email)").unwrap(),
             GlobalIndexKeyType::Text,
@@ -787,33 +810,41 @@ mod tests {
                 Err(GlobalIndexInferenceFallback::UnsupportedIndexDefinition)
             );
         }
-        for index in [
-            metadata(
+        let candidate = infer(
+            &catalog(vec![metadata(
                 1,
                 "nonunique",
                 vec![column("email", GlobalIndexKeyType::Text)],
                 None,
                 GlobalIndexLifecycle::Ready,
                 false,
+            )]),
+            "SELECT * FROM users AS u WHERE u.email = 'a@example.test'",
+            &[],
+        )
+        .unwrap();
+        assert!(!candidate.is_unique());
+        assert_eq!(candidate.query_table_alias(), Some("u"));
+        assert_eq!(
+            candidate.query_predicate_sql(),
+            "u.email = 'a@example.test'"
+        );
+
+        assert_eq!(
+            infer(
+                &catalog(vec![metadata(
+                    1,
+                    "invalid",
+                    vec![column("email", GlobalIndexKeyType::Text)],
+                    None,
+                    GlobalIndexLifecycle::Invalid,
+                    true,
+                )]),
+                "SELECT * FROM users WHERE email = 'a@example.test'",
+                &[],
             ),
-            metadata(
-                1,
-                "invalid",
-                vec![column("email", GlobalIndexKeyType::Text)],
-                None,
-                GlobalIndexLifecycle::Invalid,
-                true,
-            ),
-        ] {
-            assert_eq!(
-                infer(
-                    &catalog(vec![index]),
-                    "SELECT * FROM users WHERE email = 'a@example.test'",
-                    &[],
-                ),
-                Err(GlobalIndexInferenceFallback::NoReadyAuthoritativeIndex)
-            );
-        }
+            Err(GlobalIndexInferenceFallback::NoReadyAuthoritativeIndex)
+        );
     }
 
     proptest! {

--- a/src/sql/translator.rs
+++ b/src/sql/translator.rs
@@ -227,6 +227,57 @@ fn translate_compatibility(
     Ok(sqlite_sql)
 }
 
+/// Render one validated query predicate as canonical SQLite SQL while
+/// preserving the statement-local normalized parameter indexes. Global-index
+/// candidate verification embeds this expression in a locator-constrained
+/// physical query; it never executes the caller's projection twice.
+pub(crate) fn translated_query_predicate(
+    normalized: &NormalizedSql,
+    statement_index: usize,
+) -> EngineResult<String> {
+    let mut statement = normalized
+        .common()
+        .statements()
+        .get(statement_index)
+        .cloned()
+        .ok_or_else(translation_invariant)?;
+    let expected_placeholders = normalized
+        .statement_parameters()
+        .get(statement_index)
+        .ok_or_else(translation_invariant)?
+        .occurrence_count();
+    let mut visitor = CompatibilityVisitor {
+        normalized,
+        statement_index,
+        placeholder_count: 0,
+    };
+    if statement.visit(&mut visitor).is_break()
+        || visitor.placeholder_count != expected_placeholders
+    {
+        return Err(translation_invariant());
+    }
+    let AstStatement::Query(query) = statement else {
+        return Err(translation_invariant());
+    };
+    let sqlparser::ast::SetExpr::Select(select) = query.body.as_ref() else {
+        return Err(translation_invariant());
+    };
+    let predicate = select
+        .selection
+        .as_ref()
+        .ok_or_else(translation_invariant)?
+        .to_string();
+    let predicate = if normalized.dialect() == SqlDialect::MySql {
+        canonicalize_mysql_identifier_quotes(&predicate)?
+    } else {
+        predicate
+    };
+    if predicate.as_bytes().contains(&0) {
+        return Err(translation_invariant());
+    }
+    Ok(predicate)
+}
+
 /// Convert only MySQL-delimited identifiers in parser-rendered SQL. String
 /// literals and comments remain token-distinct, and embedded double quotes are
 /// escaped for SQLite's standard identifier spelling.

--- a/src/storage/global_index.rs
+++ b/src/storage/global_index.rs
@@ -5,6 +5,7 @@ use std::{
     fs::{self, File},
     path::{Path, PathBuf},
     str,
+    time::Instant,
 };
 
 use rusqlite::{
@@ -16,12 +17,13 @@ use crate::{
     core::{
         CancellationToken, CanonicalIndexKey, EngineError, EngineErrorKind, EngineResult,
         GlobalIndexBuildReport, GlobalIndexId, GlobalIndexKeySource, GlobalIndexKeyType,
-        GlobalIndexLifecycle, GlobalIndexMetadata, GlobalIndexOwner, GlobalIndexStorageTopology,
-        GlobalIndexValidationIssue, GlobalIndexValidationIssueKind, GlobalIndexValidationMode,
-        GlobalIndexValidationOptions, GlobalIndexValidationReport, GlobalOperationId,
-        GlobalOperationState, GlobalUniqueMutation, GlobalUniqueReservation, GlobalValueLease,
-        INDEX_KEY_ENCODING_VERSION, IndexKeyOrder, IndexKeyPart, IndexKeyValue,
-        MAX_GLOBAL_VALUE_LEASE_COUNT, UniqueNullSemantics,
+        GlobalIndexLifecycle, GlobalIndexMetadata, GlobalIndexOwner, GlobalIndexReadResolution,
+        GlobalIndexStorageTopology, GlobalIndexValidationIssue, GlobalIndexValidationIssueKind,
+        GlobalIndexValidationMode, GlobalIndexValidationOptions, GlobalIndexValidationReport,
+        GlobalOperationId, GlobalOperationState, GlobalUniqueMutation, GlobalUniqueReservation,
+        GlobalValueLease, INDEX_KEY_ENCODING_VERSION, IndexKeyOrder, IndexKeyPart, IndexKeyValue,
+        MAX_GLOBAL_INDEX_READ_CANDIDATES, MAX_GLOBAL_INDEX_READ_REPAIRS,
+        MAX_GLOBAL_VALUE_LEASE_COUNT, UniqueNullSemantics, Value,
     },
     sqlite_error,
 };
@@ -31,7 +33,7 @@ use super::{CONNECTION_BUSY_TIMEOUT, Storage};
 const DIRECTORY_NAME: &str = "global-indexes";
 const SHARED_FILE_NAME: &str = "global.sqlite";
 const APPLICATION_ID: i32 = 0x4252_4749;
-const STORAGE_VERSION: u32 = 2;
+const STORAGE_VERSION: u32 = 3;
 const BUILDING: i64 = 1;
 const COMPLETE: i64 = 2;
 const DEFINITION_DIGEST_DOMAIN: &[u8] = b"briskdb.global-index.definition.v1\0";
@@ -49,7 +51,7 @@ const VALUE_REQUEST_DIGEST_DOMAIN: &[u8] = b"briskdb.global-index.value-operatio
 const SCHEMA_SQL: &str = "
 CREATE TABLE briskdb_global_index_storage (
     singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
-    storage_version INTEGER NOT NULL CHECK (storage_version = 2),
+    storage_version INTEGER NOT NULL CHECK (storage_version = 3),
     key_encoding_version INTEGER NOT NULL CHECK (key_encoding_version = 1)
 ) STRICT;
 
@@ -97,7 +99,7 @@ CREATE TABLE briskdb_global_index_unique_keys (
 
 INSERT INTO briskdb_global_index_storage (
     singleton, storage_version, key_encoding_version
-) VALUES (1, 2, 1);
+) VALUES (1, 3, 1);
 ";
 
 const AUTHORITY_SCHEMA_SQL: &str = "
@@ -164,6 +166,24 @@ CREATE TABLE briskdb_global_value_leases (
 ) STRICT, WITHOUT ROWID;
 ";
 
+const READ_REPAIR_SCHEMA_SQL: &str = "
+CREATE TABLE briskdb_global_index_read_repairs (
+    index_id INTEGER NOT NULL CHECK (index_id > 0),
+    encoded_key BLOB NOT NULL,
+    source_shard INTEGER NOT NULL CHECK (source_shard BETWEEN 0 AND 63),
+    source_locator BLOB NOT NULL,
+    repair_kind INTEGER NOT NULL CHECK (repair_kind IN (1, 2, 3)),
+    repair_state INTEGER NOT NULL CHECK (repair_state IN (1, 2)),
+    observation_count INTEGER NOT NULL CHECK (observation_count > 0),
+    PRIMARY KEY (index_id, encoded_key, source_shard, source_locator),
+    FOREIGN KEY (index_id) REFERENCES briskdb_global_index_builds (index_id)
+        ON DELETE CASCADE
+) STRICT, WITHOUT ROWID;
+
+CREATE INDEX briskdb_global_index_read_repairs_state
+    ON briskdb_global_index_read_repairs (repair_state, index_id);
+";
+
 const UPGRADE_V1_TO_V2_SQL: &str = "
 ALTER TABLE briskdb_global_index_storage RENAME TO briskdb_global_index_storage_v1;
 CREATE TABLE briskdb_global_index_storage (
@@ -178,6 +198,20 @@ DROP TABLE briskdb_global_index_storage_v1;
 PRAGMA user_version = 2;
 ";
 
+const UPGRADE_V2_TO_V3_SQL: &str = "
+ALTER TABLE briskdb_global_index_storage RENAME TO briskdb_global_index_storage_v2;
+CREATE TABLE briskdb_global_index_storage (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    storage_version INTEGER NOT NULL CHECK (storage_version = 3),
+    key_encoding_version INTEGER NOT NULL CHECK (key_encoding_version = 1)
+) STRICT;
+INSERT INTO briskdb_global_index_storage (
+    singleton, storage_version, key_encoding_version
+) VALUES (1, 3, 1);
+DROP TABLE briskdb_global_index_storage_v2;
+PRAGMA user_version = 3;
+";
+
 const EXPECTED_OBJECTS_V1: &[&str] = &[
     "briskdb_global_index_builds",
     "briskdb_global_index_checkpoints",
@@ -186,10 +220,26 @@ const EXPECTED_OBJECTS_V1: &[&str] = &[
     "briskdb_global_index_unique_keys",
 ];
 
+const EXPECTED_OBJECTS_V2: &[&str] = &[
+    "briskdb_global_index_builds",
+    "briskdb_global_index_checkpoints",
+    "briskdb_global_index_entries",
+    "briskdb_global_index_storage",
+    "briskdb_global_index_unique_keys",
+    "briskdb_global_operations",
+    "briskdb_global_unique_mutations",
+    "briskdb_global_unique_reservations",
+    "briskdb_global_unique_reservations_operation",
+    "briskdb_global_value_leases",
+    "briskdb_global_value_sequences",
+];
+
 const EXPECTED_OBJECTS: &[&str] = &[
     "briskdb_global_index_builds",
     "briskdb_global_index_checkpoints",
     "briskdb_global_index_entries",
+    "briskdb_global_index_read_repairs",
+    "briskdb_global_index_read_repairs_state",
     "briskdb_global_index_storage",
     "briskdb_global_index_unique_keys",
     "briskdb_global_operations",
@@ -232,12 +282,18 @@ impl SourceLocator {
     }
 
     fn predicate_sql(&self) -> String {
+        self.predicate_sql_with_offset(0)
+    }
+
+    fn predicate_sql_with_offset(&self, offset: usize) -> String {
         match self {
-            Self::RowId(name) => format!("{} = ?1", quote_identifier(name)),
+            Self::RowId(name) => format!("{} = ?{}", quote_identifier(name), offset + 1),
             Self::PrimaryKey(columns) => columns
                 .iter()
                 .enumerate()
-                .map(|(offset, column)| format!("{} IS ?{}", quote_identifier(column), offset + 1))
+                .map(|(index, column)| {
+                    format!("{} IS ?{}", quote_identifier(column), offset + index + 1)
+                })
                 .collect::<Vec<_>>()
                 .join(" AND "),
         }
@@ -264,6 +320,35 @@ struct PhysicalEntry {
     source_ordinal: u64,
     encoded_key: Vec<u8>,
     source_locator: Vec<u8>,
+}
+
+#[derive(Debug, Clone)]
+struct ReadCandidate {
+    key: CanonicalIndexKey,
+    owner: GlobalIndexOwner,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReadRepairKind {
+    MissingRow,
+    MismatchedKey,
+    InvalidLocator,
+}
+
+impl ReadRepairKind {
+    const fn code(self) -> i64 {
+        match self {
+            Self::MissingRow => 1,
+            Self::MismatchedKey => 2,
+            Self::InvalidLocator => 3,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct StaleReadCandidate {
+    candidate: ReadCandidate,
+    kind: ReadRepairKind,
 }
 
 #[derive(Debug)]
@@ -319,7 +404,7 @@ pub(super) fn startup_requires_upgrade(root: &Path) -> EngineResult<bool> {
         .map_err(sqlite_error::storage)?;
     match version {
         STORAGE_VERSION => Ok(false),
-        1 => Ok(true),
+        1 | 2 => Ok(true),
         version if version > STORAGE_VERSION => Err(EngineError::new(
             EngineErrorKind::FailedPrecondition,
             format!("global-index storage version {version} is newer than this build"),
@@ -343,15 +428,30 @@ pub(super) fn upgrade_if_needed(root: &Path) -> EngineResult<()> {
     )
     .map_err(sqlite_error::storage)?;
     configure(&connection)?;
-    validate_storage_contents(&connection, 1, EXPECTED_OBJECTS_V1)?;
+    let version: u32 = connection
+        .pragma_query_value(None, "user_version", |row| row.get(0))
+        .map_err(sqlite_error::storage)?;
+    match version {
+        1 => validate_storage_contents(&connection, 1, EXPECTED_OBJECTS_V1)?,
+        2 => validate_storage_contents(&connection, 2, EXPECTED_OBJECTS_V2)?,
+        _ => return validate(&connection),
+    }
     let transaction = connection
         .transaction_with_behavior(TransactionBehavior::Immediate)
         .map_err(sqlite_error::storage)?;
+    if version == 1 {
+        transaction
+            .execute_batch(UPGRADE_V1_TO_V2_SQL)
+            .map_err(sqlite_error::storage)?;
+        transaction
+            .execute_batch(AUTHORITY_SCHEMA_SQL)
+            .map_err(sqlite_error::storage)?;
+    }
     transaction
-        .execute_batch(UPGRADE_V1_TO_V2_SQL)
+        .execute_batch(UPGRADE_V2_TO_V3_SQL)
         .map_err(sqlite_error::storage)?;
     transaction
-        .execute_batch(AUTHORITY_SCHEMA_SQL)
+        .execute_batch(READ_REPAIR_SCHEMA_SQL)
         .map_err(sqlite_error::storage)?;
     abort_at_authority_test_boundary("upgrade-before-commit");
     transaction.commit().map_err(sqlite_error::storage)?;
@@ -367,12 +467,13 @@ pub(super) fn downgrade_to_v1_for_test(root: &Path) {
     connection
         .execute_batch(
             "PRAGMA foreign_keys = OFF;
+             DROP TABLE briskdb_global_index_read_repairs;
              DROP TABLE briskdb_global_unique_reservations;
              DROP TABLE briskdb_global_unique_mutations;
              DROP TABLE briskdb_global_value_leases;
              DROP TABLE briskdb_global_value_sequences;
              DROP TABLE briskdb_global_operations;
-             ALTER TABLE briskdb_global_index_storage RENAME TO briskdb_global_index_storage_v2;
+             ALTER TABLE briskdb_global_index_storage RENAME TO briskdb_global_index_storage_v3;
              CREATE TABLE briskdb_global_index_storage (
                  singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
                  storage_version INTEGER NOT NULL CHECK (storage_version = 1),
@@ -381,8 +482,32 @@ pub(super) fn downgrade_to_v1_for_test(root: &Path) {
              INSERT INTO briskdb_global_index_storage (
                  singleton, storage_version, key_encoding_version
              ) VALUES (1, 1, 1);
-             DROP TABLE briskdb_global_index_storage_v2;
+             DROP TABLE briskdb_global_index_storage_v3;
              PRAGMA user_version = 1;
+             PRAGMA wal_checkpoint(TRUNCATE);",
+        )
+        .unwrap();
+}
+
+#[cfg(test)]
+pub(super) fn downgrade_to_v2_for_test(root: &Path) {
+    let path = root.join(DIRECTORY_NAME).join(SHARED_FILE_NAME);
+    let connection = Connection::open(&path).unwrap();
+    connection
+        .execute_batch(
+            "PRAGMA foreign_keys = OFF;
+             DROP TABLE briskdb_global_index_read_repairs;
+             ALTER TABLE briskdb_global_index_storage RENAME TO briskdb_global_index_storage_v3;
+             CREATE TABLE briskdb_global_index_storage (
+                 singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+                 storage_version INTEGER NOT NULL CHECK (storage_version = 2),
+                 key_encoding_version INTEGER NOT NULL CHECK (key_encoding_version = 1)
+             ) STRICT;
+             INSERT INTO briskdb_global_index_storage (
+                 singleton, storage_version, key_encoding_version
+             ) VALUES (1, 2, 1);
+             DROP TABLE briskdb_global_index_storage_v3;
+             PRAGMA user_version = 2;
              PRAGMA wal_checkpoint(TRUNCATE);",
         )
         .unwrap();
@@ -658,6 +783,367 @@ pub(super) fn lookup_authoritative_owners(
             .then_with(|| left.locator().cmp(right.locator()))
     });
     Ok(owners)
+}
+
+/// Verify bounded non-unique index candidates against their physical row
+/// identity and the caller's complete predicate. The result deliberately
+/// remains incomplete until #237 freshness watermarks prove which shards can
+/// be excluded. Stale observations enqueue idempotent durable tombstones;
+/// those records never alter unique authority or base index entries.
+pub(super) fn verify_nonunique_candidates(
+    storage: &Storage,
+    index: &GlobalIndexMetadata,
+    keys: &[CanonicalIndexKey],
+    query_predicate_sql: &str,
+    query_table_alias: Option<&str>,
+    parameters: &[Value],
+    read_control: (&CancellationToken, Option<Instant>),
+) -> EngineResult<GlobalIndexReadResolution> {
+    let (cancellation, deadline) = read_control;
+    ensure_read_control(
+        cancellation,
+        deadline,
+        "before reading global-index candidates",
+    )?;
+    if keys.is_empty() {
+        return Ok(GlobalIndexReadResolution::candidates(
+            Vec::new(),
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ));
+    }
+    let (connection, _) = open_existing(&storage.root)?
+        .ok_or_else(|| corrupt("ready global index has no physical storage"))?;
+    connection
+        .busy_timeout(std::time::Duration::ZERO)
+        .map_err(sqlite_error::storage)?;
+    let transaction = connection
+        .unchecked_transaction()
+        .map_err(sqlite_error::storage)?;
+    validate_physical_authority(&transaction, index, storage.shard_count())?;
+    let candidates =
+        read_nonunique_candidates(&transaction, index.id(), keys, storage.shard_count())?;
+    transaction.commit().map_err(sqlite_error::storage)?;
+    let Some(candidates) = candidates else {
+        return Ok(GlobalIndexReadResolution::candidate_limit_exceeded(
+            MAX_GLOBAL_INDEX_READ_CANDIDATES + 1,
+        ));
+    };
+    let candidate_count = candidates.len();
+
+    let table = storage
+        .catalog
+        .logical()
+        .table_by_id(index.table_id())
+        .ok_or_else(|| corrupt("global index references a missing table"))?;
+    let locator_connection = storage.open_shard(0)?;
+    let locator = inspect_source_locator(&locator_connection, table.name())?;
+    drop(locator_connection);
+    let locator_offset = parameters.len();
+    let key_expressions = index
+        .key_parts()
+        .iter()
+        .map(|part| match part.source() {
+            GlobalIndexKeySource::Column(column) => quote_identifier(column),
+            GlobalIndexKeySource::Expression(expression) => format!("({expression})"),
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    let alias = query_table_alias
+        .map(|alias| format!(" AS {}", quote_identifier(alias)))
+        .unwrap_or_default();
+    let verification_sql = format!(
+        "SELECT {key_expressions}, CASE WHEN ({query_predicate_sql}) THEN 1 ELSE 0 END
+         FROM main.{}{alias} WHERE ({})",
+        quote_identifier(table.name()),
+        locator.predicate_sql_with_offset(locator_offset),
+    );
+    let query_parameters = crate::sql::sqlite_parameters(parameters)?;
+    let mut candidates_by_shard = BTreeMap::<u16, Vec<&ReadCandidate>>::new();
+    for candidate in &candidates {
+        candidates_by_shard
+            .entry(candidate.owner.source_shard())
+            .or_default()
+            .push(candidate);
+    }
+
+    let mut verified = Vec::new();
+    let mut rejected_count = 0_usize;
+    let mut stale = Vec::new();
+    for (shard, shard_candidates) in candidates_by_shard {
+        ensure_read_control(
+            cancellation,
+            deadline,
+            "while verifying global-index candidates",
+        )?;
+        let source = storage.open_shard(shard)?;
+        let mut statement = source
+            .prepare_cached(&verification_sql)
+            .map_err(sqlite_error::statement)?;
+        for candidate in shard_candidates {
+            ensure_read_control(
+                cancellation,
+                deadline,
+                "while verifying a global-index candidate",
+            )?;
+            let locator_values =
+                match decode_locator(candidate.owner.locator(), locator.expressions().len()) {
+                    Ok(values) => values,
+                    Err(error) if error.kind() == EngineErrorKind::DataCorruption => {
+                        stale.push(StaleReadCandidate {
+                            candidate: candidate.clone(),
+                            kind: ReadRepairKind::InvalidLocator,
+                        });
+                        continue;
+                    }
+                    Err(error) => return Err(error),
+                };
+            let mut bound = query_parameters.clone();
+            bound.extend(locator_values);
+            let mut rows = statement
+                .query(rusqlite::params_from_iter(bound))
+                .map_err(sqlite_error::statement)?;
+            let Some(row) = rows.next().map_err(sqlite_error::statement)? else {
+                stale.push(StaleReadCandidate {
+                    candidate: candidate.clone(),
+                    kind: ReadRepairKind::MissingRow,
+                });
+                continue;
+            };
+            let (observed_key, _) = read_source_key(row, index, shard)?;
+            let matches_query = row
+                .get::<_, i64>(index.key_parts().len())
+                .map_err(sqlite_error::statement)?
+                == 1;
+            if rows.next().map_err(sqlite_error::statement)?.is_some() {
+                return Err(corrupt(
+                    "global-index candidate locator identifies multiple physical rows",
+                ));
+            }
+            if observed_key != candidate.key {
+                stale.push(StaleReadCandidate {
+                    candidate: candidate.clone(),
+                    kind: ReadRepairKind::MismatchedKey,
+                });
+            } else if matches_query {
+                verified.push(candidate.owner.clone());
+            } else {
+                rejected_count += 1;
+            }
+        }
+    }
+
+    ensure_read_control(
+        cancellation,
+        deadline,
+        "before queuing global-index read repair",
+    )?;
+    let stale_count = stale.len();
+    let (repairs_queued, repairs_applied, repairs_deferred) =
+        match queue_and_apply_read_repairs(storage, index, &stale, cancellation, deadline) {
+            Ok(counts) => counts,
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    EngineErrorKind::Cancelled | EngineErrorKind::DeadlineExceeded
+                ) =>
+            {
+                return Err(error);
+            }
+            Err(_) => (0, 0, stale_count),
+        };
+    Ok(GlobalIndexReadResolution::candidates(
+        verified,
+        candidate_count,
+        candidate_count - rejected_count - stale_count,
+        rejected_count,
+        stale_count,
+        repairs_queued,
+        repairs_applied,
+        repairs_deferred,
+    ))
+}
+
+fn read_nonunique_candidates(
+    transaction: &Transaction<'_>,
+    index_id: GlobalIndexId,
+    keys: &[CanonicalIndexKey],
+    shard_count: u16,
+) -> EngineResult<Option<Vec<ReadCandidate>>> {
+    let mut statement = transaction
+        .prepare_cached(
+            "SELECT entries.source_shard, entries.source_locator
+             FROM briskdb_global_index_entries AS entries
+             WHERE entries.index_id = ?1 AND entries.encoded_key = ?2
+               AND NOT EXISTS (
+                   SELECT 1 FROM briskdb_global_index_read_repairs AS repairs
+                   WHERE repairs.index_id = entries.index_id
+                     AND repairs.encoded_key = entries.encoded_key
+                     AND repairs.source_shard = entries.source_shard
+                     AND repairs.source_locator = entries.source_locator
+                     AND repairs.repair_state = 2
+               )
+             ORDER BY entries.source_shard, entries.source_locator",
+        )
+        .map_err(sqlite_error::storage)?;
+    let mut candidates = Vec::new();
+    for key in keys {
+        let mut rows = statement
+            .query(params![to_sqlite_id(index_id)?, key.as_bytes()])
+            .map_err(sqlite_error::storage)?;
+        while let Some(row) = rows.next().map_err(sqlite_error::storage)? {
+            if candidates.len() == MAX_GLOBAL_INDEX_READ_CANDIDATES {
+                return Ok(None);
+            }
+            candidates.push(ReadCandidate {
+                key: key.clone(),
+                owner: read_lookup_owner(row, shard_count)?,
+            });
+        }
+    }
+    Ok(Some(candidates))
+}
+
+fn queue_and_apply_read_repairs(
+    storage: &Storage,
+    index: &GlobalIndexMetadata,
+    stale: &[StaleReadCandidate],
+    cancellation: &CancellationToken,
+    deadline: Option<Instant>,
+) -> EngineResult<(usize, usize, usize)> {
+    let bounded = stale
+        .iter()
+        .take(MAX_GLOBAL_INDEX_READ_REPAIRS)
+        .collect::<Vec<_>>();
+    let overflow = stale.len().saturating_sub(bounded.len());
+    if bounded.is_empty() {
+        return Ok((0, 0, overflow));
+    }
+    let (mut connection, _) = open_existing(&storage.root)?
+        .ok_or_else(|| corrupt("ready global index has no physical storage"))?;
+    connection
+        .busy_timeout(std::time::Duration::ZERO)
+        .map_err(sqlite_error::storage)?;
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    validate_physical_authority(&transaction, index, storage.shard_count())?;
+    let mut queued = Vec::new();
+    for repair in bounded {
+        ensure_read_control(
+            cancellation,
+            deadline,
+            "while queuing global-index read repair",
+        )?;
+        let candidate = &repair.candidate;
+        transaction
+            .execute(
+                "INSERT INTO briskdb_global_index_read_repairs (
+                     index_id, encoded_key, source_shard, source_locator,
+                     repair_kind, repair_state, observation_count
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, 1, 1)
+                 ON CONFLICT (index_id, encoded_key, source_shard, source_locator)
+                 DO UPDATE SET
+                     repair_kind = excluded.repair_kind,
+                     observation_count = CASE
+                         WHEN observation_count < 9223372036854775807
+                         THEN observation_count + 1
+                         ELSE observation_count
+                     END",
+                params![
+                    to_sqlite_id(index.id())?,
+                    candidate.key.as_bytes(),
+                    i64::from(candidate.owner.source_shard()),
+                    candidate.owner.locator(),
+                    repair.kind.code(),
+                ],
+            )
+            .map_err(sqlite_error::storage)?;
+        let state = transaction
+            .query_row(
+                "SELECT repair_state FROM briskdb_global_index_read_repairs
+                 WHERE index_id = ?1 AND encoded_key = ?2
+                   AND source_shard = ?3 AND source_locator = ?4",
+                params![
+                    to_sqlite_id(index.id())?,
+                    candidate.key.as_bytes(),
+                    i64::from(candidate.owner.source_shard()),
+                    candidate.owner.locator(),
+                ],
+                |row| row.get::<_, i64>(0),
+            )
+            .map_err(sqlite_error::storage)?;
+        if state == 1 {
+            queued.push((*repair).clone());
+        }
+    }
+    abort_at_authority_test_boundary("read-repair-before-enqueue-commit");
+    transaction.commit().map_err(sqlite_error::storage)?;
+    abort_at_authority_test_boundary("read-repair-after-enqueue-commit");
+    if queued.is_empty() {
+        return Ok((0, 0, overflow));
+    }
+
+    ensure_read_control(
+        cancellation,
+        deadline,
+        "before applying global-index read repair",
+    )?;
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    let mut applied = 0_usize;
+    for repair in &queued {
+        ensure_read_control(
+            cancellation,
+            deadline,
+            "while applying global-index read repair",
+        )?;
+        let candidate = &repair.candidate;
+        applied += transaction
+            .execute(
+                "UPDATE briskdb_global_index_read_repairs SET repair_state = 2
+                 WHERE index_id = ?1 AND encoded_key = ?2
+                   AND source_shard = ?3 AND source_locator = ?4
+                   AND repair_state = 1",
+                params![
+                    to_sqlite_id(index.id())?,
+                    candidate.key.as_bytes(),
+                    i64::from(candidate.owner.source_shard()),
+                    candidate.owner.locator(),
+                ],
+            )
+            .map_err(sqlite_error::storage)?;
+    }
+    abort_at_authority_test_boundary("read-repair-before-apply-commit");
+    transaction.commit().map_err(sqlite_error::storage)?;
+    abort_at_authority_test_boundary("read-repair-after-apply-commit");
+    Ok((queued.len(), applied, overflow))
+}
+
+fn ensure_read_control(
+    cancellation: &CancellationToken,
+    deadline: Option<Instant>,
+    context: &str,
+) -> EngineResult<()> {
+    if cancellation.is_cancelled() {
+        return Err(EngineError::new(
+            EngineErrorKind::Cancelled,
+            format!("global-index read was cancelled {context}"),
+        ));
+    }
+    if deadline.is_some_and(|deadline| Instant::now() >= deadline) {
+        return Err(EngineError::new(
+            EngineErrorKind::DeadlineExceeded,
+            format!("global-index read deadline elapsed {context}"),
+        ));
+    }
+    Ok(())
 }
 
 fn read_lookup_owner(row: &rusqlite::Row<'_>, shard_count: u16) -> EngineResult<GlobalIndexOwner> {
@@ -2240,6 +2726,7 @@ pub(super) fn repair_non_unique(
         "briskdb_global_index_unique_keys",
         "briskdb_global_index_entries",
         "briskdb_global_index_checkpoints",
+        "briskdb_global_index_read_repairs",
     ] {
         transaction
             .execute(
@@ -4361,6 +4848,9 @@ fn initialize(connection: &Connection) -> EngineResult<()> {
         .map_err(sqlite_error::storage)?;
     connection
         .execute_batch(AUTHORITY_SCHEMA_SQL)
+        .map_err(sqlite_error::storage)?;
+    connection
+        .execute_batch(READ_REPAIR_SCHEMA_SQL)
         .map_err(sqlite_error::storage)?;
     validate(connection)
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1650,17 +1650,34 @@ impl Storage {
         self.fail_closed_on_corruption(result)
     }
 
-    pub(crate) fn global_index_read_candidates(
+    pub(crate) fn global_index_read_resolution(
         &self,
         index_id: GlobalIndexId,
         keys: &[crate::core::CanonicalIndexKey],
-    ) -> EngineResult<Vec<crate::core::GlobalIndexOwner>> {
+        query_predicate_sql: &str,
+        query_table_alias: Option<&str>,
+        parameters: &[crate::core::Value],
+        read_control: (&crate::core::CancellationToken, Option<Instant>),
+    ) -> EngineResult<crate::core::GlobalIndexReadResolution> {
         (|| {
-            let index = self.validate_authority_index(index_id, true, false)?;
+            let index = self.validate_authority_index(index_id, false, false)?;
             for key in keys {
                 self.validate_authority_key(index, key)?;
             }
-            global_index::lookup_authoritative_owners(self, index, keys)
+            if index.is_unique() {
+                global_index::lookup_authoritative_owners(self, index, keys)
+                    .map(crate::core::GlobalIndexReadResolution::authoritative)
+            } else {
+                global_index::verify_nonunique_candidates(
+                    self,
+                    index,
+                    keys,
+                    query_predicate_sql,
+                    query_table_alias,
+                    parameters,
+                    read_control,
+                )
+            }
         })()
     }
 
@@ -6667,6 +6684,26 @@ mod tests {
                 .unwrap();
                 database.repair_global_index(id).map(|_| ())
             }
+            "read-repair" => {
+                let logical_database = database.catalog().default_database().id();
+                let parsed = crate::sql::parse(
+                    crate::sql::SqlDialect::Sqlite,
+                    "SELECT id FROM events WHERE payload = ?1",
+                )
+                .unwrap();
+                let common = crate::sql::validate_common_subset(parsed).unwrap();
+                let normalized = crate::sql::normalize_placeholders(common).unwrap();
+                let engine = crate::core::Engine::from_database(Arc::new(database));
+                engine
+                    .plan_bound_statement(
+                        logical_database,
+                        &normalized,
+                        0,
+                        &[crate::core::Value::from(vec![1_u8, 2, 3])],
+                        None,
+                    )
+                    .map(|_| ())
+            }
             "authority-reserve" => {
                 let (id, operation, mutation) = authority_crash_request();
                 debug_assert_eq!(id, mutation.index_id());
@@ -7086,7 +7123,7 @@ mod tests {
     fn global_authority_format_upgrade_recovers_from_real_process_abort() {
         for (boundary, expected_version) in [
             ("upgrade-before-commit", 1_i64),
-            ("upgrade-after-commit", 2_i64),
+            ("upgrade-after-commit", 3_i64),
         ] {
             let temp = tempfile::tempdir().unwrap();
             setup_upgrade_test_root(temp.path());
@@ -7110,6 +7147,167 @@ mod tests {
             drop(Database::open(temp.path(), 2).unwrap());
             let canonical = fs::canonicalize(temp.path()).unwrap();
             assert!(!global_index::startup_requires_upgrade(&canonical).unwrap());
+        }
+    }
+
+    #[test]
+    fn global_authority_v2_upgrade_preserves_ready_index_data() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut database = setup_global_index_root(temp.path());
+        database
+            .execute(
+                "v2-upgrade-route",
+                "INSERT INTO events (id, tenant_id, payload) VALUES (1, ?1, ?2)",
+                &[
+                    crate::core::Value::from("v2-upgrade-route"),
+                    crate::core::Value::from(vec![1_u8, 2, 3]),
+                ],
+            )
+            .unwrap();
+        let index = database
+            .create_global_index(global_index_test_declaration(&database))
+            .unwrap();
+        database.build_global_index(index).unwrap();
+        drop(database);
+        global_index::downgrade_to_v2_for_test(temp.path());
+
+        let mut database = Database::open(temp.path(), 2).unwrap();
+        assert!(database.validate_global_index(index).unwrap().is_valid());
+        let authority = Connection::open(temp.path().join("global-indexes/global.sqlite")).unwrap();
+        assert_eq!(
+            authority
+                .query_row("PRAGMA user_version", [], |row| row.get::<_, i64>(0))
+                .unwrap(),
+            3
+        );
+        assert_eq!(
+            authority
+                .query_row(
+                    "SELECT COUNT(*) FROM briskdb_global_index_entries WHERE index_id = ?1",
+                    [i64::try_from(index.get()).unwrap()],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            1
+        );
+        assert!(
+            authority
+                .query_row(
+                    "SELECT EXISTS(
+                         SELECT 1 FROM sqlite_schema
+                         WHERE name = 'briskdb_global_index_read_repairs'
+                     )",
+                    [],
+                    |row| row.get::<_, bool>(0),
+                )
+                .unwrap()
+        );
+    }
+
+    fn setup_stale_read_repair_root(root: &Path) -> GlobalIndexId {
+        let mut database = setup_global_index_root(root);
+        database
+            .execute(
+                "read-repair-route",
+                "INSERT INTO events (id, tenant_id, payload) VALUES (1, ?1, ?2)",
+                &[
+                    crate::core::Value::from("read-repair-route"),
+                    crate::core::Value::from(vec![1_u8, 2, 3]),
+                ],
+            )
+            .unwrap();
+        let index = database
+            .create_global_index(global_index_test_declaration(&database))
+            .unwrap();
+        database.build_global_index(index).unwrap();
+        let shard = database.shard_for_key(&crate::core::canonical_shard_key_bytes(
+            crate::core::CanonicalShardKeyRef::Text("read-repair-route"),
+        ));
+        drop(database);
+        Connection::open(shard_file(root, shard))
+            .unwrap()
+            .execute(
+                "DELETE FROM events WHERE tenant_id = ?1 AND id = 1",
+                ["read-repair-route"],
+            )
+            .unwrap();
+        index
+    }
+
+    fn plan_stale_read_repair(root: &Path) -> crate::core::GlobalIndexRoutingPlan {
+        let database = Arc::new(Database::open(root, 2).unwrap());
+        let logical_database = database.catalog().default_database().id();
+        let engine = crate::core::Engine::from_database(database);
+        let parsed = crate::sql::parse(
+            crate::sql::SqlDialect::Sqlite,
+            "SELECT id FROM events WHERE payload = ?1",
+        )
+        .unwrap();
+        let common = crate::sql::validate_common_subset(parsed).unwrap();
+        let normalized = crate::sql::normalize_placeholders(common).unwrap();
+        engine
+            .plan_bound_statement(
+                logical_database,
+                &normalized,
+                0,
+                &[crate::core::Value::from(vec![1_u8, 2, 3])],
+                None,
+            )
+            .unwrap()
+            .global_index_routing()
+            .clone()
+    }
+
+    #[test]
+    fn global_index_read_repair_recovers_at_every_transaction_boundary() {
+        for (boundary, expected_state) in [
+            ("read-repair-before-enqueue-commit", None),
+            ("read-repair-after-enqueue-commit", Some(1_i64)),
+            ("read-repair-before-apply-commit", Some(1_i64)),
+            ("read-repair-after-apply-commit", Some(2_i64)),
+        ] {
+            let temp = tempfile::tempdir().unwrap();
+            let index = setup_stale_read_repair_root(temp.path());
+            abort_global_index_child(temp.path(), "read-repair", boundary, Some(index));
+            let authority =
+                Connection::open(temp.path().join("global-indexes/global.sqlite")).unwrap();
+            let state = authority
+                .query_row(
+                    "SELECT repair_state FROM briskdb_global_index_read_repairs
+                     WHERE index_id = ?1",
+                    [i64::try_from(index.get()).unwrap()],
+                    |row| row.get::<_, i64>(0),
+                )
+                .optional()
+                .unwrap();
+            assert_eq!(state, expected_state, "boundary {boundary}");
+            drop(authority);
+
+            let recovered = plan_stale_read_repair(temp.path());
+            assert_eq!(
+                recovered.fallback_reason(),
+                Some(crate::core::GlobalIndexRoutingFallback::FreshnessUnproven)
+            );
+            let authority =
+                Connection::open(temp.path().join("global-indexes/global.sqlite")).unwrap();
+            assert_eq!(
+                authority
+                    .query_row(
+                        "SELECT COUNT(*) FROM briskdb_global_index_read_repairs
+                         WHERE index_id = ?1 AND repair_state = 2",
+                        [i64::try_from(index.get()).unwrap()],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .unwrap(),
+                1,
+                "boundary {boundary} did not converge"
+            );
+            drop(authority);
+
+            let retry = plan_stale_read_repair(temp.path());
+            assert_eq!(retry.candidate_count(), 0);
+            assert_eq!(retry.stale_candidate_count(), 0);
+            assert_eq!(retry.repairs_queued(), 0);
         }
     }
 

--- a/tests/global_index_candidate_verification.rs
+++ b/tests/global_index_candidate_verification.rs
@@ -1,0 +1,406 @@
+use std::{path::Path, sync::Arc, time::Instant};
+
+use briskdb::core::{
+    CancellationToken, Database, Engine, EngineErrorKind, RequestContext, ShardKeyMetadata,
+    ShardKeyType, TableDeclaration,
+};
+use briskdb::{
+    CanonicalIndexKey, GlobalIndexDeclaration, GlobalIndexKeyPart, GlobalIndexKeySource,
+    GlobalIndexKeyType, GlobalIndexRoutingFallback, GlobalIndexRoutingKind,
+    GlobalIndexStorageTopology, Statement, Value,
+};
+use proptest::prelude::*;
+use rusqlite::{Connection, params};
+
+const SHARED_EMAIL: &str = "shared@example.test";
+
+fn route_for_each_shard(database: &Database) -> Vec<String> {
+    let mut routes = vec![None; usize::from(database.shard_count())];
+    for value in 0_u64..100_000 {
+        let route = format!("candidate-tenant-{value}");
+        let shard = usize::from(database.shard_for_key(route.as_bytes()));
+        routes[shard].get_or_insert(route);
+        if routes.iter().all(Option::is_some) {
+            return routes.into_iter().map(Option::unwrap).collect();
+        }
+    }
+    panic!("failed to find one candidate-verification route per shard");
+}
+
+fn normalized(dialect: briskdb::SqlDialect, source: &str) -> briskdb::sql::NormalizedSql {
+    let parsed = briskdb::sql::parse(dialect, source).unwrap();
+    let common = briskdb::sql::validate_common_subset(parsed).unwrap();
+    briskdb::sql::normalize_placeholders(common).unwrap()
+}
+
+fn setup(root: &Path) -> (Arc<Database>, Engine, Vec<String>, briskdb::GlobalIndexId) {
+    let mut database = Database::open(root, 4).unwrap();
+    database
+        .broadcast(
+            "CREATE TABLE candidate_users (
+                 tenant_id TEXT NOT NULL,
+                 email TEXT NOT NULL,
+                 payload TEXT NOT NULL,
+                 PRIMARY KEY (tenant_id, email)
+             ) STRICT",
+        )
+        .unwrap();
+    let logical = database.catalog().default_database().id();
+    database
+        .register_tables(vec![
+            TableDeclaration::sharded(
+                logical,
+                "candidate_users",
+                ShardKeyMetadata::new("tenant_id", ShardKeyType::Text).unwrap(),
+            )
+            .unwrap(),
+        ])
+        .unwrap();
+    let routes = route_for_each_shard(&database);
+    for (shard, route) in routes.iter().enumerate() {
+        database
+            .execute(
+                route,
+                "INSERT INTO candidate_users (tenant_id, email, payload)
+                 VALUES (?1, ?2, ?3)",
+                &[
+                    route.clone().into(),
+                    SHARED_EMAIL.into(),
+                    if shard == 0 { "keep" } else { "reject" }.into(),
+                ],
+            )
+            .unwrap();
+    }
+    database
+        .execute(
+            &routes[0],
+            "INSERT INTO candidate_users (tenant_id, email, payload)
+             VALUES (?1, 'invalid@example.test', 'keep')",
+            &[routes[0].clone().into()],
+        )
+        .unwrap();
+    let table = database
+        .catalog()
+        .table("default", "candidate_users")
+        .unwrap()
+        .unwrap()
+        .id();
+    let index = database
+        .create_global_index(
+            GlobalIndexDeclaration::new(
+                table,
+                "candidate_users_email",
+                vec![GlobalIndexKeyPart::new(
+                    GlobalIndexKeySource::column("email").unwrap(),
+                    GlobalIndexKeyType::Text,
+                )],
+            )
+            .unwrap()
+            .with_topology(GlobalIndexStorageTopology::selected_v1()),
+        )
+        .unwrap();
+    database.build_global_index(index).unwrap();
+    let database = Arc::new(database);
+    let engine = Engine::from_database(Arc::clone(&database));
+    (database, engine, routes, index)
+}
+
+fn inject_stale_candidates(
+    root: &Path,
+    database: &Database,
+    routes: &[String],
+    index: briskdb::GlobalIndexId,
+) {
+    database
+        .execute(
+            &routes[2],
+            "DELETE FROM candidate_users WHERE tenant_id = ?1 AND email = ?2",
+            &[routes[2].clone().into(), SHARED_EMAIL.into()],
+        )
+        .unwrap();
+    database
+        .execute(
+            &routes[3],
+            "UPDATE candidate_users SET email = 'moved@example.test'
+             WHERE tenant_id = ?1 AND email = ?2",
+            &[routes[3].clone().into(), SHARED_EMAIL.into()],
+        )
+        .unwrap();
+
+    let shared = CanonicalIndexKey::encode_values(&[Value::from(SHARED_EMAIL)]).unwrap();
+    let invalid = CanonicalIndexKey::encode_values(&[Value::from("invalid@example.test")]).unwrap();
+    Connection::open(root.join("global-indexes/global.sqlite"))
+        .unwrap()
+        .execute(
+            "UPDATE briskdb_global_index_entries
+             SET encoded_key = ?1, source_locator = x'00'
+             WHERE index_id = ?2 AND encoded_key = ?3",
+            params![shared.as_bytes(), index.get() as i64, invalid.as_bytes()],
+        )
+        .unwrap();
+}
+
+#[tokio::test]
+async fn stale_candidates_are_verified_repaired_and_never_change_query_results() {
+    let temp = tempfile::tempdir().unwrap();
+    let (database, engine, routes, index) = setup(temp.path());
+    inject_stale_candidates(temp.path(), &database, &routes, index);
+    let logical = engine.catalog().default_database().id();
+    let query = normalized(
+        briskdb::SqlDialect::Sqlite,
+        "SELECT tenant_id, payload FROM candidate_users AS u
+         WHERE u.email = ?1 AND u.payload = ?2",
+    );
+    let plan = engine
+        .plan_bound_statement(
+            logical,
+            &query,
+            0,
+            &[SHARED_EMAIL.into(), "keep".into()],
+            None,
+        )
+        .unwrap();
+    let explain = plan.global_index_routing();
+    assert_eq!(explain.kind(), GlobalIndexRoutingKind::Fallback);
+    assert_eq!(
+        explain.fallback_reason(),
+        Some(GlobalIndexRoutingFallback::FreshnessUnproven)
+    );
+    assert!(!explain.authoritative());
+    assert_eq!(explain.candidate_count(), 5);
+    assert_eq!(explain.verified_candidate_count(), 1);
+    assert_eq!(explain.rejected_candidate_count(), 1);
+    assert_eq!(explain.stale_candidate_count(), 3);
+    assert_eq!(explain.repairs_queued(), 3);
+    assert_eq!(explain.repairs_applied(), 3);
+    assert_eq!(explain.repairs_deferred(), 0);
+    assert_eq!(explain.candidate_shards(), &[0]);
+    assert_eq!(explain.target_shards(), &[0, 1, 2, 3]);
+
+    let session = engine.session();
+    let indexed = engine
+        .query_logical(
+            &session,
+            Statement::new(
+                "SELECT tenant_id, payload FROM candidate_users
+                 WHERE email = ?1 AND payload = ?2",
+                vec![SHARED_EMAIL.into(), "keep".into()],
+            ),
+        )
+        .await
+        .unwrap();
+    let forced = engine
+        .query_logical(
+            &session,
+            Statement::new(
+                "SELECT tenant_id, payload FROM candidate_users
+                 WHERE (email = ?1 AND payload = ?2) OR payload = 'never-match'",
+                vec![SHARED_EMAIL.into(), "keep".into()],
+            ),
+        )
+        .await
+        .unwrap();
+    assert_eq!(indexed.shards, vec![0, 1, 2, 3]);
+    assert_eq!(indexed.value, forced.value);
+    assert_eq!(indexed.value.len(), 1);
+
+    let moved = engine
+        .query_logical(
+            &session,
+            Statement::new(
+                "SELECT tenant_id FROM candidate_users WHERE email = ?1",
+                vec!["moved@example.test".into()],
+            ),
+        )
+        .await
+        .unwrap();
+    assert_eq!(moved.shards, vec![0, 1, 2, 3]);
+    assert_eq!(moved.value.len(), 1);
+
+    let repair_database =
+        Connection::open(temp.path().join("global-indexes/global.sqlite")).unwrap();
+    let (repairs, minimum_observations) = repair_database
+        .query_row(
+            "SELECT COUNT(*), MIN(observation_count)
+             FROM briskdb_global_index_read_repairs
+             WHERE index_id = ?1 AND repair_state = 2",
+            [index.get() as i64],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+        )
+        .unwrap();
+    assert_eq!(repairs, 3);
+    assert_eq!(minimum_observations, 1);
+
+    let postgres = normalized(
+        briskdb::SqlDialect::PostgreSql,
+        "SELECT tenant_id FROM candidate_users AS u
+         WHERE u.email = $1 AND u.payload = $2",
+    );
+    let postgres_plan = engine
+        .plan_bound_statement(
+            logical,
+            &postgres,
+            0,
+            &[SHARED_EMAIL.into(), "keep".into()],
+            None,
+        )
+        .unwrap();
+    assert_eq!(
+        postgres_plan.global_index_routing().fallback_reason(),
+        Some(GlobalIndexRoutingFallback::FreshnessUnproven)
+    );
+}
+
+#[test]
+fn excessive_candidates_fall_back_before_physical_verification() {
+    let temp = tempfile::tempdir().unwrap();
+    let (_database, engine, _, index) = setup(temp.path());
+    let shared = CanonicalIndexKey::encode_values(&[Value::from(SHARED_EMAIL)]).unwrap();
+    let mut authority = Connection::open(temp.path().join("global-indexes/global.sqlite")).unwrap();
+    let transaction = authority.transaction().unwrap();
+    let first_ordinal = transaction
+        .query_row(
+            "SELECT COALESCE(MAX(source_ordinal), -1) + 1
+             FROM briskdb_global_index_entries
+             WHERE index_id = ?1 AND source_shard = 0",
+            [index.get() as i64],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap();
+    {
+        let mut insert = transaction
+            .prepare(
+                "INSERT INTO briskdb_global_index_entries (
+                     index_id, encoded_key, source_shard, source_ordinal, source_locator
+                 ) VALUES (?1, ?2, 0, ?3, ?4)",
+            )
+            .unwrap();
+        for offset in 0_i64..4_097 {
+            insert
+                .execute(params![
+                    index.get() as i64,
+                    shared.as_bytes(),
+                    first_ordinal + offset,
+                    offset.to_be_bytes().to_vec(),
+                ])
+                .unwrap();
+        }
+    }
+    transaction.commit().unwrap();
+
+    let logical = engine.catalog().default_database().id();
+    let query = normalized(
+        briskdb::SqlDialect::Sqlite,
+        "SELECT tenant_id FROM candidate_users WHERE email = ?1",
+    );
+    let plan = engine
+        .plan_bound_statement(logical, &query, 0, &[SHARED_EMAIL.into()], None)
+        .unwrap();
+    assert_eq!(
+        plan.global_index_routing().fallback_reason(),
+        Some(GlobalIndexRoutingFallback::TooManyCandidates)
+    );
+    assert!(plan.global_index_routing().candidate_count() > 4_096);
+    assert_eq!(plan.global_index_routing().target_shards(), &[0, 1, 2, 3]);
+    assert_eq!(plan.global_index_routing().repairs_queued(), 0);
+}
+
+#[tokio::test]
+async fn cancelled_and_expired_candidate_queries_stop_before_execution_and_recover() {
+    let temp = tempfile::tempdir().unwrap();
+    let (_database, engine, _, _) = setup(temp.path());
+    let session = engine.session();
+    let statement = || {
+        Statement::new(
+            "SELECT tenant_id FROM candidate_users WHERE email = ?1",
+            vec![SHARED_EMAIL.into()],
+        )
+    };
+
+    let cancellation = CancellationToken::new();
+    cancellation.cancel();
+    let cancelled = engine
+        .query_logical_with_context(
+            &session,
+            statement(),
+            RequestContext::new().with_cancellation_token(cancellation),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(cancelled.kind(), EngineErrorKind::Cancelled);
+
+    let expired = engine
+        .query_logical_with_context(
+            &session,
+            statement(),
+            RequestContext::new().with_deadline(Instant::now()),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(expired.kind(), EngineErrorKind::DeadlineExceeded);
+
+    assert_eq!(
+        engine
+            .query_logical(&session, statement())
+            .await
+            .unwrap()
+            .value
+            .len(),
+        4
+    );
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(12))]
+
+    #[test]
+    fn indexed_reads_match_forced_scans_under_staleness(
+        email_choice in 0_usize..4,
+        payload_choice in 0_usize..3,
+    ) {
+        let emails = [
+            SHARED_EMAIL,
+            "moved@example.test",
+            "invalid@example.test",
+            "missing@example.test",
+        ];
+        let payloads = ["keep", "reject", "missing"];
+        let temp = tempfile::tempdir().unwrap();
+        let (database, engine, routes, index) = setup(temp.path());
+        inject_stale_candidates(temp.path(), &database, &routes, index);
+        let session = engine.session();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let (indexed, forced) = runtime.block_on(async {
+            let parameters = vec![emails[email_choice].into(), payloads[payload_choice].into()];
+            let indexed = engine
+                .query_logical(
+                    &session,
+                    Statement::new(
+                        "SELECT tenant_id, email, payload FROM candidate_users
+                         WHERE email = ?1 AND payload = ?2",
+                        parameters.clone(),
+                    ),
+                )
+                .await
+                .unwrap();
+            let forced = engine
+                .query_logical(
+                    &session,
+                    Statement::new(
+                        "SELECT tenant_id, email, payload FROM candidate_users
+                         WHERE (email = ?1 AND payload = ?2)
+                            OR tenant_id = '__forced_scatter_never_matches__'",
+                        parameters,
+                    ),
+                )
+                .await
+                .unwrap();
+            (indexed, forced)
+        });
+        prop_assert_eq!(indexed.value, forced.value);
+        prop_assert_eq!(indexed.shards, vec![0, 1, 2, 3]);
+    }
+}


### PR DESCRIPTION
Closes #235

## What changed
- select ready non-unique global indexes as bounded candidate sources while keeping unique authority separate
- verify every candidate by stable physical locator, recomputed canonical key, and the complete bound SQL predicate
- persist bounded idempotent read-repair tombstones, skip applied stale entries, and upgrade global-index storage atomically to version 3
- expose authoritative/candidate/verified/rejected/stale/repair counts and conservative fallback reasons in bound-plan explain data
- keep non-unique execution on the safe ordinary shard set until #237 supplies freshness watermarks
- update README, roadmap, architecture, authority, build, and storage-format docs

## Verification
- `cargo fmt --all -- --check`
- `cargo check --locked --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- differential property tests against forced scatter reads
- real subprocess abort tests before/after repair enqueue and application
- v1/v2 to v3 migration and crash-recovery tests