### PR TITLE
Define the versioned HTTP v1 transport contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,9 @@ curl -X POST http://127.0.0.1:7654/v1/query \
   -d '{"sql":"SELECT id, name FROM widgets WHERE id = ?1","params":["widget-1"]}'
 ```
 
+The [versioned HTTP contract](docs/HTTP_API.md) defines requests, response
+shapes, value encodings, and errors. `GET /v1` reports the supported API version.
+
 Have an existing SQLite database? Use the offline
 [SQLite importer](docs/SQLITE_IMPORT.md). Linux releases also include `.deb`
 packages with a hardened systemd service.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
 # Unreleased
 
+HTTP now has an explicit version-1 contract, discovery at `/v1`, a versioned
+`/v1/health` alias, and `BriskDB-API-Version: 1` on v1 responses. Existing valid
+SQL requests and result encodings are preserved. Unknown or duplicate envelope
+fields now fail before execution; JSON decoding, body-limit, media-type,
+missing-route, and method errors use fixed, redacted problem details. Clients
+that relied on ignored fields or framework error text must migrate as described
+in [the HTTP API contract](docs/HTTP_API.md). This HTTP change does not alter
+storage or engine behavior. Lossless JSON value encoding remains issue #51.
+
 Global indexes now have a production/release gate: redaction-safe Rust health
 reports, richer `/health` and `/v1/admin/global-indexes` responses, Prometheus
 `/metrics`, complete shard/manifest/global-index checkpoint reporting, and a

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -316,8 +316,10 @@ protocol-specific golden tests only for encoding and state-machine behavior.
   #110).
   This preview does not complete the versioned admin API, listener separation,
   authentication/role, pagination, or scatter/gather items below.
-- [ ] Replace the experimental endpoints with a versioned `/v1` contract built
-  on the shared session/engine types.
+- [x] Replace the experimental endpoints with a versioned `/v1` contract built
+  on the shared session/engine types, with discovery, strict envelopes, and
+  fixed transport errors; see [the HTTP contract](docs/HTTP_API.md). The default
+  `legacy-json-v1` value encoding is preserved; lossless encoding remains #51.
 - [ ] Return ordered columns and row arrays so duplicate names and binary values
   round-trip without loss; define JSON encodings for integers, decimals,
   timestamps, and blobs.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -100,6 +100,12 @@ address or `None`.
 
 ## Listener boundary
 
+HTTP routes under `/v1` have an explicit transport contract in
+[HTTP_API.md](HTTP_API.md). `protocol::http::v1` owns version discovery, the
+shared strict SQL envelope, body extraction, version headers, and transport
+errors. Existing handlers still create core sessions and send typed statements
+through the shared engine; versioning adds no routing or SQLite implementation.
+
 The HTTP address remains `Config::listen`. The independent
 `Config::postgres_listen` is either a numeric socket address or disabled with
 `None`; the binary maps the exact `disabled` CLI/environment sentinel to that

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -159,6 +159,12 @@ adapter decision.
 
 ## HTTP problem details
 
+The [HTTP v1 transport contract](HTTP_API.md#errors) also defines fixed problems
+for malformed envelopes, missing routes, wrong methods, oversized bodies, and
+non-JSON media types. These failures happen before engine execution and do not
+add protocol-specific kinds to `EngineErrorKind`. Every v1 error carries the
+`BriskDB-API-Version: 1` header.
+
 Engine failures returned by HTTP use
 [RFC 9457 Problem Details](https://www.rfc-editor.org/rfc/rfc9457.html) and the
 `application/problem+json` media type. The response has `type`, `title`,

--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -1,0 +1,187 @@
+# HTTP API version 1
+
+Status: implemented for issue #50. BriskDB remains an alpha database; HTTP is
+loopback-only and has no data/admin authorization. The `/admin` browser login
+does not authenticate `/v1` requests.
+
+## Version and compatibility
+
+`GET /v1` (also `/v1/`) describes the transport contract:
+
+```json
+{
+  "api_version": "1",
+  "value_encoding": "legacy-json-v1",
+  "session_scope": "request",
+  "sql_dialect": "sqlite",
+  "max_request_bytes": 2097152
+}
+```
+
+Every response within `/v1`, including engine errors, decoding failures,
+unknown endpoints, and unsupported methods, carries `BriskDB-API-Version: 1`.
+The URL selects the API version; a client header does not select another
+version. Unknown versions have no routes and return HTTP 404. Discovery is
+static contract metadata, not a readiness check; use `/v1/health` for engine
+health.
+
+The HTTP API major version is independent of the package version and manifest
+format. Within v1, existing request fields, successful response fields, known
+error mappings, and the default value encoding keep their documented meaning.
+Compatible additions may introduce optional request fields, new endpoints,
+response fields, or new error codes. Clients must tolerate unknown response
+fields and handle unknown error codes by status. A breaking transport change
+requires a new API major version and a documented migration; it must not
+silently reinterpret a v1 request. SQL support and storage compatibility still
+follow their separately documented alpha contracts.
+
+`legacy-json-v1` names the existing cell conversion, including its losses. It
+does not claim lossless binary, decimal, or timestamp round trips. Issue #51
+will define an explicitly selected lossless encoding or a new API major
+version; it must preserve this default. A `value_encoding` request field is
+not accepted yet.
+
+## Routes
+
+| Method and path | Success |
+| --- | --- |
+| `GET /v1`, `GET /v1/` | Version discovery above |
+| `GET /v1/health` | Same engine and global-index health report as `/health` |
+| `POST /v1/execute` | One routed write result |
+| `POST /v1/query` | Ordered result columns and positional rows |
+| `POST /v1/admin/broadcast` | Journaled application-schema migration result |
+| `GET /v1/admin/global-indexes` | [Global-index operational report](GLOBAL_INDEX_RELEASE_GATE.md) |
+
+GET routes also accept HEAD, returning headers without a body. Success is HTTP
+200 with `application/json`. The unversioned `/health` and `/metrics` routes
+remain operator conveniences. The browser's `/admin/api/*` contract is
+separate and described in [ADMIN_BROWSER.md](ADMIN_BROWSER.md).
+
+## SQL requests and session lifetime
+
+Both SQL endpoints accept this exact envelope:
+
+```json
+{
+  "sql": "SELECT id, name FROM widgets WHERE id = ?1",
+  "params": ["widget-1"],
+  "shard_key": "widget-1"
+}
+```
+
+- `sql` is a required string. Use SQLite syntax and positional parameters;
+  values are bound through the engine and never interpolated.
+- `params` is an optional array, defaulting to `[]`; explicit `null` is invalid.
+- `shard_key` is an optional string; omission or `null` means no explicit key.
+- Unknown and duplicate envelope fields, missing required fields, and wrong
+  field types are rejected before any engine operation.
+- Supply `Content-Type: application/json`, optionally with a charset. JSON
+  media types with a `+json` suffix are also accepted. The request body limit
+  is 2,097,152 bytes, including whitespace. JSON syntax, numeric-range, and
+  nesting validation occur before execution.
+
+Each SQL or migration request creates a fresh core `Session` and invokes the
+shared asynchronous `Engine` with typed `Statement`/`Value` inputs. Routing
+state does not survive the response. There are no HTTP transaction handles,
+prepared-statement handles, or selectable logical databases in this contract;
+requests operate on the default logical database. Sending fields such as
+`database`, `transaction`, or `dialect` fails instead of ignoring them.
+
+The engine retains its existing catalog-dependent behavior:
+
+- An empty catalog uses the legacy raw SQLite path and requires an explicit
+  routing key. Execute still rejects schema and transaction-control bypasses.
+- With registered tables, execute uses authoritative SQL/bound-value routing
+  and checks explicit-key conflicts. Query selects targets from catalog
+  metadata and SQL predicates; its legacy `shard_key` field is ignored.
+- Registered reads can visit multiple shards only for the documented supported
+  read shapes. Global tables are read once. Unroutable or cross-shard writes
+  are rejected before mutation, apart from explicitly supported generated-key
+  operations.
+
+The adapter does not parse SQL, hash keys, open files, or implement transaction
+or migration coordination. See [SQL compatibility](SQL_COMPATIBILITY.md),
+[generated keys](GENERATED_KEYS.md), and [request controls](REQUEST_CONTROLS.md).
+Engine deadlines, cancellation, admission, and result limits still apply.
+This API buffers bounded results; it does not expose an HTTP row stream or a
+multi-request cancellation endpoint.
+
+## Successful responses
+
+Execute returns the committing operation's shard and affected-row count:
+
+```json
+{"shard": 2, "rows_affected": 1}
+```
+
+When generated-key execution is enabled and the engine returns a key, it also
+includes `generated_key`, for example
+`{"column":"id","data_type":"int64","value":"9007199254740993"}`.
+The value is exact decimal text. An absent generated key is omitted, not null.
+
+Query returns one shard or the complete visited-shard array, never both:
+
+```json
+{
+  "shard": 2,
+  "columns": [{"name":"id","data_type":"text"}],
+  "rows": [["widget-1"]]
+}
+```
+
+For multiple shards, `"shards":[0,1]` replaces `shard`. Column order and
+duplicate names are preserved; every row is positional. Zero-row results
+retain their columns. Types use the names in
+[the SQL value contract](SQL_COMPATIBILITY.md#current-http-parameter-and-result-conversion).
+No partial rows are returned when execution or a combined result budget fails.
+Scatter reads do not establish a cross-file atomic snapshot.
+
+`legacy-json-v1` converts input arrays/objects to compact JSON **text**, not
+binary values or document commands. Results encode blobs as byte arrays,
+decimals as strings, integers as JSON numbers, invalid UTF-8 text lossily, and
+non-finite floats as null. JavaScript can round integers outside its safe
+range; returning such a number does not claim JavaScript-safe precision. The
+browser's tagged large-integer representation is a different contract.
+
+Broadcast accepts only `{"sql":"CREATE TABLE ..."}` and returns
+`{"completed_shards":[0,1]}`. It is the existing journaled schema migration
+operation, with preflight and resumable application across every shard. It
+does not create catalog metadata implicitly or accept bound parameters.
+
+## Errors
+
+Errors within v1 have `Content-Type: application/problem+json`, the version
+header, and exactly the currently defined fields `type`, `title`, `status`,
+`detail`, and `code`. Text is fixed and redacted; request bodies, unknown field
+names, query text, filesystem paths, and decoder diagnostics are not echoed.
+
+| Failure | HTTP | Code |
+| --- | ---: | --- |
+| Malformed JSON or invalid request envelope | 400 | `invalid_argument` |
+| Unknown v1 endpoint | 404 | `not_found` |
+| Unsupported method on a known endpoint | 405 | `method_not_allowed` |
+| Body exceeds 2 MiB | 413 | `request_too_large` |
+| Missing or non-JSON content type | 415 | `unsupported_media_type` |
+| Engine rejection | Per [error taxonomy](ERRORS.md) | Exact engine code |
+
+Method errors retain the `Allow` header. The four transport-only codes use
+`urn:briskdb:http:v1:` problem types with hyphenated code names; invalid
+arguments use the same problem type as engine `InvalidArgument`. Only the
+engine `busy` code advertises retryability. A write may commit before its
+response reaches the client; v1 supplies no idempotency key and makes no
+exactly-once delivery guarantee.
+
+## Migration from the experimental endpoints
+
+Existing route names, valid request bodies, successful result shapes, and cell
+encodings continue to work. Unknown fields were previously ignored and now
+return 400. Malformed-body responses previously used framework-specific text
+and statuses; they now use the fixed problems above. Clients must remove
+unused envelope fields and consume `code` instead of decoder text. No storage
+format, Rust engine behavior, or startup configuration changes are involved.
+
+`tests/http_v1.rs` exercises discovery, schema rejection before mutation, body
+limits, routing errors, method headers, version isolation, and session isolation.
+Existing HTTP tests cover catalog routing, generated keys, concurrent requests,
+deadlines, result limits, and exact response shapes; embedded differential tests
+verify shared-engine outcomes.

--- a/docs/PRE_1_COMPATIBILITY.md
+++ b/docs/PRE_1_COMPATIBILITY.md
@@ -6,6 +6,11 @@ contract, Rust API, accepted SQL subset, and on-disk format may change between
 by an older binary or that every future binary will migrate every historical
 prototype layout.
 
+The [versioned HTTP transport](HTTP_API.md) has its own compatibility boundary:
+breaking request/response or default value-encoding changes require a new API
+major version and a documented migration. This does not stabilize the alpha
+SQL subset, storage layout, browser API, or public Rust library.
+
 This policy is narrower than the stable storage-format commitment planned for
 1.0 in issue #77.
 

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -343,6 +343,11 @@ is reconciled from the retained journal prefix.
 
 ### Current HTTP parameter and result conversion
 
+The [HTTP v1 contract](HTTP_API.md) versions the existing representation as
+`legacy-json-v1`. Request envelopes are strict and decoding failures use fixed
+problem details. Versioning this encoding does not make it lossless; the
+conversion rules and limitations below remain part of v1.
+
 Use SQLite positional placeholders such as `?1` and `?2`. Values are never
 interpolated into SQL text. The HTTP adapter converts JSON parameters into
 protocol-neutral BriskDB values; the SQL layer binds only those typed values.

--- a/src/protocol/http.rs
+++ b/src/protocol/http.rs
@@ -1,6 +1,7 @@
-//! Experimental HTTP adapter.
+//! Versioned HTTP adapter over the protocol-neutral engine.
 
 mod admin;
+mod v1;
 
 use std::{fmt::Write as _, sync::Arc};
 
@@ -9,10 +10,11 @@ use axum::{
     extract::State,
     http::{HeaderValue, StatusCode, header::CONTENT_TYPE},
     response::{IntoResponse, Response},
-    routing::{get, post},
+    routing::get,
 };
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use serde_json::{Value as JsonValue, json};
+use v1::{BroadcastRequest, SqlRequest as QueryRequest, SqlRequest as RoutedSqlRequest, V1Json};
 
 use crate::{
     core::{
@@ -41,10 +43,7 @@ pub fn router_with_engine(engine: Engine) -> Router {
     Router::new()
         .route("/health", get(health))
         .route("/metrics", get(metrics))
-        .route("/v1/execute", post(execute))
-        .route("/v1/query", post(query))
-        .route("/v1/admin/broadcast", post(broadcast))
-        .route("/v1/admin/global-indexes", get(global_indexes))
+        .merge(v1::routes())
         .merge(admin::routes(state.clone()))
         .with_state(state)
 }
@@ -102,31 +101,6 @@ async fn metrics(State(state): State<HttpState>) -> Result<Response, ApiError> {
         HeaderValue::from_static("text/plain; version=0.0.4; charset=utf-8"),
     );
     Ok(response)
-}
-
-#[derive(Debug, Deserialize)]
-struct RoutedSqlRequest {
-    #[serde(default)]
-    shard_key: Option<String>,
-    sql: String,
-    #[serde(default)]
-    params: Vec<JsonValue>,
-}
-
-#[derive(Debug, Deserialize)]
-struct QueryRequest {
-    /// Retained for empty-catalog compatibility. Registered-table reads are
-    /// routed from catalog metadata and SQL predicates instead.
-    #[serde(default)]
-    shard_key: Option<String>,
-    sql: String,
-    #[serde(default)]
-    params: Vec<JsonValue>,
-}
-
-#[derive(Debug, Deserialize)]
-struct BroadcastRequest {
-    sql: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -198,7 +172,7 @@ struct QueryColumn {
 
 async fn execute(
     State(state): State<HttpState>,
-    Json(request): Json<RoutedSqlRequest>,
+    V1Json(request): V1Json<RoutedSqlRequest>,
 ) -> Result<Json<ExecuteResponse>, ApiError> {
     let engine = state.engine;
     let params = request
@@ -249,7 +223,7 @@ fn execute_generated_key(generated: GeneratedKey) -> Result<ExecuteGeneratedKey,
 
 async fn query(
     State(state): State<HttpState>,
-    Json(request): Json<QueryRequest>,
+    V1Json(request): V1Json<QueryRequest>,
 ) -> Result<Json<QueryResponse>, ApiError> {
     let engine = state.engine;
     let params = request
@@ -276,7 +250,7 @@ async fn query(
 
 async fn broadcast(
     State(state): State<HttpState>,
-    Json(request): Json<BroadcastRequest>,
+    V1Json(request): V1Json<BroadcastRequest>,
 ) -> Result<Json<JsonValue>, ApiError> {
     let engine = state.engine;
     let session = engine.session();
@@ -551,25 +525,25 @@ impl IntoResponse for ApiError {
             error_code = self.0.code(),
             "engine request failed"
         );
-        let status = StatusCode::from_u16(mapping.status)
-            .expect("the exhaustive HTTP error mapping contains valid status codes");
-        let mut response = (
-            status,
-            Json(ProblemDetails {
-                problem_type: mapping.problem_type,
-                title: mapping.title,
-                status: mapping.status,
-                detail: mapping.detail,
-                code: self.0.code(),
-            }),
-        )
-            .into_response();
-        response.headers_mut().insert(
-            CONTENT_TYPE,
-            HeaderValue::from_static("application/problem+json"),
-        );
-        response
+        problem_response(ProblemDetails {
+            problem_type: mapping.problem_type,
+            title: mapping.title,
+            status: mapping.status,
+            detail: mapping.detail,
+            code: self.0.code(),
+        })
     }
+}
+
+fn problem_response(problem: ProblemDetails) -> Response {
+    let status = StatusCode::from_u16(problem.status)
+        .expect("the HTTP contract contains valid status codes");
+    let mut response = (status, Json(problem)).into_response();
+    response.headers_mut().insert(
+        CONTENT_TYPE,
+        HeaderValue::from_static("application/problem+json"),
+    );
+    response
 }
 
 #[cfg(test)]
@@ -631,11 +605,15 @@ mod tests {
             }
             None => Body::empty(),
         };
-        router
+        let response = router
             .clone()
             .oneshot(request.body(body).unwrap())
             .await
-            .unwrap()
+            .unwrap();
+        if uri.starts_with("/v1/") {
+            assert_eq!(response.headers()["briskdb-api-version"], "1");
+        }
+        response
     }
 
     async fn response_json(response: Response) -> (StatusCode, JsonValue) {
@@ -2201,6 +2179,7 @@ mod tests {
         let (production_source, _) = include_str!("http.rs")
             .split_once(&test_module_marker)
             .expect("the HTTP unit-test module has a cfg(test) boundary");
+        let production_source = [production_source, include_str!("http/v1.rs")].concat();
 
         assert_eq!(
             production_source.matches("Database").count(),

--- a/src/protocol/http/v1.rs
+++ b/src/protocol/http/v1.rs
@@ -1,0 +1,171 @@
+//! Version 1 transport contract. Storage and SQL semantics remain in Engine.
+
+use axum::{
+    Json, Router,
+    extract::{DefaultBodyLimit, FromRequest, Request},
+    http::{HeaderValue, StatusCode},
+    middleware,
+    response::{IntoResponse, Response},
+    routing::{get, post},
+};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use serde_json::Value as JsonValue;
+
+use super::{
+    HttpState, ProblemDetails, broadcast, execute, global_indexes, health, problem_response, query,
+};
+
+const MAX_REQUEST_BYTES: usize = 2 * 1024 * 1024;
+
+pub(super) fn routes() -> Router<HttpState> {
+    let endpoints = Router::new()
+        .route("/", get(discovery))
+        .route("/health", get(health))
+        .route("/execute", post(execute))
+        .route("/query", post(query))
+        .route("/admin/broadcast", post(broadcast))
+        .route("/admin/global-indexes", get(global_indexes))
+        .fallback(not_found)
+        .method_not_allowed_fallback(method_not_allowed);
+    Router::new()
+        .route("/v1/", get(discovery))
+        .method_not_allowed_fallback(method_not_allowed)
+        .nest("/v1", endpoints)
+        .layer(DefaultBodyLimit::max(MAX_REQUEST_BYTES))
+        .layer(middleware::map_response(version_header))
+}
+
+async fn version_header(mut response: Response) -> Response {
+    response
+        .headers_mut()
+        .insert("briskdb-api-version", HeaderValue::from_static("1"));
+    response
+}
+
+#[derive(Serialize)]
+struct ApiVersion {
+    api_version: &'static str,
+    value_encoding: &'static str,
+    session_scope: &'static str,
+    sql_dialect: &'static str,
+    max_request_bytes: usize,
+}
+
+async fn discovery() -> Json<ApiVersion> {
+    Json(ApiVersion {
+        api_version: "1",
+        value_encoding: "legacy-json-v1",
+        session_scope: "request",
+        sql_dialect: "sqlite",
+        max_request_bytes: MAX_REQUEST_BYTES,
+    })
+}
+
+/// Shared SQL envelope; each handler creates a fresh core Session and Statement.
+/// Unknown fields must fail rather than silently ignoring a client's routing,
+/// transaction, dialect, or value-encoding expectations.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct SqlRequest {
+    #[serde(default)]
+    pub(super) shard_key: Option<String>,
+    pub(super) sql: String,
+    #[serde(default)]
+    pub(super) params: Vec<JsonValue>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct BroadcastRequest {
+    pub(super) sql: String,
+}
+
+pub(super) struct V1Json<T>(pub(super) T);
+
+impl<T, S> FromRequest<S> for V1Json<T>
+where
+    T: DeserializeOwned,
+    S: Send + Sync,
+{
+    type Rejection = TransportError;
+
+    async fn from_request(request: Request, state: &S) -> Result<Self, Self::Rejection> {
+        Json::<T>::from_request(request, state)
+            .await
+            .map(|Json(value)| Self(value))
+            .map_err(|rejection| match rejection.status() {
+                StatusCode::PAYLOAD_TOO_LARGE => TransportError::BodyTooLarge,
+                StatusCode::UNSUPPORTED_MEDIA_TYPE => TransportError::MediaType,
+                _ => TransportError::InvalidRequest,
+            })
+    }
+}
+
+pub(super) enum TransportError {
+    InvalidRequest,
+    BodyTooLarge,
+    MediaType,
+    NotFound,
+    MethodNotAllowed,
+}
+
+impl IntoResponse for TransportError {
+    fn into_response(self) -> Response {
+        let (status, code, title, detail) = match self {
+            Self::InvalidRequest => (
+                400,
+                "invalid_argument",
+                "Invalid argument",
+                "The request contains an invalid argument.",
+            ),
+            Self::BodyTooLarge => (
+                413,
+                "request_too_large",
+                "Request too large",
+                "The request body exceeds the HTTP API limit.",
+            ),
+            Self::MediaType => (
+                415,
+                "unsupported_media_type",
+                "Unsupported media type",
+                "The request requires a JSON content type.",
+            ),
+            Self::NotFound => (
+                404,
+                "not_found",
+                "Not found",
+                "The requested API endpoint does not exist.",
+            ),
+            Self::MethodNotAllowed => (
+                405,
+                "method_not_allowed",
+                "Method not allowed",
+                "The method is not supported by this API endpoint.",
+            ),
+        };
+        let problem_type = match self {
+            Self::InvalidRequest => {
+                super::http_error(crate::core::EngineErrorKind::InvalidArgument).problem_type
+            }
+            Self::BodyTooLarge => "urn:briskdb:http:v1:request-too-large",
+            Self::MediaType => "urn:briskdb:http:v1:unsupported-media-type",
+            Self::NotFound => "urn:briskdb:http:v1:not-found",
+            Self::MethodNotAllowed => "urn:briskdb:http:v1:method-not-allowed",
+        };
+        problem_response(ProblemDetails {
+            problem_type,
+            title,
+            status,
+            detail,
+            code,
+        })
+    }
+}
+
+async fn not_found() -> TransportError {
+    TransportError::NotFound
+}
+
+async fn method_not_allowed() -> TransportError {
+    TransportError::MethodNotAllowed
+}

--- a/tests/http_v1.rs
+++ b/tests/http_v1.rs
@@ -1,0 +1,287 @@
+#![cfg(feature = "http")]
+
+use std::sync::Arc;
+
+use axum::{
+    Router,
+    body::{Body, to_bytes},
+    http::{HeaderMap, Method, Request, StatusCode},
+};
+use briskdb::{
+    Statement,
+    core::{Database, Engine},
+};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+fn application() -> (tempfile::TempDir, Engine, Router) {
+    let temp = tempfile::tempdir().unwrap();
+    let database = Arc::new(Database::open(temp.path(), 2).unwrap());
+    database
+        .broadcast("CREATE TABLE notes (id INTEGER PRIMARY KEY)")
+        .unwrap();
+    let engine = Engine::from_database(database);
+    let router = briskdb::api::router_with_engine(engine.clone());
+    (temp, engine, router)
+}
+
+async fn request(
+    app: &Router,
+    method: Method,
+    uri: &str,
+    content_type: Option<&str>,
+    body: impl Into<Body>,
+) -> (StatusCode, HeaderMap, Vec<u8>) {
+    let mut request = Request::builder().method(method).uri(uri);
+    if let Some(content_type) = content_type {
+        request = request.header("content-type", content_type);
+    }
+    let response = app
+        .clone()
+        .oneshot(request.body(body.into()).unwrap())
+        .await
+        .unwrap();
+    let (parts, body) = response.into_parts();
+    (
+        parts.status,
+        parts.headers,
+        to_bytes(body, 4 * 1024 * 1024).await.unwrap().to_vec(),
+    )
+}
+
+fn assert_problem(
+    response: (StatusCode, HeaderMap, Vec<u8>),
+    expected_status: StatusCode,
+    expected_code: &str,
+) -> Value {
+    let (status, headers, body) = response;
+    assert_eq!(status, expected_status);
+    assert_eq!(headers["briskdb-api-version"], "1");
+    assert_eq!(headers["content-type"], "application/problem+json");
+    let body: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(body["status"], status.as_u16());
+    assert_eq!(body["code"], expected_code);
+    assert_eq!(body.as_object().unwrap().len(), 5);
+    assert!(body["type"].as_str().unwrap().contains(':'));
+    assert!(!body.to_string().contains("private-sentinel"));
+    body
+}
+
+#[tokio::test]
+async fn discovery_health_alias_and_head_identify_the_contract() {
+    let (_temp, _engine, app) = application();
+    for uri in ["/v1", "/v1/"] {
+        let (status, headers, body) = request(&app, Method::GET, uri, None, Body::empty()).await;
+        assert_eq!(status, StatusCode::OK, "{uri}");
+        assert_eq!(headers["briskdb-api-version"], "1");
+        assert_eq!(
+            serde_json::from_slice::<Value>(&body).unwrap(),
+            json!({
+                "api_version": "1",
+                "value_encoding": "legacy-json-v1",
+                "session_scope": "request",
+                "sql_dialect": "sqlite",
+                "max_request_bytes": 2097152
+            })
+        );
+        let (status, headers, body) = request(&app, Method::HEAD, uri, None, Body::empty()).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(headers["briskdb-api-version"], "1");
+        assert!(body.is_empty());
+    }
+    let versioned = request(&app, Method::GET, "/v1/health", None, Body::empty()).await;
+    let legacy = request(&app, Method::GET, "/health", None, Body::empty()).await;
+    assert_eq!(versioned.0, StatusCode::OK);
+    assert_eq!(versioned.1["briskdb-api-version"], "1");
+    assert_eq!(versioned.2, legacy.2);
+    assert!(!legacy.1.contains_key("briskdb-api-version"));
+}
+
+#[tokio::test]
+async fn invalid_envelopes_fail_before_sql_or_schema_mutation() {
+    let (_temp, engine, app) = application();
+    for body in [
+        r#"{"sql": "INSERT INTO notes VALUES (1)", "shard_key":"owner", "private-sentinel": true}"#,
+        r#"{"sql": "INSERT INTO notes VALUES (1)", "sql": "private-sentinel", "shard_key":"owner"}"#,
+        r#"{"sql": "INSERT INTO notes VALUES (1)", "shard_key":"owner", "params": null}"#,
+        r#"{"sql": "INSERT INTO notes VALUES (1)", "shard_key":"owner"} {}"#,
+        r#"{"sql": "private-sentinel""#,
+        r#"{"params": []}"#,
+        r#"{"sql": 1}"#,
+        r#"{"sql": "SELECT 1", "shard_key": 1}"#,
+        r#"[]"#,
+        r#"null"#,
+        "",
+    ] {
+        for uri in ["/v1/execute", "/v1/query"] {
+            assert_problem(
+                request(&app, Method::POST, uri, Some("application/json"), body).await,
+                StatusCode::BAD_REQUEST,
+                "invalid_argument",
+            );
+        }
+    }
+    assert_problem(
+        request(
+            &app,
+            Method::POST,
+            "/v1/admin/broadcast",
+            Some("application/json"),
+            r#"{"sql":"DROP TABLE notes", "params":["private-sentinel"]}"#,
+        )
+        .await,
+        StatusCode::BAD_REQUEST,
+        "invalid_argument",
+    );
+
+    let session = engine.session();
+    session.set_routing_key("owner").await.unwrap();
+    let rows = engine
+        .query(&session, Statement::new("SELECT id FROM notes", vec![]))
+        .await
+        .unwrap();
+    assert!(rows.value.rows().is_empty());
+}
+
+#[tokio::test]
+async fn transport_rejections_have_redacted_versioned_problems_and_allow_headers() {
+    let (_temp, _engine, app) = application();
+    for media_type in [None, Some("text/plain")] {
+        assert_problem(
+            request(
+                &app,
+                Method::POST,
+                "/v1/query",
+                media_type,
+                r#"{"sql":"private-sentinel"}"#,
+            )
+            .await,
+            StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            "unsupported_media_type",
+        );
+    }
+    for (uri, method, allow) in [
+        ("/v1/query", Method::GET, "POST"),
+        ("/v1/admin/broadcast", Method::PUT, "POST"),
+        ("/v1/admin/global-indexes", Method::POST, "GET,HEAD"),
+        ("/v1", Method::POST, "GET,HEAD"),
+    ] {
+        let response = request(&app, method, uri, None, Body::empty()).await;
+        assert_eq!(response.1["allow"], allow);
+        assert_problem(
+            response,
+            StatusCode::METHOD_NOT_ALLOWED,
+            "method_not_allowed",
+        );
+    }
+    assert_problem(
+        request(
+            &app,
+            Method::GET,
+            "/v1/private-sentinel",
+            None,
+            Body::empty(),
+        )
+        .await,
+        StatusCode::NOT_FOUND,
+        "not_found",
+    );
+    let response = request(&app, Method::GET, "/v2/query", None, Body::empty()).await;
+    assert_eq!(response.0, StatusCode::NOT_FOUND);
+    assert!(!response.1.contains_key("briskdb-api-version"));
+}
+
+#[tokio::test]
+async fn oversized_json_is_rejected_and_later_requests_still_work() {
+    let (_temp, _engine, app) = application();
+    let oversized = json!({"sql": "private-sentinel".repeat(150_000)}).to_string();
+    for uri in ["/v1/query", "/v1/execute", "/v1/admin/broadcast"] {
+        assert_problem(
+            request(
+                &app,
+                Method::POST,
+                uri,
+                Some("application/json"),
+                oversized.clone(),
+            )
+            .await,
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "request_too_large",
+        );
+    }
+    let (status, headers, body) = request(&app, Method::POST, "/v1/query",
+        Some("application/json; charset=utf-8"),
+        r#"{"shard_key":"owner", "sql":"SELECT ?1 AS duplicate, ?2 AS duplicate", "params":["hello",null]}"#).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(headers["briskdb-api-version"], "1");
+    let body: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(body["rows"], json!([["hello", null]]));
+    assert_eq!(body["columns"][0]["name"], "duplicate");
+    assert_eq!(body["columns"][1]["name"], "duplicate");
+    assert!(body.get("shard").is_some());
+    assert!(body.get("shards").is_none());
+}
+
+#[tokio::test]
+async fn engine_errors_and_request_routing_remain_session_local() {
+    let (_temp, engine, app) = application();
+    let (status, headers, body) = request(
+        &app,
+        Method::POST,
+        "/v1/execute",
+        Some("application/json"),
+        r#"{"shard_key":"owner", "sql":"INSERT INTO notes VALUES (?1)", "params":[7]}"#,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(headers["briskdb-api-version"], "1");
+    assert_eq!(
+        serde_json::from_slice::<Value>(&body).unwrap()["rows_affected"],
+        1
+    );
+
+    let session = engine.session();
+    let core = engine
+        .query_logical(&session, Statement::new("SELECT id FROM notes", vec![]))
+        .await
+        .unwrap_err();
+    let problem = assert_problem(
+        request(
+            &app,
+            Method::POST,
+            "/v1/query",
+            Some("application/json"),
+            r#"{"sql":"SELECT id FROM notes"}"#,
+        )
+        .await,
+        StatusCode::from_u16(briskdb::protocol::error::http_error(core.kind()).status).unwrap(),
+        core.code(),
+    );
+    assert_eq!(problem["code"], core.code());
+
+    assert_problem(
+        request(
+            &app,
+            Method::POST,
+            "/v1/execute",
+            Some("application/json"),
+            r#"{"shard_key":"owner", "sql":"INSERT INTO notes VALUES (7)"}"#,
+        )
+        .await,
+        StatusCode::CONFLICT,
+        "unique_violation",
+    );
+    let (status, _, body) = request(
+        &app,
+        Method::POST,
+        "/v1/query",
+        Some("application/json"),
+        r#"{"shard_key":"owner", "sql":"SELECT id FROM notes"}"#,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&body).unwrap()["rows"],
+        json!([[7]])
+    );
+}


### PR DESCRIPTION
BriskDB already exposed `/v1` paths, but their request validation and transport errors were implicit framework behavior. Unknown envelope fields were silently ignored, and clients could not discover or identify the API contract.

This change defines HTTP API version 1 over the existing shared Engine and per-request Session lifecycle. It adds discovery at `/v1` and `/v1/`, a `/v1/health` alias, version headers on v1 responses, strict SQL/migration envelopes, an explicit 2 MiB JSON body limit, and fixed redacted problems for decoding, media-type, route, and method failures. Existing valid requests, successful result shapes, engine error mappings, and the default `legacy-json-v1` cell encoding are preserved. Lossless value encoding remains #51 and must be explicitly selected or introduced under a new API major version.

The HTTP contract, alpha compatibility policy, release migration notes, and roadmap describe the change. Clients sending unused fields must remove them; clients parsing framework error text must switch to problem `code` values. Storage, SQL planning, listener configuration, and the browser API are unchanged.

Validation:

- `cargo fmt --all --check`
- `cargo test --locked --all-targets --all-features`
- `cargo test --locked --doc --all-features`
- `cargo +1.85.0 test --locked --all-targets --all-features`
- `cargo +1.85.0 test --locked --doc --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo check --locked --lib --no-default-features --features http`
- Node syntax checks for both admin scripts and all 7 browser-logic tests
- Changed Markdown local-link validation and `git diff --check`

Five new HTTP integration tests cover rejected bodies before SQL/schema mutation, redacted transport errors, body limits, Allow/version headers, version discovery/isolation, and request-local routing. The existing 38 HTTP tests additionally assert version headers and retain routing, generated-key, concurrency, deadline, result-limit, and golden-response coverage.

Closes #50
