### PR TITLE
Complete embedded transaction and cursor lifecycle

### DIFF
--- a/docs/EMBEDDED_RUST.md
+++ b/docs/EMBEDDED_RUST.md
@@ -118,9 +118,23 @@ typed dedicated-runtime and document-support modes are reserved and fail with
 The host may install any tracing subscriber it wants; the library emits through
 the normal `tracing` facade and never configures global logging itself.
 
-An engine `Session` accepts `BEGIN`, `COMMIT`, and `ROLLBACK`, retains and pins
-the first exact one-shard connection, and exposes failed-transaction recovery.
-Streaming cursors are not yet part of the embedded contract and remain
-tracked by #39. Autocommit commands, prepared portals, cancellation, bounded
-queueing, and materialized result limits use the same engine semantics as
-protocol adapters.
+`BriskDb::begin_transaction()` returns an owned `BriskTransaction` backed by a
+private core session. Its first routed statement pins one physical shard;
+cross-shard work fails the transaction, and committing a failed transaction
+rolls it back exactly as the protocol adapters do. `commit()` and `rollback()`
+consume the handle. Dropping an unfinished handle releases its private session
+and pool hygiene rolls back a pinned SQLite transaction before reusing that
+connection. Transaction commands use the catalog-aware prepared planner and
+therefore require cataloged tables.
+
+Prepared reads can be opened with `stream_bound_logical()`. The returned
+`BriskCursor` publishes ordered column metadata before the first row, buffers
+at most the engine's finite row-stream capacity, and exposes `next_row()` for
+asynchronous consumption. Dropping an unfinished cursor cancels all selected
+shard work and interrupts its active SQLite operation. Prepared portals remain
+session-owned and should be closed explicitly when the session will be reused.
+
+The public database, session, transaction, and cursor handles are `Send +
+Sync`. Autocommit commands, transactions, prepared portals, cursors,
+cancellation, bounded queueing, and result limits use the same engine semantics
+as protocol adapters.

--- a/docs/EMBEDDED_SQL.md
+++ b/docs/EMBEDDED_SQL.md
@@ -42,6 +42,19 @@ close lifecycle through `prepare`, `bind`, `describe`, `execute_bound`, and
 `execute_bound_logical`. Bound portals are immutable and retain the route and
 typed values captured at bind time.
 
+Use `BriskDb::begin_transaction()` for an owned single-shard transaction. The
+handle provides direct typed writes and queries as well as prepare, bind,
+describe, and streaming operations. `commit()` and `rollback()` consume it;
+dropping it unfinished rolls back its private session. Transaction statements
+are compiled through the catalog-aware planner, so referenced tables must be
+registered in the logical catalog.
+
+For a prepared read, `stream_bound_logical()` returns `BriskCursor`. Column
+metadata is ready immediately, `next_row()` advances asynchronously, and the
+engine retains only a bounded number of decoded rows ahead of the caller.
+Dropping the cursor cancels unfinished physical and scatter work. Close the
+portal or its prepared statement explicitly before long-term session reuse.
+
 `ResultSet` keeps columns and rows positional, including duplicate column
 names. Nulls, blobs, invalid UTF-8 text, integers, and floating-point values are
 not coerced by the facade. SQLite has no native decimal or timestamp storage

--- a/src/embedded.rs
+++ b/src/embedded.rs
@@ -12,13 +12,14 @@ use std::{
 };
 
 use crate::core::{
-    CancellationToken, Catalog, CheckpointReport, DescribeTarget, Engine, EngineOptions,
+    CancellationToken, Catalog, CheckpointReport, Column, DescribeTarget, Engine, EngineOptions,
     EngineResult, EngineState, EngineStatus, Executed, GlobalIndexAsyncOptions, GlobalIndexWorker,
     PortalId, PrepareRequest, PreparedExecution, PreparedStatementDescription, PreparedStatementId,
-    RequestContext, ResultSet, Routed, Session, SessionId, SessionState, ShutdownReport, Statement,
-    Value, WriteResult,
+    RequestContext, ResultSet, Routed, Row, RowStream, Session, SessionId, SessionState,
+    ShutdownReport, Statement, TransactionExecution, Value, WriteResult,
 };
 use crate::{EngineError, EngineErrorKind};
+use crate::{SqlDialect, SqlTranslationMode};
 
 /// Recommended number of physical shards for small embedded deployments.
 ///
@@ -198,6 +199,31 @@ pub struct BriskSession {
     session: Arc<Session>,
 }
 
+/// An owned, single-session transaction for embedded applications.
+///
+/// The handle uses the same transaction state machine as every protocol
+/// adapter. Its first routed statement pins one physical shard, later work on
+/// another shard fails the transaction, and committing a failed transaction
+/// rolls it back. Dropping an unfinished handle drops its private session; pool
+/// hygiene then rolls back any pinned SQLite transaction before the connection
+/// can be reused.
+#[must_use = "an embedded transaction must be committed, rolled back, or dropped"]
+pub struct BriskTransaction {
+    session: BriskSession,
+}
+
+/// A bounded, asynchronous cursor returned by embedded prepared reads.
+///
+/// Dropping a cursor cancels its unfinished query and interrupts the leased
+/// SQLite connection. The prepared statement and portal remain owned by the
+/// session and can be closed with [`BriskSession::close_prepared`] or
+/// [`BriskSession::close_bound`].
+#[must_use = "dropping a cursor cancels its unfinished query"]
+pub struct BriskCursor {
+    shards: Vec<u16>,
+    stream: RowStream,
+}
+
 impl fmt::Debug for BriskSession {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
@@ -205,6 +231,26 @@ impl fmt::Debug for BriskSession {
             .field("id", &self.id())
             .field("database_state", &self.database.state())
             .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Debug for BriskTransaction {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BriskTransaction")
+            .field("session", &self.session.id())
+            .field("database_state", &self.session.database_state())
+            .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Debug for BriskCursor {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BriskCursor")
+            .field("shards", &self.shards)
+            .field("stream", &self.stream)
+            .finish()
     }
 }
 
@@ -266,6 +312,23 @@ impl BriskDb {
             database: self.clone(),
             session: Arc::new(self.session()),
         }
+    }
+
+    /// Begin an owned transaction on a new private embedded session.
+    pub async fn begin_transaction(&self) -> EngineResult<BriskTransaction> {
+        self.begin_transaction_with_context(RequestContext::new())
+            .await
+    }
+
+    /// Begin an owned transaction with host-supplied request controls.
+    pub async fn begin_transaction_with_context(
+        &self,
+        context: RequestContext,
+    ) -> EngineResult<BriskTransaction> {
+        let session = self.owned_session();
+        let outcome = session.transaction_control("BEGIN", context).await?;
+        debug_assert_eq!(outcome, TransactionExecution::Started);
+        Ok(BriskTransaction { session })
     }
 
     /// Return immutable engine and resource-limit status.
@@ -466,6 +529,33 @@ impl BriskDb {
             .await
     }
 
+    /// Stream one immutable read portal through logical point/scatter planning.
+    pub async fn stream_bound_logical(
+        &self,
+        session: &Session,
+        portal: PortalId,
+    ) -> EngineResult<BriskCursor> {
+        self.stream_bound_logical_with_context(session, portal, RequestContext::new())
+            .await
+    }
+
+    /// Stream one logical read portal with host-supplied request controls.
+    pub async fn stream_bound_logical_with_context(
+        &self,
+        session: &Session,
+        portal: PortalId,
+        context: RequestContext,
+    ) -> EngineResult<BriskCursor> {
+        let Executed { shards, value } = self
+            .engine
+            .stream_portal_logical_with_context(session, portal, context)
+            .await?;
+        Ok(BriskCursor {
+            shards,
+            stream: value,
+        })
+    }
+
     /// Close a prepared statement and every portal bound from it.
     pub async fn close_prepared(
         &self,
@@ -567,6 +657,56 @@ impl BriskDb {
 }
 
 impl BriskSession {
+    async fn execute_prepared_statement(
+        &self,
+        statement: Statement,
+        context: RequestContext,
+    ) -> EngineResult<Executed<PreparedExecution>> {
+        let (sql, parameters) = statement.into_parts();
+        let request = PrepareRequest::new(
+            self.database.catalog().default_database().id(),
+            SqlDialect::Sqlite,
+            SqlTranslationMode::StrictSqlite,
+            sql,
+        );
+        let prepared = self.prepare_with_context(request, context.clone()).await?;
+        let portal = match self
+            .bind_with_context(prepared, parameters, context.clone())
+            .await
+        {
+            Ok(portal) => portal,
+            Err(error) => {
+                let _ = self.close_prepared(prepared).await;
+                return Err(error);
+            }
+        };
+        let execution = self
+            .execute_bound_logical_with_context(portal, context)
+            .await;
+        let cleanup = self.close_prepared(prepared).await;
+        let execution = execution?;
+        cleanup?;
+        Ok(execution)
+    }
+
+    async fn transaction_control(
+        &self,
+        sql: &'static str,
+        context: RequestContext,
+    ) -> EngineResult<TransactionExecution> {
+        let execution = self
+            .execute_prepared_statement(Statement::new(sql, Vec::new()), context)
+            .await;
+        let execution = execution?;
+        match execution.value {
+            PreparedExecution::Transaction(outcome) => Ok(outcome),
+            _ => Err(EngineError::new(
+                EngineErrorKind::Internal,
+                "transaction control returned a non-transaction result",
+            )),
+        }
+    }
+
     /// Return the process-unique session identity.
     pub fn id(&self) -> SessionId {
         self.session.id()
@@ -736,6 +876,35 @@ impl BriskSession {
             .await
     }
 
+    /// Execute a logical bound portal with host-supplied request controls.
+    pub async fn execute_bound_logical_with_context(
+        &self,
+        portal: PortalId,
+        context: RequestContext,
+    ) -> EngineResult<Executed<PreparedExecution>> {
+        self.database
+            .execute_bound_logical_with_context(self.session.as_ref(), portal, context)
+            .await
+    }
+
+    /// Stream one immutable read portal through logical point/scatter planning.
+    pub async fn stream_bound_logical(&self, portal: PortalId) -> EngineResult<BriskCursor> {
+        self.database
+            .stream_bound_logical(self.session.as_ref(), portal)
+            .await
+    }
+
+    /// Stream one logical read portal with host-supplied request controls.
+    pub async fn stream_bound_logical_with_context(
+        &self,
+        portal: PortalId,
+        context: RequestContext,
+    ) -> EngineResult<BriskCursor> {
+        self.database
+            .stream_bound_logical_with_context(self.session.as_ref(), portal, context)
+            .await
+    }
+
     /// Close a prepared statement and every bound portal derived from it.
     pub async fn close_prepared(&self, statement: PreparedStatementId) -> EngineResult<bool> {
         self.database
@@ -772,5 +941,175 @@ impl BriskSession {
     /// database is draining and is deterministic and idempotent.
     pub async fn close(&self) -> EngineResult<()> {
         self.session.close().await
+    }
+}
+
+impl BriskTransaction {
+    /// Return the current transaction/session state.
+    pub async fn state(&self) -> SessionState {
+        self.session.state().await
+    }
+
+    /// Set the route used by subsequent statements until it is replaced.
+    pub async fn set_routing_key(&self, routing_key: impl Into<String>) -> EngineResult<()> {
+        self.session.set_routing_key(routing_key).await
+    }
+
+    /// Execute one routed write inside the transaction.
+    pub async fn execute_write(&self, statement: Statement) -> EngineResult<Executed<WriteResult>> {
+        self.execute_write_with_context(statement, RequestContext::new())
+            .await
+    }
+
+    /// Execute one routed write with host-supplied request controls.
+    pub async fn execute_write_with_context(
+        &self,
+        statement: Statement,
+        context: RequestContext,
+    ) -> EngineResult<Executed<WriteResult>> {
+        let execution = self
+            .session
+            .execute_prepared_statement(statement, context)
+            .await?;
+        let value = match execution.value {
+            PreparedExecution::AffectedRows(rows) => WriteResult::without_generated_key(rows),
+            PreparedExecution::GeneratedWrite(write) => write,
+            _ => {
+                return Err(EngineError::new(
+                    EngineErrorKind::InvalidQuery,
+                    "transaction write returned a non-write result",
+                ));
+            }
+        };
+        Ok(Executed {
+            shards: execution.shards,
+            value,
+        })
+    }
+
+    /// Query one routed physical owner inside the transaction.
+    pub async fn query(&self, statement: Statement) -> EngineResult<Executed<ResultSet>> {
+        self.query_with_context(statement, RequestContext::new())
+            .await
+    }
+
+    /// Query one routed owner with host-supplied request controls.
+    pub async fn query_with_context(
+        &self,
+        statement: Statement,
+        context: RequestContext,
+    ) -> EngineResult<Executed<ResultSet>> {
+        let execution = self
+            .session
+            .execute_prepared_statement(statement, context)
+            .await?;
+        let PreparedExecution::Rows(value) = execution.value else {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidQuery,
+                "transaction query returned a non-row result",
+            ));
+        };
+        Ok(Executed {
+            shards: execution.shards,
+            value,
+        })
+    }
+
+    /// Compile one protocol-neutral prepared statement inside the transaction.
+    pub async fn prepare(&self, request: PrepareRequest) -> EngineResult<PreparedStatementId> {
+        self.session.prepare(request).await
+    }
+
+    /// Bind typed values and the transaction's current route into a portal.
+    pub async fn bind(
+        &self,
+        statement: PreparedStatementId,
+        parameters: Vec<Value>,
+    ) -> EngineResult<PortalId> {
+        self.session.bind(statement, parameters).await
+    }
+
+    /// Describe a prepared statement or bound portal.
+    pub async fn describe(
+        &self,
+        target: DescribeTarget,
+    ) -> EngineResult<PreparedStatementDescription> {
+        self.session.describe(target).await
+    }
+
+    /// Stream a prepared read inside the transaction.
+    pub async fn stream_bound_logical(&self, portal: PortalId) -> EngineResult<BriskCursor> {
+        self.session.stream_bound_logical(portal).await
+    }
+
+    /// Stream a prepared read with host-supplied request controls.
+    pub async fn stream_bound_logical_with_context(
+        &self,
+        portal: PortalId,
+        context: RequestContext,
+    ) -> EngineResult<BriskCursor> {
+        self.session
+            .stream_bound_logical_with_context(portal, context)
+            .await
+    }
+
+    /// Close a prepared statement and every portal derived from it.
+    pub async fn close_prepared(&self, statement: PreparedStatementId) -> EngineResult<bool> {
+        self.session.close_prepared(statement).await
+    }
+
+    /// Close one bound portal while retaining its prepared statement.
+    pub async fn close_bound(&self, portal: PortalId) -> EngineResult<bool> {
+        self.session.close_bound(portal).await
+    }
+
+    /// Commit the transaction and terminally close its private session.
+    pub async fn commit(self) -> EngineResult<TransactionExecution> {
+        self.commit_with_context(RequestContext::new()).await
+    }
+
+    /// Commit the transaction with host-supplied request controls.
+    pub async fn commit_with_context(
+        self,
+        context: RequestContext,
+    ) -> EngineResult<TransactionExecution> {
+        let outcome = self.session.transaction_control("COMMIT", context).await?;
+        self.session.close().await?;
+        Ok(outcome)
+    }
+
+    /// Roll back the transaction and terminally close its private session.
+    pub async fn rollback(self) -> EngineResult<TransactionExecution> {
+        self.rollback_with_context(RequestContext::new()).await
+    }
+
+    /// Roll back the transaction with host-supplied request controls.
+    pub async fn rollback_with_context(
+        self,
+        context: RequestContext,
+    ) -> EngineResult<TransactionExecution> {
+        let outcome = self
+            .session
+            .transaction_control("ROLLBACK", context)
+            .await?;
+        self.session.close().await?;
+        Ok(outcome)
+    }
+}
+
+impl BriskCursor {
+    /// Return the physical shards selected for this logical stream.
+    pub fn shards(&self) -> &[u16] {
+        &self.shards
+    }
+
+    /// Return stable column metadata published before the first row.
+    pub fn columns(&self) -> &[Column] {
+        self.stream.columns()
+    }
+
+    /// Wait for the next row, terminal query error, or clean end of stream.
+    pub async fn next_row(&mut self) -> Option<EngineResult<Row>> {
+        self.stream.next_row().await
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,11 +44,11 @@ pub use core::{
     RequestContext, ResultLimits, ResultSet, ResultSetShapeError, Routed, Row, Session, SessionId,
     SessionState, ShardSummaryPredicateKind, ShardSummaryPrunedShard, ShardSummaryPruningReason,
     ShardSummaryRoutingFallback, ShardSummaryRoutingPlan, ShutdownReport, Statement,
-    UniqueNullSemantics, Value, WriteResult,
+    TransactionExecution, UniqueNullSemantics, Value, WriteResult,
 };
 #[cfg(feature = "embedded")]
 pub use embedded::{
-    BriskDb, BriskDbBuilder, BriskSession, DEFAULT_EMBEDDED_SHARDS, DocumentSupport,
-    RuntimeBehavior,
+    BriskCursor, BriskDb, BriskDbBuilder, BriskSession, BriskTransaction, DEFAULT_EMBEDDED_SHARDS,
+    DocumentSupport, RuntimeBehavior,
 };
 pub use sql::{SqlDialect, SqlTranslationMode, StatementBehavior};

--- a/tests/embedded_transactions.rs
+++ b/tests/embedded_transactions.rs
@@ -1,0 +1,194 @@
+use std::time::Duration;
+
+use briskdb::{
+    BriskCursor, BriskDb, BriskSession, BriskTransaction, EngineErrorKind, PrepareRequest,
+    SessionState, SqlDialect, SqlTranslationMode, Statement, TransactionExecution, Value,
+    core::{Database, ShardKeyMetadata, ShardKeyType, TableDeclaration},
+};
+
+async fn open_database() -> (tempfile::TempDir, BriskDb) {
+    let directory = tempfile::tempdir().unwrap();
+    let mut storage = Database::open(directory.path(), 2).unwrap();
+    storage
+        .broadcast("CREATE TABLE records (id INTEGER PRIMARY KEY, value TEXT NOT NULL)")
+        .unwrap();
+    let logical_database = storage.catalog().default_database().id();
+    storage
+        .register_tables(vec![
+            TableDeclaration::sharded(
+                logical_database,
+                "records",
+                ShardKeyMetadata::new("id", ShardKeyType::Int64).unwrap(),
+            )
+            .unwrap(),
+        ])
+        .unwrap();
+    drop(storage);
+    let database = BriskDb::open(directory.path()).await.unwrap();
+    (directory, database)
+}
+
+async fn row_count(database: &BriskDb, id: i64) -> i64 {
+    let session = database.owned_session();
+    let result = session
+        .query_logical(Statement::new(
+            "SELECT COUNT(*) FROM records WHERE id = ?1",
+            vec![Value::from(id)],
+        ))
+        .await
+        .unwrap();
+    let count = result.value.rows()[0]
+        .get(0)
+        .and_then(Value::as_i64)
+        .unwrap();
+    session.close().await.unwrap();
+    count
+}
+
+async fn ids_on_different_shards(database: &BriskDb) -> (i64, i64) {
+    let session = database.owned_session();
+    let mut first = None;
+    for id in 1_i64..=128 {
+        let result = session
+            .query_logical(Statement::new(
+                "SELECT id FROM records WHERE id = ?1",
+                vec![Value::from(id)],
+            ))
+            .await
+            .unwrap();
+        let shard = result.shards[0];
+        match first {
+            None => first = Some((id, shard)),
+            Some((first_id, first_shard)) if first_shard != shard => {
+                session.close().await.unwrap();
+                return (first_id, id);
+            }
+            Some(_) => {}
+        }
+    }
+    panic!("test keys did not cover two shards")
+}
+
+#[test]
+fn embedded_handles_are_send_and_sync() {
+    fn assert_send_sync<T: Send + Sync>() {}
+
+    assert_send_sync::<BriskDb>();
+    assert_send_sync::<BriskSession>();
+    assert_send_sync::<BriskTransaction>();
+    assert_send_sync::<BriskCursor>();
+}
+
+#[tokio::test]
+async fn owned_transaction_commits_and_drop_rolls_back() {
+    let (_directory, database) = open_database().await;
+
+    let dropped = database.begin_transaction().await.unwrap();
+    dropped
+        .execute_write(Statement::new(
+            "INSERT INTO records (id, value) VALUES (?1, ?2)",
+            vec![Value::from(1_i64), Value::from("rolled back")],
+        ))
+        .await
+        .unwrap();
+    assert_eq!(dropped.state().await, SessionState::InTransaction);
+    drop(dropped);
+    assert_eq!(row_count(&database, 1).await, 0);
+
+    let committed = database.begin_transaction().await.unwrap();
+    committed
+        .execute_write(Statement::new(
+            "INSERT INTO records (id, value) VALUES (?1, ?2)",
+            vec![Value::from(2_i64), Value::from("committed")],
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        committed.commit().await.unwrap(),
+        TransactionExecution::Committed
+    );
+    assert_eq!(row_count(&database, 2).await, 1);
+
+    database.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn cross_shard_failure_puts_transaction_in_failed_state_and_commit_rolls_back() {
+    let (_directory, database) = open_database().await;
+    let (first_id, second_id) = ids_on_different_shards(&database).await;
+
+    let transaction = database.begin_transaction().await.unwrap();
+    transaction
+        .execute_write(Statement::new(
+            "INSERT INTO records (id, value) VALUES (?1, ?2)",
+            vec![Value::from(first_id), Value::from("first shard")],
+        ))
+        .await
+        .unwrap();
+    let error = transaction
+        .execute_write(Statement::new(
+            "INSERT INTO records (id, value) VALUES (?1, ?2)",
+            vec![Value::from(second_id), Value::from("second shard")],
+        ))
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+    assert_eq!(transaction.state().await, SessionState::FailedTransaction);
+    assert_eq!(
+        transaction.commit().await.unwrap(),
+        TransactionExecution::RolledBack
+    );
+    assert_eq!(row_count(&database, first_id).await, 0);
+    assert_eq!(row_count(&database, second_id).await, 0);
+
+    database.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn cursor_streams_metadata_and_rows_and_drop_does_not_block_shutdown() {
+    let (_directory, database) = open_database().await;
+    let session = database.owned_session();
+    for id in 1_i64..=32 {
+        session
+            .execute_write(Statement::new(
+                "INSERT INTO records (id, value) VALUES (?1, ?2)",
+                vec![Value::from(id), Value::from(format!("value-{id}"))],
+            ))
+            .await
+            .unwrap();
+    }
+
+    let statement = session
+        .prepare(PrepareRequest::new(
+            database.catalog().default_database().id(),
+            SqlDialect::Sqlite,
+            SqlTranslationMode::StrictSqlite,
+            "SELECT id, value FROM records",
+        ))
+        .await
+        .unwrap();
+    let portal = session.bind(statement, vec![]).await.unwrap();
+    let mut cursor = session.stream_bound_logical(portal).await.unwrap();
+    assert_eq!(cursor.shards().len(), 2);
+    assert_eq!(cursor.columns().len(), 2);
+    assert_eq!(cursor.columns()[0].name, "id");
+    assert!(cursor.next_row().await.unwrap().is_ok());
+    drop(cursor);
+
+    let retry_portal = session.bind(statement, vec![]).await.unwrap();
+    let mut retry = session.stream_bound_logical(retry_portal).await.unwrap();
+    let mut rows = 0;
+    while let Some(row) = retry.next_row().await {
+        row.unwrap();
+        rows += 1;
+    }
+    assert_eq!(rows, 32);
+    session.close_prepared(statement).await.unwrap();
+
+    session.close().await.unwrap();
+    let report = database
+        .close_with_grace(Duration::from_secs(2))
+        .await
+        .unwrap();
+    assert!(!report.forced());
+}


### PR DESCRIPTION
## Summary

- expose owned `BriskTransaction` and bounded `BriskCursor` handles
- reuse the existing prepared engine, transaction state machine, routing, cancellation, and streaming infrastructure
- document lifecycle, rollback, catalog, concurrency, and shutdown guarantees
- add integration coverage for commit/drop rollback, cross-shard failure, cursor cancellation/retry, and `Send + Sync`

Closes #192

## Validation

- `cargo fmt --all -- --check`
- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`