### PR TITLE
Add versioned document storage and TinyMongo import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,7 @@ jobs:
           - http
           - postgres
           - sqlite-import
+          - tinymongo-import
           - default
     steps:
       - name: Check out source

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1910,6 +1910,7 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,9 @@ server-cli = [
 # The offline SQLite importer is separate from the embedded query surface.
 sqlite-import = ["dep:serde", "dep:serde_json", "dep:tracing"]
 sqlite-import-cli = ["sqlite-import", "dep:anyhow", "dep:clap"]
+# Strict offline migration from TinyMongo's SQLite formats. This remains
+# opt-in because it requires the BSON model in addition to the SQL importer.
+tinymongo-import = ["documents", "sqlite-import"]
 # The BSON foundation is opt-in while the document engine and listener are
 # still being built. BSON-only dependencies stay out of ordinary SQL builds.
 documents = [
@@ -114,7 +117,7 @@ rustls-pemfile = { version = "2.2", optional = true }
 rusqlite = { version = "0.39.0", features = ["bundled", "column_decltype", "column_metadata", "hooks", "limits", "preupdate_hook"] }
 same-file = "1.0"
 serde = { version = "1.0.229", features = ["derive"], optional = true }
-serde_json = { version = "1.0", optional = true }
+serde_json = { version = "1.0", features = ["arbitrary_precision", "preserve_order"], optional = true }
 sqlparser = { version = "=0.62.0", default-features = false, features = ["std", "recursive-protection", "visitor"] }
 # `recursive` admits newer `psm` releases whose build dependencies require
 # Rust 1.88. The direct exact constraint preserves BriskDB's Rust 1.85 MSRV for

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ experimental and opt-in; the exact contract lives in
 | Debian package and hardened systemd service | Published |
 | Rust library entrypoint with optional attached listeners | Working |
 | Same-host service and embedded processes sharing one ready root | Working on local filesystems |
-| Native MongoDB wire protocol with TinyMongo parity | [Versioned parity contract](docs/MONGO_PARITY.md) and [Rust BSON foundation](docs/BSON.md) landed; engine and listener remain [planned](https://github.com/schapman1974/briskdb/issues/160) |
+| Native MongoDB wire protocol with TinyMongo parity | [Versioned parity contract](docs/MONGO_PARITY.md), [Rust BSON foundation](docs/BSON.md), and [document storage/import](docs/DOCUMENT_STORAGE.md) landed; engine and listener remain [planned](https://github.com/schapman1974/briskdb/issues/160) |
 | MySQL wire protocol | [Planned](https://github.com/schapman1974/briskdb/issues/40) |
 | Native Python extension | Sync/async API working; tagged releases build audited macOS/Linux ARM/x86 wheels |
 | Serverless lifecycle | [Planned](https://github.com/schapman1974/briskdb/issues/194) |
@@ -316,6 +316,7 @@ more valuable than a star. Start with the
 - [Tested PostgreSQL clients](docs/POSTGRES_CLIENTS.md)
 - [Mongo compatibility parity contract](docs/MONGO_PARITY.md)
 - [BSON value and codec contract](docs/BSON.md)
+- [Document catalog, storage, and TinyMongo import](docs/DOCUMENT_STORAGE.md)
 - [SQL compatibility](docs/SQL_COMPATIBILITY.md)
 - [Generated keys](docs/GENERATED_KEYS.md)
 - [Storage format](docs/STORAGE_FORMAT.md)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,9 +14,12 @@ comparison across numeric and extended BSON values, and exposes versioned
 `BBKY` semantic keys. Codec validation is bounded to MongoDB's 16 MiB document
 and 100-level nesting limits and is covered by frozen comparison vectors,
 official BSON corpus cases, property tests, and cargo-fuzz targets. This release
-does not yet add document storage, commands, a MongoDB listener, or the public
-Rust/Python collection APIs tracked by the following roadmap issues. See
-[the BSON contract](docs/BSON.md).
+also adds manifest-v14 document namespaces, exact sharded BSON records,
+canonical `_id` routing and uniqueness, restart-safe collection provisioning,
+and an atomic TinyMongo v1.3 SQLite importer. It does not yet add document
+commands, a MongoDB listener, or the public Rust/Python collection APIs tracked
+by the following roadmap issues. See [the BSON contract](docs/BSON.md) and
+[the document storage contract](docs/DOCUMENT_STORAGE.md).
 
 HTTP now has an explicit version-1 contract, discovery at `/v1`, a versioned
 `/v1/health` alias, and `BriskDB-API-Version: 1` on v1 responses. Existing valid

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -449,8 +449,9 @@ requires an earlier dependency:
     - [x] [#164](https://github.com/schapman1974/briskdb/issues/164) — canonical
       BSON model, codec, ordering, and versioned semantic keys; see
       [`docs/BSON.md`](docs/BSON.md)
-    - [ ] [#163](https://github.com/schapman1974/briskdb/issues/163) — document
-      catalog and storage layout
+    - [x] [#163](https://github.com/schapman1974/briskdb/issues/163) — versioned
+      document catalog, sharded BSON storage, and atomic TinyMongo SQLite
+      import; see [`docs/DOCUMENT_STORAGE.md`](docs/DOCUMENT_STORAGE.md)
     - [ ] [#162](https://github.com/schapman1974/briskdb/issues/162) —
       protocol-neutral document engine
     - [ ] [#191](https://github.com/schapman1974/briskdb/issues/191) — embedded

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -590,6 +590,24 @@ service or embedded process receives retryable `Busy`. Cancellation restores
 ordinary admission while retaining only complete shard checkpoints. Online
 construction remains later work.
 
+Version 14 adds the separate `briskdb_document_databases`,
+`briskdb_document_collections`, `briskdb_document_indexes`, and
+`briskdb_document_provisioning` authority plus manifest digest version 7.
+Document namespaces remain case-sensitive and independent of the SQL catalog;
+collections are never inferred from SQLite application tables. The catalog
+records exact BSON options, format and placement versions, the monotonic
+natural-order allocator, one built-in unique `_id_` definition, secondary-index
+lifecycle, and a checksummed one-collection provisioning cursor. Every shard
+uses one exact storage-owned `briskdb_documents_v1` table, outside the SQL table
+inventory, and routes canonical `_id` keys through immutable `HashByIdV1`
+placement. Creation publishes an active collection only after the cursor has
+installed or verified that table on every shard. Startup resumes a durable
+prefix under sole-process ownership and validates stored document checksums,
+canonical IDs, routes, and natural-order uniqueness before serving work. Builds
+without the optional `documents` feature still understand and checksum version
+14 metadata and recognize its exact shard schema; they refuse to activate a
+store with document collections.
+
 Each manifest version retains an intentionally incompatible
 `briskdb_metadata` definition and row as a downgrade fence. The v3-to-v4
 migration remains manifest-atomic. The v4-to-v5 step first validates the v4
@@ -619,6 +637,9 @@ The v11-to-v12 step adds the empty durable generated-table DDL bridge, raises
 the fence, and installs checksum version 5 without changing a shard.
 The v12-to-v13 step adds the empty durable global-index catalog, raises the
 fence, and installs checksum version 6 without changing a shard.
+The v13-to-v14 step adds the empty durable document catalog, raises the fence,
+and installs checksum version 7 without changing a shard. Fixed document
+storage is provisioned only after a collection-creation journal is committed.
 There is no automatic downgrade; an older binary requires a backup from before
 the newer format.
 
@@ -647,7 +668,7 @@ lock through independently durable per-shard work and `Ready` publication. A
 lagging opener re-reads `Ready` and strictly validates instead of provisioning
 from a stale `Creating` observation. Only a locked, durable `Creating` state
 permits missing canonical shard files to be created and WAL to be enabled. The
-validated v13 manifest may also retain one generated-table DDL bridge and one
+validated v14 manifest may also retain one generated-table DDL bridge and one
 matching active table-provisioning record. Startup first resumes any
 `Applying` physical migration under its ordinary exact-prefix rules. It then
 keeps admission `Pending`, advances the bridge from `ApplyingPhysical` to
@@ -661,6 +682,15 @@ record the stable table ID, seal the bridge `Complete`, reseal digest version 5,
 and publish the replacement catalog. A standalone table-provisioning journal
 retains its existing recovery path. A conflict never causes BriskDB to infer a
 new request from partial shard state.
+
+After those SQL-schema recovery paths, startup resumes any checksummed document
+collection provisioning cursor from its exact ascending shard prefix. It
+creates or verifies only the fixed storage-owned document table and advances
+the manifest cursor after each durable shard. The final manifest transaction
+activates the collection and built-in `_id_` index, removes the cursor, and
+reseals digest version 7. Existing active collections require the exact table
+and validated record set on every shard; missing, orphaned, misrouted, or
+checksum-invalid records fail closed.
 
 The final strict shard opens and catalog reconciliation complete before the
 startup guard publishes `Ready`; ordinary work is never served against a

--- a/docs/BSON.md
+++ b/docs/BSON.md
@@ -1,9 +1,9 @@
 # BSON value and codec contract
 
-BriskDB's `documents` feature provides the BSON value model used by the planned
-MongoDB listener, document storage, query engine, and Rust and Python document
-APIs. The foundation is protocol-neutral and does not start a listener or add
-document commands by itself.
+BriskDB's `documents` feature provides the BSON value model used by the
+versioned document store and planned MongoDB listener, query engine, and Rust
+and Python document APIs. The foundation is protocol-neutral and does not
+start a listener or add document commands by itself.
 
 ```toml
 [dependencies]
@@ -267,3 +267,6 @@ cargo install cargo-fuzz
 cargo fuzz run --fuzz-dir fuzz bson_codec
 cargo fuzz run --fuzz-dir fuzz bson_comparison
 ```
+
+The versioned collection catalog and shard persistence built on these types is
+documented in [document storage and TinyMongo import](DOCUMENT_STORAGE.md).

--- a/docs/CRATE_FEATURES.md
+++ b/docs/CRATE_FEATURES.md
@@ -24,6 +24,7 @@ briskdb = { version = "0.1.0-alpha.5", default-features = false, features = ["em
 | `server-cli` | `briskdb` binary, Clap, logging subscriber, multithread runtime | Process integration |
 | `sqlite-import` | Offline SQLite import library | Alpha-supported |
 | `sqlite-import-cli` | `briskdb-import` binary | Process integration |
+| `tinymongo-import` | Strict TinyMongo v1.3 SQLite reader and atomic document import; selects `documents` and `sqlite-import` | Experimental migration API |
 | `experimental-vtab` | Sharded virtual-table prototype | Experimental |
 | `documents` | BSON values, codec, comparison, and canonical semantic keys; also selects `embedded` | Experimental foundation; no document engine or listener yet |
 | `mysql` | Reserved MySQL boundary | Reserved; no listener yet |
@@ -44,11 +45,13 @@ listener assembly.
 - The public `core`, `sql`, and `storage` modules expose implementation-facing
   building blocks used by current adapters. Prefer crate-root and `embedded`
   APIs unless implementing a BriskDB adapter.
-- The `documents` feature exposes the protocol-neutral BSON foundation
-  documented in [BSON value and codec contract](BSON.md). Its value, codec,
-  comparison, and key APIs are experimental while the document engine is built.
-  It does not yet expose collections, persistence, commands, or a MongoDB
-  listener.
+- The `documents` feature exposes the protocol-neutral BSON foundation and
+  versioned internal persistence documented in
+  [BSON value and codec contract](BSON.md) and
+  [document storage](DOCUMENT_STORAGE.md). Its public value, codec,
+  comparison, key, and catalog metadata APIs are experimental while the
+  document engine is built. It does not yet expose document commands or a
+  MongoDB listener.
 - The `mysql` reserved feature compiles but intentionally exposes no claimed
   implementation.
 

--- a/docs/DOCUMENT_STORAGE.md
+++ b/docs/DOCUMENT_STORAGE.md
@@ -1,0 +1,178 @@
+# Document catalog, storage, and TinyMongo import
+
+Status: implemented by roadmap issue #163
+
+The opt-in `documents` feature stores ordered BSON documents in BriskDB's
+ordinary sharded SQLite layout. This is the persistence boundary below the
+protocol-neutral document engine tracked by issue #162. It does not expose a
+MongoDB listener or a public collection command API.
+
+## Logical catalog
+
+Manifest format 14 keeps document namespaces separate from the SQL table
+catalog. A SQL table can never become a collection through schema discovery.
+The manifest stores:
+
+- exact, case-sensitive database and collection names;
+- ordered BSON collection options;
+- BSON, storage, catalog, index, placement-policy, and placement-algorithm
+  versions;
+- one mandatory unique `_id_` definition per active collection;
+- user index declarations and their `PendingBuild` or `Ready` lifecycle; and
+- a checksummed, single-operation collection-provisioning cursor.
+
+Database names contain 1 to 63 UTF-8 bytes. A complete
+`database.collection` namespace contains at most 255 UTF-8 bytes. Names are
+compared byte-for-byte and may not contain NUL. Mongo names are not normalized
+through BriskDB's lowercase SQL identifier rules.
+
+All four document catalog tables participate in semantic manifest digest
+version 7. Every supported mutation uses an immediate SQLite transaction,
+validates the complete catalog, refreshes the digest, and commits the metadata
+as one unit. Startup validates exact table definitions, foreign keys, row and
+byte bounds, supported versions, namespace limits, built-in index state, and
+collection/provisioning lifecycle relationships before publishing Ready.
+
+## Shard records and placement
+
+Every shard that serves an active collection has one storage-owned table. Its
+abridged shape is:
+
+```sql
+CREATE TABLE briskdb_documents_v1 (
+    collection_id INTEGER NOT NULL,
+    id_key BLOB NOT NULL,
+    natural_order INTEGER NOT NULL,
+    document_bson BLOB NOT NULL,
+    document_checksum BLOB NOT NULL,
+    storage_format_version INTEGER NOT NULL,
+    PRIMARY KEY (collection_id, id_key),
+    UNIQUE (collection_id, natural_order)
+) STRICT, WITHOUT ROWID;
+```
+
+The implementation validates the full definition, types, and byte bounds.
+Ordinary SQL is denied access to this reserved table. The table remains
+directly inspectable with `sqlite3` by an operator who opens the physical file
+outside BriskDB.
+
+`document_bson` is the complete BSON document. Encoding preserves field order,
+wire families, binary subtype, Decimal128 BID bytes, timestamps, scoped code,
+and the other representation guarantees in [the BSON contract](BSON.md).
+`natural_order` is allocated monotonically per collection and provides stable
+cross-shard insertion order after restart. `document_checksum` is a
+domain-separated BLAKE3 checksum over collection ID, physical shard,
+natural-order value, canonical ID key, and exact BSON bytes. Checksums detect
+damage; they are not authentication.
+
+`id_key` is `CanonicalBsonKey(_id)`. BriskDB routes those bytes through the
+persisted virtual-bucket map using immutable placement policy
+`HashByIdV1`. Semantically equal IDs therefore always select the same shard,
+and the shard-local primary key enforces collection-wide `_id` uniqueness.
+For example, BSON integer `1` and double `1.0` collide, as do a Standard UUID
+and binary subtype 4 containing the same 16 bytes.
+
+The fixed table and exact canonical-ID key provide safe `_id` candidate
+filtering today. Later query and index work may add conservative candidate
+structures, but BSON matching remains authoritative; SQLite candidates may
+never exclude a true Mongo match. Secondary index declarations remain
+`PendingBuild` until issue #174 installs and verifies their physical authority.
+
+## Provisioning and restart
+
+Collection creation first commits the database, provisioning collection,
+pending built-in `_id_` index, operation identity, target shard count, and
+`next_shard = 0` under the manifest checksum. It then creates or verifies the
+fixed table on each shard and advances the checksummed cursor. Only after every
+shard is durable does one final transaction mark the collection and built-in
+index Ready and remove the cursor.
+
+A retained cursor forces sole-process startup ownership. Restart resumes the
+exact remaining shard prefix idempotently. An active collection with a missing
+or incompatible table is corruption. An exact document table without catalog
+authority is also rejected. Builds without the `documents` feature still
+understand manifest format 14 and validate its physical schema, but refuse to
+open a root containing active collections.
+
+## TinyMongo SQLite import
+
+Feature `tinymongo-import` selects `documents` and `sqlite-import`. Its public
+entry points are `TinyMongoImportPlan`, `read_tinymongo_source`,
+`TinyMongoImportOptions`, and `import_tinymongo_database`.
+
+The plan requires an exact database name and collection allowlist. This is
+mandatory because TinyMongo's unsharded SQLite format has no application ID or
+authoritative collection catalog; a normal SQLite table can otherwise have the
+same two-column shape. The reader understands the pinned TinyMongo v1.3 forms:
+
+1. the legacy `tinydb(id, data)` single-row JSON root;
+2. table-native `<database>.sqlite` collection tables; and
+3. a version-1 `.sqlite-sharded` directory with a manifest and 2 to 64 shards.
+
+Preflight opens each source through SQLite's read-only immutable URI, disables
+trusted-schema execution, runs `quick_check`, and installs a cancellation
+progress handler before reading rows. The source must be stopped and fully
+checkpointed: a `-wal`, `-shm`, or rollback-journal sidecar makes the import
+fail before any destination path is created. Preflight validates exact schemas,
+shard identity, manifest state, collection allowlist coverage, physical-ID
+syntax and shard route, logical `_id` presence and semantic uniqueness, durable
+logical index metadata, tagged JSON values, per-document limits, and aggregate
+document, physical-metadata, and catalog budgets. Internal tables, physical
+TinyMongo indexes, hidden order columns, and arbitrary non-allowlisted SQL
+tables never become user collections.
+
+For pre-v2 table keys, the importer proves that each reproducible Python scalar
+spelling agrees with the logical `_id`. It parses the bounded literal form of
+legacy mapping, list, and tuple IDs, compares it recursively with Mongo numeric
+semantics, and restores mapping order from that physical key. Mismatches are
+corruption. Python representations that cannot be reproduced losslessly from
+the stored BSON family fail as unsupported instead of trusting an unrelated
+physical key.
+
+The reader does not recompute TinyMongo's Python-specific SHA-256 physical-ID
+payload. That algorithm depends on Python JSON and its complete recursive BSON
+identity registry. A syntactically valid digest that disagrees with logical
+`_id` but still routes to the same source shard is therefore not diagnosed.
+The destination never trusts that digest: it derives a new canonical key and
+route from the validated logical BSON `_id`, so this limitation cannot change
+destination identity or placement.
+
+TinyMongo JSON persistence cannot recover information it did not store. Plain
+JSON integers become Int32 when possible and otherwise Int64; out-of-Int64
+values fail. Tagged Decimal128, ObjectId, binary subtype, UUID, date,
+timestamp, regex, code/scope, MinKey, and MaxKey values retain their encoded
+meaning. Python-only regex representations or unsupported flags fail instead
+of being coerced. Secondary index specifications are imported as logical
+`PendingBuild` metadata and rebuilt later; source SQLite expression indexes are
+never trusted.
+
+The complete source is validated before a destination staging directory is
+created. A directory destination may not be placed inside its source. The
+importer creates collections, writes routed documents in the source's durable
+natural order, records pending indexes, closes and reopens the new layout, and
+compares the catalog and exact ordered BSON sequence with the preflight
+material. It then writes a versioned receipt, checkpoints and synchronizes
+every SQLite file, and atomically renames the absent destination into place.
+Cancellation is checked during SQLite work and materialization as well as
+before publication. Cancellation or any error before the rename removes the
+private stage, leaving the source and destination untouched and allowing a
+clean retry.
+
+```rust,no_run
+use briskdb::import::{
+    TinyMongoImportOptions, TinyMongoImportPlan, import_tinymongo_database,
+};
+
+let plan = TinyMongoImportPlan::new("app", ["users", "orders"])?;
+let report = import_tinymongo_database(
+    "tinydb/app.sqlite",
+    "data/briskdb",
+    &plan,
+    TinyMongoImportOptions::new(4)?,
+)?;
+assert_eq!(report.target_shards(), Some(4));
+# Ok::<(), briskdb::EngineError>(())
+```
+
+The importer is a library API in this release. The existing `briskdb-import`
+binary continues to handle standard relational SQLite plans.

--- a/docs/SQLITE_IMPORT.md
+++ b/docs/SQLITE_IMPORT.md
@@ -8,6 +8,11 @@ not an in-place conversion. The source is opened read-only, the destination
 must not exist, and no running BriskDB process may use the destination while it
 is being published.
 
+TinyMongo's document-oriented SQLite formats use a separate, opt-in library
+path because their catalog, tagged JSON, and shard identity rules are not
+ordinary relational schemas. See
+[document storage and TinyMongo import](DOCUMENT_STORAGE.md).
+
 ```bash
 cargo run --bin briskdb-import -- \
   --source /path/to/source.db \

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -20,26 +20,30 @@ kernel releases their advisory locks when the process exits. They must not be
 replaced while a process is live. See the
 [multi-process contract](MULTIPROCESS.md).
 
-## Current format: version 13
+## Current format: version 14
 
 SQLite header fields identify the file and its format:
 
 | Header field | Value | Meaning |
 | --- | --- | --- |
 | `PRAGMA application_id` | `0x42524442` (`BRDB`) | Permanent BriskDB manifest-family marker |
-| `PRAGMA user_version` | `13` | Authoritative manifest schema version |
+| `PRAGMA user_version` | `14` | Authoritative manifest schema version |
 
 The application ID prevents an accidental foreign SQLite file from being
 adopted as a manifest. It is not authentication or tamper protection: a process
 that can write the data directory can forge it and the unkeyed checksums
 described below.
 
-Version 13 has nineteen strict manifest tables plus the partial unique
-allocation-owner index shown below. It retains the v12 routing,
+Version 14 has twenty-three strict manifest tables plus the partial unique
+allocation-owner index shown below. It retains the v13 routing,
 authoritative logical catalog, physical layout, application-schema migration,
 integrity, generated-ID activation, allocation-owner lifecycle, and recoverable
-table-provisioning and hi/lo leasing tables; replaces the downgrade fence; adds
-the durable global-index catalog and lifecycle; and changes no shard-file format.
+table-provisioning, hi/lo leasing, and global-index tables; replaces the
+downgrade fence; and adds the checksummed document database, collection,
+index, and provisioning catalogs. The manifest upgrade itself changes no
+shard file. Creating the first collection installs the separately versioned
+storage-owned document table described in
+[document storage](DOCUMENT_STORAGE.md).
 
 ```sql
 CREATE TABLE briskdb_manifest (
@@ -49,7 +53,7 @@ CREATE TABLE briskdb_manifest (
 
 CREATE TABLE briskdb_metadata (
     requires_manifest_version INTEGER NOT NULL
-        CHECK (requires_manifest_version >= 13)
+        CHECK (requires_manifest_version >= 14)
 ) STRICT;
 
 CREATE TABLE briskdb_routing (
@@ -386,6 +390,79 @@ CREATE TABLE briskdb_global_index_parts (
         ON DELETE CASCADE
 ) STRICT;
 
+CREATE TABLE briskdb_document_databases (
+    database_id INTEGER PRIMARY KEY CHECK (database_id > 0),
+    database_name TEXT NOT NULL COLLATE BINARY UNIQUE
+        CHECK (
+            length(CAST(database_name AS BLOB)) BETWEEN 1 AND 63
+            AND instr(database_name, char(0)) = 0
+        ),
+    catalog_version INTEGER NOT NULL CHECK (catalog_version = 1)
+) STRICT;
+
+CREATE TABLE briskdb_document_collections (
+    collection_id INTEGER PRIMARY KEY CHECK (collection_id > 0),
+    database_id INTEGER NOT NULL,
+    collection_name TEXT NOT NULL COLLATE BINARY
+        CHECK (
+            length(CAST(collection_name AS BLOB)) BETWEEN 1 AND 255
+            AND instr(collection_name, char(0)) = 0
+        ),
+    options_bson BLOB NOT NULL
+        CHECK (
+            typeof(options_bson) = 'blob'
+            AND length(options_bson) BETWEEN 5 AND 16777216
+        ),
+    bson_schema_version INTEGER NOT NULL CHECK (bson_schema_version = 1),
+    storage_format_version INTEGER NOT NULL CHECK (storage_format_version = 1),
+    placement_policy INTEGER NOT NULL CHECK (placement_policy = 1),
+    placement_version INTEGER NOT NULL CHECK (placement_version = 1),
+    next_natural_order INTEGER NOT NULL CHECK (next_natural_order > 0),
+    lifecycle_state INTEGER NOT NULL CHECK (lifecycle_state IN (1, 2)),
+    UNIQUE (database_id, collection_name),
+    FOREIGN KEY (database_id)
+        REFERENCES briskdb_document_databases (database_id)
+        ON DELETE RESTRICT
+) STRICT;
+
+CREATE TABLE briskdb_document_indexes (
+    collection_id INTEGER NOT NULL,
+    index_name TEXT NOT NULL COLLATE BINARY
+        CHECK (
+            length(CAST(index_name AS BLOB)) BETWEEN 1 AND 255
+            AND instr(index_name, char(0)) = 0
+        ),
+    spec_bson BLOB NOT NULL
+        CHECK (
+            typeof(spec_bson) = 'blob'
+            AND length(spec_bson) BETWEEN 5 AND 16777216
+        ),
+    is_unique INTEGER NOT NULL CHECK (is_unique IN (0, 1)),
+    is_builtin INTEGER NOT NULL CHECK (is_builtin IN (0, 1)),
+    index_format_version INTEGER NOT NULL CHECK (index_format_version = 1),
+    lifecycle_state INTEGER NOT NULL CHECK (lifecycle_state IN (1, 2)),
+    PRIMARY KEY (collection_id, index_name),
+    FOREIGN KEY (collection_id)
+        REFERENCES briskdb_document_collections (collection_id)
+        ON DELETE RESTRICT,
+    CHECK (
+        (is_builtin = 0 AND index_name <> '_id_')
+        OR (is_builtin = 1 AND index_name = '_id_' AND is_unique = 1)
+    )
+) STRICT;
+
+CREATE TABLE briskdb_document_provisioning (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    collection_id INTEGER NOT NULL UNIQUE CHECK (collection_id > 0),
+    operation_id BLOB NOT NULL
+        CHECK (typeof(operation_id) = 'blob' AND length(operation_id) = 32),
+    shard_count INTEGER NOT NULL CHECK (shard_count BETWEEN 2 AND 64),
+    next_shard INTEGER NOT NULL CHECK (next_shard BETWEEN 0 AND shard_count),
+    FOREIGN KEY (collection_id)
+        REFERENCES briskdb_document_collections (collection_id)
+        ON DELETE RESTRICT
+) STRICT;
+
 CREATE TABLE briskdb_table_provisioning (
     singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
     provisioning_id BLOB NOT NULL
@@ -538,37 +615,38 @@ CREATE TABLE briskdb_integrity (
 ```
 
 The manifest, metadata, routing, schema-catalog, shard-layout, and integrity
-tables each contain exactly one row. The v13 downgrade-fence row is exactly
-`13`. `briskdb_generated_table_ddl` and `briskdb_table_provisioning` each
+tables each contain exactly one row. The v14 downgrade-fence row is exactly
+`14`. `briskdb_generated_table_ddl`, `briskdb_table_provisioning`, and
+`briskdb_document_provisioning` each
 contain zero or one row. A completed generated-table bridge is retained;
 table-provisioning declaration rows exist only while their transient parent row
 exists.
 The two integrity-version columns deliberately accept any positive integer so
 a future digest encoding can remain structurally readable long enough for an
-older binary to reject it as `FailedPrecondition`; v13 writers emit manifest
-digest version `6` and schema digest version `1`.
+older binary to reject it as `FailedPrecondition`; v14 writers emit manifest
+digest version `7` and schema digest version `1`.
 Zero or negative versions are malformed and are `DataCorruption`.
 `briskdb_manifest.shard_count` is immutable and is the initial routing modulus;
 it is also the live physical-shard count. Physical IDs are exactly
 `0..shard_count - 1`. Filenames remain derived by trusted code as
 `shards/{shard_id:04}.sqlite` and are never read from catalog-controlled paths.
-Version 13 supports only the `active` physical-shard lifecycle state. Adding
+Version 14 supports only the `active` physical-shard lifecycle state. Adding
 provisioning, draining, or retirement states to the routing catalog requires a
 later format and state-machine change. The separate shard-layout state governs
 only startup identity reconciliation.
 
 ### Logical catalog
 
-Every fresh or upgraded v13 manifest contains logical database ID `1` named
+Every fresh or upgraded v14 manifest contains SQL logical database ID `1` named
 `default`. A fresh or pre-v6 upgrade begins at application-schema
 generation `0`; each completed journal row advances it by exactly one, through
 a maximum of `2,147,483,647`. The schema-catalog singleton also contains
-identifier encoding version `1` and default database ID `1`. Version 13 permits
+identifier encoding version `1` and default database ID `1`. Version 14 permits
 at most 64 logical databases and 4,096 table rows. Database and table IDs are
 positive; table names are unique within their owning database, and every table
 references an existing database.
 
-Identifier encoding version 1 is a canonical lowercase ASCII contract for
+Identifier encoding version 1 is a canonical lowercase ASCII contract for SQL
 logical-database names, table names, and shard-key column names:
 
 - the encoded name is 1 to 63 bytes;
@@ -578,6 +656,10 @@ logical-database names, table names, and shard-key column names:
 
 Names use binary comparison. There is no case folding, quoting transform, or
 Unicode normalization; a caller must supply the canonical lowercase name.
+
+Document databases and collections use their separate catalog and exact UTF-8
+namespace rules. They are never inferred from the SQL catalog. See
+[document storage](DOCUMENT_STORAGE.md).
 
 ### Global-index catalog and lifecycle
 
@@ -690,10 +772,10 @@ shard. SQLite never lowers an `AUTOINCREMENT` high-water mark, even after the
 row which established it is deleted, so a lower replacement could otherwise
 continue allocating values in a retired owner's encoded range.
 
-Fresh version 13 storage seeds active `owner_slot = physical_shard_id`, so the
+Fresh version 14 storage seeds active `owner_slot = physical_shard_id`, so the
 initial slots are the contiguous range `0..shard_count - 1`. A slot is an
 immutable ID namespace, not a value that may be recomputed from a later shard
-count or bucket map. Version 13 has no public owner-map mutation operation, but
+count or bucket map. Version 14 has no public owner-map mutation operation, but
 its format preserves the state required by a later resharding workflow: retire
 the old slot without deleting it and explicitly add a never-used replacement
 whose slot is greater than every prior owner of that physical shard.
@@ -825,7 +907,7 @@ the data root. An exact complete repeat is a read-only idempotent success;
 empty, partial, different, duplicate, nonempty, or physically mismatched
 declarations fail without replacing the catalog. Once populated, the catalog
 cannot be edited in place. The one exception is an exact declaration repeat for
-a v9 catalog migrated with an inactive native policy: v13 may provision that
+a v9 catalog migrated with an inactive native policy: v14 may provision that
 unchanged policy if all declared physical tables are still empty, but it may
 not alter a declaration or catalog ID. A later journaled schema migration must preserve the
 exact registered physical table set on every shard and retain every sharded
@@ -996,9 +1078,9 @@ acknowledged or replayed shard, resumes in ascending order, and publishes
 digests, owner ranges, or nonempty tables fail closed; BriskDB never infers a
 different request from partial shard state.
 
-Fresh v13 initialization leaves `briskdb_tables`, `briskdb_generated_ids`,
-`briskdb_hilo_leases`, `briskdb_generated_table_ddl`, both global-index tables,
-and both provisioning tables empty. The v7-to-v8 migration
+Fresh v14 initialization leaves the SQL table, generated-ID, hi/lo,
+generated-table DDL, global-index, document, and provisioning catalogs empty.
+The v7-to-v8 migration
 also clears all v7 table rows because those rows were advisory and were never
 proved against the physical schema; silently promoting them would create false
 routing authority. The upgrade preserves logical databases, routing, schema
@@ -1043,7 +1125,7 @@ additional `Applying` row may exist, and it must target
 `schema_generation + 1`. Its stored source generation, shard count, SQL text,
 digest, state, and progress are validated on every manifest open. Any journal
 history requires the physical layout to be `Ready`; `Creating` and `Adopting`
-manifests have an empty journal. Fresh v13 initialization and pre-v6 upgrades
+manifests have an empty journal. Fresh v14 initialization and pre-v6 upgrades
 begin with an empty journal at generation 0.
 
 The retained journal proves which exact batches BriskDB coordinated; it does
@@ -1065,12 +1147,12 @@ are distinct from the v5 physical-layout states:
 | Code | State | Required checksum and journal shape | Admission contract |
 | --- | --- | --- | --- |
 | `1` | `Verifying` | No active migration and no target fingerprint; the committed fingerprint may be absent during first bootstrap | Startup must verify one shard-schema consensus and seal it before serving work |
-| `2` | `Ready` | One committed fingerprint, no target fingerprint, no active schema migration, physical layout `Ready`; may contain one active table-provisioning prefix and a matching `Provisioning` bridge, or a retained `Complete` bridge | Ordinary operations may run only when no transient provisioning record exists; bridge or registration recovery otherwise owns the gate |
+| `2` | `Ready` | One committed fingerprint, no target fingerprint, no active schema migration, physical layout `Ready`; may contain one active SQL-table or document-collection provisioning prefix and a matching bridge where applicable | Ordinary operations may run only when no transient provisioning record exists; provisioning, bridge, or registration recovery otherwise owns the gate |
 | `3` | `Migrating` | Committed source and target fingerprints plus exactly one `Applying` schema-migration row, no table provisioning, physical layout `Ready`; an `ApplyingPhysical` bridge, when present, must reference that migration exactly | Only the migration coordinator may advance the validated prefix |
 | `4` | `Degraded` | Preserves whatever trusted committed/target fingerprints and active journal existed when validation failed | Terminal fail-closed state; startup and all new work return non-retryable `DataCorruption` until the complete database is restored from a known-good copy |
 
 `Pending` is an in-process admission state used after durable schema-migration,
-table-provisioning, or generated-table bridge progress, and after a
+table or document provisioning, or generated-table bridge progress, and after a
 durability-ambiguous manifest commit, including first catalog registration; it
 is not a fifth manifest state. A state transition, its checksum fields, the
 corresponding journal/catalog mutation, and the refreshed semantic root commit
@@ -1087,8 +1169,8 @@ restart as repair after any reported `DataCorruption`; whole-shard corruption
 drills and failure handling remain issue #68. Those storage failures retain
 their own error kinds and do not themselves justify rebaselining data.
 
-Manifest digest version 6 is a full 32-byte, unkeyed BLAKE3 digest. The stream
-begins with `briskdb.manifest.semantic-root.v6` plus its terminating NUL. It
+Manifest digest version 7 is a full 32-byte, unkeyed BLAKE3 digest. The stream
+begins with `briskdb.manifest.semantic-root.v7` plus its terminating NUL. It
 then encodes the length-prefixed name `application_id` and its tagged integer,
 followed by the length-prefixed name `user_version` and its tagged integer.
 These tables and columns follow in fixed order:
@@ -1102,6 +1184,10 @@ These tables and columns follow in fixed order:
 | `briskdb_allocation_owners` | `owner_slot`, `physical_shard_id`, `owner_state` |
 | `briskdb_virtual_buckets` | `bucket_id`, `physical_shard_id` |
 | `briskdb_logical_databases` | `database_id`, `database_name` |
+| `briskdb_document_databases` | `database_id`, `database_name`, `catalog_version` |
+| `briskdb_document_collections` | `collection_id`, `database_id`, `collection_name`, `options_bson`, `bson_schema_version`, `storage_format_version`, `placement_policy`, `placement_version`, `next_natural_order`, `lifecycle_state` |
+| `briskdb_document_indexes` | `collection_id`, `index_name`, `spec_bson`, `is_unique`, `is_builtin`, `index_format_version`, `lifecycle_state` |
+| `briskdb_document_provisioning` | `singleton`, `collection_id`, `operation_id`, `shard_count`, `next_shard` |
 | `briskdb_schema_catalog` | `singleton`, `identifier_encoding_version`, `schema_generation`, `default_database_id` |
 | `briskdb_tables` | `table_id`, `database_id`, `table_name`, `placement`, `shard_key_column`, `shard_key_type` |
 | `briskdb_generated_ids` | `table_id`, `policy`, `generated_column`, `encoding_version`, `activation_state` |
@@ -1128,7 +1214,7 @@ self-reference; its version, database state, and schema digest fields are
 covered. Frozen SQL definitions, STRICT flags, indexes, and foreign keys are
 validated separately rather than encoded as semantic rows.
 
-Every BriskDB-owned v13 manifest mutation recalculates the root after its row
+Every BriskDB-owned v14 manifest mutation recalculates the root after its row
 changes and before the same transaction commits. Progress acknowledgement,
 migration publication/finalization, provisioning intent/progress/finalization,
 generated-table bridge transitions, layout publication, owner/activation state
@@ -1138,7 +1224,10 @@ semantic values instead of the raw SQLite file makes the root stable across WAL
 checkpoints, page relocation, and `VACUUM`; it deliberately does not cover
 SQLite page bytes, rollback journals, WAL, or shared memory.
 
-Digest version 5 remains frozen solely to verify and migrate version-12
+Digest version 6 remains frozen solely to verify and migrate version-13
+manifests. It uses the `briskdb.manifest.semantic-root.v6` domain and the same
+encoding but omits all four document catalog tables. Digest version 5 remains
+frozen solely to verify and migrate version-12
 manifests. It uses the `briskdb.manifest.semantic-root.v5` domain and the same
 encoding but omits both global-index tables. Digest version 4 remains frozen
 solely to verify and migrate version-11
@@ -1155,8 +1244,8 @@ encoding, covers generated-ID policy and the owner-to-shard mapping, but omits
 activation, owner lifecycle, and both provisioning tables. Digest version 1
 remains frozen for version-7 and version-8 manifests. It uses the
 `briskdb.manifest.semantic-root.v1` domain and the same encoding, but omits the
-two version-9 tables. A v13 manifest must store version 6; storing an older
-digest in an otherwise v13 shape is corruption, and an unsupported future
+two version-9 tables. A v14 manifest must store version 7; storing an older
+digest in an otherwise v14 shape is corruption, and an unsupported future
 positive digest version is a failed precondition.
 
 The frozen four-shard v8/version-1 fixture with layout ID
@@ -1177,13 +1266,16 @@ bytes; nullable SQL uses `1` for present and `0` for absent; and `0` ends the
 object stream. The generation binding means identical DDL at two generations
 has different fingerprints.
 
-SQLite-owned objects whose names begin with `sqlite_` (case-insensitive) and
-the one exact `briskdb_shard_metadata` table are excluded. Any other reserved
-object is corruption. The fingerprint includes persistent application tables,
-indexes, views, and triggers exactly as SQLite records them. It excludes
-`rootpage`, application row values, shard ID and layout metadata, file headers,
-page layout, WAL state, and temporary schema objects. Thus it is stable across
-row DML, checkpoint, reopen, and `VACUUM`, while differing for any persistent
+SQLite-owned objects whose names begin with `sqlite_` (case-insensitive) are
+excluded. BriskDB also excludes only complete, exact definitions for its shard
+metadata, document store, global-index outbox, and shard-summary objects; their
+frozen schemas and validation rules appear in the physical-layout subsections
+below. A partial, changed, or otherwise unrecognized reserved object is
+corruption. The fingerprint includes persistent application tables, indexes,
+views, and triggers exactly as SQLite records them. It excludes `rootpage`,
+application row values, shard ID and layout metadata, file headers, page
+layout, WAL state, and temporary schema objects. Thus it is stable across row
+DML, checkpoint, reopen, and `VACUUM`, while differing for any persistent
 application-schema change or generation change.
 
 Every manifest connection first enables and reads back
@@ -1291,7 +1383,7 @@ The routing singleton contains exactly these generation-1 values:
 | `key_encoding_version` | `1` | Canonical bytes defined below for raw, explicit, and typed inferred routing keys |
 | `bucket_algorithm_version` | `1` | Compatibility-preserving range algorithm below |
 | `virtual_bucket_count` | `4096` | Fixed virtual bucket space `0..4095` |
-| `map_generation` | `1` | Initial committed bucket map and the only generation version 13 can interpret |
+| `map_generation` | `1` | Initial committed bucket map and the only generation version 14 can interpret |
 
 Every bucket ID exists exactly once and references an active physical shard.
 Every physical shard owns at least one bucket. The generation-1 map partitions
@@ -1314,10 +1406,21 @@ planning and policy contract is in [bound statement
 planning](SQL_PLANNING.md).
 
 This routing format is intentionally distinct from the tagged, order-preserving
-[canonical global-index key format](INDEX_KEY_ENCODING.md). Version 13 records
+[canonical global-index key format](INDEX_KEY_ENCODING.md). Version 14 records
 the codec version in every global-index definition but does not persist physical
 index entries or change shard placement. Physical entries live in the separate
 storage-version-4 `global-indexes/global.sqlite` authority, never in a shard.
+
+### Optional shard-local document storage version 1
+
+An active document catalog requires the exact storage-owned
+`briskdb_documents_v1` table on every shard. It is excluded from the ordinary
+application-schema digest and SQL table inventory only when its complete
+definition matches the frozen version. A missing active table, a changed
+definition, or an orphan table without catalog authority is corruption.
+Canonical `_id` bytes form the per-collection primary key; complete BSON bytes
+and a record checksum remain inspectable in SQLite. The exact schema and
+recovery protocol are in [document storage](DOCUMENT_STORAGE.md).
 
 ### Optional shard-local global-index outbox version 1
 
@@ -1467,7 +1570,7 @@ vectors freeze the exact key bytes, BLAKE3 prefix, little-endian hash integer,
 bucket ID, and persisted physical shard.
 
 `map_generation` is separate from manifest `user_version` and from
-`schema_generation`. Version 13 accepts only routing generation 1 and validates
+`schema_generation`. Version 14 accepts only routing generation 1 and validates
 its exact deterministic assignment; no public map-mutation operation exists
 yet. A future format that can commit a changed map must bump `user_version` and
 its downgrade fence as well as `map_generation`. That requirement makes this
@@ -1478,12 +1581,28 @@ At each open, BriskDB validates the exact objects, columns, strict flags, frozen
 schema SQL, singleton rows, logical identifiers and limits, metadata codes,
 supported algorithm values, contiguous physical and bucket IDs, active
 lifecycle states, assignments, coverage, and foreign keys. A recognized
-version-13 manifest that violates any invariant is `DataCorruption` and is
+version-14 manifest that violates any invariant is `DataCorruption` and is
 rejected before shard connections are opened. The same locked transaction
 returns routing and logical rows as one coherent shared snapshot. Request
 routing performs no manifest query and cannot fall back to modulo after a failed
 validation; only successful migration finalization publishes a newer logical
 schema generation into the snapshot.
+
+## Previous version 13
+
+Version 13 has nineteen strict manifest tables and semantic manifest digest
+version 6. It includes the durable global-index catalog but has no document
+database, collection, index, or provisioning catalog. Its downgrade fence
+requires 13 and its header stores `user_version = 13`.
+
+The atomic v13-to-v14 transaction creates all four empty document catalog
+tables, replaces the downgrade fence with 14, changes the integrity row to
+manifest digest version 7, stamps `user_version = 14`, and reseals the
+version-7 root. It preserves routing, SQL catalogs, generated-ID, DDL and
+global-index state, migration history, schema generations, layout, integrity,
+shard files, schemas, and rows. The migration never opens or mutates a shard.
+A version-13 reader rejects the version-14 header and fence before it could
+ignore document authority.
 
 ## Previous version 12
 
@@ -1711,8 +1830,8 @@ CREATE TABLE briskdb_metadata (
 
 The fence contains exactly `2`. A current opener validates this complete format
 before applying the numbered v2-to-v3, v3-to-v4, v4-to-v5, v5-to-v6,
-v6-to-v7, v7-to-v8, v8-to-v9, v9-to-v10, v10-to-v11, v11-to-v12, and v12-to-v13
-transactions.
+v6-to-v7, v7-to-v8, v8-to-v9, v9-to-v10, v10-to-v11, v11-to-v12,
+v12-to-v13, and v13-to-v14 transactions.
 
 ## Legacy version 1
 
@@ -1772,12 +1891,13 @@ returning:
    journal, and semantic digest version 3. The v10-to-v11 step adds durable
    hi/lo allocation heads and semantic digest version 4. The v11-to-v12 step
    adds the retained generated-table DDL bridge and semantic digest version 5;
-   v12-to-v13 adds the global-index catalog and semantic digest version 6.
+   v12-to-v13 adds the global-index catalog and semantic digest version 6;
+   v13-to-v14 adds the document catalog and semantic digest version 7.
    Older formats therefore cannot be mistaken for checksummed,
    authoritative-catalog, allocator-authority, recoverable provisioning, or
    durable logical-to-physical DDL identity.
 6. Fresh initialization is allowed only beside an otherwise empty physical
-   layout and commits v13 physical state `Creating`, integrity state
+   layout and commits v14 physical state `Creating`, integrity state
    `Verifying`, generation 0, and empty application-schema and provisioning
    journals. An existing
    v1/v2/v3 manifest first advances through v4; the v4-to-v5 transaction commits
@@ -1787,10 +1907,11 @@ returning:
    table catalog. The v8-to-v9 step adds the empty generated-policy catalog and
    immutable owner map; v9-to-v10 adds inactive activation fields, active owner
    states, and empty provisioning tables; v10-to-v11 adds the empty hi/lo lease
-   table; v11-to-v12 adds the empty generated-table DDL bridge; and v12-to-v13
-   adds the empty global-index catalog.
+   table; v11-to-v12 adds the empty generated-table DDL bridge; v12-to-v13
+   adds the empty global-index catalog; and v13-to-v14 adds the empty document
+   catalog.
 7. If the validated integrity state is `Degraded`, fail startup without
-   changing it. Otherwise, if a validated v13 manifest contains one `Applying`
+   changing it. Otherwise, if a validated v14 manifest contains one `Applying`
    migration, require state `Migrating`, validate every shard against the
    trusted source/target fingerprint for its exact journal-prefix position,
    and resume it in ascending order. The final transaction publishes the
@@ -1870,6 +1991,8 @@ policies, allocator state, provisioning progress, migration history, schema,
 and application rows are unchanged.
 The v12-to-v13 step likewise changes no shard: it creates the empty global-index
 catalog, raises the downgrade fence, and moves the checksum to version 6.
+The v13-to-v14 step also changes no shard: it creates the empty document
+catalog, raises the downgrade fence, and moves the checksum to version 7.
 
 A new application-schema migration follows a separate durable protocol:
 
@@ -2008,7 +2131,7 @@ header value, format version, digest input, routing metadata, schema
 fingerprint, journal record, or recovery step. Listener settings are not
 persisted. Because engine open and its existing recovery precede listener
 binding, a later bind failure does not undo a migration or recovery transaction
-that already committed; a subsequent startup revalidates the same version-13
+that already committed; a subsequent startup revalidates the same version-14
 layout normally.
 
 Issue #29's pinned `pgwire` dependency and issue #30's production startup,
@@ -2055,8 +2178,8 @@ requires a backup from before the unsupported format.
 
 ## Verification contract
 
-Tests cover fresh creation and every v1/v2/v3/v4/v5/v6/v7/v8/v9/v10/v11/v12
-upgrade path to v13, every
+Tests cover fresh creation and every
+v1/v2/v3/v4/v5/v6/v7/v8/v9/v10/v11/v12/v13 upgrade path to v14, every
 manifest layout and integrity state, the exact shard header and metadata row,
 dynamic schema generations, retained migration history, checksum golden
 vectors, and no-op ready reopen. Failure
@@ -2078,6 +2201,11 @@ clearing, v8 explicit `None` migration, v9 inactive-policy migration, atomic
 registration and commit ambiguity, provisioning-prefix replay at every commit
 boundary, exact idempotency, empty-schema and key/constraint validation,
 immutable public lookups, stale-handle exclusion, and migration enforcement.
+Document catalog and storage tests cover the v13-to-v14 migration, semantic
+root coverage, namespace and version bounds, lifecycle cross-validation,
+restart-safe shard provisioning, built-in `_id` authority, canonical-ID
+routing and uniqueness, exact BSON restart fidelity, direct SQLite inspection,
+and metadata, schema, and record corruption rejection.
 Generated-table DDL bridge tests cover exact logical, physical, and
 provisioning identity; the retained provisioning-time schema digest and a later
 schema migration; manifest-v5 checksum and downgrade fencing; strict lifecycle

--- a/src/document/catalog.rs
+++ b/src/document/catalog.rs
@@ -1,0 +1,319 @@
+//! Versioned document namespace, collection, placement, and index metadata.
+
+use super::{BsonDocument, BsonErrorContext, encode_document};
+use crate::core::{EngineError, EngineErrorKind, EngineResult};
+
+/// Durable document-catalog representation understood by this release.
+pub const DOCUMENT_CATALOG_VERSION: u32 = 1;
+/// Physical shard-table representation understood by this release.
+pub const DOCUMENT_STORAGE_FORMAT_VERSION: u32 = 1;
+/// Stored BSON document schema version understood by this release.
+pub const DOCUMENT_SCHEMA_VERSION: u32 = 1;
+/// Built-in and declared document-index metadata representation.
+pub const DOCUMENT_INDEX_FORMAT_VERSION: u32 = 1;
+
+/// Maximum UTF-8 byte length of a logical Mongo database name.
+pub const MAX_DOCUMENT_DATABASE_NAME_BYTES: usize = 63;
+/// Maximum UTF-8 byte length of a full `database.collection` namespace.
+pub const MAX_DOCUMENT_NAMESPACE_BYTES: usize = 255;
+
+/// Stable identity of one logical document database.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DocumentDatabaseId(u64);
+
+impl DocumentDatabaseId {
+    pub(crate) fn from_validated(value: u64) -> Self {
+        debug_assert!(value > 0);
+        Self(value)
+    }
+
+    /// Return the durable positive integer identity.
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+/// Stable identity of one logical document collection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DocumentCollectionId(u64);
+
+impl DocumentCollectionId {
+    pub(crate) fn from_validated(value: u64) -> Self {
+        debug_assert!(value > 0);
+        Self(value)
+    }
+
+    /// Return the durable positive integer identity.
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+/// Immutable placement rule for documents in one collection.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DocumentPlacement {
+    /// Route the canonical BSON identity of `_id` through BriskDB's persisted
+    /// hash/bucket map. Equal IDs therefore always reach the same shard.
+    HashByIdV1,
+}
+
+impl DocumentPlacement {
+    /// Return the stable persisted policy code.
+    pub const fn code(self) -> u32 {
+        match self {
+            Self::HashByIdV1 => 1,
+        }
+    }
+
+    /// Return the version of this placement algorithm.
+    pub const fn version(self) -> u32 {
+        match self {
+            Self::HashByIdV1 => 1,
+        }
+    }
+}
+
+/// Whether an index definition already has authoritative physical coverage.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DocumentIndexLifecycle {
+    /// The index is authoritative for writes and reads.
+    Ready,
+    /// Metadata is retained for a later crash-safe physical build.
+    PendingBuild,
+}
+
+impl DocumentIndexLifecycle {
+    pub(crate) fn from_code(code: u32) -> EngineResult<Self> {
+        match code {
+            1 => Ok(Self::Ready),
+            2 => Ok(Self::PendingBuild),
+            _ => Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "document index has an unsupported lifecycle",
+            )),
+        }
+    }
+}
+
+/// Exact persisted options supplied when a collection is declared.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocumentCollectionOptions {
+    document: BsonDocument,
+}
+
+impl DocumentCollectionOptions {
+    /// Construct an empty option document.
+    pub const fn empty() -> Self {
+        Self {
+            document: BsonDocument::new(),
+        }
+    }
+
+    /// Validate and retain an ordered BSON option document.
+    pub fn new(document: BsonDocument) -> EngineResult<Self> {
+        encode_document(&document)
+            .map_err(|error| error.into_engine_error(BsonErrorContext::ClientInput))?;
+        Ok(Self { document })
+    }
+
+    /// Return the ordered option document.
+    pub const fn document(&self) -> &BsonDocument {
+        &self.document
+    }
+}
+
+impl Default for DocumentCollectionOptions {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+/// Durable metadata for one document index.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocumentIndexMetadata {
+    name: String,
+    specification: BsonDocument,
+    unique: bool,
+    built_in: bool,
+    lifecycle: DocumentIndexLifecycle,
+}
+
+impl DocumentIndexMetadata {
+    pub(crate) fn from_validated_parts(
+        name: String,
+        specification: BsonDocument,
+        unique: bool,
+        built_in: bool,
+        lifecycle: DocumentIndexLifecycle,
+    ) -> Self {
+        Self {
+            name,
+            specification,
+            unique,
+            built_in,
+            lifecycle,
+        }
+    }
+
+    /// Return the exact index name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Return the ordered BSON index specification.
+    pub const fn specification(&self) -> &BsonDocument {
+        &self.specification
+    }
+
+    /// Return whether duplicate semantic keys are forbidden.
+    pub const fn is_unique(&self) -> bool {
+        self.unique
+    }
+
+    /// Return whether this is storage's mandatory `_id_` index.
+    pub const fn is_built_in(&self) -> bool {
+        self.built_in
+    }
+
+    /// Return the physical-build lifecycle.
+    pub const fn lifecycle(&self) -> DocumentIndexLifecycle {
+        self.lifecycle
+    }
+}
+
+/// Durable metadata for one logical collection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocumentCollectionMetadata {
+    id: DocumentCollectionId,
+    database_id: DocumentDatabaseId,
+    database_name: String,
+    name: String,
+    options: DocumentCollectionOptions,
+    placement: DocumentPlacement,
+    indexes: Box<[DocumentIndexMetadata]>,
+}
+
+impl DocumentCollectionMetadata {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn from_validated_parts(
+        id: DocumentCollectionId,
+        database_id: DocumentDatabaseId,
+        database_name: String,
+        name: String,
+        options: DocumentCollectionOptions,
+        placement: DocumentPlacement,
+        indexes: Box<[DocumentIndexMetadata]>,
+    ) -> Self {
+        Self {
+            id,
+            database_id,
+            database_name,
+            name,
+            options,
+            placement,
+            indexes,
+        }
+    }
+
+    pub const fn id(&self) -> DocumentCollectionId {
+        self.id
+    }
+
+    pub const fn database_id(&self) -> DocumentDatabaseId {
+        self.database_id
+    }
+
+    pub fn database_name(&self) -> &str {
+        &self.database_name
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub const fn options(&self) -> &DocumentCollectionOptions {
+        &self.options
+    }
+
+    pub const fn placement(&self) -> DocumentPlacement {
+        self.placement
+    }
+
+    pub fn indexes(&self) -> &[DocumentIndexMetadata] {
+        &self.indexes
+    }
+
+    /// Return the full Mongo namespace without normalizing either component.
+    pub fn namespace(&self) -> String {
+        format!("{}.{}", self.database_name, self.name)
+    }
+}
+
+/// Validated document-catalog snapshot in stable ID order.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DocumentCatalog {
+    collections: Box<[DocumentCollectionMetadata]>,
+}
+
+impl DocumentCatalog {
+    pub(crate) fn from_validated_collections(
+        collections: Box<[DocumentCollectionMetadata]>,
+    ) -> Self {
+        Self { collections }
+    }
+
+    pub fn collections(&self) -> &[DocumentCollectionMetadata] {
+        &self.collections
+    }
+
+    pub fn collection(
+        &self,
+        database: &str,
+        collection: &str,
+    ) -> Option<&DocumentCollectionMetadata> {
+        self.collections
+            .iter()
+            .find(|metadata| metadata.database_name == database && metadata.name == collection)
+    }
+
+    pub fn collection_by_id(
+        &self,
+        id: DocumentCollectionId,
+    ) -> Option<&DocumentCollectionMetadata> {
+        self.collections.iter().find(|metadata| metadata.id == id)
+    }
+}
+
+pub(crate) fn validate_namespace(database: &str, collection: &str) -> EngineResult<()> {
+    if database.is_empty()
+        || database.len() > MAX_DOCUMENT_DATABASE_NAME_BYTES
+        || database.contains('\0')
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            "document database name must contain 1 to 63 UTF-8 bytes and no NUL",
+        ));
+    }
+    let namespace_len = database
+        .len()
+        .checked_add(1)
+        .and_then(|length| length.checked_add(collection.len()))
+        .ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::LimitExceeded,
+                "document namespace length overflowed",
+            )
+        })?;
+    if collection.is_empty()
+        || collection.contains('\0')
+        || namespace_len > MAX_DOCUMENT_NAMESPACE_BYTES
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            "document namespace must contain at most 255 UTF-8 bytes and no NUL",
+        ));
+    }
+    Ok(())
+}

--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -4,12 +4,21 @@
 //! protocol-neutral: the MongoDB listener, embedded document API, and storage
 //! layer all consume the same value and codec rules.
 
+mod catalog;
 mod codec;
 mod error;
 mod key;
 mod number;
 mod value;
 
+pub(crate) use catalog::validate_namespace;
+pub use catalog::{
+    DOCUMENT_CATALOG_VERSION, DOCUMENT_INDEX_FORMAT_VERSION, DOCUMENT_SCHEMA_VERSION,
+    DOCUMENT_STORAGE_FORMAT_VERSION, DocumentCatalog, DocumentCollectionId,
+    DocumentCollectionMetadata, DocumentCollectionOptions, DocumentDatabaseId,
+    DocumentIndexLifecycle, DocumentIndexMetadata, DocumentPlacement,
+    MAX_DOCUMENT_DATABASE_NAME_BYTES, MAX_DOCUMENT_NAMESPACE_BYTES,
+};
 pub use codec::{
     BSON_MAX_DECODED_BYTES, BSON_MAX_DOCUMENT_BYTES, BSON_MAX_NESTING_DEPTH, BsonCodecOptions,
     DuplicateFieldPolicy, decode_document, decode_document_with_options, encode_document,

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -3,6 +3,19 @@
 mod copy;
 mod schema;
 mod staging;
+#[cfg(feature = "tinymongo-import")]
+mod tinymongo;
+
+#[cfg(feature = "tinymongo-import")]
+pub use tinymongo::{
+    MAX_TINYMONGO_IMPORT_BSON_BYTES, MAX_TINYMONGO_IMPORT_COLLECTIONS,
+    MAX_TINYMONGO_IMPORT_DOCUMENTS, MAX_TINYMONGO_IMPORT_INDEX_NAME_BYTES,
+    MAX_TINYMONGO_IMPORT_INDEXES, MAX_TINYMONGO_IMPORT_METADATA_BSON_BYTES,
+    MAX_TINYMONGO_IMPORT_SOURCE_METADATA_BYTES, TINYMONGO_IMPORT_FORMAT_VERSION,
+    TINYMONGO_IMPORT_RECEIPT_VERSION, TinyMongoImportCollection, TinyMongoImportIndex,
+    TinyMongoImportOptions, TinyMongoImportPlan, TinyMongoImportReport, TinyMongoImportSource,
+    TinyMongoSourceVariant, import_tinymongo_database, read_tinymongo_source,
+};
 
 use std::{
     fmt,

--- a/src/import/staging.rs
+++ b/src/import/staging.rs
@@ -250,11 +250,11 @@ fn canonical_source(source: &Path) -> EngineResult<PathBuf> {
             ),
         )
     })?;
-    if !metadata.is_file() {
+    if !metadata.is_file() && !metadata.is_dir() {
         return Err(EngineError::new(
             EngineErrorKind::FailedPrecondition,
             format!(
-                "SQLite import source {} is not a regular file",
+                "SQLite import source {} is neither a regular file nor a directory",
                 source.display()
             ),
         ));
@@ -289,6 +289,12 @@ fn canonical_destination(destination: &Path) -> EngineResult<(PathBuf, PathBuf)>
 }
 
 fn reject_existing_destination(source: &Path, destination: &Path) -> EngineResult<()> {
+    if source.is_dir() && destination.starts_with(source) {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "SQLite import destination must not be inside its source directory",
+        ));
+    }
     match fs::symlink_metadata(destination) {
         Ok(metadata) => {
             let aliases_source = fs::canonicalize(destination)
@@ -298,7 +304,7 @@ fn reject_existing_destination(source: &Path, destination: &Path) -> EngineResul
             if aliases_source {
                 return Err(EngineError::new(
                     EngineErrorKind::FailedPrecondition,
-                    "SQLite import source and destination resolve to the same file",
+                    "SQLite import source and destination resolve to the same path",
                 ));
             }
             let kind = if metadata.file_type().is_symlink() {
@@ -318,7 +324,7 @@ fn reject_existing_destination(source: &Path, destination: &Path) -> EngineResul
             if source == destination {
                 Err(EngineError::new(
                     EngineErrorKind::FailedPrecondition,
-                    "SQLite import source and destination resolve to the same file",
+                    "SQLite import source and destination resolve to the same path",
                 ))
             } else {
                 Ok(())
@@ -904,6 +910,26 @@ mod tests {
             let error = StagingLayout::create(&source, &link).unwrap_err();
             assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
         }
+    }
+
+    #[test]
+    fn rejects_a_destination_inside_a_directory_source() {
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("source.sqlite-sharded");
+        fs::create_dir(&source).unwrap();
+        fs::write(source.join("source-marker"), b"untouched").unwrap();
+
+        let destination = source.join("imported");
+        let error = StagingLayout::create(&source, &destination).unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+        assert!(!destination.exists());
+        assert_eq!(
+            fs::read_dir(&source)
+                .unwrap()
+                .map(|entry| entry.unwrap().file_name())
+                .collect::<Vec<_>>(),
+            [std::ffi::OsString::from("source-marker")]
+        );
     }
 
     #[test]

--- a/src/import/tinymongo.rs
+++ b/src/import/tinymongo.rs
@@ -1,0 +1,4706 @@
+//! Strict, read-only import planning for TinyMongo v1.3 SQLite stores.
+//!
+//! TinyMongo has shipped three unrelated SQLite representations under the
+//! same backend name: a TinyDB-compatible single JSON blob, one SQL table per
+//! collection, and a manifest plus several table-native SQLite shards.  This
+//! reader recognizes those representations only after the caller supplies an
+//! exact logical database name and collection allowlist.  In particular, the
+//! unsharded table-native format has no application id, user version, or
+//! collection catalog, so discovering document collections from arbitrary SQL
+//! tables would be unsafe.
+
+use std::{
+    collections::{BTreeMap, BTreeSet, HashSet},
+    fmt, fs,
+    fs::OpenOptions,
+    io::{BufWriter, Read, Write},
+    path::{Path, PathBuf},
+};
+
+use rusqlite::{Connection, OpenFlags, OptionalExtension, limits::Limit, types::ValueRef};
+use serde_json::{Map as JsonMap, Number as JsonNumber, Value as JsonValue};
+
+use super::{IMPORT_RECEIPT_FILE, MAX_SQLITE_IMPORT_ROW_BYTES, staging::StagingLayout};
+use crate::{
+    core::{CancellationToken, EngineError, EngineErrorKind, EngineResult},
+    document::{
+        BsonBinary, BsonDateTime, BsonDecimal128, BsonDocument, BsonErrorContext, BsonJavaScript,
+        BsonObjectId, BsonRegex, BsonTimestamp, BsonUuid, BsonValue, CanonicalBsonKey,
+        DocumentCollectionOptions, DocumentIndexLifecycle, DocumentPlacement,
+        MAX_DOCUMENT_DATABASE_NAME_BYTES, MAX_DOCUMENT_NAMESPACE_BYTES, UuidRepresentation,
+        encode_document,
+    },
+    sqlite_error,
+    storage::Storage,
+};
+
+/// Frozen source format understood by this reader.
+pub const TINYMONGO_IMPORT_FORMAT_VERSION: u32 = 1;
+/// Durable receipt format written into a published TinyMongo import.
+pub const TINYMONGO_IMPORT_RECEIPT_VERSION: u32 = 1;
+/// Largest explicit collection allowlist accepted by one source plan.
+pub const MAX_TINYMONGO_IMPORT_COLLECTIONS: usize = 4_096;
+/// Largest total target index catalog, including one built-in index per collection.
+pub const MAX_TINYMONGO_IMPORT_INDEXES: usize = 65_536;
+/// Maximum UTF-8 byte length accepted for one custom index name.
+pub const MAX_TINYMONGO_IMPORT_INDEX_NAME_BYTES: usize = 255;
+/// Maximum documents retained by this source-only planning API.
+pub const MAX_TINYMONGO_IMPORT_DOCUMENTS: usize = 1_000_000;
+/// Maximum encoded BSON retained by this source-only planning API.
+pub const MAX_TINYMONGO_IMPORT_BSON_BYTES: usize = 512 * 1024 * 1024;
+/// Maximum aggregate BSON retained for destination catalog metadata.
+pub const MAX_TINYMONGO_IMPORT_METADATA_BSON_BYTES: usize = 64 * 1024 * 1024;
+/// Maximum aggregate physical-ID and order-token bytes retained during preflight.
+pub const MAX_TINYMONGO_IMPORT_SOURCE_METADATA_BYTES: usize = 512 * 1024 * 1024;
+
+const TYPE_MARKER: &str = "__tinymongo_type_v1__";
+const VALUE_MARKER: &str = "value";
+const LEGACY_BLOB_TABLE: &str = "tinydb";
+const INDEX_CATALOG_TABLE: &str = "__tinymongo_indexes";
+const SHARD_CONFIG_TABLE: &str = "__tinymongo_config";
+const SHARD_COLLECTION_TABLE: &str = "__tinymongo_collections";
+const SHARD_IDENTITY_TABLE: &str = "__tinymongo_shard";
+const SHARD_ORDER_COLUMN: &str = "__tinymongo_order";
+const SHARDED_FORMAT_VERSION: i64 = 1;
+const SHARDED_HASH_ALGORITHM: &str = "physical-id-sha256-mod-v1";
+const MIN_SHARD_COUNT: usize = 2;
+const MAX_SHARD_COUNT: usize = 64;
+const PHYSICAL_ID_PREFIX: &str = "__tinymongo_id_v2__:";
+const MAX_TINYMONGO_SOURCE_TABLES: usize = MAX_TINYMONGO_IMPORT_COLLECTIONS + 3;
+
+/// Exact TinyMongo SQLite representation found at the source path.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TinyMongoSourceVariant {
+    /// Historical TinyDB root stored as JSON in `tinydb(id, data)` row 1.
+    LegacySingleRow,
+    /// One ordinary SQLite table per collection.
+    TableNative,
+    /// Version-one manifest and two to sixty-four table-native shards.
+    ShardedV1,
+}
+
+/// Explicit declaration of the TinyMongo database and collections to read.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TinyMongoImportPlan {
+    database_name: String,
+    collections: Box<[String]>,
+}
+
+impl TinyMongoImportPlan {
+    /// Construct a plan without inferring collection names from SQLite tables.
+    pub fn new<I, S>(database_name: impl Into<String>, collections: I) -> EngineResult<Self>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let database_name = database_name.into();
+        validate_database_name(&database_name)?;
+        let mut unique = BTreeSet::new();
+        for collection in collections {
+            let collection = collection.into();
+            validate_collection_name(&database_name, &collection)?;
+            if !unique.insert(collection.clone()) {
+                return Err(invalid_argument(format!(
+                    "TinyMongo import collection allowlist contains duplicate {collection:?}"
+                )));
+            }
+            if unique.len() > MAX_TINYMONGO_IMPORT_COLLECTIONS {
+                return Err(EngineError::new(
+                    EngineErrorKind::LimitExceeded,
+                    format!(
+                        "TinyMongo import collection allowlist exceeds {MAX_TINYMONGO_IMPORT_COLLECTIONS} entries"
+                    ),
+                ));
+            }
+        }
+        if unique.is_empty() {
+            return Err(invalid_argument(
+                "TinyMongo import requires at least one explicitly allowlisted collection",
+            ));
+        }
+        Ok(Self {
+            database_name,
+            collections: unique.into_iter().collect::<Vec<_>>().into_boxed_slice(),
+        })
+    }
+
+    /// Logical database name assigned to every imported collection.
+    pub fn database_name(&self) -> &str {
+        &self.database_name
+    }
+
+    /// Exact, sorted allowlist; no other physical table is interpreted as data.
+    pub fn collections(&self) -> &[String] {
+        &self.collections
+    }
+}
+
+/// Runtime controls for one atomic TinyMongo import.
+#[derive(Clone)]
+pub struct TinyMongoImportOptions {
+    shard_count: u16,
+    cancellation: CancellationToken,
+}
+
+impl TinyMongoImportOptions {
+    /// Create options for a new destination with a fixed shard count.
+    pub fn new(shard_count: u16) -> EngineResult<Self> {
+        crate::storage::validate_shard_count(shard_count)?;
+        Ok(Self {
+            shard_count,
+            cancellation: CancellationToken::new(),
+        })
+    }
+
+    /// Replace the sticky signal checked throughout preflight and staging.
+    #[must_use]
+    pub fn with_cancellation_token(mut self, cancellation: CancellationToken) -> Self {
+        self.cancellation = cancellation;
+        self
+    }
+
+    /// Return the destination's fixed physical shard count.
+    pub const fn shard_count(&self) -> u16 {
+        self.shard_count
+    }
+
+    /// Return a clone of the import cancellation signal.
+    pub fn cancellation_token(&self) -> CancellationToken {
+        self.cancellation.clone()
+    }
+}
+
+impl fmt::Debug for TinyMongoImportOptions {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("TinyMongoImportOptions")
+            .field("shard_count", &self.shard_count)
+            .field("cancelled", &self.cancellation.is_cancelled())
+            .finish()
+    }
+}
+
+/// One validated user-created TinyMongo index declaration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TinyMongoImportIndex {
+    name: String,
+    specification: BsonDocument,
+    unique: bool,
+    source_pending: bool,
+}
+
+impl TinyMongoImportIndex {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Ordered version-two TinyMongo metadata (`v`, `name`, `key`, options).
+    pub const fn specification(&self) -> &BsonDocument {
+        &self.specification
+    }
+
+    pub const fn is_unique(&self) -> bool {
+        self.unique
+    }
+
+    /// A source manifest may contain an interrupted, recoverable index build.
+    pub const fn was_pending_in_source(&self) -> bool {
+        self.source_pending
+    }
+
+    /// Source physical expression indexes are never authoritative in BriskDB.
+    pub const fn target_lifecycle(&self) -> DocumentIndexLifecycle {
+        DocumentIndexLifecycle::PendingBuild
+    }
+}
+
+/// Documents and logical index declarations for one allowlisted collection.
+#[derive(Debug, Clone)]
+pub struct TinyMongoImportCollection {
+    name: String,
+    documents: Box<[BsonDocument]>,
+    indexes: Box<[TinyMongoImportIndex]>,
+}
+
+impl TinyMongoImportCollection {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn documents(&self) -> &[BsonDocument] {
+        &self.documents
+    }
+
+    pub fn indexes(&self) -> &[TinyMongoImportIndex] {
+        &self.indexes
+    }
+}
+
+/// Fully validated, source-only import material.
+#[derive(Debug, Clone)]
+pub struct TinyMongoImportSource {
+    variant: TinyMongoSourceVariant,
+    database_name: String,
+    source_path: PathBuf,
+    source_shards: usize,
+    legacy_physical_ids: u64,
+    encoded_bson_bytes: u64,
+    collections: Box<[TinyMongoImportCollection]>,
+}
+
+impl TinyMongoImportSource {
+    pub const fn variant(&self) -> TinyMongoSourceVariant {
+        self.variant
+    }
+
+    pub fn database_name(&self) -> &str {
+        &self.database_name
+    }
+
+    pub fn source_path(&self) -> &Path {
+        &self.source_path
+    }
+
+    pub const fn source_shards(&self) -> usize {
+        self.source_shards
+    }
+
+    pub const fn legacy_physical_ids(&self) -> u64 {
+        self.legacy_physical_ids
+    }
+
+    pub const fn encoded_bson_bytes(&self) -> u64 {
+        self.encoded_bson_bytes
+    }
+
+    pub fn collections(&self) -> &[TinyMongoImportCollection] {
+        &self.collections
+    }
+
+    pub fn report(&self) -> TinyMongoImportReport {
+        TinyMongoImportReport {
+            receipt_version: TINYMONGO_IMPORT_RECEIPT_VERSION,
+            target_shards: None,
+            variant: self.variant,
+            collections: self.collections.len() as u64,
+            documents: self
+                .collections
+                .iter()
+                .map(|collection| collection.documents.len() as u64)
+                .sum(),
+            custom_indexes: self
+                .collections
+                .iter()
+                .map(|collection| collection.indexes.len() as u64)
+                .sum(),
+            source_shards: self.source_shards as u64,
+            legacy_physical_ids: self.legacy_physical_ids,
+            encoded_bson_bytes: self.encoded_bson_bytes,
+        }
+    }
+}
+
+/// Bounded counts suitable for a reviewed destination-staging plan.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TinyMongoImportReport {
+    receipt_version: u32,
+    target_shards: Option<u16>,
+    variant: TinyMongoSourceVariant,
+    collections: u64,
+    documents: u64,
+    custom_indexes: u64,
+    source_shards: u64,
+    legacy_physical_ids: u64,
+    encoded_bson_bytes: u64,
+}
+
+impl TinyMongoImportReport {
+    pub const fn receipt_version(self) -> u32 {
+        self.receipt_version
+    }
+    /// Destination shard count after publication; absent on source preflight.
+    pub const fn target_shards(self) -> Option<u16> {
+        self.target_shards
+    }
+    pub const fn variant(self) -> TinyMongoSourceVariant {
+        self.variant
+    }
+    pub const fn collections(self) -> u64 {
+        self.collections
+    }
+    pub const fn documents(self) -> u64 {
+        self.documents
+    }
+    pub const fn custom_indexes(self) -> u64 {
+        self.custom_indexes
+    }
+    pub const fn source_shards(self) -> u64 {
+        self.source_shards
+    }
+    pub const fn legacy_physical_ids(self) -> u64 {
+        self.legacy_physical_ids
+    }
+    pub const fn encoded_bson_bytes(self) -> u64 {
+        self.encoded_bson_bytes
+    }
+}
+
+/// Read and validate one offline TinyMongo v1.3 SQLite source.
+///
+/// This operation never creates, migrates, checkpoints, or repairs the source.
+/// Destination staging and atomic catalog publication intentionally live at a
+/// later storage boundary.
+pub fn read_tinymongo_source(
+    path: impl AsRef<Path>,
+    plan: &TinyMongoImportPlan,
+) -> EngineResult<TinyMongoImportSource> {
+    read_tinymongo_source_with_cancellation(path.as_ref(), plan, &CancellationToken::new())
+}
+
+fn read_tinymongo_source_with_cancellation(
+    path: &Path,
+    plan: &TinyMongoImportPlan,
+    cancellation: &CancellationToken,
+) -> EngineResult<TinyMongoImportSource> {
+    ensure_import_not_cancelled(cancellation)?;
+    let metadata = fs::symlink_metadata(path).map_err(|error| {
+        crate::sqlite_error::storage_io(
+            error,
+            format!("TinyMongo import source is unavailable: {}", path.display()),
+        )
+    })?;
+    if metadata.file_type().is_symlink() {
+        return Err(failed_precondition(
+            "TinyMongo import source must not be a symbolic link",
+        ));
+    }
+    let source = if metadata.is_file() {
+        read_single_file(path, plan, cancellation)
+    } else if metadata.is_dir() {
+        read_sharded(path, plan, cancellation)
+    } else {
+        Err(failed_precondition(
+            "TinyMongo import source must be a regular SQLite file or sharded directory",
+        ))
+    }?;
+    ensure_import_not_cancelled(cancellation)?;
+    validate_target_catalog_budget(&source)?;
+    Ok(source)
+}
+
+/// Validate a TinyMongo source, build a private BriskDB layout, verify it by
+/// ordinary reopen, and atomically publish the absent destination.
+pub fn import_tinymongo_database(
+    source: impl AsRef<Path>,
+    destination: impl AsRef<Path>,
+    plan: &TinyMongoImportPlan,
+    options: TinyMongoImportOptions,
+) -> EngineResult<TinyMongoImportReport> {
+    import_tinymongo_database_inner(
+        source.as_ref(),
+        destination.as_ref(),
+        plan,
+        options,
+        TinyMongoImportFault::None,
+    )
+}
+
+#[derive(Debug, Clone, Copy)]
+enum TinyMongoImportFault {
+    None,
+    #[cfg(test)]
+    FailAfterDocuments(usize),
+}
+
+impl TinyMongoImportFault {
+    fn requires_per_document_insertion(self) -> bool {
+        #[cfg(test)]
+        {
+            matches!(self, Self::FailAfterDocuments(_))
+        }
+        #[cfg(not(test))]
+        {
+            let _ = self;
+            false
+        }
+    }
+
+    fn after_document(self, inserted: usize) -> EngineResult<()> {
+        #[cfg(test)]
+        if matches!(self, Self::FailAfterDocuments(expected) if expected == inserted) {
+            return Err(EngineError::new(
+                EngineErrorKind::Internal,
+                format!("injected TinyMongo import failure after {inserted} documents"),
+            ));
+        }
+        #[cfg(not(test))]
+        let _ = (self, inserted);
+        Ok(())
+    }
+}
+
+fn import_tinymongo_database_inner(
+    source_path: &Path,
+    destination: &Path,
+    plan: &TinyMongoImportPlan,
+    options: TinyMongoImportOptions,
+    fault: TinyMongoImportFault,
+) -> EngineResult<TinyMongoImportReport> {
+    let cancellation = options.cancellation_token();
+    ensure_import_not_cancelled(&cancellation)?;
+
+    // This retained snapshot is also the complete preflight boundary. No
+    // destination path exists until every source file, catalog, document, ID,
+    // and index declaration has passed validation.
+    let source = read_tinymongo_source_with_cancellation(source_path, plan, &cancellation)?;
+    ensure_import_not_cancelled(&cancellation)?;
+
+    let mut staging = StagingLayout::create(source_path, destination)?;
+    let storage = Storage::open(staging.path(), options.shard_count())?;
+    let mut inserted = 0_usize;
+    for collection in source.collections() {
+        ensure_import_not_cancelled(&cancellation)?;
+        let metadata = storage.create_document_collection(
+            source.database_name(),
+            collection.name(),
+            &DocumentCollectionOptions::empty(),
+        )?;
+        if fault.requires_per_document_insertion() {
+            for document in collection.documents() {
+                ensure_import_not_cancelled(&cancellation)?;
+                storage.insert_document(metadata.id(), document)?;
+                inserted = inserted.checked_add(1).ok_or_else(|| {
+                    EngineError::new(
+                        EngineErrorKind::LimitExceeded,
+                        "TinyMongo destination document count overflowed",
+                    )
+                })?;
+                fault.after_document(inserted)?;
+            }
+        } else {
+            storage.insert_documents(metadata.id(), collection.documents(), &cancellation)?;
+            inserted = inserted
+                .checked_add(collection.documents().len())
+                .ok_or_else(|| {
+                    EngineError::new(
+                        EngineErrorKind::LimitExceeded,
+                        "TinyMongo destination document count overflowed",
+                    )
+                })?;
+        }
+        for index in collection.indexes() {
+            ensure_import_not_cancelled(&cancellation)?;
+            storage.declare_document_index(
+                metadata.id(),
+                index.name(),
+                index.specification(),
+                index.is_unique(),
+            )?;
+        }
+    }
+    drop(storage);
+
+    // Exercise startup validation and independently compare the catalog and
+    // exact BSON representation of every record before publication.
+    let reopened = Storage::open(staging.path(), options.shard_count())?;
+    verify_imported_destination(&source, &reopened)?;
+    drop(reopened);
+    ensure_import_not_cancelled(&cancellation)?;
+
+    let mut report = source.report();
+    report.target_shards = Some(options.shard_count());
+    write_tinymongo_receipt(staging.path(), &source, &report)?;
+    staging.sync_layout(options.shard_count(), &cancellation)?;
+    staging.publish(&cancellation)?;
+    Ok(report)
+}
+
+fn validate_target_catalog_budget(source: &TinyMongoImportSource) -> EngineResult<()> {
+    let custom_indexes = source
+        .collections()
+        .iter()
+        .try_fold(0_usize, |total, collection| {
+            total.checked_add(collection.indexes().len())
+        })
+        .ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::LimitExceeded,
+                "TinyMongo target index count overflowed",
+            )
+        })?;
+    let target_indexes = custom_indexes
+        .checked_add(source.collections().len())
+        .ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::LimitExceeded,
+                "TinyMongo target index count overflowed",
+            )
+        })?;
+    if target_indexes > MAX_TINYMONGO_IMPORT_INDEXES {
+        return Err(EngineError::new(
+            EngineErrorKind::LimitExceeded,
+            format!(
+                "TinyMongo target catalog exceeds {MAX_TINYMONGO_IMPORT_INDEXES} total indexes"
+            ),
+        ));
+    }
+
+    let empty_options = encode_document(&BsonDocument::new())
+        .map_err(|error| error.into_engine_error(BsonErrorContext::StoredData))?;
+    let id_key = BsonDocument::from_entries([("_id", BsonValue::Int32(1))])
+        .map_err(|error| error.into_engine_error(BsonErrorContext::StoredData))?;
+    let id_specification = BsonDocument::from_entries([
+        ("v", BsonValue::Int32(2)),
+        ("name", BsonValue::String("_id_".to_owned())),
+        ("key", BsonValue::Document(id_key)),
+        ("unique", BsonValue::Boolean(true)),
+    ])
+    .map_err(|error| error.into_engine_error(BsonErrorContext::StoredData))?;
+    let id_specification = encode_document(&id_specification)
+        .map_err(|error| error.into_engine_error(BsonErrorContext::StoredData))?;
+
+    let mut metadata_bytes = 0_usize;
+    for collection in source.collections() {
+        metadata_bytes = metadata_bytes
+            .checked_add(empty_options.len())
+            .and_then(|total| total.checked_add(id_specification.len()))
+            .ok_or_else(|| {
+                EngineError::new(
+                    EngineErrorKind::LimitExceeded,
+                    "TinyMongo target metadata BSON size overflowed",
+                )
+            })?;
+        for index in collection.indexes() {
+            let bytes = encode_document(index.specification())
+                .map_err(|error| error.into_engine_error(BsonErrorContext::StoredData))?;
+            metadata_bytes = metadata_bytes.checked_add(bytes.len()).ok_or_else(|| {
+                EngineError::new(
+                    EngineErrorKind::LimitExceeded,
+                    "TinyMongo target metadata BSON size overflowed",
+                )
+            })?;
+        }
+        if metadata_bytes > MAX_TINYMONGO_IMPORT_METADATA_BSON_BYTES {
+            return Err(EngineError::new(
+                EngineErrorKind::LimitExceeded,
+                format!(
+                    "TinyMongo target catalog exceeds {MAX_TINYMONGO_IMPORT_METADATA_BSON_BYTES} metadata BSON bytes"
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn verify_imported_destination(
+    source: &TinyMongoImportSource,
+    storage: &Storage,
+) -> EngineResult<()> {
+    let catalog = storage.document_catalog()?;
+    if catalog.collections().len() != source.collections().len() {
+        return Err(data_corruption(
+            "reopened TinyMongo import catalog has an unexpected collection count",
+        ));
+    }
+    let mut verified_bytes = 0_u64;
+    for collection in source.collections() {
+        let metadata = catalog
+            .collection(source.database_name(), collection.name())
+            .ok_or_else(|| {
+                data_corruption(format!(
+                    "reopened TinyMongo import lost collection {:?}",
+                    collection.name()
+                ))
+            })?;
+        if metadata.placement() != DocumentPlacement::HashByIdV1
+            || !metadata.options().document().is_empty()
+            || metadata.indexes().len() != collection.indexes().len() + 1
+        {
+            return Err(data_corruption(format!(
+                "reopened TinyMongo collection {:?} has unexpected catalog metadata",
+                collection.name()
+            )));
+        }
+        let built_in = metadata
+            .indexes()
+            .iter()
+            .filter(|index| index.is_built_in())
+            .collect::<Vec<_>>();
+        if built_in.len() != 1
+            || built_in[0].name() != "_id_"
+            || !built_in[0].is_unique()
+            || built_in[0].lifecycle() != DocumentIndexLifecycle::Ready
+        {
+            return Err(data_corruption(format!(
+                "reopened TinyMongo collection {:?} has invalid built-in _id metadata",
+                collection.name()
+            )));
+        }
+        for expected in collection.indexes() {
+            let actual = metadata
+                .indexes()
+                .iter()
+                .find(|index| index.name() == expected.name())
+                .ok_or_else(|| {
+                    data_corruption(format!(
+                        "reopened TinyMongo collection {:?} lost index {:?}",
+                        collection.name(),
+                        expected.name()
+                    ))
+                })?;
+            if actual.is_built_in()
+                || actual.is_unique() != expected.is_unique()
+                || actual.lifecycle() != DocumentIndexLifecycle::PendingBuild
+                || !actual
+                    .specification()
+                    .representation_eq(expected.specification())
+            {
+                return Err(data_corruption(format!(
+                    "reopened TinyMongo index {:?} changed its declaration",
+                    expected.name()
+                )));
+            }
+        }
+
+        let expected_documents = document_representation_map(collection.documents())?;
+        let restored_in_order = storage.scan_documents(metadata.id())?;
+        if restored_in_order.len() != collection.documents().len() {
+            return Err(data_corruption(format!(
+                "reopened TinyMongo collection {:?} has an unexpected ordered document count",
+                collection.name()
+            )));
+        }
+        for (actual, expected) in restored_in_order.iter().zip(collection.documents().iter()) {
+            if encode_document(actual)
+                .map_err(|error| error.into_engine_error(BsonErrorContext::StoredData))?
+                != encode_document(expected)
+                    .map_err(|error| error.into_engine_error(BsonErrorContext::StoredData))?
+            {
+                return Err(data_corruption(format!(
+                    "reopened TinyMongo collection {:?} changed natural document order",
+                    collection.name()
+                )));
+            }
+        }
+        for expected in collection.documents() {
+            let identifier = expected
+                .get_unique("_id")
+                .map_err(|error| error.into_engine_error(BsonErrorContext::StoredData))?
+                .ok_or_else(|| data_corruption("verified TinyMongo document has no _id"))?;
+            let restored = storage
+                .get_document(metadata.id(), identifier)?
+                .ok_or_else(|| {
+                    data_corruption(format!(
+                        "reopened TinyMongo collection {:?} lost a routed document",
+                        collection.name()
+                    ))
+                })?;
+            if encode_document(&restored)
+                .map_err(|error| error.into_engine_error(BsonErrorContext::StoredData))?
+                != encode_document(expected)
+                    .map_err(|error| error.into_engine_error(BsonErrorContext::StoredData))?
+            {
+                return Err(data_corruption(format!(
+                    "reopened TinyMongo collection {:?} changed a routed document",
+                    collection.name()
+                )));
+            }
+        }
+        if storage.document_count(metadata.id())?
+            != u64::try_from(expected_documents.len()).expect("bounded import count fits u64")
+        {
+            return Err(data_corruption(format!(
+                "reopened TinyMongo collection {:?} has an unexpected document count",
+                collection.name()
+            )));
+        }
+        verified_bytes = verified_bytes
+            .checked_add(
+                expected_documents
+                    .values()
+                    .try_fold(0_u64, |total, document| {
+                        total.checked_add(document.len() as u64)
+                    })
+                    .ok_or_else(|| {
+                        EngineError::new(
+                            EngineErrorKind::LimitExceeded,
+                            "verified TinyMongo BSON byte count overflowed",
+                        )
+                    })?,
+            )
+            .ok_or_else(|| {
+                EngineError::new(
+                    EngineErrorKind::LimitExceeded,
+                    "verified TinyMongo BSON byte count overflowed",
+                )
+            })?;
+    }
+    if verified_bytes != source.encoded_bson_bytes() {
+        return Err(data_corruption(
+            "reopened TinyMongo import has an unexpected encoded BSON byte count",
+        ));
+    }
+    Ok(())
+}
+
+fn document_representation_map(
+    documents: &[BsonDocument],
+) -> EngineResult<BTreeMap<Vec<u8>, Vec<u8>>> {
+    let mut result = BTreeMap::new();
+    for document in documents {
+        let identifier = document
+            .get_unique("_id")
+            .map_err(|error| {
+                error.into_engine_error(crate::document::BsonErrorContext::StoredData)
+            })?
+            .ok_or_else(|| data_corruption("verified TinyMongo document has no _id"))?;
+        let key = CanonicalBsonKey::encode(identifier).map_err(|error| {
+            error.into_engine_error(crate::document::BsonErrorContext::StoredData)
+        })?;
+        let encoded = encode_document(document).map_err(|error| {
+            error.into_engine_error(crate::document::BsonErrorContext::StoredData)
+        })?;
+        if result.insert(key.into_bytes(), encoded).is_some() {
+            return Err(data_corruption(
+                "verified TinyMongo document set has duplicate semantic IDs",
+            ));
+        }
+    }
+    Ok(result)
+}
+
+fn write_tinymongo_receipt(
+    root: &Path,
+    source: &TinyMongoImportSource,
+    report: &TinyMongoImportReport,
+) -> EngineResult<()> {
+    let path = root.join(IMPORT_RECEIPT_FILE);
+    let file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .map_err(|error| {
+            sqlite_error::storage_io(
+                error,
+                format!(
+                    "failed to create TinyMongo import receipt {}",
+                    path.display()
+                ),
+            )
+        })?;
+    let variant = match report.variant() {
+        TinyMongoSourceVariant::LegacySingleRow => "legacy_single_row",
+        TinyMongoSourceVariant::TableNative => "table_native",
+        TinyMongoSourceVariant::ShardedV1 => "sharded_v1",
+    };
+    let collections = source
+        .collections()
+        .iter()
+        .map(|collection| {
+            serde_json::json!({
+                "name": collection.name(),
+                "documents": collection.documents().len(),
+                "custom_indexes": collection.indexes().len(),
+            })
+        })
+        .collect::<Vec<_>>();
+    let receipt = serde_json::json!({
+        "receipt_version": report.receipt_version(),
+        "source_format_version": TINYMONGO_IMPORT_FORMAT_VERSION,
+        "source_variant": variant,
+        "database_name": source.database_name(),
+        "target_shards": report.target_shards(),
+        "source_shards": report.source_shards(),
+        "collections": collections,
+        "documents": report.documents(),
+        "custom_indexes": report.custom_indexes(),
+        "legacy_physical_ids": report.legacy_physical_ids(),
+        "encoded_bson_bytes": report.encoded_bson_bytes(),
+    });
+    let bytes = serde_json::to_vec_pretty(&receipt).map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::Internal,
+            "failed to encode TinyMongo import receipt",
+            error,
+        )
+    })?;
+    let mut writer = BufWriter::new(file);
+    writer.write_all(&bytes).map_err(|error| {
+        sqlite_error::storage_io(error, "failed to write TinyMongo import receipt")
+    })?;
+    writer.write_all(b"\n").map_err(|error| {
+        sqlite_error::storage_io(error, "failed to finish TinyMongo import receipt")
+    })?;
+    writer.flush().map_err(|error| {
+        sqlite_error::storage_io(error, "failed to flush TinyMongo import receipt")
+    })?;
+    writer.get_ref().sync_all().map_err(|error| {
+        sqlite_error::storage_io(error, "failed to synchronize TinyMongo import receipt")
+    })
+}
+
+fn ensure_import_not_cancelled(cancellation: &CancellationToken) -> EngineResult<()> {
+    if cancellation.is_cancelled() {
+        Err(EngineError::new(
+            EngineErrorKind::Cancelled,
+            "TinyMongo import was cancelled before publication",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LogicalIndex {
+    name: String,
+    keys: Vec<(String, i32)>,
+    unique: bool,
+    sparse: bool,
+    partial_filter: Option<BsonDocument>,
+    source_pending: bool,
+}
+
+#[derive(Debug)]
+struct PendingDocument {
+    document: BsonDocument,
+    retained_bson_bytes: usize,
+    physical_id: Option<String>,
+    order_token: Option<String>,
+    source_shard: usize,
+    rowid: i64,
+}
+
+#[derive(Default)]
+struct RetainedBudget {
+    documents: usize,
+    bson_bytes: usize,
+    source_metadata_bytes: usize,
+}
+
+impl RetainedBudget {
+    fn retain(&mut self, document: &BsonDocument) -> EngineResult<usize> {
+        let bytes = encode_document(document).map_err(|error| {
+            error.into_engine_error(crate::document::BsonErrorContext::StoredData)
+        })?;
+        self.documents = self.documents.checked_add(1).ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::LimitExceeded,
+                "TinyMongo import document count overflowed",
+            )
+        })?;
+        self.bson_bytes = self.bson_bytes.checked_add(bytes.len()).ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::LimitExceeded,
+                "TinyMongo import retained BSON size overflowed",
+            )
+        })?;
+        if self.documents > MAX_TINYMONGO_IMPORT_DOCUMENTS {
+            return Err(EngineError::new(
+                EngineErrorKind::LimitExceeded,
+                format!(
+                    "TinyMongo source exceeds {MAX_TINYMONGO_IMPORT_DOCUMENTS} retained documents"
+                ),
+            ));
+        }
+        if self.bson_bytes > MAX_TINYMONGO_IMPORT_BSON_BYTES {
+            return Err(EngineError::new(
+                EngineErrorKind::LimitExceeded,
+                format!(
+                    "TinyMongo source exceeds {MAX_TINYMONGO_IMPORT_BSON_BYTES} retained BSON bytes"
+                ),
+            ));
+        }
+        Ok(bytes.len())
+    }
+
+    fn replace_document_size(
+        &mut self,
+        previous_bytes: usize,
+        document: &BsonDocument,
+    ) -> EngineResult<()> {
+        let bytes = encode_document(document).map_err(|error| {
+            error.into_engine_error(crate::document::BsonErrorContext::StoredData)
+        })?;
+        let without_previous = self.bson_bytes.checked_sub(previous_bytes).ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::Internal,
+                "TinyMongo retained BSON accounting underflowed",
+            )
+        })?;
+        let replacement_total = without_previous.checked_add(bytes.len()).ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::LimitExceeded,
+                "TinyMongo import retained BSON size overflowed",
+            )
+        })?;
+        if replacement_total > MAX_TINYMONGO_IMPORT_BSON_BYTES {
+            return Err(EngineError::new(
+                EngineErrorKind::LimitExceeded,
+                format!(
+                    "TinyMongo source exceeds {MAX_TINYMONGO_IMPORT_BSON_BYTES} retained BSON bytes"
+                ),
+            ));
+        }
+        self.bson_bytes = replacement_total;
+        Ok(())
+    }
+
+    fn retain_source_metadata(
+        &mut self,
+        lengths: impl IntoIterator<Item = usize>,
+    ) -> EngineResult<()> {
+        for length in lengths {
+            self.source_metadata_bytes = self
+                .source_metadata_bytes
+                .checked_add(length)
+                .ok_or_else(|| {
+                    EngineError::new(
+                        EngineErrorKind::LimitExceeded,
+                        "TinyMongo retained source metadata size overflowed",
+                    )
+                })?;
+        }
+        if self.source_metadata_bytes > MAX_TINYMONGO_IMPORT_SOURCE_METADATA_BYTES {
+            return Err(EngineError::new(
+                EngineErrorKind::LimitExceeded,
+                format!(
+                    "TinyMongo source exceeds {MAX_TINYMONGO_IMPORT_SOURCE_METADATA_BYTES} retained physical metadata bytes"
+                ),
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn read_single_file(
+    path: &Path,
+    plan: &TinyMongoImportPlan,
+    cancellation: &CancellationToken,
+) -> EngineResult<TinyMongoImportSource> {
+    let connection = open_source(path, cancellation)?;
+    let tables = ordinary_tables(&connection)?;
+    let legacy =
+        tables.iter().any(|name| name == LEGACY_BLOB_TABLE) && is_legacy_blob_schema(&connection)?;
+    if legacy {
+        let unexpected: Vec<_> = tables
+            .iter()
+            .filter(|name| name.as_str() != LEGACY_BLOB_TABLE)
+            .cloned()
+            .collect();
+        if !unexpected.is_empty() {
+            return Err(data_corruption(format!(
+                "TinyMongo SQLite source mixes legacy tinydb storage with table-native tables: {unexpected:?}"
+            )));
+        }
+        read_legacy_blob(path, plan, &connection, cancellation)
+    } else {
+        read_table_native(path, plan, &connection, cancellation)
+    }
+}
+
+fn read_legacy_blob(
+    path: &Path,
+    plan: &TinyMongoImportPlan,
+    connection: &Connection,
+    cancellation: &CancellationToken,
+) -> EngineResult<TinyMongoImportSource> {
+    ensure_import_not_cancelled(cancellation)?;
+    validate_legacy_blob_schema(connection)?;
+    let mut statement = connection
+        .prepare("SELECT id, data FROM tinydb ORDER BY id")
+        .map_err(sqlite_error::storage)?;
+    let mut rows = statement.query([]).map_err(sqlite_error::storage)?;
+    let Some(row) = rows.next().map_err(sqlite_error::storage)? else {
+        return Err(data_corruption(
+            "TinyMongo legacy tinydb table has no row 1",
+        ));
+    };
+    let id = row.get::<_, i64>(0).map_err(sqlite_error::storage)?;
+    let payload = text_column(
+        row.get_ref(1).map_err(sqlite_error::storage)?,
+        "tinydb.data",
+    )?
+    .to_owned();
+    if id != 1 {
+        return Err(data_corruption(
+            "TinyMongo legacy tinydb table does not begin with row id 1",
+        ));
+    }
+    if rows.next().map_err(sqlite_error::storage)?.is_some() {
+        return Err(data_corruption(
+            "TinyMongo legacy tinydb table contains unexpected rows besides id 1",
+        ));
+    }
+    drop(rows);
+    drop(statement);
+
+    let root = parse_json(&payload, "legacy tinydb row 1")?;
+    let root = json_object(&root, "TinyMongo legacy root")?;
+    let logical_indexes = parse_legacy_index_catalog(root, cancellation)?;
+    let mut budget = RetainedBudget::default();
+    let mut collections = Vec::with_capacity(plan.collections.len());
+    for name in plan.collections.iter() {
+        ensure_import_not_cancelled(cancellation)?;
+        let raw_collection = root.get(name).ok_or_else(|| {
+            data_corruption(format!(
+                "allowlisted TinyMongo collection {name:?} is absent from the legacy root"
+            ))
+        })?;
+        let raw_documents = json_object(raw_collection, "TinyMongo legacy collection")?;
+        let mut documents = Vec::with_capacity(raw_documents.len());
+        let mut identities = HashSet::new();
+        for (entry_id, value) in raw_documents {
+            ensure_import_not_cancelled(cancellation)?;
+            let document = json_document(
+                value,
+                &format!("legacy collection {name:?} entry {entry_id:?}"),
+            )?;
+            validate_document_identity(name, &document, &mut identities)?;
+            let _ = budget.retain(&document)?;
+            documents.push(document);
+        }
+        collections.push(TinyMongoImportCollection {
+            name: name.clone(),
+            documents: documents.into_boxed_slice(),
+            indexes: import_indexes(
+                logical_indexes.get(name).cloned().unwrap_or_default(),
+                cancellation,
+            )?,
+        });
+    }
+    Ok(TinyMongoImportSource {
+        variant: TinyMongoSourceVariant::LegacySingleRow,
+        database_name: plan.database_name.clone(),
+        source_path: path.to_path_buf(),
+        source_shards: 1,
+        legacy_physical_ids: 0,
+        encoded_bson_bytes: budget.bson_bytes as u64,
+        collections: collections.into_boxed_slice(),
+    })
+}
+
+fn read_table_native(
+    path: &Path,
+    plan: &TinyMongoImportPlan,
+    connection: &Connection,
+    cancellation: &CancellationToken,
+) -> EngineResult<TinyMongoImportSource> {
+    if table_exists(connection, LEGACY_BLOB_TABLE)? && is_legacy_blob_schema(connection)? {
+        return Err(data_corruption(
+            "TinyMongo SQLite source contains a legacy blob alongside table-native state",
+        ));
+    }
+    let indexes = read_sql_index_catalog(connection, cancellation)?;
+    let mut budget = RetainedBudget::default();
+    let mut legacy_physical_ids = 0_u64;
+    let mut collections = Vec::with_capacity(plan.collections.len());
+    for name in plan.collections.iter() {
+        ensure_import_not_cancelled(cancellation)?;
+        validate_collection_schema(connection, name, false)?;
+        let pending = read_collection_rows(connection, name, 0, false, &mut budget, cancellation)?;
+        let (documents, legacy) =
+            finish_collection(name, pending, None, &mut budget, cancellation)?;
+        legacy_physical_ids = legacy_physical_ids.saturating_add(legacy);
+        collections.push(TinyMongoImportCollection {
+            name: name.clone(),
+            documents: documents.into_boxed_slice(),
+            indexes: import_indexes(indexes.get(name).cloned().unwrap_or_default(), cancellation)?,
+        });
+    }
+    Ok(TinyMongoImportSource {
+        variant: TinyMongoSourceVariant::TableNative,
+        database_name: plan.database_name.clone(),
+        source_path: path.to_path_buf(),
+        source_shards: 1,
+        legacy_physical_ids,
+        encoded_bson_bytes: budget.bson_bytes as u64,
+        collections: collections.into_boxed_slice(),
+    })
+}
+
+fn read_sharded(
+    path: &Path,
+    plan: &TinyMongoImportPlan,
+    cancellation: &CancellationToken,
+) -> EngineResult<TinyMongoImportSource> {
+    ensure_import_not_cancelled(cancellation)?;
+    let manifest_path = path.join("manifest.sqlite");
+    require_regular_nonsymlink(&manifest_path, "TinyMongo sharded manifest")?;
+    let manifest = open_source(&manifest_path, cancellation)?;
+    require_wal(&manifest_path, "TinyMongo sharded manifest")?;
+    validate_manifest_schema(&manifest)?;
+    let config = read_manifest_config(&manifest)?;
+    validate_shard_tree(path, config.shard_count, cancellation)?;
+    let collection_states = read_manifest_collections(&manifest, cancellation)?;
+    if let Some((name, state)) = collection_states
+        .iter()
+        .find(|(_, state)| *state != "ready")
+    {
+        return Err(failed_precondition(format!(
+            "TinyMongo collection {name:?} has partial manifest state {state:?}; recover it with pinned TinyMongo v1.3 before import"
+        )));
+    }
+    for name in plan.collections.iter() {
+        if !collection_states.contains_key(name) {
+            return Err(data_corruption(format!(
+                "allowlisted TinyMongo collection {name:?} is absent from the sharded manifest"
+            )));
+        }
+    }
+    let manifest_indexes = read_manifest_indexes(&manifest, cancellation)?;
+    if let Some(collection) = manifest_indexes
+        .keys()
+        .find(|collection| !collection_states.contains_key(*collection))
+    {
+        return Err(data_corruption(format!(
+            "TinyMongo sharded manifest has indexes for missing collection {collection:?}"
+        )));
+    }
+    let mut shard_connections = Vec::with_capacity(config.shard_count);
+    for shard in 0..config.shard_count {
+        ensure_import_not_cancelled(cancellation)?;
+        let shard_path = shard_path(path, shard);
+        require_regular_nonsymlink(&shard_path, "TinyMongo shard")?;
+        let connection = open_source(&shard_path, cancellation)?;
+        require_wal(&shard_path, "TinyMongo shard")?;
+        validate_shard_identity(&connection, &config, shard)?;
+        let child_tables = ordinary_tables(&connection)?;
+        let mut expected_tables: BTreeSet<_> = collection_states.keys().cloned().collect();
+        expected_tables.insert(SHARD_IDENTITY_TABLE.to_owned());
+        if table_exists(&connection, INDEX_CATALOG_TABLE)? {
+            expected_tables.insert(INDEX_CATALOG_TABLE.to_owned());
+        }
+        if child_tables.into_iter().collect::<BTreeSet<_>>() != expected_tables {
+            return Err(data_corruption(format!(
+                "TinyMongo shard {shard} has an unexpected table inventory"
+            )));
+        }
+        for name in collection_states.keys() {
+            validate_collection_schema(&connection, name, true)?;
+        }
+        let child_indexes = read_sql_index_catalog(&connection, cancellation)?;
+        if let Some(name) = child_indexes
+            .keys()
+            .find(|name| !collection_states.contains_key(*name))
+        {
+            return Err(data_corruption(format!(
+                "TinyMongo shard {shard} has indexes for undeclared collection {name:?}"
+            )));
+        }
+        for name in collection_states.keys() {
+            let declared = manifest_indexes.get(name).cloned().unwrap_or_default();
+            let actual = child_indexes.get(name).cloned().unwrap_or_default();
+            // Ready declarations must exist identically on every shard. A
+            // pending build may be present on an arbitrary shard prefix after
+            // interruption, but any present copy still has to match exactly.
+            let missing_ready = declared
+                .iter()
+                .filter(|index| !index.source_pending)
+                .any(|expected| !actual.contains(expected));
+            let undeclared_or_changed = actual.iter().any(|found| {
+                !declared
+                    .iter()
+                    .any(|expected| index_specs_equal(found, expected))
+            });
+            if missing_ready || undeclared_or_changed {
+                return Err(data_corruption(format!(
+                    "TinyMongo logical index catalog mismatch for collection {name:?} on shard {shard}"
+                )));
+            }
+        }
+        shard_connections.push(connection);
+    }
+
+    let mut budget = RetainedBudget::default();
+    let mut collections = Vec::with_capacity(plan.collections.len());
+    for name in plan.collections.iter() {
+        ensure_import_not_cancelled(cancellation)?;
+        let mut pending = Vec::new();
+        for (shard, connection) in shard_connections.iter().enumerate() {
+            ensure_import_not_cancelled(cancellation)?;
+            pending.extend(read_collection_rows(
+                connection,
+                name,
+                shard,
+                true,
+                &mut budget,
+                cancellation,
+            )?);
+        }
+        let (documents, legacy) = finish_collection(
+            name,
+            pending,
+            Some(config.shard_count),
+            &mut budget,
+            cancellation,
+        )?;
+        if legacy != 0 {
+            return Err(data_corruption(format!(
+                "TinyMongo sharded collection {name:?} contains legacy physical identifiers"
+            )));
+        }
+        collections.push(TinyMongoImportCollection {
+            name: name.clone(),
+            documents: documents.into_boxed_slice(),
+            indexes: import_indexes(
+                manifest_indexes.get(name).cloned().unwrap_or_default(),
+                cancellation,
+            )?,
+        });
+    }
+    Ok(TinyMongoImportSource {
+        variant: TinyMongoSourceVariant::ShardedV1,
+        database_name: plan.database_name.clone(),
+        source_path: path.to_path_buf(),
+        source_shards: config.shard_count,
+        legacy_physical_ids: 0,
+        encoded_bson_bytes: budget.bson_bytes as u64,
+        collections: collections.into_boxed_slice(),
+    })
+}
+
+fn index_specs_equal(left: &LogicalIndex, right: &LogicalIndex) -> bool {
+    left.name == right.name
+        && left.keys == right.keys
+        && left.unique == right.unique
+        && left.sparse == right.sparse
+        && left.partial_filter == right.partial_filter
+}
+
+fn finish_collection(
+    collection: &str,
+    mut pending: Vec<PendingDocument>,
+    shard_count: Option<usize>,
+    budget: &mut RetainedBudget,
+    cancellation: &CancellationToken,
+) -> EngineResult<(Vec<BsonDocument>, u64)> {
+    if shard_count.is_some() {
+        pending.sort_by(|left, right| {
+            (
+                left.order_token.is_none(),
+                left.order_token.as_deref().unwrap_or(""),
+                left.source_shard,
+                left.rowid,
+            )
+                .cmp(&(
+                    right.order_token.is_none(),
+                    right.order_token.as_deref().unwrap_or(""),
+                    right.source_shard,
+                    right.rowid,
+                ))
+        });
+    }
+    let mut identities = HashSet::new();
+    let mut legacy = 0_u64;
+    let mut order_tokens = HashSet::new();
+    let mut documents = Vec::with_capacity(pending.len());
+    for item in pending {
+        ensure_import_not_cancelled(cancellation)?;
+        let PendingDocument {
+            mut document,
+            retained_bson_bytes,
+            physical_id,
+            order_token,
+            source_shard,
+            rowid: _,
+        } = item;
+        if let Some(physical_id) = physical_id.as_deref() {
+            if physical_id.starts_with(PHYSICAL_ID_PREFIX) {
+                // The frozen v2 digest is SHA-256 over TinyMongo's private
+                // type-specific canonical JSON, including exact Decimal128
+                // rationalization. Reimplementing only part of that encoder
+                // would falsely reject legal IDs. Validate its complete wire
+                // shape and routing here; semantic uniqueness is checked from
+                // logical `_id`, and the destination always rekeys from that
+                // logical value. Consequently this reader does not diagnose a
+                // syntactically valid digest that disagrees with its row's
+                // logical `_id` while still landing on the same source shard.
+                validate_physical_id(physical_id)?;
+                if let Some(count) = shard_count {
+                    let routed = physical_id_route(physical_id, count)?;
+                    if routed != source_shard {
+                        return Err(data_corruption(format!(
+                            "TinyMongo row in collection {collection:?} is stored on shard {} but physical identifier routes to shard {routed}",
+                            source_shard
+                        )));
+                    }
+                }
+            } else {
+                document =
+                    restore_and_validate_legacy_document_id(collection, physical_id, document)?;
+                budget.replace_document_size(retained_bson_bytes, &document)?;
+                legacy = legacy.saturating_add(1);
+            }
+        }
+        validate_document_identity(collection, &document, &mut identities)?;
+        if let Some(token) = order_token.as_deref() {
+            validate_order_token(token)?;
+            if !order_tokens.insert(token.to_owned()) {
+                return Err(data_corruption(format!(
+                    "TinyMongo collection {collection:?} contains duplicate natural-order token"
+                )));
+            }
+        }
+        documents.push(document);
+    }
+    Ok((documents, legacy))
+}
+
+const MAX_LEGACY_PHYSICAL_ID_BYTES: usize = 16 * 1024 * 1024;
+const MAX_LEGACY_LITERAL_VALUES: usize = 1_000_000;
+
+fn restore_and_validate_legacy_document_id(
+    collection: &str,
+    physical_id: &str,
+    document: BsonDocument,
+) -> EngineResult<BsonDocument> {
+    if physical_id.len() > MAX_LEGACY_PHYSICAL_ID_BYTES {
+        return Err(EngineError::new(
+            EngineErrorKind::LimitExceeded,
+            format!(
+                "TinyMongo legacy physical identifier in collection {collection:?} exceeds {MAX_LEGACY_PHYSICAL_ID_BYTES} bytes"
+            ),
+        ));
+    }
+    let logical_id = document
+        .get_unique("_id")
+        .map_err(|error| error.into_engine_error(BsonErrorContext::StoredData))?
+        .ok_or_else(|| {
+            data_corruption(format!(
+                "TinyMongo document in collection {collection:?} has no logical _id"
+            ))
+        })?;
+
+    if matches!(logical_id, BsonValue::Document(_) | BsonValue::Array(_)) {
+        let candidate = LegacyLiteralParser::parse(physical_id).ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::Unsupported,
+                format!(
+                    "TinyMongo legacy container _id in collection {collection:?} cannot be parsed losslessly"
+                ),
+            )
+        })?;
+        if !matches!(candidate, BsonValue::Document(_) | BsonValue::Array(_))
+            || !legacy_id_values_equal(&candidate, logical_id)
+        {
+            return Err(data_corruption(format!(
+                "TinyMongo legacy physical identifier disagrees with logical _id in collection {collection:?}"
+            )));
+        }
+        return replace_document_id(document, candidate);
+    }
+
+    let matches = legacy_scalar_id_matches(physical_id, logical_id)?.ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::Unsupported,
+            format!(
+                "TinyMongo legacy physical identifier for this BSON _id family cannot be validated losslessly in collection {collection:?}"
+            ),
+        )
+    })?;
+    if !matches {
+        return Err(data_corruption(format!(
+            "TinyMongo legacy physical identifier disagrees with logical _id in collection {collection:?}"
+        )));
+    }
+    Ok(document)
+}
+
+fn replace_document_id(
+    document: BsonDocument,
+    replacement: BsonValue,
+) -> EngineResult<BsonDocument> {
+    let mut replacement = Some(replacement);
+    BsonDocument::from_entries(document.into_entries().into_iter().map(|(name, value)| {
+        if name == "_id" {
+            (
+                name,
+                replacement
+                    .take()
+                    .expect("validated document contains one _id"),
+            )
+        } else {
+            (name, value)
+        }
+    }))
+    .map_err(|error| error.into_engine_error(BsonErrorContext::StoredData))
+}
+
+fn legacy_id_values_equal(left: &BsonValue, right: &BsonValue) -> bool {
+    match (left, right) {
+        (BsonValue::Document(left), BsonValue::Document(right)) => {
+            left.len() == right.len()
+                && left.iter().all(|(name, left_value)| {
+                    right
+                        .get_unique(name)
+                        .ok()
+                        .flatten()
+                        .is_some_and(|right_value| legacy_id_values_equal(left_value, right_value))
+                })
+        }
+        (BsonValue::Array(left), BsonValue::Array(right)) => {
+            left.len() == right.len()
+                && left
+                    .iter()
+                    .zip(right)
+                    .all(|(left, right)| legacy_id_values_equal(left, right))
+        }
+        _ => left == right,
+    }
+}
+
+fn legacy_scalar_id_matches(
+    physical_id: &str,
+    logical_id: &BsonValue,
+) -> EngineResult<Option<bool>> {
+    let matches = match logical_id {
+        BsonValue::String(value) => physical_id == value,
+        BsonValue::Boolean(value) => physical_id == if *value { "True" } else { "False" },
+        BsonValue::Null => physical_id == "None",
+        BsonValue::Int32(value) => legacy_integer_id_matches(physical_id, i64::from(*value)),
+        BsonValue::Int64(value) => legacy_integer_id_matches(physical_id, *value),
+        BsonValue::Double(value) => return Ok(legacy_double_id_matches(physical_id, *value)),
+        BsonValue::Binary(value) if value.subtype() == 0 => {
+            legacy_binary_id_matches(physical_id, value)
+        }
+        BsonValue::Uuid(value) => physical_id == format_uuid(value.bytes()).as_str(),
+        BsonValue::ObjectId(value) => physical_id == value.to_hex(),
+        BsonValue::JavaScript(value) if value.scope().is_none() => physical_id == value.code(),
+        BsonValue::JavaScript(_) => return Ok(None),
+        BsonValue::Decimal128(value) => {
+            let rendered = value.to_string();
+            let Some(reparsed) = crate::document::BsonDecimal128::parse(&rendered).ok() else {
+                return Ok(None);
+            };
+            if !reparsed.representation_eq(value) {
+                return Ok(None);
+            }
+            physical_id == rendered
+        }
+        BsonValue::Timestamp(value) => {
+            physical_id == format!("Timestamp({}, {})", value.time(), value.increment())
+        }
+        BsonValue::MinKey => physical_id == "MinKey()",
+        BsonValue::MaxKey => physical_id == "MaxKey()",
+        BsonValue::Binary(_)
+        | BsonValue::DateTime(_)
+        | BsonValue::RegularExpression(_)
+        | BsonValue::Document(_)
+        | BsonValue::Array(_) => return Ok(None),
+    };
+    Ok(Some(matches))
+}
+
+fn legacy_binary_id_matches(physical_id: &str, value: &BsonBinary) -> bool {
+    if let Some(inner) = physical_id
+        .strip_prefix("bytearray(")
+        .and_then(|value| value.strip_suffix(')'))
+    {
+        return inner == canonical_python_bytes(value.bytes());
+    }
+    LegacyLiteralParser::parse(physical_id)
+        .is_some_and(|candidate| candidate == BsonValue::Binary(BsonBinary::new(0, value.bytes())))
+}
+
+fn legacy_integer_id_matches(physical_id: &str, value: i64) -> bool {
+    if physical_id == value.to_string() {
+        return true;
+    }
+    let as_double = value as f64;
+    (as_double.is_finite()
+        && BsonValue::Double(as_double) == BsonValue::Int64(value)
+        && provable_python_float_text(as_double).is_some_and(|rendered| physical_id == rendered))
+        || (value == 0 && physical_id == "-0.0")
+}
+
+fn legacy_double_id_matches(physical_id: &str, value: f64) -> Option<bool> {
+    if value.is_nan() {
+        return Some(physical_id == "nan");
+    }
+    if value == f64::INFINITY {
+        return Some(physical_id == "inf");
+    }
+    if value == f64::NEG_INFINITY {
+        return Some(physical_id == "-inf");
+    }
+    if value == 0.0 && matches!(physical_id, "0" | "0.0" | "-0.0") {
+        return Some(true);
+    }
+    if value.fract() == 0.0 && value >= i64::MIN as f64 && value < -(i64::MIN as f64) {
+        let integer = value as i64;
+        if integer as f64 == value {
+            let integer_text = integer.to_string();
+            if physical_id == integer_text {
+                return Some(true);
+            }
+            return provable_python_float_text(value).map(|float_text| physical_id == float_text);
+        }
+    }
+    None
+}
+
+fn provable_python_float_text(value: f64) -> Option<String> {
+    if value.is_nan() {
+        return Some("nan".to_owned());
+    }
+    if value == f64::INFINITY {
+        return Some("inf".to_owned());
+    }
+    if value == f64::NEG_INFINITY {
+        return Some("-inf".to_owned());
+    }
+    if value == 0.0 {
+        return Some(if value.is_sign_negative() {
+            "-0.0".to_owned()
+        } else {
+            "0.0".to_owned()
+        });
+    }
+    if value.fract() != 0.0 || value.abs() >= 10_000_000_000_000_000.0 {
+        return None;
+    }
+    let integer = value as i64;
+    (integer as f64 == value).then(|| format!("{integer}.0"))
+}
+
+fn format_uuid(bytes: [u8; 16]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(36);
+    for (index, byte) in bytes.into_iter().enumerate() {
+        if matches!(index, 4 | 6 | 8 | 10) {
+            output.push('-');
+        }
+        output.push(char::from(HEX[usize::from(byte >> 4)]));
+        output.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    output
+}
+
+struct LegacyLiteralParser<'a> {
+    input: &'a str,
+    offset: usize,
+    values: usize,
+}
+
+impl<'a> LegacyLiteralParser<'a> {
+    fn parse(input: &'a str) -> Option<BsonValue> {
+        if input.len() > MAX_LEGACY_PHYSICAL_ID_BYTES {
+            return None;
+        }
+        let mut parser = Self {
+            input,
+            offset: 0,
+            values: 0,
+        };
+        let value = parser.parse_value(1)?;
+        (parser.offset == input.len()).then_some(value)
+    }
+
+    fn parse_value(&mut self, depth: usize) -> Option<BsonValue> {
+        if depth > 100 || self.values >= MAX_LEGACY_LITERAL_VALUES {
+            return None;
+        }
+        self.values += 1;
+        if matches!(self.peek(), Some('b' | 'B')) && self.remaining()[1..].starts_with(['\'', '"'])
+        {
+            return self
+                .parse_bytes()
+                .map(|bytes| BsonValue::Binary(BsonBinary::new(0, bytes)));
+        }
+        match self.peek()? {
+            '\'' | '"' => self.parse_string().map(BsonValue::String),
+            '{' => self.parse_document(depth),
+            '[' => self.parse_list(depth),
+            '(' => self.parse_tuple(depth),
+            _ if self.take_keyword("True") => Some(BsonValue::Boolean(true)),
+            _ if self.take_keyword("False") => Some(BsonValue::Boolean(false)),
+            _ if self.take_keyword("None") => Some(BsonValue::Null),
+            _ => self.parse_number(),
+        }
+    }
+
+    fn parse_document(&mut self, depth: usize) -> Option<BsonValue> {
+        self.take_expected('{')?;
+        let mut document = BsonDocument::new();
+        if self.take_if('}') {
+            return Some(BsonValue::Document(document));
+        }
+        loop {
+            let BsonValue::String(name) = self.parse_value(depth + 1)? else {
+                return None;
+            };
+            self.take_exact(": ")?;
+            let value = self.parse_value(depth + 1)?;
+            document.push(name, value).ok()?;
+            if self.take_if('}') {
+                break;
+            }
+            self.take_exact(", ")?;
+            if self.peek() == Some('}') {
+                return None;
+            }
+        }
+        Some(BsonValue::Document(document))
+    }
+
+    fn parse_list(&mut self, depth: usize) -> Option<BsonValue> {
+        self.take_expected('[')?;
+        let mut values = Vec::new();
+        if self.take_if(']') {
+            return Some(BsonValue::Array(values));
+        }
+        loop {
+            values.push(self.parse_value(depth + 1)?);
+            if self.take_if(']') {
+                break;
+            }
+            self.take_exact(", ")?;
+            if self.peek() == Some(']') {
+                return None;
+            }
+        }
+        Some(BsonValue::Array(values))
+    }
+
+    fn parse_tuple(&mut self, depth: usize) -> Option<BsonValue> {
+        self.take_expected('(')?;
+        if self.take_if(')') {
+            return Some(BsonValue::Array(Vec::new()));
+        }
+        let first = self.parse_value(depth + 1)?;
+        self.take_expected(',')?;
+        let mut values = vec![first];
+        if self.take_if(')') {
+            return Some(BsonValue::Array(values));
+        }
+        self.take_expected(' ')?;
+        loop {
+            values.push(self.parse_value(depth + 1)?);
+            if self.take_if(')') {
+                break;
+            }
+            self.take_exact(", ")?;
+            if self.peek() == Some(')') {
+                return None;
+            }
+        }
+        Some(BsonValue::Array(values))
+    }
+
+    fn parse_number(&mut self) -> Option<BsonValue> {
+        let start = self.offset;
+        while let Some(character) = self.peek() {
+            if character.is_whitespace() || matches!(character, ',' | ']' | ')' | '}' | ':') {
+                break;
+            }
+            self.take_char()?;
+        }
+        let token = &self.input[start..self.offset];
+        if token.is_empty() {
+            return None;
+        }
+        if !token.contains(['.', 'e', 'E']) {
+            if let Ok(value) = token.parse::<i64>() {
+                if token != value.to_string() {
+                    return None;
+                }
+                return Some(if let Ok(value) = i32::try_from(value) {
+                    BsonValue::Int32(value)
+                } else {
+                    BsonValue::Int64(value)
+                });
+            }
+        }
+        let value = token.parse::<f64>().ok()?;
+        let canonical = provable_python_float_text(value)?;
+        (token == canonical).then_some(BsonValue::Double(value))
+    }
+
+    fn parse_string(&mut self) -> Option<String> {
+        let start = self.offset;
+        let quote = self.take_char()?;
+        let mut output = String::new();
+        loop {
+            let character = self.take_char()?;
+            if character == quote {
+                let canonical = canonical_python_string(&output)?;
+                return (self.input[start..self.offset] == canonical).then_some(output);
+            }
+            if character == '\\' {
+                output.push(self.parse_string_escape()?);
+            } else if character.is_control() {
+                return None;
+            } else {
+                output.push(character);
+            }
+        }
+    }
+
+    fn parse_string_escape(&mut self) -> Option<char> {
+        let escaped = self.take_char()?;
+        match escaped {
+            '\\' | '\'' | '"' => Some(escaped),
+            'a' => Some('\u{7}'),
+            'b' => Some('\u{8}'),
+            'f' => Some('\u{c}'),
+            'n' => Some('\n'),
+            'r' => Some('\r'),
+            't' => Some('\t'),
+            'v' => Some('\u{b}'),
+            'x' => char::from_u32(self.take_hex(2)?),
+            'u' => char::from_u32(self.take_hex(4)?),
+            'U' => char::from_u32(self.take_hex(8)?),
+            '0'..='7' => char::from_u32(self.take_octal(escaped)?),
+            _ => None,
+        }
+    }
+
+    fn parse_bytes(&mut self) -> Option<Vec<u8>> {
+        let start = self.offset;
+        if !matches!(self.take_char()?, 'b' | 'B') {
+            return None;
+        }
+        let quote = self.take_char()?;
+        if !matches!(quote, '\'' | '"') {
+            return None;
+        }
+        let mut output = Vec::new();
+        loop {
+            let character = self.take_char()?;
+            if character == quote {
+                let canonical = canonical_python_bytes(&output);
+                return (self.input[start..self.offset] == canonical).then_some(output);
+            }
+            if character == '\\' {
+                let escaped = self.take_char()?;
+                let value = match escaped {
+                    '\\' | '\'' | '"' => escaped as u8,
+                    'a' => 7,
+                    'b' => 8,
+                    'f' => 12,
+                    'n' => b'\n',
+                    'r' => b'\r',
+                    't' => b'\t',
+                    'v' => 11,
+                    'x' => u8::try_from(self.take_hex(2)?).ok()?,
+                    '0'..='7' => u8::try_from(self.take_octal(escaped)?).ok()?,
+                    _ => return None,
+                };
+                output.push(value);
+            } else if character.is_ascii() && !character.is_control() {
+                output.push(character as u8);
+            } else {
+                return None;
+            }
+        }
+    }
+
+    fn take_hex(&mut self, count: usize) -> Option<u32> {
+        let mut value = 0_u32;
+        for _ in 0..count {
+            value = value.checked_mul(16)?;
+            value = value.checked_add(self.take_char()?.to_digit(16)?)?;
+        }
+        Some(value)
+    }
+
+    fn take_octal(&mut self, first: char) -> Option<u32> {
+        let mut value = first.to_digit(8)?;
+        for _ in 0..2 {
+            let Some(character) = self.peek() else {
+                break;
+            };
+            let Some(digit) = character.to_digit(8) else {
+                break;
+            };
+            self.take_char()?;
+            value = value.checked_mul(8)?.checked_add(digit)?;
+        }
+        Some(value)
+    }
+
+    fn take_keyword(&mut self, keyword: &str) -> bool {
+        if !self.remaining().starts_with(keyword) {
+            return false;
+        }
+        let end = self.offset + keyword.len();
+        if self.input[end..]
+            .chars()
+            .next()
+            .is_some_and(|character| character.is_alphanumeric() || character == '_')
+        {
+            return false;
+        }
+        self.offset = end;
+        true
+    }
+
+    fn remaining(&self) -> &'a str {
+        &self.input[self.offset..]
+    }
+
+    fn peek(&self) -> Option<char> {
+        self.remaining().chars().next()
+    }
+
+    fn take_char(&mut self) -> Option<char> {
+        let character = self.peek()?;
+        self.offset += character.len_utf8();
+        Some(character)
+    }
+
+    fn take_expected(&mut self, expected: char) -> Option<()> {
+        (self.take_char()? == expected).then_some(())
+    }
+
+    fn take_exact(&mut self, expected: &str) -> Option<()> {
+        if !self.remaining().starts_with(expected) {
+            return None;
+        }
+        self.offset += expected.len();
+        Some(())
+    }
+
+    fn take_if(&mut self, expected: char) -> bool {
+        if self.peek() == Some(expected) {
+            self.take_char();
+            true
+        } else {
+            false
+        }
+    }
+}
+
+fn canonical_python_string(value: &str) -> Option<String> {
+    value.is_ascii().then(|| {
+        let quote = if value.contains('\'') && !value.contains('"') {
+            '"'
+        } else {
+            '\''
+        };
+        let mut output = String::with_capacity(value.len() + 2);
+        output.push(quote);
+        for byte in value.bytes() {
+            push_python_repr_byte(&mut output, byte, quote);
+        }
+        output.push(quote);
+        output
+    })
+}
+
+fn canonical_python_bytes(value: &[u8]) -> String {
+    let quote = if value.contains(&b'\'') && !value.contains(&b'"') {
+        '"'
+    } else {
+        '\''
+    };
+    let mut output = String::with_capacity(value.len() + 3);
+    output.push('b');
+    output.push(quote);
+    for &byte in value {
+        push_python_repr_byte(&mut output, byte, quote);
+    }
+    output.push(quote);
+    output
+}
+
+fn push_python_repr_byte(output: &mut String, byte: u8, quote: char) {
+    match byte {
+        b'\\' => output.push_str("\\\\"),
+        b'\t' => output.push_str("\\t"),
+        b'\n' => output.push_str("\\n"),
+        b'\r' => output.push_str("\\r"),
+        byte if byte == quote as u8 => {
+            output.push('\\');
+            output.push(quote);
+        }
+        0x20..=0x7e => output.push(char::from(byte)),
+        _ => {
+            const HEX: &[u8; 16] = b"0123456789abcdef";
+            output.push_str("\\x");
+            output.push(char::from(HEX[usize::from(byte >> 4)]));
+            output.push(char::from(HEX[usize::from(byte & 0x0f)]));
+        }
+    }
+}
+
+fn validate_document_identity(
+    collection: &str,
+    document: &BsonDocument,
+    identities: &mut HashSet<CanonicalBsonKey>,
+) -> EngineResult<()> {
+    let identifier = document
+        .get_unique("_id")
+        .map_err(|error| error.into_engine_error(crate::document::BsonErrorContext::StoredData))?;
+    let identifier = identifier.ok_or_else(|| {
+        data_corruption(format!(
+            "TinyMongo document in collection {collection:?} has no logical _id"
+        ))
+    })?;
+    let key = CanonicalBsonKey::encode(identifier)
+        .map_err(|error| error.into_engine_error(crate::document::BsonErrorContext::StoredData))?;
+    if !identities.insert(key) {
+        return Err(data_corruption(format!(
+            "TinyMongo collection {collection:?} contains duplicate semantic _id values"
+        )));
+    }
+    Ok(())
+}
+
+fn read_collection_rows(
+    connection: &Connection,
+    collection: &str,
+    shard: usize,
+    sharded: bool,
+    budget: &mut RetainedBudget,
+    cancellation: &CancellationToken,
+) -> EngineResult<Vec<PendingDocument>> {
+    let table = quote_identifier(collection);
+    let sql = if sharded {
+        format!(
+            "SELECT rowid, _id, data, {} FROM {table} ORDER BY rowid",
+            quote_identifier(SHARD_ORDER_COLUMN)
+        )
+    } else {
+        format!("SELECT rowid, _id, data, NULL FROM {table} ORDER BY rowid")
+    };
+    let mut statement = connection.prepare(&sql).map_err(sqlite_error::storage)?;
+    let mut rows = statement.query([]).map_err(sqlite_error::storage)?;
+    let mut documents = Vec::new();
+    while let Some(row) = rows.next().map_err(sqlite_error::storage)? {
+        ensure_import_not_cancelled(cancellation)?;
+        let rowid = row.get::<_, i64>(0).map_err(sqlite_error::storage)?;
+        let physical_id = text_column(
+            row.get_ref(1).map_err(sqlite_error::storage)?,
+            "collection _id",
+        )?
+        .to_owned();
+        let payload = text_column(
+            row.get_ref(2).map_err(sqlite_error::storage)?,
+            "collection data",
+        )?;
+        let order_token = match row.get_ref(3).map_err(sqlite_error::storage)? {
+            ValueRef::Null => None,
+            value => Some(text_column(value, "__tinymongo_order")?.to_owned()),
+        };
+        budget.retain_source_metadata([
+            physical_id.len(),
+            order_token.as_deref().map_or(0, str::len),
+        ])?;
+        let document = json_document(
+            &parse_json(payload, &format!("collection {collection:?} row {rowid}"))?,
+            &format!("collection {collection:?} row {rowid}"),
+        )?;
+        let retained_bson_bytes = budget.retain(&document)?;
+        documents.push(PendingDocument {
+            document,
+            retained_bson_bytes,
+            physical_id: Some(physical_id),
+            order_token,
+            source_shard: shard,
+            rowid,
+        });
+    }
+    Ok(documents)
+}
+
+fn parse_json(value: &str, context: &str) -> EngineResult<JsonValue> {
+    serde_json::from_str(value)
+        .map_err(|error| data_corruption(format!("invalid TinyMongo JSON in {context}: {error}")))
+}
+
+fn json_document(value: &JsonValue, context: &str) -> EngineResult<BsonDocument> {
+    let JsonValue::Object(object) = value else {
+        return Err(data_corruption(format!(
+            "TinyMongo {context} must be a JSON object"
+        )));
+    };
+    json_object_to_document(object, true, context)
+}
+
+fn json_object_to_document(
+    object: &JsonMap<String, JsonValue>,
+    interpret_tags: bool,
+    context: &str,
+) -> EngineResult<BsonDocument> {
+    let mut document = BsonDocument::new();
+    for (name, value) in object {
+        let value = if interpret_tags {
+            json_to_bson(value, context)?
+        } else {
+            json_to_plain_bson(value, context)?
+        };
+        document.push(name.clone(), value).map_err(|error| {
+            error.into_engine_error(crate::document::BsonErrorContext::StoredData)
+        })?;
+    }
+    Ok(document)
+}
+
+fn json_to_bson(value: &JsonValue, context: &str) -> EngineResult<BsonValue> {
+    match value {
+        JsonValue::Null => Ok(BsonValue::Null),
+        JsonValue::Bool(value) => Ok(BsonValue::Boolean(*value)),
+        JsonValue::Number(value) => json_number_to_bson(value, context),
+        JsonValue::String(value) => Ok(BsonValue::String(value.clone())),
+        JsonValue::Array(values) => values
+            .iter()
+            .map(|value| json_to_bson(value, context))
+            .collect::<EngineResult<Vec<_>>>()
+            .map(BsonValue::Array),
+        JsonValue::Object(object) => {
+            if object.len() == 2
+                && object.contains_key(TYPE_MARKER)
+                && object.contains_key(VALUE_MARKER)
+            {
+                if let Some(value) = decode_tag(object, context)? {
+                    return Ok(value);
+                }
+                return json_object_to_document(object, false, context).map(BsonValue::Document);
+            }
+            json_object_to_document(object, true, context).map(BsonValue::Document)
+        }
+    }
+}
+
+fn json_to_plain_bson(value: &JsonValue, context: &str) -> EngineResult<BsonValue> {
+    match value {
+        JsonValue::Null => Ok(BsonValue::Null),
+        JsonValue::Bool(value) => Ok(BsonValue::Boolean(*value)),
+        JsonValue::Number(value) => json_number_to_bson(value, context),
+        JsonValue::String(value) => Ok(BsonValue::String(value.clone())),
+        JsonValue::Array(values) => values
+            .iter()
+            .map(|value| json_to_plain_bson(value, context))
+            .collect::<EngineResult<Vec<_>>>()
+            .map(BsonValue::Array),
+        JsonValue::Object(object) => {
+            json_object_to_document(object, false, context).map(BsonValue::Document)
+        }
+    }
+}
+
+fn json_number_to_bson(number: &JsonNumber, context: &str) -> EngineResult<BsonValue> {
+    let spelling = number.to_string();
+    let is_float = spelling
+        .bytes()
+        .any(|byte| matches!(byte, b'.' | b'e' | b'E'));
+    if !is_float {
+        let integer = number.as_i64().ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::NumericOutOfRange,
+                format!("TinyMongo integer in {context} is outside BSON int64 range"),
+            )
+        })?;
+        return Ok(i32::try_from(integer).map_or(BsonValue::Int64(integer), BsonValue::Int32));
+    }
+    let value = number
+        .as_f64()
+        .filter(|value| value.is_finite())
+        .ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::NumericOutOfRange,
+                format!("TinyMongo JSON number in {context} is not an exact finite f64"),
+            )
+        })?;
+    Ok(BsonValue::Double(value))
+}
+
+fn decode_tag(
+    object: &JsonMap<String, JsonValue>,
+    context: &str,
+) -> EngineResult<Option<BsonValue>> {
+    let Some(kind) = object.get(TYPE_MARKER).and_then(JsonValue::as_str) else {
+        return Ok(None);
+    };
+    let payload = &object[VALUE_MARKER];
+    let decoded = match kind {
+        "float" => match payload.as_str() {
+            Some("nan") => Some(BsonValue::Double(f64::NAN)),
+            Some("-infinity") => Some(BsonValue::Double(f64::NEG_INFINITY)),
+            Some("infinity") => Some(BsonValue::Double(f64::INFINITY)),
+            _ => None,
+        },
+        "objectid" => payload
+            .as_str()
+            .and_then(|value| BsonObjectId::from_hex(value).ok())
+            .map(BsonValue::ObjectId),
+        "datetime" => payload
+            .as_str()
+            .and_then(parse_tinymongo_datetime)
+            .map(BsonDateTime::from_millis)
+            .map(BsonValue::DateTime),
+        "binary" => decode_binary_tag(payload)?.map(BsonValue::Binary),
+        "decimal128" => payload
+            .as_str()
+            .and_then(decode_fixed_hex::<16>)
+            .map(BsonDecimal128::from_bid)
+            .map(BsonValue::Decimal128),
+        "minkey" if json_is_integer(payload, 1) => Some(BsonValue::MinKey),
+        "maxkey" if json_is_integer(payload, 1) => Some(BsonValue::MaxKey),
+        "timestamp" => decode_timestamp_tag(payload)?.map(BsonValue::Timestamp),
+        "code" => decode_code_tag(payload, context)?.map(BsonValue::JavaScript),
+        "uuid" => payload
+            .as_str()
+            .and_then(parse_uuid)
+            .map(|bytes| BsonValue::Uuid(BsonUuid::new(bytes, UuidRepresentation::Standard))),
+        "regex" => decode_regex_tag(payload)?.map(BsonValue::RegularExpression),
+        "mapping" => decode_mapping_tag(payload, context)?.map(BsonValue::Document),
+        _ => None,
+    };
+    Ok(decoded)
+}
+
+fn decode_binary_tag(payload: &JsonValue) -> EngineResult<Option<BsonBinary>> {
+    let JsonValue::Object(payload) = payload else {
+        return Ok(None);
+    };
+    if payload.len() != 2 || !payload.contains_key("base64") || !payload.contains_key("subtype") {
+        return Ok(None);
+    }
+    let Some(encoded) = payload.get("base64").and_then(JsonValue::as_str) else {
+        return Ok(None);
+    };
+    let Some(subtype) = exact_u64(&payload["subtype"]) else {
+        return Ok(None);
+    };
+    let Ok(subtype) = u8::try_from(subtype) else {
+        return Ok(None);
+    };
+    let Some(bytes) = decode_base64(encoded) else {
+        return Ok(None);
+    };
+    Ok(Some(BsonBinary::new(subtype, bytes)))
+}
+
+fn decode_timestamp_tag(payload: &JsonValue) -> EngineResult<Option<BsonTimestamp>> {
+    let JsonValue::Object(payload) = payload else {
+        return Ok(None);
+    };
+    if payload.len() != 2 || !payload.contains_key("time") || !payload.contains_key("inc") {
+        return Ok(None);
+    }
+    let (Some(time), Some(increment)) = (exact_u64(&payload["time"]), exact_u64(&payload["inc"]))
+    else {
+        return Ok(None);
+    };
+    let (Ok(time), Ok(increment)) = (u32::try_from(time), u32::try_from(increment)) else {
+        return Ok(None);
+    };
+    Ok(Some(BsonTimestamp::new(time, increment)))
+}
+
+fn decode_code_tag(payload: &JsonValue, context: &str) -> EngineResult<Option<BsonJavaScript>> {
+    let JsonValue::Object(payload) = payload else {
+        return Ok(None);
+    };
+    if payload.len() != 2 || !payload.contains_key("code") || !payload.contains_key("scope") {
+        return Ok(None);
+    }
+    let Some(code) = payload.get("code").and_then(JsonValue::as_str) else {
+        return Ok(None);
+    };
+    match &payload["scope"] {
+        JsonValue::Null => Ok(Some(BsonJavaScript::new(code))),
+        JsonValue::Object(scope) => Ok(Some(BsonJavaScript::with_scope(
+            code,
+            json_object_to_document(scope, true, context)?,
+        ))),
+        _ => Ok(None),
+    }
+}
+
+fn decode_regex_tag(payload: &JsonValue) -> EngineResult<Option<BsonRegex>> {
+    let JsonValue::Object(payload) = payload else {
+        return Ok(None);
+    };
+    let expected = ["pattern", "flags", "representation", "pattern_type"];
+    if payload.len() != expected.len() || expected.iter().any(|key| !payload.contains_key(*key)) {
+        return Ok(None);
+    }
+    let (Some(pattern), Some(flags), Some(representation), Some(pattern_type)) = (
+        payload["pattern"].as_str(),
+        exact_i64(&payload["flags"]),
+        payload["representation"].as_str(),
+        payload["pattern_type"].as_str(),
+    ) else {
+        return Ok(None);
+    };
+    if !matches!(representation, "python" | "bson")
+        || !matches!(pattern_type, "string" | "bytes")
+        || flags < 0
+        || pattern.contains('\0')
+    {
+        return Ok(None);
+    }
+    if representation != "bson" || pattern_type != "string" {
+        return Err(EngineError::new(
+            EngineErrorKind::Unsupported,
+            "TinyMongo regex representation cannot be preserved as BSON",
+        ));
+    }
+    if flags & !126 != 0 {
+        return Err(EngineError::new(
+            EngineErrorKind::Unsupported,
+            "TinyMongo regex uses Python-only flags that have no BSON representation",
+        ));
+    }
+    let mut options = String::new();
+    for (bit, option) in [
+        (2, 'i'),
+        (4, 'l'),
+        (8, 'm'),
+        (16, 's'),
+        (32, 'u'),
+        (64, 'x'),
+    ] {
+        if flags & bit != 0 {
+            options.push(option);
+        }
+    }
+    Ok(Some(BsonRegex::new(pattern, options).map_err(|error| {
+        error.into_engine_error(crate::document::BsonErrorContext::StoredData)
+    })?))
+}
+
+fn decode_mapping_tag(payload: &JsonValue, context: &str) -> EngineResult<Option<BsonDocument>> {
+    let JsonValue::Array(entries) = payload else {
+        return Ok(None);
+    };
+    let mut names = HashSet::new();
+    let mut document = BsonDocument::new();
+    for entry in entries {
+        let JsonValue::Array(pair) = entry else {
+            return Ok(None);
+        };
+        if pair.len() != 2 {
+            return Ok(None);
+        }
+        let Some(name) = pair[0].as_str() else {
+            return Ok(None);
+        };
+        if !names.insert(name) {
+            return Err(data_corruption(
+                "TinyMongo escaped mapping contains duplicate field names",
+            ));
+        }
+        document
+            .push(name, json_to_bson(&pair[1], context)?)
+            .map_err(|error| {
+                error.into_engine_error(crate::document::BsonErrorContext::StoredData)
+            })?;
+    }
+    Ok(Some(document))
+}
+
+fn json_object<'a>(
+    value: &'a JsonValue,
+    context: &str,
+) -> EngineResult<&'a JsonMap<String, JsonValue>> {
+    value
+        .as_object()
+        .ok_or_else(|| data_corruption(format!("{context} must be a JSON object")))
+}
+
+fn exact_i64(value: &JsonValue) -> Option<i64> {
+    let number = value.as_number()?;
+    let spelling = number.to_string();
+    (!spelling
+        .bytes()
+        .any(|byte| matches!(byte, b'.' | b'e' | b'E')))
+    .then(|| number.as_i64())
+    .flatten()
+}
+
+fn exact_u64(value: &JsonValue) -> Option<u64> {
+    let value = exact_i64(value)?;
+    u64::try_from(value).ok()
+}
+
+fn json_is_integer(value: &JsonValue, expected: i64) -> bool {
+    exact_i64(value) == Some(expected)
+}
+
+fn parse_tinymongo_datetime(value: &str) -> Option<i64> {
+    let bytes = value.as_bytes();
+    if bytes.len() < 19
+        || bytes[4] != b'-'
+        || bytes[7] != b'-'
+        || !matches!(bytes[10], b'T' | b' ')
+        || bytes[13] != b':'
+        || bytes[16] != b':'
+    {
+        return None;
+    }
+    let year = decimal_digits(&bytes[0..4])? as i64;
+    let month = decimal_digits(&bytes[5..7])? as i64;
+    let day = decimal_digits(&bytes[8..10])? as i64;
+    let hour = decimal_digits(&bytes[11..13])? as i64;
+    let minute = decimal_digits(&bytes[14..16])? as i64;
+    let second = decimal_digits(&bytes[17..19])? as i64;
+    let mut cursor = 19;
+    let mut micros = 0_i64;
+    if bytes
+        .get(cursor)
+        .is_some_and(|byte| matches!(byte, b'.' | b','))
+    {
+        cursor += 1;
+        let fraction_start = cursor;
+        while bytes.get(cursor).is_some_and(u8::is_ascii_digit) {
+            cursor += 1;
+        }
+        let fraction = bytes.get(fraction_start..cursor)?;
+        if fraction.is_empty() {
+            return None;
+        }
+        // Python's datetime parser retains microseconds and ignores additional
+        // fractional precision. TinyMongo then stores only whole milliseconds.
+        for (place, digit) in fraction.iter().take(6).enumerate() {
+            micros += i64::from(*digit - b'0') * 10_i64.pow((5 - place) as u32);
+        }
+    }
+    let offset_seconds = match bytes.get(cursor..) {
+        Some([]) => 0_i64,
+        Some([b'Z']) => 0_i64,
+        Some(zone) if zone.len() == 6 && matches!(zone[0], b'+' | b'-') && zone[3] == b':' => {
+            let offset_hour = decimal_digits(&zone[1..3])? as i64;
+            let offset_minute = decimal_digits(&zone[4..6])? as i64;
+            if offset_hour >= 24 || offset_minute >= 60 {
+                return None;
+            }
+            let magnitude = offset_hour * 3_600 + offset_minute * 60;
+            if zone[0] == b'-' {
+                -magnitude
+            } else {
+                magnitude
+            }
+        }
+        _ => return None,
+    };
+    if year == 0
+        || !(1..=12).contains(&month)
+        || day == 0
+        || day > days_in_month(year, month)
+        || hour >= 24
+        || minute >= 60
+        || second >= 60
+    {
+        return None;
+    }
+    let days = days_from_civil(year, month, day);
+    let milliseconds = days
+        .checked_mul(86_400_000)?
+        .checked_add(hour * 3_600_000 + minute * 60_000 + second * 1_000 + micros / 1_000)?
+        .checked_sub(offset_seconds.checked_mul(1_000)?)?;
+    let minimum = days_from_civil(1, 1, 1) * 86_400_000;
+    let maximum = (days_from_civil(10_000, 1, 1) * 86_400_000) - 1;
+    (minimum..=maximum)
+        .contains(&milliseconds)
+        .then_some(milliseconds)
+}
+
+fn decimal_digits(bytes: &[u8]) -> Option<u32> {
+    bytes.iter().try_fold(0_u32, |value, byte| {
+        byte.is_ascii_digit()
+            .then(|| value * 10 + u32::from(*byte - b'0'))
+    })
+}
+
+fn days_in_month(year: i64, month: i64) -> i64 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if year % 4 == 0 && (year % 100 != 0 || year % 400 == 0) => 29,
+        2 => 28,
+        _ => 0,
+    }
+}
+
+fn days_from_civil(year: i64, month: i64, day: i64) -> i64 {
+    let adjusted_year = year - i64::from(month <= 2);
+    let era = adjusted_year.div_euclid(400);
+    let year_of_era = adjusted_year - era * 400;
+    let shifted_month = month + if month > 2 { -3 } else { 9 };
+    let day_of_year = (153 * shifted_month + 2) / 5 + day - 1;
+    let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+    era * 146_097 + day_of_era - 719_468
+}
+
+fn parse_uuid(value: &str) -> Option<[u8; 16]> {
+    let bytes = value.as_bytes();
+    if bytes.len() != 36 || [8, 13, 18, 23].iter().any(|index| bytes[*index] != b'-') {
+        return None;
+    }
+    let mut compact = String::with_capacity(32);
+    for (index, byte) in bytes.iter().enumerate() {
+        if !matches!(index, 8 | 13 | 18 | 23) {
+            compact.push(char::from(*byte));
+        }
+    }
+    decode_fixed_hex::<16>(&compact)
+}
+
+fn decode_fixed_hex<const N: usize>(value: &str) -> Option<[u8; N]> {
+    if value.len() != N * 2 {
+        return None;
+    }
+    let mut output = [0_u8; N];
+    for (index, pair) in value.as_bytes().chunks_exact(2).enumerate() {
+        output[index] = (hex_nibble(pair[0])? << 4) | hex_nibble(pair[1])?;
+    }
+    Some(output)
+}
+
+fn hex_nibble(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        b'A'..=b'F' => Some(value - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn decode_base64(value: &str) -> Option<Vec<u8>> {
+    let bytes = value.as_bytes();
+    if bytes.len() % 4 != 0 {
+        return None;
+    }
+    let mut output = Vec::with_capacity(bytes.len() / 4 * 3);
+    for (chunk_index, chunk) in bytes.chunks_exact(4).enumerate() {
+        let last = chunk_index + 1 == bytes.len() / 4;
+        let a = base64_value(chunk[0])?;
+        let b = base64_value(chunk[1])?;
+        let c = if chunk[2] == b'=' {
+            64
+        } else {
+            base64_value(chunk[2])?
+        };
+        let d = if chunk[3] == b'=' {
+            64
+        } else {
+            base64_value(chunk[3])?
+        };
+        if !last && (c == 64 || d == 64) {
+            return None;
+        }
+        if c == 64 && d != 64 {
+            return None;
+        }
+        output.push((a << 2) | (b >> 4));
+        if c != 64 {
+            output.push((b << 4) | (c >> 2));
+            if d != 64 {
+                output.push((c << 6) | d);
+            } else if c & 0b11 != 0 {
+                return None;
+            }
+        } else if b & 0b1111 != 0 {
+            return None;
+        }
+    }
+    Some(output)
+}
+
+fn base64_value(value: u8) -> Option<u8> {
+    match value {
+        b'A'..=b'Z' => Some(value - b'A'),
+        b'a'..=b'z' => Some(value - b'a' + 26),
+        b'0'..=b'9' => Some(value - b'0' + 52),
+        b'+' => Some(62),
+        b'/' => Some(63),
+        _ => None,
+    }
+}
+
+fn validate_database_name(name: &str) -> EngineResult<()> {
+    if name.is_empty() || name.len() > MAX_DOCUMENT_DATABASE_NAME_BYTES || name.contains('\0') {
+        return Err(invalid_argument(
+            "TinyMongo import database name must contain 1 to 63 UTF-8 bytes and no NUL",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_collection_name(database: &str, name: &str) -> EngineResult<()> {
+    if name.is_empty()
+        || name.contains('\0')
+        || name == "_default"
+        || name.starts_with("__tinymongo_")
+    {
+        return Err(invalid_argument(format!(
+            "TinyMongo import collection name {name:?} is empty or storage-reserved"
+        )));
+    }
+    let namespace = database
+        .len()
+        .checked_add(1)
+        .and_then(|length| length.checked_add(name.len()))
+        .ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::LimitExceeded,
+                "TinyMongo namespace length overflowed",
+            )
+        })?;
+    if namespace > MAX_DOCUMENT_NAMESPACE_BYTES {
+        return Err(invalid_argument(format!(
+            "TinyMongo namespace {database}.{name} exceeds {MAX_DOCUMENT_NAMESPACE_BYTES} UTF-8 bytes"
+        )));
+    }
+    Ok(())
+}
+
+fn open_source(path: &Path, cancellation: &CancellationToken) -> EngineResult<Connection> {
+    ensure_import_not_cancelled(cancellation)?;
+    let flags = OpenFlags::SQLITE_OPEN_READ_ONLY
+        | OpenFlags::SQLITE_OPEN_NO_MUTEX
+        | OpenFlags::SQLITE_OPEN_NOFOLLOW
+        | OpenFlags::SQLITE_OPEN_EXRESCODE
+        | OpenFlags::SQLITE_OPEN_URI;
+    // SQLite's NOFOLLOW flag rejects any symlink component, including macOS's
+    // system `/var` link. Resolve the already-inspected parent while retaining
+    // the final component so replacement of the database itself is rejected.
+    let parent = path.parent().ok_or_else(|| {
+        failed_precondition(format!(
+            "TinyMongo source path {} has no parent directory",
+            path.display()
+        ))
+    })?;
+    let parent = if parent.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        parent
+    };
+    let parent_metadata = fs::symlink_metadata(parent).map_err(|error| {
+        sqlite_error::storage_io(
+            error,
+            format!(
+                "failed to inspect TinyMongo source directory {}",
+                parent.display()
+            ),
+        )
+    })?;
+    if parent_metadata.file_type().is_symlink() || !parent_metadata.is_dir() {
+        return Err(failed_precondition(format!(
+            "TinyMongo source parent {} must be a real directory",
+            parent.display()
+        )));
+    }
+    let file_name = path.file_name().ok_or_else(|| {
+        failed_precondition(format!(
+            "TinyMongo source path {} has no file name",
+            path.display()
+        ))
+    })?;
+    let canonical_parent = fs::canonicalize(parent).map_err(|error| {
+        sqlite_error::storage_io(
+            error,
+            format!(
+                "failed to resolve TinyMongo source directory {}",
+                parent.display()
+            ),
+        )
+    })?;
+    let open_path = canonical_parent.join(file_name);
+    reject_source_sidecars(&open_path)?;
+    let uri = immutable_sqlite_uri(&open_path)?;
+    let connection = Connection::open_with_flags(uri, flags).map_err(sqlite_error::storage)?;
+    connection
+        .set_limit(Limit::SQLITE_LIMIT_LENGTH, MAX_SQLITE_IMPORT_ROW_BYTES)
+        .map_err(sqlite_error::storage)?;
+    let progress_cancellation = cancellation.clone();
+    connection
+        .progress_handler(1_000, Some(move || progress_cancellation.is_cancelled()))
+        .map_err(sqlite_error::storage)?;
+    connection
+        .execute_batch("PRAGMA trusted_schema = OFF; PRAGMA query_only = ON; BEGIN DEFERRED")
+        .map_err(sqlite_error::storage)?;
+    verify_source_quick_check(&connection)?;
+    reject_source_sidecars(&open_path)?;
+    ensure_import_not_cancelled(cancellation)?;
+    Ok(connection)
+}
+
+fn immutable_sqlite_uri(path: &Path) -> EngineResult<String> {
+    #[cfg(unix)]
+    let bytes = {
+        use std::os::unix::ffi::OsStrExt;
+        path.as_os_str().as_bytes().to_vec()
+    };
+    #[cfg(windows)]
+    let bytes = path
+        .to_str()
+        .ok_or_else(|| failed_precondition("TinyMongo source path is not valid UTF-8"))?
+        .replace('\\', "/")
+        .into_bytes();
+    #[cfg(not(any(unix, windows)))]
+    let bytes = path
+        .to_str()
+        .ok_or_else(|| failed_precondition("TinyMongo source path is not valid UTF-8"))?
+        .as_bytes()
+        .to_vec();
+
+    let mut uri = String::with_capacity(bytes.len().saturating_mul(3).saturating_add(25));
+    uri.push_str("file:");
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    for byte in bytes {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'/' | b':' | b'-' | b'.' | b'_' | b'~') {
+            uri.push(char::from(byte));
+        } else {
+            uri.push('%');
+            uri.push(char::from(HEX[usize::from(byte >> 4)]));
+            uri.push(char::from(HEX[usize::from(byte & 0x0f)]));
+        }
+    }
+    uri.push_str("?mode=ro&immutable=1");
+    Ok(uri)
+}
+
+fn reject_source_sidecars(path: &Path) -> EngineResult<()> {
+    for suffix in ["-wal", "-shm", "-journal"] {
+        let mut sidecar = path.as_os_str().to_os_string();
+        sidecar.push(suffix);
+        let sidecar = PathBuf::from(sidecar);
+        match fs::symlink_metadata(&sidecar) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Ok(_) => {
+                return Err(failed_precondition(format!(
+                    "TinyMongo source {} has an active SQLite sidecar; stop and checkpoint the source before import",
+                    path.display()
+                )));
+            }
+            Err(error) => {
+                return Err(sqlite_error::storage_io(
+                    error,
+                    format!(
+                        "failed to inspect TinyMongo source sidecars for {}",
+                        path.display()
+                    ),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn verify_source_quick_check(connection: &Connection) -> EngineResult<()> {
+    let mut statement = connection
+        .prepare("PRAGMA quick_check")
+        .map_err(sqlite_error::storage)?;
+    let mut rows = statement.query([]).map_err(sqlite_error::storage)?;
+    let Some(row) = rows.next().map_err(sqlite_error::storage)? else {
+        return Err(data_corruption(
+            "TinyMongo source quick_check returned no result",
+        ));
+    };
+    let result = row.get::<_, String>(0).map_err(sqlite_error::storage)?;
+    if result != "ok" || rows.next().map_err(sqlite_error::storage)?.is_some() {
+        return Err(data_corruption(
+            "TinyMongo source failed SQLite quick_check",
+        ));
+    }
+    Ok(())
+}
+
+fn ordinary_tables(connection: &Connection) -> EngineResult<Vec<String>> {
+    let mut statement = connection
+        .prepare(
+            "SELECT name FROM sqlite_schema WHERE type = 'table' AND name NOT LIKE 'sqlite\\_%' ESCAPE '\\' ORDER BY name",
+        )
+        .map_err(sqlite_error::storage)?;
+    let mut rows = statement.query([]).map_err(sqlite_error::storage)?;
+    let mut names = Vec::new();
+    let mut name_bytes = 0_usize;
+    while let Some(row) = rows.next().map_err(sqlite_error::storage)? {
+        let name = row.get::<_, String>(0).map_err(sqlite_error::storage)?;
+        if names.len() >= MAX_TINYMONGO_SOURCE_TABLES {
+            return Err(EngineError::new(
+                EngineErrorKind::LimitExceeded,
+                format!("TinyMongo source exceeds {MAX_TINYMONGO_SOURCE_TABLES} physical tables"),
+            ));
+        }
+        charge_source_metadata(
+            &mut name_bytes,
+            [name.len()],
+            MAX_TINYMONGO_IMPORT_METADATA_BSON_BYTES,
+            "physical table-name inventory",
+        )?;
+        names.push(name);
+    }
+    Ok(names)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ColumnShape {
+    cid: i64,
+    name: String,
+    declared_type: String,
+    not_null: bool,
+    default_value: Option<String>,
+    primary_key: i64,
+    hidden: i64,
+}
+
+fn table_shape(connection: &Connection, table: &str) -> EngineResult<Vec<ColumnShape>> {
+    let mut statement = connection
+        .prepare(
+            "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden FROM pragma_table_xinfo(?) ORDER BY cid",
+        )
+        .map_err(sqlite_error::storage)?;
+    statement
+        .query_map([table], |row| {
+            Ok(ColumnShape {
+                cid: row.get(0)?,
+                name: row.get(1)?,
+                declared_type: row.get(2)?,
+                not_null: row.get::<_, i64>(3)? != 0,
+                default_value: row.get(4)?,
+                primary_key: row.get(5)?,
+                hidden: row.get(6)?,
+            })
+        })
+        .map_err(sqlite_error::storage)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(sqlite_error::storage)
+}
+
+fn table_exists(connection: &Connection, table: &str) -> EngineResult<bool> {
+    connection
+        .query_row(
+            "SELECT 1 FROM sqlite_schema WHERE type = 'table' AND name = ?",
+            [table],
+            |_| Ok(()),
+        )
+        .optional()
+        .map(|value| value.is_some())
+        .map_err(sqlite_error::storage)
+}
+
+fn is_legacy_blob_schema(connection: &Connection) -> EngineResult<bool> {
+    if !table_exists(connection, LEGACY_BLOB_TABLE)? {
+        return Ok(false);
+    }
+    let shape = table_shape(connection, LEGACY_BLOB_TABLE)?;
+    Ok(shape.len() == 2
+        && shape[0].name == "id"
+        && shape[0].declared_type.eq_ignore_ascii_case("INTEGER")
+        && shape[0].primary_key == 1
+        && shape[1].name == "data"
+        && shape[1].declared_type.eq_ignore_ascii_case("TEXT"))
+}
+
+fn validate_legacy_blob_schema(connection: &Connection) -> EngineResult<()> {
+    if !is_legacy_blob_schema(connection)? {
+        return Err(data_corruption(
+            "TinyMongo legacy tinydb table has an unsupported schema",
+        ));
+    }
+    let shape = table_shape(connection, LEGACY_BLOB_TABLE)?;
+    if shape[0].cid != 0
+        || shape[0].not_null
+        || shape[0].hidden != 0
+        || shape[0].default_value.is_some()
+        || shape[1].cid != 1
+        || shape[1].not_null
+        || shape[1].primary_key != 0
+        || shape[1].hidden != 0
+        || shape[1].default_value.is_some()
+    {
+        return Err(data_corruption(
+            "TinyMongo legacy tinydb table has hidden/default columns",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_collection_schema(
+    connection: &Connection,
+    collection: &str,
+    sharded: bool,
+) -> EngineResult<()> {
+    if !table_exists(connection, collection)? {
+        return Err(data_corruption(format!(
+            "allowlisted TinyMongo collection table {collection:?} does not exist"
+        )));
+    }
+    let shape = table_shape(connection, collection)?;
+    let expected_len = if sharded { 3 } else { 2 };
+    if shape.len() != expected_len
+        || shape[0].cid != 0
+        || shape[0].name != "_id"
+        || !shape[0].declared_type.eq_ignore_ascii_case("TEXT")
+        || shape[0].not_null
+        || shape[0].primary_key != 1
+        || shape[0].hidden != 0
+        || shape[0].default_value.is_some()
+        || shape[1].cid != 1
+        || shape[1].name != "data"
+        || !shape[1].declared_type.eq_ignore_ascii_case("TEXT")
+        || !shape[1].not_null
+        || shape[1].primary_key != 0
+        || shape[1].hidden != 0
+        || shape[1].default_value.is_some()
+        || (sharded
+            && (shape[2].cid != 2
+                || shape[2].name != SHARD_ORDER_COLUMN
+                || !shape[2].declared_type.eq_ignore_ascii_case("TEXT")
+                || shape[2].not_null
+                || shape[2].primary_key != 0
+                || shape[2].hidden != 0
+                || shape[2].default_value.is_some()))
+    {
+        return Err(data_corruption(format!(
+            "TinyMongo collection table {collection:?} has an unsupported physical schema"
+        )));
+    }
+    let triggers: i64 = connection
+        .query_row(
+            "SELECT count(*) FROM sqlite_schema WHERE type = 'trigger' AND tbl_name = ?",
+            [collection],
+            |row| row.get(0),
+        )
+        .map_err(sqlite_error::storage)?;
+    if triggers != 0 {
+        return Err(data_corruption(format!(
+            "TinyMongo collection table {collection:?} has external triggers"
+        )));
+    }
+    Ok(())
+}
+
+fn read_sql_index_catalog(
+    connection: &Connection,
+    cancellation: &CancellationToken,
+) -> EngineResult<BTreeMap<String, Vec<LogicalIndex>>> {
+    if !table_exists(connection, INDEX_CATALOG_TABLE)? {
+        return Ok(BTreeMap::new());
+    }
+    let shape = table_shape(connection, INDEX_CATALOG_TABLE)?;
+    let names: Vec<_> = shape.iter().map(|column| column.name.as_str()).collect();
+    let has_token = names.get(4) == Some(&"token_version");
+    let has_spec = names.get(5) == Some(&"spec_json");
+    let allowed = matches!(
+        names.as_slice(),
+        ["collection_name", "index_name", "field_name", "unique_flag"]
+            | [
+                "collection_name",
+                "index_name",
+                "field_name",
+                "unique_flag",
+                "token_version"
+            ]
+            | [
+                "collection_name",
+                "index_name",
+                "field_name",
+                "unique_flag",
+                "token_version",
+                "spec_json"
+            ]
+    );
+    if !allowed {
+        return Err(data_corruption(
+            "TinyMongo SQLite index catalog has an unsupported schema",
+        ));
+    }
+    let common_shape_is_exact = shape.iter().take(4).enumerate().all(|(index, column)| {
+        let expected = [
+            ("collection_name", "TEXT", 1_i64),
+            ("index_name", "TEXT", 2_i64),
+            ("field_name", "TEXT", 0_i64),
+            ("unique_flag", "INTEGER", 0_i64),
+        ][index];
+        column.cid == index as i64
+            && column.name == expected.0
+            && column.declared_type.eq_ignore_ascii_case(expected.1)
+            && column.not_null
+            && column.primary_key == expected.2
+            && column.hidden == 0
+            && column.default_value.is_none()
+    });
+    let token_shape_is_exact = !has_token || {
+        let column = &shape[4];
+        column.cid == 4
+            && column.name == "token_version"
+            && column.declared_type.eq_ignore_ascii_case("INTEGER")
+            && column.not_null
+            && column.primary_key == 0
+            && column.hidden == 0
+            && matches!(column.default_value.as_deref(), Some("1" | "2" | "3"))
+    };
+    let spec_shape_is_exact = !has_spec || {
+        let column = &shape[5];
+        column.cid == 5
+            && column.name == "spec_json"
+            && column.declared_type.eq_ignore_ascii_case("TEXT")
+            && !column.not_null
+            && column.primary_key == 0
+            && column.hidden == 0
+            && column.default_value.is_none()
+    };
+    if !common_shape_is_exact || !token_shape_is_exact || !spec_shape_is_exact {
+        return Err(data_corruption(
+            "TinyMongo SQLite index catalog has an unsupported physical schema",
+        ));
+    }
+    let sql = format!(
+        "SELECT collection_name, index_name, field_name, unique_flag, {}, {} FROM {} ORDER BY collection_name, index_name",
+        if has_token { "token_version" } else { "1" },
+        if has_spec { "spec_json" } else { "NULL" },
+        quote_identifier(INDEX_CATALOG_TABLE),
+    );
+    let mut statement = connection.prepare(&sql).map_err(sqlite_error::storage)?;
+    let mut rows = statement.query([]).map_err(sqlite_error::storage)?;
+    let mut result: BTreeMap<String, Vec<LogicalIndex>> = BTreeMap::new();
+    let mut index_count = 0_usize;
+    let mut metadata_bytes = 0_usize;
+    while let Some(row) = rows.next().map_err(sqlite_error::storage)? {
+        ensure_import_not_cancelled(cancellation)?;
+        let collection: String = row.get(0).map_err(sqlite_error::storage)?;
+        let name: String = row.get(1).map_err(sqlite_error::storage)?;
+        let field: String = row.get(2).map_err(sqlite_error::storage)?;
+        let unique_flag: i64 = row.get(3).map_err(sqlite_error::storage)?;
+        let token_version: i64 = row.get(4).map_err(sqlite_error::storage)?;
+        let spec_json = match row.get_ref(5).map_err(sqlite_error::storage)? {
+            ValueRef::Null => None,
+            value => Some(text_column(value, "index spec_json")?.to_owned()),
+        };
+        charge_source_index_metadata(
+            &mut metadata_bytes,
+            [
+                collection.len(),
+                name.len(),
+                field.len(),
+                spec_json.as_deref().map_or(0, str::len),
+            ],
+        )?;
+        if collection == "_default" || collection.starts_with("__tinymongo_") {
+            return Err(data_corruption(
+                "TinyMongo index catalog references a storage-reserved collection",
+            ));
+        }
+        if !matches!(unique_flag, 0 | 1) || !(1..=3).contains(&token_version) {
+            return Err(data_corruption(format!(
+                "TinyMongo index {name:?} has invalid unique/token metadata"
+            )));
+        }
+        if !table_exists(connection, &collection)? {
+            return Err(data_corruption(format!(
+                "TinyMongo index {name:?} references missing collection {collection:?}"
+            )));
+        }
+        let mut index = if let Some(spec_json) = spec_json.filter(|value| !value.is_empty()) {
+            parse_index_metadata(&parse_json(&spec_json, "SQLite index catalog")?, false)?
+        } else {
+            legacy_index(name.clone(), field.clone(), unique_flag == 1)?
+        };
+        if index.name != name
+            || index.keys.first().map(|key| key.0.as_str()) != Some(field.as_str())
+            || index.unique != (unique_flag == 1)
+        {
+            return Err(data_corruption(format!(
+                "TinyMongo index catalog columns disagree with spec_json for {name:?}"
+            )));
+        }
+        index.source_pending = false;
+        result.entry(collection).or_default().push(index);
+        index_count = index_count.checked_add(1).ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::LimitExceeded,
+                "TinyMongo custom index count overflowed",
+            )
+        })?;
+        require_index_count(index_count)?;
+    }
+    for (collection, indexes) in &result {
+        reject_duplicate_index_names(collection, indexes)?;
+    }
+    Ok(result)
+}
+
+fn parse_legacy_index_catalog(
+    root: &JsonMap<String, JsonValue>,
+    cancellation: &CancellationToken,
+) -> EngineResult<BTreeMap<String, Vec<LogicalIndex>>> {
+    let Some(catalog) = root.get(INDEX_CATALOG_TABLE) else {
+        return Ok(BTreeMap::new());
+    };
+    let catalog = json_object(catalog, "legacy TinyMongo index catalog")?;
+    let mut result: BTreeMap<String, Vec<LogicalIndex>> = BTreeMap::new();
+    for (index_count, entry) in catalog.values().enumerate() {
+        ensure_import_not_cancelled(cancellation)?;
+        require_index_count(index_count + 1)?;
+        let entry = json_object(entry, "legacy TinyMongo index entry")?;
+        let required = ["_id", "collection", "spec"];
+        if entry.len() != required.len() || required.iter().any(|key| !entry.contains_key(*key)) {
+            return Err(data_corruption(
+                "legacy TinyMongo index entry has an unexpected shape",
+            ));
+        }
+        let collection = entry["collection"]
+            .as_str()
+            .ok_or_else(|| data_corruption("legacy TinyMongo index collection must be text"))?;
+        if collection == "_default" || collection.starts_with("__tinymongo_") {
+            return Err(data_corruption(
+                "legacy TinyMongo index references a storage-reserved collection",
+            ));
+        }
+        let index = parse_index_metadata(&entry["spec"], false)?;
+        let expected_id = serde_json::to_string(&(collection, index.name.as_str()))
+            .map_err(|error| EngineError::new(EngineErrorKind::Internal, error.to_string()))?;
+        if entry["_id"].as_str() != Some(expected_id.as_str()) {
+            return Err(data_corruption(
+                "legacy TinyMongo index entry has an invalid catalog identity",
+            ));
+        }
+        result.entry(collection.to_owned()).or_default().push(index);
+    }
+    for (collection, indexes) in &result {
+        if !root.contains_key(collection) {
+            return Err(data_corruption(format!(
+                "legacy TinyMongo indexes reference missing collection {collection:?}"
+            )));
+        }
+        reject_duplicate_index_names(collection, indexes)?;
+    }
+    Ok(result)
+}
+
+fn legacy_index(name: String, field: String, unique: bool) -> EngineResult<LogicalIndex> {
+    validate_index_name(&name)?;
+    validate_index_field(&field)?;
+    Ok(LogicalIndex {
+        name,
+        keys: vec![(field, 1)],
+        unique,
+        sparse: false,
+        partial_filter: None,
+        source_pending: false,
+    })
+}
+
+fn parse_index_metadata(value: &JsonValue, source_pending: bool) -> EngineResult<LogicalIndex> {
+    let object = json_object(value, "TinyMongo index metadata")?;
+    let version = object
+        .get("v")
+        .and_then(exact_i64)
+        .ok_or_else(|| data_corruption("TinyMongo index metadata has no integer version"))?;
+    let required_v1: BTreeSet<_> = ["v", "name", "key", "unique"].into_iter().collect();
+    let required_v2: BTreeSet<_> = [
+        "v",
+        "name",
+        "key",
+        "unique",
+        "sparse",
+        "partialFilterExpression",
+    ]
+    .into_iter()
+    .collect();
+    let actual: BTreeSet<_> = object.keys().map(String::as_str).collect();
+    if (version == 1 && actual != required_v1)
+        || (version == 2 && actual != required_v2)
+        || !matches!(version, 1 | 2)
+    {
+        return Err(data_corruption(
+            "TinyMongo index metadata has an unsupported version or field set",
+        ));
+    }
+    let name = object["name"]
+        .as_str()
+        .ok_or_else(|| data_corruption("TinyMongo index name must be text"))?
+        .to_owned();
+    validate_index_name(&name)?;
+    let keys = object["key"]
+        .as_array()
+        .ok_or_else(|| data_corruption("TinyMongo index key must be an array"))?;
+    if keys.is_empty() {
+        return Err(data_corruption("TinyMongo index key must not be empty"));
+    }
+    let mut seen = HashSet::new();
+    let mut parsed_keys = Vec::with_capacity(keys.len());
+    for key in keys {
+        let pair = key
+            .as_array()
+            .filter(|pair| pair.len() == 2)
+            .ok_or_else(|| {
+                data_corruption("TinyMongo index key entries must be two-item arrays")
+            })?;
+        let field = pair[0]
+            .as_str()
+            .ok_or_else(|| data_corruption("TinyMongo index field must be text"))?
+            .to_owned();
+        if !json_is_integer(&pair[1], 1) {
+            return Err(data_corruption(
+                "TinyMongo supports only ascending index direction 1",
+            ));
+        }
+        validate_index_field(&field)?;
+        if !seen.insert(field.clone()) {
+            return Err(data_corruption("TinyMongo compound index repeats a field"));
+        }
+        parsed_keys.push((field, 1));
+    }
+    let unique = object["unique"]
+        .as_bool()
+        .ok_or_else(|| data_corruption("TinyMongo unique index option must be boolean"))?;
+    let sparse = if version == 2 {
+        object["sparse"]
+            .as_bool()
+            .ok_or_else(|| data_corruption("TinyMongo sparse index option must be boolean"))?
+    } else {
+        false
+    };
+    let partial_filter = if version == 2 {
+        match &object["partialFilterExpression"] {
+            JsonValue::Null => None,
+            JsonValue::Object(filter) if !filter.is_empty() => {
+                validate_partial_filter(filter)?;
+                Some(json_object_to_document(
+                    filter,
+                    true,
+                    "partialFilterExpression",
+                )?)
+            }
+            _ => {
+                return Err(data_corruption(
+                    "TinyMongo partialFilterExpression must be a non-empty object or null",
+                ));
+            }
+        }
+    } else {
+        None
+    };
+    if sparse && partial_filter.is_some() {
+        return Err(data_corruption(
+            "TinyMongo index cannot combine sparse and partialFilterExpression",
+        ));
+    }
+    Ok(LogicalIndex {
+        name,
+        keys: parsed_keys,
+        unique,
+        sparse,
+        partial_filter,
+        source_pending,
+    })
+}
+
+fn validate_index_name(name: &str) -> EngineResult<()> {
+    if name.is_empty()
+        || name.len() > MAX_TINYMONGO_IMPORT_INDEX_NAME_BYTES
+        || name.contains('\0')
+        || matches!(name, "_id" | "_id_")
+    {
+        return Err(data_corruption(
+            "TinyMongo custom index name is invalid or reserved",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_index_field(field: &str) -> EngineResult<()> {
+    if field.is_empty()
+        || field.contains('\0')
+        || field
+            .split('.')
+            .any(|part| part.is_empty() || part.starts_with('$'))
+    {
+        return Err(data_corruption("TinyMongo index field path is invalid"));
+    }
+    Ok(())
+}
+
+fn validate_partial_filter(filter: &JsonMap<String, JsonValue>) -> EngineResult<()> {
+    if filter.is_empty() {
+        return Err(data_corruption(
+            "TinyMongo partial filter must not be empty",
+        ));
+    }
+    const FIELD_OPERATORS: &[&str] = &[
+        "$eq", "$exists", "$gt", "$gte", "$in", "$lt", "$lte", "$type",
+    ];
+    for (field, condition) in filter {
+        if matches!(field.as_str(), "$and" | "$or") {
+            let children = condition
+                .as_array()
+                .filter(|children| !children.is_empty())
+                .ok_or_else(|| {
+                    data_corruption("TinyMongo partial logical operator requires a non-empty array")
+                })?;
+            for child in children {
+                validate_partial_filter(json_object(child, "partial filter child")?)?;
+            }
+            continue;
+        }
+        validate_index_field(field)?;
+        let JsonValue::Object(operators) = condition else {
+            continue;
+        };
+        let operator_names: Vec<_> = operators
+            .keys()
+            .filter(|name| name.starts_with('$'))
+            .collect();
+        if operator_names.is_empty() {
+            continue;
+        }
+        if operator_names.len() != operators.len()
+            || operator_names
+                .iter()
+                .any(|name| !FIELD_OPERATORS.contains(&name.as_str()))
+            || operators
+                .get("$exists")
+                .is_some_and(|value| value != &JsonValue::Bool(true))
+            || operators.get("$in").is_some_and(|value| !value.is_array())
+        {
+            return Err(data_corruption(
+                "TinyMongo partial filter uses unsupported operators",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn import_indexes(
+    indexes: Vec<LogicalIndex>,
+    cancellation: &CancellationToken,
+) -> EngineResult<Box<[TinyMongoImportIndex]>> {
+    let mut imported = Vec::with_capacity(indexes.len());
+    for index in indexes {
+        ensure_import_not_cancelled(cancellation)?;
+        let key = BsonDocument::from_entries(
+            index
+                .keys
+                .iter()
+                .map(|(field, direction)| (field.clone(), BsonValue::Int32(*direction))),
+        )
+        .map_err(|error| error.into_engine_error(crate::document::BsonErrorContext::StoredData))?;
+        let partial = index
+            .partial_filter
+            .clone()
+            .map(BsonValue::Document)
+            .unwrap_or(BsonValue::Null);
+        let specification = BsonDocument::from_entries([
+            ("v", BsonValue::Int32(2)),
+            ("name", BsonValue::String(index.name.clone())),
+            ("key", BsonValue::Document(key)),
+            ("unique", BsonValue::Boolean(index.unique)),
+            ("sparse", BsonValue::Boolean(index.sparse)),
+            ("partialFilterExpression", partial),
+        ])
+        .map_err(|error| error.into_engine_error(crate::document::BsonErrorContext::StoredData))?;
+        encode_document(&specification).map_err(|error| {
+            error.into_engine_error(crate::document::BsonErrorContext::StoredData)
+        })?;
+        imported.push(TinyMongoImportIndex {
+            name: index.name,
+            specification,
+            unique: index.unique,
+            source_pending: index.source_pending,
+        });
+    }
+    Ok(imported.into_boxed_slice())
+}
+
+fn reject_duplicate_index_names(collection: &str, indexes: &[LogicalIndex]) -> EngineResult<()> {
+    let mut names = HashSet::new();
+    if indexes
+        .iter()
+        .any(|index| !names.insert(index.name.as_str()))
+    {
+        return Err(data_corruption(format!(
+            "TinyMongo collection {collection:?} contains duplicate custom index names"
+        )));
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+struct ShardedConfig {
+    shard_count: usize,
+    database_id: String,
+}
+
+fn validate_manifest_schema(connection: &Connection) -> EngineResult<()> {
+    let version: i64 = connection
+        .query_row("PRAGMA user_version", [], |row| row.get(0))
+        .map_err(sqlite_error::storage)?;
+    if version != SHARDED_FORMAT_VERSION {
+        return Err(failed_precondition(format!(
+            "unsupported TinyMongo sharded manifest version {version}"
+        )));
+    }
+    let tables = ordinary_tables(connection)?;
+    let expected: BTreeSet<_> = [
+        SHARD_CONFIG_TABLE,
+        SHARD_COLLECTION_TABLE,
+        INDEX_CATALOG_TABLE,
+    ]
+    .into_iter()
+    .map(str::to_owned)
+    .collect();
+    if tables.into_iter().collect::<BTreeSet<_>>() != expected {
+        return Err(data_corruption(
+            "TinyMongo sharded manifest has an unexpected table inventory",
+        ));
+    }
+    require_columns(
+        connection,
+        SHARD_CONFIG_TABLE,
+        &[
+            ("format_version", "INTEGER", true, 0),
+            ("shard_count", "INTEGER", true, 0),
+            ("hash_algorithm", "TEXT", true, 0),
+            ("database_id", "TEXT", true, 0),
+            ("state", "TEXT", true, 0),
+        ],
+    )?;
+    require_columns(
+        connection,
+        SHARD_COLLECTION_TABLE,
+        &[
+            ("collection_name", "TEXT", false, 1),
+            ("state", "TEXT", true, 0),
+        ],
+    )?;
+    require_columns(
+        connection,
+        INDEX_CATALOG_TABLE,
+        &[
+            ("collection_name", "TEXT", true, 1),
+            ("index_name", "TEXT", true, 2),
+            ("spec_json", "TEXT", true, 0),
+            ("state", "TEXT", true, 0),
+        ],
+    )?;
+    Ok(())
+}
+
+fn require_columns(
+    connection: &Connection,
+    table: &str,
+    expected: &[(&str, &str, bool, i64)],
+) -> EngineResult<()> {
+    let shape = table_shape(connection, table)?;
+    let exact = shape.len() == expected.len()
+        && shape.iter().zip(expected).enumerate().all(
+            |(index, (column, (name, declared_type, not_null, primary_key)))| {
+                column.cid == index as i64
+                    && column.name == *name
+                    && column.declared_type.eq_ignore_ascii_case(declared_type)
+                    && column.not_null == *not_null
+                    && column.primary_key == *primary_key
+                    && column.hidden == 0
+                    && column.default_value.is_none()
+            },
+        );
+    if !exact {
+        return Err(data_corruption(format!(
+            "TinyMongo metadata table {table:?} has an unsupported schema"
+        )));
+    }
+    Ok(())
+}
+
+fn read_manifest_config(connection: &Connection) -> EngineResult<ShardedConfig> {
+    let mut statement = connection
+        .prepare("SELECT format_version, shard_count, hash_algorithm, database_id, state FROM __tinymongo_config")
+        .map_err(sqlite_error::storage)?;
+    let mut rows = statement.query([]).map_err(sqlite_error::storage)?;
+    let Some(row) = rows.next().map_err(sqlite_error::storage)? else {
+        return Err(data_corruption(
+            "TinyMongo sharded manifest has no configuration row",
+        ));
+    };
+    let version: i64 = row.get(0).map_err(sqlite_error::storage)?;
+    let shard_count: i64 = row.get(1).map_err(sqlite_error::storage)?;
+    let hash_algorithm: String = row.get(2).map_err(sqlite_error::storage)?;
+    let database_id: String = row.get(3).map_err(sqlite_error::storage)?;
+    let state: String = row.get(4).map_err(sqlite_error::storage)?;
+    if rows.next().map_err(sqlite_error::storage)?.is_some() {
+        return Err(data_corruption(
+            "TinyMongo sharded manifest has multiple configuration rows",
+        ));
+    }
+    let shard_count = usize::try_from(shard_count)
+        .ok()
+        .filter(|count| (MIN_SHARD_COUNT..=MAX_SHARD_COUNT).contains(count))
+        .ok_or_else(|| data_corruption("TinyMongo sharded manifest has an invalid shard count"))?;
+    if version != SHARDED_FORMAT_VERSION
+        || hash_algorithm != SHARDED_HASH_ALGORITHM
+        || database_id.is_empty()
+    {
+        return Err(data_corruption(
+            "TinyMongo sharded manifest identity is invalid",
+        ));
+    }
+    if state != "ready" {
+        return Err(failed_precondition(format!(
+            "TinyMongo sharded manifest is {state:?}; recover it with pinned TinyMongo v1.3 before import"
+        )));
+    }
+    Ok(ShardedConfig {
+        shard_count,
+        database_id,
+    })
+}
+
+fn read_manifest_collections(
+    connection: &Connection,
+    cancellation: &CancellationToken,
+) -> EngineResult<BTreeMap<String, String>> {
+    let mut statement = connection
+        .prepare(
+            "SELECT collection_name, state FROM __tinymongo_collections ORDER BY collection_name",
+        )
+        .map_err(sqlite_error::storage)?;
+    let mut rows = statement.query([]).map_err(sqlite_error::storage)?;
+    let mut result = BTreeMap::new();
+    let mut metadata_bytes = 0_usize;
+    while let Some(row) = rows.next().map_err(sqlite_error::storage)? {
+        ensure_import_not_cancelled(cancellation)?;
+        let name: String = row.get(0).map_err(sqlite_error::storage)?;
+        let state: String = row.get(1).map_err(sqlite_error::storage)?;
+        if result.len() >= MAX_TINYMONGO_IMPORT_COLLECTIONS {
+            return Err(EngineError::new(
+                EngineErrorKind::LimitExceeded,
+                format!(
+                    "TinyMongo source exceeds {MAX_TINYMONGO_IMPORT_COLLECTIONS} manifest collections"
+                ),
+            ));
+        }
+        charge_source_metadata(
+            &mut metadata_bytes,
+            [name.len(), state.len()],
+            MAX_TINYMONGO_IMPORT_METADATA_BSON_BYTES,
+            "collection catalog",
+        )?;
+        if name.is_empty()
+            || name.contains('\0')
+            || name == "_default"
+            || name.starts_with("__tinymongo_")
+            || !matches!(state.as_str(), "ready" | "dropping")
+            || result.insert(name.clone(), state).is_some()
+        {
+            return Err(data_corruption(
+                "TinyMongo sharded collection catalog is invalid",
+            ));
+        }
+    }
+    Ok(result)
+}
+
+fn read_manifest_indexes(
+    connection: &Connection,
+    cancellation: &CancellationToken,
+) -> EngineResult<BTreeMap<String, Vec<LogicalIndex>>> {
+    let mut statement = connection
+        .prepare("SELECT collection_name, index_name, spec_json, state FROM __tinymongo_indexes ORDER BY collection_name, index_name")
+        .map_err(sqlite_error::storage)?;
+    let mut rows = statement.query([]).map_err(sqlite_error::storage)?;
+    let mut result: BTreeMap<String, Vec<LogicalIndex>> = BTreeMap::new();
+    let mut index_count = 0_usize;
+    let mut metadata_bytes = 0_usize;
+    while let Some(row) = rows.next().map_err(sqlite_error::storage)? {
+        ensure_import_not_cancelled(cancellation)?;
+        index_count = index_count.checked_add(1).ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::LimitExceeded,
+                "TinyMongo custom index count overflowed",
+            )
+        })?;
+        require_index_count(index_count)?;
+        let collection: String = row.get(0).map_err(sqlite_error::storage)?;
+        let name: String = row.get(1).map_err(sqlite_error::storage)?;
+        let spec_json: String = row.get(2).map_err(sqlite_error::storage)?;
+        let state: String = row.get(3).map_err(sqlite_error::storage)?;
+        charge_source_index_metadata(
+            &mut metadata_bytes,
+            [collection.len(), name.len(), spec_json.len(), state.len()],
+        )?;
+        if !matches!(state.as_str(), "ready" | "pending") {
+            return Err(data_corruption(
+                "TinyMongo sharded index has an invalid lifecycle state",
+            ));
+        }
+        let mut index = parse_index_metadata(
+            &parse_json(&spec_json, "sharded manifest index")?,
+            state == "pending",
+        )?;
+        if index.name != name {
+            return Err(data_corruption(
+                "TinyMongo manifest index name disagrees with spec_json",
+            ));
+        }
+        index.source_pending = state == "pending";
+        result.entry(collection).or_default().push(index);
+    }
+    for (collection, indexes) in &result {
+        reject_duplicate_index_names(collection, indexes)?;
+    }
+    Ok(result)
+}
+
+fn require_index_count(count: usize) -> EngineResult<()> {
+    if count > MAX_TINYMONGO_IMPORT_INDEXES {
+        Err(EngineError::new(
+            EngineErrorKind::LimitExceeded,
+            format!("TinyMongo source exceeds {MAX_TINYMONGO_IMPORT_INDEXES} custom indexes"),
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn charge_source_index_metadata(
+    total: &mut usize,
+    lengths: impl IntoIterator<Item = usize>,
+) -> EngineResult<()> {
+    charge_source_metadata(
+        total,
+        lengths,
+        MAX_TINYMONGO_IMPORT_METADATA_BSON_BYTES,
+        "index metadata",
+    )
+}
+
+fn charge_source_metadata(
+    total: &mut usize,
+    lengths: impl IntoIterator<Item = usize>,
+    limit: usize,
+    label: &str,
+) -> EngineResult<()> {
+    for length in lengths {
+        *total = total.checked_add(length).ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::LimitExceeded,
+                format!("TinyMongo source {label} size overflowed"),
+            )
+        })?;
+    }
+    if *total > limit {
+        return Err(EngineError::new(
+            EngineErrorKind::LimitExceeded,
+            format!("TinyMongo source {label} exceeds {limit} bytes"),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_shard_identity(
+    connection: &Connection,
+    config: &ShardedConfig,
+    shard: usize,
+) -> EngineResult<()> {
+    require_columns(
+        connection,
+        SHARD_IDENTITY_TABLE,
+        &[
+            ("format_version", "INTEGER", true, 0),
+            ("database_id", "TEXT", true, 0),
+            ("shard_index", "INTEGER", true, 0),
+            ("shard_count", "INTEGER", true, 0),
+            ("hash_algorithm", "TEXT", true, 0),
+        ],
+    )?;
+    let mut statement = connection
+        .prepare("SELECT format_version, database_id, shard_index, shard_count, hash_algorithm FROM __tinymongo_shard")
+        .map_err(sqlite_error::storage)?;
+    let mut rows = statement.query([]).map_err(sqlite_error::storage)?;
+    let Some(row) = rows.next().map_err(sqlite_error::storage)? else {
+        return Err(data_corruption(format!(
+            "TinyMongo shard {shard} has no identity row"
+        )));
+    };
+    let actual = (
+        row.get::<_, i64>(0).map_err(sqlite_error::storage)?,
+        row.get::<_, String>(1).map_err(sqlite_error::storage)?,
+        row.get::<_, i64>(2).map_err(sqlite_error::storage)?,
+        row.get::<_, i64>(3).map_err(sqlite_error::storage)?,
+        row.get::<_, String>(4).map_err(sqlite_error::storage)?,
+    );
+    if rows.next().map_err(sqlite_error::storage)?.is_some()
+        || actual
+            != (
+                SHARDED_FORMAT_VERSION,
+                config.database_id.clone(),
+                shard as i64,
+                config.shard_count as i64,
+                SHARDED_HASH_ALGORITHM.to_owned(),
+            )
+    {
+        return Err(data_corruption(format!(
+            "TinyMongo shard {shard} identity does not match its manifest"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_shard_tree(
+    path: &Path,
+    shard_count: usize,
+    cancellation: &CancellationToken,
+) -> EngineResult<()> {
+    let shards = path.join("shards");
+    let metadata = fs::symlink_metadata(&shards).map_err(|error| {
+        crate::sqlite_error::storage_io(error, "TinyMongo shards directory is unavailable")
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(failed_precondition(
+            "TinyMongo shards path must be a real directory",
+        ));
+    }
+    let mut expected = BTreeSet::new();
+    for shard in 0..shard_count {
+        expected.insert(format!("{shard:03}"));
+    }
+    let entries = fs::read_dir(&shards)
+        .map_err(|error| crate::sqlite_error::storage_io(error, "cannot list TinyMongo shards"))?;
+    let mut actual = BTreeSet::new();
+    for entry in entries {
+        ensure_import_not_cancelled(cancellation)?;
+        if actual.len() >= shard_count {
+            return Err(data_corruption(
+                "TinyMongo shard directory contains more entries than its manifest declares",
+            ));
+        }
+        let entry = entry.map_err(|error| {
+            crate::sqlite_error::storage_io(error, "cannot inspect TinyMongo shard entry")
+        })?;
+        let file_type = entry.file_type().map_err(|error| {
+            crate::sqlite_error::storage_io(error, "cannot inspect TinyMongo shard entry type")
+        })?;
+        if file_type.is_symlink() || !file_type.is_dir() {
+            return Err(data_corruption(
+                "TinyMongo shard inventory contains an entry that is not a real directory",
+            ));
+        }
+        let name = entry
+            .file_name()
+            .into_string()
+            .map_err(|_| data_corruption("TinyMongo shard directory name is not UTF-8"))?;
+        if !expected.contains(&name) {
+            return Err(data_corruption(format!(
+                "TinyMongo shard directory inventory contains undeclared entry {name:?}"
+            )));
+        }
+        actual.insert(name);
+    }
+    if actual != expected {
+        return Err(data_corruption(format!(
+            "TinyMongo shard directory inventory mismatch: expected {expected:?}, found {actual:?}"
+        )));
+    }
+    Ok(())
+}
+
+fn shard_path(root: &Path, shard: usize) -> PathBuf {
+    root.join("shards")
+        .join(format!("{shard:03}"))
+        .join("data.sqlite")
+}
+
+fn require_regular_nonsymlink(path: &Path, label: &str) -> EngineResult<()> {
+    let metadata = fs::symlink_metadata(path).map_err(|error| {
+        crate::sqlite_error::storage_io(
+            error,
+            format!("{label} is unavailable: {}", path.display()),
+        )
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(failed_precondition(format!(
+            "{label} must be a regular non-symlink file"
+        )));
+    }
+    Ok(())
+}
+
+fn require_wal(path: &Path, label: &str) -> EngineResult<()> {
+    // An immutable read-only SQLite connection deliberately reports `delete`
+    // for `PRAGMA journal_mode`, even when the durable database header records
+    // WAL mode. Inspect the two format-version bytes in the checkpointed main
+    // file instead (SQLite file-header offsets 18 and 19).
+    let mut header = [0_u8; 20];
+    fs::File::open(path)
+        .and_then(|mut source| source.read_exact(&mut header))
+        .map_err(|error| {
+            sqlite_error::storage_io(
+                error,
+                format!("failed to read {label} header at {}", path.display()),
+            )
+        })?;
+    if &header[..16] != b"SQLite format 3\0" || header[18] != 2 || header[19] != 2 {
+        return Err(failed_precondition(format!(
+            "{label} is not in WAL journal mode"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_physical_id(value: &str) -> EngineResult<()> {
+    let digest = value
+        .strip_prefix(PHYSICAL_ID_PREFIX)
+        .ok_or_else(|| data_corruption("TinyMongo physical identifier has no v2 prefix"))?;
+    if digest.len() != 64
+        || !digest
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+    {
+        return Err(data_corruption(
+            "TinyMongo v2 physical identifier has an invalid SHA-256 digest",
+        ));
+    }
+    Ok(())
+}
+
+fn physical_id_route(value: &str, shard_count: usize) -> EngineResult<usize> {
+    validate_physical_id(value)?;
+    let suffix = &value[value.len() - 16..];
+    let hash = u64::from_str_radix(suffix, 16)
+        .map_err(|_| data_corruption("TinyMongo physical identifier suffix is invalid"))?;
+    Ok((hash % shard_count as u64) as usize)
+}
+
+fn validate_order_token(value: &str) -> EngineResult<()> {
+    let Some((timestamp, nonce)) = value.split_once(':') else {
+        return Err(data_corruption(
+            "TinyMongo natural-order token is malformed",
+        ));
+    };
+    if timestamp.len() < 20
+        || !timestamp.bytes().all(|byte| byte.is_ascii_digit())
+        || nonce.len() != 12
+        || !nonce
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(data_corruption(
+            "TinyMongo natural-order token is malformed",
+        ));
+    }
+    Ok(())
+}
+
+fn text_column<'a>(value: ValueRef<'a>, label: &str) -> EngineResult<&'a str> {
+    match value {
+        ValueRef::Text(value) => std::str::from_utf8(value).map_err(|_| {
+            EngineError::new(
+                EngineErrorKind::InvalidTextEncoding,
+                format!("TinyMongo {label} is not valid UTF-8"),
+            )
+        }),
+        _ => Err(data_corruption(format!(
+            "TinyMongo {label} must use SQLite TEXT storage"
+        ))),
+    }
+}
+
+fn quote_identifier(value: &str) -> String {
+    format!("\"{}\"", value.replace('"', "\"\""))
+}
+
+fn invalid_argument(diagnostic: impl Into<String>) -> EngineError {
+    EngineError::new(EngineErrorKind::InvalidArgument, diagnostic)
+}
+
+fn failed_precondition(diagnostic: impl Into<String>) -> EngineError {
+    EngineError::new(EngineErrorKind::FailedPrecondition, diagnostic)
+}
+
+fn data_corruption(diagnostic: impl Into<String>) -> EngineError {
+    EngineError::new(EngineErrorKind::DataCorruption, diagnostic)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::params;
+    use tempfile::TempDir;
+
+    fn plan(collections: &[&str]) -> TinyMongoImportPlan {
+        TinyMongoImportPlan::new("app", collections.iter().copied()).unwrap()
+    }
+
+    fn create_collection(connection: &Connection, name: &str, sharded: bool) {
+        connection
+            .execute_batch(&format!(
+                "CREATE TABLE {} (_id TEXT PRIMARY KEY, data TEXT NOT NULL){}",
+                quote_identifier(name),
+                if sharded {
+                    format!(
+                        "; ALTER TABLE {} ADD COLUMN {} TEXT",
+                        quote_identifier(name),
+                        quote_identifier(SHARD_ORDER_COLUMN)
+                    )
+                } else {
+                    String::new()
+                }
+            ))
+            .unwrap();
+    }
+
+    fn physical_id_for_route(shard: usize) -> String {
+        format!("{PHYSICAL_ID_PREFIX}{:064x}", shard)
+    }
+
+    fn initialize_manifest(root: &Path, shard_count: usize) {
+        fs::create_dir_all(root.join("shards")).unwrap();
+        let manifest = Connection::open(root.join("manifest.sqlite")).unwrap();
+        manifest.pragma_update(None, "journal_mode", "WAL").unwrap();
+        manifest.pragma_update(None, "user_version", 1).unwrap();
+        manifest
+            .execute_batch(
+                "CREATE TABLE __tinymongo_config (
+                    format_version INTEGER NOT NULL,
+                    shard_count INTEGER NOT NULL,
+                    hash_algorithm TEXT NOT NULL,
+                    database_id TEXT NOT NULL,
+                    state TEXT NOT NULL);
+                 CREATE TABLE __tinymongo_collections (
+                    collection_name TEXT PRIMARY KEY,
+                    state TEXT NOT NULL);
+                 CREATE TABLE __tinymongo_indexes (
+                    collection_name TEXT NOT NULL,
+                    index_name TEXT NOT NULL,
+                    spec_json TEXT NOT NULL,
+                    state TEXT NOT NULL,
+                    PRIMARY KEY (collection_name, index_name));",
+            )
+            .unwrap();
+        manifest
+            .execute(
+                "INSERT INTO __tinymongo_config VALUES (1, ?, ?, 'database-id', 'ready')",
+                params![shard_count as i64, SHARDED_HASH_ALGORITHM],
+            )
+            .unwrap();
+        manifest
+            .execute(
+                "INSERT INTO __tinymongo_collections VALUES ('users', 'ready')",
+                [],
+            )
+            .unwrap();
+        for shard in 0..shard_count {
+            let directory = root.join("shards").join(format!("{shard:03}"));
+            fs::create_dir(&directory).unwrap();
+            let connection = Connection::open(directory.join("data.sqlite")).unwrap();
+            connection
+                .pragma_update(None, "journal_mode", "WAL")
+                .unwrap();
+            connection
+                .execute_batch(
+                    "CREATE TABLE __tinymongo_shard (
+                        format_version INTEGER NOT NULL,
+                        database_id TEXT NOT NULL,
+                        shard_index INTEGER NOT NULL,
+                        shard_count INTEGER NOT NULL,
+                        hash_algorithm TEXT NOT NULL);",
+                )
+                .unwrap();
+            connection
+                .execute(
+                    "INSERT INTO __tinymongo_shard VALUES (1, 'database-id', ?, ?, ?)",
+                    params![shard as i64, shard_count as i64, SHARDED_HASH_ALGORITHM],
+                )
+                .unwrap();
+            create_collection(&connection, "users", true);
+        }
+    }
+
+    #[test]
+    fn plan_requires_explicit_non_reserved_unique_names() {
+        let plan = TinyMongoImportPlan::new("app", ["z", "a"]).unwrap();
+        assert_eq!(plan.collections(), &["a".to_owned(), "z".to_owned()]);
+        assert_eq!(
+            TinyMongoImportPlan::new("app", ["users", "users"])
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::InvalidArgument
+        );
+        assert_eq!(
+            TinyMongoImportPlan::new("app", ["__tinymongo_indexes"])
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::InvalidArgument
+        );
+        assert_eq!(
+            TinyMongoImportPlan::new("app", std::iter::empty::<&str>())
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::InvalidArgument
+        );
+    }
+
+    #[test]
+    fn import_options_validate_shards_and_report_cancellation() {
+        assert_eq!(
+            TinyMongoImportOptions::new(1).unwrap_err().kind(),
+            EngineErrorKind::InvalidArgument
+        );
+        let options = TinyMongoImportOptions::new(2).unwrap();
+        assert_eq!(options.shard_count(), 2);
+        assert!(!options.cancellation_token().is_cancelled());
+        assert_eq!(
+            format!("{options:?}"),
+            "TinyMongoImportOptions { shard_count: 2, cancelled: false }"
+        );
+    }
+
+    #[test]
+    fn tagged_json_restores_bson_and_keeps_field_order() {
+        let raw = serde_json::from_str(
+            r#"{
+                "z":1,
+                "oid":{"__tinymongo_type_v1__":"objectid","value":"000000000000000000000001"},
+                "date":{"__tinymongo_type_v1__":"datetime","value":"1969-12-31T23:59:59.999"},
+                "offset_date":{"__tinymongo_type_v1__":"datetime","value":"2026-07-29T08:30:00.123999-04:00"},
+                "binary":{"__tinymongo_type_v1__":"binary","value":{"base64":"AAEC/w==","subtype":4}},
+                "decimal":{"__tinymongo_type_v1__":"decimal128","value":"3d0c0000000000000000000000003e30"},
+                "timestamp":{"__tinymongo_type_v1__":"timestamp","value":{"time":2,"inc":3}},
+                "uuid":{"__tinymongo_type_v1__":"uuid","value":"00112233-4455-6677-8899-aabbccddeeff"},
+                "regex":{"__tinymongo_type_v1__":"regex","value":{"pattern":"a+","flags":42,"representation":"bson","pattern_type":"string"}},
+                "min":{"__tinymongo_type_v1__":"minkey","value":1},
+                "max":{"__tinymongo_type_v1__":"maxkey","value":1},
+                "escaped":{"__tinymongo_type_v1__":"mapping","value":[["__tinymongo_type_v1__","objectid"],["value","literal"]]}
+            }"#,
+        )
+        .unwrap();
+        let document = json_document(&raw, "test").unwrap();
+        assert_eq!(
+            document.iter().map(|(name, _)| name).collect::<Vec<_>>(),
+            [
+                "z",
+                "oid",
+                "date",
+                "offset_date",
+                "binary",
+                "decimal",
+                "timestamp",
+                "uuid",
+                "regex",
+                "min",
+                "max",
+                "escaped"
+            ]
+        );
+        assert_eq!(
+            document.get_unique("date").unwrap(),
+            Some(&BsonValue::DateTime(BsonDateTime::from_millis(-1)))
+        );
+        assert_eq!(
+            document.get_unique("offset_date").unwrap(),
+            Some(&BsonValue::DateTime(BsonDateTime::from_millis(
+                1_785_328_200_123
+            )))
+        );
+        assert!(matches!(
+            document.get_unique("uuid").unwrap(),
+            Some(BsonValue::Uuid(_))
+        ));
+        assert!(matches!(
+            document.get_unique("escaped").unwrap(),
+            Some(BsonValue::Document(_))
+        ));
+    }
+
+    #[test]
+    fn malformed_or_unknown_tags_remain_literal_documents() {
+        let raw = serde_json::json!({
+            "_id": 1,
+            "unknown": {TYPE_MARKER: "future", VALUE_MARKER: {TYPE_MARKER: "minkey", VALUE_MARKER: 1}},
+            "bad_binary": {TYPE_MARKER: "binary", VALUE_MARKER: {"base64": "!", "subtype": 0}}
+        });
+        let document = json_document(&raw, "test").unwrap();
+        let Some(BsonValue::Document(unknown)) = document.get_unique("unknown").unwrap() else {
+            panic!("unknown tag must remain a document");
+        };
+        assert!(matches!(
+            unknown.get_unique(VALUE_MARKER).unwrap(),
+            Some(BsonValue::Document(_))
+        ));
+        assert!(matches!(
+            document.get_unique("bad_binary").unwrap(),
+            Some(BsonValue::Document(_))
+        ));
+
+        let python_only_regex = serde_json::json!({
+            "_id": 1,
+            "value": {
+                TYPE_MARKER: "regex",
+                VALUE_MARKER: {
+                    "pattern": "x",
+                    "flags": 256,
+                    "representation": "python",
+                    "pattern_type": "string"
+                }
+            }
+        });
+        assert_eq!(
+            json_document(&python_only_regex, "test")
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::Unsupported
+        );
+
+        for (representation, pattern_type) in
+            [("python", "string"), ("python", "bytes"), ("bson", "bytes")]
+        {
+            let lossy_regex = serde_json::json!({
+                "_id": 1,
+                "value": {
+                    TYPE_MARKER: "regex",
+                    VALUE_MARKER: {
+                        "pattern": "x",
+                        "flags": 2,
+                        "representation": representation,
+                        "pattern_type": pattern_type
+                    }
+                }
+            });
+            assert_eq!(
+                json_document(&lossy_regex, "test").unwrap_err().kind(),
+                EngineErrorKind::Unsupported
+            );
+        }
+    }
+
+    #[test]
+    fn legacy_blob_imports_documents_and_logical_index() {
+        let temporary = TempDir::new().unwrap();
+        let path = temporary.path().join("app.sqlite");
+        let connection = Connection::open(&path).unwrap();
+        connection
+            .execute_batch("CREATE TABLE tinydb(id INTEGER PRIMARY KEY, data TEXT)")
+            .unwrap();
+        let payload = r#"{
+            "users":{"1":{"_id":1,"name":"Ada"}},
+            "__tinymongo_indexes":{"1":{
+                "_id":"[\"users\",\"email_1\"]",
+                "collection":"users",
+                "spec":{"v":2,"name":"email_1","key":[["email",1]],"unique":true,"sparse":false,"partialFilterExpression":null}
+            }}
+        }"#;
+        connection
+            .execute("INSERT INTO tinydb VALUES (1, ?)", [payload])
+            .unwrap();
+        drop(connection);
+
+        let source = read_tinymongo_source(&path, &plan(&["users"])).unwrap();
+        assert_eq!(source.variant(), TinyMongoSourceVariant::LegacySingleRow);
+        assert_eq!(source.report().documents(), 1);
+        assert_eq!(source.collections()[0].indexes()[0].name(), "email_1");
+        assert!(source.collections()[0].indexes()[0].is_unique());
+        assert_eq!(
+            source.collections()[0].indexes()[0].target_lifecycle(),
+            DocumentIndexLifecycle::PendingBuild
+        );
+    }
+
+    #[test]
+    fn mixed_legacy_and_table_native_layout_is_rejected() {
+        let temporary = TempDir::new().unwrap();
+        let path = temporary.path().join("app.sqlite");
+        let connection = Connection::open(&path).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE tinydb(id INTEGER PRIMARY KEY, data TEXT);
+                 INSERT INTO tinydb VALUES(1, '{\"users\":{}}');
+                 CREATE TABLE users (_id TEXT PRIMARY KEY, data TEXT NOT NULL);",
+            )
+            .unwrap();
+        drop(connection);
+        assert_eq!(
+            read_tinymongo_source(&path, &plan(&["users"]))
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::DataCorruption
+        );
+    }
+
+    #[test]
+    fn table_native_reads_only_allowlisted_exact_schema() {
+        let temporary = TempDir::new().unwrap();
+        let path = temporary.path().join("app.sqlite");
+        let connection = Connection::open(&path).unwrap();
+        create_collection(&connection, "users", false);
+        create_collection(&connection, "ordinary_sql_table", false);
+        connection
+            .execute(
+                "INSERT INTO users VALUES ('user-1', ?)",
+                [r#"{"_id":"user-1","last":2,"first":1}"#],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO ordinary_sql_table VALUES ('ordinary', '{\"_id\":\"must-not-import\"}')",
+                [],
+            )
+            .unwrap();
+        drop(connection);
+
+        let source = read_tinymongo_source(&path, &plan(&["users"])).unwrap();
+        assert_eq!(source.variant(), TinyMongoSourceVariant::TableNative);
+        assert_eq!(source.collections().len(), 1);
+        assert_eq!(source.legacy_physical_ids(), 1);
+        assert_eq!(
+            source.collections()[0].documents()[0]
+                .iter()
+                .map(|(name, _)| name)
+                .collect::<Vec<_>>(),
+            ["_id", "last", "first"]
+        );
+    }
+
+    #[test]
+    fn legacy_physical_ids_are_validated_and_restore_container_order() {
+        let temporary = TempDir::new().unwrap();
+        let path = temporary.path().join("app.sqlite");
+        let connection = Connection::open(&path).unwrap();
+        create_collection(&connection, "users", false);
+        connection
+            .execute(
+                "INSERT INTO users VALUES (?1, ?2), (?3, ?4), (?5, ?6)",
+                params![
+                    "{'b': 2, 'a': 1}",
+                    r#"{"_id":{"a":1.0,"b":2.0},"kind":"object"}"#,
+                    "(1, {'b': 2, 'a': 1})",
+                    r#"{"_id":[1,{"a":1,"b":2}],"kind":"array"}"#,
+                    "[2, {'b': 2, 'a': 1}]",
+                    r#"{"_id":[2,{"a":1,"b":2}],"kind":"list"}"#,
+                ],
+            )
+            .unwrap();
+        drop(connection);
+
+        let source = read_tinymongo_source(&path, &plan(&["users"])).unwrap();
+        assert_eq!(source.legacy_physical_ids(), 3);
+        let object_id = source.collections()[0].documents()[0]
+            .get_unique("_id")
+            .unwrap()
+            .unwrap();
+        let BsonValue::Document(object_id) = object_id else {
+            panic!("legacy mapping ID must remain a document");
+        };
+        assert_eq!(
+            object_id.iter().map(|(name, _)| name).collect::<Vec<_>>(),
+            ["b", "a"]
+        );
+        assert!(matches!(
+            object_id.get_unique("b").unwrap(),
+            Some(BsonValue::Int32(2))
+        ));
+        let array_id = source.collections()[0].documents()[1]
+            .get_unique("_id")
+            .unwrap()
+            .unwrap();
+        let BsonValue::Array(array_id) = array_id else {
+            panic!("legacy list ID must remain an array");
+        };
+        let BsonValue::Document(nested) = &array_id[1] else {
+            panic!("nested legacy mapping ID must remain a document");
+        };
+        assert_eq!(
+            nested.iter().map(|(name, _)| name).collect::<Vec<_>>(),
+            ["b", "a"]
+        );
+        let list_id = source.collections()[0].documents()[2]
+            .get_unique("_id")
+            .unwrap()
+            .unwrap();
+        let BsonValue::Array(list_id) = list_id else {
+            panic!("legacy list ID must remain an array");
+        };
+        let BsonValue::Document(nested) = &list_id[1] else {
+            panic!("nested legacy mapping ID must remain a document");
+        };
+        assert_eq!(
+            nested.iter().map(|(name, _)| name).collect::<Vec<_>>(),
+            ["b", "a"]
+        );
+        let encoded_bson_bytes = source
+            .collections()
+            .iter()
+            .flat_map(TinyMongoImportCollection::documents)
+            .map(|document| encode_document(document).unwrap().len() as u64)
+            .sum::<u64>();
+        assert_eq!(source.encoded_bson_bytes(), encoded_bson_bytes);
+
+        let connection = Connection::open(&path).unwrap();
+        connection.execute("DELETE FROM users", []).unwrap();
+        connection
+            .execute(
+                "INSERT INTO users VALUES ('different', '{\"_id\":\"user-1\"}')",
+                [],
+            )
+            .unwrap();
+        drop(connection);
+        assert_eq!(
+            read_tinymongo_source(&path, &plan(&["users"]))
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::DataCorruption
+        );
+    }
+
+    #[test]
+    fn legacy_container_ids_reject_noncanonical_python_spellings() {
+        let temporary = TempDir::new().unwrap();
+        for (index, physical_id) in [
+            r#"{"b": 2, "a": 1}"#,
+            "{'b':2, 'a': 1}",
+            "{'b': 2, 'a': 1,}",
+            " {'b': 2, 'a': 1}",
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let path = temporary.path().join(format!("app-{index}.sqlite"));
+            let connection = Connection::open(&path).unwrap();
+            create_collection(&connection, "users", false);
+            connection
+                .execute(
+                    "INSERT INTO users VALUES (?1, ?2)",
+                    params![physical_id, r#"{"_id":{"a":1,"b":2}}"#],
+                )
+                .unwrap();
+            drop(connection);
+            assert_eq!(
+                read_tinymongo_source(&path, &plan(&["users"]))
+                    .unwrap_err()
+                    .kind(),
+                EngineErrorKind::Unsupported
+            );
+        }
+    }
+
+    #[test]
+    fn legacy_scalar_spellings_follow_tinymongo_numeric_and_binary_identity() {
+        assert_eq!(provable_python_float_text(1.0).as_deref(), Some("1.0"));
+        assert_eq!(provable_python_float_text(1e20), None);
+        assert_eq!(provable_python_float_text(1e-7), None);
+        assert_eq!(provable_python_float_text(-0.0).as_deref(), Some("-0.0"));
+        assert!(legacy_integer_id_matches("1", 1));
+        assert!(legacy_integer_id_matches("1.0", 1));
+        assert!(legacy_integer_id_matches("-0.0", 0));
+        assert_eq!(legacy_double_id_matches("1", 1.0), Some(true));
+        assert_eq!(legacy_double_id_matches("0", -0.0), Some(true));
+        assert_eq!(
+            legacy_double_id_matches("10000000000000000", 1e16),
+            Some(true)
+        );
+        assert_eq!(legacy_double_id_matches("1e+16", 1e16), None);
+        assert_eq!(legacy_double_id_matches("0.5", 0.5), None);
+        assert!(!legacy_integer_id_matches("1", 2));
+        assert_eq!(
+            LegacyLiteralParser::parse(r"b'\x00\xff'"),
+            Some(BsonValue::Binary(BsonBinary::new(0, [0, 255])))
+        );
+        assert_eq!(LegacyLiteralParser::parse("bytearray(b'x')"), None);
+        assert_eq!(
+            legacy_scalar_id_matches(
+                "bytearray(b'x')",
+                &BsonValue::Binary(BsonBinary::new(0, b"x")),
+            )
+            .unwrap(),
+            Some(true)
+        );
+        assert_eq!(
+            legacy_scalar_id_matches(
+                "bytearray(b\"x\")",
+                &BsonValue::Binary(BsonBinary::new(0, b"x")),
+            )
+            .unwrap(),
+            Some(false)
+        );
+        assert_eq!(
+            legacy_scalar_id_matches("1", &BsonValue::Boolean(true)).unwrap(),
+            Some(false)
+        );
+
+        let canonical_decimal = crate::document::BsonDecimal128::parse("1.00").unwrap();
+        assert_eq!(
+            legacy_scalar_id_matches("1.00", &BsonValue::Decimal128(canonical_decimal),).unwrap(),
+            Some(true)
+        );
+
+        // The Rust BSON codec and pinned PyMongo oracle render some legal raw
+        // BID values differently. Treat those representations as unsupported
+        // instead of falsely diagnosing a valid TinyMongo row as corrupt.
+        let divergent_bid = [
+            0x86, 0xcb, 0xed, 0xa6, 0xdc, 0xed, 0x38, 0x1a, 0xf1, 0xf0, 0x7e, 0x46, 0x0a, 0xfd,
+            0x6f, 0x23,
+        ];
+        let divergent = crate::document::BsonDecimal128::from_bid(divergent_bid);
+        assert_eq!(divergent.to_string(), "0E-1641");
+        assert_eq!(
+            legacy_scalar_id_matches(
+                "1.032456058729699916549522757607719E-1607",
+                &BsonValue::Decimal128(divergent),
+            )
+            .unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn source_reads_are_immutable_and_active_sqlite_sidecars_fail_closed() {
+        let temporary = TempDir::new().unwrap();
+        let path = temporary.path().join("app ?#%.sqlite");
+        let connection = Connection::open(&path).unwrap();
+        create_collection(&connection, "users", false);
+        connection
+            .execute("INSERT INTO users VALUES ('one', '{\"_id\":\"one\"}')", [])
+            .unwrap();
+        drop(connection);
+
+        let before = fs::read_dir(temporary.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect::<BTreeSet<_>>();
+        let source = read_tinymongo_source(&path, &plan(&["users"])).unwrap();
+        assert_eq!(source.report().documents(), 1);
+        let after = fs::read_dir(temporary.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(after, before);
+
+        let active_path = temporary.path().join("active.sqlite");
+        let active = Connection::open(&active_path).unwrap();
+        active.pragma_update(None, "journal_mode", "WAL").unwrap();
+        create_collection(&active, "users", false);
+        active
+            .execute("INSERT INTO users VALUES ('one', '{\"_id\":\"one\"}')", [])
+            .unwrap();
+        assert!(PathBuf::from(format!("{}-wal", active_path.display())).exists());
+        assert_eq!(
+            read_tinymongo_source(&active_path, &plan(&["users"]))
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+        drop(active);
+    }
+
+    #[test]
+    fn cancelled_preflight_opens_no_source_or_destination() {
+        let temporary = TempDir::new().unwrap();
+        let path = temporary.path().join("app.sqlite");
+        let connection = Connection::open(&path).unwrap();
+        create_collection(&connection, "users", false);
+        drop(connection);
+        let cancellation = CancellationToken::new();
+        assert!(cancellation.cancel());
+        assert_eq!(
+            read_tinymongo_source_with_cancellation(&path, &plan(&["users"]), &cancellation)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::Cancelled
+        );
+    }
+
+    #[test]
+    fn atomic_import_cleans_failed_stage_and_retry_publishes_verified_receipt() {
+        let temporary = TempDir::new().unwrap();
+        let source_path = temporary.path().join("app.sqlite");
+        let destination = temporary.path().join("imported");
+        let connection = Connection::open(&source_path).unwrap();
+        create_collection(&connection, "users", false);
+        connection
+            .execute_batch(
+                "CREATE TABLE __tinymongo_indexes (
+                    collection_name TEXT NOT NULL,
+                    index_name TEXT NOT NULL,
+                    field_name TEXT NOT NULL,
+                    unique_flag INTEGER NOT NULL,
+                    token_version INTEGER NOT NULL DEFAULT 3,
+                    spec_json TEXT,
+                    PRIMARY KEY (collection_name, index_name));",
+            )
+            .unwrap();
+        let spec = r#"{"v":2,"name":"email_1","key":[["email",1]],"unique":true,"sparse":false,"partialFilterExpression":null}"#;
+        connection
+            .execute(
+                "INSERT INTO __tinymongo_indexes VALUES ('users', 'email_1', 'email', 1, 3, ?)",
+                [spec],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO users VALUES
+                    ('one', '{\"_id\":\"one\",\"email\":\"one@example.test\"}'),
+                    ('two', '{\"_id\":\"two\",\"email\":\"two@example.test\"}')",
+                [],
+            )
+            .unwrap();
+        drop(connection);
+        let source_before = fs::read(&source_path).unwrap();
+        let import_plan = plan(&["users"]);
+
+        let error = import_tinymongo_database_inner(
+            &source_path,
+            &destination,
+            &import_plan,
+            TinyMongoImportOptions::new(3).unwrap(),
+            TinyMongoImportFault::FailAfterDocuments(1),
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Internal);
+        assert!(error.diagnostic().contains("after 1 documents"));
+        assert!(!destination.exists());
+        assert_eq!(fs::read(&source_path).unwrap(), source_before);
+        let unpublished_stages = fs::read_dir(temporary.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .filter(|name| name.to_string_lossy().starts_with(".briskdb-import-stage-"))
+            .collect::<Vec<_>>();
+        assert!(unpublished_stages.is_empty());
+
+        let report = import_tinymongo_database(
+            &source_path,
+            &destination,
+            &import_plan,
+            TinyMongoImportOptions::new(3).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(report.receipt_version(), TINYMONGO_IMPORT_RECEIPT_VERSION);
+        assert_eq!(report.target_shards(), Some(3));
+        assert_eq!(report.documents(), 2);
+        assert_eq!(report.custom_indexes(), 1);
+        assert!(destination.join("manifest.sqlite").is_file());
+        let receipt: JsonValue =
+            serde_json::from_slice(&fs::read(destination.join(IMPORT_RECEIPT_FILE)).unwrap())
+                .unwrap();
+        assert_eq!(receipt["database_name"], "app");
+        assert_eq!(receipt["target_shards"], 3);
+        assert_eq!(receipt["documents"], 2);
+    }
+
+    #[test]
+    fn semantic_duplicate_ids_and_missing_ids_fail_closed() {
+        let temporary = TempDir::new().unwrap();
+        let path = temporary.path().join("app.sqlite");
+        let connection = Connection::open(&path).unwrap();
+        create_collection(&connection, "users", false);
+        connection
+            .execute(
+                "INSERT INTO users VALUES ('one', '{\"_id\":1}'), ('double', '{\"_id\":1.0}')",
+                [],
+            )
+            .unwrap();
+        drop(connection);
+        assert_eq!(
+            read_tinymongo_source(&path, &plan(&["users"]))
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::DataCorruption
+        );
+
+        let connection = Connection::open(&path).unwrap();
+        connection.execute("DELETE FROM users", []).unwrap();
+        connection
+            .execute(
+                "INSERT INTO users VALUES ('missing', '{\"name\":\"Ada\"}')",
+                [],
+            )
+            .unwrap();
+        drop(connection);
+        assert_eq!(
+            read_tinymongo_source(&path, &plan(&["users"]))
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::DataCorruption
+        );
+    }
+
+    #[test]
+    fn arbitrary_precision_integer_is_rejected_instead_of_becoming_double() {
+        let raw = serde_json::from_str::<JsonValue>(
+            r#"{"_id":1234567890123456789012345678901234567890}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            json_document(&raw, "test").unwrap_err().kind(),
+            EngineErrorKind::NumericOutOfRange
+        );
+    }
+
+    #[test]
+    fn sharded_layout_validates_identity_route_and_global_order() {
+        let temporary = TempDir::new().unwrap();
+        let root = temporary.path().join("app.sqlite-sharded");
+        initialize_manifest(&root, 2);
+        for shard in 0..2 {
+            let connection = Connection::open(shard_path(&root, shard)).unwrap();
+            connection
+                .execute(
+                    "INSERT INTO users (_id, data, __tinymongo_order) VALUES (?, ?, ?)",
+                    params![
+                        physical_id_for_route(shard),
+                        format!("{{\"_id\":\"user-{shard}\"}}"),
+                        format!("{:020}:abcdef012345", 2 - shard)
+                    ],
+                )
+                .unwrap();
+        }
+
+        let source = read_tinymongo_source(&root, &plan(&["users"])).unwrap();
+        assert_eq!(source.variant(), TinyMongoSourceVariant::ShardedV1);
+        assert_eq!(source.source_shards(), 2);
+        assert_eq!(
+            source.collections()[0].documents()[0]
+                .get_unique("_id")
+                .unwrap(),
+            Some(&BsonValue::String("user-1".to_owned()))
+        );
+
+        let connection = Connection::open(shard_path(&root, 0)).unwrap();
+        connection
+            .execute("UPDATE users SET _id = ?", [physical_id_for_route(1)])
+            .unwrap();
+        drop(connection);
+        assert_eq!(
+            read_tinymongo_source(&root, &plan(&["users"]))
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::DataCorruption
+        );
+    }
+
+    #[test]
+    fn sharded_directory_inventory_is_exact_and_rejects_extra_entries_early() {
+        let temporary = TempDir::new().unwrap();
+        let root = temporary.path().join("app.sqlite-sharded");
+        initialize_manifest(&root, 2);
+        fs::create_dir(root.join("shards/extra")).unwrap();
+
+        assert_eq!(
+            read_tinymongo_source(&root, &plan(&["users"]))
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::DataCorruption
+        );
+    }
+
+    #[test]
+    fn sharded_partial_collection_and_swapped_identity_fail_closed() {
+        let temporary = TempDir::new().unwrap();
+        let root = temporary.path().join("app.sqlite-sharded");
+        initialize_manifest(&root, 2);
+        let manifest = Connection::open(root.join("manifest.sqlite")).unwrap();
+        manifest
+            .execute("UPDATE __tinymongo_collections SET state = 'dropping'", [])
+            .unwrap();
+        drop(manifest);
+        assert_eq!(
+            read_tinymongo_source(&root, &plan(&["users"]))
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::FailedPrecondition
+        );
+
+        let manifest = Connection::open(root.join("manifest.sqlite")).unwrap();
+        manifest
+            .execute("UPDATE __tinymongo_collections SET state = 'ready'", [])
+            .unwrap();
+        drop(manifest);
+        let shard = Connection::open(shard_path(&root, 0)).unwrap();
+        shard
+            .execute("UPDATE __tinymongo_shard SET shard_index = 1", [])
+            .unwrap();
+        drop(shard);
+        assert_eq!(
+            read_tinymongo_source(&root, &plan(&["users"]))
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::DataCorruption
+        );
+    }
+
+    #[test]
+    fn sharded_pending_index_may_exist_on_only_some_shards() {
+        let temporary = TempDir::new().unwrap();
+        let root = temporary.path().join("app.sqlite-sharded");
+        initialize_manifest(&root, 2);
+        let spec = r#"{"v":2,"name":"email_1","key":[["email",1]],"unique":false,"sparse":false,"partialFilterExpression":null}"#;
+        let manifest = Connection::open(root.join("manifest.sqlite")).unwrap();
+        manifest
+            .execute(
+                "INSERT INTO __tinymongo_indexes VALUES ('users', 'email_1', ?, 'pending')",
+                [spec],
+            )
+            .unwrap();
+        drop(manifest);
+        let shard = Connection::open(shard_path(&root, 0)).unwrap();
+        shard
+            .execute_batch(
+                "CREATE TABLE __tinymongo_indexes (
+                    collection_name TEXT NOT NULL,
+                    index_name TEXT NOT NULL,
+                    field_name TEXT NOT NULL,
+                    unique_flag INTEGER NOT NULL,
+                    token_version INTEGER NOT NULL DEFAULT 3,
+                    spec_json TEXT,
+                    PRIMARY KEY (collection_name, index_name));",
+            )
+            .unwrap();
+        shard
+            .execute(
+                "INSERT INTO __tinymongo_indexes VALUES ('users', 'email_1', 'email', 0, 3, ?)",
+                [spec],
+            )
+            .unwrap();
+        drop(shard);
+
+        let source = read_tinymongo_source(&root, &plan(&["users"])).unwrap();
+        let index = &source.collections()[0].indexes()[0];
+        assert_eq!(index.name(), "email_1");
+        assert!(index.was_pending_in_source());
+        assert_eq!(
+            index.target_lifecycle(),
+            DocumentIndexLifecycle::PendingBuild
+        );
+    }
+
+    #[test]
+    fn sharded_orphan_index_and_non_exact_metadata_schema_fail_closed() {
+        let temporary = TempDir::new().unwrap();
+        let root = temporary.path().join("app.sqlite-sharded");
+        initialize_manifest(&root, 2);
+        let spec = r#"{"v":2,"name":"email_1","key":[["email",1]],"unique":false,"sparse":false,"partialFilterExpression":null}"#;
+        let manifest = Connection::open(root.join("manifest.sqlite")).unwrap();
+        manifest
+            .execute(
+                "INSERT INTO __tinymongo_indexes VALUES ('missing', 'email_1', ?, 'ready')",
+                [spec],
+            )
+            .unwrap();
+        drop(manifest);
+        assert_eq!(
+            read_tinymongo_source(&root, &plan(&["users"]))
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::DataCorruption
+        );
+
+        let manifest = Connection::open(root.join("manifest.sqlite")).unwrap();
+        manifest
+            .execute("DELETE FROM __tinymongo_indexes", [])
+            .unwrap();
+        manifest
+            .execute_batch(
+                "ALTER TABLE __tinymongo_collections RENAME TO old_collections;
+                 CREATE TABLE __tinymongo_collections (
+                    collection_name TEXT PRIMARY KEY,
+                    state TEXT);
+                 INSERT INTO __tinymongo_collections SELECT * FROM old_collections;
+                 DROP TABLE old_collections;",
+            )
+            .unwrap();
+        drop(manifest);
+        assert_eq!(
+            read_tinymongo_source(&root, &plan(&["users"]))
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::DataCorruption
+        );
+    }
+}

--- a/src/protocol/http.rs
+++ b/src/protocol/http.rs
@@ -179,7 +179,7 @@ async fn execute(
         .params
         .into_iter()
         .map(json_to_value)
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>, _>>()?;
     let session = engine.session();
     if let Some(shard_key) = request.shard_key {
         session.set_routing_key(shard_key).await?;
@@ -230,7 +230,7 @@ async fn query(
         .params
         .into_iter()
         .map(json_to_value)
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>, _>>()?;
     let session = engine.session();
     if engine.catalog().tables().is_empty() {
         if let Some(shard_key) = request.shard_key {
@@ -419,8 +419,9 @@ fn write_index_metrics(output: &mut String, index: &GlobalIndexOperationalStatus
     );
 }
 
-fn json_to_value(value: JsonValue) -> Value {
-    match value {
+fn json_to_value(value: JsonValue) -> Result<Value, EngineError> {
+    validate_json_numbers(&value)?;
+    Ok(match value {
         JsonValue::Null => Value::Null,
         JsonValue::Bool(value) => Value::Boolean(value),
         JsonValue::Number(value) => value
@@ -428,13 +429,60 @@ fn json_to_value(value: JsonValue) -> Value {
             .map(Value::Int64)
             .or_else(|| value.as_u64().map(Value::UInt64))
             .or_else(|| value.as_f64().map(Value::Float64))
-            .unwrap_or_else(|| {
-                Value::decimal(value.to_string())
-                    .expect("a serde_json Number always has valid decimal syntax")
-            }),
+            .expect("validated JSON numbers fit the HTTP v1 numeric contract"),
         JsonValue::String(value) => Value::Text(value),
-        JsonValue::Array(value) => Value::Text(JsonValue::Array(value).to_string()),
-        JsonValue::Object(value) => Value::Text(JsonValue::Object(value).to_string()),
+        JsonValue::Array(value) => Value::Text(legacy_json_text(JsonValue::Array(value))),
+        JsonValue::Object(value) => Value::Text(legacy_json_text(JsonValue::Object(value))),
+    })
+}
+
+fn legacy_json_text(value: JsonValue) -> String {
+    fn sort_object_keys(value: JsonValue) -> JsonValue {
+        match value {
+            JsonValue::Array(values) => {
+                JsonValue::Array(values.into_iter().map(sort_object_keys).collect())
+            }
+            JsonValue::Object(values) => {
+                let mut entries = values.into_iter().collect::<Vec<_>>();
+                entries.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+                JsonValue::Object(
+                    entries
+                        .into_iter()
+                        .map(|(key, value)| (key, sort_object_keys(value)))
+                        .collect(),
+                )
+            }
+            value => value,
+        }
+    }
+
+    sort_object_keys(value).to_string()
+}
+
+fn validate_json_numbers(value: &JsonValue) -> Result<(), EngineError> {
+    match value {
+        JsonValue::Number(number) => {
+            let rendered = number.to_string();
+            let valid = if rendered
+                .as_bytes()
+                .iter()
+                .any(|byte| matches!(byte, b'.' | b'e' | b'E'))
+            {
+                number.as_f64().is_some_and(f64::is_finite)
+            } else {
+                number.as_i64().is_some() || number.as_u64().is_some()
+            };
+            if !valid {
+                return Err(EngineError::new(
+                    EngineErrorKind::InvalidArgument,
+                    "an HTTP JSON parameter contains a number outside the v1 numeric range",
+                ));
+            }
+            Ok(())
+        }
+        JsonValue::Array(values) => values.iter().try_for_each(validate_json_numbers),
+        JsonValue::Object(values) => values.values().try_for_each(validate_json_numbers),
+        JsonValue::Null | JsonValue::Bool(_) | JsonValue::String(_) => Ok(()),
     }
 }
 
@@ -629,6 +677,23 @@ mod tests {
         body: Option<JsonValue>,
     ) -> (StatusCode, JsonValue) {
         response_json(send_json(router, method, uri, body).await).await
+    }
+
+    async fn request_raw_json(router: &Router, uri: &str, body: &str) -> (StatusCode, JsonValue) {
+        let response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri(uri)
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_owned()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.headers()["briskdb-api-version"], "1");
+        response_json(response).await
     }
 
     #[tokio::test]
@@ -1936,6 +2001,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn raw_numbers_outside_json_v1_range_are_rejected_at_every_depth() {
+        let temp = tempfile::tempdir().unwrap();
+        let application = engine_router(Arc::new(Database::open(temp.path(), 4).unwrap()));
+        let expected = (
+            StatusCode::BAD_REQUEST,
+            json!({
+                "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#invalid-argument",
+                "title": "Invalid argument",
+                "status": 400,
+                "detail": "The request contains an invalid argument.",
+                "code": "invalid_argument"
+            }),
+        );
+
+        for body in [
+            r#"{"shard_key":"numeric-boundary","sql":"SELECT ?1","params":[18446744073709551616]}"#,
+            r#"{"shard_key":"numeric-boundary","sql":"SELECT ?1","params":[[18446744073709551616]]}"#,
+            r#"{"shard_key":"numeric-boundary","sql":"SELECT ?1","params":[{"nested":-9223372036854775809}]}"#,
+            r#"{"shard_key":"numeric-boundary","sql":"SELECT ?1","params":[1e400]}"#,
+            r#"{"shard_key":"numeric-boundary","sql":"SELECT ?1","params":[{"nested":[1e400]}]}"#,
+        ] {
+            assert_eq!(
+                request_raw_json(&application, "/v1/query", body).await,
+                expected
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn constraint_failures_keep_their_precise_safe_kind() {
         let temp = tempfile::tempdir().unwrap();
         let application = engine_router(Arc::new(Database::open(temp.path(), 4).unwrap()));
@@ -2216,20 +2310,29 @@ mod tests {
 
     #[test]
     fn json_parameters_keep_the_existing_binding_contract() {
-        assert_eq!(json_to_value(JsonValue::Null), Value::Null);
-        assert_eq!(json_to_value(json!(true)), Value::from(true));
-        assert_eq!(json_to_value(json!(42)), Value::from(42_i64));
-        assert_eq!(json_to_value(json!(1.5)), Value::from(1.5_f64));
-        assert_eq!(json_to_value(json!("text")), Value::from("text"));
-        assert_eq!(json_to_value(json!([1, "two"])), Value::from("[1,\"two\"]"));
+        assert_eq!(json_to_value(JsonValue::Null).unwrap(), Value::Null);
+        assert_eq!(json_to_value(json!(true)).unwrap(), Value::from(true));
+        assert_eq!(json_to_value(json!(42)).unwrap(), Value::from(42_i64));
+        assert_eq!(json_to_value(json!(1.5)).unwrap(), Value::from(1.5_f64));
+        assert_eq!(json_to_value(json!("text")).unwrap(), Value::from("text"));
         assert_eq!(
-            json_to_value(json!({"nested": true})),
+            json_to_value(json!([1, "two"])).unwrap(),
+            Value::from("[1,\"two\"]")
+        );
+        assert_eq!(
+            json_to_value(json!({"nested": true})).unwrap(),
             Value::from("{\"nested\":true}")
+        );
+        let insertion_ordered: JsonValue =
+            serde_json::from_str(r#"{"z":0,"a":{"z":1,"a":2},"m":[{"z":3,"a":4}]}"#).unwrap();
+        assert_eq!(
+            json_to_value(insertion_ordered).unwrap(),
+            Value::from(r#"{"a":{"a":2,"z":1},"m":[{"a":4,"z":3}],"z":0}"#)
         );
 
         let above_signed_i64_range = json!(9_223_372_036_854_775_809_u64);
         assert_eq!(
-            json_to_value(above_signed_i64_range),
+            json_to_value(above_signed_i64_range).unwrap(),
             Value::from(9_223_372_036_854_775_809_u64)
         );
     }
@@ -2237,11 +2340,11 @@ mod tests {
     #[test]
     fn http_parameters_use_the_shared_canonical_index_key_encoding() {
         let through_http = [
-            json_to_value(json!(true)),
-            json_to_value(json!(-42)),
-            json_to_value(json!(9_223_372_036_854_775_809_u64)),
-            json_to_value(json!(1.5)),
-            json_to_value(json!("shared")),
+            json_to_value(json!(true)).unwrap(),
+            json_to_value(json!(-42)).unwrap(),
+            json_to_value(json!(9_223_372_036_854_775_809_u64)).unwrap(),
+            json_to_value(json!(1.5)).unwrap(),
+            json_to_value(json!("shared")).unwrap(),
         ];
         let direct = [
             Value::Boolean(true),

--- a/src/storage/document.rs
+++ b/src/storage/document.rs
@@ -1,0 +1,2468 @@
+//! Versioned document catalog lifecycle and shard-local BSON records.
+
+use rusqlite::Connection;
+#[cfg(feature = "documents")]
+use rusqlite::TransactionBehavior;
+
+use crate::{
+    core::{EngineError, EngineErrorKind, EngineResult},
+    sqlite_error,
+};
+
+use super::Storage;
+
+pub(super) const RECORDS_TABLE: &str = "briskdb_documents_v1";
+const RECORDS_SCHEMA_SQL: &str = "CREATE TABLE briskdb_documents_v1 (
+    collection_id INTEGER NOT NULL CHECK (collection_id > 0),
+    id_key BLOB NOT NULL CHECK (
+        typeof(id_key) = 'blob' AND length(id_key) BETWEEN 9 AND 16777216
+    ),
+    natural_order INTEGER NOT NULL CHECK (natural_order > 0),
+    document_bson BLOB NOT NULL CHECK (
+        typeof(document_bson) = 'blob' AND length(document_bson) BETWEEN 5 AND 16777216
+    ),
+    document_checksum BLOB NOT NULL CHECK (
+        typeof(document_checksum) = 'blob' AND length(document_checksum) = 32
+    ),
+    storage_format_version INTEGER NOT NULL CHECK (storage_format_version = 1),
+    PRIMARY KEY (collection_id, id_key),
+    UNIQUE (collection_id, natural_order)
+) STRICT, WITHOUT ROWID";
+
+pub(super) fn is_exact_schema_object(
+    object_type: &str,
+    name: &str,
+    table_name: &str,
+    sql: Option<&str>,
+) -> bool {
+    object_type == "table"
+        && name == RECORDS_TABLE
+        && table_name == RECORDS_TABLE
+        && sql.is_some_and(|sql| {
+            normalize_schema_sql(sql) == normalize_schema_sql(RECORDS_SCHEMA_SQL)
+        })
+}
+
+pub(super) fn validate_optional_schema(connection: &Connection) -> EngineResult<bool> {
+    let objects = connection
+        .prepare(
+            "SELECT type, name, tbl_name, sql FROM sqlite_schema
+             WHERE name = ?1 COLLATE NOCASE
+             ORDER BY type, name, tbl_name LIMIT 2",
+        )
+        .and_then(|mut statement| {
+            statement
+                .query_map([RECORDS_TABLE], |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                        row.get::<_, Option<String>>(3)?,
+                    ))
+                })?
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .map_err(|error| shard_read_error(error, "failed to inspect document storage schema"))?;
+    if objects.is_empty() {
+        return Ok(false);
+    }
+    if objects.len() != 1
+        || !is_exact_schema_object(
+            &objects[0].0,
+            &objects[0].1,
+            &objects[0].2,
+            objects[0].3.as_deref(),
+        )
+    {
+        return Err(corrupt(
+            "shard document storage table has an incompatible schema",
+        ));
+    }
+    Ok(true)
+}
+
+#[cfg(feature = "documents")]
+fn ensure_schema(connection: &mut Connection) -> EngineResult<()> {
+    if validate_optional_schema(connection)? {
+        return Ok(());
+    }
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    if !validate_optional_schema(&transaction)? {
+        transaction
+            .execute_batch(RECORDS_SCHEMA_SQL)
+            .map_err(sqlite_error::storage)?;
+    }
+    if !validate_optional_schema(&transaction)? {
+        return Err(corrupt(
+            "document storage table creation did not produce its exact schema",
+        ));
+    }
+    transaction.commit().map_err(sqlite_error::storage)
+}
+
+#[cfg(feature = "documents")]
+fn require_schema(connection: &Connection) -> EngineResult<()> {
+    if validate_optional_schema(connection)? {
+        Ok(())
+    } else {
+        Err(corrupt(
+            "an active document collection is missing shard storage",
+        ))
+    }
+}
+
+fn normalize_schema_sql(sql: &str) -> String {
+    sql.split_ascii_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn corrupt(diagnostic: impl Into<String>) -> EngineError {
+    EngineError::new(EngineErrorKind::DataCorruption, diagnostic)
+}
+
+fn shard_read_error(error: rusqlite::Error, diagnostic: &'static str) -> EngineError {
+    let classified = sqlite_error::storage(error);
+    if matches!(
+        classified.kind(),
+        EngineErrorKind::Busy
+            | EngineErrorKind::Cancelled
+            | EngineErrorKind::PermissionDenied
+            | EngineErrorKind::ReadOnly
+            | EngineErrorKind::StorageFull
+            | EngineErrorKind::OutOfMemory
+            | EngineErrorKind::StorageUnavailable
+    ) {
+        classified.context(diagnostic)
+    } else {
+        EngineError::from_source(EngineErrorKind::DataCorruption, diagnostic, classified)
+    }
+}
+
+#[cfg(feature = "documents")]
+mod enabled {
+    use std::collections::{HashMap, HashSet};
+
+    use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params};
+
+    use crate::{
+        core::{CancellationToken, EngineError, EngineErrorKind, EngineResult},
+        document::{
+            BsonDocument, BsonErrorContext, BsonValue, CanonicalBsonKey, DocumentCatalog,
+            DocumentCollectionId, DocumentCollectionMetadata, DocumentCollectionOptions,
+            DocumentDatabaseId, DocumentIndexLifecycle, DocumentIndexMetadata, DocumentPlacement,
+            encode_document,
+        },
+        sqlite_error,
+    };
+
+    use super::{Storage, corrupt, ensure_schema, require_schema, shard_read_error};
+    use crate::storage::{
+        configure_journal_mode, configure_manifest_connection, manifest, open_existing_manifest,
+    };
+
+    const COLLECTION_PROVISIONING: i64 = manifest::DOCUMENT_COLLECTION_PROVISIONING;
+    const COLLECTION_ACTIVE: i64 = manifest::DOCUMENT_COLLECTION_ACTIVE;
+    const INDEX_READY: i64 = manifest::DOCUMENT_INDEX_READY;
+    const INDEX_PENDING_BUILD: i64 = manifest::DOCUMENT_INDEX_PENDING_BUILD;
+    const RECORD_CHECKSUM_DOMAIN: &[u8] = b"briskdb.document-record.v1\0";
+
+    fn require_ready_manifest(connection: &Connection, shard_count: u16) -> EngineResult<()> {
+        match manifest::current_integrity(connection, shard_count)?.state() {
+            manifest::DatabaseIntegrityState::Ready => Ok(()),
+            manifest::DatabaseIntegrityState::Degraded => Err(corrupt(
+                "document operation found a persistently degraded database",
+            )),
+            manifest::DatabaseIntegrityState::Verifying
+            | manifest::DatabaseIntegrityState::Migrating => Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "document operation requires a checksum-verified ready database",
+            )),
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct Provisioning {
+        collection_id: DocumentCollectionId,
+        operation_id: [u8; 32],
+        shard_count: u16,
+        next_shard: u16,
+    }
+
+    impl Storage {
+        pub(crate) fn document_catalog(&self) -> EngineResult<DocumentCatalog> {
+            let result = self.document_catalog_inner();
+            self.fail_closed_on_corruption(result)
+        }
+
+        fn document_catalog_inner(&self) -> EngineResult<DocumentCatalog> {
+            let _operation = self.enter_schema_operation()?;
+            self.load_document_catalog()
+        }
+
+        fn load_document_catalog(&self) -> EngineResult<DocumentCatalog> {
+            let manifest_path = self.root.join("manifest.sqlite");
+            let connection = open_existing_manifest(&manifest_path)?;
+            configure_manifest_connection(&connection)?;
+            require_ready_manifest(&connection, self.shard_count())?;
+            load_catalog_rows(&connection)
+        }
+
+        pub(crate) fn create_document_collection(
+            &self,
+            database: &str,
+            collection: &str,
+            options: &DocumentCollectionOptions,
+        ) -> EngineResult<DocumentCollectionMetadata> {
+            let result = self.create_document_collection_inner(database, collection, options);
+            self.fail_closed_on_corruption(result)
+        }
+
+        fn create_document_collection_inner(
+            &self,
+            database: &str,
+            collection: &str,
+            options: &DocumentCollectionOptions,
+        ) -> EngineResult<DocumentCollectionMetadata> {
+            crate::document::validate_namespace(database, collection)?;
+            let options_bson = encode_document(options.document())
+                .map_err(|error| error.into_engine_error(BsonErrorContext::ClientInput))?;
+            debug_assert!(options_bson.len() <= manifest::MAX_DOCUMENT_METADATA_BSON_BYTES);
+            let id_specification = builtin_id_specification()?;
+            let id_specification_bson = encode_document(&id_specification)
+                .map_err(|error| error.into_engine_error(BsonErrorContext::ClientInput))?;
+
+            let mut migration = super::super::SchemaMigrationGuard::new(
+                self.schema_coordination.gate.begin_new_migration()?,
+            );
+            migration.wait_for_quiescence_blocking();
+            migration.acquire_process_ownership(&self.schema_coordination.process_lease)?;
+
+            let result = (|| {
+                let manifest_path = self.root.join("manifest.sqlite");
+                let mut connection = open_existing_manifest(&manifest_path)?;
+                configure_manifest_connection(&connection)?;
+                configure_journal_mode(&connection)?;
+                require_ready_manifest(&connection, self.shard_count())?;
+
+                if let Some(existing) = existing_collection(&connection, database, collection)? {
+                    if existing.1 != options_bson {
+                        return Err(EngineError::new(
+                            EngineErrorKind::FailedPrecondition,
+                            "document collection already exists with different options",
+                        ));
+                    }
+                    if existing.0 != COLLECTION_ACTIVE {
+                        return Err(EngineError::new(
+                            EngineErrorKind::FailedPrecondition,
+                            "document collection has incomplete durable provisioning; reopen the database to recover it",
+                        ));
+                    }
+                    return load_catalog_rows(&connection)?
+                        .collection(database, collection)
+                        .cloned()
+                        .ok_or_else(|| {
+                            corrupt("active document collection disappeared from its catalog")
+                        });
+                }
+                if load_provisioning(&connection)?.is_some() {
+                    return Err(corrupt(
+                        "document catalog retained provisioning after startup recovery",
+                    ));
+                }
+
+                let transaction = connection
+                    .transaction_with_behavior(TransactionBehavior::Immediate)
+                    .map_err(sqlite_error::storage)?;
+                require_ready_manifest(&transaction, self.shard_count())?;
+                let database_id = ensure_database(&transaction, database)?;
+                let collection_id = next_positive_id(
+                    &transaction,
+                    "briskdb_document_collections",
+                    "collection_id",
+                    "document collection",
+                )?;
+                let operation_id = provisioning_id(database, collection, &options_bson);
+                transaction
+                    .execute(
+                        "INSERT INTO briskdb_document_collections (
+                            collection_id, database_id, collection_name, options_bson,
+                            bson_schema_version, storage_format_version,
+                            placement_policy, placement_version, next_natural_order,
+                            lifecycle_state
+                         ) VALUES (?1, ?2, ?3, ?4, 1, 1, 1, 1, 1, ?5)",
+                        params![
+                            collection_id,
+                            database_id,
+                            collection,
+                            options_bson,
+                            COLLECTION_PROVISIONING
+                        ],
+                    )
+                    .map_err(sqlite_error::storage)?;
+                transaction
+                    .execute(
+                        "INSERT INTO briskdb_document_indexes (
+                            collection_id, index_name, spec_bson, is_unique, is_builtin,
+                            index_format_version, lifecycle_state
+                         ) VALUES (?1, '_id_', ?2, 1, 1, 1, ?3)",
+                        params![collection_id, id_specification_bson, INDEX_PENDING_BUILD],
+                    )
+                    .map_err(sqlite_error::storage)?;
+                transaction
+                    .execute(
+                        "INSERT INTO briskdb_document_provisioning (
+                            singleton, collection_id, operation_id, shard_count, next_shard
+                         ) VALUES (1, ?1, ?2, ?3, 0)",
+                        params![collection_id, operation_id.as_slice(), self.shard_count()],
+                    )
+                    .map_err(sqlite_error::storage)?;
+                manifest::validate_document_catalog(&transaction, self.shard_count())?;
+                manifest::refresh_manifest_digest(&transaction)?;
+                require_ready_manifest(&transaction, self.shard_count())?;
+                migration.mark_pending_on_drop();
+                transaction.commit().map_err(sqlite_error::storage)?;
+
+                let provisioning = Provisioning {
+                    collection_id: DocumentCollectionId::from_validated(
+                        u64::try_from(collection_id).expect("positive SQLite document ID fits u64"),
+                    ),
+                    operation_id,
+                    shard_count: self.shard_count(),
+                    next_shard: 0,
+                };
+                recover_provisioning(self, &mut connection, provisioning)?;
+                load_catalog_rows(&connection)?
+                    .collection(database, collection)
+                    .cloned()
+                    .ok_or_else(|| {
+                        corrupt("completed document collection is missing from its catalog")
+                    })
+            })();
+
+            match result {
+                Ok(metadata) => {
+                    migration.publish_ready()?;
+                    Ok(metadata)
+                }
+                Err(error) => Err(error),
+            }
+        }
+
+        pub(crate) fn declare_document_index(
+            &self,
+            collection_id: DocumentCollectionId,
+            name: &str,
+            specification: &BsonDocument,
+            unique: bool,
+        ) -> EngineResult<DocumentIndexMetadata> {
+            let result =
+                self.declare_document_index_inner(collection_id, name, specification, unique);
+            self.fail_closed_on_corruption(result)
+        }
+
+        fn declare_document_index_inner(
+            &self,
+            collection_id: DocumentCollectionId,
+            name: &str,
+            specification: &BsonDocument,
+            unique: bool,
+        ) -> EngineResult<DocumentIndexMetadata> {
+            if name.is_empty()
+                || name.len() > manifest::MAX_DOCUMENT_INDEX_NAME_BYTES
+                || name.contains('\0')
+                || name == "_id_"
+            {
+                return Err(EngineError::new(
+                    EngineErrorKind::InvalidArgument,
+                    "document index name is invalid or reserved",
+                ));
+            }
+            let spec_bson = encode_document(specification)
+                .map_err(|error| error.into_engine_error(BsonErrorContext::ClientInput))?;
+            debug_assert!(spec_bson.len() <= manifest::MAX_DOCUMENT_METADATA_BSON_BYTES);
+            let _operation = self.enter_schema_operation()?;
+            let manifest_path = self.root.join("manifest.sqlite");
+            let mut connection = open_existing_manifest(&manifest_path)?;
+            configure_manifest_connection(&connection)?;
+            configure_journal_mode(&connection)?;
+            require_ready_manifest(&connection, self.shard_count())?;
+            require_active_collection(&connection, collection_id)?;
+            let transaction = connection
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .map_err(sqlite_error::storage)?;
+            require_ready_manifest(&transaction, self.shard_count())?;
+            require_active_collection(&transaction, collection_id)?;
+            let existing = transaction
+                .query_row(
+                    "SELECT spec_bson, is_unique, lifecycle_state
+                     FROM briskdb_document_indexes
+                     WHERE collection_id = ?1 AND index_name = ?2",
+                    params![to_sqlite_id(collection_id)?, name],
+                    |row| {
+                        Ok((
+                            row.get::<_, Vec<u8>>(0)?,
+                            row.get::<_, i64>(1)?,
+                            row.get::<_, i64>(2)?,
+                        ))
+                    },
+                )
+                .optional()
+                .map_err(sqlite_error::storage)?;
+            if let Some((existing_spec, existing_unique, lifecycle)) = existing {
+                if existing_spec != spec_bson
+                    || existing_unique != i64::from(unique)
+                    || lifecycle != INDEX_PENDING_BUILD
+                {
+                    return Err(EngineError::new(
+                        EngineErrorKind::FailedPrecondition,
+                        "document index name already has a different declaration",
+                    ));
+                }
+            } else {
+                transaction
+                    .execute(
+                        "INSERT INTO briskdb_document_indexes (
+                            collection_id, index_name, spec_bson, is_unique, is_builtin,
+                            index_format_version, lifecycle_state
+                         ) VALUES (?1, ?2, ?3, ?4, 0, 1, ?5)",
+                        params![
+                            to_sqlite_id(collection_id)?,
+                            name,
+                            spec_bson,
+                            i64::from(unique),
+                            INDEX_PENDING_BUILD
+                        ],
+                    )
+                    .map_err(sqlite_error::storage)?;
+                manifest::validate_document_catalog(&transaction, self.shard_count())?;
+                manifest::refresh_manifest_digest(&transaction)?;
+                require_ready_manifest(&transaction, self.shard_count())?;
+            }
+            transaction.commit().map_err(sqlite_error::storage)?;
+            let decoded = decode_metadata_document(&spec_bson, "document index specification")?;
+            Ok(DocumentIndexMetadata::from_validated_parts(
+                name.to_owned(),
+                decoded,
+                unique,
+                false,
+                DocumentIndexLifecycle::PendingBuild,
+            ))
+        }
+
+        pub(crate) fn insert_document(
+            &self,
+            collection_id: DocumentCollectionId,
+            document: &BsonDocument,
+        ) -> EngineResult<u16> {
+            let result = self.insert_document_inner(collection_id, document);
+            self.fail_closed_on_corruption(result)
+        }
+
+        fn insert_document_inner(
+            &self,
+            collection_id: DocumentCollectionId,
+            document: &BsonDocument,
+        ) -> EngineResult<u16> {
+            let _operation = self.enter_schema_operation()?;
+            let (id_key, document_bson, shard) = prepare_document(self, document)?;
+            let natural_order = self.reserve_document_natural_orders(collection_id, 1)?;
+            self.insert_prepared_document(
+                collection_id,
+                natural_order,
+                shard,
+                &id_key,
+                &document_bson,
+            )?;
+            Ok(shard)
+        }
+
+        pub(crate) fn insert_documents(
+            &self,
+            collection_id: DocumentCollectionId,
+            documents: &[BsonDocument],
+            cancellation: &CancellationToken,
+        ) -> EngineResult<()> {
+            let result = self.insert_documents_inner(collection_id, documents, cancellation);
+            self.fail_closed_on_corruption(result)
+        }
+
+        fn insert_documents_inner(
+            &self,
+            collection_id: DocumentCollectionId,
+            documents: &[BsonDocument],
+            cancellation: &CancellationToken,
+        ) -> EngineResult<()> {
+            let _operation = self.enter_schema_operation()?;
+            ensure_document_write_not_cancelled(cancellation)?;
+            if documents.is_empty() {
+                self.require_active_document_collection(collection_id)?;
+                return Ok(());
+            }
+            let natural_order = self.reserve_document_natural_orders(
+                collection_id,
+                u64::try_from(documents.len()).map_err(|error| {
+                    EngineError::from_source(
+                        EngineErrorKind::LimitExceeded,
+                        "document batch length exceeds its supported range",
+                        error,
+                    )
+                })?,
+            )?;
+            // A committed range is never reused. Cancellation or a later shard
+            // failure may leave gaps, preserving monotonic order after retry.
+            for (offset, document) in documents.iter().enumerate() {
+                ensure_document_write_not_cancelled(cancellation)?;
+                let offset = i64::try_from(offset).map_err(|error| {
+                    EngineError::from_source(
+                        EngineErrorKind::LimitExceeded,
+                        "document batch offset exceeds its supported range",
+                        error,
+                    )
+                })?;
+                let order = natural_order.checked_add(offset).ok_or_else(|| {
+                    EngineError::new(
+                        EngineErrorKind::LimitExceeded,
+                        "document natural-order identity space is exhausted",
+                    )
+                })?;
+                let (id_key, document_bson, shard) = prepare_document(self, document)?;
+                self.insert_prepared_document(
+                    collection_id,
+                    order,
+                    shard,
+                    &id_key,
+                    &document_bson,
+                )?;
+            }
+            Ok(())
+        }
+
+        fn reserve_document_natural_orders(
+            &self,
+            collection_id: DocumentCollectionId,
+            count: u64,
+        ) -> EngineResult<i64> {
+            debug_assert!(count > 0);
+            let count = i64::try_from(count).map_err(|error| {
+                EngineError::from_source(
+                    EngineErrorKind::LimitExceeded,
+                    "document natural-order reservation exceeds SQLite's supported range",
+                    error,
+                )
+            })?;
+            let manifest_path = self.root.join("manifest.sqlite");
+            let mut connection = open_existing_manifest(&manifest_path)?;
+            configure_manifest_connection(&connection)?;
+            configure_journal_mode(&connection)?;
+            let transaction = connection
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .map_err(sqlite_error::storage)?;
+            require_ready_manifest(&transaction, self.shard_count())?;
+            let state = transaction
+                .query_row(
+                    "SELECT next_natural_order, lifecycle_state
+                     FROM briskdb_document_collections WHERE collection_id = ?1",
+                    [to_sqlite_id(collection_id)?],
+                    |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+                )
+                .optional()
+                .map_err(sqlite_error::storage)?;
+            let (first, lifecycle) = state.ok_or_else(|| {
+                EngineError::new(
+                    EngineErrorKind::InvalidArgument,
+                    "document collection does not exist",
+                )
+            })?;
+            if lifecycle != COLLECTION_ACTIVE {
+                return Err(EngineError::new(
+                    EngineErrorKind::FailedPrecondition,
+                    "document collection is not active",
+                ));
+            }
+            let next = first.checked_add(count).ok_or_else(|| {
+                EngineError::new(
+                    EngineErrorKind::LimitExceeded,
+                    "document natural-order identity space is exhausted",
+                )
+            })?;
+            let changed = transaction
+                .execute(
+                    "UPDATE briskdb_document_collections SET next_natural_order = ?1
+                     WHERE collection_id = ?2 AND next_natural_order = ?3
+                       AND lifecycle_state = ?4",
+                    params![next, to_sqlite_id(collection_id)?, first, COLLECTION_ACTIVE],
+                )
+                .map_err(sqlite_error::storage)?;
+            if changed != 1 {
+                return Err(corrupt(
+                    "document natural-order allocator did not advance exactly once",
+                ));
+            }
+            manifest::validate_document_catalog(&transaction, self.shard_count())?;
+            manifest::refresh_manifest_digest(&transaction)?;
+            require_ready_manifest(&transaction, self.shard_count())?;
+            transaction.commit().map_err(sqlite_error::storage)?;
+            Ok(first)
+        }
+
+        fn insert_prepared_document(
+            &self,
+            collection_id: DocumentCollectionId,
+            natural_order: i64,
+            shard: u16,
+            id_key: &CanonicalBsonKey,
+            document_bson: &[u8],
+        ) -> EngineResult<()> {
+            debug_assert_eq!(self.shard_for_key(id_key.as_bytes()), shard);
+            let mut connection = self.open_unconfigured_shard(shard)?;
+            self.validate_unconfigured_shard(&connection, shard)?;
+            require_schema(&connection)?;
+            let checksum = record_checksum(
+                collection_id,
+                shard,
+                natural_order,
+                id_key.as_bytes(),
+                document_bson,
+            );
+            let transaction = connection
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .map_err(sqlite_error::storage)?;
+            transaction
+                .execute(
+                    "INSERT INTO briskdb_documents_v1 (
+                        collection_id, id_key, natural_order, document_bson,
+                        document_checksum, storage_format_version
+                     ) VALUES (?1, ?2, ?3, ?4, ?5, 1)",
+                    params![
+                        to_sqlite_id(collection_id)?,
+                        id_key.as_bytes(),
+                        natural_order,
+                        document_bson,
+                        checksum.as_slice()
+                    ],
+                )
+                .map_err(sqlite_error::statement)?;
+            transaction.commit().map_err(sqlite_error::storage)?;
+            Ok(())
+        }
+
+        pub(crate) fn get_document(
+            &self,
+            collection_id: DocumentCollectionId,
+            id: &BsonValue,
+        ) -> EngineResult<Option<BsonDocument>> {
+            let result = self.get_document_inner(collection_id, id);
+            self.fail_closed_on_corruption(result)
+        }
+
+        fn get_document_inner(
+            &self,
+            collection_id: DocumentCollectionId,
+            id: &BsonValue,
+        ) -> EngineResult<Option<BsonDocument>> {
+            let _operation = self.enter_schema_operation()?;
+            self.require_active_document_collection(collection_id)?;
+            let id_key = CanonicalBsonKey::encode(id)
+                .map_err(|error| error.into_engine_error(BsonErrorContext::ClientInput))?;
+            let shard = self.shard_for_key(id_key.as_bytes());
+            let connection = self.open_unconfigured_shard(shard)?;
+            self.validate_unconfigured_shard(&connection, shard)?;
+            require_schema(&connection)?;
+            let row = connection
+                .query_row(
+                    "SELECT natural_order, document_bson, document_checksum,
+                            storage_format_version
+                     FROM briskdb_documents_v1
+                     WHERE collection_id = ?1 AND id_key = ?2",
+                    params![to_sqlite_id(collection_id)?, id_key.as_bytes()],
+                    |row| {
+                        Ok((
+                            row.get::<_, i64>(0)?,
+                            row.get::<_, Vec<u8>>(1)?,
+                            row.get::<_, Vec<u8>>(2)?,
+                            row.get::<_, i64>(3)?,
+                        ))
+                    },
+                )
+                .optional()
+                .map_err(|error| shard_read_error(error, "failed to read stored BSON document"))?;
+            row.map(|(natural_order, bson, checksum, version)| {
+                decode_record(
+                    collection_id,
+                    shard,
+                    natural_order,
+                    id_key.as_bytes(),
+                    bson,
+                    checksum,
+                    version,
+                )
+            })
+            .transpose()
+        }
+
+        #[cfg(feature = "tinymongo-import")]
+        pub(crate) fn document_count(
+            &self,
+            collection_id: DocumentCollectionId,
+        ) -> EngineResult<u64> {
+            let result = self.document_count_inner(collection_id);
+            self.fail_closed_on_corruption(result)
+        }
+
+        #[cfg(feature = "tinymongo-import")]
+        fn document_count_inner(&self, collection_id: DocumentCollectionId) -> EngineResult<u64> {
+            let _operation = self.enter_schema_operation()?;
+            self.require_active_document_collection(collection_id)?;
+            let mut total = 0_u64;
+            for shard in 0..self.shard_count() {
+                let connection = self.open_unconfigured_shard(shard)?;
+                self.validate_unconfigured_shard(&connection, shard)?;
+                require_schema(&connection)?;
+                let count = connection
+                    .query_row(
+                        "SELECT count(*) FROM briskdb_documents_v1
+                         WHERE collection_id = ?1",
+                        [to_sqlite_id(collection_id)?],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .map_err(|error| {
+                        shard_read_error(error, "failed to count stored BSON documents")
+                    })?;
+                let count = u64::try_from(count)
+                    .map_err(|_| corrupt("stored BSON document count is outside its range"))?;
+                total = total.checked_add(count).ok_or_else(|| {
+                    corrupt("stored BSON document count exceeds its supported range")
+                })?;
+            }
+            Ok(total)
+        }
+
+        #[allow(dead_code)]
+        pub(crate) fn scan_documents(
+            &self,
+            collection_id: DocumentCollectionId,
+        ) -> EngineResult<Vec<BsonDocument>> {
+            let result = self.scan_documents_inner(collection_id);
+            self.fail_closed_on_corruption(result)
+        }
+
+        fn scan_documents_inner(
+            &self,
+            collection_id: DocumentCollectionId,
+        ) -> EngineResult<Vec<BsonDocument>> {
+            let _operation = self.enter_schema_operation()?;
+            self.require_active_document_collection(collection_id)?;
+            let mut documents = Vec::new();
+            for shard in 0..self.shard_count() {
+                let connection = self.open_unconfigured_shard(shard)?;
+                self.validate_unconfigured_shard(&connection, shard)?;
+                require_schema(&connection)?;
+                let mut statement = connection
+                    .prepare(
+                        "SELECT natural_order, id_key, document_bson, document_checksum,
+                                storage_format_version
+                         FROM briskdb_documents_v1 WHERE collection_id = ?1
+                         ORDER BY natural_order",
+                    )
+                    .map_err(sqlite_error::storage)?;
+                let mut rows = statement
+                    .query([to_sqlite_id(collection_id)?])
+                    .map_err(sqlite_error::storage)?;
+                while let Some(row) = rows.next().map_err(sqlite_error::storage)? {
+                    let natural_order = row.get::<_, i64>(0).map_err(sqlite_error::storage)?;
+                    let key = row.get::<_, Vec<u8>>(1).map_err(sqlite_error::storage)?;
+                    let bson = row.get::<_, Vec<u8>>(2).map_err(sqlite_error::storage)?;
+                    let checksum = row.get::<_, Vec<u8>>(3).map_err(sqlite_error::storage)?;
+                    let version = row.get::<_, i64>(4).map_err(sqlite_error::storage)?;
+                    CanonicalBsonKey::from_bytes(&key)
+                        .map_err(|error| error.into_engine_error(BsonErrorContext::StoredData))?;
+                    if self.shard_for_key(&key) != shard {
+                        return Err(corrupt(
+                            "stored BSON document is on a shard that disagrees with its canonical _id route",
+                        ));
+                    }
+                    documents.push((
+                        natural_order,
+                        decode_record(
+                            collection_id,
+                            shard,
+                            natural_order,
+                            &key,
+                            bson,
+                            checksum,
+                            version,
+                        )?,
+                    ));
+                }
+            }
+            documents.sort_by_key(|(natural_order, _)| *natural_order);
+            if documents.windows(2).any(|pair| pair[0].0 == pair[1].0) {
+                return Err(corrupt(
+                    "stored BSON documents have duplicate natural-order values",
+                ));
+            }
+            let next_natural_order = self.next_document_natural_order(collection_id)?;
+            if documents
+                .last()
+                .is_some_and(|(natural_order, _)| *natural_order >= next_natural_order)
+            {
+                return Err(corrupt(
+                    "stored BSON document natural order exceeds its durable allocator",
+                ));
+            }
+            Ok(documents
+                .into_iter()
+                .map(|(_, document)| document)
+                .collect())
+        }
+
+        fn next_document_natural_order(
+            &self,
+            collection_id: DocumentCollectionId,
+        ) -> EngineResult<i64> {
+            let path = self.root.join("manifest.sqlite");
+            let connection = open_existing_manifest(&path)?;
+            configure_manifest_connection(&connection)?;
+            require_ready_manifest(&connection, self.shard_count())?;
+            connection
+                .query_row(
+                    "SELECT next_natural_order FROM briskdb_document_collections
+                     WHERE collection_id = ?1 AND lifecycle_state = ?2",
+                    params![to_sqlite_id(collection_id)?, COLLECTION_ACTIVE],
+                    |row| row.get::<_, i64>(0),
+                )
+                .optional()
+                .map_err(sqlite_error::storage)?
+                .ok_or_else(|| corrupt("active document collection disappeared from its catalog"))
+        }
+
+        fn require_active_document_collection(
+            &self,
+            collection_id: DocumentCollectionId,
+        ) -> EngineResult<()> {
+            let path = self.root.join("manifest.sqlite");
+            let connection = open_existing_manifest(&path)?;
+            configure_manifest_connection(&connection)?;
+            require_ready_manifest(&connection, self.shard_count())?;
+            require_active_collection(&connection, collection_id)
+        }
+    }
+
+    pub(in crate::storage) fn recover_or_validate(
+        storage: &Storage,
+        manifest_connection: &mut Connection,
+    ) -> EngineResult<()> {
+        manifest::validate_document_catalog(manifest_connection, storage.shard_count())?;
+        if let Some(provisioning) = load_provisioning(manifest_connection)? {
+            recover_provisioning(storage, manifest_connection, provisioning)?;
+        }
+        let catalog = load_catalog_rows(manifest_connection)?;
+        if !catalog.collections().is_empty() {
+            validate_stored_records(storage, manifest_connection, &catalog)?;
+        } else {
+            for shard in 0..storage.shard_count() {
+                let connection = storage.open_unconfigured_shard(shard)?;
+                storage.validate_unconfigured_shard(&connection, shard)?;
+                if super::validate_optional_schema(&connection)? {
+                    return Err(corrupt(
+                        "document storage exists without an active or provisioning collection",
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn recover_provisioning(
+        storage: &Storage,
+        manifest_connection: &mut Connection,
+        mut provisioning: Provisioning,
+    ) -> EngineResult<()> {
+        if provisioning.shard_count != storage.shard_count() {
+            return Err(corrupt(
+                "document provisioning shard count differs from routing metadata",
+            ));
+        }
+        while provisioning.next_shard < provisioning.shard_count {
+            let shard = provisioning.next_shard;
+            let mut connection = storage.open_unconfigured_shard(shard)?;
+            storage.validate_unconfigured_shard(&connection, shard)?;
+            ensure_schema(&mut connection)?;
+            let transaction = manifest_connection
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .map_err(sqlite_error::storage)?;
+            manifest::current_integrity(&transaction, storage.shard_count())?;
+            let changed = transaction
+                .execute(
+                    "UPDATE briskdb_document_provisioning SET next_shard = ?1
+                     WHERE singleton = 1 AND collection_id = ?2
+                       AND operation_id = ?3 AND next_shard = ?4",
+                    params![
+                        shard + 1,
+                        to_sqlite_id(provisioning.collection_id)?,
+                        provisioning.operation_id.as_slice(),
+                        shard
+                    ],
+                )
+                .map_err(sqlite_error::storage)?;
+            if changed != 1 {
+                return Err(corrupt(
+                    "document provisioning journal did not advance exactly once",
+                ));
+            }
+            manifest::validate_document_catalog(&transaction, storage.shard_count())?;
+            manifest::refresh_manifest_digest(&transaction)?;
+            manifest::current_integrity(&transaction, storage.shard_count())?;
+            transaction.commit().map_err(sqlite_error::storage)?;
+            provisioning.next_shard = shard + 1;
+        }
+
+        let transaction = manifest_connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(sqlite_error::storage)?;
+        manifest::current_integrity(&transaction, storage.shard_count())?;
+        let activated_index = transaction
+            .execute(
+                "UPDATE briskdb_document_indexes SET lifecycle_state = ?1
+                 WHERE collection_id = ?2 AND index_name = '_id_'
+                   AND is_unique = 1 AND is_builtin = 1 AND lifecycle_state = ?3",
+                params![
+                    INDEX_READY,
+                    to_sqlite_id(provisioning.collection_id)?,
+                    INDEX_PENDING_BUILD
+                ],
+            )
+            .map_err(sqlite_error::storage)?;
+        if activated_index != 1 {
+            return Err(corrupt(
+                "document collection activation did not update its built-in _id index",
+            ));
+        }
+        let changed = transaction
+            .execute(
+                "UPDATE briskdb_document_collections SET lifecycle_state = ?1
+                 WHERE collection_id = ?2 AND lifecycle_state = ?3",
+                params![
+                    COLLECTION_ACTIVE,
+                    to_sqlite_id(provisioning.collection_id)?,
+                    COLLECTION_PROVISIONING
+                ],
+            )
+            .map_err(sqlite_error::storage)?;
+        if changed != 1 {
+            return Err(corrupt(
+                "document collection activation did not update exactly one row",
+            ));
+        }
+        let deleted = transaction
+            .execute(
+                "DELETE FROM briskdb_document_provisioning
+                 WHERE singleton = 1 AND collection_id = ?1 AND operation_id = ?2
+                   AND next_shard = shard_count",
+                params![
+                    to_sqlite_id(provisioning.collection_id)?,
+                    provisioning.operation_id.as_slice()
+                ],
+            )
+            .map_err(sqlite_error::storage)?;
+        if deleted != 1 {
+            return Err(corrupt(
+                "document provisioning journal did not finalize exactly once",
+            ));
+        }
+        manifest::validate_document_catalog(&transaction, storage.shard_count())?;
+        manifest::refresh_manifest_digest(&transaction)?;
+        manifest::current_integrity(&transaction, storage.shard_count())?;
+        transaction.commit().map_err(sqlite_error::storage)
+    }
+
+    fn validate_stored_records(
+        storage: &Storage,
+        manifest_connection: &Connection,
+        catalog: &DocumentCatalog,
+    ) -> EngineResult<()> {
+        manifest::current_integrity(manifest_connection, storage.shard_count())?;
+        let active_collections = catalog
+            .collections()
+            .iter()
+            .map(DocumentCollectionMetadata::id)
+            .collect::<HashSet<_>>();
+        let mut natural_orders = HashSet::new();
+        let mut maximum_orders = HashMap::<DocumentCollectionId, i64>::new();
+        for shard in 0..storage.shard_count() {
+            let connection = storage.open_unconfigured_shard(shard)?;
+            storage.validate_unconfigured_shard(&connection, shard)?;
+            require_schema(&connection)?;
+            let mut statement = connection
+                .prepare(
+                    "SELECT collection_id, natural_order, id_key, document_bson,
+                            document_checksum, storage_format_version
+                     FROM briskdb_documents_v1
+                     ORDER BY collection_id, natural_order, id_key",
+                )
+                .map_err(|error| {
+                    shard_read_error(error, "failed to inspect stored BSON documents")
+                })?;
+            let mut rows = statement.query([]).map_err(|error| {
+                shard_read_error(error, "failed to inspect stored BSON documents")
+            })?;
+            while let Some(row) = rows.next().map_err(|error| {
+                shard_read_error(error, "failed to inspect stored BSON documents")
+            })? {
+                let collection_id = row.get::<_, i64>(0).map_err(|error| {
+                    shard_read_error(error, "failed to decode stored BSON collection ID")
+                })?;
+                let collection_id = DocumentCollectionId::from_validated(positive_u64(
+                    collection_id,
+                    "stored BSON document collection ID",
+                )?);
+                if !active_collections.contains(&collection_id) {
+                    return Err(corrupt(
+                        "stored BSON document references a missing or inactive collection",
+                    ));
+                }
+                let natural_order = row.get::<_, i64>(1).map_err(|error| {
+                    shard_read_error(error, "failed to decode stored BSON natural order")
+                })?;
+                if natural_order <= 0 {
+                    return Err(corrupt(
+                        "stored BSON document natural order is not positive",
+                    ));
+                }
+                let id_key = row.get::<_, Vec<u8>>(2).map_err(|error| {
+                    shard_read_error(error, "failed to decode stored BSON canonical key")
+                })?;
+                CanonicalBsonKey::from_bytes(&id_key)
+                    .map_err(|error| error.into_engine_error(BsonErrorContext::StoredData))?;
+                if storage.shard_for_key(&id_key) != shard {
+                    return Err(corrupt(
+                        "stored BSON document is on a shard that disagrees with its canonical _id route",
+                    ));
+                }
+                let bson = row.get::<_, Vec<u8>>(3).map_err(|error| {
+                    shard_read_error(error, "failed to decode stored BSON bytes")
+                })?;
+                let checksum = row.get::<_, Vec<u8>>(4).map_err(|error| {
+                    shard_read_error(error, "failed to decode stored BSON checksum")
+                })?;
+                let version = row.get::<_, i64>(5).map_err(|error| {
+                    shard_read_error(error, "failed to decode stored BSON format version")
+                })?;
+                decode_record(
+                    collection_id,
+                    shard,
+                    natural_order,
+                    &id_key,
+                    bson,
+                    checksum,
+                    version,
+                )?;
+                if !natural_orders.insert((collection_id, natural_order)) {
+                    return Err(corrupt(
+                        "stored BSON documents have duplicate natural-order values",
+                    ));
+                }
+                maximum_orders
+                    .entry(collection_id)
+                    .and_modify(|maximum| *maximum = (*maximum).max(natural_order))
+                    .or_insert(natural_order);
+            }
+        }
+
+        let allocators = load_natural_order_allocators(manifest_connection)?;
+        if allocators.len() != active_collections.len()
+            || allocators
+                .keys()
+                .any(|collection_id| !active_collections.contains(collection_id))
+        {
+            return Err(corrupt(
+                "document natural-order allocators disagree with the active catalog",
+            ));
+        }
+        for (collection_id, maximum_order) in maximum_orders {
+            let next = allocators.get(&collection_id).ok_or_else(|| {
+                corrupt("stored BSON document collection is missing its natural-order allocator")
+            })?;
+            if maximum_order >= *next {
+                return Err(corrupt(
+                    "stored BSON document natural order exceeds its durable allocator",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn load_natural_order_allocators(
+        connection: &Connection,
+    ) -> EngineResult<HashMap<DocumentCollectionId, i64>> {
+        let rows = connection
+            .prepare(
+                "SELECT collection_id, next_natural_order
+                 FROM briskdb_document_collections
+                 WHERE lifecycle_state = 2 ORDER BY collection_id",
+            )
+            .and_then(|mut statement| {
+                statement
+                    .query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)))?
+                    .collect::<Result<Vec<_>, _>>()
+            })
+            .map_err(sqlite_error::storage)?;
+        rows.into_iter()
+            .map(|(collection_id, next_natural_order)| {
+                if next_natural_order <= 0 {
+                    return Err(corrupt("document natural-order allocator is not positive"));
+                }
+                Ok((
+                    DocumentCollectionId::from_validated(positive_u64(
+                        collection_id,
+                        "document natural-order allocator collection ID",
+                    )?),
+                    next_natural_order,
+                ))
+            })
+            .collect()
+    }
+
+    fn load_provisioning(connection: &Connection) -> EngineResult<Option<Provisioning>> {
+        connection
+            .query_row(
+                "SELECT collection_id, operation_id, shard_count, next_shard
+                 FROM briskdb_document_provisioning WHERE singleton = 1",
+                [],
+                |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, Vec<u8>>(1)?,
+                        row.get::<_, i64>(2)?,
+                        row.get::<_, i64>(3)?,
+                    ))
+                },
+            )
+            .optional()
+            .map_err(sqlite_error::storage)?
+            .map(|(collection_id, operation_id, shard_count, next_shard)| {
+                let operation_id: [u8; 32] = operation_id.try_into().map_err(|_| {
+                    corrupt("document provisioning operation ID has an invalid width")
+                })?;
+                Ok(Provisioning {
+                    collection_id: DocumentCollectionId::from_validated(positive_u64(
+                        collection_id,
+                        "document provisioning collection ID",
+                    )?),
+                    operation_id,
+                    shard_count: bounded_u16(shard_count, "document provisioning shard count")?,
+                    next_shard: bounded_u16(next_shard, "document provisioning cursor")?,
+                })
+            })
+            .transpose()
+    }
+
+    fn load_catalog_rows(connection: &Connection) -> EngineResult<DocumentCatalog> {
+        let databases = connection
+            .prepare(
+                "SELECT database_id, database_name FROM briskdb_document_databases
+                 ORDER BY database_id",
+            )
+            .and_then(|mut statement| {
+                statement
+                    .query_map([], |row| {
+                        Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+                    })?
+                    .collect::<Result<Vec<_>, _>>()
+            })
+            .map_err(sqlite_error::storage)?;
+        let databases = databases
+            .into_iter()
+            .map(|(id, name)| Ok((positive_u64(id, "document database ID")?, name)))
+            .collect::<EngineResult<HashMap<_, _>>>()?;
+        let mut collections = Vec::new();
+        let mut statement = connection
+            .prepare(
+                "SELECT collection_id, database_id, collection_name, options_bson,
+                        placement_policy, placement_version
+                 FROM briskdb_document_collections
+                 WHERE lifecycle_state = 2 ORDER BY collection_id",
+            )
+            .map_err(sqlite_error::storage)?;
+        let mut rows = statement.query([]).map_err(sqlite_error::storage)?;
+        while let Some(row) = rows.next().map_err(sqlite_error::storage)? {
+            let collection_id = positive_u64(
+                row.get::<_, i64>(0).map_err(sqlite_error::storage)?,
+                "document collection ID",
+            )?;
+            let database_id = positive_u64(
+                row.get::<_, i64>(1).map_err(sqlite_error::storage)?,
+                "document database ID",
+            )?;
+            let name = row.get::<_, String>(2).map_err(sqlite_error::storage)?;
+            let options_bson = row.get::<_, Vec<u8>>(3).map_err(sqlite_error::storage)?;
+            let placement_policy = row.get::<_, i64>(4).map_err(sqlite_error::storage)?;
+            let placement_version = row.get::<_, i64>(5).map_err(sqlite_error::storage)?;
+            if placement_policy != 1 || placement_version != 1 {
+                return Err(corrupt("document collection has an unsupported placement"));
+            }
+            let database_name = databases.get(&database_id).cloned().ok_or_else(|| {
+                corrupt("document collection references a missing logical database")
+            })?;
+            let options = DocumentCollectionOptions::new(decode_metadata_document(
+                &options_bson,
+                "document collection options",
+            )?)
+            .map_err(|error| {
+                EngineError::from_source(
+                    EngineErrorKind::DataCorruption,
+                    "stored document collection options are invalid",
+                    error,
+                )
+            })?;
+            let id = DocumentCollectionId::from_validated(collection_id);
+            let indexes = load_indexes(connection, id)?;
+            collections.push(DocumentCollectionMetadata::from_validated_parts(
+                id,
+                DocumentDatabaseId::from_validated(database_id),
+                database_name,
+                name,
+                options,
+                DocumentPlacement::HashByIdV1,
+                indexes,
+            ));
+        }
+        Ok(DocumentCatalog::from_validated_collections(
+            collections.into_boxed_slice(),
+        ))
+    }
+
+    fn load_indexes(
+        connection: &Connection,
+        collection_id: DocumentCollectionId,
+    ) -> EngineResult<Box<[DocumentIndexMetadata]>> {
+        let mut statement = connection
+            .prepare(
+                "SELECT index_name, spec_bson, is_unique, is_builtin, lifecycle_state
+                 FROM briskdb_document_indexes WHERE collection_id = ?1
+                 ORDER BY index_name COLLATE BINARY",
+            )
+            .map_err(sqlite_error::storage)?;
+        let rows = statement
+            .query_map([to_sqlite_id(collection_id)?], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Vec<u8>>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, i64>(4)?,
+                ))
+            })
+            .map_err(sqlite_error::storage)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(sqlite_error::storage)?;
+        let expected_id = builtin_id_specification()?;
+        let mut indexes = Vec::with_capacity(rows.len());
+        for (name, spec_bson, unique, built_in, lifecycle) in rows {
+            let specification =
+                decode_metadata_document(&spec_bson, "document index specification")?;
+            let lifecycle = DocumentIndexLifecycle::from_code(
+                u32::try_from(lifecycle)
+                    .map_err(|_| corrupt("document index lifecycle is outside its range"))?,
+            )?;
+            let built_in = built_in != 0;
+            let unique = unique != 0;
+            if built_in
+                && (name != "_id_"
+                    || !unique
+                    || lifecycle != DocumentIndexLifecycle::Ready
+                    || !specification.representation_eq(&expected_id))
+            {
+                return Err(corrupt("built-in document _id index metadata is invalid"));
+            }
+            if !built_in && lifecycle == DocumentIndexLifecycle::Ready {
+                return Err(corrupt(
+                    "secondary document index is marked ready before physical index support",
+                ));
+            }
+            indexes.push(DocumentIndexMetadata::from_validated_parts(
+                name,
+                specification,
+                unique,
+                built_in,
+                lifecycle,
+            ));
+        }
+        Ok(indexes.into_boxed_slice())
+    }
+
+    fn builtin_id_specification() -> EngineResult<BsonDocument> {
+        let key = BsonDocument::from_entries([("_id", BsonValue::Int32(1))])
+            .map_err(|error| error.into_engine_error(BsonErrorContext::ClientInput))?;
+        BsonDocument::from_entries([
+            ("v", BsonValue::Int32(2)),
+            ("name", BsonValue::String("_id_".to_owned())),
+            ("key", BsonValue::Document(key)),
+            ("unique", BsonValue::Boolean(true)),
+        ])
+        .map_err(|error| error.into_engine_error(BsonErrorContext::ClientInput))
+    }
+
+    fn decode_metadata_document(bytes: &[u8], context: &'static str) -> EngineResult<BsonDocument> {
+        crate::document::decode_document(bytes).map_err(|error| {
+            EngineError::from_source(
+                EngineErrorKind::DataCorruption,
+                format!("stored {context} is invalid"),
+                error,
+            )
+        })
+    }
+
+    fn ensure_database(connection: &Connection, name: &str) -> EngineResult<i64> {
+        if let Some(id) = connection
+            .query_row(
+                "SELECT database_id FROM briskdb_document_databases WHERE database_name = ?1",
+                [name],
+                |row| row.get::<_, i64>(0),
+            )
+            .optional()
+            .map_err(sqlite_error::storage)?
+        {
+            return Ok(id);
+        }
+        let id = next_positive_id(
+            connection,
+            "briskdb_document_databases",
+            "database_id",
+            "document database",
+        )?;
+        connection
+            .execute(
+                "INSERT INTO briskdb_document_databases (
+                    database_id, database_name, catalog_version
+                 ) VALUES (?1, ?2, 1)",
+                params![id, name],
+            )
+            .map_err(sqlite_error::storage)?;
+        Ok(id)
+    }
+
+    fn next_positive_id(
+        connection: &Connection,
+        table: &str,
+        column: &str,
+        kind: &str,
+    ) -> EngineResult<i64> {
+        let sql = format!("SELECT COALESCE(MAX({column}), 0) FROM {table}");
+        let current = connection
+            .query_row(&sql, [], |row| row.get::<_, i64>(0))
+            .map_err(sqlite_error::storage)?;
+        current.checked_add(1).ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::LimitExceeded,
+                format!("{kind} identity space is exhausted"),
+            )
+        })
+    }
+
+    fn existing_collection(
+        connection: &Connection,
+        database: &str,
+        collection: &str,
+    ) -> EngineResult<Option<(i64, Vec<u8>)>> {
+        connection
+            .query_row(
+                "SELECT c.lifecycle_state, c.options_bson
+                 FROM briskdb_document_collections AS c
+                 JOIN briskdb_document_databases AS d ON d.database_id = c.database_id
+                 WHERE d.database_name = ?1 AND c.collection_name = ?2",
+                params![database, collection],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()
+            .map_err(sqlite_error::storage)
+    }
+
+    fn require_active_collection(
+        connection: &Connection,
+        id: DocumentCollectionId,
+    ) -> EngineResult<()> {
+        let state = connection
+            .query_row(
+                "SELECT lifecycle_state FROM briskdb_document_collections
+                 WHERE collection_id = ?1",
+                [to_sqlite_id(id)?],
+                |row| row.get::<_, i64>(0),
+            )
+            .optional()
+            .map_err(sqlite_error::storage)?;
+        match state {
+            Some(COLLECTION_ACTIVE) => Ok(()),
+            Some(_) => Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "document collection is not active",
+            )),
+            None => Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "document collection does not exist",
+            )),
+        }
+    }
+
+    fn required_document_id(document: &BsonDocument) -> EngineResult<&BsonValue> {
+        document
+            .get_unique("_id")
+            .map_err(|error| error.into_engine_error(BsonErrorContext::ClientInput))?
+            .ok_or_else(|| {
+                EngineError::new(
+                    EngineErrorKind::InvalidArgument,
+                    "document storage requires exactly one top-level _id field",
+                )
+            })
+    }
+
+    fn prepare_document(
+        storage: &Storage,
+        document: &BsonDocument,
+    ) -> EngineResult<(CanonicalBsonKey, Vec<u8>, u16)> {
+        let id = required_document_id(document)?;
+        let id_key = CanonicalBsonKey::encode(id)
+            .map_err(|error| error.into_engine_error(BsonErrorContext::ClientInput))?;
+        let document_bson = encode_document(document)
+            .map_err(|error| error.into_engine_error(BsonErrorContext::ClientInput))?;
+        let shard = storage.shard_for_key(id_key.as_bytes());
+        Ok((id_key, document_bson, shard))
+    }
+
+    fn ensure_document_write_not_cancelled(cancellation: &CancellationToken) -> EngineResult<()> {
+        if cancellation.is_cancelled() {
+            Err(EngineError::new(
+                EngineErrorKind::Cancelled,
+                "document batch insertion was cancelled",
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn provisioning_id(database: &str, collection: &str, options: &[u8]) -> [u8; 32] {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"briskdb.document-provisioning.v1\0");
+        hash_bytes(&mut hasher, database.as_bytes());
+        hash_bytes(&mut hasher, collection.as_bytes());
+        hash_bytes(&mut hasher, options);
+        *hasher.finalize().as_bytes()
+    }
+
+    fn record_checksum(
+        collection_id: DocumentCollectionId,
+        shard: u16,
+        natural_order: i64,
+        id_key: &[u8],
+        document_bson: &[u8],
+    ) -> [u8; 32] {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(RECORD_CHECKSUM_DOMAIN);
+        hasher.update(&collection_id.get().to_le_bytes());
+        hasher.update(&shard.to_le_bytes());
+        hasher.update(&natural_order.to_le_bytes());
+        hash_bytes(&mut hasher, id_key);
+        hash_bytes(&mut hasher, document_bson);
+        *hasher.finalize().as_bytes()
+    }
+
+    fn decode_record(
+        collection_id: DocumentCollectionId,
+        shard: u16,
+        natural_order: i64,
+        id_key: &[u8],
+        bson: Vec<u8>,
+        checksum: Vec<u8>,
+        version: i64,
+    ) -> EngineResult<BsonDocument> {
+        if natural_order <= 0
+            || version != 1
+            || checksum.as_slice()
+                != record_checksum(collection_id, shard, natural_order, id_key, &bson).as_slice()
+        {
+            return Err(corrupt(
+                "stored BSON document checksum or format is invalid",
+            ));
+        }
+        let document = crate::document::decode_document(&bson)
+            .map_err(|error| error.into_engine_error(BsonErrorContext::StoredData))?;
+        let id = required_document_id(&document).map_err(|error| {
+            EngineError::from_source(
+                EngineErrorKind::DataCorruption,
+                "stored BSON document has no unambiguous _id",
+                error,
+            )
+        })?;
+        let expected = CanonicalBsonKey::encode(id)
+            .map_err(|error| error.into_engine_error(BsonErrorContext::StoredData))?;
+        if expected.as_bytes() != id_key {
+            return Err(corrupt(
+                "stored BSON document _id does not match its canonical key",
+            ));
+        }
+        Ok(document)
+    }
+
+    fn hash_bytes(hasher: &mut blake3::Hasher, bytes: &[u8]) {
+        hasher.update(&(bytes.len() as u64).to_le_bytes());
+        hasher.update(bytes);
+    }
+
+    fn to_sqlite_id(id: DocumentCollectionId) -> EngineResult<i64> {
+        i64::try_from(id.get()).map_err(|error| {
+            EngineError::from_source(
+                EngineErrorKind::NumericOutOfRange,
+                "document collection ID does not fit SQLite",
+                error,
+            )
+        })
+    }
+
+    fn positive_u64(value: i64, field: &str) -> EngineResult<u64> {
+        u64::try_from(value)
+            .ok()
+            .filter(|value| *value > 0)
+            .ok_or_else(|| corrupt(format!("{field} is not a positive integer")))
+    }
+
+    fn bounded_u16(value: i64, field: &str) -> EngineResult<u16> {
+        u16::try_from(value).map_err(|_| corrupt(format!("{field} is outside its range")))
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use rusqlite::Connection;
+
+        use super::*;
+        use crate::{
+            core::Database,
+            document::{
+                BsonBinary, BsonUuid, DocumentPlacement, UuidRepresentation, encode_document,
+            },
+            sql::SqlDialect,
+        };
+
+        fn shard_path(root: &std::path::Path, shard: u16) -> std::path::PathBuf {
+            root.join("shards").join(format!("{shard:04}.sqlite"))
+        }
+
+        fn document(entries: impl IntoIterator<Item = (&'static str, BsonValue)>) -> BsonDocument {
+            BsonDocument::from_entries(entries).unwrap()
+        }
+
+        #[test]
+        fn restart_preserves_catalog_metadata_and_exact_bson_representation() {
+            let temp = tempfile::tempdir().unwrap();
+            let options_document = document([
+                (
+                    "validator",
+                    BsonValue::Document(document([
+                        ("second", BsonValue::Int64(2)),
+                        ("first", BsonValue::Int32(1)),
+                    ])),
+                ),
+                ("capped", BsonValue::Boolean(false)),
+            ]);
+            let options = DocumentCollectionOptions::new(options_document.clone()).unwrap();
+            let stored = document([
+                ("tail_first", BsonValue::String("kept-first".to_owned())),
+                ("_id", BsonValue::Int32(17)),
+                ("i64", BsonValue::Int64(17)),
+                ("double", BsonValue::Double(-0.0)),
+                ("binary", BsonValue::Binary(BsonBinary::new(0x80, [0, 255]))),
+                ("tail_second", BsonValue::String("kept-second".to_owned())),
+            ]);
+            let encoded = encode_document(&stored).unwrap();
+
+            let storage = Storage::open(temp.path(), 4).unwrap();
+            let collection = storage
+                .create_document_collection("ordered_db", "ordered_collection", &options)
+                .unwrap();
+            let secondary_specification = document([
+                (
+                    "key",
+                    BsonValue::Document(document([
+                        ("i64", BsonValue::Int32(1)),
+                        ("tail_first", BsonValue::Int32(-1)),
+                    ])),
+                ),
+                ("sparse", BsonValue::Boolean(true)),
+            ]);
+            let secondary = storage
+                .declare_document_index(
+                    collection.id(),
+                    "i64_and_tail",
+                    &secondary_specification,
+                    false,
+                )
+                .unwrap();
+            assert_eq!(secondary.lifecycle(), DocumentIndexLifecycle::PendingBuild);
+            assert!(!secondary.is_built_in());
+            assert!(!secondary.is_unique());
+            let shard = storage.insert_document(collection.id(), &stored).unwrap();
+            let scanned = storage.scan_documents(collection.id()).unwrap();
+            assert_eq!(scanned.len(), 1);
+            assert!(scanned[0].representation_eq(&stored));
+
+            assert_eq!(collection.namespace(), "ordered_db.ordered_collection");
+            assert_eq!(collection.placement(), DocumentPlacement::HashByIdV1);
+            assert!(
+                collection
+                    .options()
+                    .document()
+                    .representation_eq(&options_document)
+            );
+            assert_eq!(collection.indexes().len(), 1);
+            let id_index = &collection.indexes()[0];
+            assert_eq!(id_index.name(), "_id_");
+            assert!(id_index.is_unique());
+            assert!(id_index.is_built_in());
+            assert_eq!(id_index.lifecycle(), DocumentIndexLifecycle::Ready);
+            assert!(
+                id_index
+                    .specification()
+                    .representation_eq(&builtin_id_specification().unwrap())
+            );
+            assert_eq!(
+                id_index
+                    .specification()
+                    .iter()
+                    .map(|(name, _)| name)
+                    .collect::<Vec<_>>(),
+                ["v", "name", "key", "unique"]
+            );
+
+            let connection = Connection::open(shard_path(temp.path(), shard)).unwrap();
+            let (
+                sqlite_collection_id,
+                id_key,
+                natural_order,
+                bson,
+                checksum,
+                format,
+                order_type,
+                bson_type,
+                key_type,
+            ) = connection
+                .query_row(
+                    "SELECT collection_id, id_key, natural_order, document_bson,
+                                document_checksum, storage_format_version,
+                                typeof(natural_order), typeof(document_bson), typeof(id_key)
+                         FROM briskdb_documents_v1",
+                    [],
+                    |row| {
+                        Ok((
+                            row.get::<_, i64>(0)?,
+                            row.get::<_, Vec<u8>>(1)?,
+                            row.get::<_, i64>(2)?,
+                            row.get::<_, Vec<u8>>(3)?,
+                            row.get::<_, Vec<u8>>(4)?,
+                            row.get::<_, i64>(5)?,
+                            row.get::<_, String>(6)?,
+                            row.get::<_, String>(7)?,
+                            row.get::<_, String>(8)?,
+                        ))
+                    },
+                )
+                .unwrap();
+            assert_eq!(sqlite_collection_id, collection.id().get() as i64);
+            assert_eq!(
+                id_key,
+                CanonicalBsonKey::encode(&BsonValue::Int32(17))
+                    .unwrap()
+                    .as_bytes()
+            );
+            assert_eq!(natural_order, 1);
+            assert_eq!(bson, encoded);
+            assert_eq!(checksum.len(), 32);
+            assert_eq!(format, 1);
+            assert_eq!(
+                (order_type.as_str(), bson_type.as_str(), key_type.as_str()),
+                ("integer", "blob", "blob")
+            );
+            drop(connection);
+            drop(storage);
+
+            let reopened = Storage::open(temp.path(), 4).unwrap();
+            let catalog = reopened.document_catalog().unwrap();
+            let reopened_collection = catalog
+                .collection("ordered_db", "ordered_collection")
+                .unwrap();
+            assert_eq!(reopened_collection.id(), collection.id());
+            assert!(
+                reopened_collection
+                    .options()
+                    .document()
+                    .representation_eq(&options_document)
+            );
+            assert_eq!(reopened_collection.indexes().len(), 2);
+            let reopened_secondary = reopened_collection
+                .indexes()
+                .iter()
+                .find(|index| index.name() == "i64_and_tail")
+                .unwrap();
+            assert_eq!(
+                reopened_secondary.lifecycle(),
+                DocumentIndexLifecycle::PendingBuild
+            );
+            assert!(
+                reopened_secondary
+                    .specification()
+                    .representation_eq(&secondary_specification)
+            );
+            let restored = reopened
+                .get_document(collection.id(), &BsonValue::Int32(17))
+                .unwrap()
+                .unwrap();
+            assert!(restored.representation_eq(&stored));
+            assert_eq!(encode_document(&restored).unwrap(), encoded);
+        }
+
+        #[test]
+        fn canonical_id_aliases_route_together_and_enforce_unique_id() {
+            let temp = tempfile::tempdir().unwrap();
+            let storage = Storage::open(temp.path(), 8).unwrap();
+            let collection = storage
+                .create_document_collection(
+                    "identity_db",
+                    "values",
+                    &DocumentCollectionOptions::empty(),
+                )
+                .unwrap();
+
+            let integer = document([
+                ("_id", BsonValue::Int32(1)),
+                ("kind", BsonValue::String("integer".to_owned())),
+            ]);
+            let integer_shard = storage.insert_document(collection.id(), &integer).unwrap();
+            let integer_alias = BsonValue::Double(1.0);
+            assert_eq!(
+                integer_shard,
+                storage.shard_for_key(CanonicalBsonKey::encode(&integer_alias).unwrap().as_bytes())
+            );
+            assert!(
+                storage
+                    .get_document(collection.id(), &integer_alias)
+                    .unwrap()
+                    .unwrap()
+                    .representation_eq(&integer)
+            );
+            let duplicate_integer = document([
+                ("_id", integer_alias),
+                ("kind", BsonValue::String("double".to_owned())),
+            ]);
+            assert_eq!(
+                storage
+                    .insert_document(collection.id(), &duplicate_integer)
+                    .unwrap_err()
+                    .kind(),
+                EngineErrorKind::UniqueViolation
+            );
+
+            let uuid_bytes = [0x5a; 16];
+            let uuid = BsonValue::Uuid(BsonUuid::new(uuid_bytes, UuidRepresentation::Standard));
+            let binary = BsonValue::Binary(BsonBinary::new(4, uuid_bytes));
+            let uuid_document = document([
+                ("_id", uuid.clone()),
+                ("kind", BsonValue::String("uuid".to_owned())),
+            ]);
+            let uuid_shard = storage
+                .insert_document(collection.id(), &uuid_document)
+                .unwrap();
+            assert_eq!(
+                uuid_shard,
+                storage.shard_for_key(CanonicalBsonKey::encode(&binary).unwrap().as_bytes())
+            );
+            let restored_uuid = storage
+                .get_document(collection.id(), &binary)
+                .unwrap()
+                .unwrap();
+            assert_eq!(restored_uuid, uuid_document);
+            assert_eq!(
+                encode_document(&restored_uuid).unwrap(),
+                encode_document(&uuid_document).unwrap()
+            );
+            let duplicate_binary = document([
+                ("_id", binary),
+                ("kind", BsonValue::String("binary".to_owned())),
+            ]);
+            assert_eq!(
+                storage
+                    .insert_document(collection.id(), &duplicate_binary)
+                    .unwrap_err()
+                    .kind(),
+                EngineErrorKind::UniqueViolation
+            );
+        }
+
+        #[test]
+        fn ordinary_sql_tables_do_not_become_document_collections() {
+            let temp = tempfile::tempdir().unwrap();
+            let database = Database::open(temp.path(), 2).unwrap();
+            database
+                .broadcast("CREATE TABLE sql_only (id INTEGER PRIMARY KEY, value TEXT)")
+                .unwrap();
+            drop(database);
+
+            let storage = Storage::open(temp.path(), 2).unwrap();
+            assert!(storage.document_catalog().unwrap().collections().is_empty());
+            for shard in 0..storage.shard_count() {
+                let connection = Connection::open(shard_path(temp.path(), shard)).unwrap();
+                assert_eq!(
+                    connection
+                        .query_row(
+                            "SELECT type FROM sqlite_schema WHERE name = 'sql_only'",
+                            [],
+                            |row| row.get::<_, String>(0),
+                        )
+                        .unwrap(),
+                    "table"
+                );
+            }
+        }
+
+        #[test]
+        fn active_document_storage_stays_outside_generated_sql_table_inventory() {
+            let temp = tempfile::tempdir().unwrap();
+            let storage = Storage::open(temp.path(), 2).unwrap();
+            storage
+                .create_document_collection(
+                    "documents",
+                    "users",
+                    &DocumentCollectionOptions::empty(),
+                )
+                .unwrap();
+            drop(storage);
+
+            let mut database = Database::open(temp.path(), 2).unwrap();
+            database
+                .apply_generated_table_ddl(
+                    SqlDialect::Sqlite,
+                    "CREATE TABLE events (
+                         id INTEGER PRIMARY KEY AUTOINCREMENT,
+                         payload TEXT NOT NULL
+                     )",
+                )
+                .unwrap();
+            assert!(
+                database
+                    .catalog()
+                    .table("default", "events")
+                    .unwrap()
+                    .is_some()
+            );
+            drop(database);
+
+            let reopened = Storage::open(temp.path(), 2).unwrap();
+            assert!(
+                reopened
+                    .document_catalog()
+                    .unwrap()
+                    .collection("documents", "users")
+                    .is_some()
+            );
+        }
+
+        #[test]
+        fn record_checksum_tampering_is_rejected_on_startup() {
+            let temp = tempfile::tempdir().unwrap();
+            let storage = Storage::open(temp.path(), 2).unwrap();
+            let collection = storage
+                .create_document_collection(
+                    "tamper_db",
+                    "checksums",
+                    &DocumentCollectionOptions::empty(),
+                )
+                .unwrap();
+            let stored = document([
+                ("_id", BsonValue::String("record-1".to_owned())),
+                ("value", BsonValue::Int32(42)),
+            ]);
+            let shard = storage.insert_document(collection.id(), &stored).unwrap();
+            drop(storage);
+
+            let connection = Connection::open(shard_path(temp.path(), shard)).unwrap();
+            connection
+                .execute(
+                    "UPDATE briskdb_documents_v1 SET document_checksum = zeroblob(32)",
+                    [],
+                )
+                .unwrap();
+            drop(connection);
+
+            let error = Storage::open(temp.path(), 2).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+        }
+
+        #[test]
+        fn batch_insert_persists_global_natural_order_across_shards_and_restart() {
+            let temp = tempfile::tempdir().unwrap();
+            let storage = Storage::open(temp.path(), 4).unwrap();
+            let collection = storage
+                .create_document_collection(
+                    "ordered_import",
+                    "events",
+                    &DocumentCollectionOptions::empty(),
+                )
+                .unwrap();
+            let documents = (0..32)
+                .map(|value| {
+                    document([
+                        ("_id", BsonValue::String(format!("event-{value}"))),
+                        ("source_order", BsonValue::Int32(value)),
+                    ])
+                })
+                .collect::<Vec<_>>();
+            storage
+                .insert_documents(collection.id(), &documents, &CancellationToken::new())
+                .unwrap();
+            let appended = document([
+                ("_id", BsonValue::String("event-appended".to_owned())),
+                ("source_order", BsonValue::Int32(32)),
+            ]);
+            storage.insert_document(collection.id(), &appended).unwrap();
+
+            let expected = documents
+                .iter()
+                .chain(std::iter::once(&appended))
+                .collect::<Vec<_>>();
+            let scanned = storage.scan_documents(collection.id()).unwrap();
+            assert_eq!(scanned.len(), expected.len());
+            assert!(
+                scanned
+                    .iter()
+                    .zip(&expected)
+                    .all(|(actual, expected)| actual.representation_eq(expected))
+            );
+
+            let mut persisted_orders = Vec::new();
+            for shard in 0..storage.shard_count() {
+                let connection = Connection::open(shard_path(temp.path(), shard)).unwrap();
+                let mut orders = connection
+                    .prepare(
+                        "SELECT natural_order FROM briskdb_documents_v1
+                         WHERE collection_id = ?1 ORDER BY natural_order",
+                    )
+                    .unwrap()
+                    .query_map([collection.id().get() as i64], |row| row.get::<_, i64>(0))
+                    .unwrap()
+                    .collect::<Result<Vec<_>, _>>()
+                    .unwrap();
+                persisted_orders.append(&mut orders);
+            }
+            persisted_orders.sort_unstable();
+            assert_eq!(persisted_orders, (1_i64..=33).collect::<Vec<_>>());
+            let manifest = Connection::open(temp.path().join("manifest.sqlite")).unwrap();
+            assert_eq!(
+                manifest
+                    .query_row(
+                        "SELECT next_natural_order FROM briskdb_document_collections
+                         WHERE collection_id = ?1",
+                        [collection.id().get() as i64],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .unwrap(),
+                34
+            );
+            drop(manifest);
+            drop(storage);
+
+            let reopened = Storage::open(temp.path(), 4).unwrap();
+            let scanned = reopened.scan_documents(collection.id()).unwrap();
+            assert!(
+                scanned
+                    .iter()
+                    .zip(expected)
+                    .all(|(actual, expected)| actual.representation_eq(expected))
+            );
+        }
+
+        #[test]
+        fn document_mutations_refuse_to_reseal_unrelated_manifest_tampering() {
+            fn tamper_manifest(root: &std::path::Path) -> Vec<u8> {
+                let connection = Connection::open(root.join("manifest.sqlite")).unwrap();
+                connection
+                    .execute(
+                        "INSERT INTO briskdb_logical_databases (database_id, database_name)
+                         VALUES (2, 'unrelated_tamper')",
+                        [],
+                    )
+                    .unwrap();
+                connection
+                    .query_row(
+                        "SELECT manifest_digest FROM briskdb_integrity WHERE singleton = 1",
+                        [],
+                        |row| row.get::<_, Vec<u8>>(0),
+                    )
+                    .unwrap()
+            }
+
+            fn assert_root_unchanged(root: &std::path::Path, expected: &[u8]) {
+                let connection = Connection::open(root.join("manifest.sqlite")).unwrap();
+                let actual = connection
+                    .query_row(
+                        "SELECT manifest_digest FROM briskdb_integrity WHERE singleton = 1",
+                        [],
+                        |row| row.get::<_, Vec<u8>>(0),
+                    )
+                    .unwrap();
+                assert_eq!(actual, expected);
+            }
+
+            let create = tempfile::tempdir().unwrap();
+            let storage = Storage::open(create.path(), 2).unwrap();
+            let root = tamper_manifest(create.path());
+            let error = storage
+                .create_document_collection("new_db", "events", &DocumentCollectionOptions::empty())
+                .unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+            assert_root_unchanged(create.path(), &root);
+
+            let index = tempfile::tempdir().unwrap();
+            let storage = Storage::open(index.path(), 2).unwrap();
+            let collection = storage
+                .create_document_collection(
+                    "existing_db",
+                    "events",
+                    &DocumentCollectionOptions::empty(),
+                )
+                .unwrap();
+            let root = tamper_manifest(index.path());
+            let error = storage
+                .declare_document_index(
+                    collection.id(),
+                    "value_1",
+                    &document([("value", BsonValue::Int32(1))]),
+                    false,
+                )
+                .unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+            assert_root_unchanged(index.path(), &root);
+
+            let insert = tempfile::tempdir().unwrap();
+            let storage = Storage::open(insert.path(), 2).unwrap();
+            let collection = storage
+                .create_document_collection(
+                    "existing_db",
+                    "events",
+                    &DocumentCollectionOptions::empty(),
+                )
+                .unwrap();
+            let root = tamper_manifest(insert.path());
+            let error = storage
+                .insert_document(
+                    collection.id(),
+                    &document([("_id", BsonValue::String("event-1".to_owned()))]),
+                )
+                .unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+            assert_root_unchanged(insert.path(), &root);
+        }
+
+        #[test]
+        fn persisted_degraded_state_fences_document_reads_and_mutations() {
+            let temp = tempfile::tempdir().unwrap();
+            let storage = Storage::open(temp.path(), 2).unwrap();
+            let collection = storage
+                .create_document_collection(
+                    "degraded_db",
+                    "events",
+                    &DocumentCollectionOptions::empty(),
+                )
+                .unwrap();
+            let stored = document([
+                ("_id", BsonValue::String("event-1".to_owned())),
+                ("value", BsonValue::Int32(1)),
+            ]);
+            storage.insert_document(collection.id(), &stored).unwrap();
+
+            let manifest_path = temp.path().join("manifest.sqlite");
+            let mut manifest_connection = open_existing_manifest(&manifest_path).unwrap();
+            configure_manifest_connection(&manifest_connection).unwrap();
+            manifest::mark_degraded(
+                &mut manifest_connection,
+                storage.shard_count(),
+                &storage.shard_layout,
+            )
+            .unwrap();
+            let degraded_digest = manifest_connection
+                .query_row(
+                    "SELECT manifest_digest FROM briskdb_integrity WHERE singleton = 1",
+                    [],
+                    |row| row.get::<_, Vec<u8>>(0),
+                )
+                .unwrap();
+            let catalog_counts = manifest_connection
+                .query_row(
+                    "SELECT
+                         (SELECT count(*) FROM briskdb_document_collections),
+                         (SELECT count(*) FROM briskdb_document_indexes),
+                         (SELECT next_natural_order FROM briskdb_document_collections
+                          WHERE collection_id = ?1)",
+                    [collection.id().get() as i64],
+                    |row| {
+                        Ok((
+                            row.get::<_, i64>(0)?,
+                            row.get::<_, i64>(1)?,
+                            row.get::<_, i64>(2)?,
+                        ))
+                    },
+                )
+                .unwrap();
+            drop(manifest_connection);
+
+            let id = BsonValue::String("event-1".to_owned());
+            for error in [
+                storage.document_catalog_inner().unwrap_err(),
+                storage
+                    .get_document_inner(collection.id(), &id)
+                    .unwrap_err(),
+                storage
+                    .insert_document_inner(
+                        collection.id(),
+                        &document([("_id", BsonValue::String("event-2".to_owned()))]),
+                    )
+                    .unwrap_err(),
+                storage
+                    .declare_document_index_inner(
+                        collection.id(),
+                        "value_1",
+                        &document([("value", BsonValue::Int32(1))]),
+                        false,
+                    )
+                    .unwrap_err(),
+                storage
+                    .create_document_collection_inner(
+                        "degraded_db",
+                        "other",
+                        &DocumentCollectionOptions::empty(),
+                    )
+                    .unwrap_err(),
+            ] {
+                assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+            }
+
+            let manifest_connection = Connection::open(&manifest_path).unwrap();
+            let unchanged = manifest_connection
+                .query_row(
+                    "SELECT
+                         manifest_digest,
+                         (SELECT count(*) FROM briskdb_document_collections),
+                         (SELECT count(*) FROM briskdb_document_indexes),
+                         (SELECT next_natural_order FROM briskdb_document_collections
+                          WHERE collection_id = ?1)
+                     FROM briskdb_integrity WHERE singleton = 1",
+                    [collection.id().get() as i64],
+                    |row| {
+                        Ok((
+                            row.get::<_, Vec<u8>>(0)?,
+                            row.get::<_, i64>(1)?,
+                            row.get::<_, i64>(2)?,
+                            row.get::<_, i64>(3)?,
+                        ))
+                    },
+                )
+                .unwrap();
+            assert_eq!(unchanged.0, degraded_digest);
+            assert_eq!((unchanged.1, unchanged.2, unchanged.3), catalog_counts);
+            let document_rows = (0..storage.shard_count())
+                .map(|shard| {
+                    Connection::open(shard_path(temp.path(), shard))
+                        .unwrap()
+                        .query_row("SELECT count(*) FROM briskdb_documents_v1", [], |row| {
+                            row.get::<_, i64>(0)
+                        })
+                        .unwrap()
+                })
+                .sum::<i64>();
+            assert_eq!(document_rows, 1);
+
+            assert_eq!(
+                storage
+                    .get_document(collection.id(), &id)
+                    .unwrap_err()
+                    .kind(),
+                EngineErrorKind::DataCorruption
+            );
+            assert_eq!(
+                storage.schema_gate_snapshot().state,
+                crate::storage::SchemaGateState::Degraded
+            );
+        }
+
+        #[test]
+        fn startup_rejects_natural_order_and_shard_route_tampering() {
+            let order = tempfile::tempdir().unwrap();
+            let storage = Storage::open(order.path(), 2).unwrap();
+            let collection = storage
+                .create_document_collection(
+                    "tamper_db",
+                    "order",
+                    &DocumentCollectionOptions::empty(),
+                )
+                .unwrap();
+            let shard = storage
+                .insert_document(
+                    collection.id(),
+                    &document([("_id", BsonValue::String("event-1".to_owned()))]),
+                )
+                .unwrap();
+            drop(storage);
+            let connection = Connection::open(shard_path(order.path(), shard)).unwrap();
+            connection
+                .execute(
+                    "UPDATE briskdb_documents_v1 SET natural_order = natural_order + 1",
+                    [],
+                )
+                .unwrap();
+            drop(connection);
+            assert_eq!(
+                Storage::open(order.path(), 2).unwrap_err().kind(),
+                EngineErrorKind::DataCorruption
+            );
+
+            let route = tempfile::tempdir().unwrap();
+            let storage = Storage::open(route.path(), 2).unwrap();
+            let collection = storage
+                .create_document_collection(
+                    "tamper_db",
+                    "route",
+                    &DocumentCollectionOptions::empty(),
+                )
+                .unwrap();
+            let source_shard = storage
+                .insert_document(
+                    collection.id(),
+                    &document([("_id", BsonValue::String("event-1".to_owned()))]),
+                )
+                .unwrap();
+            drop(storage);
+            let source = Connection::open(shard_path(route.path(), source_shard)).unwrap();
+            let record = source
+                .query_row(
+                    "SELECT collection_id, id_key, natural_order, document_bson,
+                            document_checksum, storage_format_version
+                     FROM briskdb_documents_v1",
+                    [],
+                    |row| {
+                        Ok((
+                            row.get::<_, i64>(0)?,
+                            row.get::<_, Vec<u8>>(1)?,
+                            row.get::<_, i64>(2)?,
+                            row.get::<_, Vec<u8>>(3)?,
+                            row.get::<_, Vec<u8>>(4)?,
+                            row.get::<_, i64>(5)?,
+                        ))
+                    },
+                )
+                .unwrap();
+            source
+                .execute("DELETE FROM briskdb_documents_v1", [])
+                .unwrap();
+            drop(source);
+            let destination_shard = 1 - source_shard;
+            let destination =
+                Connection::open(shard_path(route.path(), destination_shard)).unwrap();
+            destination
+                .execute(
+                    "INSERT INTO briskdb_documents_v1 (
+                        collection_id, id_key, natural_order, document_bson,
+                        document_checksum, storage_format_version
+                     ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                    rusqlite::params![record.0, record.1, record.2, record.3, record.4, record.5],
+                )
+                .unwrap();
+            drop(destination);
+            assert_eq!(
+                Storage::open(route.path(), 2).unwrap_err().kind(),
+                EngineErrorKind::DataCorruption
+            );
+        }
+
+        #[test]
+        fn record_checksum_binds_collection_shard_order_key_and_payload() {
+            let collection = DocumentCollectionId::from_validated(7);
+            let baseline = record_checksum(collection, 0, 1, b"key", b"document");
+            assert_ne!(
+                baseline,
+                record_checksum(
+                    DocumentCollectionId::from_validated(8),
+                    0,
+                    1,
+                    b"key",
+                    b"document"
+                )
+            );
+            assert_ne!(
+                baseline,
+                record_checksum(collection, 1, 1, b"key", b"document")
+            );
+            assert_ne!(
+                baseline,
+                record_checksum(collection, 0, 2, b"key", b"document")
+            );
+            assert_ne!(
+                baseline,
+                record_checksum(collection, 0, 1, b"key2", b"document")
+            );
+            assert_ne!(
+                baseline,
+                record_checksum(collection, 0, 1, b"key", b"document2")
+            );
+        }
+
+        #[test]
+        fn document_table_schema_tampering_is_rejected_on_startup() {
+            let temp = tempfile::tempdir().unwrap();
+            let storage = Storage::open(temp.path(), 2).unwrap();
+            storage
+                .create_document_collection(
+                    "tamper_db",
+                    "schema",
+                    &DocumentCollectionOptions::empty(),
+                )
+                .unwrap();
+            drop(storage);
+
+            let connection = Connection::open(shard_path(temp.path(), 0)).unwrap();
+            connection
+                .execute_batch("ALTER TABLE briskdb_documents_v1 ADD COLUMN injected INTEGER;")
+                .unwrap();
+            drop(connection);
+
+            let error = Storage::open(temp.path(), 2).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+        }
+
+        #[test]
+        fn startup_resumes_document_collection_provisioning_from_durable_cursor() {
+            let temp = tempfile::tempdir().unwrap();
+            drop(Storage::open(temp.path(), 4).unwrap());
+
+            let options_bson =
+                encode_document(DocumentCollectionOptions::empty().document()).unwrap();
+            let id_specification_bson =
+                encode_document(&builtin_id_specification().unwrap()).unwrap();
+            let operation_id = provisioning_id("recovery_db", "events", &options_bson);
+            let manifest_path = temp.path().join("manifest.sqlite");
+            let mut manifest_connection = open_existing_manifest(&manifest_path).unwrap();
+            configure_manifest_connection(&manifest_connection).unwrap();
+            configure_journal_mode(&manifest_connection).unwrap();
+            let transaction = manifest_connection
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .unwrap();
+            transaction
+                .execute(
+                    "INSERT INTO briskdb_document_databases (
+                        database_id, database_name, catalog_version
+                     ) VALUES (1, 'recovery_db', 1)",
+                    [],
+                )
+                .unwrap();
+            transaction
+                .execute(
+                    "INSERT INTO briskdb_document_collections (
+                        collection_id, database_id, collection_name, options_bson,
+                        bson_schema_version, storage_format_version,
+                        placement_policy, placement_version, next_natural_order,
+                        lifecycle_state
+                     ) VALUES (1, 1, 'events', ?1, 1, 1, 1, 1, 1, 1)",
+                    [options_bson],
+                )
+                .unwrap();
+            transaction
+                .execute(
+                    "INSERT INTO briskdb_document_indexes (
+                        collection_id, index_name, spec_bson, is_unique, is_builtin,
+                        index_format_version, lifecycle_state
+                     ) VALUES (1, '_id_', ?1, 1, 1, 1, ?2)",
+                    rusqlite::params![id_specification_bson, INDEX_PENDING_BUILD],
+                )
+                .unwrap();
+            transaction
+                .execute(
+                    "INSERT INTO briskdb_document_provisioning (
+                        singleton, collection_id, operation_id, shard_count, next_shard
+                     ) VALUES (1, 1, ?1, 4, 1)",
+                    [operation_id.as_slice()],
+                )
+                .unwrap();
+            manifest::validate_document_catalog(&transaction, 4).unwrap();
+            manifest::refresh_manifest_digest(&transaction).unwrap();
+            transaction.commit().unwrap();
+            drop(manifest_connection);
+
+            let mut first_shard = Connection::open(shard_path(temp.path(), 0)).unwrap();
+            ensure_schema(&mut first_shard).unwrap();
+            drop(first_shard);
+
+            let storage = Storage::open(temp.path(), 4).unwrap();
+            let catalog = storage.document_catalog().unwrap();
+            let collection = catalog.collection("recovery_db", "events").unwrap();
+            assert_eq!(collection.id().get(), 1);
+            assert_eq!(collection.indexes().len(), 1);
+            assert_eq!(collection.indexes()[0].name(), "_id_");
+            for shard in 0..4 {
+                let connection = Connection::open(shard_path(temp.path(), shard)).unwrap();
+                assert!(super::super::validate_optional_schema(&connection).unwrap());
+            }
+            let manifest_connection = Connection::open(manifest_path).unwrap();
+            assert_eq!(
+                manifest_connection
+                    .query_row(
+                        "SELECT COUNT(*) FROM briskdb_document_provisioning",
+                        [],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .unwrap(),
+                0
+            );
+            assert_eq!(
+                manifest_connection
+                    .query_row(
+                        "SELECT lifecycle_state FROM briskdb_document_collections
+                         WHERE collection_id = 1",
+                        [],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .unwrap(),
+                COLLECTION_ACTIVE
+            );
+        }
+    }
+}
+
+#[cfg(feature = "documents")]
+pub(super) use enabled::recover_or_validate;
+
+#[cfg(not(feature = "documents"))]
+pub(super) fn recover_or_validate(
+    storage: &Storage,
+    manifest_connection: &mut Connection,
+) -> EngineResult<()> {
+    super::manifest::validate_document_catalog(manifest_connection, storage.shard_count())?;
+    let has_catalog = manifest_connection
+        .query_row(
+            "SELECT EXISTS (SELECT 1 FROM briskdb_document_collections)",
+            [],
+            |row| row.get::<_, bool>(0),
+        )
+        .map_err(sqlite_error::storage)?;
+    if has_catalog {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "this data directory contains document collections; enable the documents feature",
+        ));
+    }
+    for shard in 0..storage.shard_count() {
+        let connection = storage.open_unconfigured_shard(shard)?;
+        storage.validate_unconfigured_shard(&connection, shard)?;
+        if validate_optional_schema(&connection)? {
+            return Err(corrupt(
+                "document storage exists without document catalog metadata",
+            ));
+        }
+    }
+    Ok(())
+}

--- a/src/storage/manifest.rs
+++ b/src/storage/manifest.rs
@@ -46,8 +46,36 @@ const V10_SCHEMA_VERSION: u32 = 10;
 const V11_SCHEMA_VERSION: u32 = 11;
 const V12_SCHEMA_VERSION: u32 = 12;
 const V13_SCHEMA_VERSION: u32 = 13;
-pub(super) const CURRENT_SCHEMA_VERSION: u32 = V13_SCHEMA_VERSION;
+const V14_SCHEMA_VERSION: u32 = 14;
+pub(super) const CURRENT_SCHEMA_VERSION: u32 = V14_SCHEMA_VERSION;
 const MAX_TABLE_SQL_BYTES: i64 = 4_096;
+
+pub(super) const DOCUMENT_CATALOG_VERSION: u32 = 1;
+pub(super) const DOCUMENT_BSON_SCHEMA_VERSION: u32 = 1;
+pub(super) const DOCUMENT_STORAGE_FORMAT_VERSION: u32 = 1;
+pub(super) const DOCUMENT_PLACEMENT_POLICY: u32 = 1;
+pub(super) const DOCUMENT_PLACEMENT_VERSION: u32 = 1;
+pub(super) const DOCUMENT_INDEX_FORMAT_VERSION: u32 = 1;
+#[cfg(feature = "documents")]
+pub(super) const DOCUMENT_COLLECTION_PROVISIONING: i64 = 1;
+#[cfg(feature = "documents")]
+pub(super) const DOCUMENT_COLLECTION_ACTIVE: i64 = 2;
+#[cfg(feature = "documents")]
+pub(super) const DOCUMENT_INDEX_READY: i64 = 1;
+#[cfg(feature = "documents")]
+pub(super) const DOCUMENT_INDEX_PENDING_BUILD: i64 = 2;
+pub(super) const MAX_DOCUMENT_DATABASES: usize = 64;
+pub(super) const MAX_DOCUMENT_COLLECTIONS: usize = 4_096;
+pub(super) const MAX_DOCUMENT_INDEXES: usize = 65_536;
+#[cfg(test)]
+const MAX_DOCUMENT_DATABASE_NAME_BYTES: usize = 63;
+#[cfg(test)]
+const MAX_DOCUMENT_NAMESPACE_BYTES: usize = 255;
+#[cfg(feature = "documents")]
+pub(super) const MAX_DOCUMENT_INDEX_NAME_BYTES: usize = 255;
+#[cfg(feature = "documents")]
+pub(super) const MAX_DOCUMENT_METADATA_BSON_BYTES: usize = 16 * 1024 * 1024;
+pub(super) const MAX_DOCUMENT_CATALOG_BSON_BYTES: usize = 64 * 1024 * 1024;
 
 pub(super) const MAX_SCHEMA_MIGRATION_SQL_BYTES: usize = 65_536;
 pub(super) const MAX_SCHEMA_GENERATION: u64 = i32::MAX as u64;
@@ -61,6 +89,7 @@ const V3_MANIFEST_DIGEST_VERSION: u32 = 3;
 const V4_MANIFEST_DIGEST_VERSION: u32 = 4;
 const V5_MANIFEST_DIGEST_VERSION: u32 = 5;
 const V6_MANIFEST_DIGEST_VERSION: u32 = 6;
+const V7_MANIFEST_DIGEST_VERSION: u32 = 7;
 pub(super) const SCHEMA_DIGEST_VERSION: u32 = 1;
 const V1_MANIFEST_DIGEST_DOMAIN: &[u8] = b"briskdb.manifest.semantic-root.v1\0";
 const V2_MANIFEST_DIGEST_DOMAIN: &[u8] = b"briskdb.manifest.semantic-root.v2\0";
@@ -68,6 +97,7 @@ const V3_MANIFEST_DIGEST_DOMAIN: &[u8] = b"briskdb.manifest.semantic-root.v3\0";
 const V4_MANIFEST_DIGEST_DOMAIN: &[u8] = b"briskdb.manifest.semantic-root.v4\0";
 const V5_MANIFEST_DIGEST_DOMAIN: &[u8] = b"briskdb.manifest.semantic-root.v5\0";
 const V6_MANIFEST_DIGEST_DOMAIN: &[u8] = b"briskdb.manifest.semantic-root.v6\0";
+const V7_MANIFEST_DIGEST_DOMAIN: &[u8] = b"briskdb.manifest.semantic-root.v7\0";
 const TABLE_PROVISIONING_DIGEST_DOMAIN: &[u8] = b"briskdb.table-provisioning.v1\0";
 const GENERATED_TABLE_DDL_DIGEST_DOMAIN: &[u8] = b"briskdb.generated-table-ddl.v1\0";
 
@@ -222,6 +252,10 @@ const V12_DOWNGRADE_FENCE_SQL: &str = "CREATE TABLE briskdb_metadata (
 const V13_DOWNGRADE_FENCE_SQL: &str = "CREATE TABLE briskdb_metadata (
     requires_manifest_version INTEGER NOT NULL
         CHECK (requires_manifest_version >= 13)
+) STRICT";
+const V14_DOWNGRADE_FENCE_SQL: &str = "CREATE TABLE briskdb_metadata (
+    requires_manifest_version INTEGER NOT NULL
+        CHECK (requires_manifest_version >= 14)
 ) STRICT";
 const V3_ROUTING_TABLE_SQL: &str = "CREATE TABLE briskdb_routing (
     singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
@@ -676,6 +710,75 @@ const V13_GLOBAL_INDEX_PARTS_TABLE_SQL: &str = "CREATE TABLE briskdb_global_inde
     FOREIGN KEY (index_id)
         REFERENCES briskdb_global_indexes (index_id)
         ON DELETE CASCADE
+) STRICT";
+const V14_DOCUMENT_DATABASES_TABLE_SQL: &str = "CREATE TABLE briskdb_document_databases (
+    database_id INTEGER PRIMARY KEY CHECK (database_id > 0),
+    database_name TEXT NOT NULL COLLATE BINARY UNIQUE
+        CHECK (
+            length(CAST(database_name AS BLOB)) BETWEEN 1 AND 63
+            AND instr(database_name, char(0)) = 0
+        ),
+    catalog_version INTEGER NOT NULL CHECK (catalog_version = 1)
+) STRICT";
+const V14_DOCUMENT_COLLECTIONS_TABLE_SQL: &str = "CREATE TABLE briskdb_document_collections (
+    collection_id INTEGER PRIMARY KEY CHECK (collection_id > 0),
+    database_id INTEGER NOT NULL,
+    collection_name TEXT NOT NULL COLLATE BINARY
+        CHECK (
+            length(CAST(collection_name AS BLOB)) BETWEEN 1 AND 255
+            AND instr(collection_name, char(0)) = 0
+        ),
+    options_bson BLOB NOT NULL
+        CHECK (
+            typeof(options_bson) = 'blob'
+            AND length(options_bson) BETWEEN 5 AND 16777216
+        ),
+    bson_schema_version INTEGER NOT NULL CHECK (bson_schema_version = 1),
+    storage_format_version INTEGER NOT NULL CHECK (storage_format_version = 1),
+    placement_policy INTEGER NOT NULL CHECK (placement_policy = 1),
+    placement_version INTEGER NOT NULL CHECK (placement_version = 1),
+    next_natural_order INTEGER NOT NULL CHECK (next_natural_order > 0),
+    lifecycle_state INTEGER NOT NULL CHECK (lifecycle_state IN (1, 2)),
+    UNIQUE (database_id, collection_name),
+    FOREIGN KEY (database_id)
+        REFERENCES briskdb_document_databases (database_id)
+        ON DELETE RESTRICT
+) STRICT";
+const V14_DOCUMENT_INDEXES_TABLE_SQL: &str = "CREATE TABLE briskdb_document_indexes (
+    collection_id INTEGER NOT NULL,
+    index_name TEXT NOT NULL COLLATE BINARY
+        CHECK (
+            length(CAST(index_name AS BLOB)) BETWEEN 1 AND 255
+            AND instr(index_name, char(0)) = 0
+        ),
+    spec_bson BLOB NOT NULL
+        CHECK (
+            typeof(spec_bson) = 'blob'
+            AND length(spec_bson) BETWEEN 5 AND 16777216
+        ),
+    is_unique INTEGER NOT NULL CHECK (is_unique IN (0, 1)),
+    is_builtin INTEGER NOT NULL CHECK (is_builtin IN (0, 1)),
+    index_format_version INTEGER NOT NULL CHECK (index_format_version = 1),
+    lifecycle_state INTEGER NOT NULL CHECK (lifecycle_state IN (1, 2)),
+    PRIMARY KEY (collection_id, index_name),
+    FOREIGN KEY (collection_id)
+        REFERENCES briskdb_document_collections (collection_id)
+        ON DELETE RESTRICT,
+    CHECK (
+        (is_builtin = 0 AND index_name <> '_id_')
+        OR (is_builtin = 1 AND index_name = '_id_' AND is_unique = 1)
+    )
+) STRICT";
+const V14_DOCUMENT_PROVISIONING_TABLE_SQL: &str = "CREATE TABLE briskdb_document_provisioning (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    collection_id INTEGER NOT NULL UNIQUE CHECK (collection_id > 0),
+    operation_id BLOB NOT NULL
+        CHECK (typeof(operation_id) = 'blob' AND length(operation_id) = 32),
+    shard_count INTEGER NOT NULL CHECK (shard_count BETWEEN 2 AND 64),
+    next_shard INTEGER NOT NULL CHECK (next_shard BETWEEN 0 AND shard_count),
+    FOREIGN KEY (collection_id)
+        REFERENCES briskdb_document_collections (collection_id)
+        ON DELETE RESTRICT
 ) STRICT";
 const V5_SHARD_LAYOUT_TABLE_SQL: &str = "CREATE TABLE briskdb_shard_layout (
     singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
@@ -1238,6 +1341,13 @@ const MIGRATIONS: &[Migration] = &[
         apply: migrate_v12_to_v13,
         validate: validate_v13,
     },
+    Migration {
+        from: V13_SCHEMA_VERSION,
+        to: V14_SCHEMA_VERSION,
+        name: "document_catalog_and_collection_lifecycle",
+        apply: migrate_v13_to_v14,
+        validate: validate_v14,
+    },
 ];
 
 #[derive(Clone, Copy)]
@@ -1251,8 +1361,8 @@ struct MigrationPlan<'a> {
 const CURRENT_PLAN: MigrationPlan<'static> = MigrationPlan {
     current_version: CURRENT_SCHEMA_VERSION,
     migrations: MIGRATIONS,
-    initialize_current: create_v13_schema,
-    initialize_interrupted_legacy: migrate_interrupted_legacy_to_v13,
+    initialize_current: create_v14_schema,
+    initialize_interrupted_legacy: migrate_interrupted_legacy_to_v14,
 };
 
 // Startup uses this frozen plan only to finish an already-active v6 journal
@@ -1383,11 +1493,22 @@ pub(super) fn startup_requires_exclusive_ownership(
         .generated_table_ddl
         .as_ref()
         .is_none_or(|ddl| ddl.lifecycle() == GeneratedTableDdlLifecycle::Complete);
+    let document_catalog_steady = connection
+        .query_row(
+            "SELECT NOT EXISTS (SELECT 1 FROM briskdb_document_provisioning)",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .map_err(|error| {
+            manifest_read_error(error, "failed to inspect document provisioning state")
+        })?
+        != 0;
     Ok(!(layout_ready
         && integrity_steady
         && snapshot.active_migration.is_none()
         && snapshot.active_table_provisioning.is_none()
-        && generated_ddl_steady))
+        && generated_ddl_steady
+        && document_catalog_steady))
 }
 
 /// Return an active v6 journal without upgrading it. Startup completes this
@@ -2865,7 +2986,11 @@ pub(super) fn inspect_with_v9_plan_for_test(
 fn downgrade_v10_manifest_to_v9_for_test(connection: &Connection) -> EngineResult<()> {
     connection
         .execute_batch(
-            "DROP TABLE IF EXISTS briskdb_global_index_parts;
+            "DROP TABLE IF EXISTS briskdb_document_provisioning;
+             DROP TABLE IF EXISTS briskdb_document_indexes;
+             DROP TABLE IF EXISTS briskdb_document_collections;
+             DROP TABLE IF EXISTS briskdb_document_databases;
+             DROP TABLE IF EXISTS briskdb_global_index_parts;
              DROP TABLE IF EXISTS briskdb_global_indexes;
              DROP TABLE IF EXISTS briskdb_hilo_leases;
              DROP TABLE IF EXISTS briskdb_generated_table_ddl;
@@ -2964,6 +3089,9 @@ fn downgrade_v12_manifest_to_v11_for_test(
     connection: &Connection,
     shard_count: u16,
 ) -> EngineResult<()> {
+    if read_identity(connection)?.1 == i64::from(V14_SCHEMA_VERSION) {
+        downgrade_v14_manifest_to_v13_for_test(connection, shard_count)?;
+    }
     if read_identity(connection)?.1 == i64::from(V13_SCHEMA_VERSION) {
         downgrade_v13_manifest_to_v12_for_test(connection, shard_count)?;
     }
@@ -2995,10 +3123,48 @@ fn downgrade_v12_manifest_to_v11_for_test(
 }
 
 #[cfg(test)]
+fn downgrade_v14_manifest_to_v13_for_test(
+    connection: &Connection,
+    shard_count: u16,
+) -> EngineResult<()> {
+    connection
+        .execute_batch(
+            "DROP TABLE briskdb_document_provisioning;
+             DROP TABLE briskdb_document_indexes;
+             DROP TABLE briskdb_document_collections;
+             DROP TABLE briskdb_document_databases;
+             DROP TABLE briskdb_metadata;",
+        )
+        .map_err(sqlite_error::storage)?;
+    connection
+        .execute_batch(V13_DOWNGRADE_FENCE_SQL)
+        .map_err(sqlite_error::storage)?;
+    connection
+        .execute(
+            "INSERT INTO briskdb_metadata (requires_manifest_version) VALUES (?1)",
+            [V13_SCHEMA_VERSION],
+        )
+        .map_err(sqlite_error::storage)?;
+    connection
+        .execute(
+            "UPDATE briskdb_integrity SET manifest_digest_version = ?1 WHERE singleton = 1",
+            [V6_MANIFEST_DIGEST_VERSION],
+        )
+        .map_err(sqlite_error::storage)?;
+    set_identity(connection, V13_SCHEMA_VERSION)?;
+    refresh_manifest_digest(connection)?;
+    validate_v13(connection, shard_count, &schema_objects(connection)?)?;
+    Ok(())
+}
+
+#[cfg(test)]
 fn downgrade_v13_manifest_to_v12_for_test(
     connection: &Connection,
     shard_count: u16,
 ) -> EngineResult<()> {
+    if read_identity(connection)?.1 == i64::from(V14_SCHEMA_VERSION) {
+        downgrade_v14_manifest_to_v13_for_test(connection, shard_count)?;
+    }
     connection
         .execute_batch(
             "DROP TABLE briskdb_global_index_parts;
@@ -4824,6 +4990,11 @@ fn create_v13_schema(transaction: &Transaction<'_>, shard_count: u16) -> EngineR
     migrate_v12_to_v13(transaction, shard_count)
 }
 
+fn create_v14_schema(transaction: &Transaction<'_>, shard_count: u16) -> EngineResult<()> {
+    create_v13_schema(transaction, shard_count)?;
+    migrate_v13_to_v14(transaction, shard_count)
+}
+
 fn migrate_interrupted_legacy_to_v6(
     transaction: &Transaction<'_>,
     shard_count: u16,
@@ -4902,6 +5073,7 @@ fn migrate_interrupted_legacy_to_v12(
     create_v12_schema(transaction, shard_count)
 }
 
+#[cfg(test)]
 fn migrate_interrupted_legacy_to_v13(
     transaction: &Transaction<'_>,
     shard_count: u16,
@@ -4910,6 +5082,16 @@ fn migrate_interrupted_legacy_to_v13(
         .execute_batch("DROP TABLE briskdb_metadata;")
         .map_err(sqlite_error::storage)?;
     create_v13_schema(transaction, shard_count)
+}
+
+fn migrate_interrupted_legacy_to_v14(
+    transaction: &Transaction<'_>,
+    shard_count: u16,
+) -> EngineResult<()> {
+    transaction
+        .execute_batch("DROP TABLE briskdb_metadata;")
+        .map_err(sqlite_error::storage)?;
+    create_v14_schema(transaction, shard_count)
 }
 
 #[cfg(test)]
@@ -5418,6 +5600,42 @@ fn migrate_v12_to_v13(transaction: &Transaction<'_>, _shard_count: u16) -> Engin
     Ok(())
 }
 
+fn migrate_v13_to_v14(transaction: &Transaction<'_>, _shard_count: u16) -> EngineResult<()> {
+    transaction
+        .execute_batch(V14_DOCUMENT_DATABASES_TABLE_SQL)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch(V14_DOCUMENT_COLLECTIONS_TABLE_SQL)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch(V14_DOCUMENT_INDEXES_TABLE_SQL)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch(V14_DOCUMENT_PROVISIONING_TABLE_SQL)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch("DROP TABLE briskdb_metadata;")
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute_batch(V14_DOWNGRADE_FENCE_SQL)
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "INSERT INTO briskdb_metadata (requires_manifest_version) VALUES (?1)",
+            [V14_SCHEMA_VERSION],
+        )
+        .map_err(sqlite_error::storage)?;
+    transaction
+        .execute(
+            "UPDATE briskdb_integrity
+             SET manifest_digest_version = ?1
+             WHERE singleton = 1",
+            [V7_MANIFEST_DIGEST_VERSION],
+        )
+        .map_err(sqlite_error::storage)?;
+    Ok(())
+}
+
 fn add_v5_schema(transaction: &Transaction<'_>, state: ShardLayoutState) -> EngineResult<()> {
     transaction
         .execute_batch("DROP TABLE briskdb_metadata;")
@@ -5780,6 +5998,25 @@ fn v13_objects() -> Vec<SchemaObject> {
     objects
 }
 
+fn v14_objects() -> Vec<SchemaObject> {
+    let mut objects = v13_objects();
+    for name in [
+        "briskdb_document_collections",
+        "briskdb_document_databases",
+        "briskdb_document_indexes",
+        "briskdb_document_provisioning",
+    ] {
+        objects.push(SchemaObject {
+            object_type: "table".to_owned(),
+            name: name.to_owned(),
+        });
+    }
+    objects.sort_by(|left, right| {
+        (&left.object_type, &left.name).cmp(&(&right.object_type, &right.name))
+    });
+    objects
+}
+
 fn schema_objects(connection: &Connection) -> EngineResult<Vec<SchemaObject>> {
     let mut statement = connection
         .prepare(
@@ -5920,6 +6157,22 @@ fn validate_table(
         "briskdb_global_index_parts" => {
             "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden
              FROM pragma_table_xinfo('briskdb_global_index_parts') LIMIT ?1"
+        }
+        "briskdb_document_databases" => {
+            "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden
+             FROM pragma_table_xinfo('briskdb_document_databases') LIMIT ?1"
+        }
+        "briskdb_document_collections" => {
+            "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden
+             FROM pragma_table_xinfo('briskdb_document_collections') LIMIT ?1"
+        }
+        "briskdb_document_indexes" => {
+            "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden
+             FROM pragma_table_xinfo('briskdb_document_indexes') LIMIT ?1"
+        }
+        "briskdb_document_provisioning" => {
+            "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden
+             FROM pragma_table_xinfo('briskdb_document_provisioning') LIMIT ?1"
         }
         _ => {
             return Err(EngineError::new(
@@ -6562,6 +6815,520 @@ fn validate_v13(
     let indexes = validate_global_indexes(connection, &catalog)?;
     snapshot.logical_catalog = Some(catalog.with_global_indexes(indexes));
     Ok(snapshot)
+}
+
+fn validate_v14(
+    connection: &Connection,
+    requested_shards: u16,
+    objects: &[SchemaObject],
+) -> EngineResult<ManifestSnapshot> {
+    let mut snapshot = validate_v12_features(
+        connection,
+        requested_shards,
+        objects,
+        IntegrityManifestDefinition {
+            version: V14_SCHEMA_VERSION,
+            downgrade_fence_sql: V14_DOWNGRADE_FENCE_SQL,
+            expected_objects: &v14_objects(),
+            expected_manifest_digest_version: V7_MANIFEST_DIGEST_VERSION,
+            generated_ids: true,
+        },
+    )?;
+    let catalog = snapshot.logical_catalog.take().ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::Internal,
+            "global-index validation omitted the logical table catalog",
+        )
+    })?;
+    let indexes = validate_global_indexes(connection, &catalog)?;
+    snapshot.logical_catalog = Some(catalog.with_global_indexes(indexes));
+    validate_document_catalog(connection, snapshot.shard_count)?;
+    Ok(snapshot)
+}
+
+/// Validate the exact document catalog schema and its cross-row lifecycle state.
+///
+/// Document mutations call this under their own `IMMEDIATE` transaction before
+/// refreshing the semantic root and committing.
+pub(super) fn validate_document_catalog(
+    connection: &Connection,
+    shard_count: u16,
+) -> EngineResult<()> {
+    validate_table(
+        connection,
+        "briskdb_document_databases",
+        &[
+            TableColumn::expected(0, "database_id", "INTEGER", false, 1),
+            TableColumn::expected(1, "database_name", "TEXT", true, 0),
+            TableColumn::expected(2, "catalog_version", "INTEGER", true, 0),
+        ],
+        true,
+    )?;
+    validate_table_sql(
+        connection,
+        "briskdb_document_databases",
+        V14_DOCUMENT_DATABASES_TABLE_SQL,
+    )?;
+    validate_table(
+        connection,
+        "briskdb_document_collections",
+        &[
+            TableColumn::expected(0, "collection_id", "INTEGER", false, 1),
+            TableColumn::expected(1, "database_id", "INTEGER", true, 0),
+            TableColumn::expected(2, "collection_name", "TEXT", true, 0),
+            TableColumn::expected(3, "options_bson", "BLOB", true, 0),
+            TableColumn::expected(4, "bson_schema_version", "INTEGER", true, 0),
+            TableColumn::expected(5, "storage_format_version", "INTEGER", true, 0),
+            TableColumn::expected(6, "placement_policy", "INTEGER", true, 0),
+            TableColumn::expected(7, "placement_version", "INTEGER", true, 0),
+            TableColumn::expected(8, "next_natural_order", "INTEGER", true, 0),
+            TableColumn::expected(9, "lifecycle_state", "INTEGER", true, 0),
+        ],
+        true,
+    )?;
+    validate_table_sql(
+        connection,
+        "briskdb_document_collections",
+        V14_DOCUMENT_COLLECTIONS_TABLE_SQL,
+    )?;
+    validate_table(
+        connection,
+        "briskdb_document_indexes",
+        &[
+            TableColumn::expected(0, "collection_id", "INTEGER", true, 1),
+            TableColumn::expected(1, "index_name", "TEXT", true, 2),
+            TableColumn::expected(2, "spec_bson", "BLOB", true, 0),
+            TableColumn::expected(3, "is_unique", "INTEGER", true, 0),
+            TableColumn::expected(4, "is_builtin", "INTEGER", true, 0),
+            TableColumn::expected(5, "index_format_version", "INTEGER", true, 0),
+            TableColumn::expected(6, "lifecycle_state", "INTEGER", true, 0),
+        ],
+        true,
+    )?;
+    validate_table_sql(
+        connection,
+        "briskdb_document_indexes",
+        V14_DOCUMENT_INDEXES_TABLE_SQL,
+    )?;
+    validate_table(
+        connection,
+        "briskdb_document_provisioning",
+        &[
+            TableColumn::expected(0, "singleton", "INTEGER", false, 1),
+            TableColumn::expected(1, "collection_id", "INTEGER", true, 0),
+            TableColumn::expected(2, "operation_id", "BLOB", true, 0),
+            TableColumn::expected(3, "shard_count", "INTEGER", true, 0),
+            TableColumn::expected(4, "next_shard", "INTEGER", true, 0),
+        ],
+        true,
+    )?;
+    validate_table_sql(
+        connection,
+        "briskdb_document_provisioning",
+        V14_DOCUMENT_PROVISIONING_TABLE_SQL,
+    )?;
+
+    validate_document_catalog_count(
+        connection,
+        "briskdb_document_databases",
+        MAX_DOCUMENT_DATABASES,
+        "document database catalog",
+    )?;
+    validate_document_catalog_count(
+        connection,
+        "briskdb_document_collections",
+        MAX_DOCUMENT_COLLECTIONS,
+        "document collection catalog",
+    )?;
+    validate_document_catalog_count(
+        connection,
+        "briskdb_document_indexes",
+        MAX_DOCUMENT_INDEXES,
+        "document index catalog",
+    )?;
+    let metadata_bson_bytes = connection
+        .query_row(
+            "SELECT
+                 coalesce((SELECT sum(length(options_bson))
+                           FROM briskdb_document_collections), 0)
+               + coalesce((SELECT sum(length(spec_bson))
+                           FROM briskdb_document_indexes), 0)",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .map_err(|error| {
+            manifest_read_error(error, "failed to measure document catalog BSON metadata")
+        })?;
+    if metadata_bson_bytes < 0
+        || usize::try_from(metadata_bson_bytes)
+            .ok()
+            .is_none_or(|bytes| bytes > MAX_DOCUMENT_CATALOG_BSON_BYTES)
+    {
+        return Err(invalid_document_catalog(
+            "document catalog BSON metadata exceeds its supported aggregate byte limit",
+        ));
+    }
+
+    ensure_document_catalog_rows_absent(
+        connection,
+        "SELECT EXISTS (
+             SELECT 1 FROM briskdb_document_databases
+             WHERE typeof(database_id) <> 'integer'
+                OR database_id <= 0
+                OR typeof(database_name) <> 'text'
+                OR length(CAST(database_name AS BLOB)) NOT BETWEEN 1 AND 63
+                OR instr(database_name, char(0)) <> 0
+                OR typeof(catalog_version) <> 'integer'
+         )",
+        "document database catalog contains invalid metadata",
+    )?;
+    ensure_supported_document_version(
+        connection,
+        "SELECT EXISTS (
+             SELECT 1 FROM briskdb_document_databases WHERE catalog_version > ?1
+         )",
+        DOCUMENT_CATALOG_VERSION,
+        "document catalog version",
+    )?;
+    ensure_document_catalog_rows_absent(
+        connection,
+        "SELECT EXISTS (
+             SELECT 1 FROM briskdb_document_databases WHERE catalog_version <> 1
+         )",
+        "document database catalog has an invalid catalog version",
+    )?;
+    validate_document_text_column(
+        connection,
+        "SELECT database_name FROM briskdb_document_databases ORDER BY database_id",
+        "document database catalog contains invalid UTF-8",
+    )?;
+
+    ensure_document_catalog_rows_absent(
+        connection,
+        "SELECT EXISTS (
+             SELECT 1 FROM briskdb_document_collections
+             WHERE typeof(collection_id) <> 'integer'
+                OR collection_id <= 0
+                OR typeof(database_id) <> 'integer'
+                OR database_id <= 0
+                OR typeof(collection_name) <> 'text'
+                OR length(CAST(collection_name AS BLOB)) NOT BETWEEN 1 AND 255
+                OR instr(collection_name, char(0)) <> 0
+                OR typeof(options_bson) <> 'blob'
+                OR length(options_bson) NOT BETWEEN 5 AND 16777216
+                OR typeof(bson_schema_version) <> 'integer'
+                OR typeof(storage_format_version) <> 'integer'
+                OR typeof(placement_policy) <> 'integer'
+                OR typeof(placement_version) <> 'integer'
+                OR typeof(next_natural_order) <> 'integer'
+                OR next_natural_order <= 0
+                OR typeof(lifecycle_state) <> 'integer'
+                OR lifecycle_state NOT IN (1, 2)
+         )",
+        "document collection catalog contains invalid metadata",
+    )?;
+    for (column, supported, description) in [
+        (
+            "bson_schema_version",
+            DOCUMENT_BSON_SCHEMA_VERSION,
+            "document BSON schema version",
+        ),
+        (
+            "storage_format_version",
+            DOCUMENT_STORAGE_FORMAT_VERSION,
+            "document storage format version",
+        ),
+        (
+            "placement_policy",
+            DOCUMENT_PLACEMENT_POLICY,
+            "document placement policy",
+        ),
+        (
+            "placement_version",
+            DOCUMENT_PLACEMENT_VERSION,
+            "document placement version",
+        ),
+    ] {
+        ensure_supported_document_version(
+            connection,
+            &format!(
+                "SELECT EXISTS (
+                     SELECT 1 FROM briskdb_document_collections WHERE {column} > ?1
+                 )"
+            ),
+            supported,
+            description,
+        )?;
+        ensure_document_catalog_rows_absent(
+            connection,
+            &format!(
+                "SELECT EXISTS (
+                     SELECT 1 FROM briskdb_document_collections WHERE {column} <> 1
+                 )"
+            ),
+            "document collection catalog has an invalid format or placement version",
+        )?;
+    }
+    validate_document_text_column(
+        connection,
+        "SELECT collection_name FROM briskdb_document_collections ORDER BY collection_id",
+        "document collection catalog contains invalid UTF-8",
+    )?;
+
+    ensure_document_catalog_rows_absent(
+        connection,
+        "SELECT EXISTS (
+             SELECT 1 FROM briskdb_document_indexes
+             WHERE typeof(collection_id) <> 'integer'
+                OR collection_id <= 0
+                OR typeof(index_name) <> 'text'
+                OR length(CAST(index_name AS BLOB)) NOT BETWEEN 1 AND 255
+                OR instr(index_name, char(0)) <> 0
+                OR typeof(spec_bson) <> 'blob'
+                OR length(spec_bson) NOT BETWEEN 5 AND 16777216
+                OR typeof(is_unique) <> 'integer'
+                OR is_unique NOT IN (0, 1)
+                OR typeof(is_builtin) <> 'integer'
+                OR is_builtin NOT IN (0, 1)
+                OR typeof(index_format_version) <> 'integer'
+                OR typeof(lifecycle_state) <> 'integer'
+                OR lifecycle_state NOT IN (1, 2)
+                OR (is_builtin = 0 AND index_name = '_id_')
+                OR (is_builtin = 1 AND (index_name <> '_id_' OR is_unique <> 1))
+         )",
+        "document index catalog contains invalid metadata",
+    )?;
+    ensure_supported_document_version(
+        connection,
+        "SELECT EXISTS (
+             SELECT 1 FROM briskdb_document_indexes WHERE index_format_version > ?1
+         )",
+        DOCUMENT_INDEX_FORMAT_VERSION,
+        "document index format version",
+    )?;
+    ensure_document_catalog_rows_absent(
+        connection,
+        "SELECT EXISTS (
+             SELECT 1 FROM briskdb_document_indexes WHERE index_format_version <> 1
+         )",
+        "document index catalog has an invalid format version",
+    )?;
+    validate_document_text_column(
+        connection,
+        "SELECT index_name FROM briskdb_document_indexes ORDER BY collection_id, index_name",
+        "document index catalog contains invalid UTF-8",
+    )?;
+
+    ensure_document_catalog_rows_absent(
+        connection,
+        "SELECT EXISTS (
+             SELECT 1 FROM briskdb_document_provisioning
+             WHERE singleton <> 1
+                OR typeof(collection_id) <> 'integer'
+                OR collection_id <= 0
+                OR typeof(operation_id) <> 'blob'
+                OR length(operation_id) <> 32
+                OR typeof(shard_count) <> 'integer'
+                OR shard_count NOT BETWEEN 2 AND 64
+                OR typeof(next_shard) <> 'integer'
+                OR next_shard NOT BETWEEN 0 AND shard_count
+         )",
+        "document provisioning catalog contains invalid metadata",
+    )?;
+
+    ensure_document_catalog_rows_absent(
+        connection,
+        "SELECT EXISTS (
+             SELECT 1
+             FROM briskdb_document_collections AS c
+             JOIN briskdb_document_databases AS d
+               ON d.database_id = c.database_id
+             WHERE length(CAST(d.database_name AS BLOB)) + 1
+                 + length(CAST(c.collection_name AS BLOB)) > 255
+         )",
+        "document namespace exceeds its supported UTF-8 byte limit",
+    )?;
+
+    let invalid_provisioning: i64 = connection
+        .query_row(
+            "SELECT EXISTS (
+                 SELECT 1
+                 FROM briskdb_document_provisioning AS p
+                 JOIN briskdb_document_collections AS c
+                   ON c.collection_id = p.collection_id
+                 WHERE p.shard_count <> ?1
+                    OR c.lifecycle_state <> 1
+             )",
+            [i64::from(shard_count)],
+            |row| row.get(0),
+        )
+        .map_err(|error| {
+            manifest_read_error(error, "failed to validate document provisioning metadata")
+        })?;
+    if invalid_provisioning != 0 {
+        return Err(invalid_document_catalog(
+            "document provisioning metadata is inconsistent with the manifest",
+        ));
+    }
+
+    let invalid_collection_lifecycle: i64 = connection
+        .query_row(
+            "SELECT EXISTS (
+                 SELECT 1
+                 FROM briskdb_document_collections AS c
+                 LEFT JOIN briskdb_document_provisioning AS p
+                   ON p.collection_id = c.collection_id
+                 WHERE (c.lifecycle_state = 1 AND p.collection_id IS NULL)
+                    OR (c.lifecycle_state = 2 AND p.collection_id IS NOT NULL)
+             )",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|error| {
+            manifest_read_error(error, "failed to validate document collection lifecycle")
+        })?;
+    if invalid_collection_lifecycle != 0 {
+        return Err(invalid_document_catalog(
+            "document collection lifecycle is inconsistent with provisioning metadata",
+        ));
+    }
+
+    let invalid_builtin_index: i64 = connection
+        .query_row(
+            "SELECT EXISTS (
+                 SELECT 1
+                 FROM briskdb_document_collections AS c
+                 LEFT JOIN briskdb_document_indexes AS i
+                   ON i.collection_id = c.collection_id
+                  AND i.is_builtin = 1
+                  AND i.index_name = '_id_'
+                  AND i.is_unique = 1
+                  AND i.lifecycle_state = CASE c.lifecycle_state WHEN 1 THEN 2 ELSE 1 END
+                 GROUP BY c.collection_id
+                 HAVING count(i.index_name) <> 1
+             )",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|error| {
+            manifest_read_error(error, "failed to validate built-in document indexes")
+        })?;
+    if invalid_builtin_index != 0 {
+        return Err(invalid_document_catalog(
+            "each document collection must have one lifecycle-matched unique _id_ index",
+        ));
+    }
+
+    let invalid_provisioning_index: i64 = connection
+        .query_row(
+            "SELECT EXISTS (
+                 SELECT 1
+                 FROM briskdb_document_indexes AS i
+                 JOIN briskdb_document_collections AS c
+                   ON c.collection_id = i.collection_id
+                 WHERE c.lifecycle_state = 1 AND i.is_builtin = 0
+             )",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|error| {
+            manifest_read_error(error, "failed to validate provisioning document indexes")
+        })?;
+    if invalid_provisioning_index != 0 {
+        return Err(invalid_document_catalog(
+            "a provisioning document collection cannot have secondary indexes",
+        ));
+    }
+    validate_foreign_keys(connection)?;
+    Ok(())
+}
+
+fn validate_document_catalog_count(
+    connection: &Connection,
+    table: &'static str,
+    maximum: usize,
+    description: &'static str,
+) -> EngineResult<()> {
+    let sql = format!("SELECT count(*) FROM {table}");
+    let count = connection
+        .query_row(&sql, [], |row| row.get::<_, i64>(0))
+        .map_err(|error| manifest_read_error(error, "failed to count document catalog rows"))?;
+    if count < 0
+        || usize::try_from(count)
+            .ok()
+            .is_none_or(|count| count > maximum)
+    {
+        return Err(invalid_document_catalog(&format!(
+            "{description} exceeds its supported entry limit"
+        )));
+    }
+    Ok(())
+}
+
+fn invalid_document_catalog(detail: &str) -> EngineError {
+    EngineError::new(EngineErrorKind::DataCorruption, detail)
+}
+
+fn ensure_document_catalog_rows_absent(
+    connection: &Connection,
+    sql: &str,
+    detail: &'static str,
+) -> EngineResult<()> {
+    let exists = connection
+        .query_row(sql, [], |row| row.get::<_, i64>(0))
+        .map_err(|error| manifest_read_error(error, "failed to validate document catalog rows"))?;
+    if exists != 0 {
+        return Err(invalid_document_catalog(detail));
+    }
+    Ok(())
+}
+
+fn ensure_supported_document_version(
+    connection: &Connection,
+    sql: &str,
+    supported: u32,
+    description: &'static str,
+) -> EngineResult<()> {
+    let exists = connection
+        .query_row(sql, [i64::from(supported)], |row| row.get::<_, i64>(0))
+        .map_err(|error| {
+            manifest_read_error(error, "failed to validate document format version")
+        })?;
+    if exists != 0 {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!("{description} is newer than this BriskDB build supports"),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_document_text_column(
+    connection: &Connection,
+    sql: &str,
+    detail: &'static str,
+) -> EngineResult<()> {
+    let mut statement = connection.prepare(sql).map_err(|error| {
+        manifest_read_error(error, "failed to prepare document name validation")
+    })?;
+    let mut rows = statement
+        .query([])
+        .map_err(|error| manifest_read_error(error, "failed to read document names"))?;
+    while let Some(row) = rows
+        .next()
+        .map_err(|error| manifest_read_error(error, "failed to read document names"))?
+    {
+        let value = row
+            .get_ref(0)
+            .map_err(|error| manifest_read_error(error, "failed to decode document name"))?;
+        let ValueRef::Text(bytes) = value else {
+            return Err(invalid_document_catalog(detail));
+        };
+        if std::str::from_utf8(bytes).is_err() {
+            return Err(invalid_document_catalog(detail));
+        }
+    }
+    Ok(())
 }
 
 fn validate_v12_features(
@@ -7577,7 +8344,7 @@ fn validate_manifest_semantic_root(
             "manifest checksum version must be positive",
         ));
     }
-    if *version > i64::from(V6_MANIFEST_DIGEST_VERSION) {
+    if *version > i64::from(V7_MANIFEST_DIGEST_VERSION) {
         return Err(EngineError::new(
             EngineErrorKind::FailedPrecondition,
             "manifest checksum version is newer than this BriskDB build supports",
@@ -7830,6 +8597,51 @@ const V6_GLOBAL_INDEX_PARTS_DIGEST_QUERY: ManifestDigestQuery = ManifestDigestQu
     ],
     sql: "SELECT index_id, ordinal, source_kind, source_text, key_type, sort_order, null_order, collation_version FROM briskdb_global_index_parts ORDER BY index_id, ordinal",
 };
+const V7_DOCUMENT_DATABASES_DIGEST_QUERY: ManifestDigestQuery = ManifestDigestQuery {
+    table: "briskdb_document_databases",
+    columns: &["database_id", "database_name", "catalog_version"],
+    sql: "SELECT database_id, database_name, catalog_version FROM briskdb_document_databases ORDER BY database_id",
+};
+const V7_DOCUMENT_COLLECTIONS_DIGEST_QUERY: ManifestDigestQuery = ManifestDigestQuery {
+    table: "briskdb_document_collections",
+    columns: &[
+        "collection_id",
+        "database_id",
+        "collection_name",
+        "options_bson",
+        "bson_schema_version",
+        "storage_format_version",
+        "placement_policy",
+        "placement_version",
+        "next_natural_order",
+        "lifecycle_state",
+    ],
+    sql: "SELECT collection_id, database_id, collection_name, options_bson, bson_schema_version, storage_format_version, placement_policy, placement_version, next_natural_order, lifecycle_state FROM briskdb_document_collections ORDER BY collection_id",
+};
+const V7_DOCUMENT_INDEXES_DIGEST_QUERY: ManifestDigestQuery = ManifestDigestQuery {
+    table: "briskdb_document_indexes",
+    columns: &[
+        "collection_id",
+        "index_name",
+        "spec_bson",
+        "is_unique",
+        "is_builtin",
+        "index_format_version",
+        "lifecycle_state",
+    ],
+    sql: "SELECT collection_id, index_name, spec_bson, is_unique, is_builtin, index_format_version, lifecycle_state FROM briskdb_document_indexes ORDER BY collection_id, index_name",
+};
+const V7_DOCUMENT_PROVISIONING_DIGEST_QUERY: ManifestDigestQuery = ManifestDigestQuery {
+    table: "briskdb_document_provisioning",
+    columns: &[
+        "singleton",
+        "collection_id",
+        "operation_id",
+        "shard_count",
+        "next_shard",
+    ],
+    sql: "SELECT singleton, collection_id, operation_id, shard_count, next_shard FROM briskdb_document_provisioning ORDER BY singleton",
+};
 
 fn manifest_semantic_digest_for_version(
     connection: &Connection,
@@ -7919,6 +8731,31 @@ fn manifest_semantic_digest_for_version(
                 }
             }
             (V6_MANIFEST_DIGEST_DOMAIN, queries)
+        }
+        V7_MANIFEST_DIGEST_VERSION => {
+            let mut queries = Vec::with_capacity(V1_MANIFEST_DIGEST_QUERIES.len() + 12);
+            for query in V1_MANIFEST_DIGEST_QUERIES {
+                queries.push(query);
+                if query.table == "briskdb_logical_databases" {
+                    queries.push(&V7_DOCUMENT_DATABASES_DIGEST_QUERY);
+                    queries.push(&V7_DOCUMENT_COLLECTIONS_DIGEST_QUERY);
+                    queries.push(&V7_DOCUMENT_INDEXES_DIGEST_QUERY);
+                    queries.push(&V7_DOCUMENT_PROVISIONING_DIGEST_QUERY);
+                }
+                if query.table == "briskdb_physical_shards" {
+                    queries.push(&V3_ALLOCATION_OWNERS_DIGEST_QUERY);
+                }
+                if query.table == "briskdb_tables" {
+                    queries.push(&V3_GENERATED_IDS_DIGEST_QUERY);
+                    queries.push(&V5_GENERATED_TABLE_DDL_DIGEST_QUERY);
+                    queries.push(&V6_GLOBAL_INDEXES_DIGEST_QUERY);
+                    queries.push(&V6_GLOBAL_INDEX_PARTS_DIGEST_QUERY);
+                    queries.push(&V4_HILO_LEASES_DIGEST_QUERY);
+                    queries.push(&V3_TABLE_PROVISIONING_DIGEST_QUERY);
+                    queries.push(&V3_TABLE_PROVISIONING_DECLARATIONS_DIGEST_QUERY);
+                }
+            }
+            (V7_MANIFEST_DIGEST_DOMAIN, queries)
         }
         0 => {
             return Err(EngineError::new(
@@ -8032,7 +8869,7 @@ fn hash_manifest_value(hasher: &mut blake3::Hasher, value: ValueRef<'_>) -> Engi
     Ok(())
 }
 
-fn refresh_manifest_digest(connection: &Connection) -> EngineResult<[u8; 32]> {
+pub(super) fn refresh_manifest_digest(connection: &Connection) -> EngineResult<[u8; 32]> {
     let digest = manifest_semantic_digest(connection)?;
     let changed = connection
         .execute(
@@ -8060,7 +8897,8 @@ fn refresh_manifest_digest_if_checksummed(connection: &Connection) -> EngineResu
                 | V10_SCHEMA_VERSION
                 | V11_SCHEMA_VERSION
                 | V12_SCHEMA_VERSION
-                | V13_SCHEMA_VERSION)
+                | V13_SCHEMA_VERSION
+                | V14_SCHEMA_VERSION)
         )
     {
         let _ = refresh_manifest_digest(connection)?;
@@ -8124,7 +8962,7 @@ fn validate_manifest_integrity(
             "manifest checksum version must be positive",
         ));
     }
-    if *manifest_version > i64::from(V6_MANIFEST_DIGEST_VERSION) {
+    if *manifest_version > i64::from(V7_MANIFEST_DIGEST_VERSION) {
         return Err(EngineError::new(
             EngineErrorKind::FailedPrecondition,
             "manifest checksum version is newer than this BriskDB build supports",
@@ -10254,6 +11092,13 @@ mod tests {
         initialize_interrupted_legacy: migrate_interrupted_legacy_to_v10,
     };
 
+    const V13_PLAN: MigrationPlan<'static> = MigrationPlan {
+        current_version: V13_SCHEMA_VERSION,
+        migrations: MIGRATIONS,
+        initialize_current: create_v13_schema,
+        initialize_interrupted_legacy: migrate_interrupted_legacy_to_v13,
+    };
+
     fn create_legacy_manifest(connection: &Connection, shards: u16, version: u32) {
         create_empty_legacy_manifest(connection);
         connection
@@ -10618,6 +11463,36 @@ mod tests {
         digest.try_into().unwrap()
     }
 
+    fn insert_active_document_catalog(connection: &Connection) {
+        connection
+            .execute_batch(
+                "INSERT INTO briskdb_document_databases
+                     (database_id, database_name, catalog_version)
+                 VALUES (7, 'tenant', 1);
+                 INSERT INTO briskdb_document_collections
+                     (collection_id, database_id, collection_name, options_bson,
+                      bson_schema_version, storage_format_version, placement_policy,
+                      placement_version, next_natural_order, lifecycle_state)
+                 VALUES (11, 7, 'widgets', x'0500000000', 1, 1, 1, 1, 1, 2);
+                 INSERT INTO briskdb_document_indexes
+                     (collection_id, index_name, spec_bson, is_unique, is_builtin,
+                      index_format_version, lifecycle_state)
+                 VALUES (11, '_id_', x'0500000000', 1, 1, 1, 1);",
+            )
+            .unwrap();
+        refresh_manifest_digest(connection).unwrap();
+        validate_document_catalog(connection, 4).unwrap();
+    }
+
+    fn assert_document_manifest_corruption(connection: &Connection) {
+        assert_eq!(
+            inspect_with_plan(connection, 4, CURRENT_PLAN)
+                .unwrap_err()
+                .kind(),
+            EngineErrorKind::DataCorruption
+        );
+    }
+
     fn insert_valid_table_catalog(connection: &Connection) {
         connection
             .execute_batch(
@@ -10691,7 +11566,7 @@ mod tests {
             identity(connection),
             (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
         );
-        assert_eq!(schema_objects(connection).unwrap(), v13_objects());
+        assert_eq!(schema_objects(connection).unwrap(), v14_objects());
         assert_eq!(
             connection
                 .query_row(
@@ -10758,7 +11633,7 @@ mod tests {
                     |row| row.get::<_, i64>(0),
                 )
                 .unwrap(),
-            i64::from(V6_MANIFEST_DIGEST_VERSION)
+            i64::from(V7_MANIFEST_DIGEST_VERSION)
         );
         let (layout_id, application_id, metadata_version, state) = shard_layout_row(connection);
         assert_eq!(layout_id.len(), 16);
@@ -10878,6 +11753,7 @@ mod tests {
                 (10, 11),
                 (11, 12),
                 (12, 13),
+                (13, 14),
             ]
         );
         assert_generation_one_catalog(&connection, 4);
@@ -10948,7 +11824,7 @@ mod tests {
 
                 load_or_create_manifest(&mut connection, 4).unwrap();
                 assert_eq!(identity(&connection).1, i64::from(CURRENT_SCHEMA_VERSION));
-                assert_eq!(schema_objects(&connection).unwrap(), v13_objects());
+                assert_eq!(schema_objects(&connection).unwrap(), v14_objects());
                 assert_eq!(
                     connection
                         .query_row(
@@ -10957,7 +11833,7 @@ mod tests {
                             |row| row.get::<_, i64>(0),
                         )
                         .unwrap(),
-                    i64::from(V6_MANIFEST_DIGEST_VERSION)
+                    i64::from(V7_MANIFEST_DIGEST_VERSION)
                 );
                 assert_eq!(
                     connection
@@ -11498,7 +12374,7 @@ mod tests {
             identity(&connection),
             (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
         );
-        assert_eq!(schema_objects(&connection).unwrap(), v13_objects());
+        assert_eq!(schema_objects(&connection).unwrap(), v14_objects());
         assert_eq!(table_metadata_rows(&connection), tables_before);
         assert_eq!(logical_databases(&connection), databases_before);
         assert_eq!(routing_configuration(&connection), routing_before);
@@ -11541,7 +12417,7 @@ mod tests {
                     |row| row.get::<_, i64>(0),
                 )
                 .unwrap(),
-            i64::from(V6_MANIFEST_DIGEST_VERSION)
+            i64::from(V7_MANIFEST_DIGEST_VERSION)
         );
         assert_eq!(
             manifest_semantic_digest(&connection).unwrap(),
@@ -11603,7 +12479,11 @@ mod tests {
             .unwrap();
         connection
             .execute_batch(
-                "DROP TABLE briskdb_global_index_parts;
+                "DROP TABLE briskdb_document_provisioning;
+                 DROP TABLE briskdb_document_indexes;
+                 DROP TABLE briskdb_document_collections;
+                 DROP TABLE briskdb_document_databases;
+                 DROP TABLE briskdb_global_index_parts;
                  DROP TABLE briskdb_global_indexes;
                  DROP TABLE briskdb_generated_table_ddl;
                  DROP TABLE briskdb_hilo_leases;
@@ -12077,7 +12957,7 @@ mod tests {
                     identity(&connection),
                     (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
                 );
-                assert_eq!(schema_objects(&connection).unwrap(), v13_objects());
+                assert_eq!(schema_objects(&connection).unwrap(), v14_objects());
                 assert_eq!(
                     manifest_semantic_digest(&connection).unwrap(),
                     stored_manifest_digest(&connection)
@@ -12443,7 +13323,7 @@ mod tests {
     fn semantic_root_covers_every_authoritative_manifest_table_and_integrity_state() {
         let mutations = [
             "UPDATE briskdb_manifest SET singleton = 2 WHERE singleton = 1",
-            "UPDATE briskdb_metadata SET requires_manifest_version = 14",
+            "UPDATE briskdb_metadata SET requires_manifest_version = 15",
             "UPDATE briskdb_routing SET hash_version = 2 WHERE singleton = 1",
             "UPDATE briskdb_physical_shards SET lifecycle_state = 'retired' WHERE shard_id = 0",
             "UPDATE briskdb_allocation_owners SET owner_slot = 100 WHERE owner_slot = 0",
@@ -12458,6 +13338,13 @@ mod tests {
             "INSERT INTO briskdb_tables VALUES (1, 1, 'events', 1, 'tenant_id', 2);
              INSERT INTO briskdb_global_indexes VALUES (1, 1, 'events_email', 0, 1, NULL, 1, 1, 0, 0, 0, 0);
              INSERT INTO briskdb_global_index_parts VALUES (1, 0, 1, 'email', 7, 1, 1, 1)",
+            "INSERT INTO briskdb_document_databases VALUES (1, 'tenant', 1)",
+            "INSERT INTO briskdb_document_collections
+             VALUES (1, 1, 'events', x'0500000000', 1, 1, 1, 1, 1, 2)",
+            "INSERT INTO briskdb_document_indexes
+             VALUES (1, '_id_', x'0500000000', 1, 1, 1, 1)",
+            "INSERT INTO briskdb_document_provisioning
+             VALUES (1, 1, zeroblob(32), 4, 0)",
             "INSERT INTO briskdb_hilo_leases VALUES (1, 4096, 1, 0, NULL, NULL, NULL)",
             "UPDATE briskdb_shard_layout SET layout_id = randomblob(16) WHERE singleton = 1",
             "INSERT INTO briskdb_schema_migrations VALUES (1, 0, randomblob(32), 1, 'SELECT 1', 4, 2, 4)",
@@ -12663,7 +13550,7 @@ mod tests {
     #[test]
     fn integrity_versions_lengths_and_forged_state_invariants_fail_closed() {
         for (version_column, unsupported_version) in
-            [("manifest_digest_version", 7), ("schema_digest_version", 2)]
+            [("manifest_digest_version", 8), ("schema_digest_version", 2)]
         {
             let mut unsupported = Connection::open_in_memory().unwrap();
             create_ready_current_manifest(&mut unsupported, 4);
@@ -12891,7 +13778,7 @@ mod tests {
             identity(&connection),
             (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
         );
-        assert_eq!(schema_objects(&connection).unwrap(), v13_objects());
+        assert_eq!(schema_objects(&connection).unwrap(), v14_objects());
         assert_eq!(
             shard_layout_row(&connection).3,
             ShardLayoutState::Adopting.code()
@@ -12915,7 +13802,7 @@ mod tests {
             identity(&connection),
             (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
         );
-        assert_eq!(schema_objects(&connection).unwrap(), v13_objects());
+        assert_eq!(schema_objects(&connection).unwrap(), v14_objects());
         assert_eq!(layout.state(), ShardLayoutState::Ready);
         assert_eq!(shard_layout_row(&connection), layout_before);
         assert_eq!(catalog.logical().schema_generation(), 0);
@@ -13007,7 +13894,7 @@ mod tests {
                 identity(&connection),
                 (MANIFEST_APPLICATION_ID, i64::from(CURRENT_SCHEMA_VERSION))
             );
-            assert_eq!(schema_objects(&connection).unwrap(), v13_objects());
+            assert_eq!(schema_objects(&connection).unwrap(), v14_objects());
         }
 
         let mut connection = Connection::open_in_memory().unwrap();
@@ -14627,7 +15514,7 @@ mod tests {
         for mutation in [
             "DELETE FROM briskdb_metadata",
             "DELETE FROM briskdb_manifest",
-            "INSERT INTO briskdb_metadata VALUES (13)",
+            "INSERT INTO briskdb_metadata VALUES (14)",
             "DELETE FROM briskdb_routing",
             "DELETE FROM briskdb_virtual_buckets WHERE bucket_id = 4095",
             "DELETE FROM briskdb_physical_shards WHERE shard_id = 3",
@@ -15162,7 +16049,8 @@ mod tests {
         assert_eq!(identity(&connection).1, i64::from(V12_SCHEMA_VERSION));
         assert_eq!(stored_manifest_digest(&connection), root);
 
-        load_or_create_manifest(&mut connection, 4).unwrap();
+        load_or_create_snapshot_with_plan(&mut connection, 4, V13_PLAN, true, &mut |_| Ok(()))
+            .unwrap();
         assert_eq!(identity(&connection).1, i64::from(V13_SCHEMA_VERSION));
         assert_eq!(schema_objects(&connection).unwrap(), v13_objects());
         assert_eq!(
@@ -15343,5 +16231,280 @@ mod tests {
             .unwrap();
         let error = load_or_create_manifest(&mut schema, 4).unwrap_err();
         assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+    }
+
+    #[test]
+    fn v13_to_v14_document_catalog_upgrade_is_atomic_and_downgrade_fenced() {
+        for phase in [
+            MigrationPhase::AfterSchemaChange,
+            MigrationPhase::AfterVersionStamp,
+        ] {
+            let mut connection = Connection::open_in_memory().unwrap();
+            create_ready_current_manifest(&mut connection, 4);
+            downgrade_v14_manifest_to_v13_for_test(&connection, 4).unwrap();
+            let objects_before = schema_objects(&connection).unwrap();
+            let root_before = stored_manifest_digest(&connection);
+
+            let error = load_or_create_with_hook(&mut connection, 4, |point| {
+                if point.from == V13_SCHEMA_VERSION && point.phase == phase {
+                    return Err(EngineError::new(
+                        EngineErrorKind::Internal,
+                        "injected v13 to v14 migration failure",
+                    ));
+                }
+                Ok(())
+            })
+            .unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::Internal);
+            assert_eq!(identity(&connection).1, i64::from(V13_SCHEMA_VERSION));
+            assert_eq!(schema_objects(&connection).unwrap(), objects_before);
+            assert_eq!(stored_manifest_digest(&connection), root_before);
+
+            load_or_create_manifest(&mut connection, 4).unwrap();
+            assert_eq!(identity(&connection).1, i64::from(V14_SCHEMA_VERSION));
+            assert_eq!(schema_objects(&connection).unwrap(), v14_objects());
+            assert_eq!(
+                connection
+                    .query_row(
+                        "SELECT requires_manifest_version, manifest_digest_version
+                         FROM briskdb_metadata
+                         JOIN briskdb_integrity ON briskdb_integrity.singleton = 1",
+                        [],
+                        |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+                    )
+                    .unwrap(),
+                (
+                    i64::from(V14_SCHEMA_VERSION),
+                    i64::from(V7_MANIFEST_DIGEST_VERSION)
+                )
+            );
+            for table in [
+                "briskdb_document_databases",
+                "briskdb_document_collections",
+                "briskdb_document_indexes",
+                "briskdb_document_provisioning",
+            ] {
+                assert_eq!(
+                    connection
+                        .query_row(&format!("SELECT count(*) FROM {table}"), [], |row| {
+                            row.get::<_, i64>(0)
+                        })
+                        .unwrap(),
+                    0
+                );
+            }
+            assert_eq!(
+                inspect_with_plan(&connection, 4, V13_PLAN)
+                    .unwrap_err()
+                    .kind(),
+                EngineErrorKind::FailedPrecondition
+            );
+        }
+    }
+
+    #[test]
+    fn document_catalog_tables_are_all_semantic_checksum_authority() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        create_ready_current_manifest(&mut connection, 4);
+        insert_active_document_catalog(&connection);
+
+        connection
+            .execute(
+                "UPDATE briskdb_document_databases SET database_name = 'tenant2'",
+                [],
+            )
+            .unwrap();
+        assert_document_manifest_corruption(&connection);
+        connection
+            .execute(
+                "UPDATE briskdb_document_databases SET database_name = 'tenant'",
+                [],
+            )
+            .unwrap();
+        refresh_manifest_digest(&connection).unwrap();
+
+        connection
+            .execute(
+                "UPDATE briskdb_document_collections SET collection_name = 'widgets2'",
+                [],
+            )
+            .unwrap();
+        assert_document_manifest_corruption(&connection);
+        connection
+            .execute(
+                "UPDATE briskdb_document_collections SET collection_name = 'widgets'",
+                [],
+            )
+            .unwrap();
+        refresh_manifest_digest(&connection).unwrap();
+
+        connection
+            .execute(
+                "UPDATE briskdb_document_collections SET next_natural_order = 2",
+                [],
+            )
+            .unwrap();
+        assert_document_manifest_corruption(&connection);
+        connection
+            .execute(
+                "UPDATE briskdb_document_collections SET next_natural_order = 1",
+                [],
+            )
+            .unwrap();
+        refresh_manifest_digest(&connection).unwrap();
+
+        connection
+            .execute(
+                "UPDATE briskdb_document_indexes SET spec_bson = x'0500000001'",
+                [],
+            )
+            .unwrap();
+        assert_document_manifest_corruption(&connection);
+        connection
+            .execute(
+                "UPDATE briskdb_document_indexes SET spec_bson = x'0500000000'",
+                [],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "UPDATE briskdb_document_collections SET lifecycle_state = 1",
+                [],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "UPDATE briskdb_document_indexes SET lifecycle_state = 2",
+                [],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO briskdb_document_provisioning
+                     (singleton, collection_id, operation_id, shard_count, next_shard)
+                 VALUES (1, 11, zeroblob(32), 4, 0)",
+                [],
+            )
+            .unwrap();
+        refresh_manifest_digest(&connection).unwrap();
+        validate_document_catalog(&connection, 4).unwrap();
+        assert!(startup_requires_exclusive_ownership(&connection, 4).unwrap());
+
+        connection
+            .execute(
+                "UPDATE briskdb_document_provisioning SET next_shard = 1",
+                [],
+            )
+            .unwrap();
+        assert_document_manifest_corruption(&connection);
+    }
+
+    #[test]
+    fn document_catalog_cross_row_invariants_fail_closed_after_resealing() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        create_ready_current_manifest(&mut connection, 4);
+        insert_active_document_catalog(&connection);
+
+        connection
+            .execute("DELETE FROM briskdb_document_indexes", [])
+            .unwrap();
+        refresh_manifest_digest(&connection).unwrap();
+        assert_document_manifest_corruption(&connection);
+
+        connection
+            .execute(
+                "INSERT INTO briskdb_document_indexes
+                     (collection_id, index_name, spec_bson, is_unique, is_builtin,
+                      index_format_version, lifecycle_state)
+                 VALUES (11, '_id_', x'0500000000', 1, 1, 1, 1)",
+                [],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "UPDATE briskdb_document_collections SET lifecycle_state = 1",
+                [],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "UPDATE briskdb_document_indexes SET lifecycle_state = 2",
+                [],
+            )
+            .unwrap();
+        refresh_manifest_digest(&connection).unwrap();
+        assert_document_manifest_corruption(&connection);
+    }
+
+    #[test]
+    fn document_catalog_future_formats_are_actionable_after_checksum_validation() {
+        for mutation in [
+            "UPDATE briskdb_document_databases SET catalog_version = 2",
+            "UPDATE briskdb_document_collections SET bson_schema_version = 2",
+            "UPDATE briskdb_document_collections SET storage_format_version = 2",
+            "UPDATE briskdb_document_collections SET placement_policy = 2",
+            "UPDATE briskdb_document_collections SET placement_version = 2",
+            "UPDATE briskdb_document_indexes SET index_format_version = 2",
+        ] {
+            let mut connection = Connection::open_in_memory().unwrap();
+            create_ready_current_manifest(&mut connection, 4);
+            insert_active_document_catalog(&connection);
+            connection
+                .pragma_update(None, "ignore_check_constraints", "ON")
+                .unwrap();
+            connection.execute_batch(mutation).unwrap();
+            connection
+                .pragma_update(None, "ignore_check_constraints", "OFF")
+                .unwrap();
+            refresh_manifest_digest(&connection).unwrap();
+
+            let error = load_or_create_manifest(&mut connection, 4).unwrap_err();
+            assert_eq!(
+                error.kind(),
+                EngineErrorKind::FailedPrecondition,
+                "{mutation}"
+            );
+            assert!(error.diagnostic().contains("newer than this BriskDB build"));
+        }
+    }
+
+    #[test]
+    fn document_namespace_limit_is_validated_across_catalog_rows() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        create_ready_current_manifest(&mut connection, 4);
+        let database_name = "d".repeat(MAX_DOCUMENT_DATABASE_NAME_BYTES);
+        let collection_name = "c".repeat(MAX_DOCUMENT_NAMESPACE_BYTES - database_name.len() - 1);
+        connection
+            .execute(
+                "INSERT INTO briskdb_document_databases VALUES (7, ?1, 1)",
+                [&database_name],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO briskdb_document_collections
+                 VALUES (11, 7, ?1, x'0500000000', 1, 1, 1, 1, 1, 2)",
+                [&collection_name],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO briskdb_document_indexes
+                 VALUES (11, '_id_', x'0500000000', 1, 1, 1, 1)",
+                [],
+            )
+            .unwrap();
+        refresh_manifest_digest(&connection).unwrap();
+        validate_document_catalog(&connection, 4).unwrap();
+
+        let oversized_collection_name = format!("{collection_name}x");
+        connection
+            .execute(
+                "UPDATE briskdb_document_collections SET collection_name = ?1",
+                [&oversized_collection_name],
+            )
+            .unwrap();
+        refresh_manifest_digest(&connection).unwrap();
+        assert_document_manifest_corruption(&connection);
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,5 +1,6 @@
 //! SQLite file layout, versioned manifest management, and connection configuration.
 
+mod document;
 mod global_index;
 mod global_index_async;
 mod hilo;
@@ -906,6 +907,24 @@ impl Storage {
             sealed.committed_schema_digest(),
             sealed.target_schema_digest(),
         )?;
+        let document_provisioning = manifest
+            .query_row(
+                "SELECT EXISTS (SELECT 1 FROM briskdb_document_provisioning)",
+                [],
+                |row| row.get::<_, bool>(0),
+            )
+            .map_err(sqlite_error::storage)?;
+        if document_provisioning {
+            startup.mark_pending_on_drop();
+        }
+        if let Err(error) = document::recover_or_validate(&storage, &mut manifest) {
+            if error.kind() == EngineErrorKind::DataCorruption {
+                storage.mark_schema_degraded();
+                let _ =
+                    manifest::mark_degraded(&mut manifest, requested_shards, &storage.shard_layout);
+            }
+            return Err(error);
+        }
         storage
             .schema_coordination
             .reconcile_validated_catalog_generation(&storage.catalog)?;
@@ -2676,6 +2695,8 @@ impl Storage {
                      WHERE name NOT GLOB 'sqlite_*'
                        AND name <> 'briskdb_shard_metadata'
                        AND tbl_name <> 'briskdb_shard_metadata'
+                       AND name <> 'briskdb_documents_v1'
+                       AND tbl_name <> 'briskdb_documents_v1'
                      ORDER BY name COLLATE BINARY
                      LIMIT 1",
                     [],
@@ -3328,6 +3349,7 @@ fn application_table_names(connection: &Connection) -> EngineResult<BTreeSet<Str
              WHERE schema = 'main' AND type IN ('table', 'virtual')
                AND name NOT GLOB 'sqlite_*'
                AND name <> 'briskdb_shard_metadata'
+               AND name <> 'briskdb_documents_v1'
              ORDER BY name COLLATE BINARY",
         )
         .map_err(sqlite_error::storage)?;
@@ -4388,6 +4410,10 @@ mod tests {
             manifest
                 .execute_batch(
                     "BEGIN IMMEDIATE;
+                     DROP TABLE briskdb_document_provisioning;
+                     DROP TABLE briskdb_document_indexes;
+                     DROP TABLE briskdb_document_collections;
+                     DROP TABLE briskdb_document_databases;
                      DROP TABLE briskdb_global_index_parts;
                      DROP TABLE briskdb_global_indexes;
                      DROP TABLE briskdb_generated_table_ddl;
@@ -4494,6 +4520,10 @@ mod tests {
             .unwrap()
             .execute_batch(
                 "BEGIN IMMEDIATE;
+                 DROP TABLE briskdb_document_provisioning;
+                 DROP TABLE briskdb_document_indexes;
+                 DROP TABLE briskdb_document_collections;
+                 DROP TABLE briskdb_document_databases;
                  DROP TABLE briskdb_global_index_parts;
                  DROP TABLE briskdb_global_indexes;
                  DROP TABLE briskdb_generated_table_ddl;
@@ -4594,6 +4624,10 @@ mod tests {
             .unwrap()
             .execute_batch(
                 "BEGIN IMMEDIATE;
+                 DROP TABLE briskdb_document_provisioning;
+                 DROP TABLE briskdb_document_indexes;
+                 DROP TABLE briskdb_document_collections;
+                 DROP TABLE briskdb_document_databases;
                  DROP TABLE briskdb_global_index_parts;
                  DROP TABLE briskdb_global_indexes;
                  DROP TABLE briskdb_generated_table_ddl;

--- a/src/storage/shard.rs
+++ b/src/storage/shard.rs
@@ -408,6 +408,12 @@ pub(super) fn calculate_schema_digest(
                 &table_name,
                 sql.as_deref(),
             )
+            || super::document::is_exact_schema_object(
+                &object_type,
+                &name,
+                &table_name,
+                sql.as_deref(),
+            )
         {
             continue;
         }
@@ -1863,6 +1869,7 @@ pub(super) fn validate_stateless_catalog_schema(connection: &Connection) -> Engi
                 &table_name,
                 Some(&sql),
             )
+            || super::document::is_exact_schema_object(&object_type, &name, &table_name, Some(&sql))
         {
             continue;
         }
@@ -2108,6 +2115,7 @@ fn application_table_names(connection: &Connection) -> EngineResult<BTreeSet<Str
                AND name <> 'briskdb_shard_metadata'
                AND name NOT GLOB 'briskdb_global_index_outbox_*'
                AND name <> 'briskdb_global_index_shard_summaries'
+               AND name <> 'briskdb_documents_v1'
              ORDER BY name COLLATE BINARY",
         )
         .map_err(sqlite_error::storage)?;
@@ -3176,6 +3184,7 @@ fn validate_exact_shard(
     require_wal(connection, path)?;
     validate_metadata(connection, shard_id, layout.layout_id())?;
     super::index_outbox::validate_optional_schema(connection)?;
+    super::document::validate_optional_schema(connection)?;
     Ok(())
 }
 
@@ -3675,6 +3684,7 @@ fn is_metadata_table(name: &str) -> bool {
 
 fn is_storage_owned_table(name: &str) -> bool {
     is_metadata_table(name)
+        || name.eq_ignore_ascii_case(super::document::RECORDS_TABLE)
         || name
             .as_bytes()
             .get(.."briskdb_global_index_outbox_".len())

--- a/tests/test_mongo_contract_runner.py
+++ b/tests/test_mongo_contract_runner.py
@@ -2,6 +2,7 @@ import ast
 import hashlib
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -36,6 +37,64 @@ def imported_roots(path):
         elif isinstance(node, ast.ImportFrom) and node.module:
             imports.append(node.module.split(".", 1)[0])
     return imports
+
+
+def cargo_manifest_declares_dependency(contents, dependency):
+    dependency = dependency.lower()
+    section = ""
+    dependency_section = False
+
+    for raw_line in contents.splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            section = line.strip("[]").strip().lower()
+            components = section.split(".")
+            dependency_section = any(
+                component in {"dependencies", "dev-dependencies", "build-dependencies"}
+                for component in components
+            )
+            if dependency_section and components[-1] == dependency:
+                return True
+            continue
+        if not dependency_section:
+            continue
+
+        assignment = re.match(r"""^["']?([a-z0-9_-]+)["']?\s*=""", line.lower())
+        if assignment and assignment.group(1) == dependency:
+            return True
+        if re.search(
+            r"""\bpackage\s*=\s*["']{}["']""".format(re.escape(dependency)),
+            line,
+            flags=re.IGNORECASE,
+        ):
+            return True
+
+    return False
+
+
+def cargo_lock_contains_package(contents, dependency):
+    return bool(
+        re.search(
+            r"""(?m)^name\s*=\s*["']{}["']\s*$""".format(re.escape(dependency)),
+            contents,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
+def pyproject_declares_dependency(contents, dependency):
+    dependency = re.escape(dependency)
+    requirement = re.compile(
+        r"""["']{}(?=[<>=!~;\[\]\s"'])""".format(dependency),
+        flags=re.IGNORECASE,
+    )
+    poetry_key = re.compile(
+        r"""(?m)^\s*["']?{}["']?\s*=""".format(dependency),
+        flags=re.IGNORECASE,
+    )
+    return bool(requirement.search(contents) or poetry_key.search(contents))
 
 
 class MongoContractProvenanceTests(unittest.TestCase):
@@ -195,14 +254,50 @@ class MongoContractImportBoundaryTests(unittest.TestCase):
         self.assertEqual(importers, [TINYMONGO_ADAPTER])
 
     def test_runtime_package_manifests_do_not_depend_on_tinymongo(self):
-        for relative in (
-            "Cargo.toml",
-            "Cargo.lock",
-            "python/Cargo.toml",
+        cargo_manifests = ("Cargo.toml", "python/Cargo.toml")
+        for relative in cargo_manifests:
+            contents = (ROOT / relative).read_text(encoding="utf-8")
+            self.assertFalse(
+                cargo_manifest_declares_dependency(contents, "tinymongo"), relative
+            )
+
+        lock = (ROOT / "Cargo.lock").read_text(encoding="utf-8")
+        self.assertFalse(cargo_lock_contains_package(lock, "tinymongo"), "Cargo.lock")
+
+        pyproject = (ROOT / "python/pyproject.toml").read_text(encoding="utf-8")
+        self.assertFalse(
+            pyproject_declares_dependency(pyproject, "tinymongo"),
             "python/pyproject.toml",
-        ):
-            contents = (ROOT / relative).read_text(encoding="utf-8").lower()
-            self.assertNotIn("tinymongo", contents, relative)
+        )
+
+    def test_dependency_checks_distinguish_features_from_packages(self):
+        feature_only = """
+[features]
+# Strict offline migration from TinyMongo's SQLite formats.
+tinymongo-import = ["documents", "sqlite-import"]
+"""
+        self.assertFalse(cargo_manifest_declares_dependency(feature_only, "tinymongo"))
+        self.assertTrue(
+            cargo_manifest_declares_dependency(
+                '[dependencies]\ntinymongo = "1.3"', "tinymongo"
+            )
+        )
+        self.assertTrue(
+            cargo_manifest_declares_dependency(
+                '[dependencies]\noracle = { package = "tinymongo", version = "1.3" }',
+                "tinymongo",
+            )
+        )
+        self.assertTrue(
+            cargo_lock_contains_package(
+                '[[package]]\nname = "tinymongo"\nversion = "1.3.0"', "tinymongo"
+            )
+        )
+        self.assertTrue(
+            pyproject_declares_dependency(
+                '[project]\ndependencies = ["tinymongo>=1.3"]', "tinymongo"
+            )
+        )
 
     def test_pinned_runner_requirements_exclude_the_oracle_package(self):
         requirements = RUNNER / "requirements.txt"


### PR DESCRIPTION
## Summary

BriskDB had BSON semantics but no authoritative document catalog or durable collection storage. This adds the persistence layer behind the opt-in `documents` feature and a strict, atomic TinyMongo SQLite importer.

- Add manifest v14 and semantic digest v7 with checksummed document database, collection, index, and provisioning catalogs.
- Store exact ordered BSON in an inspectable shard table with canonical `_id` routing, semantic uniqueness, durable natural order, record checksums, restart-safe provisioning, and fail-closed recovery.
- Keep document namespaces separate from SQL tables and exclude validated document storage from generated SQL inventory.
- Add the opt-in `tinymongo-import` feature for legacy blob, unsharded, and v1 sharded TinyMongo layouts, using immutable preflight reads, explicit allowlists, bounded validation, private staging, reopen verification, receipts, and atomic publication.
- Preserve the existing HTTP JSON numeric and object-text contract after enabling exact JSON-number parsing.

This establishes storage and import for the document roadmap. The document engine, MongoDB listener, and public Rust/Python collection APIs remain follow-up work. Secondary indexes are persisted as `PendingBuild` declarations until physical index building lands. TinyMongo is not a BriskDB runtime dependency; destination identity and placement are always derived from validated logical BSON.

## Tests

- [x] Unit tests were added or updated for behavior-changing code.
- [x] Boundary/integration tests were added where the change crosses SQLite, HTTP, protocol, filesystem, or process boundaries.
- [x] A regression test accompanies each bug fix.
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --locked --all-targets --all-features --no-fail-fast` (1,073 passed, 5 ignored; all integration, binary, benchmark, and example targets passed)
- [x] `cargo clippy --locked --all-targets --all-features -- -D warnings`
- [x] `cargo +1.85.0 check --locked --no-default-features --features tinymongo-import`
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc --locked --all-features --no-deps`
- [x] `cargo check --locked --manifest-path fuzz/Cargo.toml --bins`
- [x] `cargo package --locked --allow-dirty`
- [x] `git diff --check`

## Compatibility and operations

- [x] Public behavior and compatibility documentation were updated where needed.
- [x] Storage-format, migration, security, and recovery effects were considered.

The importer documents two intentional fail-closed limits: it does not recompute TinyMongo's Python-specific v2 physical-ID digest, and legacy identifier forms that cannot be reproduced losslessly return `Unsupported`. Target keys and shard placement never trust the source digest.

Closes #163
