### PR TITLE
Freeze the TinyMongo v1 parity contract

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+compat/mongo/v1/runner/adaptation.patch -whitespace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,89 @@ env:
   RUST_BACKTRACE: "1"
 
 jobs:
+  mongo-contract:
+    name: Mongo compatibility contract
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Python 3.9 replay environment
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          # The 3.9.6 harvest is preserved in the manifest. GitHub's Python
+          # toolcache does not publish that patch for Ubuntu 24.04.
+          python-version: "3.9.25"
+
+      - name: Check out locked TinyMongo oracle
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: schapman1974/tinymongo
+          ref: 53cbf44e98b8caa036163725d195fd29592e1cc0
+          path: target/tinymongo-source
+          persist-credentials: false
+
+      - name: Install contract-only oracle dependencies
+        run: |
+          python -m pip install -r compat/mongo/v1/runner/requirements.txt
+          python -m pip install --no-build-isolation --no-deps \
+            ./target/tinymongo-source
+
+      - name: Validate versioned Mongo contract
+        run: python scripts/mongo_parity.py validate
+
+      - name: Test Mongo contract harness
+        run: python -m unittest discover -s tests -p 'test_mongo*.py' -v
+
+      - name: Verify locked TinyMongo source
+        run: >-
+          python scripts/mongo_parity.py verify-source
+          --source-root target/tinymongo-source
+
+      - name: Execute owned fixtures against TinyMongo memory
+        run: |
+          mkdir -p target/mongo-parity
+          python -m pytest -q -p no:cacheprovider -c /dev/null \
+            compat/mongo/v1/runner/contracts \
+            --mongo-contract-target=tinymongo \
+            --mongo-contract-backend=memory \
+            --mongo-contract-require-target \
+            --junitxml=target/mongo-parity/tinymongo-memory.xml
+          python scripts/mongo_parity.py ingest \
+            --implementation tinymongo \
+            --junit target/mongo-parity/tinymongo-memory.xml \
+            --output target/mongo-parity/tinymongo-memory.json
+          cmp compat/mongo/v1/reference-results.json \
+            target/mongo-parity/tinymongo-memory.json
+
+      - name: Generate Mongo parity report
+        run: |
+          mkdir -p target/mongo-parity
+          python scripts/mongo_parity.py report \
+            --json-output target/mongo-parity/report.json \
+            --markdown-output target/mongo-parity/report.md
+
+      - name: Add Mongo parity report to summary
+        if: always()
+        run: |
+          if [ -f target/mongo-parity/report.md ]; then
+            cat target/mongo-parity/report.md >> "${GITHUB_STEP_SUMMARY}"
+          else
+            echo "Mongo parity report was not generated." >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+      - name: Upload Mongo parity report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mongo-parity-report
+          path: target/mongo-parity/*
+          if-no-files-found: ignore
+          retention-days: 14
+
   features:
     name: Features (${{ matrix.surface }}, Rust ${{ matrix.rust }})
     runs-on: ubuntu-24.04

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ experimental and opt-in; the exact contract lives in
 | Debian package and hardened systemd service | Published |
 | Rust library entrypoint with optional attached listeners | Working |
 | Same-host service and embedded processes sharing one ready root | Working on local filesystems |
-| Native MongoDB wire protocol with TinyMongo parity | [Planned](https://github.com/schapman1974/briskdb/issues/160) |
+| Native MongoDB wire protocol with TinyMongo parity | [Versioned TinyMongo contract landed](docs/MONGO_PARITY.md); engine and listener remain [planned](https://github.com/schapman1974/briskdb/issues/160) |
 | MySQL wire protocol | [Planned](https://github.com/schapman1974/briskdb/issues/40) |
 | Native Python extension | Sync/async API working; tagged releases build audited macOS/Linux ARM/x86 wheels |
 | Serverless lifecycle | [Planned](https://github.com/schapman1974/briskdb/issues/194) |
@@ -314,6 +314,7 @@ more valuable than a star. Start with the
 - [Crate features and support tiers](docs/CRATE_FEATURES.md)
 - [PostgreSQL quickstart](docs/POSTGRES_QUICKSTART.md)
 - [Tested PostgreSQL clients](docs/POSTGRES_CLIENTS.md)
+- [Mongo compatibility parity contract](docs/MONGO_PARITY.md)
 - [SQL compatibility](docs/SQL_COMPATIBILITY.md)
 - [Generated keys](docs/GENERATED_KEYS.md)
 - [Storage format](docs/STORAGE_FORMAT.md)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,12 @@
 # Unreleased
 
+Mongo compatibility now has a versioned, source-locked TinyMongo v1.3.0
+contract. Its manifest inventories the supported document surface, 228 logical
+cases cover both sync and async APIs across a 3,192-execution backend matrix,
+and CI validates the checked-in corpus and publishes a readable parity report.
+The current report is reference-only; it does not claim BriskDB parity before a
+candidate endpoint is available and tested. See [the Mongo parity contract](docs/MONGO_PARITY.md).
+
 HTTP now has an explicit version-1 contract, discovery at `/v1`, a versioned
 `/v1/health` alias, and `BriskDB-API-Version: 1` on v1 responses. Existing valid
 SQL requests and result encodings are preserved. Unknown or duplicate envelope

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -442,6 +442,22 @@ requires an earlier dependency:
     parity.** Build the document engine, BSON and wire layers, query and write
     semantics, indexes, aggregation, sharding behavior, and differential
     compatibility suites.
+
+    - [x] [#161](https://github.com/schapman1974/briskdb/issues/161) — freeze
+      the TinyMongo v1.3.0 contract, capability inventory, reference results,
+      and strict differential report
+    - [ ] [#164](https://github.com/schapman1974/briskdb/issues/164) — canonical
+      BSON model, codec, and ordering
+    - [ ] [#163](https://github.com/schapman1974/briskdb/issues/163) — document
+      catalog and storage layout
+    - [ ] [#162](https://github.com/schapman1974/briskdb/issues/162) —
+      protocol-neutral document engine
+    - [ ] [#191](https://github.com/schapman1974/briskdb/issues/191) — embedded
+      Rust document API
+    - [ ] [#198](https://github.com/schapman1974/briskdb/issues/198) — Python
+      BSON conversions and document API
+    - [ ] [#200](https://github.com/schapman1974/briskdb/issues/200) — release
+      wheels and Mongo smoke coverage
 11. [ ] **Implement online resharding and rebalance.** Add durable bucket
     movement, generation-aware retries, verification, and a supported offline
     reshard path before online movement.

--- a/compat/mongo/v1/corpus.json
+++ b/compat/mongo/v1/corpus.json
@@ -1,0 +1,2402 @@
+{
+  "cases": [
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage0]",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage10]",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage11]",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage12]",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage13]",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage14]",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage15]",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage16]",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage17]",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage18]",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage1]",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage2]",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage3]",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage4]",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage5]",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage6]",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage7]",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage8]",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage9]",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_compound_numeric_sort_paths_can_select_separate_array_indexes",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_compound_numeric_sort_rejects_parallel_selected_arrays",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_compound_sort_allows_nested_arrays_in_separate_parent_elements",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_compound_sort_preserves_shared_array_element_correlation",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_compound_sort_rejects_numeric_path_parallel_arrays[first.1]",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_compound_sort_rejects_numeric_path_parallel_arrays[first.9]",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_compound_sort_rejects_parallel_arrays",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_empty_input_stays_empty_and_count_emits_no_document",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_integral_numeric_arguments_and_pagination_boundaries",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_numeric_sort_path_compares_selected_array_as_a_whole_value",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_numeric_sort_path_keeps_empty_array_special_order",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_out_of_range_numeric_sort_path_fans_out_to_named_fields",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_sort_array_fanout_includes_missing_but_not_nested_arrays",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_sort_numeric_path_segments_address_array_indexes",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_sort_rejects_ambiguous_numeric_array_paths",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_sort_skip_limit_and_count_compose_with_other_stages",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_sort_traverses_dotted_array_paths_and_compounds_ties",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_basic_stages_contract::test_sort_uses_mongodb_keys_for_missing_null_arrays_and_bson_types",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_contract::test_aggregate_cursor_consumes_in_chunks",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_contract::test_dotted_paths_preserve_empty_array_traversals",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_contract::test_first_and_last_play_by_user",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_contract::test_latest_activity_by_course",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_contract::test_match_reuses_query_semantics_and_can_follow_group",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_contract::test_null_missing_keys_and_empty_inputs",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_contract::test_project_dotted_inclusion_preserves_array_shape",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_contract::test_project_expression_argument_and_lazy_evaluation_contract",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_contract::test_project_inclusion_id_and_expression_contract",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_contract::test_project_size_ifnull_application_rollup",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_contract::test_sum_and_min_max_follow_mongodb_value_rules",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_contract::test_whole_collection_rollup",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_projection_stages_contract::test_field_paths_do_not_descend_through_nested_arrays",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_projection_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_projection_stages_contract::test_literal_and_remove_expression_contract",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_projection_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_projection_stages_contract::test_project_computed_dotted_paths_preserve_array_shape",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_projection_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_projection_stages_contract::test_project_inclusion_exclusion_and_computed_modes",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_projection_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_projection_stages_contract::test_project_preserves_embedded_source_order_for_group_identity",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_projection_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_projection_stages_contract::test_set_and_add_fields_are_aliases_using_original_input",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_projection_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_aggregation_projection_stages_contract::test_unset_accepts_one_or_many_dotted_fields",
+      "requirements": {},
+      "source": "tests/contracts/test_aggregation_projection_stages_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_array_update_contract::test_array_updates_reject_non_array_targets[$pull-remove]",
+      "requirements": {},
+      "source": "tests/contracts/test_array_update_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_array_update_contract::test_array_updates_reject_non_array_targets[$pullAll-operand2]",
+      "requirements": {},
+      "source": "tests/contracts/test_array_update_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_array_update_contract::test_array_updates_reject_non_array_targets[$push-append]",
+      "requirements": {},
+      "source": "tests/contracts/test_array_update_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_array_update_contract::test_invalid_array_modifiers_fail_atomically",
+      "requirements": {},
+      "source": "tests/contracts/test_array_update_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_array_update_contract::test_plain_push_and_add_to_set_each_regressions",
+      "requirements": {},
+      "source": "tests/contracts/test_array_update_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_array_update_contract::test_pull_accepts_literal_and_query_operands",
+      "requirements": {},
+      "source": "tests/contracts/test_array_update_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_array_update_contract::test_pull_all_uses_literal_bson_equality",
+      "requirements": {},
+      "source": "tests/contracts/test_array_update_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_array_update_contract::test_pull_missing_fields_are_true_noops",
+      "requirements": {},
+      "source": "tests/contracts/test_array_update_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_array_update_contract::test_pull_not_and_pull_all_operand_errors_match_mongodb",
+      "requirements": {},
+      "source": "tests/contracts/test_array_update_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_array_update_contract::test_pull_query_operator_family_matches_mongodb",
+      "requirements": {},
+      "source": "tests/contracts/test_array_update_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_array_update_contract::test_push_each_slice_keeps_a_bounded_array",
+      "requirements": {},
+      "source": "tests/contracts/test_array_update_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_array_update_contract::test_push_modifiers_follow_mongodb_order_and_boundaries",
+      "requirements": {},
+      "source": "tests/contracts/test_array_update_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_array_update_contract::test_tm038_pull_expr_errors_are_preflighted_like_mongodb",
+      "requirements": {},
+      "source": "tests/contracts/test_array_update_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_array_update_contract::test_tm038_pull_remaining_field_predicates_match_mongodb",
+      "requirements": {},
+      "source": "tests/contracts/test_array_update_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_beanie_odm_contract::test_beanie_write_result_contract",
+      "requirements": {},
+      "source": "tests/contracts/test_beanie_odm_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_bson_comparison_contract::test_array_range_queries_compare_whole_and_direct_nested_arrays",
+      "requirements": {},
+      "source": "tests/contracts/test_bson_comparison_contract.py",
+      "suite": "bson-comparison"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_bson_comparison_contract::test_cursor_and_aggregation_sort_share_scalar_bson_order",
+      "requirements": {},
+      "source": "tests/contracts/test_bson_comparison_contract.py",
+      "suite": "bson-comparison"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_bson_comparison_contract::test_embedded_id_fields_use_normal_array_comparison_semantics",
+      "requirements": {},
+      "source": "tests/contracts/test_bson_comparison_contract.py",
+      "suite": "bson-comparison"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_bson_comparison_contract::test_generated_scalar_range_matrix[boolean-family]",
+      "requirements": {},
+      "source": "tests/contracts/test_bson_comparison_contract.py",
+      "suite": "bson-comparison"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_bson_comparison_contract::test_generated_scalar_range_matrix[numeric-family]",
+      "requirements": {},
+      "source": "tests/contracts/test_bson_comparison_contract.py",
+      "suite": "bson-comparison"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_bson_comparison_contract::test_generated_scalar_range_matrix[string-family]",
+      "requirements": {},
+      "source": "tests/contracts/test_bson_comparison_contract.py",
+      "suite": "bson-comparison"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_bson_comparison_contract::test_indexed_ranges_feed_every_filter_consumer",
+      "requirements": {},
+      "source": "tests/contracts/test_bson_comparison_contract.py",
+      "suite": "bson-comparison"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_bson_comparison_contract::test_legacy_binary_subtype_two_uses_its_encoded_length",
+      "requirements": {},
+      "source": "tests/contracts/test_bson_comparison_contract.py",
+      "suite": "bson-comparison"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_bson_comparison_contract::test_nested_regex_range_values_are_compared_without_compilation",
+      "requirements": {},
+      "source": "tests/contracts/test_bson_comparison_contract.py",
+      "suite": "bson-comparison"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_bson_comparison_contract::test_null_range_queries_include_missing_and_array_members",
+      "requirements": {},
+      "source": "tests/contracts/test_bson_comparison_contract.py",
+      "suite": "bson-comparison"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_bson_comparison_contract::test_object_range_queries_use_recursive_bson_field_order",
+      "requirements": {},
+      "source": "tests/contracts/test_bson_comparison_contract.py",
+      "suite": "bson-comparison"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_bson_comparison_contract::test_pull_document_ranges_share_missing_and_array_path_semantics",
+      "requirements": {},
+      "source": "tests/contracts/test_bson_comparison_contract.py",
+      "suite": "bson-comparison"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_bson_comparison_contract::test_pull_reuses_recursive_bson_range_comparison",
+      "requirements": {},
+      "source": "tests/contracts/test_bson_comparison_contract.py",
+      "suite": "bson-comparison"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_bson_comparison_contract::test_regex_range_operands_are_rejected_with_code_2[bson-malformed]",
+      "requirements": {},
+      "source": "tests/contracts/test_bson_comparison_contract.py",
+      "suite": "bson-comparison"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_bson_comparison_contract::test_regex_range_operands_are_rejected_with_code_2[bson-valid]",
+      "requirements": {},
+      "source": "tests/contracts/test_bson_comparison_contract.py",
+      "suite": "bson-comparison"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_bson_comparison_contract::test_regex_range_operands_are_rejected_with_code_2[native]",
+      "requirements": {},
+      "source": "tests/contracts/test_bson_comparison_contract.py",
+      "suite": "bson-comparison"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_bson_comparison_contract::test_scalar_ranges_share_bson_keys_and_dates_use_milliseconds",
+      "requirements": {},
+      "source": "tests/contracts/test_bson_comparison_contract.py",
+      "suite": "bson-comparison"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_bson_comparison_contract::test_tm036_extreme_array_members_preserve_exact_semantics",
+      "requirements": {},
+      "source": "tests/contracts/test_bson_comparison_contract.py",
+      "suite": "bson-comparison"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_bson_comparison_contract::test_tm036_min_max_key_range_operands_cross_type_brackets",
+      "requirements": {},
+      "source": "tests/contracts/test_bson_comparison_contract.py",
+      "suite": "bson-comparison"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_bson_comparison_contract::test_tm036_pull_reuses_unbounded_min_max_key_ranges",
+      "requirements": {},
+      "source": "tests/contracts/test_bson_comparison_contract.py",
+      "suite": "bson-comparison"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_bson_value_types_contract::test_tm035_exact_equality_and_distinct_use_bson_identity",
+      "requirements": {},
+      "source": "tests/contracts/test_bson_value_types_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_bson_value_types_contract::test_tm035_new_bson_values_round_trip_at_every_depth",
+      "requirements": {},
+      "source": "tests/contracts/test_bson_value_types_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_bson_value_types_contract::test_tm035_scoped_code_honors_recursive_client_read_options",
+      "requirements": {
+        "client_options": {
+          "document_class": "collections.OrderedDict",
+          "tz_aware": true
+        }
+      },
+      "source": "tests/contracts/test_bson_value_types_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_bson_value_types_contract::test_tm035_sort_uses_the_complete_supported_scalar_order",
+      "requirements": {},
+      "source": "tests/contracts/test_bson_value_types_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_bson_value_types_contract::test_tm035_type_aliases_and_numeric_codes_match_mongodb[code-return 1;-javascript-13]",
+      "requirements": {},
+      "source": "tests/contracts/test_bson_value_types_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_bson_value_types_contract::test_tm035_type_aliases_and_numeric_codes_match_mongodb[maximum-value4-maxKey-127]",
+      "requirements": {},
+      "source": "tests/contracts/test_bson_value_types_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_bson_value_types_contract::test_tm035_type_aliases_and_numeric_codes_match_mongodb[minimum-value0-minKey--1]",
+      "requirements": {},
+      "source": "tests/contracts/test_bson_value_types_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_bson_value_types_contract::test_tm035_type_aliases_and_numeric_codes_match_mongodb[scoped-code-return value;-javascriptWithScope-15]",
+      "requirements": {},
+      "source": "tests/contracts/test_bson_value_types_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_bson_value_types_contract::test_tm035_type_aliases_and_numeric_codes_match_mongodb[timestamp-value1-timestamp-17]",
+      "requirements": {},
+      "source": "tests/contracts/test_bson_value_types_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_bson_value_types_contract::test_tm035_unique_index_distinguishes_code_from_text_and_scope",
+      "requirements": {},
+      "source": "tests/contracts/test_bson_value_types_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_bson_value_types_contract::test_tm037_zero_timestamp_insert_many_honors_unique_indexes",
+      "requirements": {},
+      "source": "tests/contracts/test_bson_value_types_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_bson_value_types_contract::test_tm037_zero_timestamp_write_boundaries_match_mongodb",
+      "requirements": {},
+      "source": "tests/contracts/test_bson_value_types_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_client_read_fidelity_contract::test_configured_document_and_datetime_results_match_mongodb",
+      "requirements": {
+        "client_options": {
+          "document_class": "collections.OrderedDict",
+          "tz_aware": true
+        }
+      },
+      "source": "tests/contracts/test_client_read_fidelity_contract.py",
+      "suite": "client-read-fidelity"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_client_read_fidelity_contract::test_same_millisecond_write_identity_matches_mongodb",
+      "requirements": {
+        "client_options": {
+          "document_class": "collections.OrderedDict",
+          "tz_aware": true
+        }
+      },
+      "source": "tests/contracts/test_client_read_fidelity_contract.py",
+      "suite": "client-read-fidelity"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_crud_contract::test_array_in_query_contract",
+      "requirements": {},
+      "source": "tests/contracts/test_crud_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_crud_contract::test_duplicate_id_has_a_shared_error_category",
+      "requirements": {},
+      "source": "tests/contracts/test_crud_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_crud_contract::test_explicit_null_id_is_preserved_and_unique",
+      "requirements": {},
+      "source": "tests/contracts/test_crud_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_crud_contract::test_insert_query_sort_and_count",
+      "requirements": {},
+      "source": "tests/contracts/test_crud_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_crud_contract::test_replace_upsert_accepts_bson_equal_filter_and_replacement_ids",
+      "requirements": {},
+      "source": "tests/contracts/test_crud_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_crud_contract::test_replace_upsert_and_delete_metadata",
+      "requirements": {},
+      "source": "tests/contracts/test_crud_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_crud_contract::test_replace_upsert_preserves_equality_bound_id[query0-77]",
+      "requirements": {},
+      "source": "tests/contracts/test_crud_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_crud_contract::test_replace_upsert_preserves_equality_bound_id[query1-pinned-key]",
+      "requirements": {},
+      "source": "tests/contracts/test_crud_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_crud_contract::test_replace_upsert_preserves_equality_bound_id[query2-88]",
+      "requirements": {},
+      "source": "tests/contracts/test_crud_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_crud_contract::test_replace_upsert_preserves_equality_bound_id[query3-None]",
+      "requirements": {},
+      "source": "tests/contracts/test_crud_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_crud_contract::test_replace_upsert_rejects_conflicting_filter_and_replacement_ids",
+      "requirements": {},
+      "source": "tests/contracts/test_crud_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_crud_contract::test_replace_upsert_stores_id_first",
+      "requirements": {},
+      "source": "tests/contracts/test_crud_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_crud_contract::test_sort_skip_and_limit_contract",
+      "requirements": {},
+      "source": "tests/contracts/test_crud_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_crud_contract::test_unset_removes_top_level_and_nested_fields",
+      "requirements": {},
+      "source": "tests/contracts/test_crud_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_crud_contract::test_update_and_result_metadata",
+      "requirements": {},
+      "source": "tests/contracts/test_crud_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_decimal128_contract::test_decimal128_array_updates_and_distinct_reuse_numeric_identity",
+      "requirements": {},
+      "source": "tests/contracts/test_decimal128_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_decimal128_contract::test_decimal128_extreme_ids_round_trip",
+      "requirements": {},
+      "source": "tests/contracts/test_decimal128_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_decimal128_contract::test_decimal128_grouping_min_max_and_sum_use_one_numeric_family",
+      "requirements": {},
+      "source": "tests/contracts/test_decimal128_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_decimal128_contract::test_decimal128_inc_promotes_the_result",
+      "requirements": {},
+      "source": "tests/contracts/test_decimal128_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_decimal128_contract::test_decimal128_min_max_ties_and_literal_sum_match_mongodb",
+      "requirements": {},
+      "source": "tests/contracts/test_decimal128_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_decimal128_contract::test_decimal128_nan_query_comparisons_follow_mongodb",
+      "requirements": {},
+      "source": "tests/contracts/test_decimal128_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_decimal128_contract::test_decimal128_numeric_identity_is_enforced_by_ids_and_unique_indexes",
+      "requirements": {},
+      "source": "tests/contracts/test_decimal128_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_decimal128_contract::test_decimal128_projection_flags_and_stage_arguments",
+      "requirements": {},
+      "source": "tests/contracts/test_decimal128_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_decimal128_contract::test_decimal128_representation_changes_are_persisted",
+      "requirements": {},
+      "source": "tests/contracts/test_decimal128_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_decimal128_contract::test_decimal128_round_trips_and_participates_in_numeric_queries",
+      "requirements": {},
+      "source": "tests/contracts/test_decimal128_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_decimal128_contract::test_decimal128_sum_keeps_double_precision_until_promotion",
+      "requirements": {},
+      "source": "tests/contracts/test_decimal128_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_group_accumulators_contract::test_accumulators_accept_the_supported_expression_subset",
+      "requirements": {},
+      "source": "tests/contracts/test_group_accumulators_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_group_accumulators_contract::test_add_to_set_uses_recursive_bson_identity",
+      "requirements": {},
+      "source": "tests/contracts/test_group_accumulators_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_group_accumulators_contract::test_array_values_remain_whole_accumulator_values",
+      "requirements": {},
+      "source": "tests/contracts/test_group_accumulators_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_group_accumulators_contract::test_avg_ignores_non_numeric_values_and_promotes_decimal",
+      "requirements": {},
+      "source": "tests/contracts/test_group_accumulators_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_group_accumulators_contract::test_avg_preserves_cancellation_and_nonfinite_values",
+      "requirements": {},
+      "source": "tests/contracts/test_group_accumulators_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_group_accumulators_contract::test_first_last_and_push_follow_sorted_input_and_missing_rules",
+      "requirements": {},
+      "source": "tests/contracts/test_group_accumulators_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_group_accumulators_contract::test_group_accumulators_reject_array_argument_lists[$addToSet]",
+      "requirements": {},
+      "source": "tests/contracts/test_group_accumulators_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_group_accumulators_contract::test_group_accumulators_reject_array_argument_lists[$avg]",
+      "requirements": {},
+      "source": "tests/contracts/test_group_accumulators_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_group_accumulators_contract::test_group_accumulators_reject_array_argument_lists[$first]",
+      "requirements": {},
+      "source": "tests/contracts/test_group_accumulators_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_group_accumulators_contract::test_group_accumulators_reject_array_argument_lists[$last]",
+      "requirements": {},
+      "source": "tests/contracts/test_group_accumulators_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_group_accumulators_contract::test_group_accumulators_reject_array_argument_lists[$max]",
+      "requirements": {},
+      "source": "tests/contracts/test_group_accumulators_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_group_accumulators_contract::test_group_accumulators_reject_array_argument_lists[$min]",
+      "requirements": {},
+      "source": "tests/contracts/test_group_accumulators_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_group_accumulators_contract::test_group_accumulators_reject_array_argument_lists[$push]",
+      "requirements": {},
+      "source": "tests/contracts/test_group_accumulators_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_group_accumulators_contract::test_group_accumulators_reject_array_argument_lists[$sum]",
+      "requirements": {},
+      "source": "tests/contracts/test_group_accumulators_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_group_accumulators_contract::test_missing_only_arrays_and_empty_inputs_match_mongodb",
+      "requirements": {},
+      "source": "tests/contracts/test_group_accumulators_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_projection_contract::test_empty_and_invalid_projection_contract",
+      "requirements": {},
+      "source": "tests/contracts/test_projection_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_projection_contract::test_inclusion_exclusion_and_id_projection_contract",
+      "requirements": {},
+      "source": "tests/contracts/test_projection_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_projection_contract::test_nested_and_array_projection_contract",
+      "requirements": {},
+      "source": "tests/contracts/test_projection_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_projection_contract::test_projection_uses_unprojected_values_for_filter_and_sort",
+      "requirements": {},
+      "source": "tests/contracts/test_projection_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_add_to_set_non_array_errors_report_code_2_and_leave_document_atomic",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_comment_inside_document_elem_match_is_accepted",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_comment_is_accepted_and_ignored_while_matching",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_comment_remains_invalid_as_a_field_operator",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_continued_numeric_paths_ignore_scalar_index_dead_ends",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_distinct_rejects_falsey_non_document_filters",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_dotted_query_paths_traverse_document_arrays_not_raw_nested_arrays",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_duplicate_key_errors_report_code_11000",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_elem_match_document_paths_traverse_nested_arrays",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_elem_match_null_conditions_match_missing_document_fields",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_elem_match_requires_one_array_member_to_satisfy_every_condition",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_elem_match_unknown_or_misplaced_operators_report_code_2[misplaced-logical-clause]",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_elem_match_unknown_or_misplaced_operators_report_code_2[unknown-beside-field-operator]",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_elem_match_unknown_or_misplaced_operators_report_code_2[unknown]",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_embedded_regex_flags_and_options_report_code_51075",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_every_filtering_crud_entrypoint_rejects_invalid_not_operands",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_every_filtering_crud_entrypoint_rejects_operator_typos",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_find_rejects_top_level_and_field_operator_typos",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_index_name_and_key_conflict_codes_match_mongodb",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_mapping_filters_work_for_new_operators_and_dotted_paths",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_mod_uses_mongodb_integer_truncation_and_array_member_rules",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_not_accepts_operator_documents_and_compiled_regexes",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_not_rejects_non_regex_and_empty_operands_with_code_2[7]",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_not_rejects_non_regex_and_empty_operands_with_code_2[operand2]",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_not_rejects_non_regex_and_empty_operands_with_code_2[operand3]",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_not_rejects_non_regex_and_empty_operands_with_code_2[operand4]",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_not_rejects_non_regex_and_empty_operands_with_code_2[text]",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_null_equality_keeps_missing_fields_visible_after_indexing",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_numeric_query_paths_consider_array_indexes_and_document_field_names",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_recognized_query_operators_reject_malformed_operands",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_size_matches_arrays_with_the_exact_requested_length",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_tuple_equality_keeps_array_matches_visible_after_indexing",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_query_operator_contract::test_type_supports_aliases_codes_lists_and_array_element_matching",
+      "requirements": {},
+      "source": "tests/contracts/test_query_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_talkpython_contract::test_binary_ids_use_bson_equality_without_losing_subtype",
+      "requirements": {},
+      "source": "tests/contracts/test_talkpython_contract.py",
+      "suite": "talkpython"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_talkpython_contract::test_binary_round_trip_query_and_mongodb_sort_order",
+      "requirements": {},
+      "source": "tests/contracts/test_talkpython_contract.py",
+      "suite": "talkpython"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_talkpython_contract::test_boolean_and_numeric_ids_are_bson_distinct",
+      "requirements": {},
+      "source": "tests/contracts/test_talkpython_contract.py",
+      "suite": "talkpython"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_talkpython_contract::test_create_indexes_accepts_the_real_mixed_batch_and_enforces_unique",
+      "requirements": {},
+      "source": "tests/contracts/test_talkpython_contract.py",
+      "suite": "talkpython"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_talkpython_contract::test_cursor_limit_zero_means_unlimited",
+      "requirements": {},
+      "source": "tests/contracts/test_talkpython_contract.py",
+      "suite": "talkpython"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_talkpython_contract::test_cursor_skip_limit_windows_and_past_end",
+      "requirements": {},
+      "source": "tests/contracts/test_talkpython_contract.py",
+      "suite": "talkpython"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_talkpython_contract::test_cursor_to_list_accepts_both_application_spellings",
+      "requirements": {},
+      "source": "tests/contracts/test_talkpython_contract.py",
+      "suite": "talkpython"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_talkpython_contract::test_distinct_returns_scalar_field_values",
+      "requirements": {},
+      "source": "tests/contracts/test_talkpython_contract.py",
+      "suite": "talkpython"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_talkpython_contract::test_dot_notation_matches_an_embedded_document",
+      "requirements": {},
+      "source": "tests/contracts/test_talkpython_contract.py",
+      "suite": "talkpython"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_talkpython_contract::test_duplicate_errors_are_catchable_as_pymongo_errors",
+      "requirements": {},
+      "source": "tests/contracts/test_talkpython_contract.py",
+      "suite": "talkpython"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_talkpython_contract::test_find_one_sort_returns_the_newest_match",
+      "requirements": {},
+      "source": "tests/contracts/test_talkpython_contract.py",
+      "suite": "talkpython"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_talkpython_contract::test_generated_id_uses_the_standard_object_id_round_trip",
+      "requirements": {},
+      "source": "tests/contracts/test_talkpython_contract.py",
+      "suite": "talkpython"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_talkpython_contract::test_generic_binary_equality_matches_native_bytes_and_query_operators",
+      "requirements": {},
+      "source": "tests/contracts/test_talkpython_contract.py",
+      "suite": "talkpython"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_talkpython_contract::test_inc_creates_a_missing_counter",
+      "requirements": {},
+      "source": "tests/contracts/test_talkpython_contract.py",
+      "suite": "talkpython"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_talkpython_contract::test_insert_many_accepts_a_document_generator",
+      "requirements": {},
+      "source": "tests/contracts/test_talkpython_contract.py",
+      "suite": "talkpython"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_talkpython_contract::test_insert_many_reports_compatible_partial_failures[False-expected_ids1-2]",
+      "requirements": {},
+      "source": "tests/contracts/test_talkpython_contract.py",
+      "suite": "talkpython"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_talkpython_contract::test_insert_many_reports_compatible_partial_failures[True-expected_ids0-1]",
+      "requirements": {},
+      "source": "tests/contracts/test_talkpython_contract.py",
+      "suite": "talkpython"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_talkpython_contract::test_invalid_document_has_a_bson_compatible_error",
+      "requirements": {},
+      "source": "tests/contracts/test_talkpython_contract.py",
+      "suite": "talkpython"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_talkpython_contract::test_mixed_timezone_datetimes_sort_by_utc_instant",
+      "requirements": {},
+      "source": "tests/contracts/test_talkpython_contract.py",
+      "suite": "talkpython"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_talkpython_contract::test_nin_and_negated_regex_share_one_field_specification",
+      "requirements": {},
+      "source": "tests/contracts/test_talkpython_contract.py",
+      "suite": "talkpython"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_talkpython_contract::test_nin_excludes_values_and_includes_missing_fields",
+      "requirements": {},
+      "source": "tests/contracts/test_talkpython_contract.py",
+      "suite": "talkpython"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_talkpython_contract::test_not_regex_with_case_insensitive_options",
+      "requirements": {},
+      "source": "tests/contracts/test_talkpython_contract.py",
+      "suite": "talkpython"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_talkpython_contract::test_null_negation_distinguishes_missing_and_non_null_fields",
+      "requirements": {},
+      "source": "tests/contracts/test_talkpython_contract.py",
+      "suite": "talkpython"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_talkpython_contract::test_object_id_and_datetime_round_trip_and_range_query",
+      "requirements": {},
+      "source": "tests/contracts/test_talkpython_contract.py",
+      "suite": "talkpython"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_talkpython_contract::test_projection_none_absent_fields_and_integer_id",
+      "requirements": {},
+      "source": "tests/contracts/test_talkpython_contract.py",
+      "suite": "talkpython"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_talkpython_contract::test_replace_one_preserves_id_and_replaces_the_full_document",
+      "requirements": {},
+      "source": "tests/contracts/test_talkpython_contract.py",
+      "suite": "talkpython"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_talkpython_contract::test_scalar_equality_matches_an_array_member",
+      "requirements": {},
+      "source": "tests/contracts/test_talkpython_contract.py",
+      "suite": "talkpython"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_talkpython_contract::test_single_and_multi_key_sort_break_ties",
+      "requirements": {},
+      "source": "tests/contracts/test_talkpython_contract.py",
+      "suite": "talkpython"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_talkpython_contract::test_write_result_metadata_used_by_the_application",
+      "requirements": {},
+      "source": "tests/contracts/test_talkpython_contract.py",
+      "suite": "talkpython"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_update_operator_contract::test_malformed_new_update_operands_report_mongodb_codes",
+      "requirements": {},
+      "source": "tests/contracts/test_update_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_update_operator_contract::test_min_and_max_follow_bson_order_and_report_noops",
+      "requirements": {},
+      "source": "tests/contracts/test_update_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_update_operator_contract::test_min_and_max_include_null_in_whole_bson_value_order",
+      "requirements": {},
+      "source": "tests/contracts/test_update_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_update_operator_contract::test_new_update_operators_apply_to_upsert_equality_fields",
+      "requirements": {},
+      "source": "tests/contracts/test_update_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_update_operator_contract::test_new_update_operators_cover_upsert_update_many_and_find_and_modify",
+      "requirements": {},
+      "source": "tests/contracts/test_update_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_update_operator_contract::test_new_update_operators_follow_numeric_array_paths",
+      "requirements": {},
+      "source": "tests/contracts/test_update_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_update_operator_contract::test_new_update_operators_preserve_immutable_id_semantics",
+      "requirements": {},
+      "source": "tests/contracts/test_update_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_update_operator_contract::test_new_update_operators_report_target_and_path_errors_atomically",
+      "requirements": {},
+      "source": "tests/contracts/test_update_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_update_operator_contract::test_pop_handles_front_back_nested_empty_and_missing_arrays",
+      "requirements": {},
+      "source": "tests/contracts/test_update_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_update_operator_contract::test_rename_moves_nested_values_overwrites_and_ignores_missing_source",
+      "requirements": {},
+      "source": "tests/contracts/test_update_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_update_operator_contract::test_update_path_conflicts_report_code_40_before_writing",
+      "requirements": {},
+      "source": "tests/contracts/test_update_operator_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_uuid_regex_contract::test_local_regex_ids_use_exact_identity_for_duplicate_detection",
+      "requirements": {},
+      "source": "tests/contracts/test_uuid_regex_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_uuid_regex_contract::test_regex_predicates_and_exact_equality_follow_mongodb",
+      "requirements": {},
+      "source": "tests/contracts/test_uuid_regex_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_uuid_regex_contract::test_regex_sort_distinct_and_unique_index_identity",
+      "requirements": {},
+      "source": "tests/contracts/test_uuid_regex_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_uuid_regex_contract::test_uuid_and_subtype_four_binary_share_unique_identity",
+      "requirements": {
+        "mongodb_collection_options": {
+          "uuid_representation": "STANDARD"
+        }
+      },
+      "source": "tests/contracts/test_uuid_regex_contract.py",
+      "suite": "core"
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "id": "tests.contracts.test_uuid_regex_contract::test_uuid_round_trip_uses_standard_binary_identity",
+      "requirements": {
+        "mongodb_collection_options": {
+          "uuid_representation": "STANDARD"
+        }
+      },
+      "source": "tests/contracts/test_uuid_regex_contract.py",
+      "suite": "core"
+    }
+  ],
+  "contract": "tinymongo-v1",
+  "harvest_toolchain": {
+    "pymongo": "4.17.0",
+    "pytest": "8.4.2",
+    "python": "3.9.6"
+  },
+  "schema_version": 1,
+  "source_commit": "53cbf44e98b8caa036163725d195fd29592e1cc0",
+  "source_files": [
+    {
+      "path": "tests/contracts/README.md",
+      "sha256": "74416b17722036fb552e97703b763a6ea4f13959568920a60bf0cfe725cc3f87"
+    },
+    {
+      "path": "tests/contracts/__init__.py",
+      "sha256": "ce7185ce04b04dbce35c37a155ff35b26bf878939a3c188b66c8286f06db1999"
+    },
+    {
+      "path": "tests/contracts/conftest.py",
+      "sha256": "002944603a433d408c1c2b9ce067a27195c6bf78753f27086a2a5b380d5b31d5"
+    },
+    {
+      "path": "tests/contracts/known_differences.py",
+      "sha256": "06f875b4e0c75337d83ff91f95767c14ef396362ece9b300475c529f38b5311a"
+    },
+    {
+      "path": "tests/contracts/support.py",
+      "sha256": "822c4b9739243ab3885f3b4912deb9de8b9c22a1a2d11a9b9b725a9f57c39e5a"
+    },
+    {
+      "path": "tests/contracts/test_aggregation_basic_stages_contract.py",
+      "sha256": "5549d7f226a278be17315b5cbb2847d564770cf5acb1ff0eb47bd467cb0ddf40"
+    },
+    {
+      "path": "tests/contracts/test_aggregation_contract.py",
+      "sha256": "2d4255f17629bf0c51489a7e334ff3087fb1c20800ff669ba58f3abe6c25940f"
+    },
+    {
+      "path": "tests/contracts/test_aggregation_projection_stages_contract.py",
+      "sha256": "4ef68dcf01c60edf25bfe88978d32d5276d2a6076110c2eef62e8bfb3d7f4e5e"
+    },
+    {
+      "path": "tests/contracts/test_array_update_contract.py",
+      "sha256": "0ff202cc19da7acc104f899225a73c0a77c476318784b57049ac65180978c8aa"
+    },
+    {
+      "path": "tests/contracts/test_beanie_odm_contract.py",
+      "sha256": "9a08b0651be070d6353bf5d6481b99c0b1f6bdcd61b745cdade670919bb8c5b1"
+    },
+    {
+      "path": "tests/contracts/test_bson_comparison_contract.py",
+      "sha256": "8222a1292691b9440014f6272b16ec7c690b9d5b30fa94211ae2cfdfca1ac620"
+    },
+    {
+      "path": "tests/contracts/test_bson_value_types_contract.py",
+      "sha256": "a6fc6f03a112edb2a28a3f52e565fe58b7fd0f2f0c370f70301742aa0ea1fcb0"
+    },
+    {
+      "path": "tests/contracts/test_client_read_fidelity_contract.py",
+      "sha256": "db43c0924aba50237fedca0cdf75d23cab07e6f40998b2110abd40405b45fcee"
+    },
+    {
+      "path": "tests/contracts/test_crud_contract.py",
+      "sha256": "de95254dfeaef9edcfa0a3fcb86badd993010dd555d2e0481916480339cb37a2"
+    },
+    {
+      "path": "tests/contracts/test_decimal128_contract.py",
+      "sha256": "05bdee5251731d81ed44070fadaccc83032ff07be0281b7894eb8e5933c67c86"
+    },
+    {
+      "path": "tests/contracts/test_group_accumulators_contract.py",
+      "sha256": "50634de1ff2666915ce99913421eb9981d0099df9a0160387cc291bceb617e57"
+    },
+    {
+      "path": "tests/contracts/test_projection_contract.py",
+      "sha256": "a08becc90d32497b16a93bdad1dc990cce597f4f7fb0e099c61a8ecf3c780b3a"
+    },
+    {
+      "path": "tests/contracts/test_query_operator_contract.py",
+      "sha256": "c8845833a1b6dd0257236508b52766c840ec0f643940bd120e2e1b5f55019851"
+    },
+    {
+      "path": "tests/contracts/test_talkpython_contract.py",
+      "sha256": "56ea087b75a6797d8bcb9557a39b73a5622514e95917fa7151c795d3531ec99a"
+    },
+    {
+      "path": "tests/contracts/test_update_operator_contract.py",
+      "sha256": "72fc64be51f48eebe7eebda94e2cff4a0ab1a49baae38ec2b43ddc6b0938e669"
+    },
+    {
+      "path": "tests/contracts/test_uuid_regex_contract.py",
+      "sha256": "a36ecde8854dadd1d3efa1700c6d72d84ba2f23726159234272d4b4921f8ec29"
+    }
+  ],
+  "source_git_tree": "6f671122ff5f76902cfe051e4558a2c57d161bc4"
+}

--- a/compat/mongo/v1/intentional-differences.json
+++ b/compat/mongo/v1/intentional-differences.json
@@ -1,0 +1,28 @@
+{
+  "contract": "tinymongo-v1",
+  "differences": [
+    {
+      "api": "async",
+      "candidate_fingerprint": "369a49b16ea483645a6c7aadd206f54ef216822d7b214feab1b2de009369822f",
+      "candidate_outcome": "skipped",
+      "case_id": "tests.contracts.test_uuid_regex_contract::test_local_regex_ids_use_exact_identity_for_duplicate_detection",
+      "issue": "https://github.com/schapman1974/briskdb/issues/161",
+      "reason": "MongoDB forbids Regex values in _id; the frozen TinyMongo fixture marks its local extension as an ordinary MongoDB skip.",
+      "reference_fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19",
+      "reference_outcome": "passed",
+      "target": "mongodb-mongodb"
+    },
+    {
+      "api": "sync",
+      "candidate_fingerprint": "369a49b16ea483645a6c7aadd206f54ef216822d7b214feab1b2de009369822f",
+      "candidate_outcome": "skipped",
+      "case_id": "tests.contracts.test_uuid_regex_contract::test_local_regex_ids_use_exact_identity_for_duplicate_detection",
+      "issue": "https://github.com/schapman1974/briskdb/issues/161",
+      "reason": "MongoDB forbids Regex values in _id; the frozen TinyMongo fixture marks its local extension as an ordinary MongoDB skip.",
+      "reference_fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19",
+      "reference_outcome": "passed",
+      "target": "mongodb-mongodb"
+    }
+  ],
+  "schema_version": 1
+}

--- a/compat/mongo/v1/manifest.json
+++ b/compat/mongo/v1/manifest.json
@@ -1,0 +1,4070 @@
+{
+  "capabilities": {
+    "aggregation": {
+      "accumulators": [
+        "$addToSet",
+        "$avg",
+        "$first",
+        "$last",
+        "$max",
+        "$min",
+        "$push",
+        "$sum"
+      ],
+      "expressions": [
+        "$ifNull",
+        "$literal",
+        "$size"
+      ],
+      "expression_stages": [
+        "$addFields",
+        "$group",
+        "$project",
+        "$set"
+      ],
+      "remove_variable_stages": [
+        "$addFields",
+        "$project",
+        "$set"
+      ],
+      "operation_options": {
+        "other_keyword_arguments": "unsupported",
+        "session": "null-only"
+      },
+      "stage_rules": [
+        "$set is an alias of $addFields",
+        "$unset accepts a field string or a non-empty list/tuple of field strings",
+        "$group _id accepts only a field path or null"
+      ],
+      "stages": [
+        "$match",
+        "$sort",
+        "$skip",
+        "$limit",
+        "$count",
+        "$project",
+        "$set",
+        "$addFields",
+        "$unset",
+        "$group"
+      ],
+      "unsupported_special_forms": [
+        "$sort $meta",
+        "aggregation variables other than $$REMOVE in its supported stages"
+      ]
+    },
+    "api": {
+      "aliases": {
+        "tinymongo.AsyncCollection": "tinymongo.AsyncTinyMongoCollection",
+        "tinymongo.AsyncCursor": "tinymongo.AsyncTinyMongoCursor",
+        "tinymongo.AsyncDatabase": "tinymongo.AsyncTinyMongoDatabase"
+      },
+      "behavior_enum": {
+        "accepted_no_effect": "The value is accepted for call compatibility and has no effect.",
+        "applied": "The supplied value changes the operation directly.",
+        "applied_conditionally": "The supplied value changes behavior only under the stated condition.",
+        "default_or_empty_only": "Only the documented default, empty, or no-op form is accepted.",
+        "dispatched": "The option is forwarded to another inventoried operation whose behavior applies.",
+        "null_only": "None is accepted; a non-None value raises TinyMongoNotSupportedError.",
+        "rejected": "Python argument binding or explicit validation rejects the option.",
+        "rejected_unsupported": "The option or method is recognized but raises TinyMongoNotSupportedError."
+      },
+      "connection_options": {
+        "lookup": "case-insensitive against the installed pymongo.common.VALIDATORS catalog; the pinned offline contract is the 65-name fallback below",
+        "pymongo_fallback_catalog": [
+          {
+            "behavior": "accepted_no_effect",
+            "name": "appname"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "authmechanism"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "authmechanismproperties"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "authoidcallowedhosts"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "authsource"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "auto_encryption_opts"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "compressors"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "connect"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "connecttimeoutms"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "datetime_conversion"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "directconnection"
+          },
+          {
+            "behavior": "applied",
+            "name": "document_class"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "driver"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "enable_overload_retargeting"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "enableoverloadretargeting"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "event_listeners"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "fsync"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "heartbeatfrequencyms"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "journal"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "loadbalanced"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "localthresholdms"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "max_adaptive_retries"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "maxadaptiveretries"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "maxconnecting"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "maxidletimems"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "maxpoolsize"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "maxstalenessseconds"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "minpoolsize"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "password"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "read_preference"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "readconcernlevel"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "readpreference"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "readpreferencetags"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "replicaset"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "retryreads"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "retrywrites"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "server_api"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "server_selector"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "servermonitoringmode"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "serverselectiontimeoutms"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "sockettimeoutms"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "srvmaxhosts"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "srvservicename"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "ssl"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "timeoutms"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "tls"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "tlsallowinvalidcertificates"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "tlsallowinvalidhostnames"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "tlscafile"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "tlscertificatekeyfile"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "tlscertificatekeyfilepassword"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "tlscrlfile"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "tlsdisableocspendpointcheck"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "tlsinsecure"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "type_registry"
+          },
+          {
+            "behavior": "applied",
+            "name": "tz_aware"
+          },
+          {
+            "behavior": "applied_conditionally",
+            "condition": "applied to returned datetimes only when tz_aware is true",
+            "name": "tzinfo"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "unicode_decode_error_handler"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "username"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "uuidrepresentation"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "w"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "waitqueuemultiple"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "waitqueuetimeoutms"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "wtimeoutms"
+          },
+          {
+            "behavior": "accepted_no_effect",
+            "name": "zlibcompressionlevel"
+          }
+        ],
+        "pymongo_fallback_count": 65,
+        "tinymongo_storage_options": [
+          {
+            "behavior": "applied",
+            "name": "backend"
+          },
+          {
+            "behavior": "applied_conditionally",
+            "condition": "used only by remote SQL backends",
+            "name": "dsn"
+          },
+          {
+            "behavior": "applied_conditionally",
+            "condition": "passed to table backends that consume DuckDB configuration",
+            "name": "duckdb_config"
+          },
+          {
+            "behavior": "applied_conditionally",
+            "condition": "selects the local folder when no higher-precedence TinyMongo folder alias is truthy",
+            "name": "foldername"
+          },
+          {
+            "behavior": "applied_conditionally",
+            "condition": "used only by the 'sqlite-sharded' backend",
+            "name": "sqlite_shards"
+          },
+          {
+            "behavior": "applied_conditionally",
+            "condition": "used only by 'parquet' and 'parquetv2'",
+            "name": "storage_uri"
+          },
+          {
+            "behavior": "applied_conditionally",
+            "condition": "passed to table backends",
+            "name": "threads"
+          },
+          {
+            "behavior": "applied_conditionally",
+            "condition": "highest-precedence explicit local folder alias",
+            "name": "tinymongo_folder"
+          },
+          {
+            "behavior": "applied_conditionally",
+            "condition": "second-precedence explicit local folder alias",
+            "name": "tinymongo_path"
+          }
+        ],
+        "unknown_option_behavior": "raises ConfigurationError before storage is opened"
+      },
+      "constructors": {
+        "tinymongo.AsyncMongoClient": {
+          "options": [
+            {
+              "behavior": "applied_conditionally",
+              "condition": "a non-network string is a local folder; a memory URI can identify a shared namespace; network-shaped values are accepted without a connection",
+              "name": "host"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "a non-None value makes host network-shaped and prevents treating it as a local folder",
+              "name": "port"
+            },
+            {
+              "behavior": "applied",
+              "name": "document_class"
+            },
+            {
+              "behavior": "applied",
+              "name": "tz_aware"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "connect"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "type_registry"
+            },
+            {
+              "behavior": "dispatched",
+              "condition": "TinyMongo storage options and the 65-name PyMongo connection catalog below are recognized; any other name raises ConfigurationError",
+              "name": "**kwargs"
+            }
+          ],
+          "signature": "AsyncMongoClient(host=None, port=None, document_class=None, tz_aware=None, connect=None, type_registry=None, **kwargs)"
+        },
+        "tinymongo.AsyncTinyMongoClient": {
+          "options": [
+            {
+              "behavior": "applied",
+              "name": "foldername"
+            },
+            {
+              "behavior": "applied",
+              "name": "backend"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "non-None value overrides foldername",
+              "name": "tinymongo_folder"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "passed to table backends",
+              "name": "threads"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "used only by the 'sqlite-sharded' backend",
+              "name": "sqlite_shards"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "used only by 'parquet' and 'parquetv2'",
+              "name": "storage_uri"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "passed to table backends that consume DuckDB configuration",
+              "name": "duckdb_config"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "used only by remote SQL backends",
+              "name": "dsn"
+            }
+          ],
+          "signature": "AsyncTinyMongoClient(foldername='tinydb', backend='tinydb', *, tinymongo_folder=None, threads=None, sqlite_shards=None, storage_uri=None, duckdb_config=None, dsn=None)"
+        },
+        "tinymongo.AsyncTinyMongoCollection": {
+          "construction_scope": "normally returned by an async database rather than constructed directly",
+          "options": [],
+          "signature": "AsyncTinyMongoCollection(database, name)"
+        },
+        "tinymongo.AsyncTinyMongoCursor": {
+          "options": [
+            {
+              "behavior": "applied_conditionally",
+              "condition": "required for a lazy query source",
+              "name": "collection"
+            },
+            {
+              "behavior": "applied",
+              "name": "filter"
+            },
+            {
+              "behavior": "applied",
+              "name": "projection"
+            },
+            {
+              "behavior": "dispatched",
+              "condition": "forwarded to the synchronous collection find operation when lazily loaded",
+              "name": "find_args"
+            },
+            {
+              "behavior": "dispatched",
+              "condition": "forwarded to the synchronous collection find operation when lazily loaded",
+              "name": "find_kwargs"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "provides an eager seed instead of a collection query",
+              "name": "documents"
+            }
+          ],
+          "signature": "AsyncTinyMongoCursor(collection=None, filter=None, projection=None, find_args=(), find_kwargs=None, documents=None)"
+        },
+        "tinymongo.AsyncTinyMongoDatabase": {
+          "construction_scope": "normally returned by an async client rather than constructed directly",
+          "options": [],
+          "signature": "AsyncTinyMongoDatabase(client, name)"
+        },
+        "tinymongo.MongoClient": {
+          "options": [
+            {
+              "behavior": "applied_conditionally",
+              "condition": "a non-network string is a local folder; a memory URI can identify a shared namespace; network-shaped values are accepted without a connection",
+              "name": "host"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "a non-None value makes host network-shaped and prevents treating it as a local folder",
+              "name": "port"
+            },
+            {
+              "behavior": "applied",
+              "name": "document_class"
+            },
+            {
+              "behavior": "applied",
+              "name": "tz_aware"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "connect"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "type_registry"
+            },
+            {
+              "behavior": "dispatched",
+              "condition": "TinyMongo storage options and the 65-name PyMongo connection catalog below are recognized; any other name raises ConfigurationError",
+              "name": "**kwargs"
+            }
+          ],
+          "signature": "MongoClient(host=None, port=None, document_class=None, tz_aware=None, connect=None, type_registry=None, **kwargs)"
+        },
+        "tinymongo.TinyGridFS": {
+          "construction_scope": "placeholder only; no GridFS storage operations are implemented",
+          "options": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**kwargs"
+            }
+          ],
+          "signature": "TinyGridFS(*args, **kwargs)"
+        },
+        "tinymongo.TinyMongoClient": {
+          "options": [
+            {
+              "behavior": "applied",
+              "name": "foldername"
+            },
+            {
+              "behavior": "applied",
+              "name": "backend"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "non-None value overrides foldername",
+              "name": "tinymongo_folder"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "passed to table backends",
+              "name": "threads"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "used only by the 'sqlite-sharded' backend",
+              "name": "sqlite_shards"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "used only by 'parquet' and 'parquetv2'",
+              "name": "storage_uri"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "passed to table backends that consume DuckDB configuration",
+              "name": "duckdb_config"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "used only by remote SQL backends",
+              "name": "dsn"
+            }
+          ],
+          "signature": "TinyMongoClient(foldername='tinydb', backend='tinydb', *, tinymongo_folder=None, threads=None, sqlite_shards=None, storage_uri=None, duckdb_config=None, dsn=None)"
+        },
+        "tinymongo.TinyMongoCollection": {
+          "construction_scope": "normally returned by a database rather than constructed directly",
+          "options": [
+            {
+              "behavior": "applied_conditionally",
+              "condition": "supplies database, storage, engine, and read-materialization context",
+              "name": "parent"
+            }
+          ],
+          "signature": "TinyMongoCollection(table, parent=None)"
+        },
+        "tinymongo.TinyMongoCursor": {
+          "options": [
+            {
+              "behavior": "applied",
+              "name": "sort"
+            },
+            {
+              "behavior": "applied",
+              "name": "skip"
+            },
+            {
+              "behavior": "applied",
+              "name": "limit"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "retains collection context for lazy reloads and chained sort",
+              "name": "collection"
+            },
+            {
+              "behavior": "applied",
+              "name": "projection"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "retained for lazy reloads",
+              "name": "query"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "tracks projection pushdown",
+              "name": "source_projected"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "defers backend reads",
+              "name": "deferred_loader"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "converts returned BSON values",
+              "name": "materializer"
+            }
+          ],
+          "signature": "TinyMongoCursor(cursordat, sort=None, skip=None, limit=None, collection=None, projection=None, query=None, source_projected=False, deferred_loader=None, materializer=None)"
+        },
+        "tinymongo.TinyMongoDatabase": {
+          "construction_scope": "normally returned by a client rather than constructed directly",
+          "options": [
+            {
+              "behavior": "applied_conditionally",
+              "condition": "selects table-engine operations when non-None",
+              "name": "engine"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "enables closed-client checks and configured read materialization",
+              "name": "client"
+            }
+          ],
+          "signature": "TinyMongoDatabase(database, path, storage, engine=None, client=None)"
+        }
+      },
+      "inventory_version": 1,
+      "method_options": {
+        "async_client": {
+          "capabilities": [],
+          "close": [],
+          "database_names": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**kwargs"
+            }
+          ],
+          "drop_database": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "get_database": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**kwargs"
+            }
+          ],
+          "list_database_names": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**kwargs"
+            }
+          ],
+          "list_databases": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "server_info": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**kwargs"
+            }
+          ],
+          "start_session": [
+            {
+              "behavior": "rejected_unsupported",
+              "name": "*args"
+            },
+            {
+              "behavior": "rejected_unsupported",
+              "name": "**kwargs"
+            }
+          ],
+          "supports": [],
+          "watch": [
+            {
+              "behavior": "rejected_unsupported",
+              "name": "*args"
+            },
+            {
+              "behavior": "rejected_unsupported",
+              "name": "**kwargs"
+            }
+          ]
+        },
+        "async_collection": {
+          "aggregate": [
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "rejected_unsupported",
+              "name": "**aggregation options"
+            }
+          ],
+          "bulk_write": [
+            {
+              "behavior": "rejected_unsupported",
+              "name": "*args"
+            },
+            {
+              "behavior": "rejected_unsupported",
+              "name": "**kwargs"
+            }
+          ],
+          "count": [],
+          "count_documents": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "create_index": [
+            {
+              "behavior": "rejected_unsupported",
+              "name": "*positional options"
+            },
+            {
+              "behavior": "applied",
+              "name": "name"
+            },
+            {
+              "behavior": "applied",
+              "name": "partialFilterExpression"
+            },
+            {
+              "behavior": "applied",
+              "name": "sparse"
+            },
+            {
+              "behavior": "applied",
+              "name": "unique"
+            },
+            {
+              "behavior": "rejected_unsupported",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "create_indexes": [
+            {
+              "behavior": "rejected",
+              "name": "*positional options"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "delete_many": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "delete_one": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "distinct": [
+            {
+              "behavior": "applied",
+              "name": "filter"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "drop": [
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "drop_index": [],
+          "estimated_document_count": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**kwargs"
+            }
+          ],
+          "find": [
+            {
+              "behavior": "applied",
+              "name": "filter"
+            },
+            {
+              "behavior": "applied",
+              "name": "projection"
+            },
+            {
+              "behavior": "applied",
+              "name": "skip"
+            },
+            {
+              "behavior": "applied",
+              "name": "limit"
+            },
+            {
+              "behavior": "applied",
+              "name": "sort"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "find_one": [
+            {
+              "behavior": "applied_conditionally",
+              "condition": "keyword alias is used only when the primary filter argument is None",
+              "name": "filter"
+            },
+            {
+              "behavior": "applied",
+              "name": "projection"
+            },
+            {
+              "behavior": "applied",
+              "name": "sort"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "find_one_and_delete": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "applied",
+              "name": "sort"
+            },
+            {
+              "behavior": "applied",
+              "name": "projection"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "find_one_and_replace": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "enabled only by the literal true",
+              "name": "upsert"
+            },
+            {
+              "behavior": "applied",
+              "name": "sort"
+            },
+            {
+              "behavior": "applied",
+              "name": "projection"
+            },
+            {
+              "behavior": "applied",
+              "condition": "must be boolean ReturnDocument.BEFORE or ReturnDocument.AFTER",
+              "name": "return_document"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "find_one_and_update": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "enabled only by the literal true",
+              "name": "upsert"
+            },
+            {
+              "behavior": "applied",
+              "name": "sort"
+            },
+            {
+              "behavior": "applied",
+              "name": "projection"
+            },
+            {
+              "behavior": "applied",
+              "condition": "must be boolean ReturnDocument.BEFORE or ReturnDocument.AFTER",
+              "name": "return_document"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "index_information": [],
+          "insert": [
+            {
+              "behavior": "dispatched",
+              "condition": "forwarded to insert_many for list input or insert_one otherwise",
+              "name": "*args"
+            },
+            {
+              "behavior": "dispatched",
+              "condition": "forwarded to insert_many for list input or insert_one otherwise",
+              "name": "**kwargs"
+            }
+          ],
+          "insert_many": [
+            {
+              "behavior": "applied",
+              "name": "ordered"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "forwarded to table backends; storage codec validation still runs",
+              "name": "bypass_document_validation"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "comment"
+            },
+            {
+              "behavior": "rejected",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "insert_one": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "only the literal true is forwarded to table backends; storage codec validation still runs",
+              "name": "bypass_document_validation"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "list_indexes": [],
+          "remove": [
+            {
+              "behavior": "applied",
+              "name": "multi"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**kwargs"
+            }
+          ],
+          "replace_one": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "enabled only by the literal true",
+              "name": "upsert"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "update": [
+            {
+              "behavior": "dispatched",
+              "condition": "forwarded to update_one for each list member or update_many otherwise",
+              "name": "*args"
+            },
+            {
+              "behavior": "dispatched",
+              "condition": "forwarded to update_one for each list member or update_many otherwise",
+              "name": "**kwargs"
+            }
+          ],
+          "update_many": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "enabled only by the literal true",
+              "name": "upsert"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "update_one": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "enabled only by the literal true",
+              "name": "upsert"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "watch": [
+            {
+              "behavior": "rejected_unsupported",
+              "name": "*args"
+            },
+            {
+              "behavior": "rejected_unsupported",
+              "name": "**kwargs"
+            }
+          ],
+          "with_options": [
+            {
+              "behavior": "default_or_empty_only",
+              "condition": "objects exposing a non-empty .document are rejected",
+              "name": "*args"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "codec_options"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "read_preference"
+            },
+            {
+              "behavior": "default_or_empty_only",
+              "condition": "None or an object with an empty .document is accepted",
+              "name": "write_concern"
+            },
+            {
+              "behavior": "default_or_empty_only",
+              "condition": "None or an object with an empty .document is accepted",
+              "name": "read_concern"
+            },
+            {
+              "behavior": "default_or_empty_only",
+              "condition": "None or a value without a non-empty .document is accepted",
+              "name": "**unrecognized keywords"
+            }
+          ]
+        },
+        "async_cursor": {
+          "clone": [],
+          "close": [],
+          "count": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "with_limit_and_skip"
+            }
+          ],
+          "hasNext": [],
+          "has_next": [],
+          "limit": [],
+          "next": [],
+          "paginate": [],
+          "rewind": [],
+          "skip": [],
+          "sort": [
+            {
+              "behavior": "applied",
+              "name": "direction"
+            }
+          ],
+          "to_list": [
+            {
+              "behavior": "applied",
+              "name": "length"
+            }
+          ],
+          "try_next": []
+        },
+        "async_database": {
+          "close": [],
+          "collection_names": [],
+          "command": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "value"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "drop_collection": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**kwargs"
+            }
+          ],
+          "get_collection": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**kwargs"
+            }
+          ],
+          "list_collection_names": [
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "default_or_empty_only",
+              "name": "filter"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "comment"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "authorizedCollections"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "nameOnly"
+            },
+            {
+              "behavior": "rejected",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "watch": [
+            {
+              "behavior": "rejected_unsupported",
+              "name": "*args"
+            },
+            {
+              "behavior": "rejected_unsupported",
+              "name": "**kwargs"
+            }
+          ]
+        },
+        "gridfs_placeholder": {
+          "GridFS": [
+            {
+              "behavior": "applied",
+              "condition": "assigned to the placeholder database attribute; no file operations are implemented",
+              "name": "tinydatabase"
+            }
+          ],
+          "grid_fs": [
+            {
+              "behavior": "applied",
+              "condition": "assigned to the placeholder database attribute; no file operations are implemented",
+              "name": "tinydatabase"
+            }
+          ]
+        },
+        "sync_client": {
+          "capabilities": [],
+          "close": [],
+          "database_names": [],
+          "drop_database": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "get_database": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**kwargs"
+            }
+          ],
+          "list_database_names": [],
+          "list_databases": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "server_info": [],
+          "start_session": [
+            {
+              "behavior": "rejected_unsupported",
+              "name": "*args"
+            },
+            {
+              "behavior": "rejected_unsupported",
+              "name": "**kwargs"
+            }
+          ],
+          "supports": [],
+          "watch": [
+            {
+              "behavior": "rejected_unsupported",
+              "name": "*args"
+            },
+            {
+              "behavior": "rejected_unsupported",
+              "name": "**kwargs"
+            }
+          ]
+        },
+        "sync_collection": {
+          "aggregate": [
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "rejected_unsupported",
+              "name": "**aggregation options"
+            }
+          ],
+          "build_table": [],
+          "bulk_write": [
+            {
+              "behavior": "rejected_unsupported",
+              "name": "*args"
+            },
+            {
+              "behavior": "rejected_unsupported",
+              "name": "**kwargs"
+            }
+          ],
+          "count": [],
+          "count_documents": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "create_index": [
+            {
+              "behavior": "rejected_unsupported",
+              "name": "*positional options"
+            },
+            {
+              "behavior": "applied",
+              "name": "name"
+            },
+            {
+              "behavior": "applied",
+              "name": "partialFilterExpression"
+            },
+            {
+              "behavior": "applied",
+              "name": "sparse"
+            },
+            {
+              "behavior": "applied",
+              "name": "unique"
+            },
+            {
+              "behavior": "rejected_unsupported",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "create_indexes": [
+            {
+              "behavior": "rejected",
+              "name": "*positional options"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "delete_many": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "delete_one": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "distinct": [
+            {
+              "behavior": "applied",
+              "name": "filter"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "drop": [
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "drop_index": [],
+          "estimated_document_count": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**kwargs"
+            }
+          ],
+          "find": [
+            {
+              "behavior": "applied_conditionally",
+              "condition": "keyword alias is used only when the primary filter argument is None",
+              "name": "filter"
+            },
+            {
+              "behavior": "applied",
+              "name": "projection"
+            },
+            {
+              "behavior": "applied",
+              "name": "skip"
+            },
+            {
+              "behavior": "applied",
+              "name": "limit"
+            },
+            {
+              "behavior": "applied",
+              "name": "sort"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "find_one": [
+            {
+              "behavior": "applied_conditionally",
+              "condition": "keyword alias is used only when the primary filter argument is None",
+              "name": "filter"
+            },
+            {
+              "behavior": "applied",
+              "name": "projection"
+            },
+            {
+              "behavior": "applied",
+              "name": "sort"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "find_one_and_delete": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "applied",
+              "name": "sort"
+            },
+            {
+              "behavior": "applied",
+              "name": "projection"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "find_one_and_replace": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "enabled only by the literal true",
+              "name": "upsert"
+            },
+            {
+              "behavior": "applied",
+              "name": "sort"
+            },
+            {
+              "behavior": "applied",
+              "name": "projection"
+            },
+            {
+              "behavior": "applied",
+              "condition": "must be boolean ReturnDocument.BEFORE or ReturnDocument.AFTER",
+              "name": "return_document"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "find_one_and_update": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "enabled only by the literal true",
+              "name": "upsert"
+            },
+            {
+              "behavior": "applied",
+              "name": "sort"
+            },
+            {
+              "behavior": "applied",
+              "name": "projection"
+            },
+            {
+              "behavior": "applied",
+              "condition": "must be boolean ReturnDocument.BEFORE or ReturnDocument.AFTER",
+              "name": "return_document"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "index_information": [],
+          "insert": [
+            {
+              "behavior": "dispatched",
+              "condition": "forwarded to insert_many for list input or insert_one otherwise",
+              "name": "*args"
+            },
+            {
+              "behavior": "dispatched",
+              "condition": "forwarded to insert_many for list input or insert_one otherwise",
+              "name": "**kwargs"
+            }
+          ],
+          "insert_many": [
+            {
+              "behavior": "applied",
+              "name": "ordered"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "forwarded to table backends; storage codec validation still runs",
+              "name": "bypass_document_validation"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "comment"
+            },
+            {
+              "behavior": "rejected",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "insert_one": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "only the literal true is forwarded to table backends; storage codec validation still runs",
+              "name": "bypass_document_validation"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "list_indexes": [],
+          "parse_condition": [
+            {
+              "behavior": "applied_conditionally",
+              "condition": "internal recursive parser state",
+              "name": "prev_key"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "internal recursive parser state",
+              "name": "last_prev_key"
+            }
+          ],
+          "parse_query": [],
+          "remove": [
+            {
+              "behavior": "applied",
+              "name": "multi"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**kwargs"
+            }
+          ],
+          "replace_one": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "enabled only by the literal true",
+              "name": "upsert"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "update": [
+            {
+              "behavior": "dispatched",
+              "condition": "forwarded to update_one for each list member or update_many otherwise",
+              "name": "*args"
+            },
+            {
+              "behavior": "dispatched",
+              "condition": "forwarded to update_one for each list member or update_many otherwise",
+              "name": "**kwargs"
+            }
+          ],
+          "update_many": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "enabled only by the literal true",
+              "name": "upsert"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "update_one": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "applied_conditionally",
+              "condition": "enabled only by the literal true",
+              "name": "upsert"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "watch": [
+            {
+              "behavior": "rejected_unsupported",
+              "name": "*args"
+            },
+            {
+              "behavior": "rejected_unsupported",
+              "name": "**kwargs"
+            }
+          ],
+          "with_options": [
+            {
+              "behavior": "default_or_empty_only",
+              "condition": "objects exposing a non-empty .document are rejected",
+              "name": "*args"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "codec_options"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "read_preference"
+            },
+            {
+              "behavior": "default_or_empty_only",
+              "condition": "None or an object with an empty .document is accepted",
+              "name": "write_concern"
+            },
+            {
+              "behavior": "default_or_empty_only",
+              "condition": "None or an object with an empty .document is accepted",
+              "name": "read_concern"
+            },
+            {
+              "behavior": "default_or_empty_only",
+              "condition": "None or a value without a non-empty .document is accepted",
+              "name": "**unrecognized keywords"
+            }
+          ]
+        },
+        "sync_cursor": {
+          "clone": [],
+          "close": [],
+          "count": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "with_limit_and_skip"
+            }
+          ],
+          "hasNext": [],
+          "has_next": [],
+          "limit": [],
+          "next": [],
+          "paginate": [],
+          "rewind": [],
+          "skip": [],
+          "sort": [
+            {
+              "behavior": "applied",
+              "name": "direction"
+            }
+          ],
+          "to_list": [
+            {
+              "behavior": "applied",
+              "name": "length"
+            }
+          ]
+        },
+        "sync_database": {
+          "close": [],
+          "collection_names": [],
+          "command": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "value"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "drop_collection": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**kwargs"
+            }
+          ],
+          "get_collection": [
+            {
+              "behavior": "accepted_no_effect",
+              "name": "*args"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "**kwargs"
+            }
+          ],
+          "list_collection_names": [
+            {
+              "behavior": "null_only",
+              "name": "session"
+            },
+            {
+              "behavior": "default_or_empty_only",
+              "name": "filter"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "comment"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "authorizedCollections"
+            },
+            {
+              "behavior": "accepted_no_effect",
+              "name": "nameOnly"
+            },
+            {
+              "behavior": "rejected",
+              "name": "**unrecognized keywords"
+            }
+          ],
+          "watch": [
+            {
+              "behavior": "rejected_unsupported",
+              "name": "*args"
+            },
+            {
+              "behavior": "rejected_unsupported",
+              "name": "**kwargs"
+            }
+          ]
+        }
+      },
+      "owners": {
+        "async_client": {
+          "awaitability": {
+            "awaitable": [
+              "capabilities",
+              "close",
+              "database_names",
+              "drop_database",
+              "list_database_names",
+              "list_databases",
+              "server_info",
+              "supports",
+              "watch"
+            ],
+            "immediate": [
+              "get_database",
+              "start_session"
+            ]
+          },
+          "classes": [
+            "tinymongo.AsyncTinyMongoClient",
+            "tinymongo.AsyncMongoClient"
+          ],
+          "extensions": [
+            "capabilities",
+            "database_names",
+            "supports"
+          ],
+          "present_but_unsupported": [
+            "start_session",
+            "watch"
+          ],
+          "properties": [],
+          "protocols": [
+            {
+              "awaitability": "immediate",
+              "methods": [
+                "__getitem__"
+              ],
+              "name": "database selection by subscription"
+            },
+            {
+              "awaitability": "immediate",
+              "methods": [
+                "__getattr__"
+              ],
+              "name": "database selection by attribute"
+            },
+            {
+              "awaitability": "awaitable",
+              "methods": [
+                "__aenter__",
+                "__aexit__"
+              ],
+              "name": "async context manager"
+            }
+          ],
+          "supported": [
+            "close",
+            "drop_database",
+            "get_database",
+            "list_database_names",
+            "list_databases",
+            "server_info"
+          ]
+        },
+        "async_collection": {
+          "awaitability": {
+            "awaitable": [
+              "aggregate",
+              "bulk_write",
+              "count",
+              "count_documents",
+              "create_index",
+              "create_indexes",
+              "delete_many",
+              "delete_one",
+              "distinct",
+              "drop",
+              "drop_index",
+              "estimated_document_count",
+              "find_one",
+              "find_one_and_delete",
+              "find_one_and_replace",
+              "find_one_and_update",
+              "index_information",
+              "insert",
+              "insert_many",
+              "insert_one",
+              "list_indexes",
+              "remove",
+              "replace_one",
+              "update",
+              "update_many",
+              "update_one",
+              "watch"
+            ],
+            "immediate": [
+              "find",
+              "with_options"
+            ]
+          },
+          "classes": [
+            "tinymongo.AsyncTinyMongoCollection",
+            "tinymongo.AsyncCollection"
+          ],
+          "extensions": [
+            "count",
+            "insert",
+            "remove",
+            "update"
+          ],
+          "present_but_unsupported": [
+            "bulk_write",
+            "watch"
+          ],
+          "properties": [
+            {
+              "kind": "instance_attribute",
+              "name": "database"
+            },
+            {
+              "kind": "property",
+              "name": "full_name"
+            },
+            {
+              "kind": "instance_attribute",
+              "name": "name"
+            },
+            {
+              "kind": "property",
+              "meaning": "empty compatibility concern",
+              "name": "read_concern"
+            },
+            {
+              "kind": "property",
+              "name": "tablename"
+            },
+            {
+              "kind": "property",
+              "meaning": "empty compatibility concern",
+              "name": "write_concern"
+            }
+          ],
+          "protocols": [
+            {
+              "awaitability": "immediate",
+              "methods": [
+                "__getitem__",
+                "__getattr__"
+              ],
+              "name": "dotted child collection selection"
+            },
+            {
+              "awaitability": "immediate",
+              "methods": [
+                "__call__"
+              ],
+              "name": "callable typo diagnostic"
+            }
+          ],
+          "supported": [
+            "aggregate",
+            "count_documents",
+            "create_index",
+            "create_indexes",
+            "delete_many",
+            "delete_one",
+            "distinct",
+            "drop",
+            "drop_index",
+            "estimated_document_count",
+            "find",
+            "find_one",
+            "find_one_and_delete",
+            "find_one_and_replace",
+            "find_one_and_update",
+            "index_information",
+            "insert_many",
+            "insert_one",
+            "list_indexes",
+            "replace_one",
+            "update_many",
+            "update_one",
+            "with_options"
+          ]
+        },
+        "async_cursor": {
+          "awaitability": {
+            "awaitable": [
+              "close",
+              "count",
+              "hasNext",
+              "has_next",
+              "next",
+              "rewind",
+              "to_list",
+              "try_next"
+            ],
+            "immediate": [
+              "clone",
+              "limit",
+              "paginate",
+              "skip",
+              "sort"
+            ]
+          },
+          "classes": [
+            "tinymongo.AsyncTinyMongoCursor",
+            "tinymongo.AsyncCursor"
+          ],
+          "extensions": [
+            "count",
+            "hasNext",
+            "has_next",
+            "paginate"
+          ],
+          "present_but_unsupported": [],
+          "properties": [
+            {
+              "kind": "property",
+              "name": "alive"
+            }
+          ],
+          "protocols": [
+            {
+              "awaitability": "mixed",
+              "methods": [
+                "__aiter__",
+                "__anext__"
+              ],
+              "name": "async iterator"
+            },
+            {
+              "awaitability": "awaitable",
+              "methods": [
+                "__aenter__",
+                "__aexit__"
+              ],
+              "name": "async context manager"
+            }
+          ],
+          "supported": [
+            "clone",
+            "close",
+            "limit",
+            "next",
+            "rewind",
+            "skip",
+            "sort",
+            "to_list",
+            "try_next"
+          ]
+        },
+        "async_database": {
+          "awaitability": {
+            "awaitable": [
+              "close",
+              "collection_names",
+              "command",
+              "drop_collection",
+              "list_collection_names",
+              "watch"
+            ],
+            "immediate": [
+              "get_collection"
+            ]
+          },
+          "classes": [
+            "tinymongo.AsyncTinyMongoDatabase",
+            "tinymongo.AsyncDatabase"
+          ],
+          "extensions": [
+            "collection_names"
+          ],
+          "present_but_unsupported": [
+            "watch"
+          ],
+          "properties": [
+            {
+              "kind": "property",
+              "meaning": "compatibility name alias",
+              "name": "database"
+            },
+            {
+              "kind": "instance_attribute",
+              "name": "name"
+            }
+          ],
+          "protocols": [
+            {
+              "awaitability": "immediate",
+              "methods": [
+                "__getitem__"
+              ],
+              "name": "collection selection by subscription"
+            },
+            {
+              "awaitability": "immediate",
+              "methods": [
+                "__getattr__"
+              ],
+              "name": "collection selection by attribute"
+            },
+            {
+              "awaitability": "awaitable",
+              "methods": [
+                "__aenter__",
+                "__aexit__"
+              ],
+              "name": "async context manager"
+            }
+          ],
+          "supported": [
+            "close",
+            "command",
+            "drop_collection",
+            "get_collection",
+            "list_collection_names"
+          ]
+        },
+        "gridfs_placeholder": {
+          "awaitability": {
+            "awaitable": [],
+            "immediate": [
+              "GridFS",
+              "grid_fs"
+            ]
+          },
+          "classes": [
+            "tinymongo.TinyGridFS"
+          ],
+          "extensions": [],
+          "present_but_unsupported": [
+            "GridFS",
+            "grid_fs"
+          ],
+          "properties": [
+            {
+              "kind": "instance_attribute",
+              "meaning": "assigned handle only; no GridFS operations exist",
+              "name": "database"
+            }
+          ],
+          "protocols": [],
+          "supported": []
+        },
+        "sync_client": {
+          "awaitability": {
+            "awaitable": [],
+            "immediate": [
+              "close",
+              "drop_database",
+              "get_database",
+              "list_database_names",
+              "list_databases",
+              "server_info",
+              "start_session",
+              "watch",
+              "capabilities",
+              "database_names",
+              "supports"
+            ]
+          },
+          "classes": [
+            "tinymongo.TinyMongoClient",
+            "tinymongo.MongoClient"
+          ],
+          "extensions": [
+            "capabilities",
+            "database_names",
+            "supports"
+          ],
+          "present_but_unsupported": [
+            "start_session",
+            "watch"
+          ],
+          "properties": [],
+          "protocols": [
+            {
+              "awaitability": "immediate",
+              "methods": [
+                "__getitem__"
+              ],
+              "name": "database selection by subscription"
+            },
+            {
+              "awaitability": "immediate",
+              "methods": [
+                "__getattr__"
+              ],
+              "name": "database selection by attribute"
+            },
+            {
+              "awaitability": "immediate",
+              "methods": [
+                "__enter__",
+                "__exit__"
+              ],
+              "name": "context manager"
+            }
+          ],
+          "supported": [
+            "close",
+            "drop_database",
+            "get_database",
+            "list_database_names",
+            "list_databases",
+            "server_info"
+          ]
+        },
+        "sync_collection": {
+          "awaitability": {
+            "awaitable": [],
+            "immediate": [
+              "aggregate",
+              "count_documents",
+              "create_index",
+              "create_indexes",
+              "delete_many",
+              "delete_one",
+              "distinct",
+              "drop",
+              "drop_index",
+              "estimated_document_count",
+              "find",
+              "find_one",
+              "find_one_and_delete",
+              "find_one_and_replace",
+              "find_one_and_update",
+              "index_information",
+              "insert_many",
+              "insert_one",
+              "list_indexes",
+              "replace_one",
+              "update_many",
+              "update_one",
+              "with_options",
+              "bulk_write",
+              "watch",
+              "build_table",
+              "count",
+              "insert",
+              "parse_condition",
+              "parse_query",
+              "remove",
+              "update"
+            ]
+          },
+          "classes": [
+            "tinymongo.TinyMongoCollection"
+          ],
+          "extensions": [
+            "build_table",
+            "count",
+            "insert",
+            "parse_condition",
+            "parse_query",
+            "remove",
+            "update"
+          ],
+          "present_but_unsupported": [
+            "bulk_write",
+            "watch"
+          ],
+          "properties": [
+            {
+              "kind": "property",
+              "name": "database"
+            },
+            {
+              "kind": "property",
+              "name": "full_name"
+            },
+            {
+              "kind": "property",
+              "name": "name"
+            },
+            {
+              "kind": "property",
+              "meaning": "empty compatibility concern",
+              "name": "read_concern"
+            },
+            {
+              "kind": "instance_attribute",
+              "name": "tablename"
+            },
+            {
+              "kind": "property",
+              "meaning": "empty compatibility concern",
+              "name": "write_concern"
+            }
+          ],
+          "protocols": [
+            {
+              "awaitability": "immediate",
+              "methods": [
+                "__getitem__",
+                "__getattr__"
+              ],
+              "name": "dotted child collection selection"
+            },
+            {
+              "awaitability": "immediate",
+              "methods": [
+                "__call__"
+              ],
+              "name": "callable typo diagnostic"
+            }
+          ],
+          "supported": [
+            "aggregate",
+            "count_documents",
+            "create_index",
+            "create_indexes",
+            "delete_many",
+            "delete_one",
+            "distinct",
+            "drop",
+            "drop_index",
+            "estimated_document_count",
+            "find",
+            "find_one",
+            "find_one_and_delete",
+            "find_one_and_replace",
+            "find_one_and_update",
+            "index_information",
+            "insert_many",
+            "insert_one",
+            "list_indexes",
+            "replace_one",
+            "update_many",
+            "update_one",
+            "with_options"
+          ]
+        },
+        "sync_cursor": {
+          "awaitability": {
+            "awaitable": [],
+            "immediate": [
+              "clone",
+              "close",
+              "limit",
+              "next",
+              "rewind",
+              "skip",
+              "sort",
+              "to_list",
+              "count",
+              "hasNext",
+              "has_next",
+              "paginate"
+            ]
+          },
+          "classes": [
+            "tinymongo.TinyMongoCursor"
+          ],
+          "extensions": [
+            "count",
+            "hasNext",
+            "has_next",
+            "paginate"
+          ],
+          "present_but_unsupported": [],
+          "properties": [
+            {
+              "kind": "property",
+              "name": "alive"
+            }
+          ],
+          "protocols": [
+            {
+              "awaitability": "immediate",
+              "methods": [
+                "__getitem__"
+              ],
+              "name": "indexing and slicing"
+            },
+            {
+              "awaitability": "immediate",
+              "methods": [
+                "__iter__",
+                "__next__"
+              ],
+              "name": "iterator"
+            },
+            {
+              "awaitability": "immediate",
+              "methods": [
+                "__enter__",
+                "__exit__"
+              ],
+              "name": "context manager"
+            }
+          ],
+          "supported": [
+            "clone",
+            "close",
+            "limit",
+            "next",
+            "rewind",
+            "skip",
+            "sort",
+            "to_list"
+          ]
+        },
+        "sync_database": {
+          "awaitability": {
+            "awaitable": [],
+            "immediate": [
+              "close",
+              "command",
+              "drop_collection",
+              "get_collection",
+              "list_collection_names",
+              "watch",
+              "collection_names"
+            ]
+          },
+          "classes": [
+            "tinymongo.TinyMongoDatabase"
+          ],
+          "extensions": [
+            "collection_names"
+          ],
+          "present_but_unsupported": [
+            "watch"
+          ],
+          "properties": [
+            {
+              "kind": "property",
+              "name": "name"
+            },
+            {
+              "kind": "instance_attribute",
+              "meaning": "compatibility name alias",
+              "name": "database"
+            }
+          ],
+          "protocols": [
+            {
+              "awaitability": "immediate",
+              "methods": [
+                "__getitem__"
+              ],
+              "name": "collection selection by subscription"
+            },
+            {
+              "awaitability": "immediate",
+              "methods": [
+                "__getattr__"
+              ],
+              "name": "collection selection by attribute"
+            },
+            {
+              "awaitability": "immediate",
+              "methods": [
+                "__enter__",
+                "__exit__"
+              ],
+              "name": "context manager"
+            }
+          ],
+          "supported": [
+            "close",
+            "command",
+            "drop_collection",
+            "get_collection",
+            "list_collection_names"
+          ]
+        }
+      }
+    },
+    "commands": {
+      "rules": [
+        "command names are case-insensitive",
+        "session is null-only",
+        "string or non-empty command-document input; the document's first key selects the command",
+        "value, positional arguments, and other keyword arguments are ignored"
+      ],
+      "supported": [
+        "buildInfo",
+        "ping"
+      ],
+      "unsupported": [
+        "arbitrary database commands"
+      ]
+    },
+    "errors": {
+      "class_shapes": {
+        "BulkWriteError": {
+          "constructor": "BulkWriteError(results)",
+          "detail_shape": "bulk_write_details",
+          "fields": [
+            {
+              "constant": 65,
+              "kind": "pymongo_property",
+              "name": "code"
+            },
+            {
+              "kind": "pymongo_property",
+              "name": "details",
+              "shape": "bulk_write_details"
+            },
+            {
+              "kind": "inherited_pymongo_property",
+              "name": "timeout",
+              "rule": "true when the last write concern error is a write timeout or the last write error has code 50; runtime-produced insert errors use code 11000"
+            }
+          ]
+        },
+        "ConfigurationError": {
+          "fields": [
+            {
+              "constant": false,
+              "kind": "inherited_pymongo_property",
+              "name": "timeout"
+            }
+          ]
+        },
+        "ConnectionFailure": {
+          "fields": [
+            {
+              "constant": false,
+              "kind": "inherited_pymongo_property",
+              "name": "timeout"
+            }
+          ]
+        },
+        "CursorNotFound": {
+          "fields": [
+            {
+              "kind": "pymongo_property",
+              "name": "code"
+            },
+            {
+              "kind": "pymongo_property",
+              "name": "details"
+            },
+            {
+              "kind": "inherited_pymongo_property",
+              "name": "timeout",
+              "rule": "true only when code is 50"
+            }
+          ]
+        },
+        "DuplicateKeyError": {
+          "constructor": "DuplicateKeyError(error, code=11000, details=None, max_wire_version=None)",
+          "fields": [
+            {
+              "kind": "pymongo_property",
+              "name": "code"
+            },
+            {
+              "kind": "pymongo_property",
+              "name": "details"
+            },
+            {
+              "kind": "inherited_pymongo_property",
+              "name": "timeout",
+              "rule": "true only when code is 50"
+            }
+          ]
+        },
+        "InvalidDocument": {
+          "constructor": "InvalidDocument(message, document=None)",
+          "fields": [
+            {
+              "identity": "original root document rejected by the BSON codec",
+              "kind": "tinymongo_property",
+              "name": "document"
+            },
+            {
+              "constant": false,
+              "kind": "inherited_pymongo_property",
+              "name": "timeout"
+            }
+          ]
+        },
+        "InvalidOperation": {
+          "fields": [
+            {
+              "constant": false,
+              "kind": "inherited_pymongo_property",
+              "name": "timeout"
+            }
+          ]
+        },
+        "LockError": {
+          "fields": [
+            {
+              "constant": false,
+              "kind": "inherited_pymongo_property",
+              "name": "timeout"
+            }
+          ]
+        },
+        "OperationFailure": {
+          "constructor": "OperationFailure(error, code=None, details=None, max_wire_version=None)",
+          "fields": [
+            {
+              "kind": "pymongo_property",
+              "name": "code"
+            },
+            {
+              "kind": "pymongo_property",
+              "name": "details"
+            },
+            {
+              "kind": "inherited_pymongo_property",
+              "name": "timeout",
+              "rule": "true only when code is 50"
+            }
+          ]
+        },
+        "StorageCorruptionError": {
+          "fields": [
+            {
+              "constant": false,
+              "kind": "inherited_pymongo_property",
+              "name": "timeout"
+            }
+          ]
+        },
+        "StorageError": {
+          "fields": [
+            {
+              "constant": false,
+              "kind": "inherited_pymongo_property",
+              "name": "timeout"
+            }
+          ]
+        },
+        "TinyMongoError": {
+          "fields": [
+            {
+              "constant": false,
+              "kind": "inherited_pymongo_property",
+              "name": "timeout"
+            }
+          ]
+        },
+        "TinyMongoNotSupportedError": {
+          "fields": [
+            {
+              "constant": false,
+              "kind": "inherited_pymongo_property",
+              "name": "timeout"
+            }
+          ]
+        },
+        "WriteError": {
+          "fields": [
+            {
+              "kind": "pymongo_property",
+              "name": "code"
+            },
+            {
+              "kind": "pymongo_property",
+              "name": "details"
+            },
+            {
+              "kind": "inherited_pymongo_property",
+              "name": "timeout",
+              "rule": "true only when code is 50"
+            }
+          ]
+        }
+      },
+      "classes": [
+        "BulkWriteError",
+        "ConfigurationError",
+        "ConnectionFailure",
+        "CursorNotFound",
+        "DuplicateKeyError",
+        "InvalidDocument",
+        "InvalidOperation",
+        "LockError",
+        "OperationFailure",
+        "StorageCorruptionError",
+        "StorageError",
+        "TinyMongoError",
+        "TinyMongoNotSupportedError",
+        "WriteError"
+      ],
+      "contract_asserted_codes": [
+        2,
+        9,
+        14,
+        28,
+        40,
+        66,
+        85,
+        86,
+        224,
+        11000,
+        51075
+      ],
+      "detail_shapes": {
+        "bulk_write_details": {
+          "kind": "document",
+          "required_fields": {
+            "nInserted": "integer",
+            "nMatched": {
+              "constant": 0
+            },
+            "nModified": {
+              "constant": 0
+            },
+            "nRemoved": {
+              "constant": 0
+            },
+            "nUpserted": {
+              "constant": 0
+            },
+            "upserted": {
+              "constant": []
+            },
+            "writeConcernErrors": {
+              "constant": []
+            },
+            "writeErrors": {
+              "item": {
+                "kind": "document",
+                "required_fields": {
+                  "code": {
+                    "constant": 11000
+                  },
+                  "errmsg": "string",
+                  "index": "integer",
+                  "keyPattern": "document",
+                  "keyValue": "document",
+                  "op": "original_document"
+                }
+              },
+              "kind": "array"
+            }
+          }
+        }
+      },
+      "field_scope": "public TinyMongo/PyMongo properties in the pinned PyMongo 4.17.0 reference environment; BaseException.args is omitted",
+      "runtime_emitted_code_count": 60,
+      "stable_codes_by_domain": {
+        "aggregation_expression_group_unset": {
+          "1257300": "ifNull_too_few_arguments",
+          "16020": "size_wrong_arity",
+          "17124": "size_input_not_array",
+          "31002": "unset_wrong_container_type",
+          "31119": "unset_empty_array",
+          "31120": "unset_non_string_member",
+          "40234": "accumulator_missing_empty_non_document_or_non_operator",
+          "40235": "group_output_field_contains_dot",
+          "40236": "group_output_field_starts_with_dollar",
+          "40237": "accumulator_array_operand_not_unary",
+          "40238": "multiple_accumulators",
+          "40272": "set_or_add_fields_non_document"
+        },
+        "aggregation_sort_count_numeric": {
+          "13103": "sort_more_than_32_keys",
+          "15948": "count_output_field_is_id",
+          "15958": "limit_is_zero",
+          "15969": "project_stage_not_document",
+          "15973": "sort_stage_not_document",
+          "15974": "sort_key_not_string_or_direction_not_numeric",
+          "15975": "sort_direction_not_plus_or_minus_one",
+          "15976": "sort_is_empty",
+          "16746": "ambiguous_numeric_array_sort_path",
+          "40156": "count_field_not_string",
+          "40157": "count_field_empty",
+          "40158": "count_field_starts_with_dollar",
+          "40159": "count_field_contains_nul",
+          "40160": "count_field_contains_dot",
+          "5107200": "skip_invalid_type_integrality_or_i64_range",
+          "5107201": "limit_invalid_type_integrality_or_i64_range"
+        },
+        "common_query_update_index": {
+          "11000": "duplicate_key",
+          "14": "type_mismatch",
+          "197": "invalid_unique_option_on_id_index",
+          "2": "bad_value",
+          "224": "expr_forbidden_in_pull",
+          "27": "index_not_found",
+          "28": "path_not_viable",
+          "40": "conflicting_update_paths",
+          "56": "empty_update_path",
+          "65": "bulk_write_outer",
+          "66": "immutable_id",
+          "72": "cannot_drop_id_index",
+          "85": "same_key_options_different_name",
+          "86": "same_name_or_key_different_options",
+          "9": "failed_to_parse"
+        },
+        "paths_and_projection": {
+          "15998": "empty_path_component",
+          "16410": "dollar_prefixed_path_component",
+          "16411": "nul_path_component",
+          "31249": "ancestor_before_descendant_collision",
+          "31250": "descendant_before_ancestor_or_duplicate_collision",
+          "31252": "operator_expression_after_exclusion",
+          "31253": "inclusion_after_exclusion",
+          "31254": "exclusion_after_inclusion",
+          "31310": "scalar_or_field_path_expression_after_exclusion",
+          "40176": "set_or_add_fields_path_collision",
+          "40352": "empty_or_nul_projection_output_field",
+          "40353": "aggregation_path_ends_with_dot",
+          "51270": "empty_subprojection",
+          "51272": "empty_project"
+        },
+        "regex": {
+          "51075": "options_with_embedded_flags",
+          "51091": "invalid_python_regex_pattern",
+          "51108": "unsupported_option_character"
+        }
+      }
+    },
+    "indexes": {
+      "constraints": [
+        "compound indexes reject parallel array fields",
+        "dotted index paths cannot traverse arrays",
+        "indexed objects, nested arrays, non-finite numbers, and unsupported BSON values are rejected",
+        "sparse and partialFilterExpression are mutually exclusive",
+        "top-level arrays create multikey entries"
+      ],
+      "create_index": {
+        "directions": [
+          1
+        ],
+        "options": [
+          "name",
+          "partialFilterExpression",
+          "sparse",
+          "unique"
+        ]
+      },
+      "create_indexes_index_model": {
+        "directions": [
+          1,
+          -1,
+          "hashed",
+          "text"
+        ],
+        "options": [
+          "background",
+          "expireAfterSeconds",
+          "name",
+          "partialFilterExpression",
+          "sparse",
+          "unique"
+        ]
+      },
+      "degraded_with_warning": [
+        "background",
+        "descending",
+        "hashed",
+        "text",
+        "ttl"
+      ],
+      "degradation_outcomes": {
+        "ascending_fallback": [
+          "descending",
+          "hashed"
+        ],
+        "ignored_semantics": [
+          "background",
+          "ttl"
+        ],
+        "skipped_without_effective_index": [
+          "text"
+        ]
+      },
+      "operations": [
+        "create_index",
+        "create_indexes",
+        "drop_index",
+        "index_information",
+        "list_indexes"
+      ],
+      "partial_filter_operators": [
+        "$and",
+        "$eq",
+        "$exists:true",
+        "$gt",
+        "$gte",
+        "$in",
+        "$lt",
+        "$lte",
+        "$or",
+        "$type"
+      ],
+      "supported": [
+        "ascending",
+        "compound",
+        "dotted paths",
+        "multikey",
+        "named",
+        "partial",
+        "sparse",
+        "unique"
+      ],
+      "unsafe_unique_degradations_rejected": [
+        "hashed",
+        "text",
+        "ttl"
+      ]
+    },
+    "projections": {
+      "rules": [
+        "boolean and BSON-number flags only",
+        "empty mapping or field sequence means no projection",
+        "nested mappings are dotted-path shorthand",
+        "path collisions are rejected"
+      ],
+      "supported": [
+        "array traversal",
+        "dotted paths",
+        "exclusion",
+        "explicit _id inclusion/exclusion",
+        "inclusion",
+        "list-of-fields shorthand"
+      ],
+      "unsupported": [
+        "$elemMatch projection",
+        "$slice projection",
+        "expression projection in find",
+        "mixed inclusion/exclusion except _id",
+        "numeric array-index output paths",
+        "positional projection"
+      ]
+    },
+    "queries": {
+      "field_operators": [
+        "$all",
+        "$elemMatch",
+        "$eq",
+        "$exists",
+        "$gt",
+        "$gte",
+        "$in",
+        "$lt",
+        "$lte",
+        "$mod",
+        "$ne",
+        "$nin",
+        "$not",
+        "$options",
+        "$regex",
+        "$size",
+        "$type"
+      ],
+      "ignored_metadata_operators": [
+        "$comment"
+      ],
+      "ignored_metadata_operator_scope": "query-document keys only; field-operator use is invalid",
+      "logical_operators": [
+        "$and",
+        "$nor",
+        "$or"
+      ],
+      "regex_options": [
+        "i",
+        "m",
+        "s",
+        "u",
+        "x"
+      ],
+      "unsupported_operators": [
+        "$bitsAllClear",
+        "$bitsAllSet",
+        "$bitsAnyClear",
+        "$bitsAnySet",
+        "$expr",
+        "$geoIntersects",
+        "$geoWithin",
+        "$jsonSchema",
+        "$near",
+        "$nearSphere",
+        "$text",
+        "$where"
+      ],
+      "type_aliases": [
+        "minKey",
+        "double",
+        "string",
+        "object",
+        "array",
+        "binData",
+        "undefined",
+        "objectId",
+        "bool",
+        "date",
+        "null",
+        "regex",
+        "dbPointer",
+        "javascript",
+        "symbol",
+        "javascriptWithScope",
+        "int",
+        "timestamp",
+        "long",
+        "decimal",
+        "maxKey",
+        "number"
+      ],
+      "type_codes": {
+        "-1": "minKey",
+        "1": "double",
+        "2": "string",
+        "3": "object",
+        "4": "array",
+        "5": "binData",
+        "6": "undefined",
+        "7": "objectId",
+        "8": "bool",
+        "9": "date",
+        "10": "null",
+        "11": "regex",
+        "12": "dbPointer",
+        "13": "javascript",
+        "14": "symbol",
+        "15": "javascriptWithScope",
+        "16": "int",
+        "17": "timestamp",
+        "18": "long",
+        "19": "decimal",
+        "127": "maxKey"
+      },
+      "rules": [
+        "array and dotted-path traversal",
+        "BSON type brackets",
+        "missing/null distinction",
+        "numeric cross-type comparison",
+        "recursive BSON equality",
+        "regex option normalization"
+      ]
+    },
+    "results": {
+      "cursor_results": {
+        "async_class": "tinymongo.AsyncTinyMongoCursor",
+        "async_cursor_returning_operations": [
+          "aggregate",
+          "find",
+          "list_databases",
+          "list_indexes"
+        ],
+        "behavior": [
+          "lazy async collection find",
+          "ordered local iteration",
+          "clone and rewind",
+          "sort then skip then absolute limit",
+          "length-bounded to_list",
+          "close and alive state",
+          "independent materialized values"
+        ],
+        "sync_class": "tinymongo.TinyMongoCursor",
+        "sync_cursor_returning_operations": [
+          "aggregate",
+          "find",
+          "list_databases"
+        ]
+      },
+      "document_results": {
+        "datetime_conversion": "MongoClient tz_aware and tzinfo are applied recursively at read materialization",
+        "field_order": "mapping insertion order is retained, including nested documents",
+        "mapping_class": "MongoClient document_class is applied recursively to returned mappings",
+        "value_isolation": "returned documents and BSON containers are copied so caller mutation does not mutate storage"
+      },
+      "inventory_version": 1,
+      "operation_result_shapes": {
+        "async_client": {
+          "capabilities": "capabilities_document",
+          "close": "none",
+          "database_names": "string_list",
+          "drop_database": "none",
+          "get_database": "database_handle_async",
+          "list_database_names": "string_list",
+          "list_databases": "database_metadata_cursor_async",
+          "server_info": "server_info_document",
+          "start_session": "unsupported_error",
+          "supports": "boolean",
+          "watch": "unsupported_error"
+        },
+        "async_collection": {
+          "aggregate": "cursor_async",
+          "bulk_write": "unsupported_error",
+          "count": "integer",
+          "count_documents": "integer",
+          "create_index": "string",
+          "create_indexes": "string_list",
+          "delete_many": "delete_result",
+          "delete_one": "delete_result",
+          "distinct": "value_list",
+          "drop": "boolean",
+          "drop_index": "none",
+          "estimated_document_count": "integer",
+          "find": "cursor_async",
+          "find_one": "document_or_none",
+          "find_one_and_delete": "document_or_none",
+          "find_one_and_replace": "document_or_none",
+          "find_one_and_update": "document_or_none",
+          "index_information": "index_information_document",
+          "insert": "legacy_insert_result",
+          "insert_many": "insert_many_result",
+          "insert_one": "insert_one_result",
+          "list_indexes": "index_metadata_cursor_async",
+          "remove": "delete_result",
+          "replace_one": "update_result",
+          "update": "legacy_update_result",
+          "update_many": "update_result",
+          "update_one": "update_result",
+          "watch": "unsupported_error",
+          "with_options": "self_async_collection"
+        },
+        "async_cursor": {
+          "clone": "cursor_handle_async",
+          "close": "none",
+          "count": "integer",
+          "hasNext": "boolean",
+          "has_next": "boolean",
+          "limit": "self_async_cursor",
+          "next": "document",
+          "paginate": "self_async_cursor",
+          "rewind": "self_async_cursor",
+          "skip": "self_async_cursor",
+          "sort": "self_async_cursor",
+          "to_list": "document_list",
+          "try_next": "document_or_none"
+        },
+        "async_database": {
+          "close": "none",
+          "collection_names": "string_list",
+          "command": "command_document",
+          "drop_collection": "boolean",
+          "get_collection": "collection_handle_async",
+          "list_collection_names": "string_list",
+          "watch": "unsupported_error"
+        },
+        "gridfs_placeholder": {
+          "GridFS": "self_gridfs_placeholder",
+          "grid_fs": "self_gridfs_placeholder"
+        },
+        "sync_client": {
+          "capabilities": "capabilities_document",
+          "close": "none",
+          "database_names": "string_list",
+          "drop_database": "none",
+          "get_database": "database_handle_sync",
+          "list_database_names": "string_list",
+          "list_databases": "database_metadata_cursor_sync",
+          "server_info": "server_info_document",
+          "start_session": "unsupported_error",
+          "supports": "boolean",
+          "watch": "unsupported_error"
+        },
+        "sync_collection": {
+          "aggregate": "cursor_sync",
+          "build_table": "none",
+          "bulk_write": "unsupported_error",
+          "count": "integer",
+          "count_documents": "integer",
+          "create_index": "string",
+          "create_indexes": "string_list",
+          "delete_many": "delete_result",
+          "delete_one": "delete_result",
+          "distinct": "value_list",
+          "drop": "boolean",
+          "drop_index": "none",
+          "estimated_document_count": "integer",
+          "find": "cursor_sync",
+          "find_one": "document_or_none",
+          "find_one_and_delete": "document_or_none",
+          "find_one_and_replace": "document_or_none",
+          "find_one_and_update": "document_or_none",
+          "index_information": "index_information_document",
+          "insert": "legacy_insert_result",
+          "insert_many": "insert_many_result",
+          "insert_one": "insert_one_result",
+          "list_indexes": "index_metadata_list",
+          "parse_condition": "query_condition_iterator",
+          "parse_query": "query_object",
+          "remove": "delete_result",
+          "replace_one": "update_result",
+          "update": "legacy_update_result",
+          "update_many": "update_result",
+          "update_one": "update_result",
+          "watch": "unsupported_error",
+          "with_options": "self_sync_collection"
+        },
+        "sync_cursor": {
+          "clone": "cursor_handle_sync",
+          "close": "none",
+          "count": "integer",
+          "hasNext": "boolean",
+          "has_next": "boolean",
+          "limit": "self_sync_cursor",
+          "next": "document",
+          "paginate": "self_sync_cursor",
+          "rewind": "self_sync_cursor",
+          "skip": "self_sync_cursor",
+          "sort": "self_sync_cursor",
+          "to_list": "document_list"
+        },
+        "sync_database": {
+          "close": "none",
+          "collection_names": "string_list",
+          "command": "command_document",
+          "drop_collection": "boolean",
+          "get_collection": "collection_handle_sync",
+          "list_collection_names": "string_list",
+          "watch": "unsupported_error"
+        }
+      },
+      "result_shapes": {
+        "boolean": {
+          "kind": "scalar",
+          "type": "boolean"
+        },
+        "boolean_true": {
+          "kind": "literal",
+          "value": true
+        },
+        "bson_value": {
+          "families": [
+            "array",
+            "binary",
+            "boolean",
+            "datetime",
+            "double",
+            "int",
+            "long",
+            "null",
+            "object",
+            "regex",
+            "string",
+            "uuid"
+          ],
+          "kind": "value"
+        },
+        "capabilities_document": {
+          "kind": "document",
+          "required_fields": {
+            "aggregation": "document",
+            "backend": "string",
+            "bson_types": "document",
+            "bulk_writes": "boolean",
+            "change_streams": "boolean",
+            "multiprocess_writes": "boolean",
+            "native_indexes": "boolean",
+            "object_storage": "boolean",
+            "persistent": "boolean",
+            "projections": "boolean",
+            "query_operators": "document",
+            "remote_storage": "boolean",
+            "sessions": "boolean",
+            "table_native": "boolean",
+            "transactions": "boolean",
+            "update_operators": "document"
+          }
+        },
+        "collection_handle_async": {
+          "class": "tinymongo.AsyncTinyMongoCollection",
+          "kind": "object"
+        },
+        "collection_handle_sync": {
+          "class": "tinymongo.TinyMongoCollection",
+          "kind": "object"
+        },
+        "command_document": {
+          "kind": "discriminated_document",
+          "variants": {
+            "buildInfo": {
+              "exact_fields": {
+                "ok": 1.0,
+                "tinymongo": true,
+                "version": "8.0.0",
+                "versionArray": [
+                  8,
+                  0,
+                  0,
+                  0
+                ]
+              }
+            },
+            "ping": {
+              "exact_fields": {
+                "ok": 1.0
+              }
+            }
+          }
+        },
+        "cursor_async": {
+          "class": "tinymongo.AsyncTinyMongoCursor",
+          "item": "document",
+          "kind": "cursor"
+        },
+        "cursor_handle_async": {
+          "class": "tinymongo.AsyncTinyMongoCursor",
+          "kind": "object"
+        },
+        "cursor_handle_sync": {
+          "class": "tinymongo.TinyMongoCursor",
+          "kind": "object"
+        },
+        "cursor_sync": {
+          "class": "tinymongo.TinyMongoCursor",
+          "item": "document",
+          "kind": "cursor"
+        },
+        "database_handle_async": {
+          "class": "tinymongo.AsyncTinyMongoDatabase",
+          "kind": "object"
+        },
+        "database_handle_sync": {
+          "class": "tinymongo.TinyMongoDatabase",
+          "kind": "object"
+        },
+        "database_metadata_cursor_async": {
+          "class": "tinymongo.AsyncTinyMongoCursor",
+          "item": {
+            "kind": "document",
+            "required_fields": {
+              "empty": "boolean",
+              "name": "string",
+              "sizeOnDisk": "integer"
+            }
+          },
+          "kind": "cursor"
+        },
+        "database_metadata_cursor_sync": {
+          "class": "tinymongo.TinyMongoCursor",
+          "item": {
+            "kind": "document",
+            "required_fields": {
+              "empty": "boolean",
+              "name": "string",
+              "sizeOnDisk": "integer"
+            }
+          },
+          "kind": "cursor"
+        },
+        "delete_result": {
+          "class": "tinymongo.results.DeleteResult",
+          "kind": "object"
+        },
+        "document": {
+          "additional_properties": "bson_value",
+          "kind": "document"
+        },
+        "document_list": {
+          "item": "document",
+          "kind": "array"
+        },
+        "document_or_none": {
+          "kind": "union",
+          "members": [
+            "document",
+            "none"
+          ]
+        },
+        "index_information_document": {
+          "additional_property": {
+            "kind": "document",
+            "optional_fields": {
+              "partialFilterExpression": "document",
+              "sparse": "boolean_true",
+              "unique": "boolean_true"
+            },
+            "required_fields": {
+              "key": "key_direction_pair_array"
+            }
+          },
+          "kind": "document"
+        },
+        "index_metadata_cursor_async": {
+          "class": "tinymongo.AsyncTinyMongoCursor",
+          "item": "index_metadata_document",
+          "kind": "cursor"
+        },
+        "index_metadata_document": {
+          "kind": "document",
+          "optional_fields": {
+            "partialFilterExpression": "document",
+            "sparse": "boolean_true",
+            "unique": "boolean_true"
+          },
+          "required_fields": {
+            "key": "key_direction_pair_array",
+            "name": "string"
+          }
+        },
+        "index_metadata_list": {
+          "item": "index_metadata_document",
+          "kind": "array"
+        },
+        "insert_many_result": {
+          "class": "tinymongo.results.InsertManyResult",
+          "kind": "object"
+        },
+        "insert_one_result": {
+          "class": "tinymongo.results.InsertOneResult",
+          "kind": "object"
+        },
+        "integer": {
+          "kind": "scalar",
+          "type": "integer"
+        },
+        "key_direction_pair": {
+          "items": [
+            "string",
+            "integer"
+          ],
+          "kind": "tuple"
+        },
+        "key_direction_pair_array": {
+          "item": "key_direction_pair",
+          "kind": "array"
+        },
+        "legacy_insert_result": {
+          "kind": "union",
+          "members": [
+            "insert_one_result",
+            "insert_many_result"
+          ],
+          "selection": "InsertManyResult for list input; InsertOneResult otherwise"
+        },
+        "legacy_update_result": {
+          "kind": "union",
+          "members": [
+            "update_result",
+            "update_result_list"
+          ],
+          "selection": "list[UpdateResult] for list update input; UpdateResult otherwise"
+        },
+        "none": {
+          "kind": "literal",
+          "value": null
+        },
+        "original_document": {
+          "additional_properties": "bson_value",
+          "identity": "the original caller-supplied operation document",
+          "kind": "document"
+        },
+        "path_or_uri": {
+          "kind": "value",
+          "meaning": "local path or storage URI",
+          "types": [
+            "string",
+            "os.PathLike"
+          ]
+        },
+        "query_condition_iterator": {
+          "item_class": "tinydb.queries.QueryImpl",
+          "kind": "iterator"
+        },
+        "query_object": {
+          "class": "tinydb.queries.QueryImpl",
+          "kind": "object"
+        },
+        "self_async_collection": {
+          "class": "tinymongo.AsyncTinyMongoCollection",
+          "identity": "self",
+          "kind": "object"
+        },
+        "self_async_cursor": {
+          "class": "tinymongo.AsyncTinyMongoCursor",
+          "identity": "self except clone, which returns an independent cursor",
+          "kind": "object"
+        },
+        "self_gridfs_placeholder": {
+          "class": "tinymongo.TinyGridFS",
+          "identity": "self",
+          "kind": "object"
+        },
+        "self_sync_collection": {
+          "class": "tinymongo.TinyMongoCollection",
+          "identity": "self",
+          "kind": "object"
+        },
+        "self_sync_cursor": {
+          "class": "tinymongo.TinyMongoCursor",
+          "identity": "self except clone, which returns an independent cursor",
+          "kind": "object"
+        },
+        "server_info_document": {
+          "kind": "document",
+          "required_fields": {
+            "dsnConfigured": "boolean",
+            "localPath": "path_or_uri",
+            "storage": "string",
+            "storageUri": "string_or_none",
+            "tinymongo": "boolean_true",
+            "version": "string"
+          }
+        },
+        "string": {
+          "kind": "scalar",
+          "type": "string"
+        },
+        "string_list": {
+          "item": "string",
+          "kind": "array"
+        },
+        "string_or_none": {
+          "kind": "union",
+          "members": [
+            "string",
+            "none"
+          ]
+        },
+        "unsupported_error": {
+          "class": "tinymongo.errors.TinyMongoNotSupportedError",
+          "kind": "raises"
+        },
+        "update_result": {
+          "class": "tinymongo.results.UpdateResult",
+          "kind": "object"
+        },
+        "update_result_list": {
+          "item": "update_result",
+          "kind": "array"
+        },
+        "value_list": {
+          "item": "bson_value",
+          "kind": "array"
+        }
+      },
+      "write_result_classes": {
+        "tinymongo.results.DeleteResult": {
+          "constructor": "DeleteResult(raw_result, acknowledged=True)",
+          "fields": [
+            {
+              "kind": "inherited_attribute",
+              "meaning": "caller-supplied acknowledgement flag",
+              "name": "acknowledged"
+            },
+            {
+              "kind": "pymongo_property",
+              "meaning": "raw_result.n for a mapping, list length for a list, otherwise raw_result",
+              "name": "deleted_count"
+            },
+            {
+              "kind": "pymongo_property",
+              "meaning": "local Mongo-shaped result mapping or legacy result value",
+              "name": "raw_result"
+            }
+          ]
+        },
+        "tinymongo.results.InsertManyResult": {
+          "constructor": "InsertManyResult(eids, inserted_ids, acknowledged=True)",
+          "fields": [
+            {
+              "kind": "inherited_attribute",
+              "meaning": "caller-supplied acknowledgement flag",
+              "name": "acknowledged"
+            },
+            {
+              "kind": "extension_property",
+              "meaning": "TinyDB element identifiers in input order",
+              "name": "eids"
+            },
+            {
+              "kind": "pymongo_property",
+              "meaning": "inserted document _id values in input order",
+              "name": "inserted_ids"
+            }
+          ]
+        },
+        "tinymongo.results.InsertOneResult": {
+          "constructor": "InsertOneResult(eid, inserted_id, acknowledged=True)",
+          "fields": [
+            {
+              "kind": "inherited_attribute",
+              "meaning": "caller-supplied acknowledgement flag",
+              "name": "acknowledged"
+            },
+            {
+              "kind": "extension_property",
+              "meaning": "TinyDB element identifier returned by the storage backend",
+              "name": "eid"
+            },
+            {
+              "kind": "pymongo_property",
+              "meaning": "inserted document _id",
+              "name": "inserted_id"
+            }
+          ]
+        },
+        "tinymongo.results.UpdateResult": {
+          "constructor": "UpdateResult(raw_result, acknowledged=True, matched_count=None, modified_count=None, upserted_id=None)",
+          "fields": [
+            {
+              "kind": "inherited_attribute",
+              "meaning": "caller-supplied acknowledgement flag",
+              "name": "acknowledged"
+            },
+            {
+              "kind": "pymongo_property",
+              "meaning": "true when raw_result is a mapping containing an upserted key",
+              "name": "did_upsert"
+            },
+            {
+              "kind": "pymongo_property",
+              "meaning": "explicit matched count, otherwise derived from raw_result; zero for an upsert",
+              "name": "matched_count"
+            },
+            {
+              "kind": "pymongo_property",
+              "meaning": "explicit modified count, otherwise derived from raw_result",
+              "name": "modified_count"
+            },
+            {
+              "kind": "pymongo_property",
+              "meaning": "local Mongo-shaped result mapping or legacy result list",
+              "name": "raw_result"
+            },
+            {
+              "kind": "pymongo_property",
+              "meaning": "explicit upserted id, otherwise raw_result.upserted",
+              "name": "upserted_id"
+            }
+          ]
+        }
+      }
+    },
+    "unsupported": [
+      "aggregate keyword options other than session=None",
+      "arbitrary server commands",
+      "array filters and positional path tokens are not implemented; update kwargs are ignored and mapping-only operators can persist tokens as literal keys",
+      "bulk_write",
+      "change streams",
+      "filtered collection listing",
+      "geospatial operators",
+      "non-null sessions",
+      "non-default read and write concerns",
+      "server-side JavaScript",
+      "TinyGridFS storage operations",
+      "transactions",
+      "unsupported aggregation stages/expressions/accumulators",
+      "unsupported index specifications",
+      "watch"
+    ],
+    "updates": {
+      "modifiers": {
+        "$addToSet": [
+          "$each"
+        ],
+        "$push": [
+          "$each",
+          "$position",
+          "$slice",
+          "$sort"
+        ]
+      },
+      "operators": [
+        "$addToSet",
+        "$inc",
+        "$max",
+        "$min",
+        "$pop",
+        "$pull",
+        "$pullAll",
+        "$push",
+        "$rename",
+        "$set",
+        "$unset"
+      ],
+      "path_policies": {
+        "mapping_only_dotted_paths": [
+          "$addToSet",
+          "$inc",
+          "$set",
+          "$unset"
+        ],
+        "numeric_array_index_paths": [
+          "$max",
+          "$min",
+          "$pop",
+          "$pull",
+          "$pullAll",
+          "$push"
+        ],
+        "rejects_array_element_and_positional_paths": [
+          "$rename"
+        ]
+      },
+      "pull_operators": {
+        "document_field_extra": [
+          "$not"
+        ],
+        "logical": [
+          "$and",
+          "$or",
+          "$nor"
+        ],
+        "scalar_and_document_field": [
+          "$all",
+          "$elemMatch",
+          "$eq",
+          "$exists",
+          "$gt",
+          "$gte",
+          "$in",
+          "$lt",
+          "$lte",
+          "$mod",
+          "$ne",
+          "$nin",
+          "$options",
+          "$regex",
+          "$size",
+          "$type"
+        ]
+      },
+      "rules": [
+        "atomic post-image validation",
+        "root _id remains unchanged after successful updates; error behavior is operator-specific",
+        "replacement writes",
+        "single and multi writes",
+        "upsert equality seeding"
+      ]
+    },
+    "values": {
+      "bson_family_aliases": {
+        "int": "int32",
+        "long": "int64"
+      },
+      "native": [
+        "array",
+        "binary",
+        "boolean",
+        "datetime",
+        "double",
+        "int",
+        "long",
+        "null",
+        "object",
+        "regex",
+        "string",
+        "uuid"
+      ],
+      "optional_pymongo_bson": [
+        "Binary",
+        "Code",
+        "Decimal128",
+        "MaxKey",
+        "MinKey",
+        "ObjectId",
+        "Regex",
+        "Timestamp"
+      ],
+      "rules": [
+        "datetime UTC millisecond canonicalization",
+        "duplicate-safe decode policy",
+        "field-order preservation",
+        "non-finite double preservation",
+        "ordered documents",
+        "standard UUID representation",
+        "typed binary subtypes"
+      ]
+    },
+    "warnings": {
+      "class": "TinyMongoUnsupportedWarning",
+      "contexts": [
+        "create_indexes degraded model creation or skip",
+        "create_indexes degraded model reuse",
+        "cursor sorting of unsupported values",
+        "aggregation $sort of unsupported values"
+      ],
+      "degraded_index_feature_messages": {
+        "background": "background creation is ignored",
+        "descending": "descending direction is treated as ascending",
+        "hashed": "hashed indexing is replaced by ascending equality indexing",
+        "text": "text indexing is ignored because $text queries are not supported",
+        "ttl": "TTL expiration is not performed"
+      },
+      "message_templates": {
+        "index_creation": "Index {0!r} was created with reduced behavior: {1}.",
+        "index_reuse": "Index {0!r} was accepted with reduced behavior: {1}. Its effective specification matches existing index {2!r}, so TinyMongo reused that index instead of creating a duplicate.",
+        "unsupported_sort_value": "Sorting field '{0}' encountered unsupported value type '{1}'; values of this type compare as null."
+      },
+      "policy": "warnings name the reduced behavior and are attributed to the caller; sort warnings say the value compares as null and are de-duplicated per field and Python type within the cursor or aggregation engine"
+    }
+  },
+  "case_count": 228,
+  "contract": "tinymongo-v1",
+  "contract_suites": [
+    "bson-comparison",
+    "client-read-fidelity",
+    "core",
+    "talkpython"
+  ],
+  "dimensions": {
+    "apis": [
+      "sync",
+      "async"
+    ],
+    "implementations": [
+      "tinymongo",
+      "briskdb",
+      "mongodb"
+    ],
+    "tinymongo_backends": [
+      "memory",
+      "json",
+      "sqlite",
+      "sqlite-sharded",
+      "duckdb",
+      "parquet",
+      "mongodb"
+    ]
+  },
+  "files": {
+    "corpus": "corpus.json",
+    "intentional_differences": "intentional-differences.json",
+    "reference_results": "reference-results.json",
+    "runner_provenance": "runner/provenance.json",
+    "semantic_variants": "semantic-variants.json"
+  },
+  "full_matrix_execution_count": 3192,
+  "harvest_toolchain": {
+    "pymongo": "4.17.0",
+    "pytest": "8.4.2",
+    "python": "3.9.6"
+  },
+  "reference_execution_count": 456,
+  "reference_target": "tinymongo-memory",
+  "schema_version": 1,
+  "sha256": {
+    "corpus": "118cad744b2cfdf520327ec8dce20e5af4140ee836511f5ac5b139d0adcc2231",
+    "intentional_differences": "a4de8c0a846c656cb76c3d05e2ba5a08b0654374b0c678d43479ac0d64ecefcc",
+    "reference_results": "43ee15367d980adb4554748733054f99a2658d998d64cc01565047be5cf6e98c",
+    "runner_provenance": "6a360104cc19e8fde486791edaa549224a085898da19cdd15d132917dcadf484",
+    "semantic_variants": "60284936b73124e8b72492d1853fc5ae2d48d19a7ae1dd547ec7d3a5d04b6c44"
+  },
+  "source": {
+    "commit": "53cbf44e98b8caa036163725d195fd29592e1cc0",
+    "contract_git_tree": "6f671122ff5f76902cfe051e4558a2c57d161bc4",
+    "contract_tree_sha256": "8855a754113af809ad41672ab2383fa0dac9b01809a64a3d7d8dc438d2f84460",
+    "repository": "https://github.com/schapman1974/tinymongo",
+    "runtime_git_tree": "0c94915ea81697a5728f64dc04e3929bf1e036e8"
+  },
+  "suite_case_counts": {
+    "bson-comparison": 20,
+    "client-read-fidelity": 2,
+    "core": 177,
+    "talkpython": 29
+  }
+}

--- a/compat/mongo/v1/reference-results.json
+++ b/compat/mongo/v1/reference-results.json
@@ -1,0 +1,5934 @@
+{
+  "contract": "tinymongo-v1",
+  "executions": [
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage0]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage0]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage10]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage10]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage11]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage11]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage12]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage12]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage13]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage13]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage14]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage14]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage15]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage15]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage16]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage16]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage17]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage17]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage18]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage18]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage1]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage1]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage2]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage2]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage3]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage3]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage4]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage4]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage5]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage5]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage6]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage6]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage7]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage7]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage8]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage8]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage9]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_basic_stage_validation_is_mongodb_shaped[stage9]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_compound_numeric_sort_paths_can_select_separate_array_indexes",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_compound_numeric_sort_paths_can_select_separate_array_indexes",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_compound_numeric_sort_rejects_parallel_selected_arrays",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_compound_numeric_sort_rejects_parallel_selected_arrays",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_compound_sort_allows_nested_arrays_in_separate_parent_elements",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_compound_sort_allows_nested_arrays_in_separate_parent_elements",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_compound_sort_preserves_shared_array_element_correlation",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_compound_sort_preserves_shared_array_element_correlation",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_compound_sort_rejects_numeric_path_parallel_arrays[first.1]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_compound_sort_rejects_numeric_path_parallel_arrays[first.1]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_compound_sort_rejects_numeric_path_parallel_arrays[first.9]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_compound_sort_rejects_numeric_path_parallel_arrays[first.9]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_compound_sort_rejects_parallel_arrays",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_compound_sort_rejects_parallel_arrays",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_empty_input_stays_empty_and_count_emits_no_document",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_empty_input_stays_empty_and_count_emits_no_document",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_integral_numeric_arguments_and_pagination_boundaries",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_integral_numeric_arguments_and_pagination_boundaries",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_numeric_sort_path_compares_selected_array_as_a_whole_value",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_numeric_sort_path_compares_selected_array_as_a_whole_value",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_numeric_sort_path_keeps_empty_array_special_order",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_numeric_sort_path_keeps_empty_array_special_order",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_out_of_range_numeric_sort_path_fans_out_to_named_fields",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_out_of_range_numeric_sort_path_fans_out_to_named_fields",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_sort_array_fanout_includes_missing_but_not_nested_arrays",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_sort_array_fanout_includes_missing_but_not_nested_arrays",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_sort_numeric_path_segments_address_array_indexes",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_sort_numeric_path_segments_address_array_indexes",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_sort_rejects_ambiguous_numeric_array_paths",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_sort_rejects_ambiguous_numeric_array_paths",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_sort_skip_limit_and_count_compose_with_other_stages",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_sort_skip_limit_and_count_compose_with_other_stages",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_sort_traverses_dotted_array_paths_and_compounds_ties",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_sort_traverses_dotted_array_paths_and_compounds_ties",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_sort_uses_mongodb_keys_for_missing_null_arrays_and_bson_types",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_basic_stages_contract::test_sort_uses_mongodb_keys_for_missing_null_arrays_and_bson_types",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_contract::test_aggregate_cursor_consumes_in_chunks",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_contract::test_aggregate_cursor_consumes_in_chunks",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_contract::test_dotted_paths_preserve_empty_array_traversals",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_contract::test_dotted_paths_preserve_empty_array_traversals",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_contract::test_first_and_last_play_by_user",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_contract::test_first_and_last_play_by_user",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_contract::test_latest_activity_by_course",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_contract::test_latest_activity_by_course",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_contract::test_match_reuses_query_semantics_and_can_follow_group",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_contract::test_match_reuses_query_semantics_and_can_follow_group",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_contract::test_null_missing_keys_and_empty_inputs",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_contract::test_null_missing_keys_and_empty_inputs",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_contract::test_project_dotted_inclusion_preserves_array_shape",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_contract::test_project_dotted_inclusion_preserves_array_shape",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_contract::test_project_expression_argument_and_lazy_evaluation_contract",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_contract::test_project_expression_argument_and_lazy_evaluation_contract",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_contract::test_project_inclusion_id_and_expression_contract",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_contract::test_project_inclusion_id_and_expression_contract",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_contract::test_project_size_ifnull_application_rollup",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_contract::test_project_size_ifnull_application_rollup",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_contract::test_sum_and_min_max_follow_mongodb_value_rules",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_contract::test_sum_and_min_max_follow_mongodb_value_rules",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_contract::test_whole_collection_rollup",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_contract::test_whole_collection_rollup",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_projection_stages_contract::test_field_paths_do_not_descend_through_nested_arrays",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_projection_stages_contract::test_field_paths_do_not_descend_through_nested_arrays",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_projection_stages_contract::test_literal_and_remove_expression_contract",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_projection_stages_contract::test_literal_and_remove_expression_contract",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_projection_stages_contract::test_project_computed_dotted_paths_preserve_array_shape",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_projection_stages_contract::test_project_computed_dotted_paths_preserve_array_shape",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_projection_stages_contract::test_project_inclusion_exclusion_and_computed_modes",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_projection_stages_contract::test_project_inclusion_exclusion_and_computed_modes",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_projection_stages_contract::test_project_preserves_embedded_source_order_for_group_identity",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_projection_stages_contract::test_project_preserves_embedded_source_order_for_group_identity",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_projection_stages_contract::test_set_and_add_fields_are_aliases_using_original_input",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_projection_stages_contract::test_set_and_add_fields_are_aliases_using_original_input",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_projection_stages_contract::test_unset_accepts_one_or_many_dotted_fields",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_aggregation_projection_stages_contract::test_unset_accepts_one_or_many_dotted_fields",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_array_update_contract::test_array_updates_reject_non_array_targets[$pull-remove]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_array_update_contract::test_array_updates_reject_non_array_targets[$pull-remove]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_array_update_contract::test_array_updates_reject_non_array_targets[$pullAll-operand2]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_array_update_contract::test_array_updates_reject_non_array_targets[$pullAll-operand2]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_array_update_contract::test_array_updates_reject_non_array_targets[$push-append]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_array_update_contract::test_array_updates_reject_non_array_targets[$push-append]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_array_update_contract::test_invalid_array_modifiers_fail_atomically",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_array_update_contract::test_invalid_array_modifiers_fail_atomically",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_array_update_contract::test_plain_push_and_add_to_set_each_regressions",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_array_update_contract::test_plain_push_and_add_to_set_each_regressions",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_array_update_contract::test_pull_accepts_literal_and_query_operands",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_array_update_contract::test_pull_accepts_literal_and_query_operands",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_array_update_contract::test_pull_all_uses_literal_bson_equality",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_array_update_contract::test_pull_all_uses_literal_bson_equality",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_array_update_contract::test_pull_missing_fields_are_true_noops",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_array_update_contract::test_pull_missing_fields_are_true_noops",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_array_update_contract::test_pull_not_and_pull_all_operand_errors_match_mongodb",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_array_update_contract::test_pull_not_and_pull_all_operand_errors_match_mongodb",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_array_update_contract::test_pull_query_operator_family_matches_mongodb",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_array_update_contract::test_pull_query_operator_family_matches_mongodb",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_array_update_contract::test_push_each_slice_keeps_a_bounded_array",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_array_update_contract::test_push_each_slice_keeps_a_bounded_array",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_array_update_contract::test_push_modifiers_follow_mongodb_order_and_boundaries",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_array_update_contract::test_push_modifiers_follow_mongodb_order_and_boundaries",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_array_update_contract::test_tm038_pull_expr_errors_are_preflighted_like_mongodb",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_array_update_contract::test_tm038_pull_expr_errors_are_preflighted_like_mongodb",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_array_update_contract::test_tm038_pull_remaining_field_predicates_match_mongodb",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_array_update_contract::test_tm038_pull_remaining_field_predicates_match_mongodb",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_beanie_odm_contract::test_beanie_write_result_contract",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_beanie_odm_contract::test_beanie_write_result_contract",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_array_range_queries_compare_whole_and_direct_nested_arrays",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_array_range_queries_compare_whole_and_direct_nested_arrays",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_cursor_and_aggregation_sort_share_scalar_bson_order",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_cursor_and_aggregation_sort_share_scalar_bson_order",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_embedded_id_fields_use_normal_array_comparison_semantics",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_embedded_id_fields_use_normal_array_comparison_semantics",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_generated_scalar_range_matrix[boolean-family]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_generated_scalar_range_matrix[boolean-family]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_generated_scalar_range_matrix[numeric-family]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_generated_scalar_range_matrix[numeric-family]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_generated_scalar_range_matrix[string-family]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_generated_scalar_range_matrix[string-family]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_indexed_ranges_feed_every_filter_consumer",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_indexed_ranges_feed_every_filter_consumer",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_legacy_binary_subtype_two_uses_its_encoded_length",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_legacy_binary_subtype_two_uses_its_encoded_length",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_nested_regex_range_values_are_compared_without_compilation",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_nested_regex_range_values_are_compared_without_compilation",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_null_range_queries_include_missing_and_array_members",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_null_range_queries_include_missing_and_array_members",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_object_range_queries_use_recursive_bson_field_order",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_object_range_queries_use_recursive_bson_field_order",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_pull_document_ranges_share_missing_and_array_path_semantics",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_pull_document_ranges_share_missing_and_array_path_semantics",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_pull_reuses_recursive_bson_range_comparison",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_pull_reuses_recursive_bson_range_comparison",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_regex_range_operands_are_rejected_with_code_2[bson-malformed]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_regex_range_operands_are_rejected_with_code_2[bson-malformed]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_regex_range_operands_are_rejected_with_code_2[bson-valid]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_regex_range_operands_are_rejected_with_code_2[bson-valid]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_regex_range_operands_are_rejected_with_code_2[native]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_regex_range_operands_are_rejected_with_code_2[native]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_scalar_ranges_share_bson_keys_and_dates_use_milliseconds",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_scalar_ranges_share_bson_keys_and_dates_use_milliseconds",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_tm036_extreme_array_members_preserve_exact_semantics",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_tm036_extreme_array_members_preserve_exact_semantics",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_tm036_min_max_key_range_operands_cross_type_brackets",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_tm036_min_max_key_range_operands_cross_type_brackets",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_tm036_pull_reuses_unbounded_min_max_key_ranges",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_comparison_contract::test_tm036_pull_reuses_unbounded_min_max_key_ranges",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "bson-comparison",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_value_types_contract::test_tm035_exact_equality_and_distinct_use_bson_identity",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_value_types_contract::test_tm035_exact_equality_and_distinct_use_bson_identity",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_value_types_contract::test_tm035_new_bson_values_round_trip_at_every_depth",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_value_types_contract::test_tm035_new_bson_values_round_trip_at_every_depth",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_value_types_contract::test_tm035_scoped_code_honors_recursive_client_read_options",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_value_types_contract::test_tm035_scoped_code_honors_recursive_client_read_options",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_value_types_contract::test_tm035_sort_uses_the_complete_supported_scalar_order",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_value_types_contract::test_tm035_sort_uses_the_complete_supported_scalar_order",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_value_types_contract::test_tm035_type_aliases_and_numeric_codes_match_mongodb[code-return 1;-javascript-13]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_value_types_contract::test_tm035_type_aliases_and_numeric_codes_match_mongodb[code-return 1;-javascript-13]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_value_types_contract::test_tm035_type_aliases_and_numeric_codes_match_mongodb[maximum-value4-maxKey-127]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_value_types_contract::test_tm035_type_aliases_and_numeric_codes_match_mongodb[maximum-value4-maxKey-127]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_value_types_contract::test_tm035_type_aliases_and_numeric_codes_match_mongodb[minimum-value0-minKey--1]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_value_types_contract::test_tm035_type_aliases_and_numeric_codes_match_mongodb[minimum-value0-minKey--1]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_value_types_contract::test_tm035_type_aliases_and_numeric_codes_match_mongodb[scoped-code-return value;-javascriptWithScope-15]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_value_types_contract::test_tm035_type_aliases_and_numeric_codes_match_mongodb[scoped-code-return value;-javascriptWithScope-15]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_value_types_contract::test_tm035_type_aliases_and_numeric_codes_match_mongodb[timestamp-value1-timestamp-17]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_value_types_contract::test_tm035_type_aliases_and_numeric_codes_match_mongodb[timestamp-value1-timestamp-17]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_value_types_contract::test_tm035_unique_index_distinguishes_code_from_text_and_scope",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_value_types_contract::test_tm035_unique_index_distinguishes_code_from_text_and_scope",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_value_types_contract::test_tm037_zero_timestamp_insert_many_honors_unique_indexes",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_value_types_contract::test_tm037_zero_timestamp_insert_many_honors_unique_indexes",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_value_types_contract::test_tm037_zero_timestamp_write_boundaries_match_mongodb",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_bson_value_types_contract::test_tm037_zero_timestamp_write_boundaries_match_mongodb",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_client_read_fidelity_contract::test_configured_document_and_datetime_results_match_mongodb",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "client-read-fidelity",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_client_read_fidelity_contract::test_configured_document_and_datetime_results_match_mongodb",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "client-read-fidelity",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_client_read_fidelity_contract::test_same_millisecond_write_identity_matches_mongodb",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "client-read-fidelity",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_client_read_fidelity_contract::test_same_millisecond_write_identity_matches_mongodb",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "client-read-fidelity",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_crud_contract::test_array_in_query_contract",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_crud_contract::test_array_in_query_contract",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_crud_contract::test_duplicate_id_has_a_shared_error_category",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_crud_contract::test_duplicate_id_has_a_shared_error_category",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_crud_contract::test_explicit_null_id_is_preserved_and_unique",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_crud_contract::test_explicit_null_id_is_preserved_and_unique",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_crud_contract::test_insert_query_sort_and_count",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_crud_contract::test_insert_query_sort_and_count",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_crud_contract::test_replace_upsert_accepts_bson_equal_filter_and_replacement_ids",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_crud_contract::test_replace_upsert_accepts_bson_equal_filter_and_replacement_ids",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_crud_contract::test_replace_upsert_and_delete_metadata",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_crud_contract::test_replace_upsert_and_delete_metadata",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_crud_contract::test_replace_upsert_preserves_equality_bound_id[query0-77]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_crud_contract::test_replace_upsert_preserves_equality_bound_id[query0-77]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_crud_contract::test_replace_upsert_preserves_equality_bound_id[query1-pinned-key]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_crud_contract::test_replace_upsert_preserves_equality_bound_id[query1-pinned-key]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_crud_contract::test_replace_upsert_preserves_equality_bound_id[query2-88]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_crud_contract::test_replace_upsert_preserves_equality_bound_id[query2-88]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_crud_contract::test_replace_upsert_preserves_equality_bound_id[query3-None]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_crud_contract::test_replace_upsert_preserves_equality_bound_id[query3-None]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_crud_contract::test_replace_upsert_rejects_conflicting_filter_and_replacement_ids",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_crud_contract::test_replace_upsert_rejects_conflicting_filter_and_replacement_ids",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_crud_contract::test_replace_upsert_stores_id_first",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_crud_contract::test_replace_upsert_stores_id_first",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_crud_contract::test_sort_skip_and_limit_contract",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_crud_contract::test_sort_skip_and_limit_contract",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_crud_contract::test_unset_removes_top_level_and_nested_fields",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_crud_contract::test_unset_removes_top_level_and_nested_fields",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_crud_contract::test_update_and_result_metadata",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_crud_contract::test_update_and_result_metadata",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_decimal128_contract::test_decimal128_array_updates_and_distinct_reuse_numeric_identity",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_decimal128_contract::test_decimal128_array_updates_and_distinct_reuse_numeric_identity",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_decimal128_contract::test_decimal128_extreme_ids_round_trip",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_decimal128_contract::test_decimal128_extreme_ids_round_trip",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_decimal128_contract::test_decimal128_grouping_min_max_and_sum_use_one_numeric_family",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_decimal128_contract::test_decimal128_grouping_min_max_and_sum_use_one_numeric_family",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_decimal128_contract::test_decimal128_inc_promotes_the_result",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_decimal128_contract::test_decimal128_inc_promotes_the_result",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_decimal128_contract::test_decimal128_min_max_ties_and_literal_sum_match_mongodb",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_decimal128_contract::test_decimal128_min_max_ties_and_literal_sum_match_mongodb",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_decimal128_contract::test_decimal128_nan_query_comparisons_follow_mongodb",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_decimal128_contract::test_decimal128_nan_query_comparisons_follow_mongodb",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_decimal128_contract::test_decimal128_numeric_identity_is_enforced_by_ids_and_unique_indexes",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_decimal128_contract::test_decimal128_numeric_identity_is_enforced_by_ids_and_unique_indexes",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_decimal128_contract::test_decimal128_projection_flags_and_stage_arguments",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_decimal128_contract::test_decimal128_projection_flags_and_stage_arguments",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_decimal128_contract::test_decimal128_representation_changes_are_persisted",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_decimal128_contract::test_decimal128_representation_changes_are_persisted",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_decimal128_contract::test_decimal128_round_trips_and_participates_in_numeric_queries",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_decimal128_contract::test_decimal128_round_trips_and_participates_in_numeric_queries",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_decimal128_contract::test_decimal128_sum_keeps_double_precision_until_promotion",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_decimal128_contract::test_decimal128_sum_keeps_double_precision_until_promotion",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_group_accumulators_contract::test_accumulators_accept_the_supported_expression_subset",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_group_accumulators_contract::test_accumulators_accept_the_supported_expression_subset",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_group_accumulators_contract::test_add_to_set_uses_recursive_bson_identity",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_group_accumulators_contract::test_add_to_set_uses_recursive_bson_identity",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_group_accumulators_contract::test_array_values_remain_whole_accumulator_values",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_group_accumulators_contract::test_array_values_remain_whole_accumulator_values",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_group_accumulators_contract::test_avg_ignores_non_numeric_values_and_promotes_decimal",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_group_accumulators_contract::test_avg_ignores_non_numeric_values_and_promotes_decimal",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_group_accumulators_contract::test_avg_preserves_cancellation_and_nonfinite_values",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_group_accumulators_contract::test_avg_preserves_cancellation_and_nonfinite_values",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_group_accumulators_contract::test_first_last_and_push_follow_sorted_input_and_missing_rules",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_group_accumulators_contract::test_first_last_and_push_follow_sorted_input_and_missing_rules",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_group_accumulators_contract::test_group_accumulators_reject_array_argument_lists[$addToSet]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_group_accumulators_contract::test_group_accumulators_reject_array_argument_lists[$addToSet]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_group_accumulators_contract::test_group_accumulators_reject_array_argument_lists[$avg]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_group_accumulators_contract::test_group_accumulators_reject_array_argument_lists[$avg]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_group_accumulators_contract::test_group_accumulators_reject_array_argument_lists[$first]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_group_accumulators_contract::test_group_accumulators_reject_array_argument_lists[$first]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_group_accumulators_contract::test_group_accumulators_reject_array_argument_lists[$last]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_group_accumulators_contract::test_group_accumulators_reject_array_argument_lists[$last]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_group_accumulators_contract::test_group_accumulators_reject_array_argument_lists[$max]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_group_accumulators_contract::test_group_accumulators_reject_array_argument_lists[$max]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_group_accumulators_contract::test_group_accumulators_reject_array_argument_lists[$min]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_group_accumulators_contract::test_group_accumulators_reject_array_argument_lists[$min]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_group_accumulators_contract::test_group_accumulators_reject_array_argument_lists[$push]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_group_accumulators_contract::test_group_accumulators_reject_array_argument_lists[$push]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_group_accumulators_contract::test_group_accumulators_reject_array_argument_lists[$sum]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_group_accumulators_contract::test_group_accumulators_reject_array_argument_lists[$sum]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_group_accumulators_contract::test_missing_only_arrays_and_empty_inputs_match_mongodb",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_group_accumulators_contract::test_missing_only_arrays_and_empty_inputs_match_mongodb",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_projection_contract::test_empty_and_invalid_projection_contract",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_projection_contract::test_empty_and_invalid_projection_contract",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_projection_contract::test_inclusion_exclusion_and_id_projection_contract",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_projection_contract::test_inclusion_exclusion_and_id_projection_contract",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_projection_contract::test_nested_and_array_projection_contract",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_projection_contract::test_nested_and_array_projection_contract",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_projection_contract::test_projection_uses_unprojected_values_for_filter_and_sort",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_projection_contract::test_projection_uses_unprojected_values_for_filter_and_sort",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_add_to_set_non_array_errors_report_code_2_and_leave_document_atomic",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_add_to_set_non_array_errors_report_code_2_and_leave_document_atomic",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_comment_inside_document_elem_match_is_accepted",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_comment_inside_document_elem_match_is_accepted",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_comment_is_accepted_and_ignored_while_matching",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_comment_is_accepted_and_ignored_while_matching",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_comment_remains_invalid_as_a_field_operator",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_comment_remains_invalid_as_a_field_operator",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_continued_numeric_paths_ignore_scalar_index_dead_ends",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_continued_numeric_paths_ignore_scalar_index_dead_ends",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_distinct_rejects_falsey_non_document_filters",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_distinct_rejects_falsey_non_document_filters",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_dotted_query_paths_traverse_document_arrays_not_raw_nested_arrays",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_dotted_query_paths_traverse_document_arrays_not_raw_nested_arrays",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_duplicate_key_errors_report_code_11000",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_duplicate_key_errors_report_code_11000",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_elem_match_document_paths_traverse_nested_arrays",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_elem_match_document_paths_traverse_nested_arrays",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_elem_match_null_conditions_match_missing_document_fields",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_elem_match_null_conditions_match_missing_document_fields",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_elem_match_requires_one_array_member_to_satisfy_every_condition",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_elem_match_requires_one_array_member_to_satisfy_every_condition",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_elem_match_unknown_or_misplaced_operators_report_code_2[misplaced-logical-clause]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_elem_match_unknown_or_misplaced_operators_report_code_2[misplaced-logical-clause]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_elem_match_unknown_or_misplaced_operators_report_code_2[unknown-beside-field-operator]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_elem_match_unknown_or_misplaced_operators_report_code_2[unknown-beside-field-operator]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_elem_match_unknown_or_misplaced_operators_report_code_2[unknown]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_elem_match_unknown_or_misplaced_operators_report_code_2[unknown]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_embedded_regex_flags_and_options_report_code_51075",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_embedded_regex_flags_and_options_report_code_51075",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_every_filtering_crud_entrypoint_rejects_invalid_not_operands",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_every_filtering_crud_entrypoint_rejects_invalid_not_operands",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_every_filtering_crud_entrypoint_rejects_operator_typos",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_every_filtering_crud_entrypoint_rejects_operator_typos",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_find_rejects_top_level_and_field_operator_typos",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_find_rejects_top_level_and_field_operator_typos",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_index_name_and_key_conflict_codes_match_mongodb",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_index_name_and_key_conflict_codes_match_mongodb",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_mapping_filters_work_for_new_operators_and_dotted_paths",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_mapping_filters_work_for_new_operators_and_dotted_paths",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_mod_uses_mongodb_integer_truncation_and_array_member_rules",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_mod_uses_mongodb_integer_truncation_and_array_member_rules",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_not_accepts_operator_documents_and_compiled_regexes",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_not_accepts_operator_documents_and_compiled_regexes",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_not_rejects_non_regex_and_empty_operands_with_code_2[7]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_not_rejects_non_regex_and_empty_operands_with_code_2[7]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_not_rejects_non_regex_and_empty_operands_with_code_2[operand2]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_not_rejects_non_regex_and_empty_operands_with_code_2[operand2]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_not_rejects_non_regex_and_empty_operands_with_code_2[operand3]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_not_rejects_non_regex_and_empty_operands_with_code_2[operand3]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_not_rejects_non_regex_and_empty_operands_with_code_2[operand4]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_not_rejects_non_regex_and_empty_operands_with_code_2[operand4]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_not_rejects_non_regex_and_empty_operands_with_code_2[text]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_not_rejects_non_regex_and_empty_operands_with_code_2[text]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_null_equality_keeps_missing_fields_visible_after_indexing",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_null_equality_keeps_missing_fields_visible_after_indexing",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_numeric_query_paths_consider_array_indexes_and_document_field_names",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_numeric_query_paths_consider_array_indexes_and_document_field_names",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_recognized_query_operators_reject_malformed_operands",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_recognized_query_operators_reject_malformed_operands",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_size_matches_arrays_with_the_exact_requested_length",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_size_matches_arrays_with_the_exact_requested_length",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_tuple_equality_keeps_array_matches_visible_after_indexing",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_tuple_equality_keeps_array_matches_visible_after_indexing",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_type_supports_aliases_codes_lists_and_array_element_matching",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_query_operator_contract::test_type_supports_aliases_codes_lists_and_array_element_matching",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_binary_ids_use_bson_equality_without_losing_subtype",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_binary_ids_use_bson_equality_without_losing_subtype",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_binary_round_trip_query_and_mongodb_sort_order",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_binary_round_trip_query_and_mongodb_sort_order",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_boolean_and_numeric_ids_are_bson_distinct",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_boolean_and_numeric_ids_are_bson_distinct",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_create_indexes_accepts_the_real_mixed_batch_and_enforces_unique",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_create_indexes_accepts_the_real_mixed_batch_and_enforces_unique",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_cursor_limit_zero_means_unlimited",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_cursor_limit_zero_means_unlimited",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_cursor_skip_limit_windows_and_past_end",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_cursor_skip_limit_windows_and_past_end",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_cursor_to_list_accepts_both_application_spellings",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_cursor_to_list_accepts_both_application_spellings",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_distinct_returns_scalar_field_values",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_distinct_returns_scalar_field_values",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_dot_notation_matches_an_embedded_document",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_dot_notation_matches_an_embedded_document",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_duplicate_errors_are_catchable_as_pymongo_errors",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_duplicate_errors_are_catchable_as_pymongo_errors",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_find_one_sort_returns_the_newest_match",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_find_one_sort_returns_the_newest_match",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_generated_id_uses_the_standard_object_id_round_trip",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_generated_id_uses_the_standard_object_id_round_trip",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_generic_binary_equality_matches_native_bytes_and_query_operators",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_generic_binary_equality_matches_native_bytes_and_query_operators",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_inc_creates_a_missing_counter",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_inc_creates_a_missing_counter",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_insert_many_accepts_a_document_generator",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_insert_many_accepts_a_document_generator",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_insert_many_reports_compatible_partial_failures[False-expected_ids1-2]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_insert_many_reports_compatible_partial_failures[False-expected_ids1-2]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_insert_many_reports_compatible_partial_failures[True-expected_ids0-1]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_insert_many_reports_compatible_partial_failures[True-expected_ids0-1]",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_invalid_document_has_a_bson_compatible_error",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_invalid_document_has_a_bson_compatible_error",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_mixed_timezone_datetimes_sort_by_utc_instant",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_mixed_timezone_datetimes_sort_by_utc_instant",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_nin_and_negated_regex_share_one_field_specification",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_nin_and_negated_regex_share_one_field_specification",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_nin_excludes_values_and_includes_missing_fields",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_nin_excludes_values_and_includes_missing_fields",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_not_regex_with_case_insensitive_options",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_not_regex_with_case_insensitive_options",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_null_negation_distinguishes_missing_and_non_null_fields",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_null_negation_distinguishes_missing_and_non_null_fields",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_object_id_and_datetime_round_trip_and_range_query",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_object_id_and_datetime_round_trip_and_range_query",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_projection_none_absent_fields_and_integer_id",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_projection_none_absent_fields_and_integer_id",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_replace_one_preserves_id_and_replaces_the_full_document",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_replace_one_preserves_id_and_replaces_the_full_document",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_scalar_equality_matches_an_array_member",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_scalar_equality_matches_an_array_member",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_single_and_multi_key_sort_break_ties",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_single_and_multi_key_sort_break_ties",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_write_result_metadata_used_by_the_application",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_talkpython_contract::test_write_result_metadata_used_by_the_application",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "talkpython",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_update_operator_contract::test_malformed_new_update_operands_report_mongodb_codes",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_update_operator_contract::test_malformed_new_update_operands_report_mongodb_codes",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_update_operator_contract::test_min_and_max_follow_bson_order_and_report_noops",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_update_operator_contract::test_min_and_max_follow_bson_order_and_report_noops",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_update_operator_contract::test_min_and_max_include_null_in_whole_bson_value_order",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_update_operator_contract::test_min_and_max_include_null_in_whole_bson_value_order",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_update_operator_contract::test_new_update_operators_apply_to_upsert_equality_fields",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_update_operator_contract::test_new_update_operators_apply_to_upsert_equality_fields",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_update_operator_contract::test_new_update_operators_cover_upsert_update_many_and_find_and_modify",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_update_operator_contract::test_new_update_operators_cover_upsert_update_many_and_find_and_modify",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_update_operator_contract::test_new_update_operators_follow_numeric_array_paths",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_update_operator_contract::test_new_update_operators_follow_numeric_array_paths",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_update_operator_contract::test_new_update_operators_preserve_immutable_id_semantics",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_update_operator_contract::test_new_update_operators_preserve_immutable_id_semantics",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_update_operator_contract::test_new_update_operators_report_target_and_path_errors_atomically",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_update_operator_contract::test_new_update_operators_report_target_and_path_errors_atomically",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_update_operator_contract::test_pop_handles_front_back_nested_empty_and_missing_arrays",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_update_operator_contract::test_pop_handles_front_back_nested_empty_and_missing_arrays",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_update_operator_contract::test_rename_moves_nested_values_overwrites_and_ignores_missing_source",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_update_operator_contract::test_rename_moves_nested_values_overwrites_and_ignores_missing_source",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_update_operator_contract::test_update_path_conflicts_report_code_40_before_writing",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_update_operator_contract::test_update_path_conflicts_report_code_40_before_writing",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_uuid_regex_contract::test_local_regex_ids_use_exact_identity_for_duplicate_detection",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_uuid_regex_contract::test_local_regex_ids_use_exact_identity_for_duplicate_detection",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_uuid_regex_contract::test_regex_predicates_and_exact_equality_follow_mongodb",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_uuid_regex_contract::test_regex_predicates_and_exact_equality_follow_mongodb",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_uuid_regex_contract::test_regex_sort_distinct_and_unique_index_identity",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_uuid_regex_contract::test_regex_sort_distinct_and_unique_index_identity",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_uuid_regex_contract::test_uuid_and_subtype_four_binary_share_unique_identity",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_uuid_regex_contract::test_uuid_and_subtype_four_binary_share_unique_identity",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "async",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_uuid_regex_contract::test_uuid_round_trip_uses_standard_binary_identity",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    },
+    {
+      "api": "sync",
+      "backend": "memory",
+      "case_id": "tests.contracts.test_uuid_regex_contract::test_uuid_round_trip_uses_standard_binary_identity",
+      "observation": {
+        "category": "passed",
+        "fingerprint": "826a3508ea8bc4f0accdfdd786c09ff35efa1d9fc3b73ac0cc5761b2c2ad0b19"
+      },
+      "outcome": "passed",
+      "reason": null,
+      "suite": "core",
+      "target": "tinymongo-memory"
+    }
+  ],
+  "schema_version": 1
+}

--- a/compat/mongo/v1/runner/README.md
+++ b/compat/mongo/v1/runner/README.md
@@ -1,0 +1,104 @@
+# Executable Mongo compatibility corpus
+
+This directory contains an executable, target-neutral adaptation of the
+TinyMongo v1.3.0 contract suite. The same pytest corpus can run against the
+frozen TinyMongo reference, an optional real MongoDB server, and a configured
+BriskDB Mongo-compatible endpoint. BriskDB does not provide that endpoint yet,
+so its checked-in CI report remains reference-only.
+
+The contract source is frozen at TinyMongo commit
+`53cbf44e98b8caa036163725d195fd29592e1cc0`. `provenance.json` records the
+upstream Git blob and SHA-256 digest for every copied file, the digest of every
+adapted file, and the exact contract and runtime tree IDs. `adaptation.patch`
+is the complete reviewable diff from the upstream files to this runner. The
+upstream license is preserved in `UPSTREAM_LICENSE.txt`.
+
+The adaptations replace TinyMongo-owned fixtures, exception imports, BSON
+identity helpers, and the unsupported-index warning type with neutral runner
+equivalents. They also distinguish implementation identity from direct versus
+PyMongo transport behavior. The assertions and parameter values stay in the
+vendored test modules. Each pytest execution emits these JUnit properties:
+
+- `tinymongo.contract_id`: the canonical upstream case ID
+- `tinymongo.api`: `sync` or `async`
+- `tinymongo.backend`: the selected storage or server target
+- `tinymongo.suite`: the frozen contract suite
+
+TinyMongo is imported lazily and only by `adapters/tinymongo.py`. The neutral
+corpus and BriskDB code do not import it. PyMongo provides the public BSON and
+error vocabulary used by the contracts; its clients are loaded lazily only
+when a PyMongo-backed target is opened.
+
+Create an isolated test environment with the pinned reference dependencies.
+Python 3.9.6 is the recorded harvest interpreter; CI replays the corpus with
+Python 3.9.25, the pinned 3.9 patch available for Ubuntu 24.04.
+
+```bash
+python3.9 -m venv .venv-mongo-contract
+.venv-mongo-contract/bin/python -m pip install \
+  -r compat/mongo/v1/runner/requirements.txt
+git clone https://github.com/schapman1974/tinymongo \
+  target/tinymongo-source
+git -C target/tinymongo-source checkout --detach \
+  53cbf44e98b8caa036163725d195fd29592e1cc0
+.venv-mongo-contract/bin/python -m pip install \
+  --no-build-isolation --no-deps \
+  ./target/tinymongo-source
+```
+
+Run the complete in-memory reference corpus:
+
+```bash
+.venv-mongo-contract/bin/python -m pytest -o addopts='' -q \
+  compat/mongo/v1/runner/contracts \
+  --mongo-contract-target=tinymongo \
+  --mongo-contract-backend=memory \
+  --mongo-contract-api=both \
+  --junitxml=target/mongo-contract-tinymongo.xml
+```
+
+That command collects 228 canonical cases and executes each through the sync
+and async APIs, for 456 executions. A pre-existing local TinyMongo checkout can
+replace the clone above; verify that it resolves to the locked commit, then
+install it with
+`python -m pip install --no-build-isolation --no-deps /path/to/tinymongo`.
+
+Run the same corpus against a real MongoDB server:
+
+```bash
+BRISKDB_MONGODB_URI='mongodb://127.0.0.1:27017/?directConnection=true' \
+.venv-mongo-contract/bin/python -m pytest -o addopts='' -q \
+  compat/mongo/v1/runner/contracts \
+  --mongo-contract-target=mongodb \
+  --mongo-contract-api=both \
+  --mongo-contract-require-target \
+  --junitxml=target/mongo-contract-mongodb.xml
+```
+
+Without `--mongo-contract-require-target`, an unavailable MongoDB server is an
+ordinary skip.
+
+Run the same corpus against a BriskDB candidate endpoint:
+
+```bash
+.venv-mongo-contract/bin/python -m pytest -o addopts='' -q \
+  compat/mongo/v1/runner/contracts \
+  --mongo-contract-target=briskdb \
+  --mongo-contract-briskdb-uri='mongodb://127.0.0.1:27018/?directConnection=true' \
+  --mongo-contract-api=both \
+  --mongo-contract-require-target \
+  --junitxml=target/mongo-contract-briskdb.xml
+```
+
+The BriskDB adapter uses PyMongo only inside this contract environment and
+keeps the implementation identity `briskdb`. Separate `transport` metadata
+selects unavoidable PyMongo encoding and decoding behavior without granting
+the candidate real-Mongo semantic exemptions. With no configured candidate
+URI, selecting `briskdb` fails clearly with `TargetUnavailable`.
+
+Run the dependency-boundary and provenance checks without installing the
+contract dependencies:
+
+```bash
+python3 -m unittest discover -s tests -p 'test_mongo_contract_runner.py'
+```

--- a/compat/mongo/v1/runner/UPSTREAM_LICENSE.txt
+++ b/compat/mongo/v1/runner/UPSTREAM_LICENSE.txt
@@ -1,0 +1,10 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Stephen Chapman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+~

--- a/compat/mongo/v1/runner/__init__.py
+++ b/compat/mongo/v1/runner/__init__.py
@@ -1,0 +1,1 @@
+"""Executable adapters for the frozen TinyMongo v1 compatibility corpus."""

--- a/compat/mongo/v1/runner/adaptation.patch
+++ b/compat/mongo/v1/runner/adaptation.patch
@@ -1,0 +1,886 @@
+--- a/tests/contracts/conftest.py
++++ b/compat/mongo/v1/runner/contracts/conftest.py
+@@ -1,270 +1,160 @@
+-"""Factories that run one contract against every supported target."""
++"""Target-neutral fixture for the frozen TinyMongo v1 contract corpus."""
+ 
+-import asyncio
+-import inspect
+ import os
+-import time
+-from uuid import uuid4
++import re
+ 
+ import pytest
+-import tinymongo
+-from tinymongo.asyncio import AsyncMongoClient, AsyncTinyMongoClient
+ 
++from ..adapters import TargetUnavailable, open_target
+ from .support import ContractTarget
+ 
+ 
+ APIS = ("sync", "async")
+-BACKENDS = (
+-    "memory",
+-    "json",
+-    "sqlite",
+-    "sqlite-sharded",
+-    "duckdb",
+-    "parquet",
+-    "mongodb",
+-)
+-TARGETS = [
+-    pytest.param(
+-        (api, backend),
+-        id="{0}-{1}".format(api, backend),
+-        marks=(
+-            (pytest.mark.integration, pytest.mark.mongodb)
+-            if backend == "mongodb"
+-            else ()
+-        ),
+-    )
+-    for api in APIS
+-    for backend in BACKENDS
+-]
++TARGETS = ("tinymongo", "mongodb", "briskdb")
+ 
+ 
+-class _AsyncRunner:
+-    """Run one async target on a stable event loop from synchronous contracts."""
++def pytest_addoption(parser):
++    group = parser.getgroup("mongo-contract")
++    group.addoption(
++        "--mongo-contract-target",
++        choices=TARGETS,
++        default=os.environ.get("BRISKDB_MONGO_CONTRACT_TARGET", "tinymongo"),
++        help="implementation adapter used by the frozen Mongo contract",
++    )
++    group.addoption(
++        "--mongo-contract-api",
++        choices=("sync", "async", "both"),
++        default=os.environ.get("BRISKDB_MONGO_CONTRACT_API", "both"),
++        help="API flavor to execute (default: both)",
++    )
++    group.addoption(
++        "--mongo-contract-backend",
++        default=os.environ.get("BRISKDB_MONGO_CONTRACT_BACKEND", "memory"),
++        help="TinyMongo backend ID (default: memory)",
++    )
++    group.addoption(
++        "--mongo-contract-mongodb-uri",
++        default=os.environ.get("BRISKDB_MONGODB_URI"),
++        help="URI for the optional real MongoDB adapter",
++    )
++    group.addoption(
++        "--mongo-contract-briskdb-uri",
++        default=os.environ.get("BRISKDB_MONGO_PARITY_BRISKDB_URI"),
++        help="URI for the BriskDB Mongo-compatible candidate",
++    )
++    group.addoption(
++        "--mongo-contract-require-target",
++        action="store_true",
++        default=False,
++        help="turn an unavailable optional target into a test failure",
++    )
+ 
+-    def __init__(self):
+-        self.loop = asyncio.new_event_loop()
+ 
+-    def run(self, awaitable):
+-        return self.loop.run_until_complete(awaitable)
++def pytest_configure(config):
++    config.addinivalue_line("markers", "contract: frozen Mongo compatibility contract")
++    config.addinivalue_line(
++        "markers",
++        "client_options(**kwargs): constructor options required by one contract",
++    )
+ 
+-    def close(self):
+-        self.loop.close()
+ 
++def _backend_id(config):
++    target = config.getoption("--mongo-contract-target")
++    if target == "mongodb":
++        return "mongodb"
++    if target == "briskdb":
++        return "briskdb"
++    return config.getoption("--mongo-contract-backend")
+ 
+-class _AsyncCursorAdapter:
+-    """Expose async cursor behavior to the transport-neutral contract body."""
+ 
+-    def __init__(self, cursor, runner):
+-        self._cursor = cursor
+-        self._runner = runner
++def _target_uri(config, target):
++    if target == "briskdb":
++        return config.getoption("--mongo-contract-briskdb-uri")
++    return config.getoption("--mongo-contract-mongodb-uri")
+ 
+-    def sort(self, *args, **kwargs):
+-        self._cursor.sort(*args, **kwargs)
+-        return self
+ 
+-    def skip(self, *args, **kwargs):
+-        self._cursor.skip(*args, **kwargs)
+-        return self
+-
+-    def limit(self, *args, **kwargs):
+-        self._cursor.limit(*args, **kwargs)
+-        return self
+-
+-    def to_list(self, length=None):
+-        return self._runner.run(self._cursor.to_list(length=length))
+-
+-    def __iter__(self):
+-        return iter(self.to_list())
+-
+-
+-class _AsyncCollectionAdapter:
+-    """Await collection calls while preserving immediate cursor construction."""
+-
+-    def __init__(self, collection, runner):
+-        self._collection = collection
+-        self._runner = runner
+-
+-    def find(self, *args, **kwargs):
+-        return _AsyncCursorAdapter(self._collection.find(*args, **kwargs), self._runner)
+-
+-    def aggregate(self, *args, **kwargs):
+-        cursor = self._collection.aggregate(*args, **kwargs)
+-        if inspect.isawaitable(cursor):
+-            cursor = self._runner.run(cursor)
+-        return _AsyncCursorAdapter(cursor, self._runner)
+-
+-    def __getattr__(self, name):
+-        attribute = getattr(self._collection, name)
+-        if not callable(attribute):
+-            return attribute
+-
+-        def call(*args, **kwargs):
+-            result = attribute(*args, **kwargs)
+-            if inspect.isawaitable(result):
+-                return self._runner.run(result)
+-            return result
+-
+-        return call
+-
+-
+-def _mongo_client(uri, client_options=None):
+-    try:
+-        from pymongo import MongoClient
+-    except ImportError:  # pragma: no cover - guarded by dev requirements
+-        pytest.fail("Real MongoDB contracts require PyMongo; run `pip install pymongo`")
+-
+-    client = MongoClient(
+-        uri,
+-        serverSelectionTimeoutMS=1000,
+-        **dict(client_options or {}),
++def pytest_generate_tests(metafunc):
++    if "contract_target" not in metafunc.fixturenames:
++        return
++    requested = metafunc.config.getoption("--mongo-contract-api")
++    apis = APIS if requested == "both" else (requested,)
++    backend = _backend_id(metafunc.config)
++    metafunc.parametrize(
++        "contract_target",
++        [(api, backend) for api in apis],
++        indirect=True,
++        ids=["{0}-{1}".format(api, backend) for api in apis],
+     )
+-    deadline = time.monotonic() + 15
+-    last_error = None
+-    while time.monotonic() < deadline:
+-        try:
+-            client.admin.command("ping")
+-            return client
+-        except Exception as error:  # noqa: BLE001 - retry server startup
+-            last_error = error
+-            time.sleep(0.25)
+-    client.close()
+-    raise RuntimeError("MongoDB did not become ready: {0}".format(last_error))
+ 
+ 
+-def _async_mongo_client(uri, runner, client_options=None):
+-    try:
+-        from pymongo import AsyncMongoClient
+-    except ImportError:  # pragma: no cover - guarded by dev requirements
+-        pytest.fail("Real MongoDB contracts require PyMongo; run `pip install pymongo`")
+-
+-    client = AsyncMongoClient(
+-        uri,
+-        serverSelectionTimeoutMS=1000,
+-        **dict(client_options or {}),
+-    )
+-    deadline = time.monotonic() + 15
+-    last_error = None
+-    while time.monotonic() < deadline:
+-        try:
+-            runner.run(client.admin.command("ping"))
+-            return client
+-        except Exception as error:  # noqa: BLE001 - retry server startup
+-            last_error = error
+-            time.sleep(0.25)
+-    runner.run(client.close())
+-    raise RuntimeError("MongoDB did not become ready: {0}".format(last_error))
+-
+-
+ def _contract_suite(request):
+-    if "test_talkpython_contract.py" in request.node.nodeid:
++    filename = request.node.path.name
++    if filename == "test_talkpython_contract.py":
+         return "talkpython"
+-    if "test_bson_comparison_contract.py" in request.node.nodeid:
++    if filename == "test_bson_comparison_contract.py":
+         return "bson-comparison"
+-    if "test_client_read_fidelity_contract.py" in request.node.nodeid:
++    if filename == "test_client_read_fidelity_contract.py":
+         return "client-read-fidelity"
+     return "core"
+ 
+ 
+-@pytest.fixture(params=TARGETS)
+-def contract_target(request, tmp_path, monkeypatch):
+-    """Yield an isolated collection for a TinyMongo backend or real MongoDB."""
++def _upstream_case_id(request, api, backend):
++    name = request.node.name
++    match = re.search(r"\[([^][]*)\]$", name)
++    if match is not None:
++        parameters = match.group(1)
++        prefix = "{0}-{1}".format(api, backend)
++        if parameters != prefix and not parameters.startswith(prefix + "-"):
++            raise pytest.UsageError(
++                "contract parameter ID {0!r} does not begin with {1!r}".format(
++                    parameters, prefix
++                )
++            )
++        remaining = parameters[len(prefix) :].lstrip("-")
++        base = name[: match.start()]
++        name = "{0}[{1}]".format(base, remaining) if remaining else base
++    module = request.node.path.stem
++    return "tests.contracts.{0}::{1}".format(module, name)
+ 
+-    api, target_name = request.param
+-    options_marker = request.node.get_closest_marker("client_options")
+-    client_options = dict(options_marker.kwargs) if options_marker else {}
+-    database_name = "tinymongo_contract_{0}".format(uuid4().hex)
++
++@pytest.fixture
++def contract_target(request, tmp_path):
++    """Yield one sync-shaped target selected through a lazy adapter import."""
++
++    api, backend = request.param
++    target = request.config.getoption("--mongo-contract-target")
++    suite = _contract_suite(request)
+     request.node.user_properties.extend(
+         [
+             ("tinymongo.api", api),
+-            ("tinymongo.backend", target_name),
+-            ("tinymongo.suite", _contract_suite(request)),
++            ("tinymongo.backend", backend),
++            ("tinymongo.suite", suite),
++            ("tinymongo.contract_id", _upstream_case_id(request, api, backend)),
+         ]
+     )
+-
+-    if target_name == "mongodb":
+-        uri = os.environ.get("TINYMONGO_MONGODB_URI")
+-        required = os.environ.get("TINYMONGO_REQUIRE_MONGODB") == "1"
+-        if not uri:
+-            message = "Set TINYMONGO_MONGODB_URI to run real MongoDB contracts"
+-            if required:
+-                pytest.fail(message)
+-            pytest.skip(message)
+-        runner = None
+-        try:
+-            if api == "async":
+-                runner = _AsyncRunner()
+-                client = _async_mongo_client(uri, runner, client_options)
+-            else:
+-                client = _mongo_client(uri, client_options)
+-        except RuntimeError as error:
+-            if runner is not None:
+-                runner.close()
+-            if required:
+-                pytest.fail(str(error))
+-            pytest.skip(str(error))
+-        database = client[database_name]
+-        collection = database["items"]
+-        if runner is not None:
+-            collection = _AsyncCollectionAdapter(collection, runner)
+-        target = ContractTarget(
+-            name=target_name,
+-            api=api,
+-            client=client,
+-            database=database,
+-            collection=collection,
+-        )
+-        try:
+-            yield target
+-        finally:
+-            if runner is None:
+-                client.drop_database(database_name)
+-                client.close()
+-            else:
+-                runner.run(client.drop_database(database_name))
+-                runner.run(client.close())
+-                runner.close()
+-        return
+-
+-    backend = "tinydb" if target_name == "json" else target_name
+-    if backend in ("duckdb", "parquet"):
+-        pytest.importorskip("duckdb")
+-    if backend == "parquet":
+-        pytest.importorskip("pyarrow")
+-
+-    if backend == "memory":
+-        working_directory = tmp_path / "memory-cwd"
+-        working_directory.mkdir()
+-        monkeypatch.chdir(working_directory)
+-        arguments = ()
+-        options = {"backend": backend}
+-    else:
+-        arguments = (str(tmp_path / target_name),)
+-        options = {"backend": backend}
+-    runner = None
+-    if api == "async":
+-        runner = _AsyncRunner()
+-        client_class = AsyncMongoClient if client_options else AsyncTinyMongoClient
+-        client = client_class(*arguments, **options, **client_options)
+-    else:
+-        client_class = (
+-            tinymongo.MongoClient if client_options else tinymongo.TinyMongoClient
+-        )
+-        client = client_class(*arguments, **options, **client_options)
+-    database = client[database_name]
+-    collection = database["items"]
+-    if runner is not None:
+-        collection = _AsyncCollectionAdapter(collection, runner)
++    marker = request.node.get_closest_marker("client_options")
++    client_options = dict(marker.kwargs) if marker else {}
+     try:
+-        yield ContractTarget(
+-            name=target_name,
+-            api=api,
+-            client=client,
+-            database=database,
+-            collection=collection,
++        context = open_target(
++            target,
++            api,
++            tmp_path,
++            client_options,
++            backend=backend,
++            uri=_target_uri(request.config, target),
+         )
+-    finally:
+-        if runner is None:
+-            client.close()
+-        else:
+-            runner.run(client.close())
+-            runner.close()
++        with context as handles:
++            yield ContractTarget(
++                name=handles.name,
++                transport=handles.transport,
++                api=api,
++                client=handles.client,
++                database=handles.database,
++                collection=handles.collection,
++                unsupported_warning=handles.unsupported_warning,
++            )
++    except TargetUnavailable as error:
++        required = request.config.getoption("--mongo-contract-require-target")
++        if required or target != "mongodb":
++            pytest.fail(str(error), pytrace=False)
++        pytest.skip(str(error))
+--- a/tests/contracts/support.py
++++ b/compat/mongo/v1/runner/contracts/support.py
+@@ -1,19 +1,29 @@
+-"""Small reusable helpers for behavioral compatibility contracts."""
++"""Runtime-neutral helpers used by the frozen Mongo compatibility contracts.
+ 
++This module deliberately depends on PyMongo's public BSON and exception types,
++which form the compatibility surface, but never imports TinyMongo.  A target
++adapter is responsible for translating its failures to these public shapes.
++"""
++
+ from dataclasses import dataclass
++from datetime import datetime, timezone
++from decimal import Decimal
++import re
++from collections.abc import Mapping
+ from typing import Any, Callable, Optional
++from uuid import UUID
+ 
+-from tinymongo.errors import DuplicateKeyError as TinyMongoDuplicateKeyError
+-from tinymongo.errors import OperationFailure as TinyMongoOperationFailure
++from bson import Binary, Code, Decimal128, MaxKey, MinKey, ObjectId, Regex, Timestamp
++from pymongo.errors import DuplicateKeyError, OperationFailure, WriteError
+ 
+-try:
+-    from pymongo.errors import DuplicateKeyError as PyMongoDuplicateKeyError
+-    from pymongo.errors import OperationFailure as PyMongoOperationFailure
+-except ImportError:  # pragma: no cover - development dependency guard
+-    PyMongoDuplicateKeyError = ()  # type: ignore[assignment,misc]
+-    PyMongoOperationFailure = ()  # type: ignore[assignment,misc]
+ 
++DUPLICATE_KEY_ERRORS = (DuplicateKeyError,)
++OPERATION_ERRORS = (OperationFailure,)
++WRITE_ERRORS = (WriteError,)
++UNSUPPORTED_ERRORS = (NotImplementedError,)
++QUERY_REJECTION_ERRORS = OPERATION_ERRORS + UNSUPPORTED_ERRORS
+ 
++
+ @dataclass(frozen=True)
+ class Outcome:
+     """Normalized result of one operation against a contract target."""
+@@ -27,24 +37,20 @@
+     """Objects and metadata exposed to each shared contract."""
+ 
+     name: str
++    transport: str
+     api: str
+     client: Any
+     database: Any
+     collection: Any
++    unsupported_warning: type
+ 
+ 
+ def error_category(error: Exception) -> str:
+-    """Map backend-specific exceptions to a small compatibility vocabulary."""
++    """Map adapter-specific failures to the contract vocabulary."""
+ 
+-    duplicate_errors = (TinyMongoDuplicateKeyError,)
+-    if PyMongoDuplicateKeyError:
+-        duplicate_errors = duplicate_errors + (PyMongoDuplicateKeyError,)
+-    if isinstance(error, duplicate_errors):
++    if isinstance(error, DuplicateKeyError):
+         return "duplicate_key"
+-    operation_errors = (TinyMongoOperationFailure,)
+-    if PyMongoOperationFailure:
+-        operation_errors = operation_errors + (PyMongoOperationFailure,)
+-    if isinstance(error, operation_errors):
++    if isinstance(error, OperationFailure):
+         return "operation_failure"
+     return "{0}.{1}".format(type(error).__module__, type(error).__name__)
+ 
+@@ -56,3 +62,120 @@
+         return Outcome(value=operation())
+     except Exception as error:  # noqa: BLE001 - exceptions are contract output
+         return Outcome(error=error_category(error))
++
++
++def regex_type():
++    """Return the public BSON regular-expression class."""
++
++    return Regex
++
++
++def _number_identity(value: Any):
++    if isinstance(value, Decimal128):
++        decimal_value = value.to_decimal()
++    elif isinstance(value, int) and not isinstance(value, bool):
++        decimal_value = Decimal(value)
++    elif isinstance(value, float):
++        decimal_value = Decimal.from_float(value)
++    else:
++        raise TypeError("value is not a BSON number")
++    if decimal_value.is_nan():
++        return "nan"
++    if decimal_value.is_infinite():
++        return "-infinity" if decimal_value.is_signed() else "infinity"
++    return decimal_value.as_integer_ratio()
++
++
++def _regex_options(flags: Any) -> str:
++    if isinstance(flags, str):
++        return "".join(letter for letter in "ilmsux" if letter in flags)
++    return "".join(
++        letter
++        for letter, flag in (
++            ("i", re.IGNORECASE),
++            ("l", re.LOCALE),
++            ("m", re.MULTILINE),
++            ("s", re.DOTALL),
++            ("u", re.UNICODE),
++            ("x", re.VERBOSE),
++        )
++        if int(flags) & int(flag)
++    )
++
++
++def _datetime_milliseconds(value: datetime) -> int:
++    normalized = (
++        value.replace(tzinfo=timezone.utc)
++        if value.utcoffset() is None
++        else value.astimezone(timezone.utc)
++    )
++    epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
++    delta = normalized - epoch
++    return (
++        delta.days * 86_400_000
++        + delta.seconds * 1_000
++        + delta.microseconds // 1_000
++    )
++
++
++def bson_identity_key(value: Any):
++    """Return the scalar BSON equality identity used by the frozen assertions."""
++
++    if value is None:
++        return "null", None
++    if type(value) is bool:
++        return "boolean", value
++    if isinstance(value, (int, float, Decimal128)) and not isinstance(value, bool):
++        return "number", _number_identity(value)
++    if isinstance(value, UUID):
++        return "binary", (4, value.bytes)
++    if isinstance(value, Binary):
++        return "binary", (int(value.subtype), bytes(value))
++    if type(value) in (bytes, bytearray):
++        return "binary", (0, bytes(value))
++    if isinstance(value, Code):
++        scope = None if value.scope is None else bson_value_identity_key(value.scope)
++        return "code", (str(value), scope)
++    if isinstance(value, str):
++        return "string", value
++    if isinstance(value, ObjectId):
++        return "objectId", value.binary
++    if isinstance(value, datetime):
++        return "date", _datetime_milliseconds(value)
++    if isinstance(value, Timestamp):
++        return "timestamp", (value.time, value.inc)
++    if isinstance(value, (Regex, type(re.compile("")))):
++        pattern = value.pattern
++        if isinstance(pattern, bytes):
++            pattern = pattern.decode("utf-8")
++        return "regex", (pattern, _regex_options(value.flags))
++    if isinstance(value, MinKey):
++        return "minKey", None
++    if isinstance(value, MaxKey):
++        return "maxKey", None
++    return None
++
++
++def bson_value_identity_key(value: Any):
++    """Return a recursive, ordered and hashable BSON equality identity."""
++
++    scalar = bson_identity_key(value)
++    if scalar is not None:
++        return scalar
++    if isinstance(value, Mapping):
++        items = []
++        for key, item in value.items():
++            item_key = bson_value_identity_key(item)
++            if item_key is None:
++                return None
++            items.append((key, item_key))
++        return "object", tuple(items)
++    if isinstance(value, (list, tuple)):
++        items = []
++        for item in value:
++            item_key = bson_value_identity_key(item)
++            if item_key is None:
++                return None
++            items.append(item_key)
++        return "array", tuple(items)
++    return None
+--- a/tests/contracts/test_array_update_contract.py
++++ b/compat/mongo/v1/runner/contracts/test_array_update_contract.py
+@@ -2,21 +2,11 @@
+ 
+ import pytest
+ 
+-from tinymongo.errors import WriteError as TinyMongoWriteError
+-
++from .support import WRITE_ERRORS as _WRITE_ERRORS
+ from .support import observe
+ 
+ 
+ pytestmark = pytest.mark.contract
+-
+-_WRITE_ERRORS = (TinyMongoWriteError,)
+-try:
+-    from pymongo.errors import WriteError as PyMongoWriteError
+-except ImportError:  # pragma: no cover - development dependency guard
+-    PyMongoWriteError = ()  # type: ignore[assignment,misc]
+-else:
+-    _WRITE_ERRORS += (PyMongoWriteError,)
+-
+ 
+ def test_push_each_slice_keeps_a_bounded_array(contract_target):
+     collection = contract_target.collection
+--- a/tests/contracts/test_bson_comparison_contract.py
++++ b/compat/mongo/v1/runner/contracts/test_bson_comparison_contract.py
+@@ -5,8 +5,8 @@
+ 
+ import pytest
+ 
+-from tinymongo.errors import OperationFailure as TinyMongoOperationFailure
+-from tinymongo.errors import WriteError as TinyMongoWriteError
++from .support import OPERATION_ERRORS as _OPERATION_ERRORS
++from .support import WRITE_ERRORS as _WRITE_ERRORS
+ 
+ 
+ pytestmark = pytest.mark.contract
+@@ -16,19 +16,7 @@
+ MinKey = bson.MinKey
+ ObjectId = bson.ObjectId
+ Regex = bson.Regex
+-
+-_OPERATION_ERRORS = (TinyMongoOperationFailure,)
+-_WRITE_ERRORS = (TinyMongoWriteError,)
+-try:
+-    from pymongo.errors import OperationFailure as PyMongoOperationFailure
+-    from pymongo.errors import WriteError as PyMongoWriteError
+-except ImportError:  # pragma: no cover - optional dependency guard
+-    pass
+-else:
+-    _OPERATION_ERRORS += (PyMongoOperationFailure,)
+-    _WRITE_ERRORS += (PyMongoWriteError,)
+ 
+-
+ def _ids(rows):
+     return {document["_id"] for document in rows}
+ 
+--- a/tests/contracts/test_bson_value_types_contract.py
++++ b/compat/mongo/v1/runner/contracts/test_bson_value_types_contract.py
+@@ -6,8 +6,8 @@
+ 
+ import pytest
+ 
+-from tinymongo.bson_types import bson_identity_key
+-from tinymongo.errors import DuplicateKeyError as TinyMongoDuplicateKeyError
++from .support import DUPLICATE_KEY_ERRORS as _DUPLICATE_ERRORS
++from .support import bson_identity_key
+ 
+ 
+ pytestmark = pytest.mark.contract
+@@ -17,15 +17,6 @@
+ MinKey = bson.MinKey
+ Timestamp = bson.Timestamp
+ 
+-_DUPLICATE_ERRORS = (TinyMongoDuplicateKeyError,)
+-try:
+-    from pymongo.errors import DuplicateKeyError as PyMongoDuplicateKeyError
+-except ImportError:  # pragma: no cover - optional dependency guard
+-    pass
+-else:
+-    _DUPLICATE_ERRORS += (PyMongoDuplicateKeyError,)
+-
+-
+ def _ids(rows):
+     return {row["_id"] for row in rows}
+ 
+@@ -71,7 +62,7 @@
+     assert type(restored_scoped.scope["nested"]["code"]) is Code
+ 
+     restored_regex = restored["native_regex"]
+-    if contract_target.name == "mongodb":
++    if contract_target.transport == "pymongo":
+         assert type(restored_regex) is bson.Regex
+     else:
+         assert type(restored_regex) is type(native_regex)
+--- a/tests/contracts/test_crud_contract.py
++++ b/compat/mongo/v1/runner/contracts/test_crud_contract.py
+@@ -2,22 +2,12 @@
+ 
+ import pytest
+ 
+-from tinymongo.errors import WriteError as TinyMongoWriteError
+-
++from .support import WRITE_ERRORS as _WRITE_ERRORS
+ from .support import observe
+ 
+ 
+ pytestmark = pytest.mark.contract
+ 
+-_WRITE_ERRORS = (TinyMongoWriteError,)
+-try:
+-    from pymongo.errors import WriteError as PyMongoWriteError
+-except ImportError:  # pragma: no cover - optional dependency guard
+-    pass
+-else:
+-    _WRITE_ERRORS += (PyMongoWriteError,)
+-
+-
+ def test_insert_query_sort_and_count(contract_target):
+     collection = contract_target.collection
+ 
+--- a/tests/contracts/test_decimal128_contract.py
++++ b/compat/mongo/v1/runner/contracts/test_decimal128_contract.py
+@@ -1,10 +1,8 @@
+ """Decimal128 behavior shared by every API and storage target."""
+ 
+ import pytest
+-from tinymongo.bson_types import bson_identity_key
+-from tinymongo.errors import TinyMongoNotSupportedError
+ 
+-from .support import observe
++from .support import UNSUPPORTED_ERRORS, bson_identity_key, observe
+ 
+ 
+ pytestmark = pytest.mark.contract
+@@ -378,7 +376,7 @@
+ 
+     collection.create_index("amount", unique=True)
+     if contract_target.name in ("postgres", "postgresql", "mysql", "mariadb"):
+-        with pytest.raises(TinyMongoNotSupportedError, match="Decimal128 values"):
++        with pytest.raises(UNSUPPORTED_ERRORS, match="Decimal128 values"):
+             collection.insert_one({"_id": "decimal-tenth", "amount": Decimal128("0.1")})
+         return
+ 
+--- a/tests/contracts/test_group_accumulators_contract.py
++++ b/compat/mongo/v1/runner/contracts/test_group_accumulators_contract.py
+@@ -4,10 +4,8 @@
+ 
+ import pytest
+ from bson import Decimal128
+-
+-from tinymongo.bson_types import bson_value_identity_key
+ 
+-from .support import observe
++from .support import bson_value_identity_key, observe
+ 
+ 
+ pytestmark = pytest.mark.contract
+--- a/tests/contracts/test_query_operator_contract.py
++++ b/compat/mongo/v1/runner/contracts/test_query_operator_contract.py
+@@ -5,32 +5,15 @@
+ 
+ import pytest
+ 
+-from tinymongo.bson_types import regex_type
+-from tinymongo.errors import DuplicateKeyError as TinyMongoDuplicateKeyError
+-from tinymongo.errors import OperationFailure as TinyMongoOperationFailure
+-from tinymongo.errors import TinyMongoNotSupportedError
+-from tinymongo.errors import WriteError as TinyMongoWriteError
++from .support import DUPLICATE_KEY_ERRORS as _DUPLICATE_KEY_ERRORS
++from .support import OPERATION_ERRORS as _OPERATION_ERRORS
++from .support import QUERY_REJECTION_ERRORS as _QUERY_REJECTION_ERRORS
++from .support import WRITE_ERRORS as _WRITE_ERRORS
++from .support import regex_type
+ 
+ 
+ pytestmark = pytest.mark.contract
+ 
+-_DUPLICATE_KEY_ERRORS = (TinyMongoDuplicateKeyError,)
+-_OPERATION_ERRORS = (TinyMongoOperationFailure,)
+-_WRITE_ERRORS = (TinyMongoWriteError,)
+-try:
+-    from pymongo.errors import DuplicateKeyError as PyMongoDuplicateKeyError
+-    from pymongo.errors import OperationFailure as PyMongoOperationFailure
+-    from pymongo.errors import WriteError as PyMongoWriteError
+-except ImportError:  # pragma: no cover - optional dependency guard
+-    pass
+-else:
+-    _DUPLICATE_KEY_ERRORS += (PyMongoDuplicateKeyError,)
+-    _OPERATION_ERRORS += (PyMongoOperationFailure,)
+-    _WRITE_ERRORS += (PyMongoWriteError,)
+-
+-_QUERY_REJECTION_ERRORS = _OPERATION_ERRORS + (TinyMongoNotSupportedError,)
+-
+-
+ def _ids(rows):
+     return sorted(document["_id"] for document in rows)
+ 
+--- a/tests/contracts/test_talkpython_contract.py
++++ b/compat/mongo/v1/runner/contracts/test_talkpython_contract.py
+@@ -4,8 +4,6 @@
+ 
+ import pytest
+ 
+-from tinymongo.indexes import TinyMongoUnsupportedWarning
+-
+ from .support import observe
+ 
+ 
+@@ -305,10 +303,10 @@
+         ),
+     ]
+ 
+-    if contract_target.name == "mongodb":
++    if contract_target.transport == "pymongo":
+         created = collection.create_indexes(models)
+     else:
+-        with pytest.warns(TinyMongoUnsupportedWarning) as captured:
++        with pytest.warns(contract_target.unsupported_warning) as captured:
+             created = collection.create_indexes(models)
+         assert len(captured) == 4
+         warning_messages = [str(item.message) for item in captured]
+@@ -387,10 +385,10 @@
+     with pytest.raises(bson_errors.InvalidDocument) as caught:
+         collection.insert_one(document)
+ 
+-    if contract_target.name != "mongodb" and contract_target.api == "sync":
++    if contract_target.transport != "pymongo" and contract_target.api == "sync":
+         assert collection.name not in collection.database.list_collection_names()
+     assert collection.count_documents({}) == 0
+-    if contract_target.name != "mongodb":
++    if contract_target.transport != "pymongo":
+         assert isinstance(caught.value, pymongo_errors.PyMongoError)
+         assert caught.value.document is document
+         assert collection.full_name in str(caught.value)
+@@ -458,7 +456,7 @@
+ 
+     assert collection.find_one({"value": b"talk-python"})["_id"] == "binary-object"
+     assert collection.find_one({"value": generic})["_id"] == "binary-object"
+-    if contract_target.name != "mongodb":
++    if contract_target.transport != "pymongo":
+         # TinyMongo accepts bytearray as a convenience and canonicalizes it to
+         # BSON's generic binary subtype. PyMongo rejects bytearray at encoding.
+         assert (
+--- a/tests/contracts/test_update_operator_contract.py
++++ b/compat/mongo/v1/runner/contracts/test_update_operator_contract.py
+@@ -2,20 +2,11 @@
+ 
+ import pytest
+ 
+-from tinymongo.errors import WriteError as TinyMongoWriteError
++from .support import WRITE_ERRORS as _WRITE_ERRORS
+ 
+ 
+ pytestmark = pytest.mark.contract
+ 
+-_WRITE_ERRORS = (TinyMongoWriteError,)
+-try:
+-    from pymongo.errors import WriteError as PyMongoWriteError
+-except ImportError:  # pragma: no cover - optional dependency guard
+-    pass
+-else:
+-    _WRITE_ERRORS += (PyMongoWriteError,)
+-
+-
+ def test_min_and_max_follow_bson_order_and_report_noops(contract_target):
+     collection = contract_target.collection
+     collection.insert_many(
+--- a/tests/contracts/test_uuid_regex_contract.py
++++ b/compat/mongo/v1/runner/contracts/test_uuid_regex_contract.py
+@@ -5,7 +5,7 @@
+ 
+ import pytest
+ 
+-from tinymongo.bson_types import bson_identity_key
++from .support import bson_identity_key
+ 
+ 
+ pytestmark = pytest.mark.contract
+@@ -23,7 +23,7 @@
+     """Opt real MongoDB into the standard UUID representation for this test."""
+ 
+     collection = contract_target.collection
+-    if contract_target.name != "mongodb":
++    if contract_target.transport != "pymongo":
+         return collection
+ 
+     codec_options = pytest.importorskip("bson.codec_options").CodecOptions(
+@@ -143,7 +143,7 @@
+ 
+     restored_native = collection.find_one({"_id": "native"})["value"]
+     restored_bson = collection.find_one({"_id": "bson"})["value"]
+-    if contract_target.name == "mongodb":
++    if contract_target.transport == "pymongo":
+         assert isinstance(restored_native, Regex)
+     else:
+         assert isinstance(restored_native, type(native))

--- a/compat/mongo/v1/runner/adapters/__init__.py
+++ b/compat/mongo/v1/runner/adapters/__init__.py
@@ -1,0 +1,234 @@
+"""Target-neutral adapters for the vendored Mongo compatibility contracts.
+
+The contract bodies are synchronous so a single assertion corpus can exercise
+both client APIs.  Async targets therefore expose their native client and
+database handles alongside a synchronous collection facade.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+from dataclasses import dataclass
+from os import PathLike
+from types import ModuleType
+from typing import Any, ContextManager, Mapping, Optional, Protocol, Union, cast
+
+
+PathValue = Union[str, PathLike[str]]
+
+
+class AdapterError(RuntimeError):
+    """Base error raised while configuring a contract target."""
+
+
+class TargetUnavailable(AdapterError):
+    """Raised when a requested target cannot run in this environment."""
+
+
+@dataclass
+class TargetHandles:
+    """Objects and metadata exposed to each neutral contract body."""
+
+    name: str
+    transport: str
+    api: str
+    client: Any
+    database: Any
+    collection: Any
+    unsupported_warning: type[Warning]
+
+
+class TargetAdapter(Protocol):
+    """Structural interface implemented by each target adapter module."""
+
+    TARGET: str
+
+    def open_target(
+        self,
+        api: str,
+        tmp_path: PathValue,
+        client_options: Optional[Mapping[str, Any]] = None,
+        *,
+        backend: str = "memory",
+        uri: Optional[str] = None,
+        database_name: Optional[str] = None,
+        collection_name: str = "items",
+        connect_timeout: float = 15.0,
+    ) -> ContextManager[TargetHandles]:
+        """Open one isolated target and close it when the context exits."""
+
+
+class AsyncRunner:
+    """Run one async target on a stable loop from synchronous contracts."""
+
+    def __init__(self) -> None:
+        import asyncio
+
+        self.loop = asyncio.new_event_loop()
+
+    def run(self, value: Any) -> Any:
+        """Resolve an awaitable, or return an already-immediate value."""
+
+        if inspect.isawaitable(value):
+            return self.loop.run_until_complete(value)
+        return value
+
+    def close(self) -> None:
+        self.loop.close()
+
+
+class AsyncCursorAdapter:
+    """Present an async cursor through the synchronous contract interface."""
+
+    def __init__(self, cursor: Any, runner: AsyncRunner) -> None:
+        self._cursor = cursor
+        self._runner = runner
+
+    def sort(self, *args: Any, **kwargs: Any) -> "AsyncCursorAdapter":
+        self._runner.run(self._cursor.sort(*args, **kwargs))
+        return self
+
+    def skip(self, *args: Any, **kwargs: Any) -> "AsyncCursorAdapter":
+        self._runner.run(self._cursor.skip(*args, **kwargs))
+        return self
+
+    def limit(self, *args: Any, **kwargs: Any) -> "AsyncCursorAdapter":
+        self._runner.run(self._cursor.limit(*args, **kwargs))
+        return self
+
+    def to_list(self, length: Optional[int] = None) -> Any:
+        return self._runner.run(self._cursor.to_list(length=length))
+
+    def close(self) -> Any:
+        return self._runner.run(self._cursor.close())
+
+    def __iter__(self) -> Any:
+        return iter(self.to_list())
+
+
+def _is_async_cursor(value: Any) -> bool:
+    return hasattr(value, "__aiter__") and callable(getattr(value, "to_list", None))
+
+
+class AsyncCollectionAdapter:
+    """Await collection calls while preserving immediate cursor construction."""
+
+    def __init__(self, collection: Any, runner: AsyncRunner) -> None:
+        # These names deliberately match the original contract fixture.  Two
+        # UUID cases rebuild this facade after applying CodecOptions.
+        self._collection = collection
+        self._runner = runner
+
+    def _adapt_result(self, value: Any) -> Any:
+        value = self._runner.run(value)
+        if _is_async_cursor(value):
+            return AsyncCursorAdapter(value, self._runner)
+        return value
+
+    def find(self, *args: Any, **kwargs: Any) -> AsyncCursorAdapter:
+        cursor = self._collection.find(*args, **kwargs)
+        return AsyncCursorAdapter(cursor, self._runner)
+
+    def aggregate(self, *args: Any, **kwargs: Any) -> AsyncCursorAdapter:
+        cursor = self._runner.run(self._collection.aggregate(*args, **kwargs))
+        return AsyncCursorAdapter(cursor, self._runner)
+
+    def with_options(self, *args: Any, **kwargs: Any) -> "AsyncCollectionAdapter":
+        collection = self._runner.run(self._collection.with_options(*args, **kwargs))
+        return type(self)(collection, self._runner)
+
+    def __getitem__(self, name: str) -> "AsyncCollectionAdapter":
+        return type(self)(self._collection[name], self._runner)
+
+    def __getattr__(self, name: str) -> Any:
+        attribute = getattr(self._collection, name)
+        if not callable(attribute):
+            return attribute
+
+        def call(*args: Any, **kwargs: Any) -> Any:
+            return self._adapt_result(attribute(*args, **kwargs))
+
+        return call
+
+
+_ADAPTER_MODULES = {
+    "briskdb": ".briskdb",
+    "mongodb": ".mongodb",
+    "tinymongo": ".tinymongo",
+}
+
+
+def available_targets() -> tuple[str, ...]:
+    """Return the stable target names accepted by :func:`open_target`."""
+
+    return tuple(sorted(_ADAPTER_MODULES))
+
+
+def _normalize_api(api: str) -> str:
+    normalized = str(api).strip().lower()
+    if normalized not in ("sync", "async"):
+        raise ValueError("api must be 'sync' or 'async', got {0!r}".format(api))
+    return normalized
+
+
+def load_adapter(target: str) -> TargetAdapter:
+    """Load only the selected adapter and its target-specific dependencies."""
+
+    normalized = str(target).strip().lower()
+    module_name = _ADAPTER_MODULES.get(normalized)
+    if module_name is None:
+        raise ValueError(
+            "unknown Mongo compatibility target {0!r}; choose one of: {1}".format(
+                target, ", ".join(available_targets())
+            )
+        )
+    module = importlib.import_module(module_name, package=__name__)
+    if getattr(module, "TARGET", None) != normalized or not callable(
+        getattr(module, "open_target", None)
+    ):
+        raise AdapterError(
+            "adapter {0} does not implement the target protocol".format(module.__name__)
+        )
+    return cast(TargetAdapter, cast(ModuleType, module))
+
+
+def open_target(
+    target: str,
+    api: str,
+    tmp_path: PathValue,
+    client_options: Optional[Mapping[str, Any]] = None,
+    *,
+    backend: str = "memory",
+    uri: Optional[str] = None,
+    database_name: Optional[str] = None,
+    collection_name: str = "items",
+    connect_timeout: float = 15.0,
+) -> ContextManager[TargetHandles]:
+    """Open a named target through a uniform context-manager interface."""
+
+    normalized_api = _normalize_api(api)
+    return load_adapter(target).open_target(
+        normalized_api,
+        tmp_path,
+        dict(client_options or {}),
+        backend=backend,
+        uri=uri,
+        database_name=database_name,
+        collection_name=collection_name,
+        connect_timeout=connect_timeout,
+    )
+
+
+__all__ = [
+    "AdapterError",
+    "AsyncCollectionAdapter",
+    "AsyncCursorAdapter",
+    "AsyncRunner",
+    "TargetAdapter",
+    "TargetHandles",
+    "TargetUnavailable",
+    "available_targets",
+    "load_adapter",
+    "open_target",
+]

--- a/compat/mongo/v1/runner/adapters/briskdb.py
+++ b/compat/mongo/v1/runner/adapters/briskdb.py
@@ -1,0 +1,52 @@
+"""PyMongo transport adapter for a BriskDB Mongo-compatible endpoint."""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from typing import Any, Iterator, Mapping, Optional
+
+from . import PathValue, TargetHandles, TargetUnavailable
+from .mongodb import open_pymongo_target
+
+
+TARGET = "briskdb"
+
+
+def _configured_uri(uri: Optional[str]) -> str:
+    configured = uri or os.environ.get("BRISKDB_MONGO_PARITY_BRISKDB_URI")
+    if not configured:
+        raise TargetUnavailable(
+            "set BRISKDB_MONGO_PARITY_BRISKDB_URI to run the BriskDB Mongo "
+            "compatibility adapter"
+        )
+    return configured
+
+
+@contextmanager
+def open_target(
+    api: str,
+    tmp_path: PathValue,
+    client_options: Optional[Mapping[str, Any]] = None,
+    *,
+    backend: str = "memory",
+    uri: Optional[str] = None,
+    database_name: Optional[str] = None,
+    collection_name: str = "items",
+    connect_timeout: float = 15.0,
+) -> Iterator[TargetHandles]:
+    """Open one isolated database on a configured BriskDB Mongo endpoint."""
+
+    configured_uri = _configured_uri(uri)
+    with open_pymongo_target(
+        TARGET,
+        api,
+        tmp_path,
+        client_options,
+        backend=backend,
+        uri=configured_uri,
+        database_name=database_name,
+        collection_name=collection_name,
+        connect_timeout=connect_timeout,
+    ) as handles:
+        yield handles

--- a/compat/mongo/v1/runner/adapters/mongodb.py
+++ b/compat/mongo/v1/runner/adapters/mongodb.py
@@ -1,0 +1,178 @@
+"""Real MongoDB adapter for the neutral Mongo compatibility runner."""
+
+from __future__ import annotations
+
+import os
+import time
+from contextlib import contextmanager
+from typing import Any, Iterator, Mapping, Optional
+from uuid import uuid4
+
+from . import (
+    AsyncCollectionAdapter,
+    AsyncRunner,
+    PathValue,
+    TargetHandles,
+    TargetUnavailable,
+)
+
+
+TARGET = "mongodb"
+
+
+def _client_classes() -> tuple[Any, Any]:
+    # PyMongo stays lazy so importing the adapter registry or an unavailable
+    # target does not load a contract-only dependency.
+    try:
+        from pymongo import AsyncMongoClient, MongoClient
+    except ImportError as error:
+        raise TargetUnavailable(
+            "the PyMongo transport requires PyMongo with AsyncMongoClient support"
+        ) from error
+    return MongoClient, AsyncMongoClient
+
+
+def _server_selection_options(client_options: Mapping[str, Any]) -> dict[str, Any]:
+    options = dict(client_options)
+    if not any(key.lower() == "serverselectiontimeoutms" for key in options):
+        options["serverSelectionTimeoutMS"] = 1_000
+    return options
+
+
+def _configured_uri(uri: Optional[str]) -> str:
+    configured = (
+        uri
+        or os.environ.get("BRISKDB_MONGO_PARITY_MONGODB_URI")
+        or os.environ.get("TINYMONGO_MONGODB_URI")
+    )
+    if not configured:
+        raise TargetUnavailable(
+            "set BRISKDB_MONGO_PARITY_MONGODB_URI to run real MongoDB contracts"
+        )
+    return configured
+
+
+def _wait_until_ready(
+    client: Any, runner: Optional[AsyncRunner], connect_timeout: float
+) -> None:
+    if connect_timeout <= 0:
+        raise ValueError("connect_timeout must be greater than zero")
+    deadline = time.monotonic() + connect_timeout
+    last_error = None
+    while time.monotonic() < deadline:
+        try:
+            command = client.admin.command("ping")
+            if runner is not None:
+                runner.run(command)
+            return
+        except Exception as error:  # noqa: BLE001 - retry server startup
+            last_error = error
+            time.sleep(min(0.25, max(0.0, deadline - time.monotonic())))
+    raise TargetUnavailable(
+        "the Mongo-compatible target did not become ready: {0}".format(last_error)
+    )
+
+
+@contextmanager
+def open_pymongo_target(
+    target_name: str,
+    api: str,
+    tmp_path: PathValue,
+    client_options: Optional[Mapping[str, Any]] = None,
+    *,
+    backend: str = "memory",
+    uri: str,
+    database_name: Optional[str] = None,
+    collection_name: str = "items",
+    connect_timeout: float = 15.0,
+) -> Iterator[TargetHandles]:
+    """Open an isolated target through PyMongo's sync or async transport."""
+
+    del tmp_path, backend
+    if api not in ("sync", "async"):
+        raise ValueError("api must be 'sync' or 'async', got {0!r}".format(api))
+    if not target_name:
+        raise ValueError("target_name must not be empty")
+    if not uri:
+        raise ValueError("uri must not be empty")
+    database_name = database_name or "briskdb_contract_{0}".format(uuid4().hex)
+    if not database_name:
+        raise ValueError("database_name must not be empty")
+    if not collection_name:
+        raise ValueError("collection_name must not be empty")
+
+    sync_client, async_client = _client_classes()
+    options = _server_selection_options(client_options or {})
+    runner = None
+    client = None
+    ready = False
+    try:
+        if api == "async":
+            runner = AsyncRunner()
+            client = async_client(uri, **options)
+        else:
+            client = sync_client(uri, **options)
+        _wait_until_ready(client, runner, connect_timeout)
+        ready = True
+
+        database = client[database_name]
+        collection = database[collection_name]
+        exposed_collection = (
+            AsyncCollectionAdapter(collection, runner)
+            if runner is not None
+            else collection
+        )
+        yield TargetHandles(
+            name=target_name,
+            transport="pymongo",
+            api=api,
+            client=client,
+            database=database,
+            collection=exposed_collection,
+            unsupported_warning=UserWarning,
+        )
+    finally:
+        if client is not None:
+            try:
+                if ready:
+                    drop_result = client.drop_database(database_name)
+                    if runner is not None:
+                        runner.run(drop_result)
+            finally:
+                try:
+                    close_result = client.close()
+                    if runner is not None:
+                        runner.run(close_result)
+                finally:
+                    if runner is not None:
+                        runner.close()
+        elif runner is not None:
+            runner.close()
+
+
+@contextmanager
+def open_target(
+    api: str,
+    tmp_path: PathValue,
+    client_options: Optional[Mapping[str, Any]] = None,
+    *,
+    backend: str = "memory",
+    uri: Optional[str] = None,
+    database_name: Optional[str] = None,
+    collection_name: str = "items",
+    connect_timeout: float = 15.0,
+) -> Iterator[TargetHandles]:
+    """Open one isolated database on a real MongoDB server."""
+    configured_uri = _configured_uri(uri)
+    with open_pymongo_target(
+        TARGET,
+        api,
+        tmp_path,
+        client_options,
+        backend=backend,
+        uri=configured_uri,
+        database_name=database_name,
+        collection_name=collection_name,
+        connect_timeout=connect_timeout,
+    ) as handles:
+        yield handles

--- a/compat/mongo/v1/runner/adapters/tinymongo.py
+++ b/compat/mongo/v1/runner/adapters/tinymongo.py
@@ -1,0 +1,129 @@
+"""TinyMongo adapter for the neutral Mongo compatibility runner."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator, Mapping, Optional
+from uuid import uuid4
+
+from . import (
+    AsyncCollectionAdapter,
+    AsyncRunner,
+    PathValue,
+    TargetHandles,
+    TargetUnavailable,
+)
+
+
+TARGET = "tinymongo"
+
+
+def _client_classes() -> tuple[Any, Any, Any, Any, type[Warning]]:
+    # TinyMongo is intentionally imported nowhere else in the BriskDB runner.
+    try:
+        import tinymongo
+        from tinymongo.asyncio import AsyncMongoClient, AsyncTinyMongoClient
+    except ImportError as error:
+        raise TargetUnavailable(
+            "the TinyMongo target requires the frozen TinyMongo package"
+        ) from error
+    return (
+        tinymongo.TinyMongoClient,
+        tinymongo.MongoClient,
+        AsyncTinyMongoClient,
+        AsyncMongoClient,
+        tinymongo.TinyMongoUnsupportedWarning,
+    )
+
+
+def _validate_names(database_name: str, collection_name: str) -> None:
+    if not database_name:
+        raise ValueError("database_name must not be empty")
+    if not collection_name:
+        raise ValueError("collection_name must not be empty")
+
+
+@contextmanager
+def open_target(
+    api: str,
+    tmp_path: PathValue,
+    client_options: Optional[Mapping[str, Any]] = None,
+    *,
+    backend: str = "memory",
+    uri: Optional[str] = None,
+    database_name: Optional[str] = None,
+    collection_name: str = "items",
+    connect_timeout: float = 15.0,
+) -> Iterator[TargetHandles]:
+    """Open an isolated TinyMongo backend for one sync or async contract."""
+
+    del uri, connect_timeout  # These transport settings apply only to MongoDB.
+    if api not in ("sync", "async"):
+        raise ValueError("api must be 'sync' or 'async', got {0!r}".format(api))
+
+    target_name = str(backend).strip().lower()
+    storage_backend = "tinydb" if target_name == "json" else target_name
+    if not target_name:
+        raise ValueError("backend must not be empty")
+    database_name = database_name or "tinymongo_contract_{0}".format(uuid4().hex)
+    _validate_names(database_name, collection_name)
+
+    root = Path(tmp_path) / "tinymongo-{0}-{1}".format(target_name, uuid4().hex)
+    root.mkdir(parents=True, exist_ok=False)
+    options = dict(client_options or {})
+    reserved = {"backend", "foldername", "tinymongo_folder", "tinymongo_path"}
+    conflicts = sorted(reserved.intersection(options))
+    if conflicts:
+        raise ValueError(
+            "client_options cannot override adapter-owned option(s): {0}".format(
+                ", ".join(conflicts)
+            )
+        )
+
+    tiny_sync, mongo_sync, tiny_async, mongo_async, unsupported_warning = (
+        _client_classes()
+    )
+    runner = None
+    client = None
+    try:
+        if api == "async":
+            runner = AsyncRunner()
+            if options:
+                client = mongo_async(
+                    tinymongo_folder=str(root), backend=storage_backend, **options
+                )
+            else:
+                client = tiny_async(str(root), backend=storage_backend)
+        elif options:
+            client = mongo_sync(
+                tinymongo_folder=str(root), backend=storage_backend, **options
+            )
+        else:
+            client = tiny_sync(str(root), backend=storage_backend)
+
+        database = client[database_name]
+        collection = database[collection_name]
+        exposed_collection = (
+            AsyncCollectionAdapter(collection, runner)
+            if runner is not None
+            else collection
+        )
+        yield TargetHandles(
+            name=target_name,
+            transport="direct",
+            api=api,
+            client=client,
+            database=database,
+            collection=exposed_collection,
+            unsupported_warning=unsupported_warning,
+        )
+    finally:
+        if client is not None:
+            try:
+                close_result = client.close()
+                if runner is not None:
+                    runner.run(close_result)
+            finally:
+                if runner is not None:
+                    runner.close()

--- a/compat/mongo/v1/runner/contracts/__init__.py
+++ b/compat/mongo/v1/runner/contracts/__init__.py
@@ -1,0 +1,1 @@
+"""Shared behavioral contracts for TinyMongo and real MongoDB."""

--- a/compat/mongo/v1/runner/contracts/conftest.py
+++ b/compat/mongo/v1/runner/contracts/conftest.py
@@ -1,0 +1,160 @@
+"""Target-neutral fixture for the frozen TinyMongo v1 contract corpus."""
+
+import os
+import re
+
+import pytest
+
+from ..adapters import TargetUnavailable, open_target
+from .support import ContractTarget
+
+
+APIS = ("sync", "async")
+TARGETS = ("tinymongo", "mongodb", "briskdb")
+
+
+def pytest_addoption(parser):
+    group = parser.getgroup("mongo-contract")
+    group.addoption(
+        "--mongo-contract-target",
+        choices=TARGETS,
+        default=os.environ.get("BRISKDB_MONGO_CONTRACT_TARGET", "tinymongo"),
+        help="implementation adapter used by the frozen Mongo contract",
+    )
+    group.addoption(
+        "--mongo-contract-api",
+        choices=("sync", "async", "both"),
+        default=os.environ.get("BRISKDB_MONGO_CONTRACT_API", "both"),
+        help="API flavor to execute (default: both)",
+    )
+    group.addoption(
+        "--mongo-contract-backend",
+        default=os.environ.get("BRISKDB_MONGO_CONTRACT_BACKEND", "memory"),
+        help="TinyMongo backend ID (default: memory)",
+    )
+    group.addoption(
+        "--mongo-contract-mongodb-uri",
+        default=os.environ.get("BRISKDB_MONGODB_URI"),
+        help="URI for the optional real MongoDB adapter",
+    )
+    group.addoption(
+        "--mongo-contract-briskdb-uri",
+        default=os.environ.get("BRISKDB_MONGO_PARITY_BRISKDB_URI"),
+        help="URI for the BriskDB Mongo-compatible candidate",
+    )
+    group.addoption(
+        "--mongo-contract-require-target",
+        action="store_true",
+        default=False,
+        help="turn an unavailable optional target into a test failure",
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "contract: frozen Mongo compatibility contract")
+    config.addinivalue_line(
+        "markers",
+        "client_options(**kwargs): constructor options required by one contract",
+    )
+
+
+def _backend_id(config):
+    target = config.getoption("--mongo-contract-target")
+    if target == "mongodb":
+        return "mongodb"
+    if target == "briskdb":
+        return "briskdb"
+    return config.getoption("--mongo-contract-backend")
+
+
+def _target_uri(config, target):
+    if target == "briskdb":
+        return config.getoption("--mongo-contract-briskdb-uri")
+    return config.getoption("--mongo-contract-mongodb-uri")
+
+
+def pytest_generate_tests(metafunc):
+    if "contract_target" not in metafunc.fixturenames:
+        return
+    requested = metafunc.config.getoption("--mongo-contract-api")
+    apis = APIS if requested == "both" else (requested,)
+    backend = _backend_id(metafunc.config)
+    metafunc.parametrize(
+        "contract_target",
+        [(api, backend) for api in apis],
+        indirect=True,
+        ids=["{0}-{1}".format(api, backend) for api in apis],
+    )
+
+
+def _contract_suite(request):
+    filename = request.node.path.name
+    if filename == "test_talkpython_contract.py":
+        return "talkpython"
+    if filename == "test_bson_comparison_contract.py":
+        return "bson-comparison"
+    if filename == "test_client_read_fidelity_contract.py":
+        return "client-read-fidelity"
+    return "core"
+
+
+def _upstream_case_id(request, api, backend):
+    name = request.node.name
+    match = re.search(r"\[([^][]*)\]$", name)
+    if match is not None:
+        parameters = match.group(1)
+        prefix = "{0}-{1}".format(api, backend)
+        if parameters != prefix and not parameters.startswith(prefix + "-"):
+            raise pytest.UsageError(
+                "contract parameter ID {0!r} does not begin with {1!r}".format(
+                    parameters, prefix
+                )
+            )
+        remaining = parameters[len(prefix) :].lstrip("-")
+        base = name[: match.start()]
+        name = "{0}[{1}]".format(base, remaining) if remaining else base
+    module = request.node.path.stem
+    return "tests.contracts.{0}::{1}".format(module, name)
+
+
+@pytest.fixture
+def contract_target(request, tmp_path):
+    """Yield one sync-shaped target selected through a lazy adapter import."""
+
+    api, backend = request.param
+    target = request.config.getoption("--mongo-contract-target")
+    suite = _contract_suite(request)
+    request.node.user_properties.extend(
+        [
+            ("tinymongo.api", api),
+            ("tinymongo.backend", backend),
+            ("tinymongo.suite", suite),
+            ("tinymongo.contract_id", _upstream_case_id(request, api, backend)),
+        ]
+    )
+    marker = request.node.get_closest_marker("client_options")
+    client_options = dict(marker.kwargs) if marker else {}
+    try:
+        context = open_target(
+            target,
+            api,
+            tmp_path,
+            client_options,
+            backend=backend,
+            uri=_target_uri(request.config, target),
+        )
+        with context as handles:
+            yield ContractTarget(
+                name=handles.name,
+                transport=handles.transport,
+                api=api,
+                client=handles.client,
+                database=handles.database,
+                collection=handles.collection,
+                unsupported_warning=handles.unsupported_warning,
+            )
+    except TargetUnavailable as error:
+        required = request.config.getoption("--mongo-contract-require-target")
+        if required or target != "mongodb":
+            pytest.fail(str(error), pytrace=False)
+        pytest.skip(str(error))

--- a/compat/mongo/v1/runner/contracts/support.py
+++ b/compat/mongo/v1/runner/contracts/support.py
@@ -1,0 +1,181 @@
+"""Runtime-neutral helpers used by the frozen Mongo compatibility contracts.
+
+This module deliberately depends on PyMongo's public BSON and exception types,
+which form the compatibility surface, but never imports TinyMongo.  A target
+adapter is responsible for translating its failures to these public shapes.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal
+import re
+from collections.abc import Mapping
+from typing import Any, Callable, Optional
+from uuid import UUID
+
+from bson import Binary, Code, Decimal128, MaxKey, MinKey, ObjectId, Regex, Timestamp
+from pymongo.errors import DuplicateKeyError, OperationFailure, WriteError
+
+
+DUPLICATE_KEY_ERRORS = (DuplicateKeyError,)
+OPERATION_ERRORS = (OperationFailure,)
+WRITE_ERRORS = (WriteError,)
+UNSUPPORTED_ERRORS = (NotImplementedError,)
+QUERY_REJECTION_ERRORS = OPERATION_ERRORS + UNSUPPORTED_ERRORS
+
+
+@dataclass(frozen=True)
+class Outcome:
+    """Normalized result of one operation against a contract target."""
+
+    value: Any = None
+    error: Optional[str] = None
+
+
+@dataclass
+class ContractTarget:
+    """Objects and metadata exposed to each shared contract."""
+
+    name: str
+    transport: str
+    api: str
+    client: Any
+    database: Any
+    collection: Any
+    unsupported_warning: type
+
+
+def error_category(error: Exception) -> str:
+    """Map adapter-specific failures to the contract vocabulary."""
+
+    if isinstance(error, DuplicateKeyError):
+        return "duplicate_key"
+    if isinstance(error, OperationFailure):
+        return "operation_failure"
+    return "{0}.{1}".format(type(error).__module__, type(error).__name__)
+
+
+def observe(operation: Callable[[], Any]) -> Outcome:
+    """Run an operation and retain either its value or normalized error."""
+
+    try:
+        return Outcome(value=operation())
+    except Exception as error:  # noqa: BLE001 - exceptions are contract output
+        return Outcome(error=error_category(error))
+
+
+def regex_type():
+    """Return the public BSON regular-expression class."""
+
+    return Regex
+
+
+def _number_identity(value: Any):
+    if isinstance(value, Decimal128):
+        decimal_value = value.to_decimal()
+    elif isinstance(value, int) and not isinstance(value, bool):
+        decimal_value = Decimal(value)
+    elif isinstance(value, float):
+        decimal_value = Decimal.from_float(value)
+    else:
+        raise TypeError("value is not a BSON number")
+    if decimal_value.is_nan():
+        return "nan"
+    if decimal_value.is_infinite():
+        return "-infinity" if decimal_value.is_signed() else "infinity"
+    return decimal_value.as_integer_ratio()
+
+
+def _regex_options(flags: Any) -> str:
+    if isinstance(flags, str):
+        return "".join(letter for letter in "ilmsux" if letter in flags)
+    return "".join(
+        letter
+        for letter, flag in (
+            ("i", re.IGNORECASE),
+            ("l", re.LOCALE),
+            ("m", re.MULTILINE),
+            ("s", re.DOTALL),
+            ("u", re.UNICODE),
+            ("x", re.VERBOSE),
+        )
+        if int(flags) & int(flag)
+    )
+
+
+def _datetime_milliseconds(value: datetime) -> int:
+    normalized = (
+        value.replace(tzinfo=timezone.utc)
+        if value.utcoffset() is None
+        else value.astimezone(timezone.utc)
+    )
+    epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
+    delta = normalized - epoch
+    return (
+        delta.days * 86_400_000
+        + delta.seconds * 1_000
+        + delta.microseconds // 1_000
+    )
+
+
+def bson_identity_key(value: Any):
+    """Return the scalar BSON equality identity used by the frozen assertions."""
+
+    if value is None:
+        return "null", None
+    if type(value) is bool:
+        return "boolean", value
+    if isinstance(value, (int, float, Decimal128)) and not isinstance(value, bool):
+        return "number", _number_identity(value)
+    if isinstance(value, UUID):
+        return "binary", (4, value.bytes)
+    if isinstance(value, Binary):
+        return "binary", (int(value.subtype), bytes(value))
+    if type(value) in (bytes, bytearray):
+        return "binary", (0, bytes(value))
+    if isinstance(value, Code):
+        scope = None if value.scope is None else bson_value_identity_key(value.scope)
+        return "code", (str(value), scope)
+    if isinstance(value, str):
+        return "string", value
+    if isinstance(value, ObjectId):
+        return "objectId", value.binary
+    if isinstance(value, datetime):
+        return "date", _datetime_milliseconds(value)
+    if isinstance(value, Timestamp):
+        return "timestamp", (value.time, value.inc)
+    if isinstance(value, (Regex, type(re.compile("")))):
+        pattern = value.pattern
+        if isinstance(pattern, bytes):
+            pattern = pattern.decode("utf-8")
+        return "regex", (pattern, _regex_options(value.flags))
+    if isinstance(value, MinKey):
+        return "minKey", None
+    if isinstance(value, MaxKey):
+        return "maxKey", None
+    return None
+
+
+def bson_value_identity_key(value: Any):
+    """Return a recursive, ordered and hashable BSON equality identity."""
+
+    scalar = bson_identity_key(value)
+    if scalar is not None:
+        return scalar
+    if isinstance(value, Mapping):
+        items = []
+        for key, item in value.items():
+            item_key = bson_value_identity_key(item)
+            if item_key is None:
+                return None
+            items.append((key, item_key))
+        return "object", tuple(items)
+    if isinstance(value, (list, tuple)):
+        items = []
+        for item in value:
+            item_key = bson_value_identity_key(item)
+            if item_key is None:
+                return None
+            items.append(item_key)
+        return "array", tuple(items)
+    return None

--- a/compat/mongo/v1/runner/contracts/test_aggregation_basic_stages_contract.py
+++ b/compat/mongo/v1/runner/contracts/test_aggregation_basic_stages_contract.py
@@ -1,0 +1,378 @@
+"""Issue #96 contracts for basic non-transforming aggregation stages."""
+
+import pytest
+
+from .support import observe
+
+
+pytestmark = pytest.mark.contract
+
+
+def _ids(rows):
+    return [row["_id"] for row in rows]
+
+
+def test_sort_uses_mongodb_keys_for_missing_null_arrays_and_bson_types(
+    contract_target,
+):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "missing"},
+            {"_id": "null", "value": None},
+            {"_id": "empty", "value": []},
+            {"_id": "array", "value": [9, 1, 5]},
+            {"_id": "number", "value": 2},
+            {"_id": "string", "value": "a"},
+            {"_id": "object", "value": {"score": 3}},
+        ]
+    )
+
+    assert _ids(collection.aggregate([{"$sort": {"value": 1, "_id": 1}}])) == [
+        "empty",
+        "missing",
+        "null",
+        "array",
+        "number",
+        "string",
+        "object",
+    ]
+    assert _ids(collection.aggregate([{"$sort": {"value": -1, "_id": 1}}])) == [
+        "object",
+        "string",
+        "array",
+        "number",
+        "missing",
+        "null",
+        "empty",
+    ]
+
+
+def test_sort_traverses_dotted_array_paths_and_compounds_ties(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "items": [{"score": 8}, {"score": 2}]},
+            {"_id": 2, "items": [{"score": 5}]},
+            {"_id": 3, "items": [{}]},
+            {"_id": 4},
+            {"_id": 5, "items": []},
+            {"_id": 6, "items": [{"score": [7, 1]}]},
+        ]
+    )
+
+    assert _ids(collection.aggregate([{"$sort": {"items.score": 1, "_id": 1}}])) == [
+        3,
+        4,
+        5,
+        6,
+        1,
+        2,
+    ]
+    assert _ids(collection.aggregate([{"$sort": {"items.score": -1, "_id": 1}}])) == [
+        1,
+        6,
+        2,
+        3,
+        4,
+        5,
+    ]
+
+
+def test_sort_numeric_path_segments_address_array_indexes(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "items": [{"score": 9}, {"score": 1}]},
+            {"_id": 2, "items": [{"score": 2}, {"score": 8}]},
+        ]
+    )
+
+    assert _ids(collection.aggregate([{"$sort": {"items.1.score": 1}}])) == [1, 2]
+    assert _ids(collection.aggregate([{"$sort": {"items.1.score": -1}}])) == [2, 1]
+
+
+def test_compound_numeric_sort_paths_can_select_separate_array_indexes(
+    contract_target,
+):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "items": [2, 1]},
+            {"_id": 2, "items": [1, 2]},
+        ]
+    )
+
+    assert _ids(collection.aggregate([{"$sort": {"items.0": 1, "items.1": 1}}])) == [
+        2,
+        1,
+    ]
+
+
+def test_compound_numeric_sort_rejects_parallel_selected_arrays(contract_target):
+    collection = contract_target.collection
+    collection.insert_one({"_id": 1, "items": [[2], [1]]})
+
+    outcome = observe(
+        lambda: list(collection.aggregate([{"$sort": {"items.0": 1, "items.1": 1}}]))
+    )
+
+    assert outcome.error == "operation_failure"
+
+
+def test_numeric_sort_path_compares_selected_array_as_a_whole_value(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "array", "items": [[2, 1]]},
+            {"_id": "object", "items": [{"value": 1}]},
+        ]
+    )
+
+    assert _ids(collection.aggregate([{"$sort": {"items.0": 1}}])) == [
+        "object",
+        "array",
+    ]
+    assert _ids(collection.aggregate([{"$sort": {"items.0": -1}}])) == [
+        "array",
+        "object",
+    ]
+
+
+def test_numeric_sort_path_keeps_empty_array_special_order(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "empty", "items": [[]]},
+            {"_id": "missing"},
+            {"_id": "null", "items": [None]},
+        ]
+    )
+
+    assert _ids(collection.aggregate([{"$sort": {"items.0": 1, "_id": 1}}])) == [
+        "empty",
+        "missing",
+        "null",
+    ]
+    assert _ids(collection.aggregate([{"$sort": {"items.0": -1, "_id": 1}}])) == [
+        "missing",
+        "null",
+        "empty",
+    ]
+
+
+def test_sort_rejects_ambiguous_numeric_array_paths(contract_target):
+    collection = contract_target.collection
+    collection.insert_one({"_id": 1, "items": [{"0": 7}]})
+
+    outcome = observe(lambda: list(collection.aggregate([{"$sort": {"items.0": 1}}])))
+
+    assert outcome.error == "operation_failure"
+
+
+def test_sort_array_fanout_includes_missing_but_not_nested_arrays(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "items": [{"score": 3}, {}]},
+            {"_id": 2, "items": [{"score": 2}]},
+            {"_id": 3, "items": [{"score": 4}]},
+            {"_id": 4, "items": [[{"score": 9}]]},
+        ]
+    )
+
+    assert _ids(collection.aggregate([{"$sort": {"items.score": 1, "_id": 1}}])) == [
+        1,
+        4,
+        2,
+        3,
+    ]
+    assert _ids(collection.aggregate([{"$sort": {"items.score": -1, "_id": 1}}])) == [
+        3,
+        1,
+        2,
+        4,
+    ]
+
+
+def test_compound_sort_preserves_shared_array_element_correlation(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {
+                "_id": "array",
+                "values": [{"x": 1, "y": 9}, {"x": 2, "y": 8}],
+            },
+            {"_id": "scalar", "values": {"x": 1, "y": 8.5}},
+        ]
+    )
+
+    assert _ids(collection.aggregate([{"$sort": {"values.x": 1, "values.y": 1}}])) == [
+        "scalar",
+        "array",
+    ]
+
+
+def test_compound_sort_rejects_parallel_arrays(contract_target):
+    collection = contract_target.collection
+    collection.insert_one({"_id": 1, "first": [1, 2], "second": [3, 4]})
+
+    outcome = observe(
+        lambda: list(collection.aggregate([{"$sort": {"first": 1, "second": 1}}]))
+    )
+
+    assert outcome.error == "operation_failure"
+
+
+def test_compound_sort_allows_nested_arrays_in_separate_parent_elements(
+    contract_target,
+):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {
+                "_id": 1,
+                "values": [
+                    {"x": [1], "y": 0},
+                    {"x": 0, "y": [1]},
+                ],
+            },
+            {"_id": 2},
+        ]
+    )
+
+    assert _ids(
+        collection.aggregate([{"$sort": {"values.x": 1, "values.y": 1, "_id": 1}}])
+    ) == [2, 1]
+
+
+def test_out_of_range_numeric_sort_path_fans_out_to_named_fields(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "values": [{"9": 7}]},
+            {"_id": 2},
+        ]
+    )
+
+    assert _ids(collection.aggregate([{"$sort": {"values.9": 1, "_id": 1}}])) == [2, 1]
+
+
+@pytest.mark.parametrize("path", ["first.1", "first.9"])
+def test_compound_sort_rejects_numeric_path_parallel_arrays(contract_target, path):
+    collection = contract_target.collection
+    collection.insert_one({"_id": 1, "first": [1, 2], "second": [3]})
+
+    outcome = observe(
+        lambda: list(collection.aggregate([{"$sort": {path: 1, "second": 1}}]))
+    )
+
+    assert outcome.error == "operation_failure"
+
+
+def test_sort_skip_limit_and_count_compose_with_other_stages(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "keep": True, "score": 20},
+            {"_id": 2, "keep": False, "score": 100},
+            {"_id": 3, "keep": True, "score": 50},
+            {"_id": 4, "keep": True, "score": 50},
+            {"_id": 5, "keep": True, "score": 10},
+            {"_id": 6, "keep": True, "score": 30},
+        ]
+    )
+
+    page = list(
+        collection.aggregate(
+            [
+                {"$match": {"keep": True}},
+                {"$sort": {"score": -1, "_id": 1}},
+                {"$skip": 1},
+                {"$limit": 3},
+                {"$project": {"_id": 1, "score": 1}},
+            ]
+        )
+    )
+    assert page == [
+        {"_id": 4, "score": 50},
+        {"_id": 6, "score": 30},
+        {"_id": 1, "score": 20},
+    ]
+    assert list(
+        collection.aggregate(
+            [
+                {"$match": {"keep": True}},
+                {"$sort": {"score": -1, "_id": 1}},
+                {"$skip": 1},
+                {"$limit": 3},
+                {"$count": "selected"},
+                {"$set": {"label": "page"}},
+            ]
+        )
+    ) == [{"selected": 3, "label": "page"}]
+
+
+def test_integral_numeric_arguments_and_pagination_boundaries(contract_target):
+    collection = contract_target.collection
+    collection.insert_many([{"_id": value} for value in range(1, 5)])
+
+    assert _ids(
+        collection.aggregate(
+            [
+                {"$sort": {"_id": -1.0}},
+                {"$skip": 1.0},
+                {"$limit": 2.0},
+            ]
+        )
+    ) == [3, 2]
+    assert list(collection.aggregate([{"$skip": 20}])) == []
+    assert _ids(collection.aggregate([{"$limit": 20}])) == [1, 2, 3, 4]
+
+
+def test_empty_input_stays_empty_and_count_emits_no_document(contract_target):
+    collection = contract_target.collection
+
+    assert (
+        list(
+            collection.aggregate(
+                [
+                    {"$sort": {"value": 1}},
+                    {"$skip": 0},
+                    {"$limit": 1},
+                ]
+            )
+        )
+        == []
+    )
+    assert list(collection.aggregate([{"$count": "total"}])) == []
+
+
+@pytest.mark.parametrize(
+    "stage",
+    [
+        {"$sort": None},
+        {"$sort": {}},
+        {"$sort": {"value": 0}},
+        {"$sort": {"value": True}},
+        {"$sort": {"value.": 1}},
+        {"$sort": {"field{0}".format(index): 1 for index in range(33)}},
+        {"$skip": -1},
+        {"$skip": 1.5},
+        {"$skip": True},
+        {"$limit": -1},
+        {"$limit": 0},
+        {"$limit": 1.5},
+        {"$limit": True},
+        {"$count": 1},
+        {"$count": ""},
+        {"$count": "$total"},
+        {"$count": "nested.total"},
+        {"$count": "bad\x00total"},
+        {"$count": "_id"},
+    ],
+)
+def test_basic_stage_validation_is_mongodb_shaped(contract_target, stage):
+    outcome = observe(lambda: list(contract_target.collection.aggregate([stage])))
+
+    assert outcome.error == "operation_failure"

--- a/compat/mongo/v1/runner/contracts/test_aggregation_contract.py
+++ b/compat/mongo/v1/runner/contracts/test_aggregation_contract.py
@@ -1,0 +1,495 @@
+"""Aggregation behavior shared by every API and storage target."""
+
+from datetime import datetime
+
+import pytest
+
+from .support import observe
+
+
+pytestmark = pytest.mark.contract
+
+
+def _by_id(rows):
+    return {row["_id"]: row for row in rows}
+
+
+def test_latest_activity_by_course(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {
+                "_id": 1,
+                "user_id": "ada",
+                "course_id": "python",
+                "created_date": datetime(2026, 1, 1, 8),
+            },
+            {
+                "_id": 2,
+                "user_id": "ada",
+                "course_id": "python",
+                "created_date": datetime(2026, 1, 3, 8),
+            },
+            {
+                "_id": 3,
+                "user_id": "ada",
+                "course_id": "mongo",
+                "created_date": datetime(2026, 1, 2, 8),
+            },
+            {
+                "_id": 4,
+                "user_id": "grace",
+                "course_id": "python",
+                "created_date": datetime(2026, 1, 9, 8),
+            },
+        ]
+    )
+
+    rows = list(
+        collection.aggregate(
+            [
+                {"$match": {"user_id": "ada"}},
+                {
+                    "$group": {
+                        "_id": "$course_id",
+                        "last_activity": {"$max": "$created_date"},
+                    }
+                },
+            ]
+        )
+    )
+
+    assert _by_id(rows) == {
+        "python": {
+            "_id": "python",
+            "last_activity": datetime(2026, 1, 3, 8),
+        },
+        "mongo": {
+            "_id": "mongo",
+            "last_activity": datetime(2026, 1, 2, 8),
+        },
+    }
+
+
+def test_first_and_last_play_by_user(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {
+                "_id": 1,
+                "course_id": "python",
+                "user_id": "ada",
+                "created_date": datetime(2026, 2, 4),
+            },
+            {
+                "_id": 2,
+                "course_id": "python",
+                "user_id": "ada",
+                "created_date": datetime(2026, 2, 1),
+            },
+            {
+                "_id": 3,
+                "course_id": "python",
+                "user_id": "grace",
+                "created_date": datetime(2026, 2, 3),
+            },
+            {
+                "_id": 4,
+                "course_id": "mongo",
+                "user_id": "ada",
+                "created_date": datetime(2026, 2, 9),
+            },
+        ]
+    )
+
+    rows = list(
+        collection.aggregate(
+            [
+                {
+                    "$match": {
+                        "course_id": "python",
+                        "user_id": {"$in": ["ada", "grace"]},
+                    }
+                },
+                {
+                    "$group": {
+                        "_id": "$user_id",
+                        "first_play": {"$min": "$created_date"},
+                        "last_play": {"$max": "$created_date"},
+                    }
+                },
+            ]
+        )
+    )
+
+    assert _by_id(rows) == {
+        "ada": {
+            "_id": "ada",
+            "first_play": datetime(2026, 2, 1),
+            "last_play": datetime(2026, 2, 4),
+        },
+        "grace": {
+            "_id": "grace",
+            "first_play": datetime(2026, 2, 3),
+            "last_play": datetime(2026, 2, 3),
+        },
+    }
+
+
+def test_whole_collection_rollup(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {
+                "_id": 1,
+                "user_id": "ada",
+                "course_id": "python",
+                "created_date": datetime(2026, 3, 1),
+            },
+            {
+                "_id": 2,
+                "user_id": "ada",
+                "course_id": "python",
+                "created_date": datetime(2026, 3, 5),
+            },
+            {
+                "_id": 3,
+                "user_id": "grace",
+                "course_id": "python",
+                "created_date": datetime(2026, 3, 9),
+            },
+        ]
+    )
+
+    assert list(
+        collection.aggregate(
+            [
+                {"$match": {"user_id": "ada", "course_id": "python"}},
+                {
+                    "$group": {
+                        "_id": None,
+                        "last_activity": {"$max": "$created_date"},
+                    }
+                },
+            ]
+        )
+    ) == [{"_id": None, "last_activity": datetime(2026, 3, 5)}]
+
+
+def test_match_reuses_query_semantics_and_can_follow_group(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {
+                "_id": 1,
+                "team": "alpha",
+                "profile": {"name": "Ada", "score": 9},
+            },
+            {
+                "_id": 2,
+                "team": "alpha",
+                "profile": {"name": "Grace", "score": 7},
+            },
+            {
+                "_id": 3,
+                "team": "beta",
+                "profile": {"name": "Lin", "score": 10},
+            },
+        ]
+    )
+
+    matched = list(
+        collection.aggregate(
+            [
+                {
+                    "$match": {
+                        "$and": [
+                            {"profile.score": {"$gte": 7, "$lte": 9}},
+                            {"profile.name": {"$regex": "^a", "$options": "i"}},
+                            {"_id": {"$ne": 99}},
+                        ]
+                    }
+                }
+            ]
+        )
+    )
+    assert [row["_id"] for row in matched] == [1]
+
+    grouped = list(
+        collection.aggregate(
+            [
+                {"$group": {"_id": "$team", "total": {"$sum": 1}}},
+                {"$match": {"total": {"$gte": 2}}},
+            ]
+        )
+    )
+    assert grouped == [{"_id": "alpha", "total": 2}]
+
+
+def test_sum_and_min_max_follow_mongodb_value_rules(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "group": "one", "amount": 2, "value": None},
+            {"_id": 2, "group": "one", "amount": 1.5, "value": 5},
+            {"_id": 3, "group": "one", "amount": True, "value": "text"},
+            {
+                "_id": 4,
+                "group": "one",
+                "amount": "ignored",
+                "value": datetime(2026, 4, 1),
+            },
+            {"_id": 5, "group": "one", "amount": [100]},
+            {"_id": 6, "group": "one"},
+        ]
+    )
+
+    assert list(
+        collection.aggregate(
+            [
+                {
+                    "$group": {
+                        "_id": "$group",
+                        "count": {"$sum": 1},
+                        "total": {"$sum": "$amount"},
+                        "minimum": {"$min": "$value"},
+                        "maximum": {"$max": "$value"},
+                    }
+                }
+            ]
+        )
+    ) == [
+        {
+            "_id": "one",
+            "count": 6,
+            "total": 3.5,
+            "minimum": 5,
+            "maximum": datetime(2026, 4, 1),
+        }
+    ]
+
+
+def test_null_missing_keys_and_empty_inputs(contract_target):
+    collection = contract_target.collection
+    assert (
+        list(collection.aggregate([{"$group": {"_id": None, "n": {"$sum": 1}}}])) == []
+    )
+
+    collection.insert_many(
+        [
+            {"_id": 1, "bucket": None, "value": None},
+            {"_id": 2},
+        ]
+    )
+    assert list(
+        collection.aggregate(
+            [
+                {
+                    "$group": {
+                        "_id": "$bucket",
+                        "minimum": {"$min": "$value"},
+                        "maximum": {"$max": "$value"},
+                    }
+                }
+            ]
+        )
+    ) == [{"_id": None, "minimum": None, "maximum": None}]
+    assert (
+        list(
+            collection.aggregate(
+                [
+                    {"$match": {"_id": "missing"}},
+                    {"$group": {"_id": None, "n": {"$sum": 1}}},
+                ]
+            )
+        )
+        == []
+    )
+
+
+def test_dotted_paths_preserve_empty_array_traversals(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "items": []},
+            {"_id": 2, "items": [{}, {}]},
+            {"_id": 3, "items": [{}, {"score": 3}]},
+            {"_id": 4},
+        ]
+    )
+
+    rows = list(
+        collection.aggregate(
+            [{"$group": {"_id": "$items.score", "count": {"$sum": 1}}}]
+        )
+    )
+
+    assert len(rows) == 3
+    assert any(row == {"_id": [], "count": 2} for row in rows)
+    assert any(row == {"_id": [3], "count": 1} for row in rows)
+    assert any(row == {"_id": None, "count": 1} for row in rows)
+
+
+def test_project_size_ifnull_application_rollup(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "course_id": "python", "lectures": ["a", "b"]},
+            {"_id": 2, "course_id": "python", "lectures": []},
+            {"_id": 3, "course_id": "python", "lectures": None},
+            {"_id": 4, "course_id": "python"},
+            {"_id": 5, "course_id": "mongo", "lectures": ["one"]},
+            {"_id": 6, "course_id": "excluded", "lectures": [1, 2, 3]},
+        ]
+    )
+
+    rows = list(
+        collection.aggregate(
+            [
+                {"$match": {"course_id": {"$in": ["python", "mongo"]}}},
+                {
+                    "$project": {
+                        "course_id": 1,
+                        "count": {"$size": {"$ifNull": ["$lectures", []]}},
+                    }
+                },
+                {
+                    "$group": {
+                        "_id": "$course_id",
+                        "total": {"$sum": "$count"},
+                    }
+                },
+            ]
+        )
+    )
+
+    assert _by_id(rows) == {
+        "python": {"_id": "python", "total": 2},
+        "mongo": {"_id": "mongo", "total": 1},
+    }
+
+
+def test_project_inclusion_id_and_expression_contract(contract_target):
+    collection = contract_target.collection
+    collection.insert_one(
+        {
+            "_id": 1,
+            "course_id": "python",
+            "lectures": ["one", "two"],
+            "profile": {"name": "Ada", "secret": "hidden"},
+        }
+    )
+
+    assert list(
+        collection.aggregate(
+            [
+                {
+                    "$project": {
+                        "course_id": 1,
+                        "profile.name": 1,
+                        "copied": "$profile.name",
+                        "fallback": {
+                            "$ifNull": ["$missing", "$profile.name", "unknown"]
+                        },
+                    }
+                }
+            ]
+        )
+    ) == [
+        {
+            "_id": 1,
+            "course_id": "python",
+            "profile": {"name": "Ada"},
+            "copied": "Ada",
+            "fallback": "Ada",
+        }
+    ]
+    assert list(
+        collection.aggregate(
+            [
+                {
+                    "$project": {
+                        "_id": 0,
+                        "course_id": 1,
+                        "count": {"$size": "$lectures"},
+                    }
+                }
+            ]
+        )
+    ) == [{"course_id": "python", "count": 2}]
+
+
+def test_project_dotted_inclusion_preserves_array_shape(contract_target):
+    collection = contract_target.collection
+    collection.insert_one(
+        {
+            "_id": 1,
+            "items": [
+                {"name": "intro", "secret": 1},
+                {},
+                {"name": "loops", "secret": 2},
+            ],
+        }
+    )
+
+    assert list(collection.aggregate([{"$project": {"_id": 0, "items.name": 1}}])) == [
+        {"items": [{"name": "intro"}, {}, {"name": "loops"}]}
+    ]
+
+
+def test_project_expression_argument_and_lazy_evaluation_contract(contract_target):
+    collection = contract_target.collection
+    collection.insert_one(
+        {
+            "_id": 1,
+            "zero": 0,
+            "not_an_array": "bad",
+            "values": [1, 2, 3],
+        }
+    )
+
+    assert list(
+        collection.aggregate(
+            [
+                {
+                    "$project": {
+                        "_id": 0,
+                        "field_size": {"$size": ["$values"]},
+                        "literal_size": {"$size": [[1, 2]]},
+                        "literal_empty_size": {"$size": [[]]},
+                        "lazy": {"$ifNull": ["$zero", {"$size": "$not_an_array"}]},
+                        "missing_ifnull": {"$ifNull": ["$missing_one", "$missing_two"]},
+                        "tuple_literal": (1, 2),
+                        "tuple_size": {"$size": ((1, 2),)},
+                    }
+                }
+            ]
+        )
+    ) == [
+        {
+            "field_size": 3,
+            "literal_size": 2,
+            "literal_empty_size": 0,
+            "lazy": 0,
+            "tuple_literal": [1, 2],
+            "tuple_size": 2,
+        }
+    ]
+
+    for operand in ([], [1, 2]):
+        outcome = observe(
+            lambda operand=operand: list(
+                collection.aggregate([{"$project": {"invalid": {"$size": operand}}}])
+            )
+        )
+        assert outcome.error == "operation_failure"
+
+
+def test_aggregate_cursor_consumes_in_chunks(contract_target):
+    collection = contract_target.collection
+    collection.insert_many([{"_id": 1}, {"_id": 2}])
+
+    cursor = collection.aggregate([])
+    assert cursor.to_list(length=1) == [{"_id": 1}]
+    assert cursor.to_list() == [{"_id": 2}]
+    assert cursor.to_list() == []

--- a/compat/mongo/v1/runner/contracts/test_aggregation_projection_stages_contract.py
+++ b/compat/mongo/v1/runner/contracts/test_aggregation_projection_stages_contract.py
@@ -1,0 +1,283 @@
+"""Projection-stage contracts shared by TinyMongo and MongoDB."""
+
+import pytest
+
+from .support import observe
+
+
+pytestmark = pytest.mark.contract
+
+
+def test_project_inclusion_exclusion_and_computed_modes(contract_target):
+    collection = contract_target.collection
+    collection.insert_one(
+        {
+            "_id": 1,
+            "name": "Ada",
+            "secret": "hidden",
+            "profile": {"email": "ada@example.com", "age": 36},
+            "items": [{"name": "one", "extra": 1}, {}, 3],
+        }
+    )
+
+    assert list(
+        collection.aggregate([{"$project": {"name": 1, "profile.email": 1}}])
+    ) == [
+        {
+            "_id": 1,
+            "name": "Ada",
+            "profile": {"email": "ada@example.com"},
+        }
+    ]
+    assert list(
+        collection.aggregate([{"$project": {"secret": 0, "profile.age": 0}}])
+    ) == [
+        {
+            "_id": 1,
+            "name": "Ada",
+            "profile": {"email": "ada@example.com"},
+            "items": [{"name": "one", "extra": 1}, {}, 3],
+        }
+    ]
+    assert list(
+        collection.aggregate(
+            [
+                {
+                    "$project": {
+                        "_id": 0,
+                        "renamed": "$name",
+                        "profile": {"email": 1, "label": "$name"},
+                    }
+                }
+            ]
+        )
+    ) == [
+        {
+            "renamed": "Ada",
+            "profile": {"email": "ada@example.com", "label": "Ada"},
+        }
+    ]
+
+    for invalid_project in (
+        {"name": 1, "secret": 0},
+        {"secret": 0, "computed": "$name"},
+    ):
+        outcome = observe(
+            lambda invalid_project=invalid_project: list(
+                collection.aggregate([{"$project": invalid_project}])
+            )
+        )
+        assert outcome.error == "operation_failure"
+
+
+def test_project_computed_dotted_paths_preserve_array_shape(contract_target):
+    collection = contract_target.collection
+    collection.insert_one(
+        {
+            "_id": 1,
+            "title": "Course",
+            "items": [{"name": "one", "extra": 1}, {}, 3],
+            "scalar": "old",
+            "empty": [],
+        }
+    )
+
+    assert list(
+        collection.aggregate(
+            [
+                {
+                    "$project": {
+                        "_id": 0,
+                        "items.name": 1,
+                        "items.label": "$title",
+                        "created.value": "$title",
+                        "scalar.value": "$title",
+                        "empty.value": "$title",
+                        "missing.value": "$not_there",
+                    }
+                }
+            ]
+        )
+    ) == [
+        {
+            "items": [
+                {"name": "one", "label": "Course"},
+                {"label": "Course"},
+                {"label": "Course"},
+            ],
+            "created": {"value": "Course"},
+            "scalar": {"value": "Course"},
+            "empty": [],
+            "missing": {},
+        }
+    ]
+
+
+def test_set_and_add_fields_are_aliases_using_original_input(contract_target):
+    collection = contract_target.collection
+    original = {
+        "_id": 1,
+        "existing": "old",
+        "profile": {"name": "Ada"},
+        "items": [{"name": "one"}, {}, 3],
+    }
+    collection.insert_one(original.copy())
+    expected = {
+        "_id": 1,
+        "existing": "new",
+        "copied": "old",
+        "profile": {"name": "Ada", "label": "old"},
+        "items": [
+            {"name": "one", "label": "old"},
+            {"label": "old"},
+            {"label": "old"},
+        ],
+    }
+    specification = {
+        "existing": "new",
+        "copied": "$existing",
+        "missing": "$not_there",
+        "profile.label": "$existing",
+        "items.label": "$existing",
+    }
+
+    for stage in ("$set", "$addFields"):
+        assert list(collection.aggregate([{stage: specification}])) == [expected]
+        assert list(collection.aggregate([{stage: {}}])) == [original]
+
+
+def test_unset_accepts_one_or_many_dotted_fields(contract_target):
+    collection = contract_target.collection
+    collection.insert_one(
+        {
+            "_id": 1,
+            "name": "Ada",
+            "secret": "hidden",
+            "profile": {"email": "ada@example.com", "age": 36},
+            "items": [{"name": "one", "secret": 1}, {}, 3],
+        }
+    )
+
+    assert list(collection.aggregate([{"$unset": "secret"}])) == [
+        {
+            "_id": 1,
+            "name": "Ada",
+            "profile": {"email": "ada@example.com", "age": 36},
+            "items": [{"name": "one", "secret": 1}, {}, 3],
+        }
+    ]
+    assert list(
+        collection.aggregate([{"$unset": ["secret", "profile.age", "items.secret"]}])
+    ) == [
+        {
+            "_id": 1,
+            "name": "Ada",
+            "profile": {"email": "ada@example.com"},
+            "items": [{"name": "one"}, {}, 3],
+        }
+    ]
+
+
+def test_literal_and_remove_expression_contract(contract_target):
+    collection = contract_target.collection
+    collection.insert_one(
+        {
+            "_id": 1,
+            "name": "Ada",
+            "secret": "hidden",
+            "profile": {"email": "ada@example.com", "age": 36},
+            "items": [1, 2],
+        }
+    )
+
+    assert list(
+        collection.aggregate(
+            [
+                {
+                    "$project": {
+                        "_id": 0,
+                        "kept": "$name",
+                        "literal_number": {"$literal": 1},
+                        "literal_bool": {"$literal": False},
+                        "literal_path": {"$literal": "$name"},
+                        "literal_document": {"$literal": {"$size": "$items"}},
+                        "literal_array": {"$literal": ("$name", {"$size": "$items"})},
+                        "dropped": "$$REMOVE",
+                        "holder.drop": "$$REMOVE",
+                        "array": ["$$REMOVE", "$name"],
+                    }
+                }
+            ]
+        )
+    ) == [
+        {
+            "kept": "Ada",
+            "literal_number": 1,
+            "literal_bool": False,
+            "literal_path": "$name",
+            "literal_document": {"$size": "$items"},
+            "literal_array": ["$name", {"$size": "$items"}],
+            "holder": {},
+            "array": [None, "Ada"],
+        }
+    ]
+    assert list(
+        collection.aggregate(
+            [{"$set": {"secret": "$$REMOVE", "profile.age": "$$REMOVE"}}]
+        )
+    ) == [
+        {
+            "_id": 1,
+            "name": "Ada",
+            "profile": {"email": "ada@example.com"},
+            "items": [1, 2],
+        }
+    ]
+
+
+def test_field_paths_do_not_descend_through_nested_arrays(contract_target):
+    collection = contract_target.collection
+    collection.insert_one(
+        {
+            "_id": 1,
+            "nested": [[{"score": 7}], 2],
+            "direct": [{"score": 3}, [{"score": 4}], {"score": 5}],
+        }
+    )
+
+    assert list(
+        collection.aggregate(
+            [
+                {
+                    "$project": {
+                        "_id": 0,
+                        "nested_scores": "$nested.score",
+                        "direct_scores": "$direct.score",
+                    }
+                }
+            ]
+        )
+    ) == [{"nested_scores": [], "direct_scores": [3, 5]}]
+
+
+def test_project_preserves_embedded_source_order_for_group_identity(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "value": {"x": 1, "y": 2}},
+            {"_id": 2, "value": {"y": 2, "x": 1}},
+        ]
+    )
+
+    rows = list(
+        collection.aggregate(
+            [
+                {"$project": {"_id": 0, "value.x": 1, "value.y": 1}},
+                {"$group": {"_id": "$value", "count": {"$sum": 1}}},
+            ]
+        )
+    )
+
+    assert len(rows) == 2
+    assert [row["count"] for row in rows] == [1, 1]
+    assert {tuple(row["_id"]) for row in rows} == {("x", "y"), ("y", "x")}

--- a/compat/mongo/v1/runner/contracts/test_array_update_contract.py
+++ b/compat/mongo/v1/runner/contracts/test_array_update_contract.py
@@ -1,0 +1,451 @@
+"""Array-update contracts shared by every backend and both APIs."""
+
+import pytest
+
+from .support import WRITE_ERRORS as _WRITE_ERRORS
+from .support import observe
+
+
+pytestmark = pytest.mark.contract
+
+def test_push_each_slice_keeps_a_bounded_array(contract_target):
+    collection = contract_target.collection
+    collection.insert_one({"_id": "capped", "pages": ["p1"]})
+
+    result = collection.update_one(
+        {"_id": "capped"},
+        {"$push": {"pages": {"$each": ["p2", "p3"], "$slice": -2}}},
+    )
+
+    assert (result.matched_count, result.modified_count) == (1, 1)
+    assert collection.find_one({"_id": "capped"})["pages"] == ["p2", "p3"]
+
+    for number in range(4, 10):
+        collection.update_one(
+            {"_id": "capped"},
+            {
+                "$push": {
+                    "pages": {
+                        "$each": ["p{0}".format(number)],
+                        "$slice": -2,
+                    }
+                }
+            },
+        )
+
+    pages = collection.find_one({"_id": "capped"})["pages"]
+    assert pages == ["p8", "p9"]
+    assert len(pages) == 2
+
+
+def test_push_modifiers_follow_mongodb_order_and_boundaries(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "position-positive", "values": [50, 60, 70, 100]},
+            {
+                "_id": "position-negative",
+                "values": [50, 60, 20, 30, 70, 100],
+            },
+            {"_id": "position-high", "values": [2, 3]},
+            {"_id": "position-low", "values": [2, 3]},
+            {"_id": "sort-ascending", "values": [3, 1]},
+            {"_id": "sort-descending", "values": [1, 3]},
+            {"_id": "sort-bson-distinct", "values": [True, 1]},
+            {
+                "_id": "sort-document",
+                "values": [
+                    {"meta": {"score": 3}},
+                    {"meta": {"score": 1}},
+                ],
+            },
+            {
+                "_id": "sort-compound",
+                "values": [
+                    {"group": "b", "score": 1},
+                    {"group": "a", "score": 1},
+                ],
+            },
+            {"_id": "slice-positive", "values": [1, 2, 3]},
+            {"_id": "slice-negative", "values": [1, 2, 3]},
+            {"_id": "slice-zero", "values": [1, 2, 3]},
+            {"_id": "combined", "values": [3, 1]},
+        ]
+    )
+
+    updates = {
+        "position-positive": {"$each": [20, 30], "$position": 2},
+        "position-negative": {"$each": [90, 80], "$position": -2},
+        "position-high": {"$each": [4], "$position": 99},
+        "position-low": {"$each": [0, 1], "$position": -99},
+        "sort-ascending": {"$each": [2], "$sort": 1},
+        "sort-descending": {"$each": [2], "$sort": -1},
+        "sort-bson-distinct": {"$each": [], "$sort": 1},
+        "sort-document": {
+            "$each": [{"meta": {"score": 2}}],
+            "$sort": {"meta.score": 1},
+        },
+        "sort-compound": {
+            "$each": [{"group": "a", "score": 2}],
+            "$sort": {"group": 1, "score": -1},
+        },
+        "slice-positive": {"$each": [4], "$slice": 2},
+        "slice-negative": {"$each": [4], "$slice": -2},
+        "slice-zero": {"$each": [4], "$slice": 0},
+        # The deliberately scrambled keys prove semantic processing order.
+        "combined": {"$slice": 3, "$sort": 1, "$each": [2, 0], "$position": 1},
+    }
+    results = {}
+    for document_id, modifier in updates.items():
+        results[document_id] = collection.update_one(
+            {"_id": document_id}, {"$push": {"values": modifier}}
+        )
+
+    expected = {
+        "position-positive": [50, 60, 20, 30, 70, 100],
+        "position-negative": [50, 60, 20, 30, 90, 80, 70, 100],
+        "position-high": [2, 3, 4],
+        "position-low": [0, 1, 2, 3],
+        "sort-ascending": [1, 2, 3],
+        "sort-descending": [3, 2, 1],
+        "sort-bson-distinct": [1, True],
+        "sort-document": [
+            {"meta": {"score": 1}},
+            {"meta": {"score": 2}},
+            {"meta": {"score": 3}},
+        ],
+        "sort-compound": [
+            {"group": "a", "score": 2},
+            {"group": "a", "score": 1},
+            {"group": "b", "score": 1},
+        ],
+        "slice-positive": [1, 2],
+        "slice-negative": [3, 4],
+        "slice-zero": [],
+        "combined": [0, 1, 2],
+    }
+    for document_id, values in expected.items():
+        assert collection.find_one({"_id": document_id})["values"] == values
+    assert results["sort-bson-distinct"].modified_count == 1
+
+
+def test_plain_push_and_add_to_set_each_regressions(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "push", "values": []},
+            {
+                "_id": "set",
+                "values": [1, {"a": 1, "b": 2}],
+            },
+        ]
+    )
+
+    collection.update_one({"_id": "push"}, {"$push": {"values": "plain"}})
+    collection.update_one({"_id": "push"}, {"$push": {"values": {"name": "document"}}})
+    collection.update_one({"_id": "push"}, {"$push": {"values": ["nested"]}})
+
+    modifier = {
+        "$each": [
+            1.0,
+            True,
+            2,
+            2,
+            {"a": 1, "b": 2},
+            {"b": 2, "a": 1},
+        ]
+    }
+    changed = collection.update_one({"_id": "set"}, {"$addToSet": {"values": modifier}})
+    unchanged = collection.update_one(
+        {"_id": "set"}, {"$addToSet": {"values": modifier}}
+    )
+
+    assert collection.find_one({"_id": "push"})["values"] == [
+        "plain",
+        {"name": "document"},
+        ["nested"],
+    ]
+    values = collection.find_one({"_id": "set"})["values"]
+    assert values[:4] == [1, {"a": 1, "b": 2}, True, 2]
+    assert list(values[4].items()) == [("b", 2), ("a", 1)]
+    assert (changed.modified_count, unchanged.modified_count) == (1, 0)
+
+
+def test_invalid_array_modifiers_fail_atomically(contract_target):
+    collection = contract_target.collection
+    original = {"_id": "invalid", "values": [1], "status": "original"}
+    collection.insert_one(original)
+
+    malformed_each = observe(
+        lambda: collection.update_one(
+            {"_id": "invalid"},
+            {"$push": {"values": {"$each": "not-an-array"}}},
+        )
+    )
+    unknown_modifier = observe(
+        lambda: collection.update_one(
+            {"_id": "invalid"},
+            {
+                "$set": {"status": "changed"},
+                "$push": {"values": {"$each": [], "$unknown": 1}},
+            },
+        )
+    )
+    unknown_operator = observe(
+        lambda: collection.update_one({"_id": "invalid"}, {"$unknown": {"values": 1}})
+    )
+
+    assert malformed_each.error is not None
+    assert unknown_modifier.error is not None
+    assert unknown_operator.error is not None
+    assert collection.find_one({"_id": "invalid"}) == original
+
+
+def test_pull_accepts_literal_and_query_operands(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "range", "values": [5, 8, 10]},
+            {"_id": "literal", "values": [1, [1, 2], [2, 3]]},
+            {
+                "_id": "documents",
+                "values": [
+                    {"kind": "x", "meta": {"score": 5}},
+                    {"kind": "x", "meta": {"score": 9}},
+                    {"kind": "y", "meta": {"score": 10}},
+                    7,
+                ],
+            },
+        ]
+    )
+
+    collection.update_one({"_id": "range"}, {"$pull": {"values": {"$gte": 8}}})
+    collection.update_one({"_id": "literal"}, {"$pull": {"values": 1}})
+    collection.update_one(
+        {"_id": "documents"},
+        {"$pull": {"values": {"kind": "x", "meta.score": {"$gte": 8}}}},
+    )
+
+    assert collection.find_one({"_id": "range"})["values"] == [5]
+    assert collection.find_one({"_id": "literal"})["values"] == [
+        [1, 2],
+        [2, 3],
+    ]
+    assert collection.find_one({"_id": "documents"})["values"] == [
+        {"kind": "x", "meta": {"score": 5}},
+        {"kind": "y", "meta": {"score": 10}},
+        7,
+    ]
+
+
+def test_pull_query_operator_family_matches_mongodb(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "in", "values": ["alpha", "beta", "gamma"]},
+            {"_id": "nin", "values": ["alpha", "beta", "gamma"]},
+            {"_id": "regex", "values": ["alpha", "ALPHA", "beta"]},
+            {"_id": "elem", "values": [[1, 3], [1, 2], ["x"], 1]},
+        ]
+    )
+
+    collection.update_one(
+        {"_id": "in"},
+        {"$pull": {"values": {"$in": ["alpha", "gamma"]}}},
+    )
+    collection.update_one(
+        {"_id": "nin"},
+        {"$pull": {"values": {"$nin": ["alpha", "gamma"]}}},
+    )
+    collection.update_one(
+        {"_id": "regex"},
+        {"$pull": {"values": {"$regex": "^alpha$", "$options": "i"}}},
+    )
+    collection.update_one(
+        {"_id": "elem"},
+        {"$pull": {"values": {"$elemMatch": {"$gt": 2}}}},
+    )
+
+    assert collection.find_one({"_id": "in"})["values"] == ["beta"]
+    assert collection.find_one({"_id": "nin"})["values"] == ["alpha", "gamma"]
+    assert collection.find_one({"_id": "regex"})["values"] == ["beta"]
+    assert collection.find_one({"_id": "elem"})["values"] == [
+        [1, 2],
+        ["x"],
+        1,
+    ]
+
+
+def test_tm038_pull_remaining_field_predicates_match_mongodb(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "exists", "values": [{"a": 1}, {"b": 2}, {}]},
+            {"_id": "type", "values": [1, "x", [1, 2], {"a": 1}]},
+            {"_id": "ne", "values": [1, 2, 3]},
+            {"_id": "mod", "values": [1, 2, 3, 4]},
+            {"_id": "all", "values": [[1, 2], [1], [2, 1, 3], 1]},
+            {"_id": "size", "values": [[1, 2], [1], [], 1]},
+            {
+                "_id": "not",
+                "values": [{"score": 1}, {"score": 8}, {"other": 2}],
+            },
+        ]
+    )
+
+    predicates = {
+        "exists": {"a": {"$exists": False}},
+        "type": {"$type": "array"},
+        "ne": {"$ne": 2},
+        "mod": {"$mod": [2, 0]},
+        "all": {"$all": [1, 2]},
+        "size": {"$size": 2},
+        "not": {"score": {"$not": {"$gte": 5}}},
+    }
+    for document_id, predicate in predicates.items():
+        collection.update_one(
+            {"_id": document_id},
+            {"$pull": {"values": predicate}},
+        )
+
+    assert collection.find_one({"_id": "exists"})["values"] == [{"a": 1}]
+    assert collection.find_one({"_id": "type"})["values"] == [
+        1,
+        "x",
+        {"a": 1},
+    ]
+    assert collection.find_one({"_id": "ne"})["values"] == [2]
+    assert collection.find_one({"_id": "mod"})["values"] == [1, 3]
+    assert collection.find_one({"_id": "all"})["values"] == [[1], 1]
+    assert collection.find_one({"_id": "size"})["values"] == [[1], [], 1]
+    assert collection.find_one({"_id": "not"})["values"] == [{"score": 8}]
+
+
+def test_tm038_pull_expr_errors_are_preflighted_like_mongodb(contract_target):
+    collection = contract_target.collection
+    original = {
+        "_id": "expr",
+        "values": [{"score": 1}, {"score": 2}],
+    }
+    collection.insert_one(original)
+
+    expressions = [
+        {"$expr": {"$eq": [1, 1]}},
+        {"$or": [{"$expr": {"$eq": [1, 1]}}, {"score": 2}]},
+        {"$and": [{"score": {"$gte": 1}}, {"$expr": {"$eq": [1, 1]}}]},
+        {"$nor": [{"$expr": {"$eq": [1, 1]}}, {"score": 3}]},
+    ]
+    for expression in expressions:
+        with pytest.raises(_WRITE_ERRORS) as caught:
+            collection.update_one(
+                {"_id": "expr"},
+                {"$pull": {"values": expression}},
+            )
+        assert caught.value.code == 224
+        assert collection.find_one({"_id": "expr"}) == original
+
+    nested_code_two = [
+        {"score": {"$expr": {"$eq": [1, 1]}}},
+        {"score": {"$not": {"$unknown": 1}}},
+        {"$elemMatch": {"$expr": {"$eq": [1, 1]}}},
+    ]
+    for expression in nested_code_two:
+        with pytest.raises(_WRITE_ERRORS) as caught:
+            collection.update_one(
+                {"_id": "expr"},
+                {"$pull": {"values": expression}},
+            )
+        assert caught.value.code == 2
+        assert collection.find_one({"_id": "expr"}) == original
+
+
+def test_pull_missing_fields_are_true_noops(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "present", "values": ["remove", "keep"]},
+            {"_id": "missing", "other": 1},
+            {"_id": "empty", "values": []},
+        ]
+    )
+
+    result = collection.update_many({}, {"$pull": {"values": "remove"}})
+
+    assert (result.matched_count, result.modified_count) == (3, 1)
+    assert collection.find_one({"_id": "present"})["values"] == ["keep"]
+    assert "values" not in collection.find_one({"_id": "missing"})
+    assert collection.count_documents({"values": {"$exists": False}}) == 1
+
+
+def test_pull_all_uses_literal_bson_equality(contract_target):
+    collection = contract_target.collection
+    original = {
+        "_id": "values",
+        "values": [
+            True,
+            1,
+            1.0,
+            [1, 2],
+            [2, 1],
+            {"a": 1, "b": 2},
+            {"b": 2, "a": 1},
+        ],
+    }
+    collection.insert_many([original, {"_id": "missing", "other": 1}])
+
+    changed = collection.update_one(
+        {"_id": "values"},
+        {"$pullAll": {"values": [1.0, [1, 2], {"a": 1, "b": 2}]}},
+    )
+    unchanged = collection.update_one({"_id": "values"}, {"$pullAll": {"values": []}})
+    missing = collection.update_one({"_id": "missing"}, {"$pullAll": {"values": [1]}})
+
+    assert (changed.modified_count, unchanged.modified_count) == (1, 0)
+    assert missing.modified_count == 0
+    assert collection.find_one({"_id": "values"})["values"] == [
+        True,
+        [2, 1],
+        {"b": 2, "a": 1},
+    ]
+    assert "values" not in collection.find_one({"_id": "missing"})
+
+
+@pytest.mark.parametrize(
+    ("operator", "operand"),
+    [
+        ("$pull", "remove"),
+        ("$push", "append"),
+        ("$pullAll", ["remove"]),
+    ],
+)
+def test_array_updates_reject_non_array_targets(contract_target, operator, operand):
+    collection = contract_target.collection
+    collection.insert_one({"_id": "scalar", "values": "not-an-array"})
+
+    with pytest.raises(_WRITE_ERRORS) as caught:
+        collection.update_one(
+            {"_id": "scalar"},
+            {operator: {"values": operand}},
+        )
+
+    assert caught.value.code == 2
+    assert collection.find_one({"_id": "scalar"})["values"] == "not-an-array"
+
+
+def test_pull_not_and_pull_all_operand_errors_match_mongodb(contract_target):
+    collection = contract_target.collection
+    collection.insert_one({"_id": "invalid", "values": [1, 2]})
+
+    with pytest.raises(_WRITE_ERRORS) as pull_not:
+        collection.update_one(
+            {"_id": "invalid"},
+            {"$pull": {"values": {"$not": {"$eq": 2}}}},
+        )
+    with pytest.raises(_WRITE_ERRORS) as pull_all:
+        collection.update_one(
+            {"_id": "invalid"},
+            {"$pullAll": {"values": "not-an-array-operand"}},
+        )
+
+    assert (pull_not.value.code, pull_all.value.code) == (2, 2)
+    assert collection.find_one({"_id": "invalid"})["values"] == [1, 2]

--- a/compat/mongo/v1/runner/contracts/test_beanie_odm_contract.py
+++ b/compat/mongo/v1/runner/contracts/test_beanie_odm_contract.py
@@ -1,0 +1,74 @@
+from collections.abc import Mapping
+
+import pytest
+
+
+pytestmark = pytest.mark.contract
+
+
+def _assert_update_reply(result, *, matched, modified, existing, upserted=None):
+    assert isinstance(result.raw_result, Mapping)
+    assert result.raw_result["n"] == (1 if upserted is not None else matched)
+    assert result.raw_result["nModified"] == modified
+    assert result.raw_result["updatedExisting"] is existing
+    assert result.raw_result["ok"] == 1.0
+    if upserted is None:
+        assert "upserted" not in result.raw_result
+    else:
+        assert result.raw_result["upserted"] == upserted
+    assert result.matched_count == matched
+    assert result.modified_count == modified
+    assert result.upserted_id == upserted
+    assert result.did_upsert is (upserted is not None)
+
+
+def _assert_delete_reply(result, deleted):
+    assert isinstance(result.raw_result, Mapping)
+    assert result.raw_result["n"] == deleted
+    assert result.raw_result["ok"] == 1.0
+    assert result.deleted_count == deleted
+
+
+def test_beanie_write_result_contract(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "value": 0},
+            {"_id": 2, "value": 0},
+        ]
+    )
+
+    changed = collection.update_one({"_id": 1}, {"$set": {"value": 1}})
+    _assert_update_reply(changed, matched=1, modified=1, existing=True)
+
+    unchanged = collection.update_one({"_id": 1}, {"$set": {"value": 1}})
+    _assert_update_reply(unchanged, matched=1, modified=0, existing=True)
+
+    # An omitted _id can make an otherwise equal replacement count as modified
+    # on MongoDB, so exercise replacement with an intentional value change.
+    replaced = collection.replace_one({"_id": 1}, {"value": 2})
+    _assert_update_reply(replaced, matched=1, modified=1, existing=True)
+
+    missing = collection.update_one({"_id": 99}, {"$set": {"value": 1}})
+    _assert_update_reply(missing, matched=0, modified=0, existing=False)
+
+    collection.update_one({"_id": 1}, {"$set": {"seen": True}})
+    many = collection.update_many({}, {"$set": {"seen": True}})
+    _assert_update_reply(many, matched=2, modified=1, existing=True)
+
+    upserted = collection.replace_one(
+        {"_id": 3},
+        {"_id": 3, "value": 3},
+        upsert=True,
+    )
+    _assert_update_reply(
+        upserted,
+        matched=0,
+        modified=0,
+        existing=False,
+        upserted=3,
+    )
+
+    _assert_delete_reply(collection.delete_one({"_id": 2}), 1)
+    _assert_delete_reply(collection.delete_many({"_id": 99}), 0)
+    _assert_delete_reply(collection.delete_many({"seen": True}), 1)

--- a/compat/mongo/v1/runner/contracts/test_bson_comparison_contract.py
+++ b/compat/mongo/v1/runner/contracts/test_bson_comparison_contract.py
@@ -1,0 +1,619 @@
+"""Issue #94 contracts for MongoDB-compatible BSON range comparison."""
+
+from datetime import datetime, timezone
+import re
+
+import pytest
+
+from .support import OPERATION_ERRORS as _OPERATION_ERRORS
+from .support import WRITE_ERRORS as _WRITE_ERRORS
+
+
+pytestmark = pytest.mark.contract
+bson = pytest.importorskip("bson")
+Binary = bson.Binary
+MaxKey = bson.MaxKey
+MinKey = bson.MinKey
+ObjectId = bson.ObjectId
+Regex = bson.Regex
+
+def _ids(rows):
+    return {document["_id"] for document in rows}
+
+
+@pytest.mark.parametrize(
+    ("documents", "operand", "expected"),
+    [
+        pytest.param(
+            [
+                {"_id": "lower", "value": -1},
+                {"_id": "integer-equal", "value": 1},
+                {"_id": "double-equal", "value": 1.0},
+                {"_id": "decimal-equal", "value": bson.Decimal128("1.00")},
+                {"_id": "higher", "value": 2},
+                {"_id": "array-higher", "value": [2]},
+                {"_id": "boolean", "value": True},
+                {"_id": "string", "value": "2"},
+            ],
+            bson.Decimal128("1"),
+            {
+                "$gt": {"higher", "array-higher"},
+                "$gte": {
+                    "integer-equal",
+                    "double-equal",
+                    "decimal-equal",
+                    "higher",
+                    "array-higher",
+                },
+                "$lt": {"lower"},
+                "$lte": {
+                    "lower",
+                    "integer-equal",
+                    "double-equal",
+                    "decimal-equal",
+                },
+            },
+            id="numeric-family",
+        ),
+        pytest.param(
+            [
+                {"_id": "lower", "value": "a"},
+                {"_id": "equal", "value": "b"},
+                {"_id": "higher", "value": "c"},
+                {"_id": "array-higher", "value": ["c"]},
+                {"_id": "number", "value": 99},
+                {"_id": "object", "value": {"value": "c"}},
+            ],
+            "b",
+            {
+                "$gt": {"higher", "array-higher"},
+                "$gte": {"equal", "higher", "array-higher"},
+                "$lt": {"lower"},
+                "$lte": {"lower", "equal"},
+            },
+            id="string-family",
+        ),
+        pytest.param(
+            [
+                {"_id": "false", "value": False},
+                {"_id": "true", "value": True},
+                {"_id": "array-true", "value": [True]},
+                {"_id": "zero", "value": 0},
+                {"_id": "one", "value": 1},
+            ],
+            False,
+            {
+                "$gt": {"true", "array-true"},
+                "$gte": {"false", "true", "array-true"},
+                "$lt": set(),
+                "$lte": {"false"},
+            },
+            id="boolean-family",
+        ),
+    ],
+)
+def test_generated_scalar_range_matrix(
+    contract_target,
+    documents,
+    operand,
+    expected,
+):
+    collection = contract_target.collection
+    collection.insert_many(documents)
+
+    assert {
+        operator: _ids(collection.find({"value": {operator: operand}}))
+        for operator in ("$gt", "$gte", "$lt", "$lte")
+    } == expected
+
+
+def test_tm036_min_max_key_range_operands_cross_type_brackets(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "minimum", "value": MinKey()},
+            {"_id": "null", "value": None},
+            {"_id": "nan", "value": float("nan")},
+            {"_id": "decimal-nan", "value": bson.Decimal128("NaN")},
+            {"_id": "number", "value": 1},
+            {"_id": "string", "value": "value"},
+            {"_id": "object", "value": {"answer": 42}},
+            {"_id": "empty-array", "value": []},
+            {"_id": "array", "value": [1, 2]},
+            {"_id": "maximum", "value": MaxKey()},
+            {"_id": "missing"},
+        ]
+    )
+
+    all_ids = {
+        "minimum",
+        "null",
+        "nan",
+        "decimal-nan",
+        "number",
+        "string",
+        "object",
+        "empty-array",
+        "array",
+        "maximum",
+        "missing",
+    }
+    assert _ids(collection.find({"value": {"$gt": MinKey()}})) == all_ids - {"minimum"}
+    assert _ids(collection.find({"value": {"$gte": MinKey()}})) == all_ids
+    assert _ids(collection.find({"value": {"$lt": MinKey()}})) == set()
+    assert _ids(collection.find({"value": {"$lte": MinKey()}})) == {"minimum"}
+
+    assert _ids(collection.find({"value": {"$lt": MaxKey()}})) == all_ids - {"maximum"}
+    assert _ids(collection.find({"value": {"$lte": MaxKey()}})) == all_ids
+    assert _ids(collection.find({"value": {"$gt": MaxKey()}})) == set()
+    assert _ids(collection.find({"value": {"$gte": MaxKey()}})) == {"maximum"}
+
+    whole_range = {"value": {"$gte": MinKey(), "$lte": MaxKey()}}
+    assert _ids(collection.find(whole_range)) == all_ids
+    assert _ids(collection.aggregate([{"$match": whole_range}])) == all_ids
+
+    # Only MinKey and MaxKey operands span BSON type brackets. Ordinary
+    # numeric predicates still exclude stored values from every other family.
+    assert _ids(collection.find({"value": {"$gt": 0}})) == {"number", "array"}
+    assert _ids(collection.find({"value": {"$in": [MinKey()]}})) == {"minimum"}
+
+
+def test_tm036_extreme_array_members_preserve_exact_semantics(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "minimum-array", "value": [MinKey()]},
+            {"_id": "maximum-array", "value": [MaxKey()]},
+        ]
+    )
+
+    array_ids = {"minimum-array", "maximum-array"}
+    assert _ids(collection.find({"value": {"$gt": MinKey()}})) == array_ids
+    assert _ids(collection.find({"value": {"$lte": MinKey()}})) == {"minimum-array"}
+    assert _ids(collection.find({"value": {"$lt": MaxKey()}})) == array_ids
+    assert _ids(collection.find({"value": {"$gte": MaxKey()}})) == {"maximum-array"}
+
+    assert _ids(collection.find({"value": {"$elemMatch": {"$gt": MinKey()}}})) == {
+        "maximum-array"
+    }
+    assert _ids(collection.find({"value": {"$elemMatch": {"$lte": MinKey()}}})) == {
+        "minimum-array"
+    }
+
+
+def test_tm036_pull_reuses_unbounded_min_max_key_ranges(contract_target):
+    collection = contract_target.collection
+    collection.insert_one(
+        {
+            "_id": "values",
+            "items": [
+                MinKey(),
+                None,
+                1,
+                "value",
+                {"answer": 42},
+                [1, 2],
+                MaxKey(),
+            ],
+        }
+    )
+
+    result = collection.update_one(
+        {"_id": "values"},
+        {"$pull": {"items": {"$gte": MinKey(), "$lte": MaxKey()}}},
+    )
+
+    assert result.matched_count == 1
+    assert result.modified_count == 1
+    assert collection.find_one({"_id": "values"})["items"] == []
+
+
+def test_null_range_queries_include_missing_and_array_members(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "missing"},
+            {"_id": "null", "value": None},
+            {"_id": "array-null", "value": [None, 1]},
+            {"_id": "empty-array", "value": []},
+            {"_id": "zero", "value": 0},
+        ]
+    )
+
+    expected = {"missing", "null", "array-null"}
+    assert _ids(collection.find({"value": {"$gte": None}})) == expected
+    assert _ids(collection.find({"value": {"$lte": None}})) == expected
+    assert _ids(collection.find({"value": {"$gt": None}})) == set()
+    assert _ids(collection.find({"value": {"$lt": None}})) == set()
+
+
+def test_array_range_queries_compare_whole_and_direct_nested_arrays(
+    contract_target,
+):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "both", "value": [0, [2]]},
+            {"_id": "opposite", "value": [[0], 0]},
+            {"_id": "equal", "value": [1]},
+            {"_id": "longer", "value": [1, 2]},
+            {"_id": "higher", "value": [2]},
+            {"_id": "empty", "value": []},
+            {"_id": "scalar", "value": 2},
+        ]
+    )
+
+    assert _ids(collection.find({"value": {"$gt": [1]}})) == {
+        "both",
+        "opposite",
+        "longer",
+        "higher",
+    }
+    assert _ids(collection.find({"value": {"$gte": [1]}})) == {
+        "both",
+        "opposite",
+        "equal",
+        "longer",
+        "higher",
+    }
+    assert _ids(collection.find({"value": {"$lt": [1]}})) == {
+        "both",
+        "opposite",
+        "empty",
+    }
+    assert _ids(collection.find({"value": {"$lte": [1]}})) == {
+        "both",
+        "opposite",
+        "equal",
+        "empty",
+    }
+    assert _ids(collection.find({"value": {"$elemMatch": {"$gt": [1]}}})) == {"both"}
+    assert _ids(collection.find({"value": {"$elemMatch": {"$lt": [1]}}})) == {
+        "opposite"
+    }
+
+
+def test_embedded_id_fields_use_normal_array_comparison_semantics(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "array-id", "value": [{"_id": [1, 2]}]},
+            {"_id": "scalar-id", "value": [{"_id": 2}]},
+            {"_id": "lower-id", "value": [{"_id": 1}]},
+        ]
+    )
+
+    assert _ids(collection.find({"value": {"$elemMatch": {"_id": 2}}})) == {
+        "array-id",
+        "scalar-id",
+    }
+    assert _ids(collection.find({"value": {"$elemMatch": {"_id": {"$gt": 1}}}})) == {
+        "array-id",
+        "scalar-id",
+    }
+
+
+def test_object_range_queries_use_recursive_bson_field_order(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "empty", "value": {}},
+            {"_id": "lower", "value": {"a": 0}},
+            {"_id": "equal", "value": {"a": 1}},
+            {"_id": "higher-value", "value": {"a": 2}},
+            {"_id": "higher-key", "value": {"b": 0}},
+            {"_id": "higher-type", "value": {"a": "text"}},
+            {
+                "_id": "array-members",
+                "value": [{"a": 0}, {"a": 2}],
+            },
+        ]
+    )
+
+    assert _ids(collection.find({"value": {"$gt": {"a": 1}}})) == {
+        "higher-value",
+        "higher-key",
+        "higher-type",
+        "array-members",
+    }
+    assert _ids(collection.find({"value": {"$lt": {"a": 1}}})) == {
+        "empty",
+        "lower",
+        "array-members",
+    }
+
+
+def test_scalar_ranges_share_bson_keys_and_dates_use_milliseconds(
+    contract_target,
+):
+    collection = contract_target.collection
+    boundary = datetime(2026, 8, 2, 12, 0, 0, 123100, tzinfo=timezone.utc)
+    same_millisecond = boundary.replace(microsecond=123900)
+    next_millisecond = boundary.replace(microsecond=124000)
+    collection.insert_many(
+        [
+            {"_id": "binary-low", "binary": Binary(b"a", subtype=0)},
+            {"_id": "binary-long", "binary": Binary(b"bb", subtype=0)},
+            {"_id": "binary-subtype", "binary": Binary(b"a", subtype=128)},
+            {
+                "_id": "objectid-low",
+                "objectid": ObjectId("000000000000000000000001"),
+            },
+            {
+                "_id": "objectid-high",
+                "objectid": ObjectId("000000000000000000000002"),
+            },
+            {"_id": "false", "flag": False},
+            {"_id": "true", "flag": True},
+            {"_id": "same-ms", "when": same_millisecond},
+            {"_id": "next-ms", "when": next_millisecond},
+        ]
+    )
+
+    assert _ids(collection.find({"binary": {"$gt": Binary(b"a", subtype=0)}})) == {
+        "binary-long",
+        "binary-subtype",
+    }
+    assert _ids(
+        collection.find({"objectid": {"$gt": ObjectId("000000000000000000000001")}})
+    ) == {"objectid-high"}
+    assert _ids(collection.find({"flag": {"$gt": False}})) == {"true"}
+    assert _ids(collection.find({"when": {"$gt": boundary}})) == {"next-ms"}
+    assert _ids(collection.find({"when": {"$gte": boundary}})) == {
+        "same-ms",
+        "next-ms",
+    }
+
+
+def test_legacy_binary_subtype_two_uses_its_encoded_length(contract_target):
+    collection = contract_target.collection
+    values = [
+        ("generic-one", Binary(b"a", subtype=0)),
+        ("uuid-one", Binary(b"a", subtype=4)),
+        ("generic-two", Binary(b"aa", subtype=0)),
+        ("legacy-one", Binary(b"a", subtype=2)),
+    ]
+    collection.insert_many(
+        {"_id": label, "value": value} for label, value in reversed(values)
+    )
+
+    # PyMongo cannot decode legacy subtype-2 Binary values from returned
+    # documents, so project only the comparison result identifier.
+    assert [row["_id"] for row in collection.find({}, {"_id": 1}).sort("value", 1)] == [
+        label for label, _value in values
+    ]
+    assert _ids(
+        collection.find(
+            {"value": {"$gt": Binary(b"a", subtype=4)}},
+            {"_id": 1},
+        )
+    ) == {
+        "generic-two",
+        "legacy-one",
+    }
+    assert _ids(
+        collection.find(
+            {"value": {"$gt": Binary(b"aa", subtype=0)}},
+            {"_id": 1},
+        )
+    ) == {"legacy-one"}
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [Regex("a", ""), Regex("[", ""), re.compile("a")],
+    ids=("bson-valid", "bson-malformed", "native"),
+)
+def test_regex_range_operands_are_rejected_with_code_2(
+    contract_target,
+    expression,
+):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "first", "value": Regex("a", "")},
+            {"_id": "second", "value": Regex("b", "")},
+        ]
+    )
+
+    for operator in ("$gt", "$gte", "$lt", "$lte"):
+        with pytest.raises(_OPERATION_ERRORS) as caught:
+            list(collection.find({"value": {operator: expression}}))
+        assert caught.value.code == 2
+
+
+def test_nested_regex_range_values_are_compared_without_compilation(
+    contract_target,
+):
+    collection = contract_target.collection
+    invalid = Regex("[", "")
+    collection.insert_many(
+        [
+            {"_id": "object-equal", "value": {"regex": invalid}},
+            {"_id": "object-a", "value": {"regex": Regex("a", "")}},
+            {"_id": "object-b", "value": {"regex": Regex("b", "")}},
+            {"_id": "array-equal", "value": [invalid]},
+            {"_id": "array-a", "value": [Regex("a", "")]},
+            {"_id": "array-b", "value": [Regex("b", "")]},
+        ]
+    )
+
+    assert _ids(collection.find({"value": {"$eq": {"regex": invalid}}})) == {
+        "object-equal"
+    }
+    assert _ids(collection.find({"value": {"$gt": {"regex": invalid}}})) == {
+        "object-a",
+        "object-b",
+    }
+    assert _ids(collection.find({"value": {"$lte": {"regex": invalid}}})) == {
+        "object-equal"
+    }
+    assert _ids(collection.find({"value": {"$gt": [invalid]}})) == {
+        "array-a",
+        "array-b",
+    }
+
+
+def test_indexed_ranges_feed_every_filter_consumer(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "lower", "value": {"score": 0}, "marker": "lower"},
+            {"_id": "equal", "value": {"score": 1}, "marker": "equal"},
+            {"_id": "higher", "value": {"score": 2}, "marker": "higher"},
+            {
+                "_id": "array-higher",
+                "value": [{"score": 2}],
+                "marker": "array-higher",
+            },
+            {"_id": "other-type", "value": "z", "marker": "other-type"},
+        ]
+    )
+    query = {"value": {"$gt": {"score": 1}}}
+    expected = {"higher", "array-higher"}
+
+    assert _ids(collection.find(query)) == expected
+    collection.create_index("value")
+    assert _ids(collection.find(query)) == expected
+    assert collection.count_documents(query) == 2
+    assert set(collection.distinct("marker", query)) == expected
+    assert _ids(collection.aggregate([{"$match": query}])) == expected
+
+    result = collection.update_many(query, {"$set": {"matched": True}})
+    assert result.matched_count == 2
+    assert _ids(collection.find({"matched": True})) == expected
+
+
+def test_cursor_and_aggregation_sort_share_scalar_bson_order(contract_target):
+    collection = contract_target.collection
+    expected = [
+        ("number", 0),
+        ("string", "value"),
+        ("object", {"value": 1}),
+        ("binary", Binary(b"value", subtype=0)),
+        ("objectid", ObjectId("000000000000000000000001")),
+        ("boolean", False),
+        ("datetime", datetime(2026, 8, 2, tzinfo=timezone.utc)),
+        ("regex", Regex("value", "")),
+    ]
+    collection.insert_many(
+        {"_id": label, "value": value} for label, value in reversed(expected)
+    )
+
+    expected_ids = [label for label, _value in expected]
+    assert [row["_id"] for row in collection.find({}).sort("value", 1)] == expected_ids
+    assert [
+        row["_id"] for row in collection.aggregate([{"$sort": {"value": 1}}])
+    ] == expected_ids
+
+
+def test_pull_reuses_recursive_bson_range_comparison(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {
+                "_id": "arrays",
+                "values": [None, 0, [0, [2]], [[0], 0], [1], [1, 2], [2]],
+            },
+            {
+                "_id": "objects",
+                "values": [{}, {"a": 1}, {"a": 2}, {"b": 0}, {"a": "text"}],
+            },
+            {
+                "_id": "regex",
+                "values": [Regex("a", ""), Regex("b", "")],
+            },
+        ]
+    )
+
+    collection.update_one({"_id": "arrays"}, {"$pull": {"values": {"$gt": [1]}}})
+    collection.update_one({"_id": "objects"}, {"$pull": {"values": {"$gt": {"a": 1}}}})
+
+    assert collection.find_one({"_id": "arrays"})["values"] == [None, 0, [1]]
+    assert collection.find_one({"_id": "objects"})["values"] == [{}, {"a": 1}]
+
+    with pytest.raises(_WRITE_ERRORS) as caught:
+        collection.update_one(
+            {"_id": "regex"},
+            {"$pull": {"values": {"$gt": Regex("a", "")}}},
+        )
+    assert caught.value.code == 2
+    assert collection.find_one({"_id": "regex"})["values"] == [
+        Regex("a", ""),
+        Regex("b", ""),
+    ]
+
+
+def test_pull_document_ranges_share_missing_and_array_path_semantics(
+    contract_target,
+):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {
+                "_id": "null-range",
+                "values": [
+                    {"label": "missing"},
+                    {"label": "null", "score": None},
+                    {"label": "number", "score": 1},
+                ],
+            },
+            {
+                "_id": "array-fanout",
+                "values": [
+                    {"label": "hit", "items": [{"score": 2}]},
+                    {"label": "miss", "items": [{"score": 0}]},
+                ],
+            },
+            {
+                "_id": "array-index",
+                "values": [
+                    {"label": "hit", "items": [2]},
+                    {"label": "miss", "items": [0, 2]},
+                ],
+            },
+            {
+                "_id": "embedded-id-range",
+                "values": [{"_id": [1, 2]}, {"_id": 2}, {"_id": 3}],
+            },
+            {
+                "_id": "embedded-id-equality",
+                "values": [{"_id": [1, 2]}, {"_id": 2}, {"_id": 3}],
+            },
+        ]
+    )
+
+    collection.update_one(
+        {"_id": "null-range"},
+        {"$pull": {"values": {"score": {"$gte": None}}}},
+    )
+    collection.update_one(
+        {"_id": "array-fanout"},
+        {"$pull": {"values": {"items.score": {"$gt": 1}}}},
+    )
+    collection.update_one(
+        {"_id": "array-index"},
+        {"$pull": {"values": {"items.0": {"$gt": 1}}}},
+    )
+    collection.update_one(
+        {"_id": "embedded-id-range"},
+        {"$pull": {"values": {"_id": {"$gt": 1}}}},
+    )
+    collection.update_one(
+        {"_id": "embedded-id-equality"},
+        {"$pull": {"values": {"_id": 2}}},
+    )
+
+    assert collection.find_one({"_id": "null-range"})["values"] == [
+        {"label": "number", "score": 1}
+    ]
+    assert collection.find_one({"_id": "array-fanout"})["values"] == [
+        {"label": "miss", "items": [{"score": 0}]}
+    ]
+    assert collection.find_one({"_id": "array-index"})["values"] == [
+        {"label": "miss", "items": [0, 2]}
+    ]
+    assert collection.find_one({"_id": "embedded-id-range"})["values"] == []
+    assert collection.find_one({"_id": "embedded-id-equality"})["values"] == [
+        {"_id": 3}
+    ]

--- a/compat/mongo/v1/runner/contracts/test_bson_value_types_contract.py
+++ b/compat/mongo/v1/runner/contracts/test_bson_value_types_contract.py
@@ -1,0 +1,319 @@
+"""TM-035 BSON value fidelity across every synchronous and asynchronous target."""
+
+from collections import OrderedDict
+from datetime import datetime, timezone
+import re
+
+import pytest
+
+from .support import DUPLICATE_KEY_ERRORS as _DUPLICATE_ERRORS
+from .support import bson_identity_key
+
+
+pytestmark = pytest.mark.contract
+bson = pytest.importorskip("bson")
+Code = bson.Code
+MaxKey = bson.MaxKey
+MinKey = bson.MinKey
+Timestamp = bson.Timestamp
+
+def _ids(rows):
+    return {row["_id"] for row in rows}
+
+
+def test_tm035_new_bson_values_round_trip_at_every_depth(contract_target):
+    collection = contract_target.collection
+    native_regex = re.compile("native", re.IGNORECASE | re.MULTILINE)
+    scoped_code = Code(
+        "return nested;",
+        {
+            "timestamp": Timestamp(1000, 3),
+            "bounds": [MinKey(), MaxKey()],
+            "nested": {"code": Code("return inner;")},
+        },
+    )
+    collection.insert_one(
+        {
+            "_id": "round-trip",
+            "minimum": MinKey(),
+            "maximum": MaxKey(),
+            "timestamp": Timestamp(1_700_000_000, 17),
+            "code": Code("return value;"),
+            "nested": [{"scoped": scoped_code}],
+            "native_regex": native_regex,
+        }
+    )
+
+    restored = collection.find_one({"_id": "round-trip"})
+
+    assert type(restored["minimum"]) is MinKey
+    assert type(restored["maximum"]) is MaxKey
+    assert restored["timestamp"] == Timestamp(1_700_000_000, 17)
+    assert type(restored["timestamp"]) is Timestamp
+    assert restored["code"] == Code("return value;")
+    assert type(restored["code"]) is Code
+
+    restored_scoped = restored["nested"][0]["scoped"]
+    assert type(restored_scoped) is Code
+    assert restored_scoped == scoped_code
+    assert type(restored_scoped.scope["timestamp"]) is Timestamp
+    assert type(restored_scoped.scope["bounds"][0]) is MinKey
+    assert type(restored_scoped.scope["bounds"][1]) is MaxKey
+    assert type(restored_scoped.scope["nested"]["code"]) is Code
+
+    restored_regex = restored["native_regex"]
+    if contract_target.transport == "pymongo":
+        assert type(restored_regex) is bson.Regex
+    else:
+        assert type(restored_regex) is type(native_regex)
+    assert restored_regex.pattern == native_regex.pattern
+    assert int(restored_regex.flags) == int(native_regex.flags)
+
+
+def test_tm035_exact_equality_and_distinct_use_bson_identity(contract_target):
+    collection = contract_target.collection
+    values = [
+        ("string", "same"),
+        ("code", Code("same")),
+        ("scoped-a", Code("same", {"answer": 1})),
+        ("scoped-b", Code("same", {"answer": 2})),
+        ("timestamp", Timestamp(1000, 1)),
+        ("minimum", MinKey()),
+        ("maximum", MaxKey()),
+    ]
+    collection.insert_many({"_id": label, "value": value} for label, value in values)
+
+    assert _ids(collection.find({"value": {"$eq": "same"}})) == {"string"}
+    assert _ids(collection.find({"value": {"$eq": Code("same")}})) == {"code"}
+    assert _ids(collection.find({"value": {"$eq": Code("same", {"answer": 1})}})) == {
+        "scoped-a"
+    }
+    assert _ids(collection.find({"value": {"$eq": Timestamp(1000, 1)}})) == {
+        "timestamp"
+    }
+    assert _ids(collection.find({"value": {"$eq": MinKey()}})) == {"minimum"}
+    assert _ids(collection.find({"value": {"$eq": MaxKey()}})) == {"maximum"}
+
+    distinct = collection.distinct("value")
+    assert len(distinct) == len(values)
+    assert {bson_identity_key(value) for value in distinct} == {
+        bson_identity_key(value) for _label, value in values
+    }
+
+
+@pytest.mark.parametrize(
+    ("label", "value", "alias", "code"),
+    [
+        ("minimum", MinKey(), "minKey", -1),
+        ("timestamp", Timestamp(1000, 1), "timestamp", 17),
+        ("code", Code("return 1;"), "javascript", 13),
+        (
+            "scoped-code",
+            Code("return value;", {"value": 1}),
+            "javascriptWithScope",
+            15,
+        ),
+        ("maximum", MaxKey(), "maxKey", 127),
+    ],
+)
+def test_tm035_type_aliases_and_numeric_codes_match_mongodb(
+    contract_target,
+    label,
+    value,
+    alias,
+    code,
+):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": label, "value": value},
+            {"_id": "ordinary-string", "value": "return 1;"},
+            {"_id": "ordinary-number", "value": 17},
+        ]
+    )
+
+    assert _ids(collection.find({"value": {"$type": alias}})) == {label}
+    assert _ids(collection.find({"value": {"$type": code}})) == {label}
+
+
+def test_tm035_sort_uses_the_complete_supported_scalar_order(contract_target):
+    collection = contract_target.collection
+    ordered = [
+        ("minimum", MinKey()),
+        ("empty-array", []),
+        ("null", None),
+        ("number", 1),
+        ("string", "text"),
+        ("object", {"value": 1}),
+        ("binary", bson.Binary(b"x")),
+        ("object-id", bson.ObjectId("000000000000000000000001")),
+        ("boolean", False),
+        ("date", datetime(2026, 8, 3, 12, 0, tzinfo=timezone.utc)),
+        ("timestamp", Timestamp(1000, 1)),
+        ("regex", bson.Regex("pattern")),
+        ("code", Code("return 1;")),
+        ("scoped-code", Code("return scoped;", {"value": 1})),
+        ("maximum", MaxKey()),
+    ]
+    collection.insert_many(
+        {"_id": label, "value": value} for label, value in reversed(ordered)
+    )
+
+    assert [
+        row["_id"] for row in collection.find({}).sort([("value", 1), ("_id", 1)])
+    ] == [label for label, _value in ordered]
+    assert [
+        row["_id"] for row in collection.find({}).sort([("value", -1), ("_id", 1)])
+    ] == [label for label, _value in reversed(ordered)]
+
+
+def test_tm035_unique_index_distinguishes_code_from_text_and_scope(
+    contract_target,
+):
+    collection = contract_target.collection
+    collection.create_index("value", unique=True)
+    collection.insert_many(
+        [
+            {"_id": "string", "value": "same"},
+            {"_id": "code", "value": Code("same")},
+            {"_id": "scoped", "value": Code("same", {"answer": 1})},
+        ]
+    )
+
+    assert collection.count_documents({}) == 3
+    with pytest.raises(_DUPLICATE_ERRORS):
+        collection.insert_one({"_id": "duplicate-code", "value": Code("same")})
+    with pytest.raises(_DUPLICATE_ERRORS):
+        collection.insert_one(
+            {
+                "_id": "duplicate-scoped",
+                "value": Code("same", {"answer": 1}),
+            }
+        )
+
+
+@pytest.mark.client_options(document_class=OrderedDict, tz_aware=True)
+def test_tm035_scoped_code_honors_recursive_client_read_options(contract_target):
+    collection = contract_target.collection
+    collection.insert_one(
+        {
+            "_id": "options",
+            "script": Code(
+                "return value;",
+                {
+                    "nested": {"value": 1},
+                    "at": datetime(2026, 8, 3, 12, 0, tzinfo=timezone.utc),
+                },
+            ),
+        }
+    )
+
+    restored = collection.find_one({"_id": "options"})
+    script = restored["script"]
+
+    assert type(restored) is OrderedDict
+    assert type(script) is Code
+    assert type(script.scope) is OrderedDict
+    assert type(script.scope["nested"]) is OrderedDict
+    assert script.scope["at"].utcoffset() == timezone.utc.utcoffset(None)
+
+
+def test_tm037_zero_timestamp_write_boundaries_match_mongodb(contract_target):
+    collection = contract_target.collection
+    zero = Timestamp(0, 0)
+
+    inserted = {
+        "_id": "insert-one",
+        "first": zero,
+        "second": zero,
+        "zero-seconds-only": Timestamp(0, 1),
+        "zero-increment-only": Timestamp(1, 0),
+        "nested": {"value": zero},
+        "values": [zero],
+    }
+    collection.insert_one(inserted)
+
+    stored = collection.find_one({"_id": "insert-one"})
+    assert inserted["first"] == zero
+    assert inserted["second"] == zero
+    assert stored["first"] != zero
+    assert stored["second"] != zero
+    assert stored["first"] != stored["second"]
+    assert stored["zero-seconds-only"] == Timestamp(0, 1)
+    assert stored["zero-increment-only"] == Timestamp(1, 0)
+    assert stored["nested"]["value"] == zero
+    assert stored["values"] == [zero]
+
+    batch = [
+        {"_id": "insert-many-a", "stamp": zero},
+        {"_id": "insert-many-b", "stamp": zero},
+    ]
+    collection.insert_many(batch)
+
+    batch_stamps = [
+        collection.find_one({"_id": document["_id"]})["stamp"] for document in batch
+    ]
+    assert [document["stamp"] for document in batch] == [zero, zero]
+    assert all(stamp != zero for stamp in batch_stamps)
+    assert batch_stamps[0] != batch_stamps[1]
+
+    collection.insert_one({"_id": zero, "stamp": zero})
+    timestamp_id = collection.find_one({"_id": zero})
+    assert timestamp_id["_id"] == zero
+    assert timestamp_id["stamp"] != zero
+
+    replacement = {"stamp": zero, "nested": {"value": zero}}
+    collection.replace_one({"_id": "insert-one"}, replacement)
+    replaced = collection.find_one({"_id": "insert-one"})
+    assert replacement["stamp"] == zero
+    assert replaced["stamp"] != zero
+    assert replaced["nested"]["value"] == zero
+
+    collection.update_one(
+        {"_id": "insert-one"},
+        {"$set": {"stamp": zero, "nested.value": zero}},
+    )
+    updated = collection.find_one({"_id": "insert-one"})
+    assert updated["stamp"] == zero
+    assert updated["nested"]["value"] == zero
+
+    collection.update_one(
+        {"_id": "modifier-upsert"},
+        {"$set": {"stamp": zero}},
+        upsert=True,
+    )
+    assert collection.find_one({"_id": "modifier-upsert"})["stamp"] == zero
+
+    collection.update_one(
+        {"_id": "filter-upsert", "stamp": zero},
+        {"$set": {"value": 1}},
+        upsert=True,
+    )
+    assert collection.find_one({"_id": "filter-upsert"})["stamp"] == zero
+
+    upsert_replacement = {"stamp": zero, "nested": {"value": zero}}
+    result = collection.replace_one(
+        {"_id": "replacement-upsert"},
+        upsert_replacement,
+        upsert=True,
+    )
+    upserted = collection.find_one({"_id": result.upserted_id})
+    assert upsert_replacement["stamp"] == zero
+    assert upserted["stamp"] != zero
+    assert upserted["nested"]["value"] == zero
+
+
+def test_tm037_zero_timestamp_insert_many_honors_unique_indexes(contract_target):
+    collection = contract_target.collection
+    zero = Timestamp(0, 0)
+    collection.create_index("stamp", unique=True)
+    documents = [
+        {"_id": "unique-{0}".format(index), "stamp": zero} for index in range(3)
+    ]
+
+    collection.insert_many(documents)
+
+    stored = list(collection.find({}))
+    assert [document["stamp"] for document in documents] == [zero, zero, zero]
+    assert all(document["stamp"] != zero for document in stored)
+    assert len({document["stamp"] for document in stored}) == 3

--- a/compat/mongo/v1/runner/contracts/test_client_read_fidelity_contract.py
+++ b/compat/mongo/v1/runner/contracts/test_client_read_fidelity_contract.py
@@ -1,0 +1,112 @@
+"""Configured-client read contracts shared with a real MongoDB server."""
+
+from collections import OrderedDict
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+pytestmark = [
+    pytest.mark.contract,
+    pytest.mark.client_options(document_class=OrderedDict, tz_aware=True),
+]
+
+
+_STORED = datetime(
+    2026,
+    1,
+    2,
+    3,
+    4,
+    5,
+    123456,
+    tzinfo=timezone(timedelta(hours=-5)),
+)
+_UTC_MILLIS = datetime(
+    2026,
+    1,
+    2,
+    8,
+    4,
+    5,
+    123000,
+    tzinfo=timezone.utc,
+)
+
+
+def _assert_recursive_class(document):
+    assert type(document) is OrderedDict
+    assert type(document["inner"]) is OrderedDict
+    assert type(document["items"][0]) is OrderedDict
+    assert type(document["items"][0]["deep"]) is OrderedDict
+
+
+def test_configured_document_and_datetime_results_match_mongodb(contract_target):
+    collection = contract_target.collection
+    collection.insert_one(
+        {
+            "_id": "main",
+            "when": _STORED,
+            "inner": {"when": _STORED},
+            "items": [{"deep": {"when": _STORED}}],
+        }
+    )
+
+    found = collection.find_one({"_id": "main"})
+    _assert_recursive_class(found)
+    assert found["when"] == _UTC_MILLIS
+    assert found["when"].utcoffset() == timedelta(0)
+    assert found["inner"]["when"] == _UTC_MILLIS
+    assert found["items"][0]["deep"]["when"] == _UTC_MILLIS
+
+    projected = list(
+        collection.find(
+            {"_id": "main"},
+            {"inner": 1, "items": 1, "when": 1},
+        )
+    )[0]
+    _assert_recursive_class(projected)
+
+    aggregated = list(
+        collection.aggregate(
+            [
+                {"$match": {"_id": "main"}},
+                {"$project": {"inner": 1, "items": 1, "when": 1}},
+            ]
+        )
+    )[0]
+    _assert_recursive_class(aggregated)
+
+    distinct = collection.distinct("inner")
+    assert len(distinct) == 1
+    assert type(distinct[0]) is OrderedDict
+    assert distinct[0]["when"] == _UTC_MILLIS
+
+    collection.insert_one({"_id": "modify", "inner": {"value": 1}})
+    modified = collection.find_one_and_update(
+        {"_id": "modify"},
+        {"$set": {"inner.value": 2}},
+        projection={"_id": 0, "inner": 1},
+        return_document=True,
+    )
+    assert type(modified) is OrderedDict
+    assert type(modified["inner"]) is OrderedDict
+
+
+def test_same_millisecond_write_identity_matches_mongodb(contract_target):
+    collection = contract_target.collection
+    first = datetime(2026, 1, 2, 3, 4, 5, 123001, tzinfo=timezone.utc)
+    same_millisecond = first.replace(microsecond=123999)
+    collection.insert_one({"_id": "same-millisecond", "when": first})
+
+    updated = collection.update_one(
+        {"_id": "same-millisecond"},
+        {"$set": {"when": same_millisecond}},
+    )
+    replaced = collection.replace_one(
+        {"_id": "same-millisecond"},
+        {"_id": "same-millisecond", "when": same_millisecond},
+    )
+
+    assert updated.modified_count == 0
+    assert replaced.modified_count == 0

--- a/compat/mongo/v1/runner/contracts/test_crud_contract.py
+++ b/compat/mongo/v1/runner/contracts/test_crud_contract.py
@@ -1,0 +1,225 @@
+"""Application-focused CRUD contracts shared by every backend."""
+
+import pytest
+
+from .support import WRITE_ERRORS as _WRITE_ERRORS
+from .support import observe
+
+
+pytestmark = pytest.mark.contract
+
+def test_insert_query_sort_and_count(contract_target):
+    collection = contract_target.collection
+
+    result = collection.insert_many(
+        [
+            {"_id": 1, "name": "Ada", "score": 7, "tags": ["math"]},
+            {"_id": 2, "name": "Grace", "score": 9, "tags": ["code"]},
+            {"_id": 3, "name": "Lin", "score": 8, "tags": ["systems"]},
+        ]
+    )
+
+    assert result.inserted_ids == [1, 2, 3]
+    rows = list(collection.find({"score": {"$gte": 8}}).sort("score", -1))
+    assert rows == [
+        {"_id": 2, "name": "Grace", "score": 9, "tags": ["code"]},
+        {"_id": 3, "name": "Lin", "score": 8, "tags": ["systems"]},
+    ]
+    assert collection.count_documents({"score": {"$gte": 8}}) == 2
+
+
+def test_array_in_query_contract(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "tags": ["math"]},
+            {"_id": 2, "tags": ["code"]},
+            {"_id": 3, "tags": ["systems"]},
+        ]
+    )
+
+    assert collection.count_documents({"tags": {"$in": ["math", "code"]}}) == 2
+
+
+def test_update_and_result_metadata(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "team": "compiler", "score": 7},
+            {"_id": 2, "team": "compiler", "score": 9},
+        ]
+    )
+
+    updated = collection.update_one({"_id": 1}, {"$inc": {"score": 2}})
+    unchanged = collection.update_one({"_id": 1}, {"$set": {"score": 9}})
+    many = collection.update_many({"team": "compiler"}, {"$set": {"active": True}})
+
+    assert (updated.matched_count, updated.modified_count) == (1, 1)
+    assert (unchanged.matched_count, unchanged.modified_count) == (1, 0)
+    assert (many.matched_count, many.modified_count) == (2, 2)
+    assert list(collection.find({"active": True}).sort("_id", 1)) == [
+        {"_id": 1, "team": "compiler", "score": 9, "active": True},
+        {"_id": 2, "team": "compiler", "score": 9, "active": True},
+    ]
+
+
+def test_unset_removes_top_level_and_nested_fields(contract_target):
+    collection = contract_target.collection
+    collection.insert_one(
+        {
+            "_id": "unset",
+            "remove_me": True,
+            "nested": {"keep": 1, "remove_me": 2},
+        }
+    )
+
+    result = collection.update_one(
+        {"_id": "unset"},
+        {"$unset": {"remove_me": "", "nested.remove_me": ""}},
+    )
+
+    assert (result.matched_count, result.modified_count) == (1, 1)
+    assert collection.find_one({"_id": "unset"}) == {
+        "_id": "unset",
+        "nested": {"keep": 1},
+    }
+
+
+def test_replace_upsert_and_delete_metadata(contract_target):
+    collection = contract_target.collection
+    collection.insert_one({"_id": 1, "name": "Ada", "active": False})
+
+    replaced = collection.replace_one(
+        {"_id": 1}, {"_id": 1, "name": "Ada", "active": True}
+    )
+    upserted = collection.update_one(
+        {"_id": 2}, {"$set": {"name": "Grace", "active": True}}, upsert=True
+    )
+    deleted = collection.delete_one({"_id": 1})
+    missing = collection.delete_one({"_id": 99})
+
+    assert (replaced.matched_count, replaced.modified_count) == (1, 1)
+    assert upserted.upserted_id == 2
+    assert (deleted.deleted_count, missing.deleted_count) == (1, 0)
+    assert collection.find_one({"_id": 2}) == {
+        "_id": 2,
+        "name": "Grace",
+        "active": True,
+    }
+
+
+@pytest.mark.parametrize(
+    ("query", "pinned_id"),
+    [
+        ({"_id": 77}, 77),
+        ({"_id": {"$eq": "pinned-key"}}, "pinned-key"),
+        ({"_id": 88, "state": "missing"}, 88),
+        ({"_id": None}, None),
+    ],
+)
+def test_replace_upsert_preserves_equality_bound_id(contract_target, query, pinned_id):
+    collection = contract_target.collection
+    replacement = {"value": 7}
+
+    result = collection.replace_one(query, replacement, upsert=True)
+
+    assert replacement == {"value": 7}
+    assert result.raw_result == {
+        "n": 1,
+        "nModified": 0,
+        "ok": 1.0,
+        "updatedExisting": False,
+        "upserted": pinned_id,
+    }
+    expected_matched = 1 if pinned_id is None else 0
+    assert (result.matched_count, result.modified_count) == (expected_matched, 0)
+    assert result.did_upsert is True
+    assert result.upserted_id == pinned_id
+    assert collection.find_one({"_id": pinned_id}) == {
+        "_id": pinned_id,
+        "value": 7,
+    }
+
+
+def test_replace_upsert_stores_id_first(contract_target):
+    collection = contract_target.collection
+    replacement = {"value": 7}
+
+    result = collection.replace_one({"_id": 77}, replacement, upsert=True)
+    stored = collection.find_one({"_id": 77})
+
+    assert result.upserted_id == 77
+    assert list(stored) == ["_id", "value"]
+
+
+def test_replace_upsert_accepts_bson_equal_filter_and_replacement_ids(
+    contract_target,
+):
+    collection = contract_target.collection
+    replacement = {"value": 7, "_id": 1.0}
+
+    result = collection.replace_one(
+        {"_id": 1},
+        replacement,
+        upsert=True,
+    )
+    stored = collection.find_one({"_id": 1})
+
+    assert list(replacement) == ["value", "_id"]
+    assert type(result.upserted_id) is float
+    assert type(stored["_id"]) is float
+    assert list(stored) == ["_id", "value"]
+    assert stored["value"] == 7
+
+
+def test_replace_upsert_rejects_conflicting_filter_and_replacement_ids(
+    contract_target,
+):
+    collection = contract_target.collection
+
+    with pytest.raises(_WRITE_ERRORS) as caught:
+        collection.replace_one(
+            {"_id": "filter-id"},
+            {"_id": "replacement-id", "value": 7},
+            upsert=True,
+        )
+
+    assert caught.value.code == 66
+    assert collection.count_documents({}) == 0
+
+
+def test_duplicate_id_has_a_shared_error_category(contract_target):
+    collection = contract_target.collection
+    collection.insert_one({"_id": 1, "name": "first"})
+
+    outcome = observe(lambda: collection.insert_one({"_id": 1, "name": "duplicate"}))
+
+    assert outcome.error == "duplicate_key"
+    assert collection.count_documents({"_id": 1}) == 1
+
+
+def test_explicit_null_id_is_preserved_and_unique(contract_target):
+    collection = contract_target.collection
+    document = {"_id": None, "name": "explicit null"}
+
+    result = collection.insert_one(document)
+    duplicate = observe(
+        lambda: collection.insert_one({"_id": None, "name": "duplicate"})
+    )
+
+    assert result.inserted_id is None
+    assert document["_id"] is None
+    assert duplicate.error == "duplicate_key"
+    assert collection.find_one({"_id": None})["name"] == "explicit null"
+
+
+def test_sort_skip_and_limit_contract(contract_target):
+    collection = contract_target.collection
+    collection.insert_many([{"_id": number, "score": number} for number in range(1, 6)])
+
+    rows = list(collection.find({}, sort=[("score", 1)], skip=1, limit=2))
+
+    assert rows == [
+        {"_id": 2, "score": 2},
+        {"_id": 3, "score": 3},
+    ]

--- a/compat/mongo/v1/runner/contracts/test_decimal128_contract.py
+++ b/compat/mongo/v1/runner/contracts/test_decimal128_contract.py
@@ -1,0 +1,425 @@
+"""Decimal128 behavior shared by every API and storage target."""
+
+import pytest
+
+from .support import UNSUPPORTED_ERRORS, bson_identity_key, observe
+
+
+pytestmark = pytest.mark.contract
+bson = pytest.importorskip("bson")
+Decimal128 = bson.Decimal128
+
+
+def _ids(rows):
+    return {row["_id"] for row in rows}
+
+
+def test_decimal128_extreme_ids_round_trip(contract_target):
+    collection = contract_target.collection
+    high = Decimal128("1E+6144")
+    low = Decimal128("1E-6143")
+
+    collection.insert_many(
+        [
+            {"_id": high, "label": "high"},
+            {"_id": low, "label": "low"},
+        ]
+    )
+
+    assert collection.find_one({"_id": Decimal128.from_bid(high.bid)})["label"] == (
+        "high"
+    )
+    assert collection.find_one({"_id": Decimal128.from_bid(low.bid)})["label"] == (
+        "low"
+    )
+
+
+def test_decimal128_round_trips_and_participates_in_numeric_queries(contract_target):
+    collection = contract_target.collection
+    exact = Decimal128("0.1")
+    collection.insert_many(
+        [
+            {"_id": "negative", "amount": Decimal128("-2.5")},
+            {"_id": "integer", "amount": 1},
+            {"_id": "decimal-one", "amount": Decimal128("1.00")},
+            {"_id": "exact", "amount": exact},
+            {"_id": "double", "amount": 0.1},
+            {"_id": "high", "amount": Decimal128("3.75")},
+        ]
+    )
+
+    restored = collection.find_one({"_id": "exact"})["amount"]
+    assert isinstance(restored, Decimal128)
+    assert restored.bid == exact.bid
+    assert _ids(collection.find({"amount": Decimal128("1")})) == {
+        "integer",
+        "decimal-one",
+    }
+    assert _ids(collection.find({"amount": Decimal128("0.1")})) == {"exact"}
+    assert _ids(collection.find({"amount": 0.1})) == {"double"}
+    assert _ids(collection.find({"amount": {"$gt": Decimal128("1")}})) == {"high"}
+    assert _ids(collection.find({"amount": {"$gt": 1}})) == {"high"}
+    assert [
+        row["_id"]
+        for row in collection.find(
+            {"_id": {"$in": ["negative", "integer", "high"]}}
+        ).sort("amount", 1)
+    ] == ["negative", "integer", "high"]
+
+
+def test_decimal128_nan_query_comparisons_follow_mongodb(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "nan", "amount": Decimal128("NaN")},
+            {"_id": "signaling", "amount": Decimal128("sNaN")},
+            {"_id": "one", "amount": 1},
+        ]
+    )
+
+    assert _ids(collection.find({"amount": Decimal128("NaN")})) == {
+        "nan",
+        "signaling",
+    }
+    assert _ids(collection.find({"amount": {"$gt": Decimal128("NaN")}})) == set()
+    assert _ids(collection.find({"amount": {"$lt": Decimal128("NaN")}})) == set()
+    assert _ids(collection.find({"amount": {"$gt": 1}})) == set()
+    assert _ids(collection.find({"amount": {"$gte": Decimal128("NaN")}})) == {
+        "nan",
+        "signaling",
+    }
+    assert _ids(collection.find({"amount": {"$lte": Decimal128("NaN")}})) == {
+        "nan",
+        "signaling",
+    }
+
+
+def test_decimal128_grouping_min_max_and_sum_use_one_numeric_family(
+    contract_target,
+):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "first", "category": 1, "amount": Decimal128("1.00")},
+            {
+                "_id": "second",
+                "category": Decimal128("1.0"),
+                "amount": Decimal128("2.5"),
+            },
+            {"_id": "other", "category": 2, "amount": 4},
+        ]
+    )
+
+    rows = list(
+        collection.aggregate(
+            [
+                {"$sort": {"_id": 1}},
+                {
+                    "$group": {
+                        "_id": "$category",
+                        "total": {"$sum": "$amount"},
+                        "minimum": {"$min": "$amount"},
+                        "maximum": {"$max": "$amount"},
+                        "count": {"$sum": 1},
+                    }
+                },
+                {"$sort": {"_id": 1}},
+            ]
+        )
+    )
+
+    assert rows == [
+        {
+            "_id": 1,
+            "total": Decimal128("3.50"),
+            "minimum": Decimal128("1.00"),
+            "maximum": Decimal128("2.5"),
+            "count": 2,
+        },
+        {"_id": 2, "total": 4, "minimum": 4, "maximum": 4, "count": 1},
+    ]
+
+
+def test_decimal128_min_max_ties_and_literal_sum_match_mongodb(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "amount": Decimal128("1.00")},
+            {"_id": 2, "amount": 1},
+            {"_id": 3, "amount": 1.0},
+        ]
+    )
+
+    assert list(
+        collection.aggregate(
+            [
+                {"$sort": {"_id": 1}},
+                {
+                    "$group": {
+                        "_id": None,
+                        "minimum": {"$min": "$amount"},
+                        "maximum": {"$max": "$amount"},
+                        "literal_total": {"$sum": Decimal128("1.25")},
+                    }
+                },
+            ]
+        )
+    ) == [
+        {
+            "_id": None,
+            "minimum": 1.0,
+            "maximum": 1.0,
+            "literal_total": Decimal128("3.75"),
+        }
+    ]
+
+
+def test_decimal128_inc_promotes_the_result(contract_target):
+    collection = contract_target.collection
+    collection.insert_one({"_id": "balance", "amount": Decimal128("1.00")})
+
+    result = collection.update_one(
+        {"_id": "balance"}, {"$inc": {"amount": Decimal128("2.5")}}
+    )
+
+    assert result.matched_count == 1
+    assert result.modified_count == 1
+    assert collection.find_one({"_id": "balance"})["amount"] == Decimal128("3.50")
+
+    collection.update_one({"_id": "balance"}, {"$set": {"amount": Decimal128("2")}})
+    collection.update_one({"_id": "balance"}, {"$inc": {"amount": 0.1}})
+    assert collection.find_one({"_id": "balance"})["amount"] == Decimal128(
+        "2.100000000000000"
+    )
+
+
+def test_decimal128_representation_changes_are_persisted(contract_target):
+    collection = contract_target.collection
+    collection.insert_one({"_id": "value", "amount": 1})
+
+    first = collection.update_one(
+        {"_id": "value"}, {"$set": {"amount": Decimal128("1.0")}}
+    )
+    assert first.modified_count == 1
+    assert collection.find_one({"_id": "value"})["amount"].bid == Decimal128("1.0").bid
+
+    second = collection.update_one(
+        {"_id": "value"}, {"$set": {"amount": Decimal128("1.00")}}
+    )
+    assert second.modified_count == 1
+    assert collection.find_one({"_id": "value"})["amount"].bid == Decimal128("1.00").bid
+
+    unchanged = collection.update_one(
+        {"_id": "value"}, {"$inc": {"amount": Decimal128("0.000")}}
+    )
+    assert unchanged.modified_count == 0
+    assert collection.find_one({"_id": "value"})["amount"].bid == Decimal128("1.00").bid
+
+    collection.update_one({"_id": "value"}, {"$set": {"amount": Decimal128("2")}})
+    rounded_noop = collection.update_one(
+        {"_id": "value"}, {"$inc": {"amount": Decimal128("1E-300")}}
+    )
+    assert rounded_noop.modified_count == 0
+    assert collection.find_one({"_id": "value"})["amount"].bid == Decimal128("2").bid
+
+    collection.update_one({"_id": "value"}, {"$set": {"amount": Decimal128("sNaN")}})
+    quieted = collection.update_one(
+        {"_id": "value"}, {"$inc": {"amount": Decimal128("0")}}
+    )
+    assert quieted.modified_count == 1
+    assert collection.find_one({"_id": "value"})["amount"].bid == Decimal128("NaN").bid
+
+    quiet_nan = collection.update_one(
+        {"_id": "value"}, {"$inc": {"amount": Decimal128("0")}}
+    )
+    assert quiet_nan.modified_count == 1
+    assert collection.find_one({"_id": "value"})["amount"].bid == Decimal128("NaN").bid
+
+
+def test_decimal128_sum_keeps_double_precision_until_promotion(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "mixed": 0.1, "cancellation": 1e16},
+            {"_id": 2, "mixed": 0.2, "cancellation": 1.0},
+            {
+                "_id": 3,
+                "mixed": Decimal128("1"),
+                "cancellation": -1e16,
+            },
+        ]
+    )
+
+    assert list(
+        collection.aggregate(
+            [
+                {
+                    "$group": {
+                        "_id": None,
+                        "mixed": {"$sum": "$mixed"},
+                        "cancellation": {"$sum": "$cancellation"},
+                    }
+                }
+            ]
+        )
+    ) == [
+        {
+            "_id": None,
+            "mixed": Decimal128("1.300000000000000016653345369377348"),
+            "cancellation": 0.0,
+        }
+    ]
+
+
+def test_decimal128_projection_flags_and_stage_arguments(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "rank": 1, "keep": "first", "remove": "x"},
+            {"_id": 2, "rank": 2, "keep": "second", "remove": "y"},
+            {"_id": 3, "rank": 3, "keep": "third", "remove": "z"},
+            {"_id": 4, "rank": 4, "keep": "fourth", "remove": "w"},
+        ]
+    )
+
+    projected = collection.find_one({"_id": 1}, {"remove": Decimal128("0")})
+    assert projected == {"_id": 1, "rank": 1, "keep": "first"}
+    assert list(
+        collection.aggregate(
+            [
+                {"$sort": {"rank": Decimal128("1")}},
+                {"$skip": Decimal128("1")},
+                {"$limit": Decimal128("2.0")},
+                {
+                    "$project": {
+                        "_id": Decimal128("0"),
+                        "keep": Decimal128("NaN"),
+                    }
+                },
+            ]
+        )
+    ) == [{"keep": "second"}, {"keep": "third"}]
+
+
+def test_decimal128_array_updates_and_distinct_reuse_numeric_identity(
+    contract_target,
+):
+    collection = contract_target.collection
+    collection.insert_one(
+        {
+            "_id": "values",
+            "members": [1, Decimal128("3.0")],
+            "amount": 1,
+        }
+    )
+    collection.insert_many(
+        [
+            {"_id": "same", "amount": Decimal128("1.00")},
+            {"_id": "decimal", "amount": Decimal128("0.1")},
+            {"_id": "double", "amount": 0.1},
+        ]
+    )
+
+    collection.update_one(
+        {"_id": "values"},
+        {"$addToSet": {"members": {"$each": [Decimal128("1.0"), 2]}}},
+    )
+    collection.update_one(
+        {"_id": "values"},
+        {
+            "$push": {
+                "members": {
+                    "$each": [Decimal128("-1.5")],
+                    "$position": Decimal128("-1"),
+                    "$sort": Decimal128("1.0"),
+                    "$slice": Decimal128("4.0"),
+                }
+            }
+        },
+    )
+    assert collection.find_one({"_id": "values"})["members"] == [
+        Decimal128("-1.5"),
+        1,
+        2,
+        Decimal128("3.0"),
+    ]
+
+    collection.update_one(
+        {"_id": "values"},
+        {"$pull": {"members": {"$gte": Decimal128("2")}}},
+    )
+    assert collection.find_one({"_id": "values"})["members"] == [
+        Decimal128("-1.5"),
+        1,
+    ]
+
+    distinct = collection.distinct("amount")
+    assert {bson_identity_key(value) for value in distinct} == {
+        bson_identity_key(1),
+        bson_identity_key(Decimal128("0.1")),
+        bson_identity_key(0.1),
+    }
+
+
+def test_decimal128_numeric_identity_is_enforced_by_ids_and_unique_indexes(
+    contract_target,
+):
+    collection = contract_target.collection
+    collection.insert_one({"_id": 1, "amount": 1})
+
+    duplicate_id = observe(
+        lambda: collection.insert_one(
+            {"_id": Decimal128("1.0"), "amount": Decimal128("2")}
+        )
+    )
+    assert duplicate_id.error == "duplicate_key"
+
+    collection.create_index("amount", unique=True)
+    if contract_target.name in ("postgres", "postgresql", "mysql", "mariadb"):
+        with pytest.raises(UNSUPPORTED_ERRORS, match="Decimal128 values"):
+            collection.insert_one({"_id": "decimal-tenth", "amount": Decimal128("0.1")})
+        return
+
+    collection.insert_one({"_id": "decimal-tenth", "amount": Decimal128("0.1")})
+    collection.insert_one({"_id": "double-tenth", "amount": 0.1})
+    collection.insert_one(
+        {
+            "_id": "precision-a",
+            "amount": Decimal128("1.234567890123456789012345678901234"),
+        }
+    )
+    collection.insert_one(
+        {
+            "_id": "precision-b",
+            "amount": Decimal128("1.234567890123456789012345678901235"),
+        }
+    )
+    collection.insert_one({"_id": "large-decimal", "amount": Decimal128("1E+23")})
+    collection.insert_one({"_id": "large-double", "amount": 1e23})
+    exact_double = observe(
+        lambda: collection.insert_one(
+            {
+                "_id": "large-double-exact-decimal",
+                "amount": Decimal128(str(int(1e23))),
+            }
+        )
+    )
+    assert exact_double.error == "duplicate_key"
+    exact_integer = 2**60
+    collection.insert_one({"_id": "exact-integer", "amount": exact_integer})
+    for identifier, equivalent in (
+        ("exact-integer-double", float(exact_integer)),
+        ("exact-integer-decimal", Decimal128(str(exact_integer))),
+    ):
+        duplicate_integer = observe(
+            lambda identifier=identifier, equivalent=equivalent: collection.insert_one(
+                {"_id": identifier, "amount": equivalent}
+            )
+        )
+        assert duplicate_integer.error == "duplicate_key"
+    duplicate_value = observe(
+        lambda: collection.insert_one(
+            {"_id": "duplicate", "amount": Decimal128("1.00")}
+        )
+    )
+    assert duplicate_value.error == "duplicate_key"

--- a/compat/mongo/v1/runner/contracts/test_group_accumulators_contract.py
+++ b/compat/mongo/v1/runner/contracts/test_group_accumulators_contract.py
@@ -1,0 +1,327 @@
+"""Common ``$group`` accumulator behavior shared by every target."""
+
+import math
+
+import pytest
+from bson import Decimal128
+
+from .support import bson_value_identity_key, observe
+
+
+pytestmark = pytest.mark.contract
+
+
+def _by_id(rows):
+    return {row["_id"]: row for row in rows}
+
+
+def test_avg_ignores_non_numeric_values_and_promotes_decimal(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "bucket": "decimal", "value": 1},
+            {"_id": 2, "bucket": "decimal", "value": 2.0},
+            {"_id": 3, "bucket": "decimal", "value": Decimal128("3.00")},
+            {"_id": 4, "bucket": "decimal", "value": True},
+            {"_id": 5, "bucket": "decimal", "value": "ignored"},
+            {"_id": 6, "bucket": "decimal", "value": None},
+            {"_id": 7, "bucket": "decimal"},
+            {"_id": 8, "bucket": "double", "value": 1},
+            {"_id": 9, "bucket": "double", "value": 2},
+            {"_id": 10, "bucket": "empty", "value": False},
+            {"_id": 11, "bucket": "empty", "value": [100]},
+            {"_id": 12, "bucket": "mixed-exact", "value": Decimal128("1.00")},
+            {"_id": 13, "bucket": "mixed-exact", "value": 2.1},
+        ]
+    )
+
+    rows = _by_id(
+        collection.aggregate(
+            [{"$group": {"_id": "$bucket", "average": {"$avg": "$value"}}}]
+        )
+    )
+
+    assert rows["decimal"] == {
+        "_id": "decimal",
+        "average": Decimal128("2.00"),
+    }
+    assert rows["double"] == {"_id": "double", "average": 1.5}
+    assert isinstance(rows["double"]["average"], float)
+    assert rows["empty"] == {"_id": "empty", "average": None}
+    assert rows["mixed-exact"] == {
+        "_id": "mixed-exact",
+        "average": Decimal128("1.550000000000000044408920985006262"),
+    }
+
+
+def test_avg_preserves_cancellation_and_nonfinite_values(contract_target):
+    collection = contract_target.collection
+    grouped_values = {
+        "cancel-middle": [1e16, 1.0, -1e16],
+        "cancel-last": [1e16, -1e16, 1.0],
+        "large-integers": [2**60, (2**60) + 2],
+        "large-negative-integers": [-(2**60), -(2**60) + 2],
+        "int64-cancellation": [
+            7900154101625246752,
+            -1259608310039654329,
+            -6593466016263951012,
+        ],
+        "int64-cancellation-with-double": [
+            7900154101625246752,
+            -1259608310039654329,
+            float(-6593466016263951012),
+        ],
+        "decimal-cancel": [
+            Decimal128("1E+34"),
+            1.0,
+            Decimal128("-1E+34"),
+        ],
+        "nan": [float("nan"), 1.0],
+        "infinity": [float("inf"), 1.0],
+        "opposite-infinities": [float("inf"), float("-inf")],
+        "decimal-infinity": [Decimal128("Infinity"), 1.0],
+        "decimal-opposite-infinities": [Decimal128("Infinity"), float("-inf")],
+    }
+    documents = []
+    document_id = 0
+    for bucket, values in grouped_values.items():
+        for value in values:
+            documents.append({"_id": document_id, "bucket": bucket, "value": value})
+            document_id += 1
+    collection.insert_many(documents)
+
+    rows = _by_id(
+        collection.aggregate(
+            [
+                {"$sort": {"_id": 1}},
+                {"$group": {"_id": "$bucket", "average": {"$avg": "$value"}}},
+            ]
+        )
+    )
+
+    assert rows["cancel-middle"]["average"] == 0.0
+    assert rows["cancel-last"]["average"] == 1.0 / 3.0
+    assert rows["large-integers"]["average"] == float((2**60) + 1)
+    assert rows["large-negative-integers"]["average"] == float(-(2**60) + 1)
+    assert rows["int64-cancellation"]["average"] == 1.5693258440547136e16
+    assert rows["int64-cancellation-with-double"]["average"] == 1.5693258440546986e16
+    assert rows["decimal-cancel"]["average"] == Decimal128(
+        "0.3333333333333333333333333333333333"
+    )
+    assert math.isnan(rows["nan"]["average"])
+    assert rows["infinity"]["average"] == float("inf")
+    assert math.isnan(rows["opposite-infinities"]["average"])
+    assert rows["decimal-infinity"]["average"] == Decimal128("Infinity")
+    assert rows["decimal-opposite-infinities"]["average"].to_decimal().is_nan()
+
+
+def test_first_last_and_push_follow_sorted_input_and_missing_rules(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "bucket": "first-missing", "rank": 2, "value": "last"},
+            {"_id": 2, "bucket": "first-missing", "rank": 1},
+            {"_id": 3, "bucket": "first-missing", "rank": 3, "value": None},
+            {"_id": 4, "bucket": "last-missing", "rank": 1, "value": "first"},
+            {"_id": 5, "bucket": "last-missing", "rank": 2, "value": None},
+            {"_id": 6, "bucket": "last-missing", "rank": 3},
+        ]
+    )
+
+    rows = _by_id(
+        collection.aggregate(
+            [
+                {"$sort": {"rank": 1}},
+                {
+                    "$group": {
+                        "_id": "$bucket",
+                        "first_rank": {"$first": "$rank"},
+                        "last_rank": {"$last": "$rank"},
+                        "first_value": {"$first": "$value"},
+                        "last_value": {"$last": "$value"},
+                        "values": {"$push": "$value"},
+                    }
+                },
+            ]
+        )
+    )
+
+    assert rows["first-missing"] == {
+        "_id": "first-missing",
+        "first_rank": 1,
+        "last_rank": 3,
+        "first_value": None,
+        "last_value": None,
+        "values": ["last", None],
+    }
+    assert rows["last-missing"] == {
+        "_id": "last-missing",
+        "first_rank": 1,
+        "last_rank": 3,
+        "first_value": "first",
+        "last_value": None,
+        "values": ["first", None],
+    }
+
+
+def test_add_to_set_uses_recursive_bson_identity(contract_target):
+    collection = contract_target.collection
+    values = [
+        1,
+        1.0,
+        Decimal128("1.00"),
+        True,
+        None,
+        {"a": 1, "b": 2},
+        {"a": 1.0, "b": 2},
+        {"b": 2, "a": 1},
+        [1, 2],
+        [1.0, 2],
+        [2, 1],
+        float("nan"),
+        Decimal128("NaN"),
+    ]
+    collection.insert_many(
+        [{"_id": index, "value": value} for index, value in enumerate(values)]
+        + [{"_id": len(values)}, {"_id": len(values) + 1}]
+    )
+
+    result = list(
+        collection.aggregate(
+            [{"$group": {"_id": None, "values": {"$addToSet": "$value"}}}]
+        )
+    )[0]["values"]
+    actual_keys = {bson_value_identity_key(value) for value in result}
+    expected_values = [
+        1,
+        True,
+        None,
+        {"a": 1, "b": 2},
+        {"b": 2, "a": 1},
+        [1, 2],
+        [2, 1],
+        float("nan"),
+    ]
+    expected_keys = {bson_value_identity_key(value) for value in expected_values}
+
+    assert len(result) == len(expected_values)
+    assert actual_keys == expected_keys
+    assert any(isinstance(value, float) and math.isnan(value) for value in result)
+
+
+def test_array_values_remain_whole_accumulator_values(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "value": [1, 2]},
+            {"_id": 2, "value": [1, 2]},
+            {"_id": 3, "value": [3, 4]},
+        ]
+    )
+
+    result = list(
+        collection.aggregate(
+            [
+                {
+                    "$group": {
+                        "_id": None,
+                        "first": {"$first": "$value"},
+                        "last": {"$last": "$value"},
+                        "pushed": {"$push": "$value"},
+                        "unique": {"$addToSet": "$value"},
+                    }
+                }
+            ]
+        )
+    )[0]
+    unique = result.pop("unique")
+    assert result == {
+        "_id": None,
+        "first": [1, 2],
+        "last": [3, 4],
+        "pushed": [[1, 2], [1, 2], [3, 4]],
+    }
+    assert {tuple(value) for value in unique} == {(1, 2), (3, 4)}
+
+
+def test_accumulators_accept_the_supported_expression_subset(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "items": [1, 2]},
+            {"_id": 2, "items": []},
+        ]
+    )
+
+    assert list(
+        collection.aggregate(
+            [
+                {
+                    "$group": {
+                        "_id": None,
+                        "literal": {"$first": {"$literal": "$not-a-path"}},
+                        "arrays": {"$push": {"$literal": [1, 2]}},
+                        "sizes": {"$push": {"$size": "$items"}},
+                        "fallbacks": {
+                            "$addToSet": {"$ifNull": ["$missing", "fallback"]}
+                        },
+                    }
+                }
+            ]
+        )
+    ) == [
+        {
+            "_id": None,
+            "literal": "$not-a-path",
+            "arrays": [[1, 2], [1, 2]],
+            "sizes": [2, 0],
+            "fallbacks": ["fallback"],
+        }
+    ]
+
+
+def test_missing_only_arrays_and_empty_inputs_match_mongodb(contract_target):
+    collection = contract_target.collection
+    collection.insert_many([{"_id": 1}, {"_id": 2}])
+
+    pipeline = [
+        {
+            "$group": {
+                "_id": None,
+                "average": {"$avg": "$missing"},
+                "first": {"$first": "$missing"},
+                "last": {"$last": "$missing"},
+                "pushed": {"$push": "$missing"},
+                "unique": {"$addToSet": "$missing"},
+            }
+        }
+    ]
+    assert list(collection.aggregate(pipeline)) == [
+        {
+            "_id": None,
+            "average": None,
+            "first": None,
+            "last": None,
+            "pushed": [],
+            "unique": [],
+        }
+    ]
+
+    collection.delete_many({})
+    assert list(collection.aggregate(pipeline)) == []
+
+
+@pytest.mark.parametrize(
+    "operator",
+    ["$addToSet", "$avg", "$first", "$last", "$max", "$min", "$push", "$sum"],
+)
+def test_group_accumulators_reject_array_argument_lists(contract_target, operator):
+    outcome = observe(
+        lambda: list(
+            contract_target.collection.aggregate(
+                [{"$group": {"_id": None, "value": {operator: [1, 2]}}}]
+            )
+        )
+    )
+
+    assert outcome.error == "operation_failure"

--- a/compat/mongo/v1/runner/contracts/test_projection_contract.py
+++ b/compat/mongo/v1/runner/contracts/test_projection_contract.py
@@ -1,0 +1,110 @@
+"""Field projection contracts shared by TinyMongo and MongoDB."""
+
+import pytest
+
+from .support import observe
+
+
+pytestmark = pytest.mark.contract
+
+
+def _seed(collection):
+    collection.insert_many(
+        [
+            {
+                "_id": 1,
+                "name": "Ada",
+                "secret": "x",
+                "score": 7,
+                "profile": {"email": "ada@example.com", "age": 36},
+                "items": [{"sku": "a", "qty": 1}, {"qty": 2}, {}],
+            },
+            {
+                "_id": 2,
+                "name": "Grace",
+                "score": 9,
+                "profile": {"age": 40},
+                "items": [],
+            },
+        ]
+    )
+
+
+def test_inclusion_exclusion_and_id_projection_contract(contract_target):
+    collection = contract_target.collection
+    _seed(collection)
+
+    assert list(collection.find({}, {"name": 1}).sort("_id", 1)) == [
+        {"_id": 1, "name": "Ada"},
+        {"_id": 2, "name": "Grace"},
+    ]
+    assert collection.find_one({"_id": 1}, {"name": 2, "_id": 0}) == {"name": "Ada"}
+    assert collection.find_one({"_id": 1}, {"secret": 0, "_id": 1}) == {
+        "_id": 1,
+        "name": "Ada",
+        "score": 7,
+        "profile": {"email": "ada@example.com", "age": 36},
+        "items": [{"sku": "a", "qty": 1}, {"qty": 2}, {}],
+    }
+    assert collection.find_one({"_id": 1}, {"_id.missing": 1}) == {}
+
+
+def test_nested_and_array_projection_contract(contract_target):
+    collection = contract_target.collection
+    _seed(collection)
+
+    assert list(collection.find({}, {"profile.email": 1}).sort("_id", 1)) == [
+        {"_id": 1, "profile": {"email": "ada@example.com"}},
+        {"_id": 2, "profile": {}},
+    ]
+    assert collection.find_one({"_id": 1}, {"items.sku": 1}) == {
+        "_id": 1,
+        "items": [{"sku": "a"}, {}, {}],
+    }
+    assert collection.find_one({"_id": 1}, {"items.qty": 0})["items"] == [
+        {"sku": "a"},
+        {},
+        {},
+    ]
+
+
+def test_projection_uses_unprojected_values_for_filter_and_sort(contract_target):
+    collection = contract_target.collection
+    _seed(collection)
+
+    assert list(
+        collection.find({"score": {"$gte": 7}}, {"name": 1}).sort("score", -1)
+    ) == [
+        {"_id": 2, "name": "Grace"},
+        {"_id": 1, "name": "Ada"},
+    ]
+
+
+def test_empty_and_invalid_projection_contract(contract_target):
+    collection = contract_target.collection
+    _seed(collection)
+    full = collection.find_one({"_id": 1})
+
+    assert collection.find_one({"_id": 1}, {}) == full
+    assert collection.find_one({"_id": 1}, []) == full
+    assert observe(
+        lambda: list(collection.find({}, {"name": 1, "secret": 0}))
+    ).error == ("operation_failure")
+    assert (
+        observe(
+            lambda: list(collection.find({}, {"profile": 1, "profile.email": 1}))
+        ).error
+        == "operation_failure"
+    )
+    assert (
+        observe(lambda: list(collection.find({}, {"_id": 1, "_id.value": 1}))).error
+        == "operation_failure"
+    )
+    assert (
+        observe(
+            lambda: list(
+                collection.find({}, {"profile": {"email": 1}, "profile.email": 1})
+            )
+        ).error
+        == "operation_failure"
+    )

--- a/compat/mongo/v1/runner/contracts/test_query_operator_contract.py
+++ b/compat/mongo/v1/runner/contracts/test_query_operator_contract.py
@@ -1,0 +1,761 @@
+"""Query-validation and write-error contracts shared by every target."""
+
+import re
+from collections import UserDict
+
+import pytest
+
+from .support import DUPLICATE_KEY_ERRORS as _DUPLICATE_KEY_ERRORS
+from .support import OPERATION_ERRORS as _OPERATION_ERRORS
+from .support import QUERY_REJECTION_ERRORS as _QUERY_REJECTION_ERRORS
+from .support import WRITE_ERRORS as _WRITE_ERRORS
+from .support import regex_type
+
+
+pytestmark = pytest.mark.contract
+
+def _ids(rows):
+    return sorted(document["_id"] for document in rows)
+
+
+def _run_filter_operation(collection, operation, query):
+    """Exercise every PyMongo-style CRUD entry point that accepts a filter."""
+
+    if operation == "find":
+        return list(collection.find(query))
+    if operation == "find_one":
+        return collection.find_one(query)
+    if operation == "count_documents":
+        return collection.count_documents(query)
+    if operation == "distinct":
+        return collection.distinct("value", query)
+    if operation == "update_one":
+        return collection.update_one(query, {"$set": {"touched": True}})
+    if operation == "update_many":
+        return collection.update_many(query, {"$set": {"touched": True}})
+    if operation == "replace_one":
+        return collection.replace_one(query, {"value": "replacement"})
+    if operation == "delete_one":
+        return collection.delete_one(query)
+    if operation == "delete_many":
+        return collection.delete_many(query)
+    if operation == "find_one_and_update":
+        return collection.find_one_and_update(
+            query,
+            {"$set": {"touched": True}},
+        )
+    if operation == "find_one_and_replace":
+        return collection.find_one_and_replace(
+            query,
+            {"value": "replacement"},
+        )
+    if operation == "find_one_and_delete":
+        return collection.find_one_and_delete(query)
+    raise AssertionError("Unknown test operation: {0}".format(operation))
+
+
+def test_size_matches_arrays_with_the_exact_requested_length(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "empty", "values": []},
+            {"_id": "one", "values": [1]},
+            {"_id": "two", "values": [1, 2]},
+            {"_id": "nested-two", "values": [[1], [2, 3]]},
+            {"_id": "scalar", "values": "not-an-array"},
+            {"_id": "missing"},
+        ]
+    )
+
+    assert _ids(collection.find({"values": {"$size": 0}})) == ["empty"]
+    assert _ids(collection.find({"values": {"$size": 2}})) == [
+        "nested-two",
+        "two",
+    ]
+
+
+def test_elem_match_requires_one_array_member_to_satisfy_every_condition(
+    contract_target,
+):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {
+                "_id": "same-document",
+                "results": [
+                    {"kind": "quiz", "score": 8},
+                    {"kind": "exam", "score": 10},
+                ],
+                "values": [2, 7, 12],
+            },
+            {
+                "_id": "split-documents",
+                "results": [
+                    {"kind": "quiz", "score": 3},
+                    {"kind": "exam", "score": 8},
+                ],
+                "values": [1, 3, 12],
+            },
+            {
+                "_id": "scalar-field",
+                "results": {"kind": "quiz", "score": 8},
+                "values": 7,
+            },
+        ]
+    )
+
+    assert _ids(
+        collection.find(
+            {
+                "results": {
+                    "$elemMatch": {
+                        "kind": "quiz",
+                        "score": {"$gte": 8},
+                    }
+                }
+            }
+        )
+    ) == ["same-document"]
+    assert _ids(
+        collection.find({"values": {"$elemMatch": {"$gte": 5, "$lt": 10}}})
+    ) == ["same-document"]
+
+
+def test_elem_match_document_paths_traverse_nested_arrays(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "nested-array", "values": [[1, 2], [3]]},
+            {
+                "_id": "nested-document",
+                "values": [{"a": [{"b": 1}, {"b": 2}]}],
+            },
+            {"_id": "raw-nested-document", "values": [[{"x": 2}]]},
+        ]
+    )
+
+    assert (
+        collection.find_one(
+            {
+                "_id": "nested-array",
+                "values": {"$elemMatch": {"0": 1}},
+            }
+        )["_id"]
+        == "nested-array"
+    )
+    assert (
+        collection.find_one(
+            {
+                "_id": "nested-array",
+                "values": {"$elemMatch": {"missing": {"$exists": False}}},
+            }
+        )["_id"]
+        == "nested-array"
+    )
+    assert (
+        collection.find_one(
+            {
+                "_id": "nested-document",
+                "values": {"$elemMatch": {"a.b": {"$type": "int"}}},
+            }
+        )["_id"]
+        == "nested-document"
+    )
+    assert (
+        _ids(
+            collection.find(
+                {
+                    "_id": "raw-nested-document",
+                    "values": {"$elemMatch": {"x": 2}},
+                }
+            )
+        )
+        == []
+    )
+    assert (
+        _ids(
+            collection.find(
+                {
+                    "_id": "raw-nested-document",
+                    "values": {"$all": [{"$elemMatch": {"x": 2}}]},
+                }
+            )
+        )
+        == []
+    )
+    assert (
+        collection.find_one(
+            {
+                "_id": "nested-document",
+                "values": {"$elemMatch": {"a.0.b": 1}},
+            }
+        )["_id"]
+        == "nested-document"
+    )
+
+    for condition in (
+        1,
+        {"$type": "int"},
+        {"$mod": [2, 1]},
+        {"$gt": 0},
+        {"$all": [1, 2]},
+    ):
+        assert (
+            collection.find_one({"_id": "nested-array", "values.0": condition}) is None
+        )
+    for condition in (
+        [1, 2],
+        {"$size": 2},
+        {"$type": "array"},
+        {"$elemMatch": {"$gt": 1}},
+    ):
+        assert (
+            collection.find_one({"_id": "nested-array", "values.0": condition})["_id"]
+            == "nested-array"
+        )
+
+
+def test_elem_match_null_conditions_match_missing_document_fields(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "raw-array", "values": [[1, 2]]},
+            {"_id": "missing-field", "values": [{"other": 1}]},
+            {"_id": "explicit-null", "values": [{"value": None}]},
+        ]
+    )
+
+    for condition in (
+        None,
+        {"$eq": None},
+        {"$in": [None]},
+        {"$all": [None]},
+    ):
+        assert _ids(
+            collection.find({"values": {"$elemMatch": {"value": condition}}})
+        ) == ["explicit-null", "missing-field", "raw-array"]
+
+
+def test_dotted_query_paths_traverse_document_arrays_not_raw_nested_arrays(
+    contract_target,
+):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "documents", "items": [{"score": 1}, {"score": 5}]},
+            {"_id": "partly-missing", "items": [{"other": 1}, {"score": 2}]},
+            {"_id": "raw-array", "items": [[{"score": 1}]]},
+        ]
+    )
+
+    assert _ids(collection.find({"items.score": 1})) == ["documents"]
+    assert _ids(collection.find({"items.score": {"$type": "int"}})) == [
+        "documents",
+        "partly-missing",
+    ]
+    assert _ids(collection.find({"items.score": {"$exists": False}})) == ["raw-array"]
+    assert _ids(collection.find({"items.score": {"$ne": None}})) == [
+        "documents",
+        "raw-array",
+    ]
+    assert _ids(collection.find({"items.score": {"$nin": [None]}})) == [
+        "documents",
+        "raw-array",
+    ]
+
+    collection.create_index("items.score")
+    assert _ids(collection.find({"items.score": 1})) == ["documents"]
+
+
+def test_null_equality_keeps_missing_fields_visible_after_indexing(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "missing"},
+            {"_id": "null", "value": None},
+            {"_id": "other", "value": 1},
+        ]
+    )
+
+    assert _ids(collection.find({"value": None})) == ["missing", "null"]
+    collection.create_index("value")
+    assert _ids(collection.find({"value": None})) == ["missing", "null"]
+
+
+def test_tuple_equality_keeps_array_matches_visible_after_indexing(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "exact-array", "value": [1, 2]},
+            {"_id": "array-member", "value": [[1, 2]]},
+            {"_id": "other", "value": [2, 3]},
+        ]
+    )
+
+    assert _ids(collection.find({"value": (1, 2)})) == [
+        "array-member",
+        "exact-array",
+    ]
+    collection.create_index("value")
+    assert _ids(collection.find({"value": (1, 2)})) == [
+        "array-member",
+        "exact-array",
+    ]
+
+
+def test_continued_numeric_paths_ignore_scalar_index_dead_ends(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "scalar-index", "items": [1, 2]},
+            {"_id": "numeric-field", "items": [1, {"0": {"score": 3}}]},
+        ]
+    )
+
+    assert _ids(collection.find({"items.0.score": {"$ne": None}})) == [
+        "numeric-field",
+        "scalar-index",
+    ]
+    assert _ids(collection.find({"items.0.score": {"$nin": [None]}})) == [
+        "numeric-field",
+        "scalar-index",
+    ]
+    assert _ids(collection.find({"items.0.score": 3})) == ["numeric-field"]
+
+
+def test_numeric_query_paths_consider_array_indexes_and_document_field_names(
+    contract_target,
+):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "array-index", "items": ["index-zero"]},
+            {"_id": "first-field", "items": [{"0": "field-zero"}]},
+            {
+                "_id": "later-field",
+                "items": [{"other": 1}, {"0": "later-zero"}],
+            },
+            {"_id": "indexed-array-only", "items": [[1, 2]]},
+            {"_id": "mixed", "items": [[1, 2], {"0": 1}]},
+        ]
+    )
+
+    assert _ids(collection.find({"items.0": "index-zero"})) == ["array-index"]
+    assert _ids(collection.find({"items.0": "field-zero"})) == ["first-field"]
+    assert _ids(collection.find({"items.0": "later-zero"})) == ["later-field"]
+    assert _ids(collection.find({"items.0": 1})) == ["mixed"]
+
+
+def test_mapping_filters_work_for_new_operators_and_dotted_paths(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "match", "values": [1, 2], "items": [{"score": 1}]},
+            {"_id": "other", "values": [1], "items": [{"score": 2}]},
+        ]
+    )
+
+    assert _ids(collection.find(UserDict({"values": UserDict({"$size": 2})}))) == [
+        "match"
+    ]
+    assert _ids(collection.find(UserDict({"items.score": 1}))) == ["match"]
+    assert _ids(
+        collection.find(
+            UserDict({"items": UserDict({"$elemMatch": UserDict({"score": 1})})})
+        )
+    ) == ["match"]
+
+
+def test_type_supports_aliases_codes_lists_and_array_element_matching(
+    contract_target,
+):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "string", "value": "hello"},
+            {"_id": "int", "value": 7},
+            {"_id": "long", "value": 2**40},
+            {"_id": "double", "value": 7.5},
+            {"_id": "bool", "value": True},
+            {"_id": "array", "value": ["hello", 7]},
+            {"_id": "object", "value": {"nested": 1}},
+            {"_id": "null", "value": None},
+        ]
+    )
+
+    assert _ids(collection.find({"value": {"$type": "string"}})) == [
+        "array",
+        "string",
+    ]
+    assert _ids(collection.find({"value": {"$type": 2}})) == [
+        "array",
+        "string",
+    ]
+    assert _ids(collection.find({"value": {"$type": "int"}})) == [
+        "array",
+        "int",
+    ]
+    assert _ids(collection.find({"value": {"$type": "array"}})) == ["array"]
+    assert _ids(collection.find({"value": {"$type": ["long", "double"]}})) == [
+        "double",
+        "long",
+    ]
+    assert _ids(collection.find({"value": {"$type": "number"}})) == [
+        "array",
+        "double",
+        "int",
+        "long",
+    ]
+
+
+def test_mod_uses_mongodb_integer_truncation_and_array_member_rules(
+    contract_target,
+):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "ten", "value": 10},
+            {"_id": "eleven", "value": 11},
+            {"_id": "fraction", "value": 10.9},
+            {"_id": "negative", "value": -10},
+            {"_id": "array", "value": [1, 14]},
+            {"_id": "string", "value": "10"},
+        ]
+    )
+
+    expected = ["array", "fraction", "ten"]
+    assert _ids(collection.find({"value": {"$mod": [4, 2]}})) == expected
+    assert _ids(collection.find({"value": {"$mod": [4.9, 2.9]}})) == expected
+    assert _ids(collection.find({"value": {"$mod": [4, -2]}})) == ["negative"]
+
+
+def test_recognized_query_operators_reject_malformed_operands(contract_target):
+    collection = contract_target.collection
+    collection.insert_one({"_id": "original", "value": [1, 2]})
+    malformed_queries = [
+        {"value": {"$size": "2"}},
+        {"value": {"$elemMatch": 1}},
+        {"value": {"$type": "not-a-real-bson-type"}},
+        {"value": {"$mod": [4]}},
+    ]
+
+    for query in malformed_queries:
+        with pytest.raises(_OPERATION_ERRORS):
+            list(collection.find(query))
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        {"numbers": {"$elemMatch": {"$nonsense": 1}}},
+        {"numbers": {"$elemMatch": {"$gt": 4, "$nonsense": 1}}},
+        {"numbers": {"$elemMatch": {"$and": [{"$gt": 4}]}}},
+    ],
+    ids=("unknown", "unknown-beside-field-operator", "misplaced-logical-clause"),
+)
+def test_elem_match_unknown_or_misplaced_operators_report_code_2(
+    contract_target,
+    query,
+):
+    collection = contract_target.collection
+    collection.insert_one({"_id": "original", "numbers": [1, 5, 10]})
+
+    with pytest.raises(_OPERATION_ERRORS) as caught:
+        list(collection.find(query))
+
+    assert caught.value.code == 2
+
+
+def test_comment_is_accepted_and_ignored_while_matching(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "first", "value": 1},
+            {"_id": "second", "value": 2},
+        ]
+    )
+
+    assert _ids(collection.find({"$comment": "application context"})) == [
+        "first",
+        "second",
+    ]
+    assert _ids(collection.find({"value": 2, "$comment": "application context"})) == [
+        "second"
+    ]
+
+
+def test_comment_inside_document_elem_match_is_accepted(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "scalars", "tags": ["a", "b"]},
+            {"_id": "documents", "tags": [{"kind": "match"}]},
+            {"_id": "nested-array", "tags": [["nested"]]},
+            {"_id": "empty", "tags": []},
+        ]
+    )
+
+    assert _ids(collection.find({"tags": {"$elemMatch": {"$comment": "context"}}})) == [
+        "documents",
+        "nested-array",
+    ]
+    assert _ids(
+        collection.find(
+            {
+                "tags": {
+                    "$elemMatch": {
+                        "kind": "match",
+                        "$comment": "context",
+                    }
+                }
+            }
+        )
+    ) == ["documents"]
+    assert _ids(
+        collection.aggregate(
+            [{"$match": {"tags": {"$elemMatch": {"$comment": "context"}}}}]
+        )
+    ) == ["documents", "nested-array"]
+    assert _ids(
+        collection.find(
+            {
+                "tags": {
+                    "$all": [
+                        {"$elemMatch": {"$comment": "context"}},
+                    ]
+                }
+            }
+        )
+    ) == ["documents", "nested-array"]
+
+
+def test_comment_remains_invalid_as_a_field_operator(contract_target):
+    collection = contract_target.collection
+    original = {"_id": "original", "value": 1}
+    collection.insert_one(original)
+
+    operations = (
+        "find",
+        "find_one",
+        "count_documents",
+        "distinct",
+        "update_one",
+        "update_many",
+        "replace_one",
+        "delete_one",
+        "delete_many",
+        "find_one_and_update",
+        "find_one_and_replace",
+        "find_one_and_delete",
+    )
+    for operation in operations:
+        with pytest.raises(_OPERATION_ERRORS) as caught:
+            _run_filter_operation(
+                collection,
+                operation,
+                {"value": {"$comment": "context"}},
+            )
+        assert caught.value.code == 2
+        assert collection.find_one({"_id": "original"}) == original
+
+    with pytest.raises(_OPERATION_ERRORS) as caught:
+        list(
+            collection.find(
+                {
+                    "value": {
+                        "$elemMatch": {
+                            "$gt": 0,
+                            "$comment": "context",
+                        }
+                    }
+                }
+            )
+        )
+    assert caught.value.code == 2
+
+    with pytest.raises(_OPERATION_ERRORS) as caught:
+        list(collection.aggregate([{"$match": {"value": {"$comment": "context"}}}]))
+    assert caught.value.code == 2
+
+
+def test_embedded_regex_flags_and_options_report_code_51075(contract_target):
+    collection = contract_target.collection
+    collection.insert_one({"_id": "text", "value": "text"})
+
+    with pytest.raises(_OPERATION_ERRORS) as caught:
+        list(
+            collection.find(
+                {
+                    "value": {
+                        "$regex": re.compile("te", re.IGNORECASE),
+                        "$options": "i",
+                    }
+                }
+            )
+        )
+    assert caught.value.code == 51075
+
+
+def test_index_name_and_key_conflict_codes_match_mongodb(contract_target):
+    collection = contract_target.collection
+    collection.create_index("value", name="ix")
+
+    conflicts = (
+        ("value", {"name": "ix", "unique": True}, 86),
+        ("other", {"name": "ix"}, 86),
+        ("value", {"name": "other_ix"}, 85),
+    )
+    for key, options, code in conflicts:
+        with pytest.raises(_OPERATION_ERRORS) as caught:
+            collection.create_index(key, **options)
+        assert caught.value.code == code
+
+
+@pytest.mark.parametrize("operand", ["text", 7, ["text"], {}, {"literal": 1}])
+def test_not_rejects_non_regex_and_empty_operands_with_code_2(
+    contract_target,
+    operand,
+):
+    collection = contract_target.collection
+    collection.insert_one({"_id": "original", "value": "text"})
+
+    with pytest.raises(_OPERATION_ERRORS) as caught:
+        list(collection.find({"value": {"$not": operand}}))
+
+    assert caught.value.code == 2
+
+
+def test_not_accepts_operator_documents_and_compiled_regexes(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "text", "value": "text"},
+            {"_id": "other", "value": "other"},
+            {"_id": "missing"},
+        ]
+    )
+
+    expected = ["missing", "other"]
+    assert _ids(collection.find({"value": {"$not": {"$eq": "text"}}})) == expected
+    assert _ids(collection.find({"value": {"$not": {"$regex": "^text$"}}})) == expected
+    assert _ids(collection.find({"value": {"$not": re.compile("^text$")}})) == expected
+    bson_regex = regex_type()
+    if bson_regex is not None:
+        assert (
+            _ids(collection.find({"value": {"$not": bson_regex("^text$")}})) == expected
+        )
+
+
+def test_every_filtering_crud_entrypoint_rejects_invalid_not_operands(
+    contract_target,
+):
+    collection = contract_target.collection
+    original = {"_id": "original", "value": "text"}
+    collection.insert_one(original)
+    operations = (
+        "find",
+        "find_one",
+        "count_documents",
+        "distinct",
+        "update_one",
+        "update_many",
+        "replace_one",
+        "delete_one",
+        "delete_many",
+        "find_one_and_update",
+        "find_one_and_replace",
+        "find_one_and_delete",
+    )
+
+    for operation in operations:
+        with pytest.raises(_OPERATION_ERRORS) as caught:
+            _run_filter_operation(
+                collection,
+                operation,
+                {"value": {"$not": "text"}},
+            )
+        assert caught.value.code == 2
+        assert collection.find_one({"_id": "original"}) == original
+
+
+def test_find_rejects_top_level_and_field_operator_typos(contract_target):
+    collection = contract_target.collection
+    collection.insert_one({"_id": "original", "value": 1})
+
+    for query in ({"$madeUp": 1}, {"value": {"$madeUp": 1}}):
+        with pytest.raises(_QUERY_REJECTION_ERRORS):
+            list(collection.find(query))
+
+
+def test_every_filtering_crud_entrypoint_rejects_operator_typos(contract_target):
+    collection = contract_target.collection
+    original = {"_id": "original", "value": 1}
+    collection.insert_one(original)
+    operations = (
+        "find",
+        "find_one",
+        "count_documents",
+        "distinct",
+        "update_one",
+        "update_many",
+        "replace_one",
+        "delete_one",
+        "delete_many",
+        "find_one_and_update",
+        "find_one_and_replace",
+        "find_one_and_delete",
+    )
+    typo = {"value": {"$madeUp": 1}}
+
+    for operation in operations:
+        with pytest.raises(_QUERY_REJECTION_ERRORS):
+            _run_filter_operation(collection, operation, typo)
+        assert collection.find_one({"_id": "original"}) == original
+
+
+def test_distinct_rejects_falsey_non_document_filters(contract_target):
+    collection = contract_target.collection
+    collection.insert_one({"_id": "original", "value": 1})
+
+    for malformed_filter in ([], (), 0, False, ""):
+        with pytest.raises(_OPERATION_ERRORS) as caught:
+            collection.distinct("value", malformed_filter)
+        assert caught.value.code == 14
+
+
+def test_duplicate_key_errors_report_code_11000(contract_target):
+    collection = contract_target.collection
+    collection.insert_one({"_id": "first", "email": "ada@example.test"})
+
+    with pytest.raises(_DUPLICATE_KEY_ERRORS) as duplicate_id:
+        collection.insert_one({"_id": "first", "email": "grace@example.test"})
+    assert duplicate_id.value.code == 11000
+
+    collection.create_index("email", unique=True)
+    with pytest.raises(_DUPLICATE_KEY_ERRORS) as duplicate_index:
+        collection.insert_one({"_id": "second", "email": "ada@example.test"})
+    assert duplicate_index.value.code == 11000
+
+
+def test_add_to_set_non_array_errors_report_code_2_and_leave_document_atomic(
+    contract_target,
+):
+    collection = contract_target.collection
+    originals = [
+        {"_id": "scalar", "values": "not-an-array", "status": "original"},
+        {"_id": "null", "values": None, "status": "original"},
+    ]
+    collection.insert_many(originals)
+
+    for method in (collection.update_one, collection.update_many):
+        for original in originals:
+            with pytest.raises(_WRITE_ERRORS) as caught:
+                method(
+                    {"_id": original["_id"]},
+                    {
+                        "$set": {"status": "changed"},
+                        "$addToSet": {"values": "new"},
+                    },
+                )
+            assert caught.value.code == 2
+            assert collection.find_one({"_id": original["_id"]}) == original

--- a/compat/mongo/v1/runner/contracts/test_talkpython_contract.py
+++ b/compat/mongo/v1/runner/contracts/test_talkpython_contract.py
@@ -1,0 +1,620 @@
+"""High-signal compatibility contracts derived from the Talk Python application."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from .support import observe
+
+
+pytestmark = pytest.mark.contract
+
+
+def _ids(documents):
+    return [document["_id"] for document in documents]
+
+
+def test_projection_none_absent_fields_and_integer_id(contract_target):
+    collection = contract_target.collection
+    collection.insert_one(
+        {
+            "_id": 42,
+            "title": "Python Bytes",
+            "description": "A short episode summary",
+        }
+    )
+
+    full = collection.find_one({"_id": 42}, None)
+    projected = collection.find_one({"_id": 42}, {"title": 1, "_id": 0})
+
+    assert full == {
+        "_id": 42,
+        "title": "Python Bytes",
+        "description": "A short episode summary",
+    }
+    assert type(full["_id"]) is int
+    assert projected == {"title": "Python Bytes"}
+    assert "description" not in projected
+    assert collection.find_one({"_id": 404}) is None
+
+
+def test_find_one_sort_returns_the_newest_match(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "show_id": 201, "is_published": True},
+            {"_id": 2, "show_id": 203, "is_published": True},
+            {"_id": 3, "show_id": 202, "is_published": False},
+        ]
+    )
+
+    newest = collection.find_one({"is_published": True}, sort=[("show_id", -1)])
+
+    assert newest["_id"] == 2
+
+
+def test_single_and_multi_key_sort_break_ties(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "show_id": 101, "times": 5, "last_missed": 10},
+            {"_id": 2, "show_id": 103, "times": 5, "last_missed": 30},
+            {"_id": 3, "show_id": 102, "times": 4, "last_missed": 99},
+        ]
+    )
+
+    by_show_id = collection.find({}).sort("show_id", -1)
+    by_miss_count = collection.find({}).sort([("times", -1), ("last_missed", -1)])
+
+    assert _ids(by_show_id) == [2, 3, 1]
+    assert _ids(by_miss_count) == [2, 1, 3]
+
+
+def test_cursor_to_list_accepts_both_application_spellings(contract_target):
+    collection = contract_target.collection
+    collection.insert_many([{"_id": number} for number in range(3)])
+
+    implicit_length = collection.find({}).sort("_id", 1).to_list()
+    unlimited_length = collection.find({}).sort("_id", 1).to_list(length=None)
+
+    assert isinstance(implicit_length, list)
+    assert isinstance(unlimited_length, list)
+    assert _ids(implicit_length) == [0, 1, 2]
+    assert _ids(unlimited_length) == [0, 1, 2]
+
+
+def test_cursor_skip_limit_windows_and_past_end(contract_target):
+    collection = contract_target.collection
+    collection.insert_many([{"_id": number} for number in range(6)])
+
+    window = collection.find({}).sort("_id", 1).skip(2).limit(3).to_list(length=None)
+    past_end = collection.find({}).sort("_id", 1).skip(20).to_list(length=None)
+
+    assert _ids(window) == [2, 3, 4]
+    assert past_end == []
+
+
+def test_cursor_limit_zero_means_unlimited(contract_target):
+    collection = contract_target.collection
+    collection.insert_many([{"_id": number} for number in range(4)])
+
+    documents = list(collection.find({}).sort("_id", 1).limit(0))
+
+    assert _ids(documents) == [0, 1, 2, 3]
+
+
+def test_scalar_equality_matches_an_array_member(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "guest_ids": ["mike", "brian"]},
+            {"_id": 2, "guest_ids": ["carol"]},
+            {"_id": 3, "guest_ids": "mike"},
+        ]
+    )
+
+    assert sorted(_ids(collection.find({"guest_ids": "mike"}))) == [1, 3]
+
+
+def test_dot_notation_matches_an_embedded_document(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "membership": {"memberful_id": "member-42"}},
+            {"_id": 2, "membership": {"memberful_id": "member-99"}},
+            {"_id": 3},
+        ]
+    )
+
+    assert collection.find_one({"membership.memberful_id": "member-42"})["_id"] == 1
+
+
+def test_not_regex_with_case_insensitive_options(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "title": "Talk Python To Me"},
+            {"_id": 2, "title": "PYTHON NEWS"},
+            {"_id": 3, "title": "MongoDB internals"},
+            {"_id": 4},
+        ]
+    )
+
+    documents = collection.find(
+        {"title": {"$not": {"$regex": "python", "$options": "i"}}}
+    )
+
+    assert sorted(_ids(documents)) == [3, 4]
+
+
+def test_nin_excludes_values_and_includes_missing_fields(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "status": "public"},
+            {"_id": 2, "status": "private"},
+            {"_id": 3, "status": "archived"},
+            {"_id": 4},
+        ]
+    )
+
+    documents = collection.find({"status": {"$nin": ["private", "archived"]}})
+
+    assert sorted(_ids(documents)) == [1, 4]
+
+
+def test_null_negation_distinguishes_missing_and_non_null_fields(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "value": "real"},
+            {"_id": 2, "value": ""},
+            {"_id": 3, "value": None},
+            {"_id": 4},
+            {"_id": 5, "value": "other"},
+        ]
+    )
+
+    expectations = [
+        ({"value": {"$nin": [None, ""]}}, [1, 5]),
+        ({"value": {"$nin": (None, "")}}, [1, 5]),
+        ({"value": {"$ne": None}}, [1, 2, 5]),
+        ({"value": {"$ne": ""}}, [1, 3, 4, 5]),
+        ({"value": {"$nin": ["real"]}}, [2, 3, 4, 5]),
+        ({"value": {"$not": {"$regex": "^r"}}}, [2, 3, 4, 5]),
+        ({"value": {"$exists": True}}, [1, 2, 3, 5]),
+        ({"value": {"$exists": False}}, [4]),
+    ]
+
+    for query, expected_ids in expectations:
+        assert sorted(_ids(collection.find(query))) == expected_ids
+
+
+def test_nin_and_negated_regex_share_one_field_specification(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "title": "Private episode"},
+            {"_id": 2, "title": "Python News"},
+            {"_id": 3, "title": "MongoDB internals"},
+            {"_id": 4},
+        ]
+    )
+
+    documents = collection.find(
+        {
+            "title": {
+                "$nin": ["Private episode"],
+                "$not": {"$regex": "python", "$options": "i"},
+            }
+        }
+    )
+
+    assert sorted(_ids(documents)) == [3, 4]
+
+
+def test_write_result_metadata_used_by_the_application(contract_target):
+    collection = contract_target.collection
+
+    inserted = collection.insert_one({"_id": 1, "status": "ready"})
+    unchanged = collection.update_one({"_id": 1}, {"$set": {"status": "ready"}})
+    missing = collection.update_one({"_id": 404}, {"$set": {"status": "ready"}})
+    collection.insert_many(
+        [
+            {"_id": 2, "status": "delete"},
+            {"_id": 3, "status": "delete"},
+        ]
+    )
+    deleted_one = collection.delete_one({"_id": 1})
+    deleted_many = collection.delete_many({"status": "delete"})
+
+    assert inserted.inserted_id == 1
+    assert (unchanged.matched_count, unchanged.modified_count) == (1, 0)
+    assert (missing.matched_count, missing.modified_count) == (0, 0)
+    assert deleted_one.deleted_count == 1
+    assert deleted_many.deleted_count == 2
+
+
+def test_inc_creates_a_missing_counter(contract_target):
+    collection = contract_target.collection
+    collection.insert_one({"_id": 1, "show_id": 42})
+
+    result = collection.update_one({"show_id": 42}, {"$inc": {"download_totals": 1}})
+
+    assert (result.matched_count, result.modified_count) == (1, 1)
+    assert collection.find_one({"_id": 1})["download_totals"] == 1
+
+
+def test_replace_one_preserves_id_and_replaces_the_full_document(contract_target):
+    collection = contract_target.collection
+    collection.insert_one(
+        {"_id": 1, "title": "Old title", "obsolete": True, "views": 10}
+    )
+
+    replaced = collection.replace_one({"_id": 1}, {"title": "New title", "views": 11})
+    unchanged = collection.replace_one(
+        {"_id": 1}, {"_id": 1, "title": "New title", "views": 11}
+    )
+    missing = collection.replace_one({"_id": 404}, {"title": "Missing"})
+
+    assert (replaced.matched_count, replaced.modified_count) == (1, 1)
+    assert (unchanged.matched_count, unchanged.modified_count) == (1, 0)
+    assert (missing.matched_count, missing.modified_count) == (0, 0)
+    assert collection.find_one({"_id": 1}) == {
+        "_id": 1,
+        "title": "New title",
+        "views": 11,
+    }
+
+
+def test_distinct_returns_scalar_field_values(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "user_agent": "Firefox"},
+            {"_id": 2, "user_agent": "Safari"},
+            {"_id": 3, "user_agent": "Firefox"},
+            {"_id": 4},
+        ]
+    )
+
+    assert sorted(collection.distinct("user_agent")) == ["Firefox", "Safari"]
+
+
+def test_create_indexes_accepts_the_real_mixed_batch_and_enforces_unique(
+    contract_target,
+):
+    pymongo = pytest.importorskip("pymongo")
+    collection = contract_target.collection
+    models = [
+        pymongo.IndexModel([("show_id", -1)], name="newest_show"),
+        pymongo.IndexModel([("is_published", 1)], name="is_published"),
+        pymongo.IndexModel(
+            [("is_published", 1), ("show_id", -1)],
+            name="published_show_priority",
+        ),
+        pymongo.IndexModel([("api_key", "hashed")], name="api_key_lookup"),
+        pymongo.IndexModel([("optional_slug", 1)], name="optional_slug", sparse=True),
+        pymongo.IndexModel([("email", 1)], name="email_unique", unique=True),
+        pymongo.IndexModel(
+            [("created_date", 1)],
+            name="expire_geo_lookup",
+            expireAfterSeconds=63_072_000,
+        ),
+    ]
+
+    if contract_target.transport == "pymongo":
+        created = collection.create_indexes(models)
+    else:
+        with pytest.warns(contract_target.unsupported_warning) as captured:
+            created = collection.create_indexes(models)
+        assert len(captured) == 4
+        warning_messages = [str(item.message) for item in captured]
+        assert any("newest_show" in message for message in warning_messages)
+        assert any("published_show_priority" in message for message in warning_messages)
+        assert any("api_key_lookup" in message for message in warning_messages)
+        assert any("expire_geo_lookup" in message for message in warning_messages)
+    collection.insert_one({"_id": 1, "email": "mike@example.com"})
+    duplicate = observe(
+        lambda: collection.insert_one({"_id": 2, "email": "mike@example.com"})
+    )
+
+    expected_created = {
+        "newest_show",
+        "is_published",
+        "api_key_lookup",
+        "optional_slug",
+        "email_unique",
+        "expire_geo_lookup",
+        "published_show_priority",
+    }
+    assert set(created) == expected_created
+    assert duplicate.error == "duplicate_key"
+
+
+def test_object_id_and_datetime_round_trip_and_range_query(contract_target):
+    bson = pytest.importorskip("bson")
+    collection = contract_target.collection
+    episode_id = bson.ObjectId()
+    created_date = datetime(2025, 2, 3, 12, 30, 45, 123000)
+    collection.insert_one(
+        {"_id": episode_id, "title": "Async Python", "created_date": created_date}
+    )
+
+    document = collection.find_one({"_id": episode_id})
+    in_range = list(
+        collection.find(
+            {
+                "created_date": {
+                    "$gt": created_date - timedelta(seconds=1),
+                    "$lt": created_date + timedelta(seconds=1),
+                }
+            }
+        )
+    )
+
+    assert document["_id"] == episode_id
+    assert isinstance(document["_id"], bson.ObjectId)
+    assert document["created_date"] == created_date
+    assert isinstance(document["created_date"], datetime)
+    assert _ids(in_range) == [episode_id]
+
+
+def test_generated_id_uses_the_standard_object_id_round_trip(contract_target):
+    bson = pytest.importorskip("bson")
+    collection = contract_target.collection
+    document = {"title": "A newly-created episode"}
+
+    result = collection.insert_one(document)
+    reconstructed = bson.ObjectId(str(result.inserted_id))
+    found = collection.find_one({"_id": reconstructed})
+
+    assert isinstance(result.inserted_id, bson.ObjectId)
+    assert document["_id"] == result.inserted_id
+    assert len(str(result.inserted_id)) == 24
+    assert reconstructed == result.inserted_id
+    assert found["title"] == document["title"]
+
+
+def test_invalid_document_has_a_bson_compatible_error(contract_target):
+    bson_errors = pytest.importorskip("bson.errors")
+    pymongo_errors = pytest.importorskip("pymongo.errors")
+    collection = contract_target.collection
+    document = {"payload": {"tags": {1, 2, 3}}}
+
+    with pytest.raises(bson_errors.InvalidDocument) as caught:
+        collection.insert_one(document)
+
+    if contract_target.transport != "pymongo" and contract_target.api == "sync":
+        assert collection.name not in collection.database.list_collection_names()
+    assert collection.count_documents({}) == 0
+    if contract_target.transport != "pymongo":
+        assert isinstance(caught.value, pymongo_errors.PyMongoError)
+        assert caught.value.document is document
+        assert collection.full_name in str(caught.value)
+        assert "payload" in str(caught.value)
+        assert "tags" in str(caught.value)
+        assert "set" in str(caught.value)
+
+
+def test_binary_round_trip_query_and_mongodb_sort_order(contract_target):
+    bson = pytest.importorskip("bson")
+    collection = contract_target.collection
+    uuid_binary = bson.Binary(bytes(range(16)), subtype=4)
+    sort_values = [
+        ("short-custom", bson.Binary(b"\xff", subtype=128)),
+        ("two-generic", b"\xff\xff"),
+        ("two-custom-low", bson.Binary(b"\x00\x00", subtype=128)),
+        ("two-custom-high", bson.Binary(b"\xff\x00", subtype=128)),
+        ("three-generic", b"\x00\x00\x00"),
+    ]
+    collection.insert_many(
+        [
+            {
+                "_id": label,
+                "label": label,
+                "value": value,
+                "nested": {"token": uuid_binary},
+            }
+            for label, value in reversed(sort_values)
+        ]
+    )
+
+    by_binary = list(collection.find({}).sort("value", 1))
+    matched = collection.find_one({"nested.token": uuid_binary})
+
+    assert [document["label"] for document in by_binary] == [
+        label for label, _value in sort_values
+    ]
+    assert matched is not None
+    assert isinstance(matched["value"], (bytes, bson.Binary))
+    assert isinstance(matched["nested"]["token"], bson.Binary)
+    assert matched["nested"]["token"].subtype == 4
+    assert bytes(matched["nested"]["token"]) == bytes(uuid_binary)
+
+
+def test_generic_binary_equality_matches_native_bytes_and_query_operators(
+    contract_target,
+):
+    bson = pytest.importorskip("bson")
+    collection = contract_target.collection
+    generic = bson.Binary(b"talk-python", subtype=0)
+    collection.insert_many(
+        [
+            {
+                "_id": "binary-object",
+                "value": generic,
+                "values": [generic, "other"],
+            },
+            {
+                "_id": "native-bytes",
+                "value": b"python-bytes",
+                "values": [b"python-bytes"],
+            },
+        ]
+    )
+
+    assert collection.find_one({"value": b"talk-python"})["_id"] == "binary-object"
+    assert collection.find_one({"value": generic})["_id"] == "binary-object"
+    if contract_target.transport != "pymongo":
+        # TinyMongo accepts bytearray as a convenience and canonicalizes it to
+        # BSON's generic binary subtype. PyMongo rejects bytearray at encoding.
+        assert (
+            collection.find_one({"value": bytearray(b"talk-python")})["_id"]
+            == "binary-object"
+        )
+    assert (
+        collection.find_one({"value": bson.Binary(b"python-bytes", subtype=0)})["_id"]
+        == "native-bytes"
+    )
+    assert collection.find_one({"values": generic})["_id"] == "binary-object"
+    assert collection.find_one({"values": {"$in": [generic]}})["_id"] == "binary-object"
+    assert (
+        collection.find_one({"values": {"$all": [b"talk-python"]}})["_id"]
+        == "binary-object"
+    )
+    assert sorted(_ids(collection.find({"value": {"$nin": [b"talk-python"]}}))) == [
+        "native-bytes"
+    ]
+
+
+def test_binary_ids_use_bson_equality_without_losing_subtype(contract_target):
+    bson = pytest.importorskip("bson")
+    pymongo_errors = pytest.importorskip("pymongo.errors")
+    collection = contract_target.collection
+    raw = bytes(range(16))
+    generic_id = bson.Binary(raw, subtype=0)
+    uuid_id = bson.Binary(raw, subtype=4)
+
+    collection.insert_one({"_id": generic_id, "kind": "generic"})
+
+    assert collection.find_one({"_id": raw})["kind"] == "generic"
+    with pytest.raises(pymongo_errors.DuplicateKeyError):
+        collection.insert_one({"_id": raw, "kind": "duplicate"})
+
+    collection.insert_one({"_id": uuid_id, "kind": "uuid"})
+    assert collection.find_one({"_id": uuid_id})["kind"] == "uuid"
+    assert sorted(document["kind"] for document in collection.find({})) == [
+        "generic",
+        "uuid",
+    ]
+    collection.update_one({"_id": uuid_id}, {"$set": {"updated": True}})
+    assert collection.find_one({"_id": raw}).get("updated") is None
+    assert collection.find_one({"_id": uuid_id})["updated"] is True
+    collection.delete_one({"_id": raw})
+    assert collection.find_one({"_id": raw}) is None
+    assert collection.find_one({"_id": uuid_id}) is not None
+
+
+def test_boolean_and_numeric_ids_are_bson_distinct(contract_target):
+    pymongo_errors = pytest.importorskip("pymongo.errors")
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "kind": "number"},
+            {"_id": True, "kind": "boolean"},
+        ]
+    )
+
+    assert collection.find_one({"_id": 1})["kind"] == "number"
+    assert collection.find_one({"_id": True})["kind"] == "boolean"
+    assert collection.find_one({"_id": 1.0})["kind"] == "number"
+    with pytest.raises(pymongo_errors.DuplicateKeyError):
+        collection.insert_one({"_id": 1.0, "kind": "duplicate-number"})
+    collection.update_one({"_id": True}, {"$set": {"updated": True}})
+    assert collection.find_one({"_id": 1}).get("updated") is None
+    assert collection.find_one({"_id": True})["updated"] is True
+    collection.delete_one({"_id": 1.0})
+    assert collection.find_one({"_id": 1}) is None
+    assert collection.find_one({"_id": True}) is not None
+
+
+def test_mixed_timezone_datetimes_sort_by_utc_instant(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {
+                "_id": "late",
+                "published": datetime(2026, 1, 1, 3, tzinfo=timezone.utc),
+            },
+            {
+                "_id": "early",
+                "published": datetime(
+                    2025,
+                    12,
+                    31,
+                    21,
+                    tzinfo=timezone(timedelta(hours=-3)),
+                ),
+            },
+            {"_id": "middle", "published": datetime(2026, 1, 1, 1)},
+        ]
+    )
+
+    assert _ids(collection.find({}).sort("published", 1)) == [
+        "early",
+        "middle",
+        "late",
+    ]
+    assert _ids(collection.find({}).sort("published", -1)) == [
+        "late",
+        "middle",
+        "early",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("ordered", "expected_ids", "expected_inserted"),
+    [
+        (True, [1], 1),
+        (False, [1, 2], 2),
+    ],
+)
+def test_insert_many_reports_compatible_partial_failures(
+    contract_target,
+    ordered,
+    expected_ids,
+    expected_inserted,
+):
+    pymongo_errors = pytest.importorskip("pymongo.errors")
+    collection = contract_target.collection
+    documents = [
+        {"_id": 1, "label": "first"},
+        {"_id": 1, "label": "duplicate"},
+        {"_id": 2, "label": "last"},
+    ]
+
+    with pytest.raises(pymongo_errors.BulkWriteError) as caught:
+        collection.insert_many(documents, ordered=ordered)
+
+    details = caught.value.details
+    assert _ids(collection.find({}).sort("_id", 1)) == expected_ids
+    assert details["nInserted"] == expected_inserted
+    assert details["writeConcernErrors"] == []
+    assert [(error["index"], error["code"]) for error in details["writeErrors"]] == [
+        (1, 11000)
+    ]
+
+
+def test_insert_many_accepts_a_document_generator(contract_target):
+    collection = contract_target.collection
+    documents = ({"_id": number, "label": str(number)} for number in range(3))
+
+    result = collection.insert_many(documents)
+
+    assert result.inserted_ids == [0, 1, 2]
+    assert _ids(collection.find({}).sort("_id", 1)) == [0, 1, 2]
+
+
+def test_duplicate_errors_are_catchable_as_pymongo_errors(contract_target):
+    pymongo_errors = pytest.importorskip("pymongo.errors")
+    collection = contract_target.collection
+    collection.insert_one({"_id": 42})
+
+    caught = None
+    try:
+        collection.insert_one({"_id": 42})
+    except pymongo_errors.PyMongoError as error:
+        caught = error
+
+    assert isinstance(caught, pymongo_errors.DuplicateKeyError)

--- a/compat/mongo/v1/runner/contracts/test_update_operator_contract.py
+++ b/compat/mongo/v1/runner/contracts/test_update_operator_contract.py
@@ -1,0 +1,401 @@
+"""Issue #77 update-operator contracts shared by every target."""
+
+import pytest
+
+from .support import WRITE_ERRORS as _WRITE_ERRORS
+
+
+pytestmark = pytest.mark.contract
+
+def test_min_and_max_follow_bson_order_and_report_noops(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {
+                "_id": "changes",
+                "minimum": "text",
+                "maximum": 99,
+                "nested": {"score": 3},
+                "array": [2],
+            },
+            {
+                "_id": "numeric-equal",
+                "minimum": 1.0,
+                "maximum": 1.0,
+            },
+        ]
+    )
+
+    changed = collection.update_one(
+        {"_id": "changes"},
+        {
+            "$min": {
+                "minimum": 7,
+                "nested.score": 2,
+                "array": [1],
+                "created.low": 4,
+            },
+            "$max": {
+                "maximum": {"rank": 1},
+                "created.high": 9,
+            },
+        },
+    )
+    unchanged = collection.update_one(
+        {"_id": "numeric-equal"},
+        {
+            "$min": {"minimum": 1},
+            "$max": {"maximum": 1},
+        },
+    )
+
+    assert (changed.matched_count, changed.modified_count) == (1, 1)
+    assert (unchanged.matched_count, unchanged.modified_count) == (1, 0)
+    assert collection.find_one({"_id": "changes"}) == {
+        "_id": "changes",
+        "minimum": 7,
+        "maximum": {"rank": 1},
+        "nested": {"score": 2},
+        "array": [1],
+        "created": {"low": 4, "high": 9},
+    }
+    equal = collection.find_one({"_id": "numeric-equal"})
+    assert type(equal["minimum"]) is float
+    assert type(equal["maximum"]) is float
+
+
+def test_min_and_max_include_null_in_whole_bson_value_order(contract_target):
+    collection = contract_target.collection
+    collection.insert_one(
+        {
+            "_id": "null-order",
+            "min-null": None,
+            "max-null": None,
+            "min-number": 1,
+            "max-number": 1,
+        }
+    )
+
+    result = collection.update_one(
+        {"_id": "null-order"},
+        {
+            "$min": {"min-null": 1, "min-number": None},
+            "$max": {"max-null": 1, "max-number": None},
+        },
+    )
+
+    assert (result.matched_count, result.modified_count) == (1, 1)
+    assert collection.find_one({"_id": "null-order"}) == {
+        "_id": "null-order",
+        "min-null": None,
+        "max-null": 1,
+        "min-number": None,
+        "max-number": 1,
+    }
+
+
+def test_rename_moves_nested_values_overwrites_and_ignores_missing_source(
+    contract_target,
+):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {
+                "_id": "move",
+                "source": {"value": 1},
+                "destination": {"stale": True},
+                "profile": {"old": "nested", "keep": True},
+            },
+            {
+                "_id": "missing",
+                "destination": "unchanged",
+            },
+        ]
+    )
+
+    moved = collection.update_one(
+        {"_id": "move"},
+        {
+            "$rename": {
+                "source": "destination",
+                "profile.old": "moved.value",
+            }
+        },
+    )
+    missing = collection.update_one(
+        {"_id": "missing"},
+        {"$rename": {"absent": "destination"}},
+    )
+
+    assert (moved.matched_count, moved.modified_count) == (1, 1)
+    assert (missing.matched_count, missing.modified_count) == (1, 0)
+    assert collection.find_one({"_id": "move"}) == {
+        "_id": "move",
+        "destination": {"value": 1},
+        "profile": {"keep": True},
+        "moved": {"value": "nested"},
+    }
+    assert collection.find_one({"_id": "missing"}) == {
+        "_id": "missing",
+        "destination": "unchanged",
+    }
+
+
+def test_pop_handles_front_back_nested_empty_and_missing_arrays(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {
+                "_id": "values",
+                "front": [1, 2, 3],
+                "back": [1, 2, 3],
+                "nested": {"values": [4, 5]},
+            },
+            {"_id": "empty", "values": []},
+            {"_id": "missing"},
+        ]
+    )
+
+    changed = collection.update_one(
+        {"_id": "values"},
+        {
+            "$pop": {
+                "front": -1,
+                "back": 1,
+                "nested.values": -1,
+            }
+        },
+    )
+    empty = collection.update_one({"_id": "empty"}, {"$pop": {"values": 1}})
+    missing = collection.update_one(
+        {"_id": "missing"}, {"$pop": {"values": 1, "nested.values": -1}}
+    )
+
+    assert (changed.matched_count, changed.modified_count) == (1, 1)
+    assert (empty.matched_count, empty.modified_count) == (1, 0)
+    assert (missing.matched_count, missing.modified_count) == (1, 0)
+    assert collection.find_one({"_id": "values"}) == {
+        "_id": "values",
+        "front": [2, 3],
+        "back": [1, 2],
+        "nested": {"values": [5]},
+    }
+
+
+def test_new_update_operators_follow_numeric_array_paths(contract_target):
+    collection = contract_target.collection
+    collection.insert_one(
+        {
+            "_id": "array-paths",
+            "values": [5, 8],
+            "nested": [[1, 2], [3]],
+            "documents": [{"score": 9}],
+        }
+    )
+
+    result = collection.update_one(
+        {"_id": "array-paths"},
+        {
+            "$min": {
+                "values.0": 3,
+                "values.3": 7,
+                "documents.2.score": 4,
+            },
+            "$max": {"values.1": 10},
+            "$pop": {"nested.0": 1},
+        },
+    )
+
+    assert (result.matched_count, result.modified_count) == (1, 1)
+    assert collection.find_one({"_id": "array-paths"}) == {
+        "_id": "array-paths",
+        "values": [3, 10, None, 7],
+        "nested": [[1], [3]],
+        "documents": [{"score": 9}, None, {"score": 4}],
+    }
+
+
+def test_new_update_operators_cover_upsert_update_many_and_find_and_modify(
+    contract_target,
+):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "many-change", "group": "many", "low": 10, "high": 0},
+            {"_id": "many-noop", "group": "many", "low": 1, "high": 10},
+            {"_id": "find", "old": "value", "score": 1},
+        ]
+    )
+
+    many = collection.update_many(
+        {"group": "many"},
+        {"$min": {"low": 5}, "$max": {"high": 5}},
+    )
+    upserted = collection.update_one(
+        {"_id": "upserted"},
+        {
+            "$min": {"low": 3},
+            "$max": {"high": 7},
+            "$pop": {"missing_array": 1},
+        },
+        upsert=True,
+    )
+    after = collection.find_one_and_update(
+        {"_id": "find"},
+        {"$rename": {"old": "new"}, "$max": {"score": 2}},
+        return_document=True,
+    )
+
+    assert (many.matched_count, many.modified_count) == (2, 1)
+    assert collection.find_one({"_id": "many-change"})["low"] == 5
+    assert collection.find_one({"_id": "many-change"})["high"] == 5
+    assert collection.find_one({"_id": "many-noop"})["low"] == 1
+    assert collection.find_one({"_id": "many-noop"})["high"] == 10
+    assert upserted.upserted_id == "upserted"
+    assert collection.find_one({"_id": "upserted"}) == {
+        "_id": "upserted",
+        "low": 3,
+        "high": 7,
+    }
+    assert after == {"_id": "find", "new": "value", "score": 2}
+
+
+def test_new_update_operators_apply_to_upsert_equality_fields(contract_target):
+    collection = contract_target.collection
+
+    minimum = collection.update_one(
+        {"_id": "minimum", "score": 5},
+        {"$min": {"score": 3}},
+        upsert=True,
+    )
+    maximum = collection.update_one(
+        {"_id": "maximum", "score": 5},
+        {"$max": {"score": 7}},
+        upsert=True,
+    )
+    popped = collection.update_one(
+        {"_id": "popped", "values": [1, 2]},
+        {"$pop": {"values": 1}},
+        upsert=True,
+    )
+    renamed = collection.update_one(
+        {"_id": "renamed", "source": "value"},
+        {"$rename": {"source": "destination"}},
+        upsert=True,
+    )
+
+    assert minimum.upserted_id == "minimum"
+    assert maximum.upserted_id == "maximum"
+    assert popped.upserted_id == "popped"
+    assert renamed.upserted_id == "renamed"
+    assert collection.find_one({"_id": "minimum"})["score"] == 3
+    assert collection.find_one({"_id": "maximum"})["score"] == 7
+    assert collection.find_one({"_id": "popped"})["values"] == [1]
+    assert collection.find_one({"_id": "renamed"}) == {
+        "_id": "renamed",
+        "destination": "value",
+    }
+
+
+def test_malformed_new_update_operands_report_mongodb_codes(contract_target):
+    collection = contract_target.collection
+    original = {"_id": "original", "field": 1, "values": [1]}
+    collection.insert_one(original)
+    cases = (
+        ("rename-non-string", {"$rename": {"field": 1}}, 2),
+        ("rename-self", {"$rename": {"field": "field"}}, 2),
+        ("rename-prefix", {"$rename": {"field": "field.child"}}, 2),
+        ("pop-zero", {"$pop": {"values": 0}}, 9),
+        ("pop-two", {"$pop": {"values": 2}}, 9),
+        ("pop-fraction", {"$pop": {"values": 1.5}}, 9),
+        ("pop-boolean", {"$pop": {"values": True}}, 9),
+        ("pop-string", {"$pop": {"values": "1"}}, 9),
+        ("pop-body", {"$pop": []}, 9),
+    )
+
+    for label, update, code in cases:
+        with pytest.raises(_WRITE_ERRORS) as caught:
+            collection.update_one({"_id": "original"}, update)
+        assert caught.value.code == code, label
+        assert collection.find_one({"_id": "original"}) == original, label
+
+
+def test_update_path_conflicts_report_code_40_before_writing(contract_target):
+    collection = contract_target.collection
+    original = {
+        "_id": "conflict",
+        "field": {"child": [1, 2]},
+        "other": 2,
+    }
+    collection.insert_one(original)
+    conflicts = (
+        {"$min": {"other": 1}, "$max": {"other": 3}},
+        {"$set": {"field": {}}, "$pop": {"field.child": 1}},
+        {"$rename": {"other": "moved"}, "$set": {"moved": 3}},
+    )
+
+    for update in conflicts:
+        with pytest.raises(_WRITE_ERRORS) as caught:
+            collection.update_one({"_id": "conflict"}, update)
+        assert caught.value.code == 40
+        assert collection.find_one({"_id": "conflict"}) == original
+
+
+def test_new_update_operators_preserve_immutable_id_semantics(contract_target):
+    collection = contract_target.collection
+    collection.insert_one({"_id": 5, "value": 1})
+
+    unchanged = collection.update_one({"_id": 5}, {"$min": {"_id": 7}})
+    assert (unchanged.matched_count, unchanged.modified_count) == (1, 0)
+
+    for update in ({"$min": {"_id": 3}}, {"$rename": {"_id": "former_id"}}):
+        with pytest.raises(_WRITE_ERRORS) as caught:
+            collection.update_one({"_id": 5}, update)
+        assert caught.value.code == 66
+        assert collection.find_one({"_id": 5}) == {"_id": 5, "value": 1}
+
+
+def test_new_update_operators_report_target_and_path_errors_atomically(
+    contract_target,
+):
+    collection = contract_target.collection
+    cases = (
+        ("pop-null", {"values": None}, {"$pop": {"values": 1}}, 14),
+        (
+            "pop-scalar",
+            {"values": "scalar"},
+            {"$pop": {"values": -1}},
+            14,
+        ),
+        (
+            "pop-blocked-path",
+            {"path": "scalar"},
+            {"$pop": {"path.values": 1}},
+            28,
+        ),
+        (
+            "rename-out-of-array",
+            {"path": [1, 2]},
+            {"$rename": {"path.0": "moved"}},
+            2,
+        ),
+        (
+            "rename-into-array",
+            {"path": [1, 2], "moved": 3},
+            {"$rename": {"moved": "path.0"}},
+            2,
+        ),
+    )
+
+    for label, document, update, code in cases:
+        original = {"_id": label, "status": "unchanged"}
+        original.update(document)
+        collection.insert_one(original)
+        atomic_update = {"$set": {"status": "changed"}}
+        atomic_update.update(update)
+
+        with pytest.raises(_WRITE_ERRORS) as caught:
+            collection.update_one({"_id": label}, atomic_update)
+
+        assert caught.value.code == code, label
+        assert collection.find_one({"_id": label}) == original, label

--- a/compat/mongo/v1/runner/contracts/test_uuid_regex_contract.py
+++ b/compat/mongo/v1/runner/contracts/test_uuid_regex_contract.py
@@ -1,0 +1,217 @@
+"""UUID and regular-expression contracts shared by every backend and API."""
+
+import re
+from uuid import UUID
+
+import pytest
+
+from .support import bson_identity_key
+
+
+pytestmark = pytest.mark.contract
+bson = pytest.importorskip("bson")
+pymongo_errors = pytest.importorskip("pymongo.errors")
+Binary = bson.Binary
+Regex = bson.Regex
+
+
+def _ids(cursor):
+    return [document["_id"] for document in cursor]
+
+
+def _standard_uuid_collection(contract_target):
+    """Opt real MongoDB into the standard UUID representation for this test."""
+
+    collection = contract_target.collection
+    if contract_target.transport != "pymongo":
+        return collection
+
+    codec_options = pytest.importorskip("bson.codec_options").CodecOptions(
+        uuid_representation=pytest.importorskip(
+            "bson.binary"
+        ).UuidRepresentation.STANDARD
+    )
+    if contract_target.api == "sync":
+        return collection.with_options(codec_options=codec_options)
+
+    configured = collection._collection.with_options(codec_options=codec_options)
+    return collection.__class__(configured, collection._runner)
+
+
+def test_uuid_round_trip_uses_standard_binary_identity(contract_target):
+    collection = _standard_uuid_collection(contract_target)
+    first = UUID("00112233-4455-6677-8899-aabbccddeeff")
+    second = UUID("00112233-4455-6677-8899-aabbccddeefe")
+    first_binary = Binary(first.bytes, subtype=4)
+
+    collection.insert_many(
+        [
+            {"_id": "second", "value": second},
+            {"_id": "first", "value": first},
+        ]
+    )
+
+    restored = collection.find_one({"value": first_binary})["value"]
+    assert restored == first
+    assert type(restored) is UUID
+    assert _ids(collection.find({}).sort("value", 1)) == ["second", "first"]
+    collection.insert_one({"_id": "binary-equivalent", "value": first_binary})
+    distinct = collection.distinct("value")
+    assert len(distinct) == 2
+    assert {bson_identity_key(value) for value in distinct} == {
+        bson_identity_key(first),
+        bson_identity_key(second),
+    }
+
+    collection.insert_one({"_id": first, "kind": "uuid-id"})
+    assert collection.find_one({"_id": first_binary})["kind"] == "uuid-id"
+    with pytest.raises(pymongo_errors.DuplicateKeyError):
+        collection.insert_one({"_id": first_binary, "kind": "duplicate-id"})
+
+
+def test_uuid_and_subtype_four_binary_share_unique_identity(contract_target):
+    collection = _standard_uuid_collection(contract_target)
+    value = UUID("00112233-4455-6677-8899-aabbccddeeff")
+    collection.create_index("value", unique=True)
+    collection.insert_one({"_id": "uuid", "value": value})
+
+    with pytest.raises(pymongo_errors.DuplicateKeyError):
+        collection.insert_one(
+            {"_id": "binary", "value": Binary(value.bytes, subtype=4)}
+        )
+
+    collection.insert_one(
+        {"_id": "legacy-binary", "value": Binary(value.bytes, subtype=3)}
+    )
+    assert collection.count_documents({}) == 2
+
+
+def test_regex_predicates_and_exact_equality_follow_mongodb(contract_target):
+    collection = contract_target.collection
+    native = re.compile("Ab.c", re.IGNORECASE)
+    bson_i = Regex("Ab.c", "i")
+    documents = [
+        {"_id": "string", "value": "Abxc"},
+        {"_id": "array", "value": ["no", "Abxc"]},
+        {"_id": "native", "value": native},
+        {"_id": "bson", "value": bson_i},
+        {"_id": "other", "value": Regex("Z", 0)},
+    ]
+    collection.insert_many(documents)
+
+    assert sorted(_ids(collection.find({"value": bson_i}))) == [
+        "array",
+        "bson",
+        "string",
+    ]
+    assert sorted(_ids(collection.find({"value": native}))) == [
+        "array",
+        "native",
+        "string",
+    ]
+    assert sorted(_ids(collection.find({"value": {"$regex": bson_i}}))) == [
+        "array",
+        "bson",
+        "string",
+    ]
+    assert sorted(
+        _ids(collection.find({"value": {"$regex": "Ab.c", "$options": "i"}}))
+    ) == ["array", "bson", "string"]
+    assert sorted(
+        _ids(collection.find({"value": {"$regex": "Ab.c", "$options": "iu"}}))
+    ) == ["array", "native", "string"]
+    assert _ids(collection.find({"value": {"$eq": bson_i}})) == ["bson"]
+    assert sorted(_ids(collection.find({"value": {"$in": [bson_i]}}))) == [
+        "array",
+        "bson",
+        "string",
+    ]
+    assert sorted(_ids(collection.find({"value": {"$nin": [bson_i]}}))) == [
+        "native",
+        "other",
+    ]
+    assert sorted(_ids(collection.find({"value": {"$all": [bson_i]}}))) == [
+        "array",
+        "bson",
+        "string",
+    ]
+    assert _ids(collection.find({"value": {"$all": []}})) == []
+    assert sorted(_ids(collection.find({"value": {"$not": bson_i}}))) == [
+        "native",
+        "other",
+    ]
+
+    restored_native = collection.find_one({"_id": "native"})["value"]
+    restored_bson = collection.find_one({"_id": "bson"})["value"]
+    if contract_target.transport == "pymongo":
+        assert isinstance(restored_native, Regex)
+    else:
+        assert isinstance(restored_native, type(native))
+        assert restored_native.pattern == native.pattern
+        assert restored_native.flags == native.flags
+    assert isinstance(restored_bson, Regex)
+    assert bson_identity_key(restored_native) == bson_identity_key(native)
+    assert bson_identity_key(restored_bson) == bson_identity_key(bson_i)
+
+
+def test_regex_sort_distinct_and_unique_index_identity(contract_target):
+    collection = contract_target.collection
+    values = [
+        ("u", Regex("same", "u")),
+        ("iu", Regex("same", "iu")),
+        ("imu", Regex("same", "imu")),
+        ("im", Regex("same", "im")),
+        ("i", Regex("same", "i")),
+        ("none", Regex("same", "")),
+    ]
+    collection.insert_many(
+        {"_id": label, "value": value} for label, value in reversed(values)
+    )
+
+    assert _ids(collection.find({}).sort("value", 1)) == [
+        "none",
+        "i",
+        "im",
+        "imu",
+        "iu",
+        "u",
+    ]
+    collection.insert_many(
+        [
+            {"_id": "duplicate-im", "value": Regex("same", "mi")},
+            {
+                "_id": "native-iu",
+                "value": re.compile("same", re.IGNORECASE),
+            },
+        ]
+    )
+    assert len(collection.distinct("value")) == len(values)
+
+    collection.delete_many({})
+    collection.create_index("value", unique=True)
+    native = re.compile("unique", re.IGNORECASE)
+    collection.insert_one({"_id": "native", "value": native})
+    with pytest.raises(pymongo_errors.DuplicateKeyError):
+        collection.insert_one({"_id": "bson", "value": Regex("unique", "iu")})
+
+
+def test_local_regex_ids_use_exact_identity_for_duplicate_detection(contract_target):
+    if contract_target.name == "mongodb":
+        pytest.skip(
+            "MongoDB forbids Regex values in _id; TinyMongo retains this extension"
+        )
+    collection = contract_target.collection
+    regex_id = Regex("^alpha$", "i")
+
+    collection.insert_one({"_id": "ALPHA", "kind": "string"})
+    collection.insert_one({"_id": regex_id, "kind": "regex"})
+
+    assert collection.count_documents({}) == 2
+    assert collection.find_one({"_id": {"$eq": regex_id}})["kind"] == "regex"
+    with pytest.raises(pymongo_errors.DuplicateKeyError):
+        collection.insert_one({"_id": Regex("^alpha$", "i"), "kind": "duplicate"})
+
+    native_identity = re.compile("native", re.IGNORECASE)
+    collection.insert_one({"_id": native_identity, "kind": "native"})
+    with pytest.raises(pymongo_errors.DuplicateKeyError):
+        collection.insert_one({"_id": Regex("native", "iu"), "kind": "duplicate"})

--- a/compat/mongo/v1/runner/provenance.json
+++ b/compat/mongo/v1/runner/provenance.json
@@ -1,0 +1,244 @@
+{
+  "adaptation": {
+    "excluded_upstream_files": [
+      {
+        "reason": "Replaced by the runner-specific README with neutral target commands.",
+        "upstream_git_blob": "b7f435d1d92ba5bc9831d7e0afbafbd32669fe17",
+        "upstream_path": "tests/contracts/README.md",
+        "upstream_sha256": "74416b17722036fb552e97703b763a6ea4f13959568920a60bf0cfe725cc3f87"
+      },
+      {
+        "reason": "Reference-only expected outcomes remain in the frozen parity metadata; the executable corpus preserves strict assertions.",
+        "upstream_git_blob": "25dda37fddf9d4f920fb470bdb5fc7d433f3d4c1",
+        "upstream_path": "tests/contracts/known_differences.py",
+        "upstream_sha256": "06f875b4e0c75337d83ff91f95767c14ef396362ece9b300475c529f38b5311a"
+      }
+    ],
+    "files": [
+      {
+        "runner_path": "compat/mongo/v1/runner/contracts/__init__.py",
+        "runner_sha256": "ce7185ce04b04dbce35c37a155ff35b26bf878939a3c188b66c8286f06db1999",
+        "status": "exact",
+        "upstream_git_blob": "fc8fe671710305f85b98e1fa1376fd64981ec0f0",
+        "upstream_path": "tests/contracts/__init__.py",
+        "upstream_sha256": "ce7185ce04b04dbce35c37a155ff35b26bf878939a3c188b66c8286f06db1999"
+      },
+      {
+        "runner_path": "compat/mongo/v1/runner/contracts/conftest.py",
+        "runner_sha256": "b090e7ee63cd673819aa49419cccca626a29793bacfcc4030dad4a7441def4b0",
+        "status": "adapted",
+        "upstream_git_blob": "6c555a3a6d887a510b7b9403499815cd8cdb14d5",
+        "upstream_path": "tests/contracts/conftest.py",
+        "upstream_sha256": "002944603a433d408c1c2b9ce067a27195c6bf78753f27086a2a5b380d5b31d5"
+      },
+      {
+        "runner_path": "compat/mongo/v1/runner/contracts/support.py",
+        "runner_sha256": "5e0e76fbef6829754fb1cc314fb4d9d4ab196883cadd15879b72fd763de41e72",
+        "status": "adapted",
+        "upstream_git_blob": "af2d610d31ad7eb490e68678052cc1d8830d630f",
+        "upstream_path": "tests/contracts/support.py",
+        "upstream_sha256": "822c4b9739243ab3885f3b4912deb9de8b9c22a1a2d11a9b9b725a9f57c39e5a"
+      },
+      {
+        "runner_path": "compat/mongo/v1/runner/contracts/test_aggregation_basic_stages_contract.py",
+        "runner_sha256": "5549d7f226a278be17315b5cbb2847d564770cf5acb1ff0eb47bd467cb0ddf40",
+        "status": "exact",
+        "upstream_git_blob": "07a4f172d4278d7ad76360959ecddffa3da27fab",
+        "upstream_path": "tests/contracts/test_aggregation_basic_stages_contract.py",
+        "upstream_sha256": "5549d7f226a278be17315b5cbb2847d564770cf5acb1ff0eb47bd467cb0ddf40"
+      },
+      {
+        "runner_path": "compat/mongo/v1/runner/contracts/test_aggregation_contract.py",
+        "runner_sha256": "2d4255f17629bf0c51489a7e334ff3087fb1c20800ff669ba58f3abe6c25940f",
+        "status": "exact",
+        "upstream_git_blob": "13f67cde5e4783462fd1375f77daae0b6df223ed",
+        "upstream_path": "tests/contracts/test_aggregation_contract.py",
+        "upstream_sha256": "2d4255f17629bf0c51489a7e334ff3087fb1c20800ff669ba58f3abe6c25940f"
+      },
+      {
+        "runner_path": "compat/mongo/v1/runner/contracts/test_aggregation_projection_stages_contract.py",
+        "runner_sha256": "4ef68dcf01c60edf25bfe88978d32d5276d2a6076110c2eef62e8bfb3d7f4e5e",
+        "status": "exact",
+        "upstream_git_blob": "3fd4d4fc4f0816c89279089e40fa600f2bdf5086",
+        "upstream_path": "tests/contracts/test_aggregation_projection_stages_contract.py",
+        "upstream_sha256": "4ef68dcf01c60edf25bfe88978d32d5276d2a6076110c2eef62e8bfb3d7f4e5e"
+      },
+      {
+        "runner_path": "compat/mongo/v1/runner/contracts/test_array_update_contract.py",
+        "runner_sha256": "082be9f4c040b773eff76610a3a10bb960a7f20e7219ae8cd27fe42f69eeb9bf",
+        "status": "adapted",
+        "upstream_git_blob": "a0a712a677f626f7429306a02fa2d6ec2ee8838c",
+        "upstream_path": "tests/contracts/test_array_update_contract.py",
+        "upstream_sha256": "0ff202cc19da7acc104f899225a73c0a77c476318784b57049ac65180978c8aa"
+      },
+      {
+        "runner_path": "compat/mongo/v1/runner/contracts/test_beanie_odm_contract.py",
+        "runner_sha256": "9a08b0651be070d6353bf5d6481b99c0b1f6bdcd61b745cdade670919bb8c5b1",
+        "status": "exact",
+        "upstream_git_blob": "b85b370bb040540d2c3287b2af808d43069f1a3d",
+        "upstream_path": "tests/contracts/test_beanie_odm_contract.py",
+        "upstream_sha256": "9a08b0651be070d6353bf5d6481b99c0b1f6bdcd61b745cdade670919bb8c5b1"
+      },
+      {
+        "runner_path": "compat/mongo/v1/runner/contracts/test_bson_comparison_contract.py",
+        "runner_sha256": "99b6064dd0177ad8fd6d1c07d1564e89d8a5b0ee24b3cc3beb981db6245d4e0e",
+        "status": "adapted",
+        "upstream_git_blob": "215e7523cf9130b69855a67c75c4a67a0cadb2dd",
+        "upstream_path": "tests/contracts/test_bson_comparison_contract.py",
+        "upstream_sha256": "8222a1292691b9440014f6272b16ec7c690b9d5b30fa94211ae2cfdfca1ac620"
+      },
+      {
+        "runner_path": "compat/mongo/v1/runner/contracts/test_bson_value_types_contract.py",
+        "runner_sha256": "e9cba14c83d12e8735da92a7ee6c36879ff2d14ed861509c21572a3e7c67988d",
+        "status": "adapted",
+        "upstream_git_blob": "2f91d6c549b127cbc445549f3b1ab8bf8924ee59",
+        "upstream_path": "tests/contracts/test_bson_value_types_contract.py",
+        "upstream_sha256": "a6fc6f03a112edb2a28a3f52e565fe58b7fd0f2f0c370f70301742aa0ea1fcb0"
+      },
+      {
+        "runner_path": "compat/mongo/v1/runner/contracts/test_client_read_fidelity_contract.py",
+        "runner_sha256": "db43c0924aba50237fedca0cdf75d23cab07e6f40998b2110abd40405b45fcee",
+        "status": "exact",
+        "upstream_git_blob": "ba844c72deb7f099a56c3e5dd413d4aa99f7ab6c",
+        "upstream_path": "tests/contracts/test_client_read_fidelity_contract.py",
+        "upstream_sha256": "db43c0924aba50237fedca0cdf75d23cab07e6f40998b2110abd40405b45fcee"
+      },
+      {
+        "runner_path": "compat/mongo/v1/runner/contracts/test_crud_contract.py",
+        "runner_sha256": "fc86fa35854430bb274eb546dafb37c017546ebf9a6190968c6f1b3c42072a19",
+        "status": "adapted",
+        "upstream_git_blob": "6e7ba4097f0613043ec77caeedc0198de07c0a41",
+        "upstream_path": "tests/contracts/test_crud_contract.py",
+        "upstream_sha256": "de95254dfeaef9edcfa0a3fcb86badd993010dd555d2e0481916480339cb37a2"
+      },
+      {
+        "runner_path": "compat/mongo/v1/runner/contracts/test_decimal128_contract.py",
+        "runner_sha256": "93af51d3142a90dc1ca01cb41c25a609631a5563567117592165ea4ee54f28e1",
+        "status": "adapted",
+        "upstream_git_blob": "0146f49757443c6eec420e91da1f6112f199c373",
+        "upstream_path": "tests/contracts/test_decimal128_contract.py",
+        "upstream_sha256": "05bdee5251731d81ed44070fadaccc83032ff07be0281b7894eb8e5933c67c86"
+      },
+      {
+        "runner_path": "compat/mongo/v1/runner/contracts/test_group_accumulators_contract.py",
+        "runner_sha256": "878d1d22022c078b60352c06b974962dd5e34a3a0dd3d8589988bd60e77f351f",
+        "status": "adapted",
+        "upstream_git_blob": "e784932d6698f00eaacbe00e1f444edcde09d551",
+        "upstream_path": "tests/contracts/test_group_accumulators_contract.py",
+        "upstream_sha256": "50634de1ff2666915ce99913421eb9981d0099df9a0160387cc291bceb617e57"
+      },
+      {
+        "runner_path": "compat/mongo/v1/runner/contracts/test_projection_contract.py",
+        "runner_sha256": "a08becc90d32497b16a93bdad1dc990cce597f4f7fb0e099c61a8ecf3c780b3a",
+        "status": "exact",
+        "upstream_git_blob": "7146c4cad8605204f44d82c8e184285975874677",
+        "upstream_path": "tests/contracts/test_projection_contract.py",
+        "upstream_sha256": "a08becc90d32497b16a93bdad1dc990cce597f4f7fb0e099c61a8ecf3c780b3a"
+      },
+      {
+        "runner_path": "compat/mongo/v1/runner/contracts/test_query_operator_contract.py",
+        "runner_sha256": "5a722a514ae23ea8b6f3b9240eeb07cb56ca343d7e2bb1af4a44309c12fd278c",
+        "status": "adapted",
+        "upstream_git_blob": "b1b7b237afbf4516962c764731906c180372db14",
+        "upstream_path": "tests/contracts/test_query_operator_contract.py",
+        "upstream_sha256": "c8845833a1b6dd0257236508b52766c840ec0f643940bd120e2e1b5f55019851"
+      },
+      {
+        "runner_path": "compat/mongo/v1/runner/contracts/test_talkpython_contract.py",
+        "runner_sha256": "146fcde2fc8c0ec546a2d236084f49f6a902c569ac3c11f719be65eed4055943",
+        "status": "adapted",
+        "upstream_git_blob": "672de437d8a1583d605095cfee795ab8c22fb063",
+        "upstream_path": "tests/contracts/test_talkpython_contract.py",
+        "upstream_sha256": "56ea087b75a6797d8bcb9557a39b73a5622514e95917fa7151c795d3531ec99a"
+      },
+      {
+        "runner_path": "compat/mongo/v1/runner/contracts/test_update_operator_contract.py",
+        "runner_sha256": "f17fa5c18022d5828b1c0a7232dd95a2115656eb52db5c5b2299b419692d56c2",
+        "status": "adapted",
+        "upstream_git_blob": "d6705f8782594bcdb22d307ac01539e7adffced0",
+        "upstream_path": "tests/contracts/test_update_operator_contract.py",
+        "upstream_sha256": "72fc64be51f48eebe7eebda94e2cff4a0ab1a49baae38ec2b43ddc6b0938e669"
+      },
+      {
+        "runner_path": "compat/mongo/v1/runner/contracts/test_uuid_regex_contract.py",
+        "runner_sha256": "417feac57bd0a5c162d638319e454c0add904f2ffb9892c9e9be09c49011a27c",
+        "status": "adapted",
+        "upstream_git_blob": "f395cc801a004fd9b06944ee02c9c804a5409d5d",
+        "upstream_path": "tests/contracts/test_uuid_regex_contract.py",
+        "upstream_sha256": "a36ecde8854dadd1d3efa1700c6d72d84ba2f23726159234272d4b4921f8ec29"
+      }
+    ],
+    "patch": "compat/mongo/v1/runner/adaptation.patch",
+    "patch_sha256": "05309161733d39769c159f3ba07ef0afb97abd9804256df9cf9da3f8b6382291",
+    "rules": [
+      "Preserve test assertions, values, and parameter IDs.",
+      "Replace target-owned fixtures with a neutral adapter fixture.",
+      "Use public BSON and PyMongo error types in neutral contract modules.",
+      "Confine TinyMongo imports to adapters/tinymongo.py.",
+      "Record implementation identity separately from transport-specific behavior.",
+      "Emit canonical upstream contract IDs as JUnit properties."
+    ]
+  },
+  "corpus": "tinymongo-v1",
+  "inventory": {
+    "apis": [
+      "sync",
+      "async"
+    ],
+    "case_catalog": "compat/mongo/v1/corpus.json",
+    "expected_tinymongo_memory_executions": 456,
+    "logical_cases": 228
+  },
+  "reference_environment": {
+    "pymongo": "4.17.0",
+    "pytest": "8.4.2",
+    "python": "3.9.6",
+    "requirements": "compat/mongo/v1/runner/requirements.txt"
+  },
+  "runner_files": [
+    {
+      "path": "compat/mongo/v1/runner/__init__.py",
+      "sha256": "cd210a7e402cb23134d602ed811a1126385ab25c850e8d7558a7011f5e7fbe2e"
+    },
+    {
+      "path": "compat/mongo/v1/runner/README.md",
+      "sha256": "1f53bad86de1960149456bf2be968070bf50819ffc0c940c44ada82c92a4b684"
+    },
+    {
+      "path": "compat/mongo/v1/runner/requirements.txt",
+      "sha256": "69d187f01a8aff10c3fee3df076da2909793470d62939b581324badf2dddd626"
+    },
+    {
+      "path": "compat/mongo/v1/runner/adapters/__init__.py",
+      "sha256": "1ea573312526ef3398db494429eca74efb4d821b03a6de70507f43004d6d3c81"
+    },
+    {
+      "path": "compat/mongo/v1/runner/adapters/briskdb.py",
+      "sha256": "823d6bf0b443d210929c9438f1b4be2dbb8957890b296eae975dbe4a3759d3db"
+    },
+    {
+      "path": "compat/mongo/v1/runner/adapters/mongodb.py",
+      "sha256": "a6a75defaac2a81553af78da420254a1ba26f5a1390a92bf27f382302237d288"
+    },
+    {
+      "path": "compat/mongo/v1/runner/adapters/tinymongo.py",
+      "sha256": "d11e90bba4d6cf0a22418d7f79e18af33c4685d6cfef0128fdb2a79bf6cfe457"
+    }
+  ],
+  "schema_version": 1,
+  "source": {
+    "commit": "53cbf44e98b8caa036163725d195fd29592e1cc0",
+    "contract_git_tree": "6f671122ff5f76902cfe051e4558a2c57d161bc4",
+    "license": {
+      "runner_path": "compat/mongo/v1/runner/UPSTREAM_LICENSE.txt",
+      "runner_sha256": "60fa36a0e364df592e2db06ad8269242c082917031ab8291bad60ddafbf728fd",
+      "spdx": "MIT",
+      "upstream_git_blob": "0d9fa009e02c7a58019b420332d542a637f71be1",
+      "upstream_path": "LICENSE.txt",
+      "upstream_sha256": "60fa36a0e364df592e2db06ad8269242c082917031ab8291bad60ddafbf728fd"
+    },
+    "release": "v1.3.0",
+    "repository": "https://github.com/schapman1974/tinymongo",
+    "runtime_git_tree": "0c94915ea81697a5728f64dc04e3929bf1e036e8"
+  }
+}

--- a/compat/mongo/v1/runner/requirements.txt
+++ b/compat/mongo/v1/runner/requirements.txt
@@ -1,0 +1,17 @@
+# Test-only environment frozen for the TinyMongo v1.3.0 reference corpus.
+# Nothing in this file is a BriskDB runtime dependency.
+pip==26.0.1
+setuptools==82.0.1
+wheel==0.47.0
+pytest==8.4.2
+pymongo==4.17.0
+tinydb==3.15.2
+portalocker==3.2.0
+dnspython==2.7.0
+exceptiongroup==1.3.1; python_version < "3.11"
+iniconfig==2.1.0
+packaging==26.2
+pluggy==1.6.0
+Pygments==2.20.0
+tomli==2.4.1; python_version < "3.11"
+typing-extensions==4.16.0; python_version < "3.11"

--- a/compat/mongo/v1/semantic-variants.json
+++ b/compat/mongo/v1/semantic-variants.json
@@ -1,0 +1,78 @@
+{
+  "contract": "tinymongo-v1",
+  "schema_version": 1,
+  "variants": [
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "backend": "mongodb",
+      "backend_behavior": "A native Python regular expression is decoded as bson.Regex.",
+      "case_id": "tests.contracts.test_bson_value_types_contract::test_tm035_new_bson_values_round_trip_at_every_depth",
+      "dimension": "native-regex-result-type",
+      "issue": "https://github.com/schapman1974/briskdb/issues/161",
+      "reference_behavior": "Embedded TinyMongo backends retain the native compiled regular-expression type."
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "backend": "mongodb",
+      "backend_behavior": "A native Python regular expression is decoded as bson.Regex; predicate and identity behavior remains shared.",
+      "case_id": "tests.contracts.test_uuid_regex_contract::test_regex_predicates_and_exact_equality_follow_mongodb",
+      "dimension": "native-regex-result-type",
+      "issue": "https://github.com/schapman1974/briskdb/issues/161",
+      "reference_behavior": "Embedded TinyMongo backends retain the native compiled regular-expression type."
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "backend": "mongodb",
+      "backend_behavior": "MongoDB rejects Regex values in _id, so the frozen test records an ordinary skip for this TinyMongo extension.",
+      "case_id": "tests.contracts.test_uuid_regex_contract::test_local_regex_ids_use_exact_identity_for_duplicate_detection",
+      "dimension": "regex-id-support",
+      "issue": "https://github.com/schapman1974/briskdb/issues/161",
+      "reference_behavior": "Embedded TinyMongo backends accept Regex _id values and use exact BSON identity for duplicate detection."
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "backend": "mongodb",
+      "backend_behavior": "MongoDB creates the mixed index batch without TinyMongo degradation warnings.",
+      "case_id": "tests.contracts.test_talkpython_contract::test_create_indexes_accepts_the_real_mixed_batch_and_enforces_unique",
+      "dimension": "degraded-index-warnings",
+      "issue": "https://github.com/schapman1974/briskdb/issues/161",
+      "reference_behavior": "Embedded TinyMongo backends emit four TinyMongoUnsupportedWarning values: one for each of the two descending index specifications, one for hashed, and one for TTL. Compound indexes themselves are supported."
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "backend": "mongodb",
+      "backend_behavior": "MongoDB rejects the invalid document without TinyMongo's additional PyMongoError inheritance, document identity, and message-context guarantees.",
+      "case_id": "tests.contracts.test_talkpython_contract::test_invalid_document_has_a_bson_compatible_error",
+      "dimension": "invalid-document-details",
+      "issue": "https://github.com/schapman1974/briskdb/issues/161",
+      "reference_behavior": "Embedded TinyMongo backends expose PyMongoError inheritance, the original document, collection and field context; the sync path also avoids creating the collection."
+    },
+    {
+      "apis": [
+        "sync",
+        "async"
+      ],
+      "backend": "mongodb",
+      "backend_behavior": "PyMongo rejects bytearray query values before sending them to MongoDB.",
+      "case_id": "tests.contracts.test_talkpython_contract::test_generic_binary_equality_matches_native_bytes_and_query_operators",
+      "dimension": "bytearray-query-convenience",
+      "issue": "https://github.com/schapman1974/briskdb/issues/161",
+      "reference_behavior": "Embedded TinyMongo backends accept bytearray query values and canonicalize them to generic BSON binary."
+    }
+  ]
+}

--- a/docs/MONGO_PARITY.md
+++ b/docs/MONGO_PARITY.md
@@ -1,0 +1,272 @@
+# Mongo compatibility parity contract
+
+Status: TinyMongo v1 contract frozen for issue
+[#161](https://github.com/schapman1974/briskdb/issues/161); BriskDB candidate
+endpoint not yet implemented
+
+BriskDB uses a versioned differential contract to define the document behavior
+that its Rust and Python APIs, and later its MongoDB listener, must preserve.
+The first contract is source-locked to
+[TinyMongo v1.3.0](https://github.com/schapman1974/tinymongo/releases/tag/v1.3.0)
+at commit `53cbf44e98b8caa036163725d195fd29592e1cc0`. It covers 228 logical cases
+through both synchronous and asynchronous APIs. Across TinyMongo's seven
+contract backends, that is a 3,192-execution discovery matrix.
+
+This is a frozen behavioral input, not a claim that BriskDB already has MongoDB
+parity. The checked-in report contains only the 456 sync/async executions from
+the `tinymongo-memory` reference. BriskDB's owned runner reproduces all 456 in
+CI and byte-compares the normalized result with the checked-in reference. The
+report remains `reference-only` until a BriskDB endpoint supplies candidate
+results through the checked-in adapter.
+
+## Versioned files
+
+[`compat/mongo/v1/manifest.json`](../compat/mongo/v1/manifest.json) is the
+entry point. It records the source commit and contract-tree digests, suite and
+backend dimensions, file hashes, reference target, counts, and the reviewed
+capability inventory. That inventory includes client, database, collection,
+and cursor APIs; options; BSON values and ordering; query and update operators;
+projections; indexes; aggregation; result shapes; warnings; errors and codes;
+and unsupported behavior.
+
+The remaining files have distinct roles:
+
+- `corpus.json` assigns stable IDs, suites, APIs, and source provenance to each
+  logical case. The source-file hashes cover the complete TinyMongo contract
+  tree at the locked commit, and the harvest metadata pins Python, pytest, and
+  PyMongo.
+- `reference-results.json` holds the normalized `tinymongo-memory` outcomes for
+  all 228 cases through both APIs.
+- `semantic-variants.json` records reviewed backend-specific branches and skips
+  already present in the locked TinyMongo tests. These entries explain the
+  intended behavior; they do not permit a candidate result mismatch.
+- `intentional-differences.json` is the strict candidate-difference allow-list.
+  Every entry is scoped to one target, case, and API and requires a BriskDB
+  issue. Its current sync and async entries record the `mongodb-mongodb` skip
+  for a Regex `_id`, which real MongoDB forbids. When that target is present,
+  an entry that no longer matches the observed result is stale and makes the
+  comparison fail.
+- `runner/contracts/` contains BriskDB-owned, target-neutral copies of the 228
+  executable contract bodies. `runner/adapters/` is the only target-specific
+  boundary, with modules for TinyMongo, real MongoDB, and a configurable
+  BriskDB candidate endpoint.
+
+The manifest hashes every checked-in contract input. Changing the source
+commit, corpus, reference results, capability inventory, semantic variants, or
+difference policy therefore requires a normal reviewed BriskDB change. Do not
+silently refresh a snapshot while implementing a candidate.
+
+## Process boundary
+
+The BriskDB Rust library, Python wheel, and server do not declare or load
+TinyMongo. CI installs TinyMongo, PyMongo, and pytest separately inside the
+Mongo contract test environment. None is pulled in by BriskDB's Cargo or Python
+dependency metadata, and production code does not import the oracle.
+
+Source distributions, including the Rust `.crate` and Python sdist, may retain
+the checked-in manifest, fixtures, adapters, and harness for provenance and
+offline audit. Those files are inert package source: a normal build or install
+does not execute them or install TinyMongo. Built wheels and binaries do not
+contain the TinyMongo package.
+
+The normalization harness in
+[`scripts/mongo_parity.py`](../scripts/mongo_parity.py) uses only the Python
+standard library. The executable fixtures use pytest plus PyMongo's public BSON
+and exception types as the compatibility vocabulary. They do not import
+TinyMongo. The only TinyMongo import in the owned runner is lazy and isolated
+in `runner/adapters/tinymongo.py`; selecting the BriskDB or MongoDB adapter does
+not load it.
+
+A producer identifies each execution with the exact JUnit properties
+`tinymongo.api`, `tinymongo.backend`, and `tinymongo.suite`. Its test name maps
+to a stable corpus case ID. Assertions inside the producer cover ordered BSON,
+document mutation, result and cursor behavior, warning categories, exception
+classes and stable codes, and explicit unsupported operations. The normalized
+result preserves the target, API, backend, suite, outcome, and a normalized
+observation. The observation combines a category with a SHA-256 fingerprint of
+the outcome, category, and redacted reason, so a different failure cannot pass
+by sharing only the expected outcome.
+
+This adapter boundary lets the owned fixtures exercise each implementation and
+publish the same result envelope. TinyMongo remains an oracle-only test
+dependency. Its adapter source may remain visible in a source distribution, but
+the oracle is neither installed nor imported by building, installing, or using
+BriskDB. An optional real MongoDB target follows the same boundary.
+
+## Validate and report
+
+Validate the locked files and hashes from the repository root:
+
+```bash
+python3 scripts/mongo_parity.py validate
+```
+
+If a TinyMongo Git checkout is available, verify the locked source objects
+against it. This reads blobs from the manifest's commit and does not trust the
+checkout's working tree:
+
+```bash
+python3 scripts/mongo_parity.py verify-source \
+  --source-root /path/to/tinymongo
+```
+
+Install the pinned test tools and the locked TinyMongo checkout into a test
+environment, then reproduce the reference with BriskDB's owned fixtures:
+
+```bash
+python3 -m pip install -r compat/mongo/v1/runner/requirements.txt
+python3 -m pip install --no-build-isolation --no-deps /path/to/tinymongo
+
+mkdir -p target/mongo-parity
+python3 -m pytest -q -p no:cacheprovider -c /dev/null \
+  compat/mongo/v1/runner/contracts \
+  --mongo-contract-target=tinymongo \
+  --mongo-contract-backend=memory \
+  --mongo-contract-require-target \
+  --junitxml=target/mongo-parity/tinymongo-memory.xml
+
+python3 scripts/mongo_parity.py ingest \
+  --implementation tinymongo \
+  --junit target/mongo-parity/tinymongo-memory.xml \
+  --output target/mongo-parity/tinymongo-memory.json
+
+cmp compat/mongo/v1/reference-results.json \
+  target/mongo-parity/tinymongo-memory.json
+```
+
+CI checks out commit `53cbf44e98b8caa036163725d195fd29592e1cc0`
+under `target/`, installs it only in this contract job, runs the same 456 owned
+fixture executions, and requires the byte comparison to pass. The source
+snapshot records its original Python 3.9.6 harvest environment. CI replays it
+with Python 3.9.25, the pinned 3.9 patch available for Ubuntu 24.04.
+
+Generate the currently available reference report:
+
+```bash
+mkdir -p target/mongo-parity
+python3 scripts/mongo_parity.py report \
+  --json-output target/mongo-parity/report.json \
+  --markdown-output target/mongo-parity/report.md
+```
+
+The report should say `reference-only`. CI runs both commands, publishes the
+Markdown report in the workflow summary, and uploads the JSON and Markdown as
+the `mongo-parity-report` artifact. This baseline comparison permits absent
+optional targets, including real MongoDB.
+
+To normalize JUnit produced by a candidate adapter:
+
+```bash
+python3 scripts/mongo_parity.py ingest \
+  --implementation briskdb \
+  --junit target/mongo-parity/briskdb.xml \
+  --output target/mongo-parity/briskdb.json
+
+python3 scripts/mongo_parity.py report \
+  --require-target briskdb-briskdb \
+  --json-output target/mongo-parity/report.json \
+  --markdown-output target/mongo-parity/report.md \
+  target/mongo-parity/briskdb.json
+```
+
+`--require-target` is repeatable for publish gates. `report` fails when a
+required target is absent, or for an uncovered case, an unexpected observation
+fingerprint, or a stale intentional difference. An intentional difference must
+name the exact reference and candidate fingerprints as well as their outcomes.
+Once a BriskDB candidate endpoint exists, its normalized result belongs in the
+required CI comparison; the checked-in TinyMongo reference remains the
+comparison baseline.
+
+A publish gate that includes reviewed optional targets should also require
+every target named by the allow-list and supply its normalized result:
+
+```bash
+python3 scripts/mongo_parity.py report \
+  --require-target briskdb-briskdb \
+  --require-allowlist-targets \
+  --json-output target/mongo-parity/report.json \
+  --markdown-output target/mongo-parity/report.md \
+  target/mongo-parity/briskdb.json \
+  target/mongo-parity/mongodb.json
+```
+
+Without `--require-allowlist-targets`, absent optional targets do not fail a
+reference-only or partial comparison. If an allow-listed target is present,
+its stale entries always fail regardless of that flag.
+
+## Runner targets and options
+
+The owned pytest runner accepts these target controls:
+
+| Option | Environment fallback | Behavior |
+| --- | --- | --- |
+| `--mongo-contract-target=tinymongo|mongodb|briskdb` | `BRISKDB_MONGO_CONTRACT_TARGET` | Selects one lazy-loaded adapter. |
+| `--mongo-contract-api=sync|async|both` | `BRISKDB_MONGO_CONTRACT_API` | Runs one API or both; the default is both. |
+| `--mongo-contract-backend=<id>` | `BRISKDB_MONGO_CONTRACT_BACKEND` | Selects a TinyMongo backend; the default is `memory`. |
+| `--mongo-contract-mongodb-uri=<uri>` | `BRISKDB_MONGODB_URI` | Supplies the optional real MongoDB endpoint. |
+| `--mongo-contract-briskdb-uri=<uri>` | `BRISKDB_MONGO_PARITY_BRISKDB_URI` | Supplies the BriskDB candidate endpoint. |
+| `--mongo-contract-require-target` | none | Fails instead of skipping when an optional target is unavailable. |
+
+For example, an available real MongoDB instance can produce its normalized
+candidate this way:
+
+```bash
+python3 -m pytest -q -p no:cacheprovider -c /dev/null \
+  compat/mongo/v1/runner/contracts \
+  --mongo-contract-target=mongodb \
+  --mongo-contract-mongodb-uri="$BRISKDB_MONGODB_URI" \
+  --mongo-contract-require-target \
+  --junitxml=target/mongo-parity/mongodb.xml
+
+python3 scripts/mongo_parity.py ingest \
+  --implementation mongodb \
+  --junit target/mongo-parity/mongodb.xml \
+  --output target/mongo-parity/mongodb.json
+```
+
+Run the same corpus against a BriskDB candidate endpoint when one is available:
+
+```bash
+python3 -m pytest -q -p no:cacheprovider -c /dev/null \
+  compat/mongo/v1/runner/contracts \
+  --mongo-contract-target=briskdb \
+  --mongo-contract-briskdb-uri='mongodb://127.0.0.1:27018/?directConnection=true' \
+  --mongo-contract-api=both \
+  --mongo-contract-require-target \
+  --junitxml=target/mongo-parity/briskdb.xml
+```
+
+The candidate adapter uses PyMongo's sync and async transports but retains the
+implementation identity `briskdb`. The runner records transport separately so
+UUID configuration, Regex decoding, bytearray encoding, client-side
+validation, and warning behavior follow PyMongo without inheriting semantic
+exemptions that belong only to real MongoDB. No candidate endpoint is built in
+this issue, and the reference-only CI job does not attempt this command.
+
+## Refreshing the source snapshot
+
+Refreshing the corpus is a compatibility-policy change. Check out the reviewed
+TinyMongo commit separately, run its entire contract matrix to JUnit, then use
+`snapshot` with the full 40-character commit:
+
+```bash
+python3 scripts/mongo_parity.py snapshot \
+  --junit /path/to/tinymongo-contract.xml \
+  --source-root /path/to/tinymongo \
+  --source-commit <reviewed-commit> \
+  --python-version 3.9.6 \
+  --pytest-version 8.4.2 \
+  --pymongo-version 4.17.0 \
+  --corpus-output compat/mongo/v1/corpus.json \
+  --results-output compat/mongo/v1/reference-results.json
+```
+
+After generating a reviewed snapshot, repeat the same `snapshot` command with
+`--check`; this regenerates the canonical bytes and fails on drift without
+rewriting either output file.
+
+Review the source-tree identity, capability inventory, case additions and
+removals, target-specific semantics, pinned harvest toolchain, normalized
+reference results, and every intentional difference. Then update the manifest
+counts and hashes, run `snapshot --check`, `validate`, and `verify-source`
+against the updated manifest before committing the refresh.

--- a/scripts/mongo_parity.py
+++ b/scripts/mongo_parity.py
@@ -1,0 +1,3389 @@
+#!/usr/bin/env python3
+"""Validate, run, ingest, and compare BriskDB's Mongo compatibility contract.
+
+The harness intentionally uses only the Python standard library. Contract
+implementations run as child processes and communicate through JUnit XML, so
+BriskDB never imports TinyMongo or PyMongo into its own runtime.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+
+SCHEMA_VERSION = 1
+OUTCOMES = frozenset(("passed", "failed", "error", "skipped", "xfailed", "xpassed"))
+EXPECTED_APIS = ("sync", "async")
+EXPECTED_BACKENDS = (
+    "memory",
+    "json",
+    "sqlite",
+    "sqlite-sharded",
+    "duckdb",
+    "parquet",
+    "mongodb",
+)
+EXPECTED_CASE_COUNT = 228
+EXPECTED_MODULE_COUNT = 16
+
+EXPECTED_CAPABILITY_CATEGORIES = frozenset(
+    (
+        "aggregation",
+        "api",
+        "commands",
+        "errors",
+        "indexes",
+        "projections",
+        "queries",
+        "results",
+        "unsupported",
+        "updates",
+        "values",
+        "warnings",
+    )
+)
+
+EXPECTED_API_OWNER_CLASSES = {
+    "async_client": ("tinymongo.AsyncTinyMongoClient", "tinymongo.AsyncMongoClient"),
+    "async_collection": (
+        "tinymongo.AsyncTinyMongoCollection",
+        "tinymongo.AsyncCollection",
+    ),
+    "async_cursor": ("tinymongo.AsyncTinyMongoCursor", "tinymongo.AsyncCursor"),
+    "async_database": ("tinymongo.AsyncTinyMongoDatabase", "tinymongo.AsyncDatabase"),
+    "gridfs_placeholder": ("tinymongo.TinyGridFS",),
+    "sync_client": ("tinymongo.TinyMongoClient", "tinymongo.MongoClient"),
+    "sync_collection": ("tinymongo.TinyMongoCollection",),
+    "sync_cursor": ("tinymongo.TinyMongoCursor",),
+    "sync_database": ("tinymongo.TinyMongoDatabase",),
+}
+
+EXPECTED_API_CONSTRUCTOR_SIGNATURES = {
+    "tinymongo.AsyncMongoClient": "AsyncMongoClient(host=None, port=None, "
+    "document_class=None, tz_aware=None, connect=None, "
+    "type_registry=None, **kwargs)",
+    "tinymongo.AsyncTinyMongoClient": "AsyncTinyMongoClient(foldername='tinydb', "
+    "backend='tinydb', *, tinymongo_folder=None, "
+    "threads=None, sqlite_shards=None, "
+    "storage_uri=None, duckdb_config=None, dsn=None)",
+    "tinymongo.AsyncTinyMongoCollection": "AsyncTinyMongoCollection(database, name)",
+    "tinymongo.AsyncTinyMongoCursor": "AsyncTinyMongoCursor(collection=None, filter=None, "
+    "projection=None, find_args=(), find_kwargs=None, "
+    "documents=None)",
+    "tinymongo.AsyncTinyMongoDatabase": "AsyncTinyMongoDatabase(client, name)",
+    "tinymongo.MongoClient": "MongoClient(host=None, port=None, document_class=None, "
+    "tz_aware=None, connect=None, type_registry=None, **kwargs)",
+    "tinymongo.TinyGridFS": "TinyGridFS(*args, **kwargs)",
+    "tinymongo.TinyMongoClient": "TinyMongoClient(foldername='tinydb', backend='tinydb', "
+    "*, tinymongo_folder=None, threads=None, "
+    "sqlite_shards=None, storage_uri=None, "
+    "duckdb_config=None, dsn=None)",
+    "tinymongo.TinyMongoCollection": "TinyMongoCollection(table, parent=None)",
+    "tinymongo.TinyMongoCursor": "TinyMongoCursor(cursordat, sort=None, skip=None, "
+    "limit=None, collection=None, projection=None, "
+    "query=None, source_projected=False, "
+    "deferred_loader=None, materializer=None)",
+    "tinymongo.TinyMongoDatabase": "TinyMongoDatabase(database, path, storage, "
+    "engine=None, client=None)",
+}
+
+EXPECTED_API_CONSTRUCTOR_OPTIONS = {
+    "tinymongo.AsyncMongoClient": (
+        "host",
+        "port",
+        "document_class",
+        "tz_aware",
+        "connect",
+        "type_registry",
+        "**kwargs",
+    ),
+    "tinymongo.AsyncTinyMongoClient": (
+        "foldername",
+        "backend",
+        "tinymongo_folder",
+        "threads",
+        "sqlite_shards",
+        "storage_uri",
+        "duckdb_config",
+        "dsn",
+    ),
+    "tinymongo.AsyncTinyMongoCollection": (),
+    "tinymongo.AsyncTinyMongoCursor": (
+        "collection",
+        "filter",
+        "projection",
+        "find_args",
+        "find_kwargs",
+        "documents",
+    ),
+    "tinymongo.AsyncTinyMongoDatabase": (),
+    "tinymongo.MongoClient": (
+        "host",
+        "port",
+        "document_class",
+        "tz_aware",
+        "connect",
+        "type_registry",
+        "**kwargs",
+    ),
+    "tinymongo.TinyGridFS": ("*args", "**kwargs"),
+    "tinymongo.TinyMongoClient": (
+        "foldername",
+        "backend",
+        "tinymongo_folder",
+        "threads",
+        "sqlite_shards",
+        "storage_uri",
+        "duckdb_config",
+        "dsn",
+    ),
+    "tinymongo.TinyMongoCollection": ("parent",),
+    "tinymongo.TinyMongoCursor": (
+        "sort",
+        "skip",
+        "limit",
+        "collection",
+        "projection",
+        "query",
+        "source_projected",
+        "deferred_loader",
+        "materializer",
+    ),
+    "tinymongo.TinyMongoDatabase": ("engine", "client"),
+}
+
+EXPECTED_OPERATION_RESULT_SHAPES = {
+    "async_client": {
+        "capabilities": "capabilities_document",
+        "close": "none",
+        "database_names": "string_list",
+        "drop_database": "none",
+        "get_database": "database_handle_async",
+        "list_database_names": "string_list",
+        "list_databases": "database_metadata_cursor_async",
+        "server_info": "server_info_document",
+        "start_session": "unsupported_error",
+        "supports": "boolean",
+        "watch": "unsupported_error",
+    },
+    "async_collection": {
+        "aggregate": "cursor_async",
+        "bulk_write": "unsupported_error",
+        "count": "integer",
+        "count_documents": "integer",
+        "create_index": "string",
+        "create_indexes": "string_list",
+        "delete_many": "delete_result",
+        "delete_one": "delete_result",
+        "distinct": "value_list",
+        "drop": "boolean",
+        "drop_index": "none",
+        "estimated_document_count": "integer",
+        "find": "cursor_async",
+        "find_one": "document_or_none",
+        "find_one_and_delete": "document_or_none",
+        "find_one_and_replace": "document_or_none",
+        "find_one_and_update": "document_or_none",
+        "index_information": "index_information_document",
+        "insert": "legacy_insert_result",
+        "insert_many": "insert_many_result",
+        "insert_one": "insert_one_result",
+        "list_indexes": "index_metadata_cursor_async",
+        "remove": "delete_result",
+        "replace_one": "update_result",
+        "update": "legacy_update_result",
+        "update_many": "update_result",
+        "update_one": "update_result",
+        "watch": "unsupported_error",
+        "with_options": "self_async_collection",
+    },
+    "async_cursor": {
+        "clone": "cursor_handle_async",
+        "close": "none",
+        "count": "integer",
+        "hasNext": "boolean",
+        "has_next": "boolean",
+        "limit": "self_async_cursor",
+        "next": "document",
+        "paginate": "self_async_cursor",
+        "rewind": "self_async_cursor",
+        "skip": "self_async_cursor",
+        "sort": "self_async_cursor",
+        "to_list": "document_list",
+        "try_next": "document_or_none",
+    },
+    "async_database": {
+        "close": "none",
+        "collection_names": "string_list",
+        "command": "command_document",
+        "drop_collection": "boolean",
+        "get_collection": "collection_handle_async",
+        "list_collection_names": "string_list",
+        "watch": "unsupported_error",
+    },
+    "gridfs_placeholder": {
+        "GridFS": "self_gridfs_placeholder",
+        "grid_fs": "self_gridfs_placeholder",
+    },
+    "sync_client": {
+        "capabilities": "capabilities_document",
+        "close": "none",
+        "database_names": "string_list",
+        "drop_database": "none",
+        "get_database": "database_handle_sync",
+        "list_database_names": "string_list",
+        "list_databases": "database_metadata_cursor_sync",
+        "server_info": "server_info_document",
+        "start_session": "unsupported_error",
+        "supports": "boolean",
+        "watch": "unsupported_error",
+    },
+    "sync_collection": {
+        "aggregate": "cursor_sync",
+        "build_table": "none",
+        "bulk_write": "unsupported_error",
+        "count": "integer",
+        "count_documents": "integer",
+        "create_index": "string",
+        "create_indexes": "string_list",
+        "delete_many": "delete_result",
+        "delete_one": "delete_result",
+        "distinct": "value_list",
+        "drop": "boolean",
+        "drop_index": "none",
+        "estimated_document_count": "integer",
+        "find": "cursor_sync",
+        "find_one": "document_or_none",
+        "find_one_and_delete": "document_or_none",
+        "find_one_and_replace": "document_or_none",
+        "find_one_and_update": "document_or_none",
+        "index_information": "index_information_document",
+        "insert": "legacy_insert_result",
+        "insert_many": "insert_many_result",
+        "insert_one": "insert_one_result",
+        "list_indexes": "index_metadata_list",
+        "parse_condition": "query_condition_iterator",
+        "parse_query": "query_object",
+        "remove": "delete_result",
+        "replace_one": "update_result",
+        "update": "legacy_update_result",
+        "update_many": "update_result",
+        "update_one": "update_result",
+        "watch": "unsupported_error",
+        "with_options": "self_sync_collection",
+    },
+    "sync_cursor": {
+        "clone": "cursor_handle_sync",
+        "close": "none",
+        "count": "integer",
+        "hasNext": "boolean",
+        "has_next": "boolean",
+        "limit": "self_sync_cursor",
+        "next": "document",
+        "paginate": "self_sync_cursor",
+        "rewind": "self_sync_cursor",
+        "skip": "self_sync_cursor",
+        "sort": "self_sync_cursor",
+        "to_list": "document_list",
+    },
+    "sync_database": {
+        "close": "none",
+        "collection_names": "string_list",
+        "command": "command_document",
+        "drop_collection": "boolean",
+        "get_collection": "collection_handle_sync",
+        "list_collection_names": "string_list",
+        "watch": "unsupported_error",
+    },
+}
+
+EXPECTED_WRITE_RESULT_FIELDS = {
+    "tinymongo.results.DeleteResult": ("acknowledged", "deleted_count", "raw_result"),
+    "tinymongo.results.InsertManyResult": ("acknowledged", "eids", "inserted_ids"),
+    "tinymongo.results.InsertOneResult": ("acknowledged", "eid", "inserted_id"),
+    "tinymongo.results.UpdateResult": (
+        "acknowledged",
+        "did_upsert",
+        "matched_count",
+        "modified_count",
+        "raw_result",
+        "upserted_id",
+    ),
+}
+
+EXPECTED_WRITE_RESULT_CONSTRUCTORS = {
+    "tinymongo.results.DeleteResult": "DeleteResult(raw_result, acknowledged=True)",
+    "tinymongo.results.InsertManyResult": (
+        "InsertManyResult(eids, inserted_ids, acknowledged=True)"
+    ),
+    "tinymongo.results.InsertOneResult": (
+        "InsertOneResult(eid, inserted_id, acknowledged=True)"
+    ),
+    "tinymongo.results.UpdateResult": (
+        "UpdateResult(raw_result, acknowledged=True, matched_count=None, "
+        "modified_count=None, upserted_id=None)"
+    ),
+}
+
+EXPECTED_RESULT_SHAPE_IDS = frozenset(
+    (
+        "boolean",
+        "boolean_true",
+        "bson_value",
+        "capabilities_document",
+        "collection_handle_async",
+        "collection_handle_sync",
+        "command_document",
+        "cursor_async",
+        "cursor_handle_async",
+        "cursor_handle_sync",
+        "cursor_sync",
+        "database_handle_async",
+        "database_handle_sync",
+        "database_metadata_cursor_async",
+        "database_metadata_cursor_sync",
+        "delete_result",
+        "document",
+        "document_list",
+        "document_or_none",
+        "index_information_document",
+        "index_metadata_cursor_async",
+        "index_metadata_document",
+        "index_metadata_list",
+        "insert_many_result",
+        "insert_one_result",
+        "integer",
+        "key_direction_pair",
+        "key_direction_pair_array",
+        "legacy_insert_result",
+        "legacy_update_result",
+        "none",
+        "original_document",
+        "path_or_uri",
+        "query_condition_iterator",
+        "query_object",
+        "self_async_collection",
+        "self_async_cursor",
+        "self_gridfs_placeholder",
+        "self_sync_collection",
+        "self_sync_cursor",
+        "server_info_document",
+        "string",
+        "string_list",
+        "string_or_none",
+        "unsupported_error",
+        "update_result",
+        "update_result_list",
+        "value_list",
+    )
+)
+EXPECTED_RESULT_SHAPES_SHA256 = (
+    "e3f5096f041eb120bc260ac0b05058fddad3f63ee8a10d278cdda098386ac204"
+)
+EXPECTED_PYMONGO_CONNECTION_OPTIONS = (
+    "appname",
+    "authmechanism",
+    "authmechanismproperties",
+    "authoidcallowedhosts",
+    "authsource",
+    "auto_encryption_opts",
+    "compressors",
+    "connect",
+    "connecttimeoutms",
+    "datetime_conversion",
+    "directconnection",
+    "document_class",
+    "driver",
+    "enable_overload_retargeting",
+    "enableoverloadretargeting",
+    "event_listeners",
+    "fsync",
+    "heartbeatfrequencyms",
+    "journal",
+    "loadbalanced",
+    "localthresholdms",
+    "max_adaptive_retries",
+    "maxadaptiveretries",
+    "maxconnecting",
+    "maxidletimems",
+    "maxpoolsize",
+    "maxstalenessseconds",
+    "minpoolsize",
+    "password",
+    "read_preference",
+    "readconcernlevel",
+    "readpreference",
+    "readpreferencetags",
+    "replicaset",
+    "retryreads",
+    "retrywrites",
+    "server_api",
+    "server_selector",
+    "servermonitoringmode",
+    "serverselectiontimeoutms",
+    "sockettimeoutms",
+    "srvmaxhosts",
+    "srvservicename",
+    "ssl",
+    "timeoutms",
+    "tls",
+    "tlsallowinvalidcertificates",
+    "tlsallowinvalidhostnames",
+    "tlscafile",
+    "tlscertificatekeyfile",
+    "tlscertificatekeyfilepassword",
+    "tlscrlfile",
+    "tlsdisableocspendpointcheck",
+    "tlsinsecure",
+    "type_registry",
+    "tz_aware",
+    "tzinfo",
+    "unicode_decode_error_handler",
+    "username",
+    "uuidrepresentation",
+    "w",
+    "waitqueuemultiple",
+    "waitqueuetimeoutms",
+    "wtimeoutms",
+    "zlibcompressionlevel",
+)
+
+EXPECTED_API_ALIASES = {
+    "tinymongo.AsyncCollection": "tinymongo.AsyncTinyMongoCollection",
+    "tinymongo.AsyncCursor": "tinymongo.AsyncTinyMongoCursor",
+    "tinymongo.AsyncDatabase": "tinymongo.AsyncTinyMongoDatabase",
+}
+EXPECTED_API_UNSUPPORTED_METHODS = {
+    "async_client": frozenset(("start_session", "watch")),
+    "async_collection": frozenset(("bulk_write", "watch")),
+    "async_cursor": frozenset(),
+    "async_database": frozenset(("watch",)),
+    "gridfs_placeholder": frozenset(("GridFS", "grid_fs")),
+    "sync_client": frozenset(("start_session", "watch")),
+    "sync_collection": frozenset(("bulk_write", "watch")),
+    "sync_cursor": frozenset(),
+    "sync_database": frozenset(("watch",)),
+}
+EXPECTED_API_EXTENSION_METHODS = {
+    "async_client": frozenset(("capabilities", "database_names", "supports")),
+    "async_collection": frozenset(("count", "insert", "remove", "update")),
+    "async_cursor": frozenset(("count", "hasNext", "has_next", "paginate")),
+    "async_database": frozenset(("collection_names",)),
+    "gridfs_placeholder": frozenset(),
+    "sync_client": frozenset(("capabilities", "database_names", "supports")),
+    "sync_collection": frozenset(
+        (
+            "build_table",
+            "count",
+            "insert",
+            "parse_condition",
+            "parse_query",
+            "remove",
+            "update",
+        )
+    ),
+    "sync_cursor": frozenset(("count", "hasNext", "has_next", "paginate")),
+    "sync_database": frozenset(("collection_names",)),
+}
+EXPECTED_AWAITABLE_METHODS = {
+    "async_client": frozenset(
+        (
+            "capabilities",
+            "close",
+            "database_names",
+            "drop_database",
+            "list_database_names",
+            "list_databases",
+            "server_info",
+            "supports",
+            "watch",
+        )
+    ),
+    "async_collection": frozenset(
+        (
+            "aggregate",
+            "bulk_write",
+            "count",
+            "count_documents",
+            "create_index",
+            "create_indexes",
+            "delete_many",
+            "delete_one",
+            "distinct",
+            "drop",
+            "drop_index",
+            "estimated_document_count",
+            "find_one",
+            "find_one_and_delete",
+            "find_one_and_replace",
+            "find_one_and_update",
+            "index_information",
+            "insert",
+            "insert_many",
+            "insert_one",
+            "list_indexes",
+            "remove",
+            "replace_one",
+            "update",
+            "update_many",
+            "update_one",
+            "watch",
+        )
+    ),
+    "async_cursor": frozenset(
+        (
+            "close",
+            "count",
+            "hasNext",
+            "has_next",
+            "next",
+            "rewind",
+            "to_list",
+            "try_next",
+        )
+    ),
+    "async_database": frozenset(
+        (
+            "close",
+            "collection_names",
+            "command",
+            "drop_collection",
+            "list_collection_names",
+            "watch",
+        )
+    ),
+    "gridfs_placeholder": frozenset(),
+    "sync_client": frozenset(),
+    "sync_collection": frozenset(),
+    "sync_cursor": frozenset(),
+    "sync_database": frozenset(),
+}
+EXPECTED_API_BEHAVIORS = frozenset(
+    (
+        "accepted_no_effect",
+        "applied",
+        "applied_conditionally",
+        "default_or_empty_only",
+        "dispatched",
+        "null_only",
+        "rejected",
+        "rejected_unsupported",
+    )
+)
+EXPECTED_TINYMONGO_STORAGE_OPTIONS = frozenset(
+    (
+        "backend",
+        "dsn",
+        "duckdb_config",
+        "foldername",
+        "sqlite_shards",
+        "storage_uri",
+        "threads",
+        "tinymongo_folder",
+        "tinymongo_path",
+    )
+)
+EXPECTED_NATIVE_BSON_TYPES = (
+    "array",
+    "binary",
+    "boolean",
+    "datetime",
+    "double",
+    "int",
+    "long",
+    "null",
+    "object",
+    "regex",
+    "string",
+    "uuid",
+)
+EXPECTED_BSON_FAMILY_ALIASES = {"int": "int32", "long": "int64"}
+EXPECTED_OPTIONAL_PYMONGO_BSON_TYPES = (
+    "Binary",
+    "Code",
+    "Decimal128",
+    "MaxKey",
+    "MinKey",
+    "ObjectId",
+    "Regex",
+    "Timestamp",
+)
+EXPECTED_ERROR_CLASSES = frozenset(
+    (
+        "BulkWriteError",
+        "ConfigurationError",
+        "ConnectionFailure",
+        "CursorNotFound",
+        "DuplicateKeyError",
+        "InvalidDocument",
+        "InvalidOperation",
+        "LockError",
+        "OperationFailure",
+        "StorageCorruptionError",
+        "StorageError",
+        "TinyMongoError",
+        "TinyMongoNotSupportedError",
+        "WriteError",
+    )
+)
+EXPECTED_ERROR_FIELDS = {
+    "BulkWriteError": frozenset(("code", "details", "timeout")),
+    "ConfigurationError": frozenset(("timeout",)),
+    "ConnectionFailure": frozenset(("timeout",)),
+    "CursorNotFound": frozenset(("code", "details", "timeout")),
+    "DuplicateKeyError": frozenset(("code", "details", "timeout")),
+    "InvalidDocument": frozenset(("document", "timeout")),
+    "InvalidOperation": frozenset(("timeout",)),
+    "LockError": frozenset(("timeout",)),
+    "OperationFailure": frozenset(("code", "details", "timeout")),
+    "StorageCorruptionError": frozenset(("timeout",)),
+    "StorageError": frozenset(("timeout",)),
+    "TinyMongoError": frozenset(("timeout",)),
+    "TinyMongoNotSupportedError": frozenset(("timeout",)),
+    "WriteError": frozenset(("code", "details", "timeout")),
+}
+EXPECTED_QUERY_CAPABILITIES = {
+    "field_operators": [
+        "$all",
+        "$elemMatch",
+        "$eq",
+        "$exists",
+        "$gt",
+        "$gte",
+        "$in",
+        "$lt",
+        "$lte",
+        "$mod",
+        "$ne",
+        "$nin",
+        "$not",
+        "$options",
+        "$regex",
+        "$size",
+        "$type",
+    ],
+    "ignored_metadata_operators": ["$comment"],
+    "ignored_metadata_operator_scope": (
+        "query-document keys only; field-operator use is invalid"
+    ),
+    "logical_operators": ["$and", "$nor", "$or"],
+    "regex_options": ["i", "m", "s", "u", "x"],
+    "unsupported_operators": [
+        "$bitsAllClear",
+        "$bitsAllSet",
+        "$bitsAnyClear",
+        "$bitsAnySet",
+        "$expr",
+        "$geoIntersects",
+        "$geoWithin",
+        "$jsonSchema",
+        "$near",
+        "$nearSphere",
+        "$text",
+        "$where",
+    ],
+    "type_aliases": [
+        "minKey",
+        "double",
+        "string",
+        "object",
+        "array",
+        "binData",
+        "undefined",
+        "objectId",
+        "bool",
+        "date",
+        "null",
+        "regex",
+        "dbPointer",
+        "javascript",
+        "symbol",
+        "javascriptWithScope",
+        "int",
+        "timestamp",
+        "long",
+        "decimal",
+        "maxKey",
+        "number",
+    ],
+    "type_codes": {
+        "-1": "minKey",
+        "1": "double",
+        "2": "string",
+        "3": "object",
+        "4": "array",
+        "5": "binData",
+        "6": "undefined",
+        "7": "objectId",
+        "8": "bool",
+        "9": "date",
+        "10": "null",
+        "11": "regex",
+        "12": "dbPointer",
+        "13": "javascript",
+        "14": "symbol",
+        "15": "javascriptWithScope",
+        "16": "int",
+        "17": "timestamp",
+        "18": "long",
+        "19": "decimal",
+        "127": "maxKey",
+    },
+    "rules": [
+        "array and dotted-path traversal",
+        "BSON type brackets",
+        "missing/null distinction",
+        "numeric cross-type comparison",
+        "recursive BSON equality",
+        "regex option normalization",
+    ],
+}
+EXPECTED_UPDATE_CAPABILITIES = {
+    "modifiers": {
+        "$addToSet": ["$each"],
+        "$push": ["$each", "$position", "$slice", "$sort"],
+    },
+    "operators": [
+        "$addToSet",
+        "$inc",
+        "$max",
+        "$min",
+        "$pop",
+        "$pull",
+        "$pullAll",
+        "$push",
+        "$rename",
+        "$set",
+        "$unset",
+    ],
+    "path_policies": {
+        "mapping_only_dotted_paths": ["$addToSet", "$inc", "$set", "$unset"],
+        "numeric_array_index_paths": [
+            "$max",
+            "$min",
+            "$pop",
+            "$pull",
+            "$pullAll",
+            "$push",
+        ],
+        "rejects_array_element_and_positional_paths": ["$rename"],
+    },
+    "pull_operators": {
+        "document_field_extra": ["$not"],
+        "logical": ["$and", "$or", "$nor"],
+        "scalar_and_document_field": [
+            "$all",
+            "$elemMatch",
+            "$eq",
+            "$exists",
+            "$gt",
+            "$gte",
+            "$in",
+            "$lt",
+            "$lte",
+            "$mod",
+            "$ne",
+            "$nin",
+            "$options",
+            "$regex",
+            "$size",
+            "$type",
+        ],
+    },
+    "rules": [
+        "atomic post-image validation",
+        (
+            "root _id remains unchanged after successful updates; error behavior "
+            "is operator-specific"
+        ),
+        "replacement writes",
+        "single and multi writes",
+        "upsert equality seeding",
+    ],
+}
+EXPECTED_PROJECTION_CAPABILITIES = {
+    "rules": [
+        "boolean and BSON-number flags only",
+        "empty mapping or field sequence means no projection",
+        "nested mappings are dotted-path shorthand",
+        "path collisions are rejected",
+    ],
+    "supported": [
+        "array traversal",
+        "dotted paths",
+        "exclusion",
+        "explicit _id inclusion/exclusion",
+        "inclusion",
+        "list-of-fields shorthand",
+    ],
+    "unsupported": [
+        "$elemMatch projection",
+        "$slice projection",
+        "expression projection in find",
+        "mixed inclusion/exclusion except _id",
+        "numeric array-index output paths",
+        "positional projection",
+    ],
+}
+EXPECTED_INDEX_CAPABILITIES = {
+    "constraints": [
+        "compound indexes reject parallel array fields",
+        "dotted index paths cannot traverse arrays",
+        (
+            "indexed objects, nested arrays, non-finite numbers, and unsupported "
+            "BSON values are rejected"
+        ),
+        "sparse and partialFilterExpression are mutually exclusive",
+        "top-level arrays create multikey entries",
+    ],
+    "create_index": {
+        "directions": [1],
+        "options": ["name", "partialFilterExpression", "sparse", "unique"],
+    },
+    "create_indexes_index_model": {
+        "directions": [1, -1, "hashed", "text"],
+        "options": [
+            "background",
+            "expireAfterSeconds",
+            "name",
+            "partialFilterExpression",
+            "sparse",
+            "unique",
+        ],
+    },
+    "degraded_with_warning": [
+        "background",
+        "descending",
+        "hashed",
+        "text",
+        "ttl",
+    ],
+    "degradation_outcomes": {
+        "ascending_fallback": ["descending", "hashed"],
+        "ignored_semantics": ["background", "ttl"],
+        "skipped_without_effective_index": ["text"],
+    },
+    "operations": [
+        "create_index",
+        "create_indexes",
+        "drop_index",
+        "index_information",
+        "list_indexes",
+    ],
+    "partial_filter_operators": [
+        "$and",
+        "$eq",
+        "$exists:true",
+        "$gt",
+        "$gte",
+        "$in",
+        "$lt",
+        "$lte",
+        "$or",
+        "$type",
+    ],
+    "supported": [
+        "ascending",
+        "compound",
+        "dotted paths",
+        "multikey",
+        "named",
+        "partial",
+        "sparse",
+        "unique",
+    ],
+    "unsafe_unique_degradations_rejected": ["hashed", "text", "ttl"],
+}
+EXPECTED_AGGREGATION_CAPABILITIES = {
+    "accumulators": [
+        "$addToSet",
+        "$avg",
+        "$first",
+        "$last",
+        "$max",
+        "$min",
+        "$push",
+        "$sum",
+    ],
+    "expressions": ["$ifNull", "$literal", "$size"],
+    "expression_stages": ["$addFields", "$group", "$project", "$set"],
+    "remove_variable_stages": ["$addFields", "$project", "$set"],
+    "operation_options": {
+        "other_keyword_arguments": "unsupported",
+        "session": "null-only",
+    },
+    "stage_rules": [
+        "$set is an alias of $addFields",
+        ("$unset accepts a field string or a non-empty list/tuple of field strings"),
+        "$group _id accepts only a field path or null",
+    ],
+    "stages": [
+        "$match",
+        "$sort",
+        "$skip",
+        "$limit",
+        "$count",
+        "$project",
+        "$set",
+        "$addFields",
+        "$unset",
+        "$group",
+    ],
+    "unsupported_special_forms": [
+        "$sort $meta",
+        "aggregation variables other than $$REMOVE in its supported stages",
+    ],
+}
+EXPECTED_COMMAND_CAPABILITIES = {
+    "rules": [
+        "command names are case-insensitive",
+        "session is null-only",
+        (
+            "string or non-empty command-document input; the document's first key "
+            "selects the command"
+        ),
+        "value, positional arguments, and other keyword arguments are ignored",
+    ],
+    "supported": ["buildInfo", "ping"],
+    "unsupported": ["arbitrary database commands"],
+}
+EXPECTED_WARNING_CAPABILITIES = {
+    "class": "TinyMongoUnsupportedWarning",
+    "contexts": [
+        "create_indexes degraded model creation or skip",
+        "create_indexes degraded model reuse",
+        "cursor sorting of unsupported values",
+        "aggregation $sort of unsupported values",
+    ],
+    "degraded_index_feature_messages": {
+        "background": "background creation is ignored",
+        "descending": "descending direction is treated as ascending",
+        "hashed": "hashed indexing is replaced by ascending equality indexing",
+        "text": "text indexing is ignored because $text queries are not supported",
+        "ttl": "TTL expiration is not performed",
+    },
+    "message_templates": {
+        "index_creation": "Index {0!r} was created with reduced behavior: {1}.",
+        "index_reuse": (
+            "Index {0!r} was accepted with reduced behavior: {1}. Its effective "
+            "specification matches existing index {2!r}, so TinyMongo reused that "
+            "index instead of creating a duplicate."
+        ),
+        "unsupported_sort_value": (
+            "Sorting field '{0}' encountered unsupported value type '{1}'; values "
+            "of this type compare as null."
+        ),
+    },
+    "policy": (
+        "warnings name the reduced behavior and are attributed to the caller; sort "
+        "warnings say the value compares as null and are de-duplicated per field "
+        "and Python type within the cursor or aggregation engine"
+    ),
+}
+EXPECTED_UNSUPPORTED_CAPABILITIES = [
+    "aggregate keyword options other than session=None",
+    "arbitrary server commands",
+    (
+        "array filters and positional path tokens are not implemented; update "
+        "kwargs are ignored and mapping-only operators can persist tokens as "
+        "literal keys"
+    ),
+    "bulk_write",
+    "change streams",
+    "filtered collection listing",
+    "geospatial operators",
+    "non-null sessions",
+    "non-default read and write concerns",
+    "server-side JavaScript",
+    "TinyGridFS storage operations",
+    "transactions",
+    "unsupported aggregation stages/expressions/accumulators",
+    "unsupported index specifications",
+    "watch",
+]
+EXPECTED_SEMANTIC_CAPABILITIES = {
+    "aggregation": EXPECTED_AGGREGATION_CAPABILITIES,
+    "commands": EXPECTED_COMMAND_CAPABILITIES,
+    "indexes": EXPECTED_INDEX_CAPABILITIES,
+    "projections": EXPECTED_PROJECTION_CAPABILITIES,
+    "queries": EXPECTED_QUERY_CAPABILITIES,
+    "unsupported": EXPECTED_UNSUPPORTED_CAPABILITIES,
+    "updates": EXPECTED_UPDATE_CAPABILITIES,
+    "warnings": EXPECTED_WARNING_CAPABILITIES,
+}
+EXPECTED_CAPABILITIES_SHA256 = (
+    "786b11215470f2dbc51a84e9718dc84928209ab0cfdaf828fbcb9a574c96dc0e"
+)
+
+TARGET_PATTERN = re.compile(r"^[a-z][a-z0-9-]*$")
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+ISSUE_PATTERN = re.compile(
+    r"^https://github\.com/schapman1974/briskdb/issues/[1-9][0-9]*$"
+)
+ABSOLUTE_PATH_TOKEN = "<ABSOLUTE_PATH>"
+QUOTED_ABSOLUTE_PATH_PATTERN = re.compile(
+    r"""(?P<quote>["'])(?:[A-Za-z]:[\\/]|\\\\|/(?!/))[^"']*(?P=quote)"""
+)
+WINDOWS_ABSOLUTE_PATH_PATTERN = re.compile(
+    r"""(?<![A-Za-z0-9_\\/])(?:[A-Za-z]:[\\/]|\\\\)[^\s"'<>()[\]{},;]+"""
+)
+UNIX_ABSOLUTE_PATH_PATTERN = re.compile(
+    r"""(?<![A-Za-z0-9_:/\\])/(?!/)[^\s"'<>()[\]{},;]+"""
+)
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MANIFEST = ROOT / "compat" / "mongo" / "v1" / "manifest.json"
+
+
+class ContractError(Exception):
+    """A deterministic contract, result, or comparison failure."""
+
+
+def _load_json(path: Path) -> Any:
+    try:
+        with path.open("r", encoding="utf-8") as source:
+            return json.load(source)
+    except (OSError, json.JSONDecodeError) as error:
+        raise ContractError("cannot read valid JSON from {0}: {1}".format(path, error))
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode(
+        "utf-8"
+    )
+
+
+def _pretty_bytes(value: Any) -> bytes:
+    return (json.dumps(value, indent=2, sort_keys=True) + "\n").encode("utf-8")
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(_pretty_bytes(value))
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as source:
+            for chunk in iter(lambda: source.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError as error:
+        raise ContractError("cannot hash {0}: {1}".format(path, error))
+    return digest.hexdigest()
+
+
+def _git(source_root: Path, arguments: Sequence[str]) -> bytes:
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(source_root)] + list(arguments),
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except (OSError, subprocess.CalledProcessError) as error:
+        detail = getattr(error, "stderr", b"").decode("utf-8", "replace").strip()
+        raise ContractError(
+            "cannot read source Git snapshot: {0}".format(detail or error)
+        )
+    return completed.stdout
+
+
+def _object(value: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, dict):
+        raise ContractError("{0} must be a JSON object".format(label))
+    return value
+
+
+def _list(value: Any, label: str) -> List[Any]:
+    if not isinstance(value, list):
+        raise ContractError("{0} must be a JSON array".format(label))
+    return value
+
+
+def _string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ContractError("{0} must be a nonempty string".format(label))
+    return value
+
+
+def _unique_strings(value: Any, label: str) -> List[str]:
+    items = _list(value, label)
+    strings = [_string(item, "{0} item".format(label)) for item in items]
+    if len(strings) != len(set(strings)):
+        raise ContractError("{0} contains duplicates".format(label))
+    return strings
+
+
+def _sha256_string(value: Any, label: str) -> str:
+    digest = _string(value, label)
+    if not SHA256_PATTERN.fullmatch(digest):
+        raise ContractError("{0} must be a lowercase SHA-256".format(label))
+    return digest
+
+
+def _runner_local_path(contract_base: Path, value: Any, label: str) -> Tuple[str, Path]:
+    relative = _string(value, label)
+    parts = Path(relative).parts
+    prefix = ("compat", "mongo", "v1")
+    if (
+        Path(relative).is_absolute()
+        or ".." in parts
+        or tuple(parts[: len(prefix)]) != prefix
+        or len(parts) <= len(prefix)
+        or parts[len(prefix)] != "runner"
+    ):
+        raise ContractError(
+            "{0} must be a repository-relative path under compat/mongo/v1/runner".format(
+                label
+            )
+        )
+    return relative, contract_base.joinpath(*parts[len(prefix) :])
+
+
+def _exact_keys(value: Any, expected: Sequence[str], label: str) -> Mapping[str, Any]:
+    mapping = _object(value, label)
+    actual = set(mapping)
+    expected_set = set(expected)
+    if actual != expected_set:
+        raise ContractError(
+            "{0} keys differ; missing={1}, unexpected={2}".format(
+                label,
+                sorted(expected_set - actual),
+                sorted(actual - expected_set),
+            )
+        )
+    return mapping
+
+
+def _validate_option_records(
+    value: Any, behaviors: Sequence[str], label: str
+) -> Tuple[str, ...]:
+    records = _list(value, label)
+    names = []
+    for index, raw_record in enumerate(records):
+        record_label = "{0}[{1}]".format(label, index)
+        record = _object(raw_record, record_label)
+        if not {"name", "behavior"}.issubset(record) or not set(record).issubset(
+            {"name", "behavior", "condition"}
+        ):
+            raise ContractError(
+                "{0} must contain name, behavior, and optional condition".format(
+                    record_label
+                )
+            )
+        name = _string(record.get("name"), "{0}.name".format(record_label))
+        behavior = _string(record.get("behavior"), "{0}.behavior".format(record_label))
+        if behavior not in behaviors:
+            raise ContractError(
+                "{0} references unknown option behavior {1}".format(
+                    record_label, behavior
+                )
+            )
+        condition = record.get("condition")
+        if condition is not None:
+            _string(condition, "{0}.condition".format(record_label))
+        if behavior == "applied_conditionally" and condition is None:
+            raise ContractError(
+                "{0} conditionally applied option needs a condition".format(
+                    record_label
+                )
+            )
+        names.append(name)
+    if len(names) != len(set(names)):
+        raise ContractError("{0} contains duplicate option names".format(label))
+    return tuple(names)
+
+
+def _validate_api_capabilities(value: Any) -> None:
+    api = _exact_keys(
+        value,
+        (
+            "aliases",
+            "behavior_enum",
+            "connection_options",
+            "constructors",
+            "inventory_version",
+            "method_options",
+            "owners",
+        ),
+        "capabilities.api",
+    )
+    if api.get("inventory_version") != 1:
+        raise ContractError("capabilities.api inventory_version must be 1")
+
+    behavior_enum = _object(api.get("behavior_enum"), "API option behavior enum")
+    if set(behavior_enum) != set(EXPECTED_API_BEHAVIORS):
+        raise ContractError("API option behavior enum does not match TinyMongo v1.3.0")
+    for behavior, description in behavior_enum.items():
+        _string(description, "API option behavior {0}".format(behavior))
+
+    aliases = _object(api.get("aliases"), "API aliases")
+    if aliases != EXPECTED_API_ALIASES:
+        raise ContractError("API aliases do not match TinyMongo v1.3.0")
+
+    owners = _exact_keys(api.get("owners"), EXPECTED_API_OWNER_CLASSES, "API owners")
+    method_options = _exact_keys(
+        api.get("method_options"), EXPECTED_API_OWNER_CLASSES, "API method options"
+    )
+    for owner_name, expected_classes in EXPECTED_API_OWNER_CLASSES.items():
+        owner_label = "API owner {0}".format(owner_name)
+        owner = _exact_keys(
+            owners[owner_name],
+            (
+                "awaitability",
+                "classes",
+                "extensions",
+                "present_but_unsupported",
+                "properties",
+                "protocols",
+                "supported",
+            ),
+            owner_label,
+        )
+        classes = tuple(_unique_strings(owner.get("classes"), owner_label + " classes"))
+        if classes != expected_classes:
+            raise ContractError(
+                "{0} classes do not match TinyMongo v1.3.0".format(owner_label)
+            )
+
+        supported = set(
+            _unique_strings(owner.get("supported"), owner_label + " supported methods")
+        )
+        unsupported = set(
+            _unique_strings(
+                owner.get("present_but_unsupported"),
+                owner_label + " unsupported methods",
+            )
+        )
+        extensions = set(
+            _unique_strings(owner.get("extensions"), owner_label + " extensions")
+        )
+        expected_methods = set(EXPECTED_OPERATION_RESULT_SHAPES[owner_name])
+        if unsupported != set(EXPECTED_API_UNSUPPORTED_METHODS[owner_name]):
+            raise ContractError(
+                "{0} unsupported methods do not match source".format(owner_label)
+            )
+        if extensions != set(EXPECTED_API_EXTENSION_METHODS[owner_name]):
+            raise ContractError(
+                "{0} extensions do not match source".format(owner_label)
+            )
+        expected_supported = expected_methods - unsupported - extensions
+        if supported != expected_supported:
+            raise ContractError(
+                "{0} supported methods do not match source".format(owner_label)
+            )
+        if (
+            (supported & unsupported)
+            or (supported & extensions)
+            or (unsupported & extensions)
+        ):
+            raise ContractError("{0} method categories overlap".format(owner_label))
+
+        awaitability = _exact_keys(
+            owner.get("awaitability"),
+            ("awaitable", "immediate"),
+            owner_label + " awaitability",
+        )
+        awaitable = set(
+            _unique_strings(
+                awaitability.get("awaitable"), owner_label + " awaitable methods"
+            )
+        )
+        immediate = set(
+            _unique_strings(
+                awaitability.get("immediate"), owner_label + " immediate methods"
+            )
+        )
+        if awaitable != set(EXPECTED_AWAITABLE_METHODS[owner_name]):
+            raise ContractError(
+                "{0} awaitable methods do not match source".format(owner_label)
+            )
+        if immediate != expected_methods - awaitable or awaitable & immediate:
+            raise ContractError(
+                "{0} awaitability does not cover each method once".format(owner_label)
+            )
+
+        properties = _list(owner.get("properties"), owner_label + " properties")
+        property_names = []
+        for index, raw_property in enumerate(properties):
+            property_label = "{0} property {1}".format(owner_label, index)
+            property_record = _object(raw_property, property_label)
+            if not {"kind", "name"}.issubset(property_record) or not set(
+                property_record
+            ).issubset({"kind", "meaning", "name"}):
+                raise ContractError("{0} has invalid fields".format(property_label))
+            _string(property_record.get("kind"), property_label + " kind")
+            property_names.append(
+                _string(property_record.get("name"), property_label + " name")
+            )
+            if "meaning" in property_record:
+                _string(property_record["meaning"], property_label + " meaning")
+        if len(property_names) != len(set(property_names)):
+            raise ContractError("{0} contains duplicate properties".format(owner_label))
+
+        protocol_methods = set()
+        for index, raw_protocol in enumerate(
+            _list(owner.get("protocols"), owner_label + " protocols")
+        ):
+            protocol_label = "{0} protocol {1}".format(owner_label, index)
+            protocol = _exact_keys(
+                raw_protocol,
+                ("awaitability", "methods", "name"),
+                protocol_label,
+            )
+            _string(protocol.get("name"), protocol_label + " name")
+            if protocol.get("awaitability") not in ("awaitable", "immediate", "mixed"):
+                raise ContractError(
+                    "{0} has invalid awaitability".format(protocol_label)
+                )
+            methods = set(
+                _unique_strings(protocol.get("methods"), protocol_label + " methods")
+            )
+            if not methods or methods & protocol_methods or methods & expected_methods:
+                raise ContractError(
+                    "{0} has duplicate or ordinary methods".format(protocol_label)
+                )
+            protocol_methods.update(methods)
+
+        owner_options = _exact_keys(
+            method_options[owner_name],
+            expected_methods,
+            owner_label + " method options",
+        )
+        for method in sorted(expected_methods):
+            _validate_option_records(
+                owner_options[method],
+                EXPECTED_API_BEHAVIORS,
+                "{0}.{1} options".format(owner_label, method),
+            )
+
+    constructors = _exact_keys(
+        api.get("constructors"),
+        EXPECTED_API_CONSTRUCTOR_SIGNATURES,
+        "API constructors",
+    )
+    for class_name, expected_signature in EXPECTED_API_CONSTRUCTOR_SIGNATURES.items():
+        label = "constructor {0}".format(class_name)
+        constructor = _object(constructors[class_name], label)
+        if not {"options", "signature"}.issubset(constructor) or not set(
+            constructor
+        ).issubset({"construction_scope", "options", "signature"}):
+            raise ContractError("{0} has invalid fields".format(label))
+        if constructor.get("signature") != expected_signature:
+            raise ContractError("{0} signature does not match source".format(label))
+        option_names = _validate_option_records(
+            constructor.get("options"), EXPECTED_API_BEHAVIORS, label + " options"
+        )
+        if option_names != EXPECTED_API_CONSTRUCTOR_OPTIONS[class_name]:
+            raise ContractError("{0} options do not match source".format(label))
+        if "construction_scope" in constructor:
+            _string(constructor["construction_scope"], label + " construction scope")
+
+    connection = _exact_keys(
+        api.get("connection_options"),
+        (
+            "lookup",
+            "pymongo_fallback_catalog",
+            "pymongo_fallback_count",
+            "tinymongo_storage_options",
+            "unknown_option_behavior",
+        ),
+        "API connection options",
+    )
+    _string(connection.get("lookup"), "connection option lookup")
+    _string(
+        connection.get("unknown_option_behavior"),
+        "unknown connection option behavior",
+    )
+    pymongo_names = _validate_option_records(
+        connection.get("pymongo_fallback_catalog"),
+        EXPECTED_API_BEHAVIORS,
+        "PyMongo fallback connection options",
+    )
+    if (
+        connection.get("pymongo_fallback_count") != 65
+        or len(pymongo_names) != 65
+        or pymongo_names != EXPECTED_PYMONGO_CONNECTION_OPTIONS
+    ):
+        raise ContractError(
+            "PyMongo fallback connection options must be the exact 65-name catalog"
+        )
+    storage_names = _validate_option_records(
+        connection.get("tinymongo_storage_options"),
+        EXPECTED_API_BEHAVIORS,
+        "TinyMongo storage options",
+    )
+    if set(storage_names) != set(EXPECTED_TINYMONGO_STORAGE_OPTIONS):
+        raise ContractError("TinyMongo storage options do not match source")
+
+
+def _validate_result_shape_references(
+    value: Any, known_shapes: Sequence[str], label: str
+) -> None:
+    known = set(known_shapes)
+
+    def walk(node: Any, node_label: str) -> None:
+        if not isinstance(node, dict):
+            return
+        for key in ("additional_properties", "item"):
+            reference = node.get(key)
+            if isinstance(reference, str) and reference not in known:
+                raise ContractError(
+                    "{0}.{1} references unknown result shape {2}".format(
+                        node_label, key, reference
+                    )
+                )
+            if isinstance(reference, dict):
+                walk(reference, "{0}.{1}".format(node_label, key))
+        for key in ("members", "items"):
+            references = node.get(key)
+            if references is not None:
+                for index, reference in enumerate(
+                    _list(references, node_label + "." + key)
+                ):
+                    if not isinstance(reference, str) or reference not in known:
+                        raise ContractError(
+                            "{0}.{1}[{2}] references unknown result shape".format(
+                                node_label, key, index
+                            )
+                        )
+        for key in ("optional_fields", "required_fields"):
+            fields = node.get(key)
+            if fields is None:
+                continue
+            for field, field_shape in _object(fields, node_label + "." + key).items():
+                _string(field, node_label + " field name")
+                if isinstance(field_shape, str):
+                    if field_shape not in known:
+                        raise ContractError(
+                            "{0}.{1}.{2} references unknown result shape {3}".format(
+                                node_label, key, field, field_shape
+                            )
+                        )
+                elif isinstance(field_shape, dict):
+                    walk(field_shape, "{0}.{1}.{2}".format(node_label, key, field))
+                else:
+                    raise ContractError(
+                        "{0}.{1}.{2} must be a shape reference or inline shape".format(
+                            node_label, key, field
+                        )
+                    )
+
+    walk(value, label)
+
+
+def _validate_result_capabilities(value: Any) -> None:
+    results = _exact_keys(
+        value,
+        (
+            "cursor_results",
+            "document_results",
+            "inventory_version",
+            "operation_result_shapes",
+            "result_shapes",
+            "write_result_classes",
+        ),
+        "capabilities.results",
+    )
+    if results.get("inventory_version") != 1:
+        raise ContractError("capabilities.results inventory_version must be 1")
+
+    shapes = _exact_keys(
+        results.get("result_shapes"), EXPECTED_RESULT_SHAPE_IDS, "result shapes"
+    )
+    for shape_name, raw_shape in shapes.items():
+        shape = _object(raw_shape, "result shape {0}".format(shape_name))
+        _string(shape.get("kind"), "result shape {0} kind".format(shape_name))
+        _validate_result_shape_references(
+            shape, EXPECTED_RESULT_SHAPE_IDS, "result shape {0}".format(shape_name)
+        )
+    if _sha256_bytes(_canonical_bytes(shapes)) != EXPECTED_RESULT_SHAPES_SHA256:
+        raise ContractError("result shape definitions do not match TinyMongo v1.3.0")
+
+    operation_shapes = _exact_keys(
+        results.get("operation_result_shapes"),
+        EXPECTED_OPERATION_RESULT_SHAPES,
+        "operation result shapes",
+    )
+    for owner, expected in EXPECTED_OPERATION_RESULT_SHAPES.items():
+        observed = _object(operation_shapes[owner], "operation results for " + owner)
+        if observed != expected:
+            raise ContractError(
+                "operation result shapes for {0} do not match source".format(owner)
+            )
+        for method, shape_name in observed.items():
+            if shape_name not in shapes:
+                raise ContractError(
+                    "operation {0}.{1} references unknown shape {2}".format(
+                        owner, method, shape_name
+                    )
+                )
+
+    cursor_results = _exact_keys(
+        results.get("cursor_results"),
+        (
+            "async_class",
+            "async_cursor_returning_operations",
+            "behavior",
+            "sync_class",
+            "sync_cursor_returning_operations",
+        ),
+        "cursor results",
+    )
+    if (
+        cursor_results.get("sync_class") != "tinymongo.TinyMongoCursor"
+        or cursor_results.get("async_class") != "tinymongo.AsyncTinyMongoCursor"
+    ):
+        raise ContractError("cursor result classes do not match source")
+    if _unique_strings(
+        cursor_results.get("sync_cursor_returning_operations"),
+        "sync cursor-returning operations",
+    ) != ["aggregate", "find", "list_databases"]:
+        raise ContractError("sync cursor-returning operations do not match source")
+    if _unique_strings(
+        cursor_results.get("async_cursor_returning_operations"),
+        "async cursor-returning operations",
+    ) != ["aggregate", "find", "list_databases", "list_indexes"]:
+        raise ContractError("async cursor-returning operations do not match source")
+    if not _unique_strings(cursor_results.get("behavior"), "cursor result behavior"):
+        raise ContractError("cursor result behavior must be inventoried")
+
+    document_results = _exact_keys(
+        results.get("document_results"),
+        ("datetime_conversion", "field_order", "mapping_class", "value_isolation"),
+        "document results",
+    )
+    for field, description in document_results.items():
+        _string(description, "document result {0}".format(field))
+
+    write_results = _exact_keys(
+        results.get("write_result_classes"),
+        EXPECTED_WRITE_RESULT_FIELDS,
+        "write result classes",
+    )
+    for class_name, expected_fields in EXPECTED_WRITE_RESULT_FIELDS.items():
+        class_shape = _exact_keys(
+            write_results[class_name],
+            ("constructor", "fields"),
+            "write result " + class_name,
+        )
+        if (
+            class_shape.get("constructor")
+            != EXPECTED_WRITE_RESULT_CONSTRUCTORS[class_name]
+        ):
+            raise ContractError(
+                "{0} constructor does not match source".format(class_name)
+            )
+        fields = _list(class_shape.get("fields"), class_name + " fields")
+        field_names = []
+        for index, raw_field in enumerate(fields):
+            field = _object(raw_field, "{0} field {1}".format(class_name, index))
+            if not {"kind", "meaning", "name"}.issubset(field) or set(field) != {
+                "kind",
+                "meaning",
+                "name",
+            }:
+                raise ContractError(
+                    "{0} has an invalid field record".format(class_name)
+                )
+            _string(field.get("kind"), class_name + " field kind")
+            _string(field.get("meaning"), class_name + " field meaning")
+            field_names.append(_string(field.get("name"), class_name + " field name"))
+        if tuple(field_names) != expected_fields:
+            raise ContractError("{0} fields do not match source".format(class_name))
+
+
+def _validate_error_shapes(errors: Mapping[str, Any]) -> None:
+    classes = set(_unique_strings(errors.get("classes"), "error classes"))
+    if classes != set(EXPECTED_ERROR_CLASSES):
+        raise ContractError("error classes do not match TinyMongo v1.3.0")
+    _string(errors.get("field_scope"), "error field scope")
+    class_shapes = _exact_keys(
+        errors.get("class_shapes"), EXPECTED_ERROR_CLASSES, "error class shapes"
+    )
+    for class_name, expected_fields in EXPECTED_ERROR_FIELDS.items():
+        shape = _object(class_shapes[class_name], "error shape " + class_name)
+        if not {"fields"}.issubset(shape) or not set(shape).issubset(
+            {"constructor", "detail_shape", "fields"}
+        ):
+            raise ContractError("error shape {0} has invalid fields".format(class_name))
+        if "constructor" in shape:
+            _string(shape["constructor"], class_name + " constructor")
+        fields = _list(shape.get("fields"), class_name + " public fields")
+        names = []
+        for index, raw_field in enumerate(fields):
+            field = _object(raw_field, "{0} field {1}".format(class_name, index))
+            names.append(_string(field.get("name"), class_name + " field name"))
+            _string(field.get("kind"), class_name + " field kind")
+        if set(names) != set(expected_fields) or len(names) != len(expected_fields):
+            raise ContractError(
+                "error shape {0} fields do not match source".format(class_name)
+            )
+    if class_shapes["InvalidDocument"].get("constructor") != (
+        "InvalidDocument(message, document=None)"
+    ):
+        raise ContractError("InvalidDocument constructor does not match source")
+    invalid_document_fields = {
+        field["name"]: field for field in class_shapes["InvalidDocument"]["fields"]
+    }
+    if invalid_document_fields["document"].get("identity") != (
+        "original root document rejected by the BSON codec"
+    ):
+        raise ContractError("InvalidDocument.document identity is not exact")
+
+    bulk_error = class_shapes["BulkWriteError"]
+    bulk_error_fields = {field["name"]: field for field in bulk_error["fields"]}
+    if (
+        bulk_error.get("constructor") != "BulkWriteError(results)"
+        or bulk_error.get("detail_shape") != "bulk_write_details"
+        or bulk_error_fields["code"].get("constant") != 65
+        or bulk_error_fields["details"].get("shape") != "bulk_write_details"
+    ):
+        raise ContractError("BulkWriteError public shape does not match source")
+
+    detail_shapes = _exact_keys(
+        errors.get("detail_shapes"), ("bulk_write_details",), "error detail shapes"
+    )
+    bulk = _object(detail_shapes["bulk_write_details"], "bulk write details")
+    if bulk.get("kind") != "document":
+        raise ContractError("bulk write details must be a document")
+    fields = _exact_keys(
+        bulk.get("required_fields"),
+        (
+            "nInserted",
+            "nMatched",
+            "nModified",
+            "nRemoved",
+            "nUpserted",
+            "upserted",
+            "writeConcernErrors",
+            "writeErrors",
+        ),
+        "bulk write detail fields",
+    )
+    if fields["nInserted"] != "integer":
+        raise ContractError("bulk write nInserted must be an integer")
+    for field_name in ("nMatched", "nModified", "nRemoved", "nUpserted"):
+        if fields[field_name] != {"constant": 0}:
+            raise ContractError(
+                "bulk write {0} must be the constant zero".format(field_name)
+            )
+    for field_name in ("upserted", "writeConcernErrors"):
+        if fields[field_name] != {"constant": []}:
+            raise ContractError(
+                "bulk write {0} must be the constant empty array".format(field_name)
+            )
+    write_errors = _object(fields["writeErrors"], "bulk write errors")
+    if write_errors.get("kind") != "array":
+        raise ContractError("bulk writeErrors must be an array")
+    item = _object(write_errors.get("item"), "bulk write error item")
+    if item.get("kind") != "document":
+        raise ContractError("bulk write error item must be a document")
+    item_fields = _exact_keys(
+        item.get("required_fields"),
+        ("code", "errmsg", "index", "keyPattern", "keyValue", "op"),
+        "bulk write error item fields",
+    )
+    if (
+        item_fields["code"] != {"constant": 11000}
+        or item_fields["errmsg"] != "string"
+        or item_fields["index"] != "integer"
+        or item_fields["keyPattern"] != "document"
+        or item_fields["keyValue"] != "document"
+        or item_fields["op"] != "original_document"
+    ):
+        raise ContractError("bulk write error item shape does not match source")
+
+
+def _validate_capabilities(value: Any) -> Mapping[str, Any]:
+    capabilities = _exact_keys(
+        value, EXPECTED_CAPABILITY_CATEGORIES, "manifest.capabilities"
+    )
+    for category, category_value in capabilities.items():
+        if not isinstance(category_value, (dict, list)) or not category_value:
+            raise ContractError("capabilities.{0} must be nonempty".format(category))
+    for category, expected in EXPECTED_SEMANTIC_CAPABILITIES.items():
+        if capabilities[category] != expected:
+            raise ContractError(
+                "capabilities.{0} do not match TinyMongo v1.3.0".format(category)
+            )
+    _validate_api_capabilities(capabilities["api"])
+    _validate_result_capabilities(capabilities["results"])
+    errors = _object(capabilities["errors"], "capabilities.errors")
+    _validate_error_shapes(errors)
+
+    values = _exact_keys(
+        capabilities["values"],
+        ("bson_family_aliases", "native", "optional_pymongo_bson", "rules"),
+        "capabilities.values",
+    )
+    if tuple(_unique_strings(values.get("native"), "native BSON types")) != (
+        EXPECTED_NATIVE_BSON_TYPES
+    ):
+        raise ContractError("native BSON types do not match supported_bson_types()")
+    aliases = _object(values.get("bson_family_aliases"), "BSON family aliases")
+    if aliases != EXPECTED_BSON_FAMILY_ALIASES:
+        raise ContractError("BSON family aliases must map int/long to int32/int64")
+    if (
+        tuple(
+            _unique_strings(
+                values.get("optional_pymongo_bson"), "optional PyMongo BSON types"
+            )
+        )
+        != EXPECTED_OPTIONAL_PYMONGO_BSON_TYPES
+    ):
+        raise ContractError(
+            "optional PyMongo BSON type inventory does not match source"
+        )
+    if not _unique_strings(values.get("rules"), "BSON value rules"):
+        raise ContractError("BSON value rules must be inventoried")
+    if _sha256_bytes(_canonical_bytes(capabilities)) != EXPECTED_CAPABILITIES_SHA256:
+        raise ContractError(
+            "capability definitions do not match the frozen TinyMongo v1.3.0 inventory"
+        )
+    return capabilities
+
+
+def _validate_runner_provenance(
+    provenance_path: Path,
+    contract_base: Path,
+    manifest: Mapping[str, Any],
+    source_hashes: Mapping[str, str],
+) -> None:
+    provenance = _object(_load_json(provenance_path), "runner provenance")
+    if provenance.get("schema_version") != SCHEMA_VERSION:
+        raise ContractError("runner provenance schema_version must be 1")
+    if provenance.get("corpus") != manifest.get("contract"):
+        raise ContractError("runner provenance contract does not match manifest")
+
+    provenance_source = _object(provenance.get("source"), "runner provenance source")
+    manifest_source = _object(manifest.get("source"), "manifest.source")
+    for key in ("repository", "commit", "contract_git_tree", "runtime_git_tree"):
+        if provenance_source.get(key) != manifest_source.get(key):
+            raise ContractError(
+                "runner provenance source {0} does not match manifest".format(key)
+            )
+
+    listed_paths = set()
+    recorded_upstream = {}
+
+    def record_local(path_value: Any, digest_value: Any, label: str) -> str:
+        relative, local_path = _runner_local_path(contract_base, path_value, label)
+        if relative in listed_paths:
+            raise ContractError("duplicate runner provenance path {0}".format(relative))
+        expected = _sha256_string(digest_value, "{0} sha256".format(label))
+        actual = _sha256_file(local_path)
+        if actual != expected:
+            raise ContractError(
+                "{0} hash mismatch: expected {1}, found {2}".format(
+                    local_path, expected, actual
+                )
+            )
+        listed_paths.add(relative)
+        return relative
+
+    def record_upstream(entry: Mapping[str, Any], label: str) -> Tuple[str, str]:
+        relative = _string(entry.get("upstream_path"), "{0} path".format(label))
+        parts = Path(relative).parts
+        if (
+            Path(relative).is_absolute()
+            or ".." in parts
+            or tuple(parts[:2]) != ("tests", "contracts")
+        ):
+            raise ContractError(
+                "{0} must identify a frozen tests/contracts source".format(label)
+            )
+        if relative in recorded_upstream:
+            raise ContractError(
+                "duplicate upstream provenance path {0}".format(relative)
+            )
+        blob = _string(entry.get("upstream_git_blob"), "{0} Git blob".format(label))
+        if not re.fullmatch(r"[0-9a-f]{40}", blob):
+            raise ContractError("{0} Git blob must be a full object ID".format(label))
+        digest = _sha256_string(
+            entry.get("upstream_sha256"), "{0} upstream sha256".format(label)
+        )
+        recorded_upstream[relative] = digest
+        return relative, digest
+
+    adaptation = _object(provenance.get("adaptation"), "runner adaptation")
+    adapted_paths = []
+    for index, value in enumerate(_list(adaptation.get("files"), "adaptation files")):
+        label = "adaptation file {0}".format(index)
+        entry = _object(value, label)
+        upstream_path, upstream_digest = record_upstream(entry, label)
+        runner_path = record_local(
+            entry.get("runner_path"), entry.get("runner_sha256"), label
+        )
+        expected_runner = "compat/mongo/v1/runner/contracts/" + Path(upstream_path).name
+        if runner_path != expected_runner:
+            raise ContractError(
+                "{0} does not map to the matching runner contract path".format(label)
+            )
+        status = _string(entry.get("status"), "{0} status".format(label))
+        runner_digest = _sha256_string(
+            entry.get("runner_sha256"), "{0} runner sha256".format(label)
+        )
+        if status == "exact":
+            if runner_digest != upstream_digest:
+                raise ContractError(
+                    "exact {0} has different source and runner hashes".format(label)
+                )
+        elif status == "adapted":
+            if runner_digest == upstream_digest:
+                raise ContractError(
+                    "adapted {0} has identical source and runner hashes".format(label)
+                )
+            adapted_paths.append((upstream_path, runner_path))
+        else:
+            raise ContractError("{0} status must be exact or adapted".format(label))
+
+    for index, value in enumerate(
+        _list(
+            adaptation.get("excluded_upstream_files"),
+            "excluded upstream files",
+        )
+    ):
+        label = "excluded upstream file {0}".format(index)
+        entry = _object(value, label)
+        record_upstream(entry, label)
+        _string(entry.get("reason"), "{0} reason".format(label))
+
+    if recorded_upstream != dict(source_hashes):
+        raise ContractError(
+            "runner provenance does not account for every frozen contract source"
+        )
+
+    patch_path = record_local(
+        adaptation.get("patch"), adaptation.get("patch_sha256"), "adaptation patch"
+    )
+    try:
+        patch_text = (
+            contract_base / Path(patch_path).relative_to("compat/mongo/v1")
+        ).read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as error:
+        raise ContractError("cannot read adaptation patch: {0}".format(error))
+    for upstream_path, runner_path in adapted_paths:
+        source_header = "--- a/{0}".format(upstream_path)
+        runner_header = "+++ b/{0}".format(runner_path)
+        if source_header not in patch_text or runner_header not in patch_text:
+            raise ContractError(
+                "adaptation patch does not contain {0}".format(upstream_path)
+            )
+
+    license_entry = _object(provenance_source.get("license"), "runner source license")
+    if (
+        license_entry.get("spdx") != "MIT"
+        or license_entry.get("upstream_path") != "LICENSE.txt"
+    ):
+        raise ContractError("runner provenance must preserve the upstream MIT license")
+    license_blob = _string(
+        license_entry.get("upstream_git_blob"), "runner source license Git blob"
+    )
+    if not re.fullmatch(r"[0-9a-f]{40}", license_blob):
+        raise ContractError("runner source license Git blob must be a full object ID")
+    upstream_license_hash = _sha256_string(
+        license_entry.get("upstream_sha256"), "upstream license sha256"
+    )
+    runner_license_hash = _sha256_string(
+        license_entry.get("runner_sha256"), "runner license sha256"
+    )
+    if runner_license_hash != upstream_license_hash:
+        raise ContractError("runner license must be byte-for-byte upstream")
+    record_local(
+        license_entry.get("runner_path"), runner_license_hash, "runner source license"
+    )
+
+    for index, value in enumerate(
+        _list(provenance.get("runner_files"), "runner files")
+    ):
+        entry = _object(value, "runner file {0}".format(index))
+        record_local(
+            entry.get("path"), entry.get("sha256"), "runner file {0}".format(index)
+        )
+
+    expected_local = {
+        Path(relative).relative_to("compat/mongo/v1").as_posix()
+        for relative in listed_paths
+    }
+    actual_local = set()
+    cache_directories = {"__pycache__", ".pytest_cache", ".ruff_cache", ".mypy_cache"}
+    for local_path in provenance_path.parent.rglob("*"):
+        if not local_path.is_file() or local_path == provenance_path:
+            continue
+        runner_relative = local_path.relative_to(contract_base)
+        if cache_directories.intersection(runner_relative.parts):
+            continue
+        if local_path.suffix in (".pyc", ".pyo"):
+            continue
+        actual_local.add(runner_relative.as_posix())
+    if actual_local != expected_local:
+        missing = sorted(expected_local - actual_local)
+        unlisted = sorted(actual_local - expected_local)
+        raise ContractError(
+            "runner file inventory mismatch; missing={0}, unlisted={1}".format(
+                missing, unlisted
+            )
+        )
+
+
+def _manifest_paths(
+    manifest_path: Path,
+) -> Tuple[Mapping[str, Any], Path, Path, Path, Path]:
+    manifest = _object(_load_json(manifest_path), "manifest")
+    base = manifest_path.parent
+    files = _object(manifest.get("files"), "manifest.files")
+    corpus = base / _string(files.get("corpus"), "manifest.files.corpus")
+    reference = base / _string(
+        files.get("reference_results"), "manifest.files.reference_results"
+    )
+    differences = base / _string(
+        files.get("intentional_differences"),
+        "manifest.files.intentional_differences",
+    )
+    variants = base / _string(
+        files.get("semantic_variants"), "manifest.files.semantic_variants"
+    )
+    return manifest, corpus, reference, differences, variants
+
+
+def validate_contract(manifest_path: Path) -> Mapping[str, Any]:
+    manifest, corpus_path, reference_path, differences_path, variants_path = (
+        _manifest_paths(manifest_path)
+    )
+    files = _object(manifest.get("files"), "manifest.files")
+    provenance_path = manifest_path.parent / _string(
+        files.get("runner_provenance"), "manifest.files.runner_provenance"
+    )
+    if manifest.get("schema_version") != SCHEMA_VERSION:
+        raise ContractError("manifest schema_version must be 1")
+    contract = _string(manifest.get("contract"), "manifest.contract")
+    if contract != "tinymongo-v1":
+        raise ContractError("manifest.contract must be tinymongo-v1")
+
+    source = _object(manifest.get("source"), "manifest.source")
+    _string(source.get("repository"), "manifest.source.repository")
+    commit = _string(source.get("commit"), "manifest.source.commit")
+    if not re.fullmatch(r"[0-9a-f]{40}", commit):
+        raise ContractError("manifest.source.commit must be a full Git commit")
+    tree_digest = _string(source.get("contract_tree_sha256"), "source digest")
+    if not SHA256_PATTERN.fullmatch(tree_digest):
+        raise ContractError("source contract_tree_sha256 must be lowercase SHA-256")
+    git_tree = _string(source.get("contract_git_tree"), "source Git tree")
+    if not re.fullmatch(r"[0-9a-f]{40}", git_tree):
+        raise ContractError(
+            "manifest.source.contract_git_tree must be a Git tree object"
+        )
+    runtime_git_tree = _string(
+        source.get("runtime_git_tree"), "source runtime Git tree"
+    )
+    if not re.fullmatch(r"[0-9a-f]{40}", runtime_git_tree):
+        raise ContractError(
+            "manifest.source.runtime_git_tree must be a Git tree object"
+        )
+
+    hashes = _object(manifest.get("sha256"), "manifest.sha256")
+    for label, path in (
+        ("corpus", corpus_path),
+        ("reference_results", reference_path),
+        ("intentional_differences", differences_path),
+        ("semantic_variants", variants_path),
+        ("runner_provenance", provenance_path),
+    ):
+        expected = _string(hashes.get(label), "manifest.sha256.{0}".format(label))
+        if not SHA256_PATTERN.fullmatch(expected):
+            raise ContractError("manifest.sha256.{0} is invalid".format(label))
+        actual = _sha256_file(path)
+        if actual != expected:
+            raise ContractError(
+                "{0} hash mismatch: expected {1}, found {2}".format(
+                    path, expected, actual
+                )
+            )
+
+    dimensions = _object(manifest.get("dimensions"), "manifest.dimensions")
+    apis = _unique_strings(dimensions.get("apis"), "manifest.dimensions.apis")
+    if apis != list(EXPECTED_APIS):
+        raise ContractError("manifest APIs must be ordered as sync, async")
+    backends = _unique_strings(
+        dimensions.get("tinymongo_backends"), "manifest.dimensions.tinymongo_backends"
+    )
+    if backends != list(EXPECTED_BACKENDS):
+        raise ContractError(
+            "manifest TinyMongo backends do not match the frozen matrix"
+        )
+
+    toolchain = _object(manifest.get("harvest_toolchain"), "manifest.harvest_toolchain")
+    for component in ("python", "pytest", "pymongo"):
+        _string(
+            toolchain.get(component), "manifest.harvest_toolchain.{0}".format(component)
+        )
+
+    suites = _unique_strings(
+        manifest.get("contract_suites"), "manifest.contract_suites"
+    )
+    if not suites:
+        raise ContractError("at least one contract suite is required")
+    capabilities = _validate_capabilities(manifest.get("capabilities"))
+    errors = _object(capabilities["errors"], "capabilities.errors")
+    code_domains = _object(
+        errors.get("stable_codes_by_domain"),
+        "capabilities.errors.stable_codes_by_domain",
+    )
+    emitted_codes = set()
+    for domain, mapping_value in code_domains.items():
+        mapping = _object(mapping_value, "error-code domain {0}".format(domain))
+        for code, description in mapping.items():
+            if (
+                not str(code).isdigit()
+                or not isinstance(description, str)
+                or not description
+            ):
+                raise ContractError("invalid stable error-code inventory entry")
+            if int(code) in emitted_codes:
+                raise ContractError("duplicate stable error code {0}".format(code))
+            emitted_codes.add(int(code))
+    if (
+        errors.get("runtime_emitted_code_count") != len(emitted_codes)
+        or len(emitted_codes) != 60
+    ):
+        raise ContractError(
+            "stable error-code inventory must contain all 60 runtime codes"
+        )
+    asserted_values = _list(
+        errors.get("contract_asserted_codes"), "contract asserted error codes"
+    )
+    if any(
+        isinstance(code, bool) or not isinstance(code, int) for code in asserted_values
+    ):
+        raise ContractError("contract-asserted error codes must be integers")
+    asserted_codes = set(asserted_values)
+    if not asserted_codes or not asserted_codes.issubset(emitted_codes):
+        raise ContractError(
+            "contract-asserted error codes must be emitted runtime codes"
+        )
+
+    corpus = _object(_load_json(corpus_path), "corpus")
+    if (
+        corpus.get("schema_version") != SCHEMA_VERSION
+        or corpus.get("contract") != contract
+    ):
+        raise ContractError("corpus version or contract does not match manifest")
+    if corpus.get("source_commit") != commit:
+        raise ContractError("corpus source commit does not match manifest")
+    if corpus.get("source_git_tree") != git_tree:
+        raise ContractError("corpus source Git tree does not match manifest")
+    if corpus.get("harvest_toolchain") != toolchain:
+        raise ContractError("corpus harvest toolchain does not match manifest")
+    source_files = _list(corpus.get("source_files"), "corpus.source_files")
+    if len(source_files) != 21:
+        raise ContractError("corpus must inventory all 21 frozen contract files")
+    tree_hasher = hashlib.sha256()
+    seen_sources = set()
+    source_hashes = {}
+    for entry_value in source_files:
+        entry = _object(entry_value, "corpus source file")
+        relative = _string(entry.get("path"), "source file path")
+        digest = _string(entry.get("sha256"), "source file sha256")
+        if (
+            relative in seen_sources
+            or relative.startswith("/")
+            or ".." in Path(relative).parts
+        ):
+            raise ContractError(
+                "invalid or duplicate source file path {0}".format(relative)
+            )
+        if not SHA256_PATTERN.fullmatch(digest):
+            raise ContractError("invalid source hash for {0}".format(relative))
+        seen_sources.add(relative)
+        source_hashes[relative] = digest
+        tree_hasher.update(relative.encode("utf-8"))
+        tree_hasher.update(b"\0")
+        tree_hasher.update(bytes.fromhex(digest))
+        tree_hasher.update(b"\0")
+    if tree_hasher.hexdigest() != tree_digest:
+        raise ContractError(
+            "corpus source file inventory does not match source tree digest"
+        )
+    _validate_runner_provenance(
+        provenance_path,
+        manifest_path.parent,
+        manifest,
+        source_hashes,
+    )
+
+    cases = _list(corpus.get("cases"), "corpus.cases")
+    expected_count = manifest.get("case_count")
+    if not isinstance(expected_count, int) or expected_count != len(cases):
+        raise ContractError("manifest case_count does not match corpus")
+    seen_cases = set()
+    suite_counts = Counter()
+    expected_executions = 0
+    for value in cases:
+        case = _object(value, "corpus case")
+        case_id = _string(case.get("id"), "case id")
+        if case_id in seen_cases:
+            raise ContractError("duplicate case id {0}".format(case_id))
+        seen_cases.add(case_id)
+        suite = _string(case.get("suite"), "case suite")
+        if suite not in suites:
+            raise ContractError("case {0} has unknown suite {1}".format(case_id, suite))
+        relative = _string(case.get("source"), "case source")
+        if relative not in seen_sources:
+            raise ContractError(
+                "case {0} has untracked source {1}".format(case_id, relative)
+            )
+        case_apis = _unique_strings(case.get("apis"), "case APIs")
+        if case_apis != apis:
+            raise ContractError(
+                "case {0} must cover sync and async APIs".format(case_id)
+            )
+        requirements = case.get("requirements", {})
+        if not isinstance(requirements, dict):
+            raise ContractError(
+                "case {0} requirements must be an object".format(case_id)
+            )
+        suite_counts[suite] += 1
+        expected_executions += len(case_apis)
+    if dict(sorted(suite_counts.items())) != manifest.get("suite_case_counts"):
+        raise ContractError("manifest suite_case_counts does not match corpus")
+    if manifest.get("reference_execution_count") != expected_executions:
+        raise ContractError("manifest reference_execution_count does not match corpus")
+    full_matrix_count = expected_executions * len(backends)
+    if manifest.get("full_matrix_execution_count") != full_matrix_count:
+        raise ContractError(
+            "manifest full_matrix_execution_count does not match dimensions"
+        )
+    if len(cases) != EXPECTED_CASE_COUNT:
+        raise ContractError("frozen corpus must contain exactly 228 logical cases")
+    test_modules = {case["source"] for case in cases}
+    if len(test_modules) != EXPECTED_MODULE_COUNT:
+        raise ContractError("frozen corpus must contain exactly 16 test modules")
+
+    differences = _object(_load_json(differences_path), "intentional differences")
+    if (
+        differences.get("schema_version") != SCHEMA_VERSION
+        or differences.get("contract") != contract
+    ):
+        raise ContractError("intentional differences version or contract is invalid")
+    difference_keys = set()
+    for value in _list(differences.get("differences"), "differences"):
+        difference = _object(value, "intentional difference")
+        target = _string(difference.get("target"), "difference target")
+        case_id = _string(difference.get("case_id"), "difference case_id")
+        api = _string(difference.get("api"), "difference api")
+        issue = _string(difference.get("issue"), "difference issue")
+        _string(difference.get("reason"), "difference reason")
+        reference_outcome = _string(
+            difference.get("reference_outcome"), "difference reference outcome"
+        )
+        candidate_outcome = _string(
+            difference.get("candidate_outcome"), "difference candidate outcome"
+        )
+        reference_fingerprint = _string(
+            difference.get("reference_fingerprint"),
+            "difference reference fingerprint",
+        )
+        candidate_fingerprint = _string(
+            difference.get("candidate_fingerprint"),
+            "difference candidate fingerprint",
+        )
+        if not TARGET_PATTERN.fullmatch(target):
+            raise ContractError("invalid difference target {0}".format(target))
+        if case_id not in seen_cases or api not in apis:
+            raise ContractError("difference references an unknown case or API")
+        if not ISSUE_PATTERN.fullmatch(issue):
+            raise ContractError("difference must link one BriskDB issue")
+        if reference_outcome not in OUTCOMES or candidate_outcome not in OUTCOMES:
+            raise ContractError("difference outcomes are invalid")
+        if not SHA256_PATTERN.fullmatch(
+            reference_fingerprint
+        ) or not SHA256_PATTERN.fullmatch(candidate_fingerprint):
+            raise ContractError("difference fingerprints must be lowercase SHA-256")
+        key = (target, case_id, api)
+        if key in difference_keys:
+            raise ContractError("duplicate intentional difference {0}".format(key))
+        difference_keys.add(key)
+
+    variants = _object(_load_json(variants_path), "semantic variants")
+    if (
+        variants.get("schema_version") != SCHEMA_VERSION
+        or variants.get("contract") != contract
+    ):
+        raise ContractError("semantic variants version or contract is invalid")
+    variant_keys = set()
+    for value in _list(variants.get("variants"), "semantic variants"):
+        variant = _object(value, "semantic variant")
+        case_id = _string(variant.get("case_id"), "variant case_id")
+        backend = _string(variant.get("backend"), "variant backend")
+        dimension = _string(variant.get("dimension"), "variant dimension")
+        issue = _string(variant.get("issue"), "variant issue")
+        _string(variant.get("reference_behavior"), "variant reference behavior")
+        _string(variant.get("backend_behavior"), "variant backend behavior")
+        variant_apis = _unique_strings(variant.get("apis"), "variant APIs")
+        if case_id not in seen_cases or backend not in backends:
+            raise ContractError(
+                "semantic variant references an unknown case or backend"
+            )
+        if any(api not in apis for api in variant_apis):
+            raise ContractError("semantic variant references an unknown API")
+        if not ISSUE_PATTERN.fullmatch(issue):
+            raise ContractError("semantic variant must link one BriskDB issue")
+        key = (case_id, backend, dimension)
+        if key in variant_keys:
+            raise ContractError("duplicate semantic variant {0}".format(key))
+        variant_keys.add(key)
+
+    reference = validate_results(
+        _load_json(reference_path), corpus, "reference results"
+    )
+    target_ids = {execution["target"] for execution in reference["executions"]}
+    if target_ids != {manifest.get("reference_target")}:
+        raise ContractError("reference results contain an unexpected target")
+    expected_keys = {(case["id"], api) for case in cases for api in case["apis"]}
+    actual_keys = {
+        (execution["case_id"], execution["api"])
+        for execution in reference["executions"]
+    }
+    if actual_keys != expected_keys:
+        raise ContractError("reference results do not cover the entire corpus")
+    return manifest
+
+
+def validate_results(
+    value: Any, corpus: Mapping[str, Any], label: str = "results"
+) -> Mapping[str, Any]:
+    results = _object(value, label)
+    if results.get("schema_version") != SCHEMA_VERSION:
+        raise ContractError("{0} schema_version must be 1".format(label))
+    if results.get("contract") != corpus.get("contract"):
+        raise ContractError("{0} contract does not match corpus".format(label))
+    known_cases = {
+        case["id"]: {
+            "apis": set(case["apis"]),
+            "suite": case["suite"],
+        }
+        for case in _list(corpus.get("cases"), "corpus.cases")
+    }
+    seen = set()
+    for value in _list(results.get("executions"), "{0}.executions".format(label)):
+        execution = _object(value, "result execution")
+        target = _string(execution.get("target"), "execution target")
+        if not TARGET_PATTERN.fullmatch(target):
+            raise ContractError("invalid execution target {0}".format(target))
+        case_id = _string(execution.get("case_id"), "execution case_id")
+        api = _string(execution.get("api"), "execution api")
+        outcome = _string(execution.get("outcome"), "execution outcome")
+        backend = _string(execution.get("backend"), "execution backend")
+        suite = _string(execution.get("suite"), "execution suite")
+        if case_id not in known_cases or api not in known_cases[case_id]["apis"]:
+            raise ContractError(
+                "result references unknown case/API {0}/{1}".format(case_id, api)
+            )
+        if suite != known_cases[case_id]["suite"]:
+            raise ContractError(
+                "execution suite does not match corpus case {0}".format(case_id)
+            )
+        if outcome not in OUTCOMES:
+            raise ContractError("invalid outcome {0}".format(outcome))
+        key = (target, case_id, api)
+        if key in seen:
+            raise ContractError("duplicate execution {0}".format(key))
+        seen.add(key)
+        if not TARGET_PATTERN.fullmatch(backend):
+            raise ContractError("invalid backend {0}".format(backend))
+        if not target.endswith("-" + backend):
+            raise ContractError(
+                "execution backend {0} does not match target {1}".format(
+                    backend, target
+                )
+            )
+        reason = execution.get("reason")
+        if reason is not None and not isinstance(reason, str):
+            raise ContractError("execution reason must be a string or null")
+        observation = _object(execution.get("observation"), "execution observation")
+        category = _string(observation.get("category"), "observation category")
+        if outcome == "passed" and (category != "passed" or reason is not None):
+            raise ContractError(
+                "passed execution requires category passed and a null reason"
+            )
+        fingerprint = _string(observation.get("fingerprint"), "observation fingerprint")
+        if not SHA256_PATTERN.fullmatch(fingerprint):
+            raise ContractError("observation fingerprint must be lowercase SHA-256")
+        expected_fingerprint = _observation(outcome, category, reason)["fingerprint"]
+        if fingerprint != expected_fingerprint:
+            raise ContractError(
+                "observation fingerprint does not match normalized result"
+            )
+    return results
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def _properties(testcase: Any) -> Dict[str, List[str]]:
+    values: Dict[str, List[str]] = defaultdict(list)
+    for element in testcase.iter():
+        if _local_name(element.tag) != "property":
+            continue
+        name = element.get("name")
+        if name:
+            values[name].append((element.get("value") or element.text or "").strip())
+    return values
+
+
+def _one_property(properties: Mapping[str, List[str]], name: str) -> Optional[str]:
+    values = properties.get(name, [])
+    return values[0] if len(values) == 1 and values[0] else None
+
+
+def _normalize_reason(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+    message = " ".join(value.split())
+    message = QUOTED_ABSOLUTE_PATH_PATTERN.sub(
+        lambda match: "{0}{1}{0}".format(match.group("quote"), ABSOLUTE_PATH_TOKEN),
+        message,
+    )
+    message = WINDOWS_ABSOLUTE_PATH_PATTERN.sub(ABSOLUTE_PATH_TOKEN, message)
+    message = UNIX_ABSOLUTE_PATH_PATTERN.sub(ABSOLUTE_PATH_TOKEN, message)
+    return message
+
+
+def _display_reason(value: Optional[str]) -> Optional[str]:
+    return value[:500] if value is not None else None
+
+
+def _observation(
+    outcome: str, category: str, reason: Optional[str]
+) -> Mapping[str, str]:
+    payload = "{0}\0{1}\0{2}".format(outcome, category, reason or "").encode("utf-8")
+    return {"category": category, "fingerprint": _sha256_bytes(payload)}
+
+
+def _result(testcase: Any) -> Tuple[str, Optional[str], Mapping[str, str]]:
+    child = next(
+        (
+            item
+            for item in testcase
+            if _local_name(item.tag) in ("failure", "error", "skipped")
+        ),
+        None,
+    )
+    if child is None:
+        outcome, reason, category = "passed", None, "passed"
+        return outcome, reason, _observation(outcome, category, reason)
+    tag = _local_name(child.tag)
+    raw_type = child.get("type") or tag
+    result_type = raw_type.lower()
+    reason = _normalize_reason(child.get("message") or child.text)
+    if tag == "error":
+        outcome = "error"
+    elif tag == "skipped":
+        outcome = "xfailed" if "xfail" in result_type else "skipped"
+    elif tag == "failure" and (
+        result_type in ("xpass", "pytest.xpass")
+        or (reason or "").startswith("[XPASS(strict)]")
+    ):
+        outcome = "xpassed"
+    else:
+        outcome = "failed"
+    return outcome, reason, _observation(outcome, raw_type, reason)
+
+
+def _case_name(name: str, api: str, backend: str) -> str:
+    match = re.search(r"\[([^][]*)\]$", name)
+    if match is None:
+        raise ContractError(
+            "test name {0} lacks API/backend parameters {1}/{2}".format(
+                name, api, backend
+            )
+        )
+    base = name[: match.start()]
+    parameters = match.group(1)
+    target_prefix = "{0}-{1}".format(api, backend)
+    if parameters != target_prefix and not parameters.startswith(target_prefix + "-"):
+        raise ContractError(
+            "test name {0} does not begin with API/backend {1}/{2}".format(
+                name, api, backend
+            )
+        )
+    remaining = parameters[len(target_prefix) :].lstrip("-")
+    return "{0}[{1}]".format(base, remaining) if remaining else base
+
+
+def ingest_junit(
+    junit_path: Path,
+    implementation: str,
+    corpus: Optional[Mapping[str, Any]] = None,
+) -> Mapping[str, Any]:
+    if not TARGET_PATTERN.fullmatch(implementation):
+        raise ContractError(
+            "implementation must use lowercase letters, digits, and hyphens"
+        )
+    try:
+        import xml.etree.ElementTree as element_tree
+
+        root = element_tree.parse(str(junit_path)).getroot()
+    except (OSError, element_tree.ParseError) as error:
+        raise ContractError("cannot read JUnit XML {0}: {1}".format(junit_path, error))
+
+    executions = []
+    for testcase in root.iter():
+        if _local_name(testcase.tag) != "testcase":
+            continue
+        properties = _properties(testcase)
+        api = _one_property(properties, "tinymongo.api")
+        backend = _one_property(properties, "tinymongo.backend")
+        suite = _one_property(properties, "tinymongo.suite")
+        if not api or not backend or not suite:
+            raise ContractError(
+                "JUnit testcase {0} lacks unique tinymongo.api, tinymongo.backend, "
+                "or tinymongo.suite properties".format(
+                    testcase.get("name") or "<unnamed>"
+                )
+            )
+        classname = _string(testcase.get("classname"), "JUnit classname")
+        name = _string(testcase.get("name"), "JUnit test name")
+        normalized_name = _case_name(name, api, backend)
+        explicit_values = properties.get("tinymongo.contract_id", [])
+        explicit_case_id = _one_property(properties, "tinymongo.contract_id")
+        if explicit_values and explicit_case_id is None:
+            raise ContractError(
+                "JUnit testcase {0} lacks a unique tinymongo.contract_id property".format(
+                    name
+                )
+            )
+        case_id = explicit_case_id or "{0}::{1}".format(classname, normalized_name)
+        outcome, reason, observation = _result(testcase)
+        executions.append(
+            {
+                "api": api,
+                "backend": backend,
+                "case_id": case_id,
+                "outcome": outcome,
+                "observation": observation,
+                "reason": reason,
+                "suite": suite,
+                "target": "{0}-{1}".format(implementation, backend),
+            }
+        )
+    executions.sort(key=lambda item: (item["target"], item["case_id"], item["api"]))
+    result = {
+        "schema_version": SCHEMA_VERSION,
+        "contract": "tinymongo-v1",
+        "executions": executions,
+    }
+    if corpus is not None:
+        validate_results(result, corpus, "ingested results")
+    return result
+
+
+def _case_requirements(case_id: str) -> Mapping[str, Any]:
+    ordered_reads = {
+        "tests.contracts.test_client_read_fidelity_contract::"
+        "test_configured_document_and_datetime_results_match_mongodb",
+        "tests.contracts.test_client_read_fidelity_contract::"
+        "test_same_millisecond_write_identity_matches_mongodb",
+        "tests.contracts.test_bson_value_types_contract::"
+        "test_tm035_scoped_code_honors_recursive_client_read_options",
+    }
+    if case_id in ordered_reads:
+        return {
+            "client_options": {
+                "document_class": "collections.OrderedDict",
+                "tz_aware": True,
+            }
+        }
+    standard_uuid = {
+        "tests.contracts.test_uuid_regex_contract::"
+        "test_uuid_round_trip_uses_standard_binary_identity",
+        "tests.contracts.test_uuid_regex_contract::"
+        "test_uuid_and_subtype_four_binary_share_unique_identity",
+    }
+    if case_id in standard_uuid:
+        return {
+            "mongodb_collection_options": {
+                "uuid_representation": "STANDARD",
+            }
+        }
+    return {}
+
+
+def snapshot_corpus(
+    junit_path: Path,
+    source_root: Path,
+    source_commit: str,
+    expected_apis: Sequence[str] = EXPECTED_APIS,
+    expected_backends: Sequence[str] = EXPECTED_BACKENDS,
+    expected_case_count: int = EXPECTED_CASE_COUNT,
+    harvest_toolchain: Optional[Mapping[str, str]] = None,
+) -> Tuple[Mapping[str, Any], Mapping[str, Any], str]:
+    matrix_results = ingest_junit(junit_path, "tinymongo")
+    expected_cells = {
+        (api, backend) for api in expected_apis for backend in expected_backends
+    }
+    seen_cells = set()
+    grouped: Dict[str, Dict[str, Any]] = {}
+    for execution in matrix_results["executions"]:
+        case_id = execution["case_id"]
+        cell = (case_id, execution["api"], execution["backend"])
+        if cell in seen_cells:
+            raise ContractError("duplicate matrix cell {0}".format(cell))
+        seen_cells.add(cell)
+        if (execution["api"], execution["backend"]) not in expected_cells:
+            raise ContractError(
+                "matrix contains an unexpected API/backend cell {0}".format(cell)
+            )
+        source_module = case_id.split("::", 1)[0]
+        relative = source_module.replace(".", "/") + ".py"
+        entry = grouped.setdefault(
+            case_id,
+            {
+                "apis": [],
+                "id": case_id,
+                "source": relative,
+                "suite": execution["suite"],
+                "matrix_cells": set(),
+            },
+        )
+        if entry["suite"] != execution["suite"] or entry["source"] != relative:
+            raise ContractError(
+                "case metadata disagrees across executions: {0}".format(case_id)
+            )
+        entry["apis"].append(execution["api"])
+        entry["matrix_cells"].add((execution["api"], execution["backend"]))
+    if len(grouped) != expected_case_count:
+        raise ContractError(
+            "complete matrix must contain {0} logical cases; found {1}".format(
+                expected_case_count, len(grouped)
+            )
+        )
+    cases = []
+    for case_id in sorted(grouped):
+        entry = grouped[case_id]
+        if entry.pop("matrix_cells") != expected_cells:
+            raise ContractError(
+                "complete matrix has missing cells for {0}".format(case_id)
+            )
+        entry["apis"] = list(expected_apis)
+        entry["requirements"] = _case_requirements(case_id)
+        cases.append(entry)
+
+    reference_executions = [
+        execution
+        for execution in matrix_results["executions"]
+        if execution["backend"] == "memory"
+    ]
+    results = {
+        "schema_version": SCHEMA_VERSION,
+        "contract": "tinymongo-v1",
+        "executions": reference_executions,
+    }
+
+    resolved_commit = (
+        _git(source_root, ["rev-parse", "{0}^{{commit}}".format(source_commit)])
+        .decode("ascii")
+        .strip()
+    )
+    if resolved_commit != source_commit:
+        raise ContractError(
+            "--source-commit does not resolve to the exact supplied commit"
+        )
+    source_git_tree = (
+        _git(source_root, ["rev-parse", "{0}:tests/contracts".format(source_commit)])
+        .decode("ascii")
+        .strip()
+    )
+    source_paths = set(
+        _git(
+            source_root,
+            ["ls-tree", "-r", "--name-only", source_commit, "--", "tests/contracts"],
+        )
+        .decode("utf-8")
+        .splitlines()
+    )
+    if not source_paths or any(case["source"] not in source_paths for case in cases):
+        raise ContractError(
+            "source commit does not contain every collected contract module"
+        )
+    source_files = []
+    tree_hasher = hashlib.sha256()
+    for relative in sorted(source_paths):
+        blob = _git(source_root, ["show", "{0}:{1}".format(source_commit, relative)])
+        digest = _sha256_bytes(blob)
+        source_files.append({"path": relative, "sha256": digest})
+        tree_hasher.update(relative.encode("utf-8"))
+        tree_hasher.update(b"\0")
+        tree_hasher.update(bytes.fromhex(digest))
+        tree_hasher.update(b"\0")
+    corpus = {
+        "schema_version": SCHEMA_VERSION,
+        "contract": "tinymongo-v1",
+        "source_commit": source_commit,
+        "source_git_tree": source_git_tree,
+        "source_files": source_files,
+        "cases": cases,
+    }
+    if harvest_toolchain is not None:
+        corpus["harvest_toolchain"] = dict(harvest_toolchain)
+    return corpus, results, tree_hasher.hexdigest()
+
+
+def _load_result_files(
+    paths: Sequence[Path], corpus: Mapping[str, Any]
+) -> List[Mapping[str, Any]]:
+    loaded = []
+    for path in paths:
+        loaded.append(validate_results(_load_json(path), corpus, str(path)))
+    return loaded
+
+
+def compare_results(
+    manifest: Mapping[str, Any],
+    corpus: Mapping[str, Any],
+    differences: Mapping[str, Any],
+    results: Sequence[Mapping[str, Any]],
+    reference_target: str,
+    required_targets: Sequence[str] = (),
+    require_allowlist_targets: bool = False,
+) -> Tuple[Mapping[str, Any], str, bool]:
+    executions = []
+    for result in results:
+        executions.extend(result["executions"])
+    by_target: Dict[str, Dict[Tuple[str, str], Mapping[str, Any]]] = defaultdict(dict)
+    for execution in executions:
+        key = (execution["case_id"], execution["api"])
+        if key in by_target[execution["target"]]:
+            raise ContractError(
+                "duplicate execution across result files for {0}/{1}/{2}".format(
+                    execution["target"], key[0], key[1]
+                )
+            )
+        by_target[execution["target"]][key] = execution
+    if reference_target not in by_target:
+        raise ContractError(
+            "reference target {0} has no results".format(reference_target)
+        )
+
+    expected = {(case["id"], api) for case in corpus["cases"] for api in case["apis"]}
+    reference = by_target[reference_target]
+    if set(reference) != expected:
+        raise ContractError("reference target does not cover the complete corpus")
+    allowlist = {
+        (item["target"], item["case_id"], item["api"]): item
+        for item in differences["differences"]
+    }
+    observed_allowlist = set()
+    target_reports = []
+    missing_required_targets = sorted(set(required_targets) - set(by_target))
+    failed = bool(missing_required_targets)
+
+    def fingerprint(execution: Mapping[str, Any]) -> str:
+        observation = execution.get("observation")
+        if isinstance(observation, dict) and isinstance(
+            observation.get("fingerprint"), str
+        ):
+            return observation["fingerprint"]
+        category = execution.get("outcome", "missing")
+        return _observation(execution["outcome"], category, execution.get("reason"))[
+            "fingerprint"
+        ]
+
+    for target in sorted(by_target):
+        observed = by_target[target]
+        counts = Counter(item["outcome"] for item in observed.values())
+        mismatches = []
+        if target != reference_target:
+            for key in sorted(expected):
+                expected_execution = reference[key]
+                actual = observed.get(key)
+                actual_outcome = actual["outcome"] if actual else "missing"
+                expected_fingerprint = fingerprint(expected_execution)
+                actual_fingerprint = fingerprint(actual) if actual else None
+                if (
+                    actual_outcome == expected_execution["outcome"]
+                    and actual_fingerprint == expected_fingerprint
+                ):
+                    continue
+                difference = allowlist.get((target, key[0], key[1]))
+                allowed = bool(
+                    actual
+                    and difference
+                    and difference["reference_outcome"] == expected_execution["outcome"]
+                    and difference["candidate_outcome"] == actual_outcome
+                    and difference.get("reference_fingerprint", expected_fingerprint)
+                    == expected_fingerprint
+                    and difference["candidate_fingerprint"] == actual_fingerprint
+                )
+                if allowed:
+                    observed_allowlist.add((target, key[0], key[1]))
+                else:
+                    failed = True
+                mismatches.append(
+                    {
+                        "allowed": allowed,
+                        "api": key[1],
+                        "case_id": key[0],
+                        "expected": expected_execution["outcome"],
+                        "expected_fingerprint": expected_fingerprint,
+                        "expected_reason": _display_reason(
+                            expected_execution.get("reason")
+                        ),
+                        "observed": actual_outcome,
+                        "observed_fingerprint": actual_fingerprint,
+                        "observed_reason": _display_reason(
+                            actual.get("reason") if actual else None
+                        ),
+                        "policy": (
+                            {
+                                "issue": difference["issue"],
+                                "reason": difference["reason"],
+                            }
+                            if difference is not None
+                            else None
+                        ),
+                    }
+                )
+        target_reports.append(
+            {
+                "counts": dict(sorted(counts.items())),
+                "executions": len(observed),
+                "mismatches": mismatches,
+                "target": target,
+            }
+        )
+    stale = []
+    targets = set(by_target)
+    for key, item in sorted(allowlist.items()):
+        if (
+            key[0] in targets or require_allowlist_targets
+        ) and key not in observed_allowlist:
+            stale.append(item)
+            failed = True
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "contract": manifest["contract"],
+        "reference_target": reference_target,
+        "status": "failed"
+        if failed
+        else ("reference-only" if len(by_target) == 1 else "passed"),
+        "targets": target_reports,
+        "missing_required_targets": missing_required_targets,
+        "stale_intentional_differences": stale,
+    }
+    lines = [
+        "# Mongo compatibility parity",
+        "",
+        "Contract: `{0}`  ".format(manifest["contract"]),
+        "TinyMongo source: `{0}`  ".format(manifest["source"]["commit"]),
+        "Reference: `{0}`  ".format(reference_target),
+        "Status: **{0}**".format(report["status"]),
+        "",
+        "| Target | Executions | Passed | Failed/error | Skipped/xfail | Mismatches |",
+        "| --- | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    if missing_required_targets:
+        lines.extend(
+            [
+                "",
+                "Missing required targets: {0}".format(
+                    ", ".join(
+                        "`{0}`".format(target) for target in missing_required_targets
+                    )
+                ),
+            ]
+        )
+    for target in target_reports:
+        counts = target["counts"]
+        lines.append(
+            "| `{0}` | {1} | {2} | {3} | {4} | {5} |".format(
+                target["target"],
+                target["executions"],
+                counts.get("passed", 0) + counts.get("xpassed", 0),
+                counts.get("failed", 0) + counts.get("error", 0),
+                counts.get("skipped", 0) + counts.get("xfailed", 0),
+                len(target["mismatches"]),
+            )
+        )
+    mismatch_rows = [
+        (target["target"], mismatch)
+        for target in target_reports
+        for mismatch in target["mismatches"]
+    ]
+    if mismatch_rows:
+        lines.extend(
+            [
+                "",
+                "## Outcome differences",
+                "",
+                "| Target | API | Contract | Reference | Observed | Policy |",
+                "| --- | --- | --- | --- | --- | --- |",
+            ]
+        )
+        for target, mismatch in mismatch_rows:
+            lines.append(
+                "| `{0}` | `{1}` | `{2}` | `{3}` | `{4}` | {5} |".format(
+                    target,
+                    mismatch["api"],
+                    mismatch["case_id"].replace("|", "\\|"),
+                    mismatch["expected"],
+                    mismatch["observed"],
+                    (
+                        "[allowed]({0})".format(mismatch["policy"]["issue"])
+                        if mismatch["allowed"]
+                        else "uncovered"
+                    ),
+                )
+            )
+    if stale:
+        lines.extend(
+            [
+                "",
+                "## Stale intentional differences",
+                "",
+                "Strict allow-list entries must be removed when the recorded difference is not observed.",
+                "",
+            ]
+        )
+        lines.extend(
+            "- `{0}` ({1})".format(item["case_id"], item["issue"]) for item in stale
+        )
+    lines.append("")
+    return report, "\n".join(lines), failed
+
+
+def _command_validate(arguments: argparse.Namespace) -> int:
+    manifest = validate_contract(arguments.manifest)
+    print(
+        "validated {0}: {1} cases, {2} reference executions".format(
+            manifest["contract"],
+            manifest["case_count"],
+            manifest["reference_execution_count"],
+        )
+    )
+    return 0
+
+
+def _command_snapshot(arguments: argparse.Namespace) -> int:
+    if not re.fullmatch(r"[0-9a-f]{40}", arguments.source_commit):
+        raise ContractError("--source-commit must be a full Git commit")
+    corpus, results, tree_digest = snapshot_corpus(
+        arguments.junit,
+        arguments.source_root,
+        arguments.source_commit,
+        harvest_toolchain={
+            "pymongo": arguments.pymongo_version,
+            "pytest": arguments.pytest_version,
+            "python": arguments.python_version,
+        },
+    )
+    if any(item["outcome"] != "passed" for item in results["executions"]):
+        raise ContractError("memory reference must pass every collected contract")
+    artifacts = (
+        (arguments.corpus_output, _pretty_bytes(corpus)),
+        (arguments.results_output, _pretty_bytes(results)),
+    )
+    if arguments.check:
+        for path, expected in artifacts:
+            try:
+                actual = path.read_bytes()
+            except OSError as error:
+                raise ContractError(
+                    "cannot check snapshot {0}: {1}".format(path, error)
+                )
+            if actual != expected:
+                raise ContractError("snapshot drift detected in {0}".format(path))
+    else:
+        for path, value in (
+            (arguments.corpus_output, corpus),
+            (arguments.results_output, results),
+        ):
+            _write_json(path, value)
+    print(
+        "{0} {1} cases, {2} matrix cells, and {3} reference executions; "
+        "source tree {4}".format(
+            "checked" if arguments.check else "snapshotted",
+            len(corpus["cases"]),
+            len(corpus["cases"]) * len(EXPECTED_APIS) * len(EXPECTED_BACKENDS),
+            len(results["executions"]),
+            tree_digest,
+        )
+    )
+    return 0
+
+
+def _command_ingest(arguments: argparse.Namespace) -> int:
+    manifest = validate_contract(arguments.manifest)
+    _, corpus_path, _, _, _ = _manifest_paths(arguments.manifest)
+    corpus = _object(_load_json(corpus_path), "corpus")
+    results = ingest_junit(arguments.junit, arguments.implementation, corpus)
+    _write_json(arguments.output, results)
+    print(
+        "ingested {0} executions for {1} under {2}".format(
+            len(results["executions"]), arguments.implementation, manifest["contract"]
+        )
+    )
+    return 0
+
+
+def _command_run(arguments: argparse.Namespace) -> int:
+    if not arguments.command:
+        raise ContractError("run requires a command after --")
+    command = list(arguments.command)
+    if command and command[0] == "--":
+        command = command[1:]
+    if not command:
+        raise ContractError("run requires a command after --")
+    environment = os.environ.copy()
+    environment["BRISKDB_MONGO_PARITY_JUNIT"] = str(arguments.junit.resolve())
+    try:
+        arguments.junit.unlink()
+    except FileNotFoundError:
+        pass
+    except OSError as error:
+        raise ContractError("cannot remove stale JUnit output: {0}".format(error))
+    completed = subprocess.run(
+        command, cwd=str(arguments.working_directory), env=environment
+    )
+    if not arguments.junit.is_file():
+        raise ContractError(
+            "runner did not create {0}; use BRISKDB_MONGO_PARITY_JUNIT".format(
+                arguments.junit
+            )
+        )
+    ingest_arguments = argparse.Namespace(
+        implementation=arguments.implementation,
+        junit=arguments.junit,
+        manifest=arguments.manifest,
+        output=arguments.output,
+    )
+    _command_ingest(ingest_arguments)
+    return completed.returncode
+
+
+def _command_report(arguments: argparse.Namespace) -> int:
+    manifest = validate_contract(arguments.manifest)
+    for target in arguments.require_target:
+        if not TARGET_PATTERN.fullmatch(target):
+            raise ContractError("invalid required target {0}".format(target))
+    _, corpus_path, reference_path, differences_path, _ = _manifest_paths(
+        arguments.manifest
+    )
+    corpus = _object(_load_json(corpus_path), "corpus")
+    differences = _object(_load_json(differences_path), "intentional differences")
+    paths = [reference_path] + list(arguments.results)
+    results = _load_result_files(paths, corpus)
+    report, markdown, failed = compare_results(
+        manifest,
+        corpus,
+        differences,
+        results,
+        arguments.reference_target or manifest["reference_target"],
+        arguments.require_target,
+        arguments.require_allowlist_targets,
+    )
+    _write_json(arguments.json_output, report)
+    arguments.markdown_output.parent.mkdir(parents=True, exist_ok=True)
+    arguments.markdown_output.write_text(markdown, encoding="utf-8")
+    print(markdown, end="")
+    return 1 if failed else 0
+
+
+def _verify_provenance_git_blob(
+    source_root: Path,
+    commit: str,
+    entry: Mapping[str, Any],
+    label: str,
+) -> Tuple[str, bytes]:
+    relative = _string(entry.get("upstream_path"), "{0} path".format(label))
+    expected_object = _string(
+        entry.get("upstream_git_blob"), "{0} Git blob".format(label)
+    )
+    if not re.fullmatch(r"[0-9a-f]{40}", expected_object):
+        raise ContractError("{0} Git blob must be a full object ID".format(label))
+
+    actual_object = (
+        _git(
+            source_root,
+            ["rev-parse", "--verify", "{0}:{1}".format(commit, relative)],
+        )
+        .decode("ascii")
+        .strip()
+    )
+    if actual_object != expected_object:
+        raise ContractError(
+            "{0} Git blob mismatch for {1}: expected {2}, found {3}".format(
+                label, relative, expected_object, actual_object
+            )
+        )
+    object_type = (
+        _git(source_root, ["cat-file", "-t", actual_object]).decode("ascii").strip()
+    )
+    if object_type != "blob":
+        raise ContractError("{0} is not a Git blob: {1}".format(label, relative))
+
+    contents = _git(source_root, ["cat-file", "blob", actual_object])
+    expected_digest = _sha256_string(
+        entry.get("upstream_sha256"), "{0} upstream sha256".format(label)
+    )
+    actual_digest = _sha256_bytes(contents)
+    if actual_digest != expected_digest:
+        raise ContractError(
+            "{0} source hash mismatch for {1}: expected {2}, found {3}".format(
+                label, relative, expected_digest, actual_digest
+            )
+        )
+    return relative, contents
+
+
+def _run_git_apply(
+    staging_root: Path, patch_path: Path, arguments: Sequence[str]
+) -> bytes:
+    try:
+        completed = subprocess.run(
+            ["git", "apply"] + list(arguments) + ["--", str(patch_path.resolve())],
+            cwd=str(staging_root),
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except (OSError, subprocess.CalledProcessError) as error:
+        detail = getattr(error, "stderr", b"").decode("utf-8", "replace").strip()
+        raise ContractError(
+            "cannot replay adaptation patch against pinned source blobs: {0}".format(
+                detail or error
+            )
+        )
+    return completed.stdout
+
+
+def _verify_source_provenance(
+    source_root: Path,
+    commit: str,
+    provenance_path: Path,
+    contract_base: Path,
+) -> None:
+    provenance = _object(_load_json(provenance_path), "runner provenance")
+    provenance_source = _object(provenance.get("source"), "runner provenance source")
+    if provenance_source.get("commit") != commit:
+        raise ContractError("runner provenance source commit does not match manifest")
+
+    adaptation = _object(provenance.get("adaptation"), "runner adaptation")
+    adaptation_files = [
+        _object(value, "adaptation file {0}".format(index))
+        for index, value in enumerate(
+            _list(adaptation.get("files"), "adaptation files")
+        )
+    ]
+    excluded_files = [
+        _object(value, "excluded upstream file {0}".format(index))
+        for index, value in enumerate(
+            _list(
+                adaptation.get("excluded_upstream_files"),
+                "excluded upstream files",
+            )
+        )
+    ]
+
+    upstream_blobs = {}
+    for index, entry in enumerate(adaptation_files):
+        label = "adaptation file {0}".format(index)
+        relative, contents = _verify_provenance_git_blob(
+            source_root, commit, entry, label
+        )
+        upstream_blobs[relative] = contents
+    for index, entry in enumerate(excluded_files):
+        label = "excluded upstream file {0}".format(index)
+        relative, contents = _verify_provenance_git_blob(
+            source_root, commit, entry, label
+        )
+        upstream_blobs[relative] = contents
+
+    license_entry = _object(provenance_source.get("license"), "runner source license")
+    license_path, license_contents = _verify_provenance_git_blob(
+        source_root, commit, license_entry, "runner source license"
+    )
+    if license_path != "LICENSE.txt":
+        raise ContractError("runner source license must come from LICENSE.txt")
+    _, local_license_path = _runner_local_path(
+        contract_base,
+        license_entry.get("runner_path"),
+        "runner source license",
+    )
+    try:
+        local_license = local_license_path.read_bytes()
+    except OSError as error:
+        raise ContractError("cannot read runner source license: {0}".format(error))
+    if local_license != license_contents:
+        raise ContractError("runner source license is not byte-for-byte upstream")
+
+    _, patch_path = _runner_local_path(
+        contract_base, adaptation.get("patch"), "adaptation patch"
+    )
+    expected_patch_digest = _sha256_string(
+        adaptation.get("patch_sha256"), "adaptation patch sha256"
+    )
+    if _sha256_file(patch_path) != expected_patch_digest:
+        raise ContractError("adaptation patch hash does not match runner provenance")
+
+    with tempfile.TemporaryDirectory(prefix="briskdb-mongo-provenance-") as temporary:
+        staging_root = Path(temporary)
+        expected_paths = set()
+        expected_adapted_paths = set()
+        local_outputs = {}
+        for index, entry in enumerate(adaptation_files):
+            label = "adaptation file {0}".format(index)
+            upstream_path = _string(
+                entry.get("upstream_path"), "{0} path".format(label)
+            )
+            runner_relative, local_output = _runner_local_path(
+                contract_base, entry.get("runner_path"), label
+            )
+            staged_output = staging_root.joinpath(*Path(runner_relative).parts)
+            staged_output.parent.mkdir(parents=True, exist_ok=True)
+            staged_output.write_bytes(upstream_blobs[upstream_path])
+            expected_paths.add(runner_relative)
+            local_outputs[runner_relative] = local_output
+            status = _string(entry.get("status"), "{0} status".format(label))
+            if status == "adapted":
+                expected_adapted_paths.add(runner_relative)
+
+        # The unified diff names the upstream file in its `a/` header and the
+        # vendored destination in its `b/` header. Seed each destination with
+        # the pinned upstream blob, then require Git to apply every hunk.
+        numstat = _run_git_apply(staging_root, patch_path, ["--numstat", "-z"])
+        touched_paths = set()
+        for record in numstat.split(b"\0"):
+            if not record:
+                continue
+            fields = record.split(b"\t", 2)
+            if len(fields) != 3:
+                raise ContractError("adaptation patch has invalid numstat output")
+            try:
+                touched_paths.add(fields[2].decode("utf-8"))
+            except UnicodeDecodeError as error:
+                raise ContractError(
+                    "adaptation patch contains a non-UTF-8 path: {0}".format(error)
+                )
+        if touched_paths != expected_adapted_paths:
+            raise ContractError(
+                "adaptation patch path inventory mismatch; expected={0}, found={1}".format(
+                    sorted(expected_adapted_paths), sorted(touched_paths)
+                )
+            )
+
+        _run_git_apply(staging_root, patch_path, ["--check", "--whitespace=error-all"])
+        _run_git_apply(staging_root, patch_path, ["--whitespace=error-all"])
+
+        reconstructed_paths = {
+            path.relative_to(staging_root).as_posix()
+            for path in staging_root.rglob("*")
+            if path.is_file()
+        }
+        if reconstructed_paths != expected_paths:
+            raise ContractError(
+                "adaptation patch output inventory mismatch; expected={0}, found={1}".format(
+                    sorted(expected_paths), sorted(reconstructed_paths)
+                )
+            )
+
+        for index, entry in enumerate(adaptation_files):
+            label = "adaptation file {0}".format(index)
+            runner_relative = _string(
+                entry.get("runner_path"), "{0} runner path".format(label)
+            )
+            reconstructed = staging_root.joinpath(*Path(runner_relative).parts)
+            expected_digest = _sha256_string(
+                entry.get("runner_sha256"), "{0} runner sha256".format(label)
+            )
+            reconstructed_digest = _sha256_file(reconstructed)
+            if reconstructed_digest != expected_digest:
+                raise ContractError(
+                    "adaptation patch does not reconstruct {0}: expected {1}, found {2}".format(
+                        runner_relative, expected_digest, reconstructed_digest
+                    )
+                )
+            try:
+                local_contents = local_outputs[runner_relative].read_bytes()
+            except OSError as error:
+                raise ContractError(
+                    "cannot read adapted runner file {0}: {1}".format(
+                        runner_relative, error
+                    )
+                )
+            if reconstructed.read_bytes() != local_contents:
+                raise ContractError(
+                    "adaptation patch output differs from checked-in runner file {0}".format(
+                        runner_relative
+                    )
+                )
+
+
+def _command_verify_source(arguments: argparse.Namespace) -> int:
+    manifest = validate_contract(arguments.manifest)
+    _, corpus_path, _, _, _ = _manifest_paths(arguments.manifest)
+    corpus = _object(_load_json(corpus_path), "corpus")
+    commit = manifest["source"]["commit"]
+    resolved = (
+        _git(arguments.source_root, ["rev-parse", "{0}^{{commit}}".format(commit)])
+        .decode("ascii")
+        .strip()
+    )
+    if resolved != commit:
+        raise ContractError("source repository does not contain the locked commit")
+    git_tree = (
+        _git(arguments.source_root, ["rev-parse", "{0}:tests/contracts".format(commit)])
+        .decode("ascii")
+        .strip()
+    )
+    if git_tree != manifest["source"]["contract_git_tree"]:
+        raise ContractError("locked source Git tree does not match the manifest")
+    runtime_git_tree = (
+        _git(arguments.source_root, ["rev-parse", "{0}:tinymongo".format(commit)])
+        .decode("ascii")
+        .strip()
+    )
+    if runtime_git_tree != manifest["source"]["runtime_git_tree"]:
+        raise ContractError("locked runtime Git tree does not match the manifest")
+    paths = (
+        _git(
+            arguments.source_root,
+            ["ls-tree", "-r", "--name-only", commit, "--", "tests/contracts"],
+        )
+        .decode("utf-8")
+        .splitlines()
+    )
+    recorded = {entry["path"]: entry["sha256"] for entry in corpus["source_files"]}
+    if set(paths) != set(recorded):
+        raise ContractError("locked source path inventory does not match the corpus")
+    for path in paths:
+        blob = _git(arguments.source_root, ["show", "{0}:{1}".format(commit, path)])
+        if _sha256_bytes(blob) != recorded[path]:
+            raise ContractError(
+                "locked source blob does not match corpus: {0}".format(path)
+            )
+    manifest_files = _object(manifest.get("files"), "manifest.files")
+    provenance_path = arguments.manifest.parent / _string(
+        manifest_files.get("runner_provenance"), "manifest.files.runner_provenance"
+    )
+    _verify_source_provenance(
+        arguments.source_root,
+        commit,
+        provenance_path,
+        arguments.manifest.parent,
+    )
+    print(
+        "verified TinyMongo source {0} ({1}) and runner provenance".format(
+            commit, git_tree
+        )
+    )
+    return 0
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.set_defaults(function=None)
+    subparsers = parser.add_subparsers(dest="subcommand")
+
+    validate = subparsers.add_parser(
+        "validate", help="validate the checked-in contract"
+    )
+    validate.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    validate.set_defaults(function=_command_validate)
+
+    snapshot = subparsers.add_parser(
+        "snapshot", help="snapshot a TinyMongo JUnit corpus"
+    )
+    snapshot.add_argument("--junit", type=Path, required=True)
+    snapshot.add_argument("--source-root", type=Path, required=True)
+    snapshot.add_argument("--source-commit", required=True)
+    snapshot.add_argument("--corpus-output", type=Path, required=True)
+    snapshot.add_argument("--results-output", type=Path, required=True)
+    snapshot.add_argument("--python-version", required=True)
+    snapshot.add_argument("--pytest-version", required=True)
+    snapshot.add_argument("--pymongo-version", required=True)
+    snapshot.add_argument(
+        "--check",
+        action="store_true",
+        help="compare a regenerated snapshot with the output files",
+    )
+    snapshot.set_defaults(function=_command_snapshot)
+
+    verify_source = subparsers.add_parser(
+        "verify-source", help="verify the locked TinyMongo Git blobs"
+    )
+    verify_source.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    verify_source.add_argument("--source-root", type=Path, required=True)
+    verify_source.set_defaults(function=_command_verify_source)
+
+    ingest = subparsers.add_parser(
+        "ingest", help="normalize one implementation's JUnit"
+    )
+    ingest.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    ingest.add_argument("--junit", type=Path, required=True)
+    ingest.add_argument("--implementation", required=True)
+    ingest.add_argument("--output", type=Path, required=True)
+    ingest.set_defaults(function=_command_ingest)
+
+    run = subparsers.add_parser(
+        "run", help="run an external contract producer and ingest JUnit"
+    )
+    run.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    run.add_argument("--implementation", required=True)
+    run.add_argument("--working-directory", type=Path, required=True)
+    run.add_argument("--junit", type=Path, required=True)
+    run.add_argument("--output", type=Path, required=True)
+    run.add_argument("command", nargs=argparse.REMAINDER)
+    run.set_defaults(function=_command_run)
+
+    report = subparsers.add_parser("report", help="compare normalized results")
+    report.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    report.add_argument("--reference-target")
+    report.add_argument("--json-output", type=Path, required=True)
+    report.add_argument("--markdown-output", type=Path, required=True)
+    report.add_argument(
+        "--require-target",
+        action="append",
+        default=[],
+        help="fail unless the named target is present; repeatable",
+    )
+    report.add_argument(
+        "--require-allowlist-targets",
+        action="store_true",
+        help="fail when a target named by the allow-list has no result",
+    )
+    report.add_argument("results", nargs="*", type=Path)
+    report.set_defaults(function=_command_report)
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = _parser()
+    arguments = parser.parse_args(argv)
+    if arguments.function is None:
+        parser.error("a subcommand is required")
+    try:
+        return int(arguments.function(arguments))
+    except ContractError as error:
+        print("mongo parity contract error: {0}".format(error), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_mongo_capabilities.py
+++ b/tests/test_mongo_capabilities.py
@@ -1,0 +1,220 @@
+import copy
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "mongo_parity.py"
+MANIFEST = ROOT / "compat" / "mongo" / "v1" / "manifest.json"
+SPEC = importlib.util.spec_from_file_location("mongo_capability_validation", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+mongo_parity = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(mongo_parity)
+
+
+class CapabilityManifestValidationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.capabilities = json.loads(MANIFEST.read_text(encoding="utf-8"))[
+            "capabilities"
+        ]
+
+    def assert_invalid(self, mutate, pattern):
+        capabilities = copy.deepcopy(self.capabilities)
+        mutate(capabilities)
+        with self.assertRaisesRegex(mongo_parity.ContractError, pattern):
+            mongo_parity._validate_capabilities(capabilities)
+
+    def test_complete_inventory_covers_all_124_operations_and_four_write_results(self):
+        mongo_parity._validate_capabilities(copy.deepcopy(self.capabilities))
+        operations = self.capabilities["results"]["operation_result_shapes"]
+        self.assertEqual(sum(len(methods) for methods in operations.values()), 124)
+        self.assertEqual(
+            set(self.capabilities["results"]["write_result_classes"]),
+            {
+                "tinymongo.results.DeleteResult",
+                "tinymongo.results.InsertManyResult",
+                "tinymongo.results.InsertOneResult",
+                "tinymongo.results.UpdateResult",
+            },
+        )
+
+    def test_missing_owner_method_is_rejected(self):
+        self.assert_invalid(
+            lambda value: value["api"]["owners"]["sync_client"]["supported"].remove(
+                "server_info"
+            ),
+            "supported methods do not match source",
+        )
+
+    def test_missing_method_option_record_is_rejected(self):
+        self.assert_invalid(
+            lambda value: value["api"]["method_options"]["sync_client"].pop(
+                "server_info"
+            ),
+            "method options keys differ",
+        )
+
+    def test_unknown_constructor_option_behavior_is_rejected(self):
+        self.assert_invalid(
+            lambda value: value["api"]["constructors"]["tinymongo.MongoClient"][
+                "options"
+            ][0].update(behavior="fabricated"),
+            "unknown option behavior",
+        )
+
+    def test_duplicate_pymongo_connection_option_is_rejected(self):
+        def duplicate(value):
+            catalog = value["api"]["connection_options"]["pymongo_fallback_catalog"]
+            catalog[-1]["name"] = catalog[0]["name"]
+
+        self.assert_invalid(duplicate, "duplicate option names")
+
+    def test_missing_write_result_class_is_rejected(self):
+        self.assert_invalid(
+            lambda value: value["results"]["write_result_classes"].pop(
+                "tinymongo.results.DeleteResult"
+            ),
+            "write result classes keys differ",
+        )
+
+    def test_wrong_operation_result_shape_is_rejected(self):
+        self.assert_invalid(
+            lambda value: value["results"]["operation_result_shapes"][
+                "sync_collection"
+            ].update(list_indexes="cursor_sync"),
+            "operation result shapes for sync_collection do not match source",
+        )
+
+    def test_undefined_nested_result_shape_is_rejected(self):
+        self.assert_invalid(
+            lambda value: value["results"]["result_shapes"]["document_list"].update(
+                item="fabricated"
+            ),
+            "references unknown result shape fabricated",
+        )
+
+    def test_changed_result_shape_definition_is_rejected(self):
+        self.assert_invalid(
+            lambda value: value["results"]["result_shapes"]["integer"].update(
+                type="number"
+            ),
+            "result shape definitions do not match TinyMongo v1.3.0",
+        )
+
+    def test_invalid_document_must_expose_original_document(self):
+        def remove_document(value):
+            fields = value["errors"]["class_shapes"]["InvalidDocument"]["fields"]
+            fields[:] = [field for field in fields if field["name"] != "document"]
+
+        self.assert_invalid(
+            remove_document, "InvalidDocument fields do not match source"
+        )
+
+    def test_bulk_write_detail_shape_is_exact(self):
+        self.assert_invalid(
+            lambda value: value["errors"]["detail_shapes"]["bulk_write_details"][
+                "required_fields"
+            ].pop("writeErrors"),
+            "bulk write detail fields keys differ",
+        )
+
+    def test_public_int_and_long_bson_names_are_required(self):
+        def use_storage_width_names(value):
+            native = value["values"]["native"]
+            native[native.index("int")] = "int32"
+            native[native.index("long")] = "int64"
+
+        self.assert_invalid(
+            use_storage_width_names,
+            r"native BSON types do not match supported_bson_types\(\)",
+        )
+
+    def test_semantic_capability_reductions_are_rejected(self):
+        reductions = {
+            "aggregation": lambda category: category["stages"].remove("$group"),
+            "commands": lambda category: category["supported"].remove("ping"),
+            "indexes": lambda category: category["operations"].remove("create_indexes"),
+            "projections": lambda category: category["supported"].remove(
+                "array traversal"
+            ),
+            "queries": lambda category: category["unsupported_operators"].remove(
+                "$where"
+            ),
+            "unsupported": lambda category: category.remove("transactions"),
+            "updates": lambda category: category["operators"].remove("$rename"),
+            "warnings": lambda category: category["contexts"].remove(
+                "create_indexes degraded model reuse"
+            ),
+        }
+        for category, mutate in reductions.items():
+            with self.subTest(category=category):
+                self.assert_invalid(
+                    lambda value, category=category, mutate=mutate: mutate(
+                        value[category]
+                    ),
+                    r"capabilities\.{0} do not match TinyMongo v1\.3\.0".format(
+                        category
+                    ),
+                )
+
+    def test_semantic_capability_fabrications_are_rejected(self):
+        fabrications = {
+            "aggregation": lambda category: category["stages"].append("$lookup"),
+            "commands": lambda category: category["supported"].append("hello"),
+            "indexes": lambda category: category["operations"].append("rebuild_index"),
+            "projections": lambda category: category["supported"].append(
+                "positional projection"
+            ),
+            "queries": lambda category: category["field_operators"].append("$where"),
+            "unsupported": lambda category: category.append(
+                "fabricated unsupported feature"
+            ),
+            "updates": lambda category: category["operators"].append("$mul"),
+            "warnings": lambda category: category["contexts"].append(
+                "fabricated warning context"
+            ),
+        }
+        for category, mutate in fabrications.items():
+            with self.subTest(category=category):
+                self.assert_invalid(
+                    lambda value, category=category, mutate=mutate: mutate(
+                        value[category]
+                    ),
+                    r"capabilities\.{0} do not match TinyMongo v1\.3\.0".format(
+                        category
+                    ),
+                )
+
+    def test_all_named_unsupported_query_operators_are_frozen(self):
+        self.assertEqual(
+            self.capabilities["queries"]["unsupported_operators"],
+            [
+                "$bitsAllClear",
+                "$bitsAllSet",
+                "$bitsAnyClear",
+                "$bitsAnySet",
+                "$expr",
+                "$geoIntersects",
+                "$geoWithin",
+                "$jsonSchema",
+                "$near",
+                "$nearSphere",
+                "$text",
+                "$where",
+            ],
+        )
+
+    def test_less_structured_capability_text_is_digest_locked(self):
+        self.assert_invalid(
+            lambda value: value["values"]["rules"].__setitem__(
+                0, "fabricated BSON value rule"
+            ),
+            "capability definitions do not match the frozen TinyMongo v1.3.0 inventory",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mongo_contract_runner.py
+++ b/tests/test_mongo_contract_runner.py
@@ -1,0 +1,351 @@
+import ast
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPAT = ROOT / "compat" / "mongo" / "v1"
+RUNNER = COMPAT / "runner"
+PROVENANCE = RUNNER / "provenance.json"
+TINYMONGO_ADAPTER = RUNNER / "adapters" / "tinymongo.py"
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def imported_roots(path):
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.extend(alias.name.split(".", 1)[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.append(node.module.split(".", 1)[0])
+    return imports
+
+
+class MongoContractProvenanceTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.provenance = json.loads(PROVENANCE.read_text(encoding="utf-8"))
+        cls.corpus = json.loads((COMPAT / "corpus.json").read_text(encoding="utf-8"))
+
+    def test_frozen_source_identity_and_local_hashes(self):
+        source = self.provenance["source"]
+        self.assertEqual(source["commit"], "53cbf44e98b8caa036163725d195fd29592e1cc0")
+        self.assertEqual(
+            source["contract_git_tree"],
+            "6f671122ff5f76902cfe051e4558a2c57d161bc4",
+        )
+        self.assertEqual(
+            source["runtime_git_tree"],
+            "0c94915ea81697a5728f64dc04e3929bf1e036e8",
+        )
+
+        license_entry = source["license"]
+        self.assertEqual(
+            sha256(ROOT / license_entry["runner_path"]),
+            license_entry["runner_sha256"],
+        )
+        self.assertEqual(
+            license_entry["runner_sha256"], license_entry["upstream_sha256"]
+        )
+
+        patch = self.provenance["adaptation"]
+        patch_path = ROOT / patch["patch"]
+        self.assertEqual(sha256(patch_path), patch["patch_sha256"])
+        patch_text = patch_path.read_text(encoding="utf-8")
+
+        for entry in patch["files"]:
+            runner_path = ROOT / entry["runner_path"]
+            self.assertEqual(sha256(runner_path), entry["runner_sha256"])
+            if entry["status"] == "exact":
+                self.assertEqual(entry["runner_sha256"], entry["upstream_sha256"])
+            else:
+                self.assertEqual(entry["status"], "adapted")
+                self.assertNotEqual(entry["runner_sha256"], entry["upstream_sha256"])
+                self.assertIn("--- a/" + entry["upstream_path"], patch_text)
+                self.assertIn("+++ b/" + entry["runner_path"], patch_text)
+
+        for entry in self.provenance["runner_files"]:
+            self.assertEqual(sha256(ROOT / entry["path"]), entry["sha256"])
+
+    def test_every_owned_runner_file_is_listed(self):
+        adaptation = self.provenance["adaptation"]
+        listed = {entry["runner_path"] for entry in adaptation["files"]}
+        listed.update(entry["path"] for entry in self.provenance["runner_files"])
+        listed.add(adaptation["patch"])
+        listed.add(self.provenance["source"]["license"]["runner_path"])
+
+        actual = {
+            path.relative_to(ROOT).as_posix()
+            for path in RUNNER.rglob("*")
+            if path.is_file()
+            and path != PROVENANCE
+            and "__pycache__" not in path.parts
+            and path.suffix not in (".pyc", ".pyo")
+        }
+        self.assertEqual(actual, listed)
+
+    def test_manifest_transitively_locks_the_provenance_ledger(self):
+        manifest = json.loads((COMPAT / "manifest.json").read_text(encoding="utf-8"))
+        relative = manifest["files"]["runner_provenance"]
+        self.assertEqual(relative, "runner/provenance.json")
+        self.assertEqual(
+            sha256(COMPAT / relative), manifest["sha256"]["runner_provenance"]
+        )
+
+    def test_public_validator_rejects_runner_file_drift(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            copied_compat = Path(temporary_directory) / "v1"
+            shutil.copytree(
+                COMPAT,
+                copied_compat,
+                ignore=shutil.ignore_patterns("__pycache__", ".pytest_cache", "*.pyc"),
+            )
+            requirements = copied_compat / "runner" / "requirements.txt"
+            requirements.write_text(
+                requirements.read_text(encoding="utf-8") + "# drift\n",
+                encoding="utf-8",
+            )
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "scripts" / "mongo_parity.py"),
+                    "validate",
+                    "--manifest",
+                    str(copied_compat / "manifest.json"),
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("requirements.txt hash mismatch", completed.stderr)
+
+    def test_provenance_accounts_for_every_frozen_contract_source(self):
+        adaptation = self.provenance["adaptation"]
+        recorded = {
+            entry["upstream_path"]: entry["upstream_sha256"]
+            for entry in adaptation["files"]
+        }
+        recorded.update(
+            {
+                entry["upstream_path"]: entry["upstream_sha256"]
+                for entry in adaptation["excluded_upstream_files"]
+            }
+        )
+        catalog = {
+            entry["path"]: entry["sha256"] for entry in self.corpus["source_files"]
+        }
+        self.assertEqual(recorded, catalog)
+        self.assertEqual(
+            self.corpus["source_commit"], self.provenance["source"]["commit"]
+        )
+        self.assertEqual(
+            self.corpus["source_git_tree"],
+            self.provenance["source"]["contract_git_tree"],
+        )
+
+    def test_all_228_catalog_cases_resolve_to_vendored_test_functions(self):
+        cases = self.corpus["cases"]
+        self.assertEqual(len(cases), 228)
+        self.assertTrue(all(case["apis"] == ["sync", "async"] for case in cases))
+
+        definitions = {}
+        for module_path in sorted((RUNNER / "contracts").glob("test_*.py")):
+            tree = ast.parse(
+                module_path.read_text(encoding="utf-8"), filename=str(module_path)
+            )
+            definitions[module_path.stem] = {
+                node.name
+                for node in tree.body
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            }
+
+        self.assertEqual(len(definitions), 16)
+        for case in cases:
+            module_name, item_name = case["id"].split("::", 1)
+            module_name = module_name.rsplit(".", 1)[-1]
+            function_name = item_name.partition("[")[0]
+            self.assertIn(module_name, definitions)
+            self.assertIn(function_name, definitions[module_name])
+
+
+class MongoContractImportBoundaryTests(unittest.TestCase):
+    def test_only_the_tinymongo_adapter_imports_tinymongo(self):
+        importers = []
+        for path in sorted(RUNNER.rglob("*.py")):
+            if "tinymongo" in imported_roots(path):
+                importers.append(path)
+        self.assertEqual(importers, [TINYMONGO_ADAPTER])
+
+    def test_runtime_package_manifests_do_not_depend_on_tinymongo(self):
+        for relative in (
+            "Cargo.toml",
+            "Cargo.lock",
+            "python/Cargo.toml",
+            "python/pyproject.toml",
+        ):
+            contents = (ROOT / relative).read_text(encoding="utf-8").lower()
+            self.assertNotIn("tinymongo", contents, relative)
+
+    def test_pinned_runner_requirements_exclude_the_oracle_package(self):
+        requirements = RUNNER / "requirements.txt"
+        for number, raw_line in enumerate(
+            requirements.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            self.assertNotIn("tinymongo", line.lower(), "line {0}".format(number))
+
+    def test_importing_adapter_registry_loads_no_target_dependencies(self):
+        code = "\n".join(
+            [
+                "import sys",
+                "sys.path.insert(0, {!r})".format(str(ROOT)),
+                "import compat.mongo.v1.runner.adapters",
+                "loaded = sorted(name for name in sys.modules "
+                "if name == 'tinymongo' or name.startswith('tinymongo.') "
+                "or name == 'pymongo' or name.startswith('pymongo.'))",
+                "assert loaded == [], loaded",
+            ]
+        )
+        subprocess.run([sys.executable, "-I", "-c", code], check=True)
+
+    def test_briskdb_adapter_requires_an_explicit_candidate_uri(self):
+        sys.path.insert(0, str(ROOT))
+        try:
+            from compat.mongo.v1.runner.adapters import TargetUnavailable, open_target
+
+            with tempfile.TemporaryDirectory() as temporary_directory:
+                with mock.patch.dict(
+                    os.environ,
+                    {"BRISKDB_MONGO_PARITY_BRISKDB_URI": ""},
+                ):
+                    with self.assertRaisesRegex(
+                        TargetUnavailable, "BRISKDB_MONGO_PARITY_BRISKDB_URI"
+                    ):
+                        with open_target("briskdb", "sync", temporary_directory):
+                            self.fail("the unconfigured adapter unexpectedly yielded")
+        finally:
+            if sys.path[0] == str(ROOT):
+                sys.path.pop(0)
+
+    def test_briskdb_adapter_forwards_uri_through_pymongo_transport(self):
+        sys.path.insert(0, str(ROOT))
+        try:
+            from compat.mongo.v1.runner.adapters import TargetHandles, load_adapter
+
+            adapter = load_adapter("briskdb")
+            captured = {}
+            client = object()
+            database = object()
+            collection = object()
+
+            @contextmanager
+            def fake_transport(target_name, api, tmp_path, options, **kwargs):
+                captured.update(
+                    target_name=target_name,
+                    api=api,
+                    tmp_path=tmp_path,
+                    options=options,
+                    kwargs=kwargs,
+                )
+                yield TargetHandles(
+                    name=target_name,
+                    transport="pymongo",
+                    api=api,
+                    client=client,
+                    database=database,
+                    collection=collection,
+                    unsupported_warning=UserWarning,
+                )
+
+            with tempfile.TemporaryDirectory() as temporary_directory:
+                with mock.patch.object(
+                    adapter, "open_pymongo_target", new=fake_transport
+                ):
+                    with adapter.open_target(
+                        "async",
+                        temporary_directory,
+                        {"appname": "mongo-contract"},
+                        backend="briskdb",
+                        uri="mongodb://127.0.0.1:27018/?directConnection=true",
+                        database_name="contract_database",
+                        collection_name="contract_collection",
+                        connect_timeout=2.5,
+                    ) as handles:
+                        self.assertEqual(handles.name, "briskdb")
+                        self.assertEqual(handles.transport, "pymongo")
+                        self.assertIs(handles.client, client)
+                        self.assertIs(handles.database, database)
+                        self.assertIs(handles.collection, collection)
+
+                    with mock.patch.dict(
+                        os.environ,
+                        {
+                            "BRISKDB_MONGO_PARITY_BRISKDB_URI": (
+                                "mongodb://127.0.0.1:27019/?directConnection=true"
+                            )
+                        },
+                    ):
+                        with adapter.open_target(
+                            "sync", temporary_directory
+                        ) as handles:
+                            self.assertEqual(handles.name, "briskdb")
+                            self.assertEqual(handles.transport, "pymongo")
+
+                    self.assertEqual(
+                        captured["kwargs"]["uri"],
+                        "mongodb://127.0.0.1:27019/?directConnection=true",
+                    )
+
+                    with adapter.open_target(
+                        "async",
+                        temporary_directory,
+                        {"appname": "mongo-contract"},
+                        backend="briskdb",
+                        uri="mongodb://127.0.0.1:27018/?directConnection=true",
+                        database_name="contract_database",
+                        collection_name="contract_collection",
+                        connect_timeout=2.5,
+                    ):
+                        pass
+
+            self.assertEqual(captured["target_name"], "briskdb")
+            self.assertEqual(captured["api"], "async")
+            self.assertEqual(captured["tmp_path"], temporary_directory)
+            self.assertEqual(captured["options"], {"appname": "mongo-contract"})
+            self.assertEqual(captured["kwargs"]["backend"], "briskdb")
+            self.assertEqual(
+                captured["kwargs"]["uri"],
+                "mongodb://127.0.0.1:27018/?directConnection=true",
+            )
+            self.assertEqual(captured["kwargs"]["database_name"], "contract_database")
+            self.assertEqual(
+                captured["kwargs"]["collection_name"], "contract_collection"
+            )
+            self.assertEqual(captured["kwargs"]["connect_timeout"], 2.5)
+        finally:
+            if sys.path[0] == str(ROOT):
+                sys.path.pop(0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mongo_hardening.py
+++ b/tests/test_mongo_hardening.py
@@ -1,0 +1,225 @@
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+from xml.etree import ElementTree
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "mongo_parity.py"
+SPEC = importlib.util.spec_from_file_location("mongo_parity_hardening", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+mongo_parity = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(mongo_parity)
+
+CASE_ID = "tests.contracts.test_contract::test_case"
+
+
+def corpus():
+    return {
+        "schema_version": 1,
+        "contract": "tinymongo-v1",
+        "cases": [
+            {
+                "apis": ["sync"],
+                "id": CASE_ID,
+                "requirements": {},
+                "source": "tests/contracts/test_contract.py",
+                "suite": "core",
+            }
+        ],
+    }
+
+
+def execution(
+    *,
+    target="candidate-memory",
+    backend="memory",
+    suite="core",
+    outcome="passed",
+    category="passed",
+    reason=None,
+):
+    return {
+        "api": "sync",
+        "backend": backend,
+        "case_id": CASE_ID,
+        "observation": mongo_parity._observation(outcome, category, reason),
+        "outcome": outcome,
+        "reason": reason,
+        "suite": suite,
+        "target": target,
+    }
+
+
+def results(item):
+    return {
+        "schema_version": 1,
+        "contract": "tinymongo-v1",
+        "executions": [item],
+    }
+
+
+def write_junit(path, *, name="test_case[sync-memory]", extra_properties=()):
+    root = ElementTree.Element("testsuites")
+    suite = ElementTree.SubElement(root, "testsuite", name="contract")
+    testcase = ElementTree.SubElement(
+        suite,
+        "testcase",
+        classname="compat.mongo.v1.runner.contracts.test_contract",
+        name=name,
+    )
+    properties = ElementTree.SubElement(testcase, "properties")
+    values = [
+        ("tinymongo.api", "sync"),
+        ("tinymongo.backend", "memory"),
+        ("tinymongo.suite", "core"),
+    ]
+    values.extend(extra_properties)
+    for property_name, value in values:
+        ElementTree.SubElement(properties, "property", name=property_name, value=value)
+    ElementTree.ElementTree(root).write(path, encoding="utf-8", xml_declaration=True)
+    return testcase
+
+
+class JunitMetadataHardeningTests(unittest.TestCase):
+    def test_identical_duplicate_required_property_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            junit = Path(temporary_directory) / "duplicate.xml"
+            write_junit(junit, extra_properties=(("tinymongo.api", "sync"),))
+            with self.assertRaisesRegex(mongo_parity.ContractError, "lacks unique"):
+                mongo_parity.ingest_junit(junit, "candidate")
+
+    def test_identical_duplicate_explicit_contract_id_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            junit = Path(temporary_directory) / "duplicate-id.xml"
+            write_junit(
+                junit,
+                extra_properties=(
+                    ("tinymongo.contract_id", CASE_ID),
+                    ("tinymongo.contract_id", CASE_ID),
+                ),
+            )
+            with self.assertRaisesRegex(
+                mongo_parity.ContractError, "unique tinymongo.contract_id"
+            ):
+                mongo_parity.ingest_junit(junit, "candidate")
+
+    def test_explicit_contract_id_does_not_bypass_target_prefix_validation(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            junit = Path(temporary_directory) / "wrong-prefix.xml"
+            write_junit(
+                junit,
+                name="test_case[async-memory]",
+                extra_properties=(("tinymongo.contract_id", CASE_ID),),
+            )
+            with self.assertRaisesRegex(
+                mongo_parity.ContractError, "does not begin with API/backend"
+            ):
+                mongo_parity.ingest_junit(junit, "candidate")
+
+    def test_explicit_contract_id_requires_target_parameters_in_name(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            junit = Path(temporary_directory) / "missing-prefix.xml"
+            write_junit(
+                junit,
+                name="test_case",
+                extra_properties=(("tinymongo.contract_id", CASE_ID),),
+            )
+            with self.assertRaisesRegex(
+                mongo_parity.ContractError, "lacks API/backend parameters"
+            ):
+                mongo_parity.ingest_junit(junit, "candidate")
+
+
+class ResultInvariantTests(unittest.TestCase):
+    def test_suite_must_match_the_corpus_case(self):
+        with self.assertRaisesRegex(mongo_parity.ContractError, "suite.*corpus"):
+            mongo_parity.validate_results(
+                results(execution(suite="talkpython")), corpus()
+            )
+
+    def test_backend_must_match_the_target_suffix(self):
+        with self.assertRaisesRegex(mongo_parity.ContractError, "backend.*target"):
+            mongo_parity.validate_results(results(execution(backend="json")), corpus())
+
+    def test_passed_result_requires_passed_category(self):
+        with self.assertRaisesRegex(
+            mongo_parity.ContractError, "requires category passed"
+        ):
+            mongo_parity.validate_results(
+                results(execution(category="AssertionError")), corpus()
+            )
+
+    def test_passed_result_requires_null_reason(self):
+        with self.assertRaisesRegex(mongo_parity.ContractError, "null reason"):
+            mongo_parity.validate_results(results(execution(reason="")), corpus())
+
+
+class FailureFingerprintTests(unittest.TestCase):
+    def test_suffix_after_500_characters_changes_fingerprint(self):
+        prefix = "x" * 500
+        observed = []
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            for suffix in ("A", "B"):
+                junit = Path(temporary_directory) / (suffix + ".xml")
+                write_junit(junit)
+                tree = ElementTree.parse(junit)
+                testcase = next(tree.getroot().iter("testcase"))
+                ElementTree.SubElement(
+                    testcase,
+                    "failure",
+                    type="AssertionError",
+                    message=prefix + suffix,
+                )
+                tree.write(junit, encoding="utf-8", xml_declaration=True)
+                observed.append(
+                    mongo_parity.ingest_junit(junit, "candidate")["executions"][0]
+                )
+
+        self.assertEqual(observed[0]["reason"], prefix + "A")
+        self.assertEqual(observed[1]["reason"], prefix + "B")
+        self.assertNotEqual(
+            observed[0]["observation"]["fingerprint"],
+            observed[1]["observation"]["fingerprint"],
+        )
+
+    def test_report_truncates_reason_without_truncating_fingerprint_input(self):
+        prefix = "x" * 500
+        reference_execution = execution(
+            target="tinymongo-memory",
+            outcome="failed",
+            category="AssertionError",
+            reason=prefix + "A",
+        )
+        candidate_execution = execution(
+            outcome="failed",
+            category="AssertionError",
+            reason=prefix + "B",
+        )
+        report, _, failed = mongo_parity.compare_results(
+            {
+                "contract": "tinymongo-v1",
+                "source": {"commit": "0" * 40},
+            },
+            corpus(),
+            {"differences": []},
+            [results(reference_execution), results(candidate_execution)],
+            "tinymongo-memory",
+        )
+
+        self.assertTrue(failed)
+        mismatch = next(
+            target["mismatches"][0]
+            for target in report["targets"]
+            if target["target"] == "candidate-memory"
+        )
+        self.assertEqual(mismatch["expected_reason"], prefix)
+        self.assertEqual(mismatch["observed_reason"], prefix)
+        self.assertNotEqual(
+            mismatch["expected_fingerprint"], mismatch["observed_fingerprint"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mongo_parity.py
+++ b/tests/test_mongo_parity.py
@@ -1,0 +1,517 @@
+import argparse
+import importlib.util
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+from xml.etree import ElementTree
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "mongo_parity.py"
+SPEC = importlib.util.spec_from_file_location("mongo_parity", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+mongo_parity = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(mongo_parity)
+
+APIS = ("sync", "async")
+BACKENDS = (
+    "memory",
+    "json",
+    "sqlite",
+    "sqlite-sharded",
+    "duckdb",
+    "parquet",
+    "mongodb",
+)
+
+
+def add_testcase(
+    suite,
+    name,
+    *,
+    api="sync",
+    backend="memory",
+    contract_suite="core",
+    properties=None,
+    outcome=None,
+    outcome_type=None,
+    message=None,
+):
+    testcase = ElementTree.SubElement(
+        suite,
+        "testcase",
+        classname="tests.contracts.test_contract",
+        name=name,
+    )
+    testcase_properties = ElementTree.SubElement(testcase, "properties")
+    values = [
+        ("tinymongo.api", api),
+        ("tinymongo.backend", backend),
+        ("tinymongo.suite", contract_suite),
+    ]
+    values.extend(properties or [])
+    for key, value in values:
+        ElementTree.SubElement(testcase_properties, "property", name=key, value=value)
+    if outcome is not None:
+        attributes = {}
+        if outcome_type is not None:
+            attributes["type"] = outcome_type
+        if message is not None:
+            attributes["message"] = message
+        ElementTree.SubElement(testcase, outcome, **attributes)
+    return testcase
+
+
+def write_junit(path, testcases):
+    root = ElementTree.Element("testsuites")
+    suite = ElementTree.SubElement(root, "testsuite", name="contract")
+    testcases(suite)
+    ElementTree.ElementTree(root).write(path, encoding="utf-8", xml_declaration=True)
+
+
+def execution(target, outcome="passed", *, reason=None, observation=None):
+    value = {
+        "api": "sync",
+        "backend": target.rsplit("-", 1)[-1],
+        "case_id": "tests.contracts.test_contract::test_case",
+        "outcome": outcome,
+        "reason": reason,
+        "suite": "core",
+        "target": target,
+    }
+    if observation is not None:
+        value["observation"] = observation
+    return value
+
+
+class JunitIngestTests(unittest.TestCase):
+    def test_only_exact_tinymongo_properties_define_contract_dimensions(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            junit = Path(temporary_directory) / "results.xml"
+
+            def cases(suite):
+                add_testcase(
+                    suite,
+                    "test_case[sync-memory]",
+                    properties=[
+                        ("impostor.api", "async"),
+                        ("impostor.backend", "mongodb"),
+                        ("impostor.suite", "other"),
+                    ],
+                )
+
+            write_junit(junit, cases)
+            result = mongo_parity.ingest_junit(junit, "tinymongo")
+
+        self.assertEqual(len(result["executions"]), 1)
+        self.assertEqual(result["executions"][0]["api"], "sync")
+        self.assertEqual(result["executions"][0]["backend"], "memory")
+        self.assertEqual(result["executions"][0]["suite"], "core")
+
+    def test_suffix_lookalike_properties_are_rejected(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            junit = Path(temporary_directory) / "results.xml"
+
+            def cases(suite):
+                testcase = add_testcase(suite, "test_case[sync-memory]")
+                properties = next(
+                    child for child in testcase if child.tag == "properties"
+                )
+                for property_element in properties:
+                    property_element.set(
+                        "name", "impostor." + property_element.get("name")
+                    )
+
+            write_junit(junit, cases)
+            with self.assertRaisesRegex(
+                mongo_parity.ContractError, "tinymongo.api.*tinymongo.backend"
+            ):
+                mongo_parity.ingest_junit(junit, "tinymongo")
+
+    def test_target_prefix_is_removed_without_consuming_equal_user_parameters(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            junit = Path(temporary_directory) / "results.xml"
+
+            def cases(suite):
+                add_testcase(
+                    suite,
+                    "test_case[sync-sqlite-sharded-sync-sqlite-sharded]",
+                    api="sync",
+                    backend="sqlite-sharded",
+                )
+
+            write_junit(junit, cases)
+            result = mongo_parity.ingest_junit(junit, "candidate")
+
+        self.assertEqual(
+            result["executions"][0]["case_id"],
+            "tests.contracts.test_contract::test_case[sync-sqlite-sharded]",
+        )
+
+    def test_target_tokens_outside_the_parameter_prefix_are_rejected(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            junit = Path(temporary_directory) / "results.xml"
+
+            def cases(suite):
+                add_testcase(suite, "test_case[variant-sync-memory]")
+
+            write_junit(junit, cases)
+            with self.assertRaisesRegex(
+                mongo_parity.ContractError, "does not begin with API/backend"
+            ):
+                mongo_parity.ingest_junit(junit, "tinymongo")
+
+    def test_explicit_contract_id_supports_vendored_runner_modules(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            junit = Path(temporary_directory) / "results.xml"
+
+            def cases(suite):
+                add_testcase(
+                    suite,
+                    "test_case[sync-memory]",
+                    properties=[
+                        (
+                            "tinymongo.contract_id",
+                            "tests.contracts.test_contract::test_case",
+                        )
+                    ],
+                )
+
+            write_junit(junit, cases)
+            result = mongo_parity.ingest_junit(junit, "tinymongo")
+
+        self.assertEqual(
+            result["executions"][0]["case_id"],
+            "tests.contracts.test_contract::test_case",
+        )
+
+    def test_reason_redaction_preserves_uris_and_produces_stable_fingerprint(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_directory = Path(temporary_directory)
+            first = temporary_directory / "first.xml"
+            second = temporary_directory / "second.xml"
+            message_one = (
+                "failed at /Users/alice/project/test.py:42; "
+                "docs https://example.test/api/v1; "
+                "database mongodb://localhost:27017/contracts"
+            )
+            message_two = (
+                "failed at /home/bob/project/test.py:42; "
+                "docs https://example.test/api/v1; "
+                "database mongodb://localhost:27017/contracts"
+            )
+
+            def first_case(suite):
+                add_testcase(
+                    suite,
+                    "test_case[sync-memory]",
+                    outcome="failure",
+                    outcome_type="AssertionError",
+                    message=message_one,
+                )
+
+            def second_case(suite):
+                add_testcase(
+                    suite,
+                    "test_case[sync-memory]",
+                    outcome="failure",
+                    outcome_type="AssertionError",
+                    message=message_two,
+                )
+
+            write_junit(first, first_case)
+            write_junit(second, second_case)
+            observed_one = mongo_parity.ingest_junit(first, "candidate")["executions"][
+                0
+            ]
+            observed_two = mongo_parity.ingest_junit(second, "candidate")["executions"][
+                0
+            ]
+
+        self.assertIn("https://example.test/api/v1", observed_one["reason"])
+        self.assertIn("mongodb://localhost:27017/contracts", observed_one["reason"])
+        self.assertNotIn("/Users/alice", observed_one["reason"])
+        self.assertEqual(observed_one["reason"], observed_two["reason"])
+        self.assertEqual(
+            observed_one["observation"]["fingerprint"],
+            observed_two["observation"]["fingerprint"],
+        )
+        self.assertEqual(observed_one["observation"]["category"], "AssertionError")
+        self.assertRegex(observed_one["observation"]["fingerprint"], r"^[0-9a-f]{64}$")
+
+
+class SnapshotMatrixTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.source_temporary_directory = tempfile.TemporaryDirectory()
+        cls.source_root = Path(cls.source_temporary_directory.name)
+        contracts = cls.source_root / "tests" / "contracts"
+        contracts.mkdir(parents=True)
+        (contracts / "__init__.py").write_text("", encoding="utf-8")
+        (contracts / "test_contract.py").write_text(
+            "# Frozen synthetic contract source.\n", encoding="utf-8"
+        )
+        subprocess.run(["git", "init", "-q"], cwd=cls.source_root, check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "parity-tests@example.invalid"],
+            cwd=cls.source_root,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Parity Tests"],
+            cwd=cls.source_root,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "add", "tests/contracts"], cwd=cls.source_root, check=True
+        )
+        subprocess.run(
+            ["git", "commit", "-q", "-m", "synthetic contract"],
+            cwd=cls.source_root,
+            check=True,
+        )
+        cls.source_commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=cls.source_root, text=True
+        ).strip()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.source_temporary_directory.cleanup()
+
+    def write_matrix(self, path, *, omit=None, duplicate=None):
+        def cases(suite):
+            for case_number in range(228):
+                for api in APIS:
+                    for backend in BACKENDS:
+                        cell = (case_number, api, backend)
+                        if cell == omit:
+                            continue
+                        add_testcase(
+                            suite,
+                            "test_case_{0:03d}[{1}-{2}]".format(
+                                case_number, api, backend
+                            ),
+                            api=api,
+                            backend=backend,
+                        )
+                        if cell == duplicate:
+                            add_testcase(
+                                suite,
+                                "test_case_{0:03d}[{1}-{2}]".format(
+                                    case_number, api, backend
+                                ),
+                                api=api,
+                                backend=backend,
+                            )
+
+        write_junit(path, cases)
+
+    def test_complete_matrix_yields_228_cases_and_memory_reference(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            junit = Path(temporary_directory) / "matrix.xml"
+            self.write_matrix(junit)
+            corpus, reference, digest = mongo_parity.snapshot_corpus(
+                junit, self.source_root, self.source_commit
+            )
+
+        self.assertEqual(len(corpus["cases"]), 228)
+        self.assertTrue(
+            all(case["apis"] == ["sync", "async"] for case in corpus["cases"])
+        )
+        self.assertEqual(len(reference["executions"]), 456)
+        self.assertEqual(
+            {item["target"] for item in reference["executions"]},
+            {"tinymongo-memory"},
+        )
+        self.assertRegex(digest, r"^[0-9a-f]{64}$")
+
+    def test_snapshot_rejects_one_missing_matrix_cell(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            junit = Path(temporary_directory) / "matrix.xml"
+            self.write_matrix(junit, omit=(227, "async", "mongodb"))
+            with self.assertRaisesRegex(
+                mongo_parity.ContractError, "complete.*matrix|matrix.*missing"
+            ):
+                mongo_parity.snapshot_corpus(
+                    junit, self.source_root, self.source_commit
+                )
+
+    def test_snapshot_rejects_one_duplicate_matrix_cell(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            junit = Path(temporary_directory) / "matrix.xml"
+            self.write_matrix(junit, duplicate=(0, "sync", "memory"))
+            with self.assertRaisesRegex(mongo_parity.ContractError, "duplicate"):
+                mongo_parity.snapshot_corpus(
+                    junit, self.source_root, self.source_commit
+                )
+
+
+class StrictDifferenceTests(unittest.TestCase):
+    def setUp(self):
+        self.manifest = {
+            "contract": "tinymongo-v1",
+            "source": {"commit": "0" * 40},
+        }
+        self.corpus = {
+            "contract": "tinymongo-v1",
+            "cases": [
+                {
+                    "id": "tests.contracts.test_contract::test_case",
+                    "apis": ["sync"],
+                }
+            ],
+        }
+        self.reference = {
+            "schema_version": 1,
+            "contract": "tinymongo-v1",
+            "executions": [execution("tinymongo-memory")],
+        }
+
+    def difference(self):
+        return {
+            "api": "sync",
+            "candidate_outcome": "failed",
+            "candidate_fingerprint": "1" * 64,
+            "case_id": "tests.contracts.test_contract::test_case",
+            "issue": "https://github.com/schapman1974/briskdb/issues/161",
+            "reason": "reviewed synthetic difference",
+            "reference_outcome": "passed",
+            "target": "briskdb-memory",
+        }
+
+    def test_allowlist_for_absent_target_is_stale_and_fails_report(self):
+        difference = self.difference()
+        report, _, failed = mongo_parity.compare_results(
+            self.manifest,
+            self.corpus,
+            {"differences": [difference]},
+            [self.reference],
+            "tinymongo-memory",
+            require_allowlist_targets=True,
+        )
+
+        self.assertTrue(failed)
+        self.assertEqual(report["status"], "failed")
+        self.assertEqual(report["stale_intentional_differences"], [difference])
+
+    def test_optional_allowlist_target_can_be_absent_from_reference_report(self):
+        report, _, failed = mongo_parity.compare_results(
+            self.manifest,
+            self.corpus,
+            {"differences": [self.difference()]},
+            [self.reference],
+            "tinymongo-memory",
+        )
+
+        self.assertFalse(failed)
+        self.assertEqual(report["status"], "reference-only")
+        self.assertEqual(report["stale_intentional_differences"], [])
+
+    def test_allowlist_is_stale_when_target_no_longer_differs(self):
+        difference = self.difference()
+        candidate = {
+            "schema_version": 1,
+            "contract": "tinymongo-v1",
+            "executions": [execution("briskdb-memory")],
+        }
+        report, _, failed = mongo_parity.compare_results(
+            self.manifest,
+            self.corpus,
+            {"differences": [difference]},
+            [self.reference, candidate],
+            "tinymongo-memory",
+        )
+
+        self.assertTrue(failed)
+        self.assertEqual(report["stale_intentional_differences"], [difference])
+
+    def test_allowlist_rejects_a_different_failure_fingerprint(self):
+        difference = self.difference()
+        candidate = {
+            "schema_version": 1,
+            "contract": "tinymongo-v1",
+            "executions": [
+                execution(
+                    "briskdb-memory",
+                    "failed",
+                    reason="a different failure",
+                    observation={
+                        "category": "AssertionError",
+                        "fingerprint": "2" * 64,
+                    },
+                )
+            ],
+        }
+        report, _, failed = mongo_parity.compare_results(
+            self.manifest,
+            self.corpus,
+            {"differences": [difference]},
+            [self.reference, candidate],
+            "tinymongo-memory",
+        )
+
+        self.assertTrue(failed)
+        self.assertFalse(report["targets"][0]["mismatches"][0]["allowed"])
+
+    def test_allowlist_accepts_the_reviewed_failure_fingerprint(self):
+        difference = self.difference()
+        candidate = {
+            "schema_version": 1,
+            "contract": "tinymongo-v1",
+            "executions": [
+                execution(
+                    "briskdb-memory",
+                    "failed",
+                    reason="the reviewed failure",
+                    observation={
+                        "category": "AssertionError",
+                        "fingerprint": "1" * 64,
+                    },
+                )
+            ],
+        }
+        report, _, failed = mongo_parity.compare_results(
+            self.manifest,
+            self.corpus,
+            {"differences": [difference]},
+            [self.reference, candidate],
+            "tinymongo-memory",
+        )
+
+        self.assertFalse(failed)
+        self.assertEqual(report["status"], "passed")
+        self.assertTrue(report["targets"][0]["mismatches"][0]["allowed"])
+
+
+class CommandValidationTests(unittest.TestCase):
+    def test_ingest_validates_contract_before_reading_results(self):
+        arguments = argparse.Namespace(manifest=Path("manifest.json"))
+        with mock.patch.object(
+            mongo_parity,
+            "validate_contract",
+            side_effect=mongo_parity.ContractError("invalid contract sentinel"),
+        ) as validate:
+            with self.assertRaisesRegex(
+                mongo_parity.ContractError, "invalid contract sentinel"
+            ):
+                mongo_parity._command_ingest(arguments)
+        validate.assert_called_once_with(arguments.manifest)
+
+    def test_report_validates_contract_before_reading_results(self):
+        arguments = argparse.Namespace(manifest=Path("manifest.json"))
+        with mock.patch.object(
+            mongo_parity,
+            "validate_contract",
+            side_effect=mongo_parity.ContractError("invalid contract sentinel"),
+        ) as validate:
+            with self.assertRaisesRegex(
+                mongo_parity.ContractError, "invalid contract sentinel"
+            ):
+                mongo_parity._command_report(arguments)
+        validate.assert_called_once_with(arguments.manifest)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mongo_source_provenance.py
+++ b/tests/test_mongo_source_provenance.py
@@ -1,0 +1,210 @@
+import copy
+import hashlib
+import importlib.util
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "mongo_parity.py"
+SPEC = importlib.util.spec_from_file_location("mongo_parity_source_provenance", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+mongo_parity = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(mongo_parity)
+
+
+def sha256(contents):
+    return hashlib.sha256(contents).hexdigest()
+
+
+class MongoSourceProvenanceTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.fixture_root = Path(self.temporary_directory.name)
+        self.source_root = self.fixture_root / "source"
+        self.contract_base = self.fixture_root / "v1"
+        self.runner_root = self.contract_base / "runner"
+        self.source_root.mkdir()
+
+        self.upstream = {
+            "tests/contracts/exact.py": b"EXACT = 1\n",
+            "tests/contracts/adapted.py": b'VALUE = "upstream"\n',
+            "tests/contracts/README.md": b"Upstream notes.\n",
+            "LICENSE.txt": b"Fixture license.\n",
+        }
+        for relative, contents in self.upstream.items():
+            target = self.source_root / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(contents)
+
+        self.git("init", "-q")
+        self.git("config", "user.name", "BriskDB Tests")
+        self.git("config", "user.email", "briskdb-tests@example.invalid")
+        self.git("add", ".")
+        self.git("commit", "-q", "-m", "fixture")
+        self.commit = self.git("rev-parse", "HEAD").strip()
+
+        self.exact_runner = "compat/mongo/v1/runner/contracts/exact.py"
+        self.adapted_runner = "compat/mongo/v1/runner/contracts/adapted.py"
+        self.license_runner = "compat/mongo/v1/runner/UPSTREAM_LICENSE.txt"
+        self.patch_runner = "compat/mongo/v1/runner/adaptation.patch"
+        self.adapted_contents = b'VALUE = "adapted"\n'
+        self.patch_contents = (
+            "--- a/tests/contracts/adapted.py\n"
+            "+++ b/compat/mongo/v1/runner/contracts/adapted.py\n"
+            "@@ -1 +1 @@\n"
+            '-VALUE = "upstream"\n'
+            '+VALUE = "adapted"\n'
+        ).encode("utf-8")
+
+        self.write_runner(self.exact_runner, self.upstream["tests/contracts/exact.py"])
+        self.write_runner(self.adapted_runner, self.adapted_contents)
+        self.write_runner(self.license_runner, self.upstream["LICENSE.txt"])
+        self.write_runner(self.patch_runner, self.patch_contents)
+
+        self.provenance = {
+            "source": {
+                "commit": self.commit,
+                "license": self.source_entry(
+                    "LICENSE.txt",
+                    runner_path=self.license_runner,
+                    runner_contents=self.upstream["LICENSE.txt"],
+                ),
+            },
+            "adaptation": {
+                "files": [
+                    self.source_entry(
+                        "tests/contracts/exact.py",
+                        runner_path=self.exact_runner,
+                        runner_contents=self.upstream["tests/contracts/exact.py"],
+                        status="exact",
+                    ),
+                    self.source_entry(
+                        "tests/contracts/adapted.py",
+                        runner_path=self.adapted_runner,
+                        runner_contents=self.adapted_contents,
+                        status="adapted",
+                    ),
+                ],
+                "excluded_upstream_files": [
+                    self.source_entry("tests/contracts/README.md")
+                ],
+                "patch": self.patch_runner,
+                "patch_sha256": sha256(self.patch_contents),
+            },
+        }
+        self.provenance_path = self.runner_root / "provenance.json"
+        self.write_provenance()
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    def git(self, *arguments):
+        return subprocess.check_output(
+            ["git", "-C", str(self.source_root)] + list(arguments),
+            text=True,
+        )
+
+    def blob_id(self, relative):
+        return self.git("rev-parse", "{0}:{1}".format(self.commit, relative)).strip()
+
+    def source_entry(
+        self,
+        relative,
+        *,
+        runner_path=None,
+        runner_contents=None,
+        status=None,
+    ):
+        entry = {
+            "upstream_path": relative,
+            "upstream_git_blob": self.blob_id(relative),
+            "upstream_sha256": sha256(self.upstream[relative]),
+        }
+        if runner_path is not None:
+            entry["runner_path"] = runner_path
+            entry["runner_sha256"] = sha256(runner_contents)
+        if status is not None:
+            entry["status"] = status
+        return entry
+
+    def write_runner(self, relative, contents):
+        target = self.contract_base.joinpath(*Path(relative).parts[3:])
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(contents)
+
+    def write_provenance(self):
+        self.provenance_path.parent.mkdir(parents=True, exist_ok=True)
+        self.provenance_path.write_text(
+            json.dumps(self.provenance, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    def verify(self):
+        mongo_parity._verify_source_provenance(
+            self.source_root,
+            self.commit,
+            self.provenance_path,
+            self.contract_base,
+        )
+
+    def test_verifies_blob_oids_license_and_replays_adaptation_patch(self):
+        self.verify()
+
+    def test_rejects_contract_blob_oid_drift_even_when_sha256_is_unchanged(self):
+        adapted = self.provenance["adaptation"]["files"][1]
+        adapted["upstream_git_blob"] = self.blob_id("tests/contracts/exact.py")
+        self.write_provenance()
+
+        with self.assertRaisesRegex(
+            mongo_parity.ContractError,
+            "Git blob mismatch for tests/contracts/adapted.py",
+        ):
+            self.verify()
+
+    def test_rejects_license_blob_oid_drift(self):
+        license_entry = self.provenance["source"]["license"]
+        license_entry["upstream_git_blob"] = self.blob_id("tests/contracts/exact.py")
+        self.write_provenance()
+
+        with self.assertRaisesRegex(
+            mongo_parity.ContractError, "Git blob mismatch for LICENSE.txt"
+        ):
+            self.verify()
+
+    def test_rejects_a_license_copy_that_differs_from_the_pinned_blob(self):
+        self.write_runner(self.license_runner, b"Different license.\n")
+
+        with self.assertRaisesRegex(
+            mongo_parity.ContractError, "license is not byte-for-byte upstream"
+        ):
+            self.verify()
+
+    def test_rejects_patch_output_that_does_not_reconstruct_runner(self):
+        bad_patch = self.patch_contents.replace(b'"adapted"', b'"different"')
+        self.write_runner(self.patch_runner, bad_patch)
+        self.provenance["adaptation"]["patch_sha256"] = sha256(bad_patch)
+        self.write_provenance()
+
+        with self.assertRaisesRegex(
+            mongo_parity.ContractError, "adaptation patch does not reconstruct"
+        ):
+            self.verify()
+
+    def test_rejects_patch_paths_outside_the_adapted_inventory(self):
+        provenance = copy.deepcopy(self.provenance)
+        provenance["adaptation"]["files"][1]["status"] = "exact"
+        self.provenance = provenance
+        self.write_provenance()
+
+        with self.assertRaisesRegex(
+            mongo_parity.ContractError, "adaptation patch path inventory mismatch"
+        ):
+            self.verify()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
TinyMongo behavior was previously an external, mutable reference, so the Mongo roadmap had no source-locked corpus or enforceable comparison gate. This freezes TinyMongo v1.3.0 as `tinymongo-v1`: 228 logical cases, 456 sync/async memory-reference executions, and a validated 3,192-cell discovery matrix across seven upstream backends.

The change adds a machine-readable capability manifest covering all 124 public operations, BSON/query/update/projection/index/aggregation behavior, result and error shapes, 60 emitted error codes, warnings, options, and unsupported behavior. A BriskDB-owned neutral runner executes the same assertions through lazy TinyMongo, real MongoDB, or BriskDB endpoint adapters. Corpus/source/provenance hashes, patch reconstruction, normalized observation fingerprints, exact allow-list entries, stale-policy checks, and readable JSON/Markdown reports make drift reviewable.

TinyMongo is installed only in the isolated compatibility CI job as the pinned oracle. BriskDB's Cargo/Python dependency metadata, wheels, binaries, and runtime do not depend on or import it. The current CI report is intentionally reference-only because the BSON model, document storage, and DocumentEngine land in subsequent roadmap issues; the BriskDB URI adapter and required-target gate are ready for those candidate runs, and this PR makes no parity claim.

Validation:

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features`
- `cargo test --locked --doc --all-features`
- `cargo +1.85.0 test --locked --all-targets --all-features`
- `cargo +1.85.0 test --locked --doc --all-features`
- `cargo package --locked --allow-dirty`
- `python scripts/mongo_parity.py validate`
- `python scripts/mongo_parity.py verify-source --source-root /path/to/tinymongo`
- `python -m unittest discover -s tests -p 'test_mongo*.py' -v` (60 passed)
- owned TinyMongo runner (456 passed; normalized output byte-identical)
- snapshot `--check` (228 cases / 3,192 cells / 456 references)
- strict real-Mongo policy simulation (454 passed / 2 reviewed skips)

Closes #161
