### PR TITLE
Add protocol-neutral document engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ experimental and opt-in; the exact contract lives in
 | Debian package and hardened systemd service | Published |
 | Rust library entrypoint with optional attached listeners | Working |
 | Same-host service and embedded processes sharing one ready root | Working on local filesystems |
-| Native MongoDB wire protocol with TinyMongo parity | [Versioned parity contract](docs/MONGO_PARITY.md), [Rust BSON foundation](docs/BSON.md), and [document storage/import](docs/DOCUMENT_STORAGE.md) landed; engine and listener remain [planned](https://github.com/schapman1974/briskdb/issues/160) |
+| Native MongoDB wire protocol with TinyMongo parity | [Versioned parity contract](docs/MONGO_PARITY.md), [Rust BSON foundation](docs/BSON.md), [document storage/import](docs/DOCUMENT_STORAGE.md), and the first [protocol-neutral document commands](docs/DOCUMENT_ENGINE.md) landed; remaining matcher/write semantics and the listener remain [planned](https://github.com/schapman1974/briskdb/issues/160) |
 | MySQL wire protocol | [Planned](https://github.com/schapman1974/briskdb/issues/40) |
 | Native Python extension | Sync/async API working; tagged releases build audited macOS/Linux ARM/x86 wheels |
 | Serverless lifecycle | [Planned](https://github.com/schapman1974/briskdb/issues/194) |
@@ -317,6 +317,7 @@ more valuable than a star. Start with the
 - [Mongo compatibility parity contract](docs/MONGO_PARITY.md)
 - [BSON value and codec contract](docs/BSON.md)
 - [Document catalog, storage, and TinyMongo import](docs/DOCUMENT_STORAGE.md)
+- [Protocol-neutral document engine](docs/DOCUMENT_ENGINE.md)
 - [SQL compatibility](docs/SQL_COMPATIBILITY.md)
 - [Generated keys](docs/GENERATED_KEYS.md)
 - [Storage format](docs/STORAGE_FORMAT.md)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,10 +16,17 @@ and 100-level nesting limits and is covered by frozen comparison vectors,
 official BSON corpus cases, property tests, and cargo-fuzz targets. This release
 also adds manifest-v14 document namespaces, exact sharded BSON records,
 canonical `_id` routing and uniqueness, restart-safe collection provisioning,
-and an atomic TinyMongo v1.3 SQLite importer. It does not yet add document
-commands, a MongoDB listener, or the public Rust/Python collection APIs tracked
-by the following roadmap issues. See [the BSON contract](docs/BSON.md) and
-[the document storage contract](docs/DOCUMENT_STORAGE.md).
+and an atomic TinyMongo v1.3 SQLite importer. A new protocol-neutral document
+engine executes collection and index metadata commands, single explicit-ID
+inserts, empty-filter or exact-`_id` find/count commands, and exact-`_id`
+single-document deletion through the same session, pool, routing, cancellation,
+deadline, shutdown, and result-limit boundaries as SQL. Point plans target one
+shard; scatter reads merge in durable natural order while preserving exact
+ordered BSON. General matchers, update expressions, replacements, aggregation,
+retained cursors, the MongoDB listener, and public Rust/Python collection APIs
+remain follow-up work. See [the BSON contract](docs/BSON.md),
+[the document storage contract](docs/DOCUMENT_STORAGE.md), and
+[the document engine contract](docs/DOCUMENT_ENGINE.md).
 
 HTTP now has an explicit version-1 contract, discovery at `/v1`, a versioned
 `/v1/health` alias, and `BriskDB-API-Version: 1` on v1 responses. Existing valid

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -452,8 +452,9 @@ requires an earlier dependency:
     - [x] [#163](https://github.com/schapman1974/briskdb/issues/163) — versioned
       document catalog, sharded BSON storage, and atomic TinyMongo SQLite
       import; see [`docs/DOCUMENT_STORAGE.md`](docs/DOCUMENT_STORAGE.md)
-    - [ ] [#162](https://github.com/schapman1974/briskdb/issues/162) —
-      protocol-neutral document engine
+    - [x] [#162](https://github.com/schapman1974/briskdb/issues/162) —
+      protocol-neutral document engine with controlled point/scatter commands;
+      see [`docs/DOCUMENT_ENGINE.md`](docs/DOCUMENT_ENGINE.md)
     - [ ] [#191](https://github.com/schapman1974/briskdb/issues/191) — embedded
       Rust document API
     - [ ] [#198](https://github.com/schapman1974/briskdb/issues/198) — Python

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -608,6 +608,21 @@ without the optional `documents` feature still understand and checksum version
 14 metadata and recognize its exact shard schema; they refuse to activate a
 store with document collections.
 
+The optional document engine sits above that persistence boundary. Owned
+`DocumentRequest` values carry request identity, cancellation, deadline, read
+or write options, and narrower result limits through `Engine::execute_document`.
+Collection and index metadata commands, single explicit-ID inserts,
+single-document exact-ID deletion, and the first exact-`_id` or empty-filter
+find/count paths use ordinary engine session, lifecycle, worker, and
+connection-pool admission. Exact IDs compile to one point shard; empty filters
+compile to a deterministic all-shard plan whose results merge by durable
+natural order. The returned `DocumentExecution`
+retains that redaction-safe plan and the request identity while its result
+preserves BSON field order and representation. Protocol adapters have no
+direct SQLite or document-storage path. General matching, transformations,
+retained cursors, and Mongo wire behavior build on this boundary in later
+issues; see [the document engine contract](DOCUMENT_ENGINE.md).
+
 Each manifest version retains an intentionally incompatible
 `briskdb_metadata` definition and row as a downgrade fence. The v3-to-v4
 migration remains manifest-atomic. The v4-to-v5 step first validates the v4

--- a/docs/CRATE_FEATURES.md
+++ b/docs/CRATE_FEATURES.md
@@ -26,7 +26,7 @@ briskdb = { version = "0.1.0-alpha.5", default-features = false, features = ["em
 | `sqlite-import-cli` | `briskdb-import` binary | Process integration |
 | `tinymongo-import` | Strict TinyMongo v1.3 SQLite reader and atomic document import; selects `documents` and `sqlite-import` | Experimental migration API |
 | `experimental-vtab` | Sharded virtual-table prototype | Experimental |
-| `documents` | BSON values, codec, comparison, and canonical semantic keys; also selects `embedded` | Experimental foundation; no document engine or listener yet |
+| `documents` | BSON values and codec, catalog/storage, TinyMongo-ready semantic keys, and protocol-neutral document commands; also selects `embedded` | Experimental document engine; no MongoDB listener yet |
 | `mysql` | Reserved MySQL boundary | Reserved; no listener yet |
 | `tls` | Compatibility alias for the secure `postgres` surface | Alpha-supported; selected by `listeners` |
 
@@ -45,13 +45,13 @@ listener assembly.
 - The public `core`, `sql`, and `storage` modules expose implementation-facing
   building blocks used by current adapters. Prefer crate-root and `embedded`
   APIs unless implementing a BriskDB adapter.
-- The `documents` feature exposes the protocol-neutral BSON foundation and
-  versioned internal persistence documented in
+- The `documents` feature exposes the protocol-neutral BSON foundation,
+  versioned persistence, and first document-engine commands documented in
   [BSON value and codec contract](BSON.md) and
-  [document storage](DOCUMENT_STORAGE.md). Its public value, codec,
-  comparison, key, and catalog metadata APIs are experimental while the
-  document engine is built. It does not yet expose document commands or a
-  MongoDB listener.
+  [document storage](DOCUMENT_STORAGE.md), and
+  [protocol-neutral document engine](DOCUMENT_ENGINE.md). Its public value,
+  command, result, and metadata APIs remain experimental while Mongo semantics
+  are completed. It does not expose a MongoDB listener.
 - The `mysql` reserved feature compiles but intentionally exposes no claimed
   implementation.
 

--- a/docs/DOCUMENT_ENGINE.md
+++ b/docs/DOCUMENT_ENGINE.md
@@ -1,0 +1,72 @@
+# Protocol-neutral document engine
+
+Status: implemented by roadmap issue #162
+
+The opt-in `documents` feature adds an asynchronous document command boundary
+to `core::Engine`. A caller submits an owned `DocumentRequest` to
+`Engine::execute_document`; no HTTP, PostgreSQL, MongoDB, or other network
+listener participates. This is the shared execution boundary for future Rust,
+Python, and MongoDB adapters.
+
+Every request carries a nonzero 128-bit request identity and the same
+`RequestContext` controls as SQL operations: cancellation, an absolute
+deadline, and result limits that may narrow the engine defaults. The returned
+`DocumentExecution` echoes the request identity and, for routed data commands,
+the selected point or scatter plan. Reusing an identity helps correlate logs;
+it does not make a write idempotent.
+
+## Implemented commands
+
+This first engine slice executes:
+
+| Command | Current behavior |
+| --- | --- |
+| `CreateCollection` | Provisions the catalog entry and fixed document table on every shard, then returns the active collection metadata |
+| `ListCollections` | Returns collection metadata for one exact database name |
+| `CreateIndex` | Declares index metadata and returns its name; non-built-in indexes remain pending until physical index work lands |
+| `ListIndexes` | Returns the built-in `_id_` definition and declared secondary-index metadata |
+| `Insert` | Inserts one document containing an explicit `_id`; the typed request retains batch shape for later bulk-write semantics |
+| `Find` | Supports an empty filter or an exact top-level `{_id: value}` filter and returns one exhausted cursor batch |
+| `Count` | Supports an empty filter or an exact top-level `{_id: value}` filter |
+| `Delete` | Deletes one document selected by exact `_id` |
+
+An exact `_id` filter produces a `DocumentPlan::Point` with one collection and
+one physical shard. An empty filter produces a deterministic
+`DocumentPlan::Scatter` over every shard. Scatter reads merge by the durable
+cross-shard natural-order value, so insertion order remains stable across
+restarts. `skip`, `limit`, and `batch_size` are applied after that merge. A
+result that would require cursor continuation currently fails unless the caller
+uses a limit that fits in one batch.
+
+The engine preserves BSON field order and exact BSON representations in stored
+and returned documents. It accounts returned rows and encoded BSON bytes
+against the effective `ResultLimits`; exceeding either bound fails the whole
+command rather than returning a partial batch.
+
+## Execution and storage boundary
+
+Document commands use the same engine lifecycle, session serialization,
+bounded blocking-worker admission, per-shard connection pools, cancellation,
+deadline, shutdown, and classified `EngineError` behavior as SQL commands.
+Protocol code is not allowed to open SQLite connections or call the document
+storage layer directly.
+
+The reserved `briskdb_documents_v1` table remains unavailable to ordinary SQL.
+The engine grants its pooled connection only the narrow read/write operations
+needed for one admitted document storage primitive, then restores the ordinary
+authorizer before that connection can be reused.
+
+## Current boundary
+
+General match expressions, projection, sort, update expressions, replacements,
+multi-document insertion or deletion, upsert, distinct, aggregation, retained
+cursors, and physical secondary-index builds remain later roadmap work.
+Unsupported command shapes return the stable `EngineErrorKind::Unsupported`
+category. Inserts require caller-supplied `_id` values until generated document
+IDs land.
+
+This release does not add a MongoDB listener or the higher-level embedded Rust
+and Python collection APIs. Those adapters will translate into this engine
+boundary instead of implementing routing or storage behavior themselves. See
+[the Mongo parity contract](MONGO_PARITY.md), [the BSON contract](BSON.md), and
+[document storage](DOCUMENT_STORAGE.md) for the adjacent contracts.

--- a/docs/DOCUMENT_STORAGE.md
+++ b/docs/DOCUMENT_STORAGE.md
@@ -4,8 +4,9 @@ Status: implemented by roadmap issue #163
 
 The opt-in `documents` feature stores ordered BSON documents in BriskDB's
 ordinary sharded SQLite layout. This is the persistence boundary below the
-protocol-neutral document engine tracked by issue #162. It does not expose a
-MongoDB listener or a public collection command API.
+[protocol-neutral document engine](DOCUMENT_ENGINE.md). Protocol adapters use
+that engine rather than this storage API. This layer does not expose a MongoDB
+listener or a high-level embedded collection API.
 
 ## Logical catalog
 

--- a/docs/EMBEDDED_SQL.md
+++ b/docs/EMBEDDED_SQL.md
@@ -77,6 +77,9 @@ one finite runtime outside the GIL/host lock, submit these async calls to it,
 and map cancellation back through `RequestContext`; they must not create a new
 runtime per query.
 
-Native document commands remain unavailable until the BSON/document engine in
-#162–#164 lands. Selecting `DocumentSupport::Enabled` fails before storage is
-touched, so SQL-only embedding cannot accidentally claim Mongo compatibility.
+The opt-in `documents` feature now exposes protocol-neutral document commands
+on `core::Engine`; see [the document engine contract](DOCUMENT_ENGINE.md).
+`BriskDb` does not yet wrap those commands as a high-level collection API.
+Selecting `DocumentSupport::Enabled` therefore still fails before storage is
+touched until issue #191 lands, so SQL-only embedding cannot accidentally claim
+Mongo compatibility.

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -1,5 +1,8 @@
 //! Asynchronous protocol-neutral engine boundary.
 
+#[cfg(feature = "documents")]
+mod document_engine;
+
 use std::{
     path::{Path, PathBuf},
     sync::{

--- a/src/core/engine/document_engine.rs
+++ b/src/core/engine/document_engine.rs
@@ -1,0 +1,1866 @@
+//! Protocol-neutral document command execution through engine-owned resources.
+
+use std::{cmp::Reverse, collections::BinaryHeap, sync::Arc, time::Instant};
+
+use tokio::task::JoinHandle;
+
+use super::{Engine, Operation, flatten_join, pending_cancellation_reason, retire_if_broken};
+use crate::{
+    core::{
+        CancelOnDrop, CancellationToken, EngineError, EngineErrorKind, EngineResult,
+        OperationControl, ResultLimits, Session, SessionInner, SessionState, wait_for_cancellation,
+        wait_pending,
+    },
+    document::{
+        BSON_MAX_DECODED_BYTES, BsonDocument, BsonErrorContext, BsonValue, DocumentCollectionId,
+        DocumentCollectionMetadata, DocumentCollectionOptions, DocumentCommand,
+        DocumentDeleteResult, DocumentExecution, DocumentFilter, DocumentIndexMetadata,
+        DocumentInsertResult, DocumentMutationScope, DocumentNamespace, DocumentPlan,
+        DocumentPointPlan, DocumentReadOptions, DocumentRequest, DocumentResult,
+        DocumentScatterPlan, DocumentWriteOptions, MAX_DOCUMENT_REQUEST_BYTES, encode_document,
+    },
+    storage::{
+        ConnectionOwner, DocumentStorageRecord, MAX_DOCUMENT_SHARD_SCAN_RECORDS, PooledConnection,
+        PreparedDocumentWrite, SchemaOperationGuard, Storage,
+    },
+};
+
+const DOCUMENT_RESULT_ENVELOPE_BYTES: u64 = 16;
+const DOCUMENT_RESULT_ROW_BYTES: u64 = 8;
+const DOCUMENT_RESULT_VALUE_BYTES: u64 = 9;
+const DOCUMENT_MERGE_PAGE_SIZE: usize = 1;
+const _: () = assert!(DOCUMENT_MERGE_PAGE_SIZE <= MAX_DOCUMENT_SHARD_SCAN_RECORDS);
+
+impl Engine {
+    /// Execute one owned document command through the same lifecycle, session,
+    /// cancellation, deadline, worker, connection-pool, and result-limit
+    /// boundaries used by SQL protocols.
+    pub async fn execute_document(
+        &self,
+        session: &Session,
+        request: DocumentRequest,
+    ) -> EngineResult<DocumentExecution> {
+        let (request_id, context, command) = request.into_parts();
+        let mut operation = self.operation(context)?;
+        if session.owner != self.inner.id {
+            return operation.finish(Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "the session belongs to a different engine",
+            )));
+        }
+        let result = match command {
+            DocumentCommand::CreateCollection(request) => {
+                let (namespace, options, write_options) = request.into_parts();
+                if let Err(error) = require_catalog_write_options(write_options) {
+                    Err(error)
+                } else {
+                    self.run_document_create_collection(
+                        &mut operation,
+                        session,
+                        request_id,
+                        namespace,
+                        options,
+                    )
+                    .await
+                }
+            }
+            command => {
+                let schema_operation = match self.inner.database.storage.enter_schema_operation() {
+                    Ok(guard) => guard,
+                    Err(error) => return operation.finish(Err(error)),
+                };
+                let session_guard = match operation.wait_pending(self.ready_session(session)).await
+                {
+                    Ok(guard) => guard,
+                    Err(error) => return operation.finish(Err(error)),
+                };
+                if let Err(error) = require_document_session_ready(&session_guard) {
+                    return operation.finish(Err(error));
+                }
+                let owner = ConnectionOwner::new(session.id().get());
+                self.run_document_command(
+                    &mut operation,
+                    owner,
+                    session_guard,
+                    schema_operation,
+                    request_id,
+                    command,
+                )
+                .await
+            }
+        };
+        if operation.lease.is_some() {
+            operation.finish(result)
+        } else {
+            operation.finish_started(result)
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn run_document_command(
+        &self,
+        operation: &mut Operation,
+        owner: ConnectionOwner,
+        session: tokio::sync::OwnedMutexGuard<SessionInner>,
+        schema_operation: SchemaOperationGuard,
+        request_id: crate::document::DocumentRequestId,
+        command: DocumentCommand,
+    ) -> EngineResult<DocumentExecution> {
+        operation.check_before_start()?;
+        let cancellation = CancellationToken::new();
+        let cancel_operation = cancellation.clone();
+        if let Err(reason) = operation.control.arm(Arc::new(move || {
+            cancel_operation.cancel();
+        })) {
+            return operation.control.complete(Err(reason.error()));
+        }
+
+        let lease = operation.take_lease();
+        let control = Arc::clone(&operation.control);
+        let worker_control = Arc::clone(&control);
+        let engine = self.clone();
+        let deadline = operation.deadline;
+        let result_limits = operation.result_limits;
+        let join = tokio::spawn(async move {
+            let _lease = lease;
+            let _schema_operation = schema_operation;
+            let _session = session;
+            let result = engine
+                .coordinate_document_command(
+                    owner,
+                    request_id,
+                    command,
+                    cancellation,
+                    deadline,
+                    result_limits,
+                )
+                .await;
+            worker_control.complete(result)
+        });
+        operation.wait_started(join).await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn coordinate_document_command(
+        &self,
+        owner: ConnectionOwner,
+        request_id: crate::document::DocumentRequestId,
+        command: DocumentCommand,
+        cancellation: CancellationToken,
+        deadline: Option<Instant>,
+        result_limits: ResultLimits,
+    ) -> EngineResult<DocumentExecution> {
+        let storage = self.inner.database.storage.clone();
+        let result_cancellation = cancellation.clone();
+        let execution = match command {
+            DocumentCommand::ListCollections(request) => {
+                let (database, options) = request.into_parts();
+                require_catalog_read_options(&options)?;
+                let collections = self
+                    .run_document_storage_task(
+                        cancellation.clone(),
+                        deadline,
+                        move |cancellation, control| {
+                            let collections = storage
+                                .document_collections_for_database_controlled(
+                                    &database,
+                                    Arc::clone(&control),
+                                )?;
+                            ensure_document_cpu_active(cancellation, &control)?;
+                            let collections = apply_slice_options(&collections, &options)?;
+                            ensure_document_cpu_active(cancellation, &control)?;
+                            Ok(collections)
+                        },
+                    )
+                    .await?;
+                Ok(DocumentExecution::new(
+                    request_id,
+                    None,
+                    DocumentResult::Collections(collections.into_boxed_slice()),
+                ))
+            }
+            DocumentCommand::CreateIndex(request) => {
+                let (namespace, index, write_options) = request.into_parts();
+                require_catalog_write_options(write_options)?;
+                if index.sparse() || index.partial_filter().is_some() {
+                    return Err(unsupported(
+                        "sparse and partial document indexes require the document-index execution milestone",
+                    ));
+                }
+                let name = index.name().ok_or_else(|| {
+                    unsupported("unnamed document indexes require deterministic name generation")
+                })?;
+                let name = name.to_owned();
+                enforce_execution_result_limits(
+                    &DocumentExecution::new(
+                        request_id,
+                        None,
+                        DocumentResult::IndexName(name.clone()),
+                    ),
+                    result_limits,
+                )?;
+                let (keys, _, unique, _, _) = index.into_parts();
+                let catalog_storage = storage.clone();
+                let collection_id = self
+                    .run_document_storage_task(
+                        cancellation.clone(),
+                        deadline,
+                        move |cancellation, control| {
+                            let collection = catalog_storage.document_collection_controlled(
+                                namespace.database(),
+                                namespace.collection(),
+                                Arc::clone(&control),
+                            )?;
+                            let collection_id = require_collection(collection)?.id();
+                            ensure_document_cpu_active(cancellation, &control)?;
+                            Ok(collection_id)
+                        },
+                    )
+                    .await?;
+                let metadata_storage = storage.clone();
+                let metadata_name = name.clone();
+                self.run_document_storage_task(
+                    cancellation,
+                    deadline,
+                    move |_cancellation, control| {
+                        metadata_storage.declare_document_index_controlled(
+                            collection_id,
+                            &metadata_name,
+                            &keys,
+                            unique,
+                            control,
+                        )
+                    },
+                )
+                .await?;
+                Ok(DocumentExecution::new(
+                    request_id,
+                    None,
+                    DocumentResult::IndexName(name),
+                ))
+            }
+            DocumentCommand::ListIndexes(request) => {
+                let (namespace, options) = request.into_parts();
+                require_catalog_read_options(&options)?;
+                let indexes = self
+                    .run_document_storage_task(
+                        cancellation,
+                        deadline,
+                        move |cancellation, control| {
+                            let collection = storage.document_collection_controlled(
+                                namespace.database(),
+                                namespace.collection(),
+                                Arc::clone(&control),
+                            )?;
+                            let collection = require_collection(collection)?;
+                            let indexes = apply_slice_options(collection.indexes(), &options)?;
+                            ensure_document_cpu_active(cancellation, &control)?;
+                            Ok(indexes)
+                        },
+                    )
+                    .await?;
+                Ok(DocumentExecution::new(
+                    request_id,
+                    None,
+                    DocumentResult::Indexes(indexes.into_boxed_slice()),
+                ))
+            }
+            DocumentCommand::Insert(request) => {
+                let (namespace, documents, options) = request.into_parts();
+                require_insert_options(options)?;
+                if documents.len() != 1 {
+                    return Err(unsupported(
+                        "multi-document inserts require the bulk-write result semantics milestone",
+                    ));
+                }
+                let catalog_storage = storage.clone();
+                let collection_id = self
+                    .run_document_storage_task(
+                        cancellation.clone(),
+                        deadline,
+                        move |cancellation, control| {
+                            let collection = catalog_storage.document_collection_controlled(
+                                namespace.database(),
+                                namespace.collection(),
+                                Arc::clone(&control),
+                            )?;
+                            let collection_id = require_collection(collection)?.id();
+                            ensure_document_cpu_active(cancellation, &control)?;
+                            Ok(collection_id)
+                        },
+                    )
+                    .await?;
+                let prepare_storage = storage.clone();
+                let (prepared, ids, plan) = self
+                    .run_document_storage_task(
+                        cancellation.clone(),
+                        deadline,
+                        move |cancellation, control| {
+                            let (prepared, ids) = prepare_documents(
+                                &prepare_storage,
+                                &documents,
+                                cancellation,
+                                &control,
+                            )?;
+                            enforce_prepared_write_budget(&prepared, cancellation, &control)?;
+                            let plan =
+                                insert_plan(collection_id, &prepared, cancellation, &control)?;
+                            enforce_insert_execution_limits(
+                                &plan,
+                                &ids,
+                                result_limits,
+                                cancellation,
+                                &control,
+                            )?;
+                            ensure_document_cpu_active(cancellation, &control)?;
+                            Ok((prepared, ids, plan))
+                        },
+                    )
+                    .await?;
+                let count = u64::try_from(prepared.len()).map_err(|_| {
+                    EngineError::new(
+                        EngineErrorKind::LimitExceeded,
+                        "document insert count exceeds the supported range",
+                    )
+                })?;
+                let reserve_storage = storage.clone();
+                let first_order = self
+                    .run_document_storage_task(
+                        cancellation.clone(),
+                        deadline,
+                        move |_cancellation, control| {
+                            reserve_storage.reserve_document_natural_orders_controlled(
+                                collection_id,
+                                count,
+                                control,
+                            )
+                        },
+                    )
+                    .await?;
+                for (offset, prepared_document) in prepared.into_iter().enumerate() {
+                    let natural_order = first_order
+                        .checked_add(u64::try_from(offset).expect("bounded insert count fits u64"))
+                        .ok_or_else(|| {
+                            EngineError::new(
+                                EngineErrorKind::LimitExceeded,
+                                "document natural-order identity overflowed",
+                            )
+                        })?;
+                    let shard = prepared_document.shard();
+                    let write = prepared_document;
+                    self.run_document_shard(
+                        shard,
+                        owner,
+                        cancellation.clone(),
+                        deadline,
+                        move |storage, connection, cancellation| {
+                            storage.insert_prepared_document_on_connection(
+                                connection,
+                                collection_id,
+                                natural_order,
+                                shard,
+                                &write,
+                                cancellation,
+                            )
+                        },
+                    )
+                    .await?;
+                }
+                Ok(DocumentExecution::new(
+                    request_id,
+                    Some(plan),
+                    DocumentResult::Insert(DocumentInsertResult::from_validated(ids)),
+                ))
+            }
+            DocumentCommand::Find(request) => {
+                let (namespace, filter, options) = request.into_parts();
+                require_find_options(&options)?;
+                let catalog_storage = storage.clone();
+                let catalog_namespace = namespace.clone();
+                let (collection_id, route) = self
+                    .run_document_storage_task(
+                        cancellation.clone(),
+                        deadline,
+                        move |cancellation, control| {
+                            let collection = catalog_storage.document_collection_controlled(
+                                catalog_namespace.database(),
+                                catalog_namespace.collection(),
+                                Arc::clone(&control),
+                            )?;
+                            let collection_id = require_collection(collection)?.id();
+                            let route = prepare_filter_route(
+                                &catalog_storage,
+                                filter,
+                                cancellation,
+                                &control,
+                            )?;
+                            ensure_document_cpu_active(cancellation, &control)?;
+                            Ok((collection_id, route))
+                        },
+                    )
+                    .await?;
+                let (plan, documents) = match route {
+                    PreparedFilterRoute::Point { id_key, shard } => {
+                        let (id_key, record) = self
+                            .run_document_shard(
+                                shard,
+                                owner,
+                                cancellation,
+                                deadline,
+                                move |storage, connection, cancellation| {
+                                    let record = storage.get_document_on_connection(
+                                        connection,
+                                        collection_id,
+                                        shard,
+                                        &id_key,
+                                        cancellation,
+                                    )?;
+                                    Ok((id_key, record))
+                                },
+                            )
+                            .await?;
+                        if let Some(record) = &record {
+                            validate_point_record(record, collection_id, shard, &id_key)?;
+                        }
+                        let documents = apply_point_read(record, &options, result_limits)?;
+                        (
+                            DocumentPlan::Point(DocumentPointPlan::new(
+                                collection_id,
+                                shard,
+                                id_key,
+                            )?),
+                            documents,
+                        )
+                    }
+                    PreparedFilterRoute::Scatter => {
+                        let documents = self
+                            .scan_document_collection(
+                                owner,
+                                collection_id,
+                                cancellation,
+                                deadline,
+                                &options,
+                                result_limits,
+                            )
+                            .await?;
+                        (scatter_plan(collection_id, self.shard_count())?, documents)
+                    }
+                };
+                let batch = crate::document::DocumentCursorBatch::from_validated(
+                    namespace, None, documents,
+                );
+                Ok(DocumentExecution::new(
+                    request_id,
+                    Some(plan),
+                    DocumentResult::Cursor(batch),
+                ))
+            }
+            DocumentCommand::Count(request) => {
+                let (namespace, filter, options) = request.into_parts();
+                require_count_options(&options)?;
+                let catalog_storage = storage.clone();
+                let (collection_id, route) = self
+                    .run_document_storage_task(
+                        cancellation.clone(),
+                        deadline,
+                        move |cancellation, control| {
+                            let collection = catalog_storage.document_collection_controlled(
+                                namespace.database(),
+                                namespace.collection(),
+                                Arc::clone(&control),
+                            )?;
+                            let collection_id = require_collection(collection)?.id();
+                            let route = prepare_filter_route(
+                                &catalog_storage,
+                                filter,
+                                cancellation,
+                                &control,
+                            )?;
+                            ensure_document_cpu_active(cancellation, &control)?;
+                            Ok((collection_id, route))
+                        },
+                    )
+                    .await?;
+                let (plan, count) = match route {
+                    PreparedFilterRoute::Point { id_key, shard } => {
+                        let (id_key, found) = self
+                            .run_document_shard(
+                                shard,
+                                owner,
+                                cancellation,
+                                deadline,
+                                move |storage, connection, cancellation| {
+                                    let found = storage.get_document_on_connection(
+                                        connection,
+                                        collection_id,
+                                        shard,
+                                        &id_key,
+                                        cancellation,
+                                    )?;
+                                    Ok((id_key, found))
+                                },
+                            )
+                            .await?;
+                        if let Some(record) = &found {
+                            validate_point_record(record, collection_id, shard, &id_key)?;
+                        }
+                        let found = found.is_some();
+                        (
+                            DocumentPlan::Point(DocumentPointPlan::new(
+                                collection_id,
+                                shard,
+                                id_key,
+                            )?),
+                            u64::from(found),
+                        )
+                    }
+                    PreparedFilterRoute::Scatter => {
+                        let mut count = 0_u64;
+                        for shard in 0..self.shard_count() {
+                            let shard_count = self
+                                .run_document_shard(
+                                    shard,
+                                    owner,
+                                    cancellation.clone(),
+                                    deadline,
+                                    move |storage, connection, cancellation| {
+                                        storage.count_document_shard_on_connection(
+                                            connection,
+                                            collection_id,
+                                            shard,
+                                            cancellation,
+                                        )
+                                    },
+                                )
+                                .await?;
+                            count = count.checked_add(shard_count).ok_or_else(|| {
+                                EngineError::new(
+                                    EngineErrorKind::LimitExceeded,
+                                    "document count exceeded the supported range",
+                                )
+                            })?;
+                        }
+                        (scatter_plan(collection_id, self.shard_count())?, count)
+                    }
+                };
+                let count = apply_count_options(count, &options);
+                enforce_scalar_result_limit(result_limits)?;
+                Ok(DocumentExecution::new(
+                    request_id,
+                    Some(plan),
+                    DocumentResult::Count(count),
+                ))
+            }
+            DocumentCommand::Delete(request) => {
+                let (namespace, filter, scope, options) = request.into_parts();
+                require_delete_options(options)?;
+                if scope != DocumentMutationScope::One {
+                    return Err(unsupported(
+                        "multi-document deletes require the matcher semantics milestone",
+                    ));
+                }
+                let catalog_storage = storage.clone();
+                let (collection_id, id_key, shard, plan) = self
+                    .run_document_storage_task(
+                        cancellation.clone(),
+                        deadline,
+                        move |cancellation, control| {
+                            let collection = catalog_storage.document_collection_controlled(
+                                namespace.database(),
+                                namespace.collection(),
+                                Arc::clone(&control),
+                            )?;
+                            let collection_id = require_collection(collection)?.id();
+                            let id = require_point_filter(filter, cancellation, &control)?;
+                            ensure_document_cpu_active(cancellation, &control)?;
+                            let (id_key, shard) = catalog_storage.prepare_document_id(&id)?;
+                            let plan = DocumentPlan::Point(DocumentPointPlan::new(
+                                collection_id,
+                                shard,
+                                id_key.clone(),
+                            )?);
+                            enforce_execution_result_limits(
+                                &DocumentExecution::new(
+                                    request_id,
+                                    Some(plan.clone()),
+                                    DocumentResult::Delete(DocumentDeleteResult::new(0)),
+                                ),
+                                result_limits,
+                            )?;
+                            ensure_document_cpu_active(cancellation, &control)?;
+                            Ok((collection_id, id_key, shard, plan))
+                        },
+                    )
+                    .await?;
+                let delete_key = id_key;
+                let deleted = self
+                    .run_document_shard(
+                        shard,
+                        owner,
+                        cancellation,
+                        deadline,
+                        move |storage, connection, cancellation| {
+                            storage.delete_document_on_connection(
+                                connection,
+                                collection_id,
+                                shard,
+                                &delete_key,
+                                cancellation,
+                            )
+                        },
+                    )
+                    .await?;
+                Ok(DocumentExecution::new(
+                    request_id,
+                    Some(plan),
+                    DocumentResult::Delete(DocumentDeleteResult::new(u64::from(deleted))),
+                ))
+            }
+            DocumentCommand::DropCollection(_)
+            | DocumentCommand::Aggregate(_)
+            | DocumentCommand::Distinct(_)
+            | DocumentCommand::Update(_)
+            | DocumentCommand::Replace(_)
+            | DocumentCommand::DropIndex(_)
+            | DocumentCommand::ContinueCursor(_)
+            | DocumentCommand::KillCursor(_) => Err(unsupported(
+                "this document command is modeled but requires a later document-semantics milestone",
+            )),
+            DocumentCommand::CreateCollection(_) => Err(EngineError::new(
+                EngineErrorKind::Internal,
+                "document collection creation reached the data-command coordinator",
+            )),
+        }?;
+        if execution_result_is_mutation(execution.result()) {
+            // Every supported mutation preflights this exact result shape
+            // before its first durable write. Once that write commits, return
+            // success even if cancellation wins the race to result delivery.
+            Ok(execution)
+        } else {
+            self.run_document_storage_task(
+                result_cancellation,
+                deadline,
+                move |cancellation, control| {
+                    enforce_execution_result_limits_controlled(
+                        &execution,
+                        result_limits,
+                        cancellation,
+                        &control,
+                    )?;
+                    ensure_document_cpu_active(cancellation, &control)?;
+                    Ok(execution)
+                },
+            )
+            .await
+        }
+    }
+
+    async fn run_document_create_collection(
+        &self,
+        operation: &mut Operation,
+        session: &Session,
+        request_id: crate::document::DocumentRequestId,
+        namespace: DocumentNamespace,
+        options: DocumentCollectionOptions,
+    ) -> EngineResult<DocumentExecution> {
+        let migration = self.inner.database.storage.begin_schema_migration()?;
+        // Close the same-session transaction race before waiting for existing
+        // schema operations to drain. Once migration admission succeeds, no
+        // new transaction can retain a schema-operation guard behind this
+        // session check.
+        let session_preflight = operation.wait_pending(self.ready_session(session)).await?;
+        require_document_session_ready(&session_preflight)?;
+        drop(session_preflight);
+        operation
+            .wait_pending(async {
+                migration.wait_for_quiescence().await;
+                Ok(())
+            })
+            .await?;
+        let session = operation.wait_pending(self.ready_session(session)).await?;
+        require_document_session_ready(&session)?;
+        let worker = operation.wait_pending(self.inner.workers.acquire()).await?;
+        operation.check_before_start()?;
+        let lease = operation.take_lease();
+        let worker_control = Arc::clone(&operation.control);
+        let result_limits = operation.result_limits;
+        let storage = self.inner.database.storage.clone();
+        let storage_for_corruption = storage.clone();
+        let connections = self.inner.connections.clone();
+        let join = worker.spawn(move || {
+            let _lease = lease;
+            let _session = session;
+            let result =
+                enforce_create_collection_result_limits(&namespace, &options, result_limits)
+                    .and_then(|_| connections.retire_idle_for_schema_migration())
+                    .and_then(|_| {
+                        storage.create_document_collection_controlled(
+                            namespace.database(),
+                            namespace.collection(),
+                            &options,
+                            migration,
+                            Arc::clone(&worker_control),
+                        )
+                    })
+                    .map(|metadata| {
+                        DocumentExecution::new(
+                            request_id,
+                            None,
+                            DocumentResult::Collection(metadata),
+                        )
+                    })
+                    .and_then(|execution| {
+                        enforce_execution_result_limits(&execution, result_limits)?;
+                        Ok(execution)
+                    });
+            if result
+                .as_ref()
+                .is_err_and(|error| error.kind() == EngineErrorKind::DataCorruption)
+            {
+                storage_for_corruption.record_schema_degraded();
+            }
+            worker_control.complete(result)
+        });
+        operation.wait_started(join).await
+    }
+
+    async fn run_document_storage_task<T, F>(
+        &self,
+        cancellation: CancellationToken,
+        deadline: Option<Instant>,
+        work: F,
+    ) -> EngineResult<T>
+    where
+        T: Send + 'static,
+        F: FnOnce(&CancellationToken, Arc<OperationControl>) -> EngineResult<T> + Send + 'static,
+    {
+        let control = OperationControl::new(deadline);
+        let mut cancel_on_drop = CancelOnDrop::new(Arc::clone(&control));
+        let shutdown = self.inner.shutdown_cancel.clone();
+        let worker = wait_pending(
+            self.inner.workers.acquire(),
+            &cancellation,
+            &shutdown,
+            deadline,
+            &control,
+        )
+        .await?;
+        if let Some(reason) = pending_cancellation_reason(&cancellation, &shutdown, deadline) {
+            control.request_cancel(reason);
+            let result = control.complete(Err(reason.error()));
+            cancel_on_drop.disarm();
+            return result;
+        }
+        let worker_control = Arc::clone(&control);
+        let storage = self.inner.database.storage.clone();
+        let task_cancellation = cancellation.clone();
+        let mut join: JoinHandle<EngineResult<T>> = worker.spawn(move || {
+            let result = work(&task_cancellation, Arc::clone(&worker_control));
+            if result
+                .as_ref()
+                .is_err_and(|error| error.kind() == EngineErrorKind::DataCorruption)
+            {
+                storage.record_schema_degraded();
+            }
+            worker_control.complete(result)
+        });
+        let result = tokio::select! {
+            biased;
+            result = &mut join => flatten_join(result),
+            reason = wait_for_cancellation(&cancellation, &shutdown, deadline) => {
+                control.request_cancel(reason);
+                flatten_join(join.await)
+            }
+        };
+        let result = control.complete(result);
+        cancel_on_drop.disarm();
+        result
+    }
+
+    async fn run_document_shard<T, F>(
+        &self,
+        shard: u16,
+        owner: ConnectionOwner,
+        cancellation: CancellationToken,
+        deadline: Option<Instant>,
+        work: F,
+    ) -> EngineResult<T>
+    where
+        T: Send + 'static,
+        F: FnOnce(&Storage, &mut PooledConnection, &CancellationToken) -> EngineResult<T>
+            + Send
+            + 'static,
+    {
+        let control = OperationControl::new(deadline);
+        let mut cancel_on_drop = CancelOnDrop::new(Arc::clone(&control));
+        let shutdown = self.inner.shutdown_cancel.clone();
+        let permit = wait_pending(
+            self.inner.connections.acquire_for_owner(shard, owner),
+            &cancellation,
+            &shutdown,
+            deadline,
+            &control,
+        )
+        .await?;
+        let worker = wait_pending(
+            self.inner.workers.acquire(),
+            &cancellation,
+            &shutdown,
+            deadline,
+            &control,
+        )
+        .await?;
+        if let Some(reason) = pending_cancellation_reason(&cancellation, &shutdown, deadline) {
+            control.request_cancel(reason);
+            let result = control.complete(Err(reason.error()));
+            cancel_on_drop.disarm();
+            return result;
+        }
+        let worker_control = Arc::clone(&control);
+        let storage = self.inner.database.storage.clone();
+        let error_storage = storage.clone();
+        let task_cancellation = cancellation.clone();
+        let mut join = worker.spawn(move || {
+            let result = permit
+                .checkout_controlled(Arc::clone(&worker_control))
+                .and_then(|mut connection| {
+                    let result = connection
+                        .run_document_controlled(Arc::clone(&worker_control), |connection| {
+                            work(&storage, connection, &task_cancellation)
+                        });
+                    retire_if_broken(&mut connection, &result);
+                    result
+                });
+            if result
+                .as_ref()
+                .is_err_and(|error| error.kind() == EngineErrorKind::DataCorruption)
+            {
+                error_storage.record_schema_degraded();
+            }
+            worker_control.complete(result)
+        });
+        let result = tokio::select! {
+            biased;
+            result = &mut join => flatten_join(result),
+            reason = wait_for_cancellation(&cancellation, &shutdown, deadline) => {
+                control.request_cancel(reason);
+                flatten_join(join.await)
+            }
+        };
+        let result = control.complete(result);
+        cancel_on_drop.disarm();
+        result
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn scan_document_collection(
+        &self,
+        owner: ConnectionOwner,
+        collection_id: DocumentCollectionId,
+        cancellation: CancellationToken,
+        deadline: Option<Instant>,
+        options: &DocumentReadOptions,
+        limits: ResultLimits,
+    ) -> EngineResult<Vec<BsonDocument>> {
+        enforce_empty_result_limit(limits)?;
+        let frontier_limit = limits
+            .max_bytes()
+            .max(u64::try_from(BSON_MAX_DECODED_BYTES).unwrap_or(u64::MAX));
+        let mut frontiers: Vec<Option<DocumentStorageRecord>> =
+            Vec::with_capacity(usize::from(self.shard_count()));
+        let mut retained_bytes = 0_u64;
+        for shard in 0..self.shard_count() {
+            let page = self
+                .run_document_shard(
+                    shard,
+                    owner,
+                    cancellation.clone(),
+                    deadline,
+                    move |storage, connection, cancellation| {
+                        storage.scan_document_shard_on_connection(
+                            connection,
+                            collection_id,
+                            shard,
+                            None,
+                            DOCUMENT_MERGE_PAGE_SIZE,
+                            cancellation,
+                        )
+                    },
+                )
+                .await?;
+            let record = page.into_iter().next();
+            if let Some(record) = &record {
+                validate_point_record(record, collection_id, shard, record.id_key())?;
+                retained_bytes = retained_bytes
+                    .checked_add(u64::try_from(record.encoded_len()).unwrap_or(u64::MAX))
+                    .ok_or_else(result_size_overflow)?;
+                if retained_bytes > frontier_limit {
+                    return Err(limit_exceeded(
+                        "document scatter merge frontier exceeds its bounded memory limit",
+                    ));
+                }
+            }
+            frontiers.push(record);
+        }
+
+        let mut heap = BinaryHeap::new();
+        for (shard, record) in frontiers.iter().enumerate() {
+            if let Some(record) = record {
+                heap.push(Reverse((record.natural_order(), shard)));
+            }
+        }
+
+        let mut skipped = 0_u64;
+        let mut documents = Vec::new();
+        let mut result_bytes = DOCUMENT_RESULT_ENVELOPE_BYTES;
+        let requested = options
+            .limit()
+            .unwrap_or(u64::MAX)
+            .min(options.batch_size());
+        let retained_documents = requested.min(limits.max_rows());
+        documents
+            .try_reserve_exact(usize::try_from(retained_documents).unwrap_or(usize::MAX))
+            .map_err(|error| {
+                EngineError::from_source(
+                    EngineErrorKind::OutOfMemory,
+                    "unable to reserve bounded document result storage",
+                    error,
+                )
+            })?;
+        let mut has_more = false;
+
+        while let Some(Reverse((_natural_order, shard_index))) = heap.pop() {
+            let record = frontiers[shard_index]
+                .take()
+                .expect("the document frontier heap references a record");
+            let natural_order = record.natural_order();
+            retained_bytes = retained_bytes
+                .saturating_sub(u64::try_from(record.encoded_len()).unwrap_or(u64::MAX));
+
+            if skipped < options.skip() {
+                skipped += 1;
+            } else if u64::try_from(documents.len()).unwrap_or(u64::MAX) < requested {
+                add_document_result_budget(&mut result_bytes, record.encoded_len(), limits)?;
+                if u64::try_from(documents.len()).unwrap_or(u64::MAX) >= limits.max_rows() {
+                    return Err(limit_exceeded(
+                        "document result exceeds the request row limit",
+                    ));
+                }
+                documents.push(record.into_document());
+            } else {
+                has_more = true;
+                break;
+            }
+
+            let shard = u16::try_from(shard_index).expect("document shard index fits u16");
+            let after = Some(natural_order);
+            let page = self
+                .run_document_shard(
+                    shard,
+                    owner,
+                    cancellation.clone(),
+                    deadline,
+                    move |storage, connection, cancellation| {
+                        storage.scan_document_shard_on_connection(
+                            connection,
+                            collection_id,
+                            shard,
+                            after,
+                            DOCUMENT_MERGE_PAGE_SIZE,
+                            cancellation,
+                        )
+                    },
+                )
+                .await?;
+            let next = page.into_iter().next();
+            if let Some(next) = &next {
+                validate_point_record(next, collection_id, shard, next.id_key())?;
+                retained_bytes = retained_bytes
+                    .checked_add(u64::try_from(next.encoded_len()).unwrap_or(u64::MAX))
+                    .ok_or_else(result_size_overflow)?;
+                if retained_bytes > frontier_limit {
+                    return Err(limit_exceeded(
+                        "document scatter merge frontier exceeds its bounded memory limit",
+                    ));
+                }
+                heap.push(Reverse((next.natural_order(), shard_index)));
+            }
+            frontiers[shard_index] = next;
+        }
+
+        if has_more
+            && options
+                .limit()
+                .is_none_or(|limit| limit > options.batch_size())
+        {
+            return Err(unsupported(
+                "document cursor continuation is not available yet; use a limit within one batch",
+            ));
+        }
+        Ok(documents)
+    }
+}
+
+fn require_document_session_ready(session: &SessionInner) -> EngineResult<()> {
+    match session.state() {
+        SessionState::Ready => Ok(()),
+        SessionState::InTransaction => Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "document commands cannot run inside a SQL transaction",
+        )),
+        SessionState::FailedTransaction => Err(EngineError::new(
+            EngineErrorKind::TransactionAborted,
+            "document commands cannot run in a failed SQL transaction",
+        )),
+        SessionState::Closed => Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            "the session is closed",
+        )),
+    }
+}
+
+fn require_catalog_write_options(options: DocumentWriteOptions) -> EngineResult<()> {
+    if !options.ordered() || options.upsert() || options.bypass_document_validation() {
+        return Err(unsupported(
+            "non-default document catalog write options are not supported",
+        ));
+    }
+    Ok(())
+}
+
+fn require_insert_options(options: DocumentWriteOptions) -> EngineResult<()> {
+    if !options.ordered() {
+        return Err(unsupported(
+            "unordered document inserts require the bulk-write semantics milestone",
+        ));
+    }
+    if options.upsert() {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            "upsert is not an insert option",
+        ));
+    }
+    if options.bypass_document_validation() {
+        return Err(unsupported(
+            "bypassing document validation requires the validation semantics milestone",
+        ));
+    }
+    Ok(())
+}
+
+fn require_delete_options(options: DocumentWriteOptions) -> EngineResult<()> {
+    if !options.ordered() || options.upsert() || options.bypass_document_validation() {
+        return Err(unsupported(
+            "non-default document delete options are not supported",
+        ));
+    }
+    Ok(())
+}
+
+fn require_find_options(options: &DocumentReadOptions) -> EngineResult<()> {
+    if options.projection().is_some() {
+        return Err(unsupported(
+            "document projections require the projection semantics milestone",
+        ));
+    }
+    if options.sort().is_some() {
+        return Err(unsupported(
+            "document sort expressions require the query semantics milestone",
+        ));
+    }
+    Ok(())
+}
+
+fn require_count_options(options: &DocumentReadOptions) -> EngineResult<()> {
+    require_find_options(options)
+}
+
+fn require_catalog_read_options(options: &DocumentReadOptions) -> EngineResult<()> {
+    require_find_options(options)
+}
+
+fn require_collection(
+    collection: Option<DocumentCollectionMetadata>,
+) -> EngineResult<DocumentCollectionMetadata> {
+    collection.ok_or_else(|| {
+        EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            "document collection does not exist",
+        )
+    })
+}
+
+enum FilterRoute {
+    Point(BsonValue),
+    Scatter,
+}
+
+enum PreparedFilterRoute {
+    Point {
+        id_key: crate::document::CanonicalBsonKey,
+        shard: u16,
+    },
+    Scatter,
+}
+
+fn classify_filter(
+    filter: DocumentFilter,
+    cancellation: &CancellationToken,
+    control: &OperationControl,
+) -> EngineResult<FilterRoute> {
+    ensure_document_cpu_active(cancellation, control)?;
+    if filter.is_empty() {
+        return Ok(FilterRoute::Scatter);
+    }
+    let mut entries = filter.into_document().into_entries().into_iter();
+    match (entries.next(), entries.next()) {
+        (Some((name, value)), None)
+            if name == "_id" && is_literal_id_filter(&value, cancellation, control)? =>
+        {
+            ensure_document_cpu_active(cancellation, control)?;
+            Ok(FilterRoute::Point(value))
+        }
+        _ => Err(unsupported(
+            "document matcher expressions require the query semantics milestone",
+        )),
+    }
+}
+
+fn is_literal_id_filter(
+    value: &BsonValue,
+    cancellation: &CancellationToken,
+    control: &OperationControl,
+) -> EngineResult<bool> {
+    match value {
+        BsonValue::RegularExpression(_) => Ok(false),
+        BsonValue::Document(document) => {
+            for (name, _) in document.iter() {
+                ensure_document_cpu_active(cancellation, control)?;
+                if name.starts_with('$') {
+                    return Ok(false);
+                }
+            }
+            Ok(true)
+        }
+        _ => Ok(true),
+    }
+}
+
+fn prepare_filter_route(
+    storage: &Storage,
+    filter: DocumentFilter,
+    cancellation: &CancellationToken,
+    control: &OperationControl,
+) -> EngineResult<PreparedFilterRoute> {
+    match classify_filter(filter, cancellation, control)? {
+        FilterRoute::Point(id) => {
+            let (id_key, shard) = storage.prepare_document_id(&id)?;
+            ensure_document_cpu_active(cancellation, control)?;
+            Ok(PreparedFilterRoute::Point { id_key, shard })
+        }
+        FilterRoute::Scatter => Ok(PreparedFilterRoute::Scatter),
+    }
+}
+
+fn require_point_filter(
+    filter: DocumentFilter,
+    cancellation: &CancellationToken,
+    control: &OperationControl,
+) -> EngineResult<BsonValue> {
+    match classify_filter(filter, cancellation, control)? {
+        FilterRoute::Point(id) => Ok(id),
+        FilterRoute::Scatter => Err(unsupported("this mutation requires an exact _id filter")),
+    }
+}
+
+fn validate_point_record(
+    record: &DocumentStorageRecord,
+    collection_id: DocumentCollectionId,
+    shard: u16,
+    id_key: &crate::document::CanonicalBsonKey,
+) -> EngineResult<()> {
+    if record.collection_id() != collection_id
+        || record.shard() != shard
+        || record.id_key() != id_key
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "document point read returned inconsistent storage identity",
+        ));
+    }
+    // The storage decoder already validates the checksum, BSON payload,
+    // canonical `_id`, and shard route while running on the blocking worker.
+    // Repeating canonical BSON work here would move attacker-sized CPU work
+    // onto the async coordinator.
+    Ok(())
+}
+
+fn scatter_plan(
+    collection_id: DocumentCollectionId,
+    shard_count: u16,
+) -> EngineResult<DocumentPlan> {
+    DocumentScatterPlan::new(collection_id, (0..shard_count).collect::<Vec<_>>())
+        .map(DocumentPlan::Scatter)
+}
+
+fn insert_plan(
+    collection_id: DocumentCollectionId,
+    prepared: &[PreparedDocumentWrite],
+    cancellation: &CancellationToken,
+    control: &OperationControl,
+) -> EngineResult<DocumentPlan> {
+    ensure_document_cpu_active(cancellation, control)?;
+    if prepared.len() == 1 {
+        let plan = DocumentPointPlan::new(
+            collection_id,
+            prepared[0].shard(),
+            prepared[0].id_key().clone(),
+        )
+        .map(DocumentPlan::Point)?;
+        ensure_document_cpu_active(cancellation, control)?;
+        return Ok(plan);
+    }
+    let mut shards = prepared
+        .iter()
+        .map(PreparedDocumentWrite::shard)
+        .collect::<Vec<_>>();
+    ensure_document_cpu_active(cancellation, control)?;
+    shards.sort_unstable();
+    shards.dedup();
+    let plan = DocumentScatterPlan::new(collection_id, shards).map(DocumentPlan::Scatter)?;
+    ensure_document_cpu_active(cancellation, control)?;
+    Ok(plan)
+}
+
+fn prepare_documents(
+    storage: &Storage,
+    documents: &[BsonDocument],
+    cancellation: &CancellationToken,
+    control: &OperationControl,
+) -> EngineResult<(Vec<PreparedDocumentWrite>, Vec<BsonValue>)> {
+    ensure_document_cpu_active(cancellation, control)?;
+    let mut prepared = Vec::new();
+    let mut ids = Vec::new();
+    prepared
+        .try_reserve_exact(documents.len())
+        .map_err(|error| {
+            EngineError::from_source(
+                EngineErrorKind::OutOfMemory,
+                "unable to reserve prepared document write storage",
+                error,
+            )
+        })?;
+    ids.try_reserve_exact(documents.len()).map_err(|error| {
+        EngineError::from_source(
+            EngineErrorKind::OutOfMemory,
+            "unable to reserve document insert identity storage",
+            error,
+        )
+    })?;
+    for document in documents {
+        ensure_document_cpu_active(cancellation, control)?;
+        let id = document
+            .get_unique("_id")
+            .map_err(|error| error.into_engine_error(BsonErrorContext::ClientInput))?
+            .ok_or_else(|| {
+                EngineError::new(
+                    EngineErrorKind::InvalidArgument,
+                    "document inserts require an explicit _id",
+                )
+            })?;
+        let write = storage.prepare_document_write(document)?;
+        ensure_document_cpu_active(cancellation, control)?;
+        prepared.push(write);
+        ids.push(id.clone());
+    }
+    ensure_document_cpu_active(cancellation, control)?;
+    Ok((prepared, ids))
+}
+
+fn apply_point_read(
+    record: Option<DocumentStorageRecord>,
+    options: &DocumentReadOptions,
+    limits: ResultLimits,
+) -> EngineResult<Vec<BsonDocument>> {
+    let Some(record) = record else {
+        enforce_empty_result_limit(limits)?;
+        return Ok(Vec::new());
+    };
+    if options.skip() > 0 {
+        enforce_empty_result_limit(limits)?;
+        return Ok(Vec::new());
+    }
+    let mut bytes = DOCUMENT_RESULT_ENVELOPE_BYTES;
+    add_document_result_budget(&mut bytes, record.encoded_len(), limits)?;
+    if limits.max_rows() < 1 {
+        return Err(limit_exceeded(
+            "document result exceeds the request row limit",
+        ));
+    }
+    Ok(vec![record.into_document()])
+}
+
+fn apply_count_options(count: u64, options: &DocumentReadOptions) -> u64 {
+    count
+        .saturating_sub(options.skip())
+        .min(options.limit().unwrap_or(u64::MAX))
+}
+
+fn apply_slice_options<T: Clone>(
+    values: &[T],
+    options: &DocumentReadOptions,
+) -> EngineResult<Vec<T>> {
+    let skip = usize::try_from(options.skip()).unwrap_or(usize::MAX);
+    let take = usize::try_from(options.limit().unwrap_or(u64::MAX)).unwrap_or(usize::MAX);
+    let batch = usize::try_from(options.batch_size()).expect("bounded batch size fits usize");
+    if values.len().saturating_sub(skip) > batch && take > batch {
+        return Err(unsupported(
+            "document cursor continuation is not available yet; use a limit within one batch",
+        ));
+    }
+    Ok(values
+        .iter()
+        .skip(skip)
+        .take(take.min(batch))
+        .cloned()
+        .collect())
+}
+
+struct DocumentResultBudget {
+    rows: u64,
+    bytes: u64,
+    limits: ResultLimits,
+}
+
+impl DocumentResultBudget {
+    fn new(limits: ResultLimits) -> Self {
+        Self {
+            rows: 0,
+            bytes: DOCUMENT_RESULT_ENVELOPE_BYTES,
+            limits,
+        }
+    }
+
+    fn add_rows(&mut self, rows: usize) -> EngineResult<()> {
+        self.rows = self
+            .rows
+            .checked_add(u64::try_from(rows).unwrap_or(u64::MAX))
+            .ok_or_else(result_size_overflow)?;
+        if self.rows > self.limits.max_rows() {
+            return Err(limit_exceeded(
+                "document result exceeds the request row limit",
+            ));
+        }
+        Ok(())
+    }
+
+    fn add_bytes(&mut self, bytes: u64) -> EngineResult<()> {
+        self.bytes = self
+            .bytes
+            .checked_add(bytes)
+            .ok_or_else(result_size_overflow)?;
+        if self.bytes > self.limits.max_bytes() {
+            return Err(limit_exceeded(
+                "document result exceeds the request byte limit",
+            ));
+        }
+        Ok(())
+    }
+
+    fn add_document(
+        &mut self,
+        document: &BsonDocument,
+        check: &mut dyn FnMut() -> EngineResult<()>,
+    ) -> EngineResult<()> {
+        check()?;
+        let encoded = encode_document(document)
+            .map_err(|error| error.into_engine_error(BsonErrorContext::StoredData))?;
+        check()?;
+        self.add_bytes(DOCUMENT_RESULT_ROW_BYTES + DOCUMENT_RESULT_VALUE_BYTES)?;
+        self.add_bytes(u64::try_from(encoded.len()).unwrap_or(u64::MAX))
+    }
+
+    fn add_value(
+        &mut self,
+        value: &BsonValue,
+        check: &mut dyn FnMut() -> EngineResult<()>,
+    ) -> EngineResult<()> {
+        check()?;
+        let wrapper = BsonDocument::from_entries([("value", value.clone())])
+            .map_err(|error| error.into_engine_error(BsonErrorContext::StoredData))?;
+        check()?;
+        self.add_document(&wrapper, check)
+    }
+
+    fn add_index(
+        &mut self,
+        index: &DocumentIndexMetadata,
+        check: &mut dyn FnMut() -> EngineResult<()>,
+    ) -> EngineResult<()> {
+        check()?;
+        let specification = encode_document(index.specification())
+            .map_err(|error| error.into_engine_error(BsonErrorContext::StoredData))?;
+        check()?;
+        self.add_bytes(DOCUMENT_RESULT_VALUE_BYTES + 3)?;
+        self.add_bytes(u64::try_from(index.name().len()).unwrap_or(u64::MAX))?;
+        self.add_bytes(u64::try_from(specification.len()).unwrap_or(u64::MAX))
+    }
+
+    fn add_collection(
+        &mut self,
+        collection: &DocumentCollectionMetadata,
+        check: &mut dyn FnMut() -> EngineResult<()>,
+    ) -> EngineResult<()> {
+        check()?;
+        let options = encode_document(collection.options().document())
+            .map_err(|error| error.into_engine_error(BsonErrorContext::StoredData))?;
+        check()?;
+        self.add_bytes(DOCUMENT_RESULT_ROW_BYTES + 24)?;
+        self.add_bytes(u64::try_from(collection.namespace().len()).unwrap_or(u64::MAX))?;
+        self.add_bytes(u64::try_from(options.len()).unwrap_or(u64::MAX))?;
+        for index in collection.indexes() {
+            self.add_index(index, check)?;
+        }
+        Ok(())
+    }
+
+    fn add_plan(&mut self, plan: &DocumentPlan) -> EngineResult<()> {
+        match plan {
+            DocumentPlan::Point(plan) => {
+                self.add_bytes(DOCUMENT_RESULT_VALUE_BYTES + 10)?;
+                self.add_bytes(u64::try_from(plan.id_key().as_bytes().len()).unwrap_or(u64::MAX))
+            }
+            DocumentPlan::Scatter(plan) => {
+                self.add_bytes(DOCUMENT_RESULT_VALUE_BYTES + 8)?;
+                self.add_bytes(
+                    u64::try_from(plan.shards().len())
+                        .unwrap_or(u64::MAX)
+                        .saturating_mul(2),
+                )
+            }
+        }
+    }
+
+    fn finish(self) -> EngineResult<()> {
+        if self.bytes > self.limits.max_bytes() {
+            Err(limit_exceeded(
+                "document result exceeds the request byte limit",
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+fn enforce_execution_result_limits(
+    execution: &DocumentExecution,
+    limits: ResultLimits,
+) -> EngineResult<()> {
+    enforce_execution_result_limits_with_check(execution, limits, &mut || Ok(()))
+}
+
+fn enforce_execution_result_limits_controlled(
+    execution: &DocumentExecution,
+    limits: ResultLimits,
+    cancellation: &CancellationToken,
+    control: &OperationControl,
+) -> EngineResult<()> {
+    enforce_execution_result_limits_with_check(execution, limits, &mut || {
+        ensure_document_cpu_active(cancellation, control)
+    })
+}
+
+fn enforce_execution_result_limits_with_check(
+    execution: &DocumentExecution,
+    limits: ResultLimits,
+    check: &mut dyn FnMut() -> EngineResult<()>,
+) -> EngineResult<()> {
+    check()?;
+    let mut budget = DocumentResultBudget::new(limits);
+    if let Some(plan) = execution.plan() {
+        budget.add_plan(plan)?;
+        check()?;
+    }
+    match execution.result() {
+        DocumentResult::Acknowledged(_) | DocumentResult::CursorKilled(_) => {
+            budget.add_rows(1)?;
+            budget.add_bytes(DOCUMENT_RESULT_ROW_BYTES + DOCUMENT_RESULT_VALUE_BYTES + 1)?;
+        }
+        DocumentResult::Collection(collection) => {
+            budget.add_rows(1)?;
+            budget.add_collection(collection, check)?;
+        }
+        DocumentResult::Collections(collections) => {
+            budget.add_rows(collections.len())?;
+            for collection in collections {
+                budget.add_collection(collection, check)?;
+            }
+        }
+        DocumentResult::Document(document) => {
+            if let Some(document) = document {
+                budget.add_rows(1)?;
+                budget.add_document(document, check)?;
+            }
+        }
+        DocumentResult::Cursor(batch) => {
+            let namespace_bytes = batch
+                .namespace()
+                .database()
+                .len()
+                .saturating_add(1)
+                .saturating_add(batch.namespace().collection().len());
+            budget.add_bytes(u64::try_from(namespace_bytes).unwrap_or(u64::MAX) + 8)?;
+            budget.add_rows(batch.documents().len())?;
+            for document in batch.documents() {
+                budget.add_document(document, check)?;
+            }
+        }
+        DocumentResult::Count(_) | DocumentResult::Delete(_) => {
+            budget.add_rows(1)?;
+            budget.add_bytes(DOCUMENT_RESULT_ROW_BYTES + DOCUMENT_RESULT_VALUE_BYTES + 8)?;
+        }
+        DocumentResult::Distinct(values) => {
+            budget.add_rows(values.len())?;
+            for value in values {
+                budget.add_value(value, check)?;
+            }
+        }
+        DocumentResult::Insert(result) => {
+            budget.add_rows(result.inserted_ids().len())?;
+            for id in result.inserted_ids() {
+                budget.add_value(id, check)?;
+            }
+        }
+        DocumentResult::Update(result) => {
+            budget.add_rows(1)?;
+            budget.add_bytes(DOCUMENT_RESULT_ROW_BYTES + DOCUMENT_RESULT_VALUE_BYTES + 17)?;
+            if let Some(id) = result.upserted_id() {
+                budget.add_value(id, check)?;
+            }
+        }
+        DocumentResult::IndexName(name) => {
+            budget.add_rows(1)?;
+            budget.add_bytes(DOCUMENT_RESULT_ROW_BYTES + DOCUMENT_RESULT_VALUE_BYTES)?;
+            budget.add_bytes(u64::try_from(name.len()).unwrap_or(u64::MAX))?;
+        }
+        DocumentResult::Indexes(indexes) => {
+            budget.add_rows(indexes.len())?;
+            for index in indexes {
+                budget.add_index(index, check)?;
+            }
+        }
+    }
+    let result = budget.finish();
+    check()?;
+    result
+}
+
+fn enforce_create_collection_result_limits(
+    namespace: &DocumentNamespace,
+    options: &DocumentCollectionOptions,
+    limits: ResultLimits,
+) -> EngineResult<()> {
+    let mut budget = DocumentResultBudget::new(limits);
+    budget.add_rows(1)?;
+    let options = encode_document(options.document())
+        .map_err(|error| error.into_engine_error(BsonErrorContext::ClientInput))?;
+    let id_specification = BsonDocument::from_entries([("_id", BsonValue::Int32(1))])
+        .map_err(|error| error.into_engine_error(BsonErrorContext::ClientInput))?;
+    let id_specification = encode_document(&id_specification)
+        .map_err(|error| error.into_engine_error(BsonErrorContext::ClientInput))?;
+    let namespace_bytes = namespace
+        .database()
+        .len()
+        .saturating_add(1)
+        .saturating_add(namespace.collection().len());
+    budget.add_bytes(DOCUMENT_RESULT_ROW_BYTES + 24)?;
+    budget.add_bytes(u64::try_from(namespace_bytes).unwrap_or(u64::MAX))?;
+    budget.add_bytes(u64::try_from(options.len()).unwrap_or(u64::MAX))?;
+    budget.add_bytes(DOCUMENT_RESULT_VALUE_BYTES + 3)?;
+    budget.add_bytes(4)?;
+    budget.add_bytes(u64::try_from(id_specification.len()).unwrap_or(u64::MAX))?;
+    budget.finish()
+}
+
+fn enforce_prepared_write_budget(
+    prepared: &[PreparedDocumentWrite],
+    cancellation: &CancellationToken,
+    control: &OperationControl,
+) -> EngineResult<()> {
+    let mut bytes = 0_usize;
+    for prepared in prepared {
+        ensure_document_cpu_active(cancellation, control)?;
+        bytes = bytes
+            .checked_add(prepared.document_bson_len())
+            .filter(|bytes| *bytes <= MAX_DOCUMENT_REQUEST_BYTES)
+            .ok_or_else(|| {
+                limit_exceeded("prepared document writes exceed the request memory limit")
+            })?;
+    }
+    ensure_document_cpu_active(cancellation, control)?;
+    Ok(())
+}
+
+fn enforce_insert_execution_limits(
+    plan: &DocumentPlan,
+    ids: &[BsonValue],
+    limits: ResultLimits,
+    cancellation: &CancellationToken,
+    control: &OperationControl,
+) -> EngineResult<()> {
+    let mut budget = DocumentResultBudget::new(limits);
+    let mut check = || ensure_document_cpu_active(cancellation, control);
+    ensure_document_cpu_active(cancellation, control)?;
+    budget.add_plan(plan)?;
+    budget.add_rows(ids.len())?;
+    for id in ids {
+        ensure_document_cpu_active(cancellation, control)?;
+        budget.add_value(id, &mut check)?;
+        ensure_document_cpu_active(cancellation, control)?;
+    }
+    let result = budget.finish();
+    ensure_document_cpu_active(cancellation, control)?;
+    result
+}
+
+fn add_document_result_budget(
+    bytes: &mut u64,
+    document_len: usize,
+    limits: ResultLimits,
+) -> EngineResult<()> {
+    *bytes = bytes
+        .checked_add(DOCUMENT_RESULT_ROW_BYTES + DOCUMENT_RESULT_VALUE_BYTES)
+        .and_then(|value| value.checked_add(u64::try_from(document_len).ok()?))
+        .ok_or_else(result_size_overflow)?;
+    if *bytes > limits.max_bytes() {
+        return Err(limit_exceeded(
+            "document result exceeds the request byte limit",
+        ));
+    }
+    Ok(())
+}
+
+fn enforce_empty_result_limit(limits: ResultLimits) -> EngineResult<()> {
+    if DOCUMENT_RESULT_ENVELOPE_BYTES > limits.max_bytes() {
+        Err(limit_exceeded(
+            "document result exceeds the request byte limit",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn enforce_scalar_result_limit(limits: ResultLimits) -> EngineResult<()> {
+    if DOCUMENT_RESULT_ENVELOPE_BYTES + DOCUMENT_RESULT_VALUE_BYTES + 8 > limits.max_bytes() {
+        Err(limit_exceeded(
+            "document scalar result exceeds the request byte limit",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn execution_result_is_mutation(result: &DocumentResult) -> bool {
+    matches!(
+        result,
+        DocumentResult::Acknowledged(_)
+            | DocumentResult::Collection(_)
+            | DocumentResult::Insert(_)
+            | DocumentResult::Update(_)
+            | DocumentResult::Delete(_)
+            | DocumentResult::IndexName(_)
+            | DocumentResult::CursorKilled(_)
+    )
+}
+
+fn ensure_document_cpu_active(
+    cancellation: &CancellationToken,
+    control: &OperationControl,
+) -> EngineResult<()> {
+    if let Some(reason) = control.reason() {
+        return Err(reason.error());
+    }
+    if cancellation.is_cancelled() {
+        return Err(EngineError::new(
+            EngineErrorKind::Cancelled,
+            "the document request was cancelled during CPU-bound work",
+        ));
+    }
+    Ok(())
+}
+
+fn limit_exceeded(message: &'static str) -> EngineError {
+    EngineError::new(EngineErrorKind::LimitExceeded, message)
+}
+
+fn result_size_overflow() -> EngineError {
+    limit_exceeded("document result byte accounting overflowed")
+}
+
+fn unsupported(message: &'static str) -> EngineError {
+    EngineError::new(EngineErrorKind::Unsupported, message)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::Arc, time::Duration};
+
+    use tokio::{sync::oneshot, time::timeout};
+
+    use super::*;
+    use crate::{
+        core::{EngineOptions, RequestContext},
+        document::{DocumentCollectionOptions, DocumentCreateCollectionRequest, DocumentRequestId},
+        storage::SchemaGateState,
+    };
+
+    #[tokio::test]
+    async fn collection_creation_excludes_schema_operations_before_waiting_for_its_session() {
+        let temp = tempfile::tempdir().unwrap();
+        let engine = Engine::open_with_options(temp.path(), 2, EngineOptions::new(1, 1).unwrap())
+            .await
+            .unwrap();
+        let first_holder_session = Arc::new(engine.session());
+        let second_holder_session = Arc::new(engine.session());
+        let create_session = Arc::new(engine.session());
+        let (first_started_tx, first_started_rx) = oneshot::channel();
+        let (first_release_tx, first_release_rx) = std::sync::mpsc::channel();
+        let first_engine = engine.clone();
+        let first_session_for_task = Arc::clone(&first_holder_session);
+        let first_holder = tokio::spawn(async move {
+            first_engine
+                .hold_session_for_test(
+                    &first_session_for_task,
+                    0,
+                    first_started_tx,
+                    first_release_rx,
+                )
+                .await
+        });
+        let (second_started_tx, second_started_rx) = oneshot::channel();
+        let (second_release_tx, second_release_rx) = std::sync::mpsc::channel();
+        let second_engine = engine.clone();
+        let second_session_for_task = Arc::clone(&second_holder_session);
+        let second_holder = tokio::spawn(async move {
+            second_engine
+                .hold_session_for_test(
+                    &second_session_for_task,
+                    1,
+                    second_started_tx,
+                    second_release_rx,
+                )
+                .await
+        });
+        timeout(Duration::from_secs(2), first_started_rx)
+            .await
+            .unwrap()
+            .unwrap();
+        timeout(Duration::from_secs(2), second_started_rx)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let create_engine = engine.clone();
+        let create_session_for_task = Arc::clone(&create_session);
+        let create = tokio::spawn(async move {
+            let namespace = DocumentNamespace::new("app", "events").unwrap();
+            let command = DocumentCommand::CreateCollection(DocumentCreateCollectionRequest::new(
+                namespace,
+                DocumentCollectionOptions::empty(),
+                DocumentWriteOptions::new(),
+            ));
+            create_engine
+                .execute_document(
+                    &create_session_for_task,
+                    DocumentRequest::new(
+                        DocumentRequestId::new([1; 16]).unwrap(),
+                        RequestContext::new(),
+                        command,
+                    ),
+                )
+                .await
+        });
+
+        timeout(Duration::from_secs(2), async {
+            loop {
+                if engine.inner.database.storage.schema_gate_snapshot().state
+                    == SchemaGateState::Migrating
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("collection creation should exclude new schema operations before session wait");
+
+        let busy = timeout(Duration::from_secs(2), engine.status(&create_session))
+            .await
+            .expect("schema admission must fail before waiting for the creation session")
+            .unwrap_err();
+        assert_eq!(busy.kind(), EngineErrorKind::Busy);
+
+        first_release_tx.send(()).unwrap();
+        second_release_tx.send(()).unwrap();
+        first_holder.await.unwrap().unwrap();
+        second_holder.await.unwrap().unwrap();
+        let created = timeout(Duration::from_secs(2), create)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert!(matches!(created.result(), DocumentResult::Collection(_)));
+        engine.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn collection_creation_rejects_its_own_transaction_before_schema_quiescence() {
+        let temp = tempfile::tempdir().unwrap();
+        let engine = Engine::open(temp.path(), 2).await.unwrap();
+        let session = engine.session();
+        let schema = engine
+            .inner
+            .database
+            .storage
+            .enter_schema_operation()
+            .unwrap();
+        let lifecycle = engine.inner.lifecycle.try_acquire().unwrap();
+        session
+            .inner
+            .lock()
+            .await
+            .begin_transaction(crate::core::session::TransactionState::new(
+                lifecycle, schema,
+            ));
+
+        let command = DocumentCommand::CreateCollection(DocumentCreateCollectionRequest::new(
+            DocumentNamespace::new("app", "events").unwrap(),
+            DocumentCollectionOptions::empty(),
+            DocumentWriteOptions::new(),
+        ));
+        let error = timeout(
+            Duration::from_secs(2),
+            engine.execute_document(
+                &session,
+                DocumentRequest::new(
+                    DocumentRequestId::new([2; 16]).unwrap(),
+                    RequestContext::new(),
+                    command,
+                ),
+            ),
+        )
+        .await
+        .expect("collection creation must not wait on its own transaction schema guard")
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+
+        let transaction = session
+            .inner
+            .lock()
+            .await
+            .finish_transaction()
+            .expect("test session owns transaction state");
+        transaction.finish(false, None).unwrap();
+        engine.shutdown().await.unwrap();
+    }
+}

--- a/src/document/command.rs
+++ b/src/document/command.rs
@@ -1,0 +1,1307 @@
+//! Owned commands accepted by the protocol-neutral document engine.
+
+use std::fmt;
+
+use crate::core::{EngineError, EngineErrorKind, EngineResult, RequestContext};
+
+use super::{
+    BsonDocument, BsonErrorContext, DocumentCollectionOptions, DocumentFilter, DocumentPipeline,
+    DocumentReadOptions, DocumentUpdate, DocumentWriteOptions, MAX_DOCUMENT_BATCH_SIZE,
+    MAX_DOCUMENT_REQUEST_BYTES, encode_document, validate_namespace,
+};
+
+/// Maximum UTF-8 byte length of a user-defined document index name.
+pub const MAX_DOCUMENT_INDEX_NAME_BYTES: usize = 255;
+
+fn invalid_argument(message: impl Into<String>) -> EngineError {
+    EngineError::new(EngineErrorKind::InvalidArgument, message)
+}
+
+fn validate_document(document: &BsonDocument) -> EngineResult<()> {
+    encode_document(document)
+        .map(|_| ())
+        .map_err(|error| error.into_engine_error(BsonErrorContext::ClientInput))
+}
+
+fn validate_database_name(database: &str) -> EngineResult<()> {
+    validate_namespace(database, "_")
+}
+
+fn validate_index_name(name: &str) -> EngineResult<()> {
+    if name.is_empty() || name.len() > MAX_DOCUMENT_INDEX_NAME_BYTES || name.contains('\0') {
+        return Err(invalid_argument(format!(
+            "document index name must contain 1 to {MAX_DOCUMENT_INDEX_NAME_BYTES} UTF-8 bytes and no NUL"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_field_path(path: &str) -> EngineResult<()> {
+    if path.is_empty() || path.contains('\0') {
+        return Err(invalid_argument(
+            "document field path must be nonempty and contain no NUL",
+        ));
+    }
+    Ok(())
+}
+
+/// Exact, case-sensitive identity of one logical document collection.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct DocumentNamespace {
+    database: String,
+    collection: String,
+}
+
+impl DocumentNamespace {
+    /// Validate and own one database and collection name.
+    pub fn new(database: impl Into<String>, collection: impl Into<String>) -> EngineResult<Self> {
+        let database = database.into();
+        let collection = collection.into();
+        validate_namespace(&database, &collection)?;
+        Ok(Self {
+            database,
+            collection,
+        })
+    }
+
+    pub fn database(&self) -> &str {
+        &self.database
+    }
+
+    pub fn collection(&self) -> &str {
+        &self.collection
+    }
+
+    pub fn into_parts(self) -> (String, String) {
+        (self.database, self.collection)
+    }
+}
+
+impl fmt::Display for DocumentNamespace {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}.{}", self.database, self.collection)
+    }
+}
+
+/// Caller-owned identity of one document request.
+///
+/// A retry can reuse the same identity for logs and observability. This type
+/// alone does not promise write idempotency.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct DocumentRequestId([u8; 16]);
+
+impl DocumentRequestId {
+    /// Validate a nonzero 128-bit request identity.
+    pub fn new(value: [u8; 16]) -> EngineResult<Self> {
+        if value == [0; 16] {
+            return Err(invalid_argument(
+                "document request IDs must not be all zero",
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    pub const fn as_bytes(self) -> [u8; 16] {
+        self.0
+    }
+}
+
+impl fmt::Debug for DocumentRequestId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_tuple("DocumentRequestId")
+            .field(&format_args!("{:02x}{:02x}…", self.0[0], self.0[1]))
+            .finish()
+    }
+}
+
+/// Opaque identity of a live engine-owned document cursor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct DocumentCursorId(u64);
+
+impl DocumentCursorId {
+    pub fn new(value: u64) -> EngineResult<Self> {
+        if value == 0 {
+            return Err(invalid_argument("document cursor IDs must be positive"));
+        }
+        Ok(Self(value))
+    }
+
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+/// Whether a mutation stops after its first match or visits every match.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DocumentMutationScope {
+    One,
+    Many,
+}
+
+/// Owned declaration for one document index.
+#[derive(Clone, PartialEq, Eq)]
+pub struct DocumentIndexRequest {
+    keys: BsonDocument,
+    name: Option<String>,
+    unique: bool,
+    sparse: bool,
+    partial_filter: Option<DocumentFilter>,
+}
+
+impl DocumentIndexRequest {
+    /// Validate and own an ordered BSON key specification.
+    pub fn new(keys: BsonDocument) -> EngineResult<Self> {
+        validate_document(&keys)?;
+        Ok(Self {
+            keys,
+            name: None,
+            unique: false,
+            sparse: false,
+            partial_filter: None,
+        })
+    }
+
+    pub fn with_name(mut self, name: impl Into<String>) -> EngineResult<Self> {
+        let name = name.into();
+        validate_index_name(&name)?;
+        self.name = Some(name);
+        Ok(self)
+    }
+
+    #[must_use]
+    pub const fn with_unique(mut self, unique: bool) -> Self {
+        self.unique = unique;
+        self
+    }
+
+    #[must_use]
+    pub const fn with_sparse(mut self, sparse: bool) -> Self {
+        self.sparse = sparse;
+        self
+    }
+
+    #[must_use]
+    pub fn with_partial_filter(mut self, filter: DocumentFilter) -> Self {
+        self.partial_filter = Some(filter);
+        self
+    }
+
+    pub const fn keys(&self) -> &BsonDocument {
+        &self.keys
+    }
+
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_deref()
+    }
+
+    pub const fn unique(&self) -> bool {
+        self.unique
+    }
+
+    pub const fn sparse(&self) -> bool {
+        self.sparse
+    }
+
+    pub const fn partial_filter(&self) -> Option<&DocumentFilter> {
+        self.partial_filter.as_ref()
+    }
+
+    pub fn into_parts(
+        self,
+    ) -> (
+        BsonDocument,
+        Option<String>,
+        bool,
+        bool,
+        Option<DocumentFilter>,
+    ) {
+        (
+            self.keys,
+            self.name,
+            self.unique,
+            self.sparse,
+            self.partial_filter,
+        )
+    }
+}
+
+impl fmt::Debug for DocumentIndexRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DocumentIndexRequest")
+            .field("keys", &"<redacted>")
+            .field("name", &self.name)
+            .field("unique", &self.unique)
+            .field("sparse", &self.sparse)
+            .field(
+                "partial_filter",
+                &self.partial_filter.as_ref().map(|_| "<redacted>"),
+            )
+            .finish()
+    }
+}
+
+/// Request to create one collection if its namespace is absent.
+#[non_exhaustive]
+#[derive(Clone, PartialEq, Eq)]
+pub struct DocumentCreateCollectionRequest {
+    namespace: DocumentNamespace,
+    options: DocumentCollectionOptions,
+    write_options: DocumentWriteOptions,
+}
+
+impl DocumentCreateCollectionRequest {
+    pub fn new(
+        namespace: DocumentNamespace,
+        options: DocumentCollectionOptions,
+        write_options: DocumentWriteOptions,
+    ) -> Self {
+        Self {
+            namespace,
+            options,
+            write_options,
+        }
+    }
+
+    pub const fn namespace(&self) -> &DocumentNamespace {
+        &self.namespace
+    }
+
+    pub const fn options(&self) -> &DocumentCollectionOptions {
+        &self.options
+    }
+
+    pub const fn write_options(&self) -> DocumentWriteOptions {
+        self.write_options
+    }
+
+    pub fn into_parts(
+        self,
+    ) -> (
+        DocumentNamespace,
+        DocumentCollectionOptions,
+        DocumentWriteOptions,
+    ) {
+        (self.namespace, self.options, self.write_options)
+    }
+}
+
+impl fmt::Debug for DocumentCreateCollectionRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DocumentCreateCollectionRequest")
+            .field("namespace", &self.namespace)
+            .field("options", &"<redacted>")
+            .field("write_options", &self.write_options)
+            .finish()
+    }
+}
+
+/// Request to list collections in one validated database name.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocumentListCollectionsRequest {
+    database: String,
+    read_options: DocumentReadOptions,
+}
+
+impl DocumentListCollectionsRequest {
+    pub fn new(
+        database: impl Into<String>,
+        read_options: DocumentReadOptions,
+    ) -> EngineResult<Self> {
+        let database = database.into();
+        validate_database_name(&database)?;
+        Ok(Self {
+            database,
+            read_options,
+        })
+    }
+
+    pub fn database(&self) -> &str {
+        &self.database
+    }
+
+    pub const fn read_options(&self) -> &DocumentReadOptions {
+        &self.read_options
+    }
+
+    pub fn into_parts(self) -> (String, DocumentReadOptions) {
+        (self.database, self.read_options)
+    }
+}
+
+macro_rules! namespace_options_request {
+    (
+        $(#[$meta:meta])*
+        $name:ident,
+        $options_ty:ty,
+        $field:ident,
+        $getter:ident
+    ) => {
+        $(#[$meta])*
+        #[non_exhaustive]
+        #[derive(Clone, PartialEq, Eq)]
+        pub struct $name {
+            namespace: DocumentNamespace,
+            $field: $options_ty,
+        }
+
+        impl $name {
+            pub fn new(namespace: DocumentNamespace, $field: $options_ty) -> Self {
+                Self { namespace, $field }
+            }
+
+            pub const fn namespace(&self) -> &DocumentNamespace {
+                &self.namespace
+            }
+
+            pub const fn $getter(&self) -> &$options_ty {
+                &self.$field
+            }
+
+            pub fn into_parts(self) -> (DocumentNamespace, $options_ty) {
+                (self.namespace, self.$field)
+            }
+        }
+
+        impl fmt::Debug for $name {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter
+                    .debug_struct(stringify!($name))
+                    .field("namespace", &self.namespace)
+                    .field(stringify!($field), &self.$field)
+                    .finish()
+            }
+        }
+    };
+}
+
+namespace_options_request!(
+    /// Request to drop one collection.
+    DocumentDropCollectionRequest,
+    DocumentWriteOptions,
+    write_options,
+    write_options
+);
+namespace_options_request!(
+    /// Request to list index metadata for one collection.
+    DocumentListIndexesRequest,
+    DocumentReadOptions,
+    read_options,
+    read_options
+);
+
+macro_rules! filter_read_request {
+    ($(#[$meta:meta])* $name:ident) => {
+        $(#[$meta])*
+        #[non_exhaustive]
+        #[derive(Clone, PartialEq, Eq)]
+        pub struct $name {
+            namespace: DocumentNamespace,
+            filter: DocumentFilter,
+            read_options: DocumentReadOptions,
+        }
+
+        impl $name {
+            pub fn new(
+                namespace: DocumentNamespace,
+                filter: DocumentFilter,
+                read_options: DocumentReadOptions,
+            ) -> Self {
+                Self {
+                    namespace,
+                    filter,
+                    read_options,
+                }
+            }
+
+            pub const fn namespace(&self) -> &DocumentNamespace {
+                &self.namespace
+            }
+
+            pub const fn filter(&self) -> &DocumentFilter {
+                &self.filter
+            }
+
+            pub const fn read_options(&self) -> &DocumentReadOptions {
+                &self.read_options
+            }
+
+            pub fn into_parts(
+                self,
+            ) -> (DocumentNamespace, DocumentFilter, DocumentReadOptions) {
+                (self.namespace, self.filter, self.read_options)
+            }
+        }
+
+        impl fmt::Debug for $name {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter
+                    .debug_struct(stringify!($name))
+                    .field("namespace", &self.namespace)
+                    .field("filter", &"<redacted>")
+                    .field("read_options", &self.read_options)
+                    .finish()
+            }
+        }
+    };
+}
+
+filter_read_request!(
+    /// Request to read an ordered batch of matching documents.
+    DocumentFindRequest
+);
+filter_read_request!(
+    /// Request to count matching documents.
+    DocumentCountRequest
+);
+
+/// Request to run an owned aggregation pipeline.
+#[non_exhaustive]
+#[derive(Clone, PartialEq, Eq)]
+pub struct DocumentAggregateRequest {
+    namespace: DocumentNamespace,
+    pipeline: DocumentPipeline,
+    read_options: DocumentReadOptions,
+}
+
+impl DocumentAggregateRequest {
+    pub fn new(
+        namespace: DocumentNamespace,
+        pipeline: DocumentPipeline,
+        read_options: DocumentReadOptions,
+    ) -> EngineResult<Self> {
+        let mut encoded_bytes = 0_usize;
+        for stage in pipeline.stages() {
+            add_request_payload_bytes(&mut encoded_bytes, stage)?;
+        }
+        if let Some(projection) = read_options.projection() {
+            add_request_payload_bytes(&mut encoded_bytes, projection.document())?;
+        }
+        if let Some(sort) = read_options.sort() {
+            add_request_payload_bytes(&mut encoded_bytes, sort.document())?;
+        }
+        Ok(Self {
+            namespace,
+            pipeline,
+            read_options,
+        })
+    }
+
+    pub const fn namespace(&self) -> &DocumentNamespace {
+        &self.namespace
+    }
+
+    pub const fn pipeline(&self) -> &DocumentPipeline {
+        &self.pipeline
+    }
+
+    pub const fn read_options(&self) -> &DocumentReadOptions {
+        &self.read_options
+    }
+
+    pub fn into_parts(self) -> (DocumentNamespace, DocumentPipeline, DocumentReadOptions) {
+        (self.namespace, self.pipeline, self.read_options)
+    }
+}
+
+fn add_request_payload_bytes(total: &mut usize, document: &BsonDocument) -> EngineResult<()> {
+    let encoded = encode_document(document)
+        .map_err(|error| error.into_engine_error(BsonErrorContext::ClientInput))?;
+    add_request_payload_len(total, encoded.len())
+}
+
+fn add_request_payload_len(total: &mut usize, length: usize) -> EngineResult<()> {
+    *total = total
+        .checked_add(length)
+        .filter(|bytes| *bytes <= MAX_DOCUMENT_REQUEST_BYTES)
+        .ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::LimitExceeded,
+                format!("document request exceeds {MAX_DOCUMENT_REQUEST_BYTES} encoded BSON bytes"),
+            )
+        })?;
+    Ok(())
+}
+
+impl fmt::Debug for DocumentAggregateRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DocumentAggregateRequest")
+            .field("namespace", &self.namespace)
+            .field("pipeline", &"<redacted>")
+            .field("read_options", &self.read_options)
+            .finish()
+    }
+}
+
+/// Request to return distinct values for one field path.
+#[non_exhaustive]
+#[derive(Clone, PartialEq, Eq)]
+pub struct DocumentDistinctRequest {
+    namespace: DocumentNamespace,
+    field: String,
+    filter: DocumentFilter,
+    read_options: DocumentReadOptions,
+}
+
+impl DocumentDistinctRequest {
+    pub fn new(
+        namespace: DocumentNamespace,
+        field: impl Into<String>,
+        filter: DocumentFilter,
+        read_options: DocumentReadOptions,
+    ) -> EngineResult<Self> {
+        let field = field.into();
+        validate_field_path(&field)?;
+        Ok(Self {
+            namespace,
+            field,
+            filter,
+            read_options,
+        })
+    }
+
+    pub const fn namespace(&self) -> &DocumentNamespace {
+        &self.namespace
+    }
+
+    pub fn field(&self) -> &str {
+        &self.field
+    }
+
+    pub const fn filter(&self) -> &DocumentFilter {
+        &self.filter
+    }
+
+    pub const fn read_options(&self) -> &DocumentReadOptions {
+        &self.read_options
+    }
+
+    pub fn into_parts(
+        self,
+    ) -> (
+        DocumentNamespace,
+        String,
+        DocumentFilter,
+        DocumentReadOptions,
+    ) {
+        (self.namespace, self.field, self.filter, self.read_options)
+    }
+}
+
+impl fmt::Debug for DocumentDistinctRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DocumentDistinctRequest")
+            .field("namespace", &self.namespace)
+            .field("field", &self.field)
+            .field("filter", &"<redacted>")
+            .field("read_options", &self.read_options)
+            .finish()
+    }
+}
+
+/// Request to insert one or more BSON documents in input order.
+#[non_exhaustive]
+#[derive(Clone, PartialEq, Eq)]
+pub struct DocumentInsertRequest {
+    namespace: DocumentNamespace,
+    documents: Box<[BsonDocument]>,
+    write_options: DocumentWriteOptions,
+}
+
+impl DocumentInsertRequest {
+    pub fn new(
+        namespace: DocumentNamespace,
+        documents: impl Into<Vec<BsonDocument>>,
+        write_options: DocumentWriteOptions,
+    ) -> EngineResult<Self> {
+        let documents = documents.into();
+        if documents.is_empty() {
+            return Err(invalid_argument(
+                "document insert request must contain at least one document",
+            ));
+        }
+        if documents.len() as u64 > MAX_DOCUMENT_BATCH_SIZE {
+            return Err(EngineError::new(
+                EngineErrorKind::LimitExceeded,
+                format!(
+                    "document insert request must not exceed {MAX_DOCUMENT_BATCH_SIZE} documents"
+                ),
+            ));
+        }
+        let mut encoded_bytes = 0_usize;
+        for document in &documents {
+            let encoded = encode_document(document)
+                .map_err(|error| error.into_engine_error(BsonErrorContext::ClientInput))?;
+            encoded_bytes = encoded_bytes
+                .checked_add(encoded.len())
+                .filter(|bytes| *bytes <= MAX_DOCUMENT_REQUEST_BYTES)
+                .ok_or_else(|| {
+                    EngineError::new(
+                        EngineErrorKind::LimitExceeded,
+                        format!(
+                            "document insert request exceeds {MAX_DOCUMENT_REQUEST_BYTES} encoded BSON bytes"
+                        ),
+                    )
+                })?;
+        }
+        Ok(Self {
+            namespace,
+            documents: documents.into_boxed_slice(),
+            write_options,
+        })
+    }
+
+    pub const fn namespace(&self) -> &DocumentNamespace {
+        &self.namespace
+    }
+
+    pub fn documents(&self) -> &[BsonDocument] {
+        &self.documents
+    }
+
+    pub const fn write_options(&self) -> DocumentWriteOptions {
+        self.write_options
+    }
+
+    pub fn into_parts(self) -> (DocumentNamespace, Vec<BsonDocument>, DocumentWriteOptions) {
+        (
+            self.namespace,
+            self.documents.into_vec(),
+            self.write_options,
+        )
+    }
+}
+
+impl fmt::Debug for DocumentInsertRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DocumentInsertRequest")
+            .field("namespace", &self.namespace)
+            .field("document_count", &self.documents.len())
+            .field("documents", &"<redacted>")
+            .field("write_options", &self.write_options)
+            .finish()
+    }
+}
+
+/// Request to apply an update expression to one or many matching documents.
+#[non_exhaustive]
+#[derive(Clone, PartialEq, Eq)]
+pub struct DocumentUpdateRequest {
+    namespace: DocumentNamespace,
+    filter: DocumentFilter,
+    update: DocumentUpdate,
+    scope: DocumentMutationScope,
+    write_options: DocumentWriteOptions,
+}
+
+impl DocumentUpdateRequest {
+    pub fn new(
+        namespace: DocumentNamespace,
+        filter: DocumentFilter,
+        update: DocumentUpdate,
+        scope: DocumentMutationScope,
+        write_options: DocumentWriteOptions,
+    ) -> Self {
+        Self {
+            namespace,
+            filter,
+            update,
+            scope,
+            write_options,
+        }
+    }
+
+    pub const fn namespace(&self) -> &DocumentNamespace {
+        &self.namespace
+    }
+
+    pub const fn filter(&self) -> &DocumentFilter {
+        &self.filter
+    }
+
+    pub const fn update(&self) -> &DocumentUpdate {
+        &self.update
+    }
+
+    pub const fn scope(&self) -> DocumentMutationScope {
+        self.scope
+    }
+
+    pub const fn write_options(&self) -> DocumentWriteOptions {
+        self.write_options
+    }
+
+    pub fn into_parts(
+        self,
+    ) -> (
+        DocumentNamespace,
+        DocumentFilter,
+        DocumentUpdate,
+        DocumentMutationScope,
+        DocumentWriteOptions,
+    ) {
+        (
+            self.namespace,
+            self.filter,
+            self.update,
+            self.scope,
+            self.write_options,
+        )
+    }
+}
+
+impl fmt::Debug for DocumentUpdateRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DocumentUpdateRequest")
+            .field("namespace", &self.namespace)
+            .field("filter", &"<redacted>")
+            .field("update", &"<redacted>")
+            .field("scope", &self.scope)
+            .field("write_options", &self.write_options)
+            .finish()
+    }
+}
+
+/// Request to replace the first matching document.
+#[non_exhaustive]
+#[derive(Clone, PartialEq, Eq)]
+pub struct DocumentReplaceRequest {
+    namespace: DocumentNamespace,
+    filter: DocumentFilter,
+    replacement: BsonDocument,
+    write_options: DocumentWriteOptions,
+}
+
+impl DocumentReplaceRequest {
+    pub fn new(
+        namespace: DocumentNamespace,
+        filter: DocumentFilter,
+        replacement: BsonDocument,
+        write_options: DocumentWriteOptions,
+    ) -> EngineResult<Self> {
+        validate_document(&replacement)?;
+        Ok(Self {
+            namespace,
+            filter,
+            replacement,
+            write_options,
+        })
+    }
+
+    pub const fn namespace(&self) -> &DocumentNamespace {
+        &self.namespace
+    }
+
+    pub const fn filter(&self) -> &DocumentFilter {
+        &self.filter
+    }
+
+    pub const fn replacement(&self) -> &BsonDocument {
+        &self.replacement
+    }
+
+    pub const fn write_options(&self) -> DocumentWriteOptions {
+        self.write_options
+    }
+
+    pub fn into_parts(
+        self,
+    ) -> (
+        DocumentNamespace,
+        DocumentFilter,
+        BsonDocument,
+        DocumentWriteOptions,
+    ) {
+        (
+            self.namespace,
+            self.filter,
+            self.replacement,
+            self.write_options,
+        )
+    }
+}
+
+impl fmt::Debug for DocumentReplaceRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DocumentReplaceRequest")
+            .field("namespace", &self.namespace)
+            .field("filter", &"<redacted>")
+            .field("replacement", &"<redacted>")
+            .field("write_options", &self.write_options)
+            .finish()
+    }
+}
+
+/// Request to delete one or many matching documents.
+#[non_exhaustive]
+#[derive(Clone, PartialEq, Eq)]
+pub struct DocumentDeleteRequest {
+    namespace: DocumentNamespace,
+    filter: DocumentFilter,
+    scope: DocumentMutationScope,
+    write_options: DocumentWriteOptions,
+}
+
+impl DocumentDeleteRequest {
+    pub fn new(
+        namespace: DocumentNamespace,
+        filter: DocumentFilter,
+        scope: DocumentMutationScope,
+        write_options: DocumentWriteOptions,
+    ) -> Self {
+        Self {
+            namespace,
+            filter,
+            scope,
+            write_options,
+        }
+    }
+
+    pub const fn namespace(&self) -> &DocumentNamespace {
+        &self.namespace
+    }
+
+    pub const fn filter(&self) -> &DocumentFilter {
+        &self.filter
+    }
+
+    pub const fn scope(&self) -> DocumentMutationScope {
+        self.scope
+    }
+
+    pub const fn write_options(&self) -> DocumentWriteOptions {
+        self.write_options
+    }
+
+    pub fn into_parts(
+        self,
+    ) -> (
+        DocumentNamespace,
+        DocumentFilter,
+        DocumentMutationScope,
+        DocumentWriteOptions,
+    ) {
+        (self.namespace, self.filter, self.scope, self.write_options)
+    }
+}
+
+impl fmt::Debug for DocumentDeleteRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DocumentDeleteRequest")
+            .field("namespace", &self.namespace)
+            .field("filter", &"<redacted>")
+            .field("scope", &self.scope)
+            .field("write_options", &self.write_options)
+            .finish()
+    }
+}
+
+/// Request to declare one index.
+#[non_exhaustive]
+#[derive(Clone, PartialEq, Eq)]
+pub struct DocumentCreateIndexRequest {
+    namespace: DocumentNamespace,
+    index: DocumentIndexRequest,
+    write_options: DocumentWriteOptions,
+}
+
+impl DocumentCreateIndexRequest {
+    pub fn new(
+        namespace: DocumentNamespace,
+        index: DocumentIndexRequest,
+        write_options: DocumentWriteOptions,
+    ) -> Self {
+        Self {
+            namespace,
+            index,
+            write_options,
+        }
+    }
+
+    pub const fn namespace(&self) -> &DocumentNamespace {
+        &self.namespace
+    }
+
+    pub const fn index(&self) -> &DocumentIndexRequest {
+        &self.index
+    }
+
+    pub const fn write_options(&self) -> DocumentWriteOptions {
+        self.write_options
+    }
+
+    pub fn into_parts(
+        self,
+    ) -> (
+        DocumentNamespace,
+        DocumentIndexRequest,
+        DocumentWriteOptions,
+    ) {
+        (self.namespace, self.index, self.write_options)
+    }
+}
+
+impl fmt::Debug for DocumentCreateIndexRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DocumentCreateIndexRequest")
+            .field("namespace", &self.namespace)
+            .field("index", &self.index)
+            .field("write_options", &self.write_options)
+            .finish()
+    }
+}
+
+/// Request to drop one named index.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocumentDropIndexRequest {
+    namespace: DocumentNamespace,
+    name: String,
+    write_options: DocumentWriteOptions,
+}
+
+impl DocumentDropIndexRequest {
+    pub fn new(
+        namespace: DocumentNamespace,
+        name: impl Into<String>,
+        write_options: DocumentWriteOptions,
+    ) -> EngineResult<Self> {
+        let name = name.into();
+        validate_index_name(&name)?;
+        Ok(Self {
+            namespace,
+            name,
+            write_options,
+        })
+    }
+
+    pub const fn namespace(&self) -> &DocumentNamespace {
+        &self.namespace
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub const fn write_options(&self) -> DocumentWriteOptions {
+        self.write_options
+    }
+
+    pub fn into_parts(self) -> (DocumentNamespace, String, DocumentWriteOptions) {
+        (self.namespace, self.name, self.write_options)
+    }
+}
+
+/// Request the next batch from one cursor.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocumentContinueCursorRequest {
+    namespace: DocumentNamespace,
+    cursor_id: DocumentCursorId,
+    read_options: DocumentReadOptions,
+}
+
+impl DocumentContinueCursorRequest {
+    pub fn new(
+        namespace: DocumentNamespace,
+        cursor_id: DocumentCursorId,
+        read_options: DocumentReadOptions,
+    ) -> Self {
+        Self {
+            namespace,
+            cursor_id,
+            read_options,
+        }
+    }
+
+    pub const fn namespace(&self) -> &DocumentNamespace {
+        &self.namespace
+    }
+
+    pub const fn cursor_id(&self) -> DocumentCursorId {
+        self.cursor_id
+    }
+
+    pub const fn read_options(&self) -> &DocumentReadOptions {
+        &self.read_options
+    }
+
+    pub fn into_parts(self) -> (DocumentNamespace, DocumentCursorId, DocumentReadOptions) {
+        (self.namespace, self.cursor_id, self.read_options)
+    }
+}
+
+/// Request to discard one live cursor.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocumentKillCursorRequest {
+    namespace: DocumentNamespace,
+    cursor_id: DocumentCursorId,
+    write_options: DocumentWriteOptions,
+}
+
+impl DocumentKillCursorRequest {
+    pub fn new(
+        namespace: DocumentNamespace,
+        cursor_id: DocumentCursorId,
+        write_options: DocumentWriteOptions,
+    ) -> Self {
+        Self {
+            namespace,
+            cursor_id,
+            write_options,
+        }
+    }
+
+    pub const fn namespace(&self) -> &DocumentNamespace {
+        &self.namespace
+    }
+
+    pub const fn cursor_id(&self) -> DocumentCursorId {
+        self.cursor_id
+    }
+
+    pub const fn write_options(&self) -> DocumentWriteOptions {
+        self.write_options
+    }
+
+    pub fn into_parts(self) -> (DocumentNamespace, DocumentCursorId, DocumentWriteOptions) {
+        (self.namespace, self.cursor_id, self.write_options)
+    }
+}
+
+/// Stable, payload-free classification of a document command.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DocumentCommandKind {
+    CreateCollection,
+    ListCollections,
+    DropCollection,
+    Find,
+    Aggregate,
+    Count,
+    Distinct,
+    Insert,
+    Update,
+    Replace,
+    Delete,
+    CreateIndex,
+    DropIndex,
+    ListIndexes,
+    ContinueCursor,
+    KillCursor,
+}
+
+/// One protocol-neutral document command with all payloads owned.
+#[non_exhaustive]
+#[derive(Clone, PartialEq, Eq)]
+pub enum DocumentCommand {
+    CreateCollection(DocumentCreateCollectionRequest),
+    ListCollections(DocumentListCollectionsRequest),
+    DropCollection(DocumentDropCollectionRequest),
+    Find(DocumentFindRequest),
+    Aggregate(DocumentAggregateRequest),
+    Count(DocumentCountRequest),
+    Distinct(DocumentDistinctRequest),
+    Insert(DocumentInsertRequest),
+    Update(DocumentUpdateRequest),
+    Replace(DocumentReplaceRequest),
+    Delete(DocumentDeleteRequest),
+    CreateIndex(DocumentCreateIndexRequest),
+    DropIndex(DocumentDropIndexRequest),
+    ListIndexes(DocumentListIndexesRequest),
+    ContinueCursor(DocumentContinueCursorRequest),
+    KillCursor(DocumentKillCursorRequest),
+}
+
+impl DocumentCommand {
+    pub const fn kind(&self) -> DocumentCommandKind {
+        match self {
+            Self::CreateCollection(_) => DocumentCommandKind::CreateCollection,
+            Self::ListCollections(_) => DocumentCommandKind::ListCollections,
+            Self::DropCollection(_) => DocumentCommandKind::DropCollection,
+            Self::Find(_) => DocumentCommandKind::Find,
+            Self::Aggregate(_) => DocumentCommandKind::Aggregate,
+            Self::Count(_) => DocumentCommandKind::Count,
+            Self::Distinct(_) => DocumentCommandKind::Distinct,
+            Self::Insert(_) => DocumentCommandKind::Insert,
+            Self::Update(_) => DocumentCommandKind::Update,
+            Self::Replace(_) => DocumentCommandKind::Replace,
+            Self::Delete(_) => DocumentCommandKind::Delete,
+            Self::CreateIndex(_) => DocumentCommandKind::CreateIndex,
+            Self::DropIndex(_) => DocumentCommandKind::DropIndex,
+            Self::ListIndexes(_) => DocumentCommandKind::ListIndexes,
+            Self::ContinueCursor(_) => DocumentCommandKind::ContinueCursor,
+            Self::KillCursor(_) => DocumentCommandKind::KillCursor,
+        }
+    }
+}
+
+impl fmt::Debug for DocumentCommand {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DocumentCommand")
+            .field("kind", &self.kind())
+            .field("payload", &"<redacted>")
+            .finish()
+    }
+}
+
+/// One document command together with its identity, cancellation, deadline,
+/// and result-limit controls.
+#[derive(Clone)]
+pub struct DocumentRequest {
+    request_id: DocumentRequestId,
+    context: RequestContext,
+    command: DocumentCommand,
+}
+
+impl DocumentRequest {
+    pub fn new(
+        request_id: DocumentRequestId,
+        context: RequestContext,
+        command: DocumentCommand,
+    ) -> Self {
+        Self {
+            request_id,
+            context,
+            command,
+        }
+    }
+
+    pub const fn request_id(&self) -> DocumentRequestId {
+        self.request_id
+    }
+
+    pub const fn context(&self) -> &RequestContext {
+        &self.context
+    }
+
+    pub const fn command(&self) -> &DocumentCommand {
+        &self.command
+    }
+
+    pub fn into_parts(self) -> (DocumentRequestId, RequestContext, DocumentCommand) {
+        (self.request_id, self.context, self.command)
+    }
+}
+
+impl fmt::Debug for DocumentRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DocumentRequest")
+            .field("request_id", &self.request_id)
+            .field("context", &self.context)
+            .field("command_kind", &self.command.kind())
+            .field("command", &"<redacted>")
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::BsonValue;
+    use super::*;
+
+    fn namespace() -> DocumentNamespace {
+        DocumentNamespace::new("database", "records").unwrap()
+    }
+
+    fn secret_document() -> BsonDocument {
+        BsonDocument::from_entries([("token", BsonValue::from("private-token"))]).unwrap()
+    }
+
+    #[test]
+    fn namespace_and_request_ids_are_validated() {
+        assert!(DocumentNamespace::new("", "records").is_err());
+        assert!(DocumentNamespace::new("database", "").is_err());
+        let namespace = namespace();
+        assert_eq!(namespace.to_string(), "database.records");
+        assert!(DocumentRequestId::new([0; 16]).is_err());
+        assert!(DocumentCursorId::new(0).is_err());
+        assert_eq!(DocumentCursorId::new(7).unwrap().get(), 7);
+    }
+
+    #[test]
+    fn request_owns_controls_and_redacts_command_payload() {
+        fn assert_owned<T: Clone + Send + Sync + 'static>() {}
+        assert_owned::<DocumentRequest>();
+
+        let insert = DocumentInsertRequest::new(
+            namespace(),
+            vec![secret_document()],
+            DocumentWriteOptions::new(),
+        )
+        .unwrap();
+        let request = DocumentRequest::new(
+            DocumentRequestId::new([9; 16]).unwrap(),
+            RequestContext::new(),
+            DocumentCommand::Insert(insert),
+        );
+        assert_eq!(request.command().kind(), DocumentCommandKind::Insert);
+        let debug = format!("{request:?} {:?}", request.command());
+        assert!(debug.contains("Insert"));
+        assert!(!debug.contains("private-token"));
+    }
+
+    #[test]
+    fn aggregate_request_payload_accounting_is_whole_request_bounded() {
+        let mut total = 0;
+        add_request_payload_len(&mut total, MAX_DOCUMENT_REQUEST_BYTES).unwrap();
+        assert_eq!(total, MAX_DOCUMENT_REQUEST_BYTES);
+        assert!(add_request_payload_len(&mut total, 1).is_err());
+    }
+
+    #[test]
+    fn typed_payloads_round_trip_through_request_parts() {
+        let filter = DocumentFilter::new(secret_document()).unwrap();
+        let update = DocumentUpdate::new(secret_document()).unwrap();
+        let command = DocumentUpdateRequest::new(
+            namespace(),
+            filter,
+            update,
+            DocumentMutationScope::Many,
+            DocumentWriteOptions::new().with_upsert(true),
+        );
+        let (_, filter, update, scope, options) = command.into_parts();
+        assert_eq!(
+            filter.document().get_first("token"),
+            Some(&BsonValue::from("private-token"))
+        );
+        assert_eq!(
+            update.document().get_first("token"),
+            Some(&BsonValue::from("private-token"))
+        );
+        assert_eq!(scope, DocumentMutationScope::Many);
+        assert!(options.upsert());
+    }
+
+    #[test]
+    fn insert_batch_and_index_names_are_bounded() {
+        assert!(
+            DocumentInsertRequest::new(namespace(), Vec::new(), DocumentWriteOptions::new())
+                .is_err()
+        );
+        assert!(
+            DocumentIndexRequest::new(secret_document())
+                .unwrap()
+                .with_name("")
+                .is_err()
+        );
+        assert!(
+            DocumentDropIndexRequest::new(namespace(), "bad\0name", DocumentWriteOptions::new())
+                .is_err()
+        );
+    }
+}

--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -6,9 +6,13 @@
 
 mod catalog;
 mod codec;
+mod command;
 mod error;
 mod key;
 mod number;
+mod options;
+mod plan;
+mod result;
 mod value;
 
 pub(crate) use catalog::validate_namespace;
@@ -24,8 +28,28 @@ pub use codec::{
     DuplicateFieldPolicy, decode_document, decode_document_with_options, encode_document,
     encode_document_with_options,
 };
+pub use command::{
+    DocumentAggregateRequest, DocumentCommand, DocumentCommandKind, DocumentContinueCursorRequest,
+    DocumentCountRequest, DocumentCreateCollectionRequest, DocumentCreateIndexRequest,
+    DocumentCursorId, DocumentDeleteRequest, DocumentDistinctRequest,
+    DocumentDropCollectionRequest, DocumentDropIndexRequest, DocumentFindRequest,
+    DocumentIndexRequest, DocumentInsertRequest, DocumentKillCursorRequest,
+    DocumentListCollectionsRequest, DocumentListIndexesRequest, DocumentMutationScope,
+    DocumentNamespace, DocumentReplaceRequest, DocumentRequest, DocumentRequestId,
+    DocumentUpdateRequest, MAX_DOCUMENT_INDEX_NAME_BYTES,
+};
 pub use error::{BsonError, BsonErrorContext, BsonErrorKind, BsonResult};
 pub use key::{BSON_KEY_ENCODING_VERSION, BSON_MAX_CANONICAL_KEY_BYTES, CanonicalBsonKey};
+pub use options::{
+    DEFAULT_DOCUMENT_BATCH_SIZE, DocumentFilter, DocumentPipeline, DocumentProjection,
+    DocumentReadOptions, DocumentSort, DocumentUpdate, DocumentWriteOptions,
+    MAX_DOCUMENT_BATCH_SIZE, MAX_DOCUMENT_REQUEST_BYTES,
+};
+pub use plan::{DocumentPlan, DocumentPointPlan, DocumentScatterPlan};
+pub use result::{
+    DocumentCursorBatch, DocumentDeleteResult, DocumentExecution, DocumentInsertResult,
+    DocumentResult, DocumentResultKind, DocumentUpdateResult,
+};
 pub use value::{
     BsonBinary, BsonDateTime, BsonDecimal128, BsonDocument, BsonJavaScript, BsonObjectId,
     BsonRegex, BsonTimestamp, BsonUuid, BsonValue, UuidRepresentation,

--- a/src/document/options.rs
+++ b/src/document/options.rs
@@ -1,0 +1,404 @@
+//! Protocol-neutral options for document reads and writes.
+
+use std::{fmt, num::NonZeroU64};
+
+use crate::core::{EngineError, EngineErrorKind, EngineResult};
+
+use super::{BSON_MAX_DECODED_BYTES, BsonDocument, BsonErrorContext, encode_document};
+
+/// Default number of documents requested for one cursor batch.
+pub const DEFAULT_DOCUMENT_BATCH_SIZE: u64 = 101;
+/// Maximum number of documents accepted in one request or cursor batch.
+pub const MAX_DOCUMENT_BATCH_SIZE: u64 = 100_000;
+/// Maximum aggregate encoded BSON retained by one owned document request.
+pub const MAX_DOCUMENT_REQUEST_BYTES: usize = BSON_MAX_DECODED_BYTES;
+
+fn payload_len(document: &BsonDocument) -> EngineResult<usize> {
+    encode_document(document)
+        .map(|encoded| encoded.len())
+        .map_err(|error| error.into_engine_error(BsonErrorContext::ClientInput))
+}
+
+fn validate_payload(document: &BsonDocument) -> EngineResult<()> {
+    payload_len(document).map(|_| ())
+}
+
+macro_rules! document_payload {
+    ($name:ident, $description:literal) => {
+        #[doc = $description]
+        #[derive(Clone, PartialEq, Eq)]
+        pub struct $name {
+            document: BsonDocument,
+        }
+
+        impl $name {
+            /// Validate and own an ordered BSON document.
+            pub fn new(document: BsonDocument) -> EngineResult<Self> {
+                validate_payload(&document)?;
+                Ok(Self { document })
+            }
+
+            /// Borrow the exact ordered BSON document.
+            pub const fn document(&self) -> &BsonDocument {
+                &self.document
+            }
+
+            /// Consume this wrapper and return its ordered BSON document.
+            pub fn into_document(self) -> BsonDocument {
+                self.document
+            }
+        }
+
+        impl fmt::Debug for $name {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter
+                    .debug_struct(stringify!($name))
+                    .field("document", &"<redacted>")
+                    .finish()
+            }
+        }
+    };
+}
+
+document_payload!(
+    DocumentFilter,
+    "An owned, structurally valid BSON match expression."
+);
+document_payload!(
+    DocumentProjection,
+    "An owned, structurally valid BSON projection specification."
+);
+document_payload!(
+    DocumentSort,
+    "An owned, structurally valid BSON sort specification."
+);
+document_payload!(
+    DocumentUpdate,
+    "An owned, structurally valid BSON update specification."
+);
+
+impl DocumentFilter {
+    /// Construct the empty filter, which matches every document once command
+    /// semantics are applied by the document engine.
+    pub const fn empty() -> Self {
+        Self {
+            document: BsonDocument::new(),
+        }
+    }
+
+    /// Return whether this filter has no direct fields.
+    pub fn is_empty(&self) -> bool {
+        self.document.is_empty()
+    }
+}
+
+impl Default for DocumentFilter {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+/// An owned sequence of structurally valid aggregation stages.
+#[derive(Clone, PartialEq, Eq)]
+pub struct DocumentPipeline {
+    stages: Box<[BsonDocument]>,
+}
+
+impl DocumentPipeline {
+    /// Validate and own aggregation stages without interpreting their
+    /// operators.
+    pub fn new(stages: impl Into<Vec<BsonDocument>>) -> EngineResult<Self> {
+        let stages = stages.into();
+        if stages.len() as u64 > MAX_DOCUMENT_BATCH_SIZE {
+            return Err(EngineError::new(
+                EngineErrorKind::LimitExceeded,
+                format!("document pipeline must not exceed {MAX_DOCUMENT_BATCH_SIZE} stages"),
+            ));
+        }
+        let mut encoded_bytes = 0_usize;
+        for stage in &stages {
+            encoded_bytes = encoded_bytes
+                .checked_add(payload_len(stage)?)
+                .filter(|bytes| *bytes <= MAX_DOCUMENT_REQUEST_BYTES)
+                .ok_or_else(|| {
+                    EngineError::new(
+                        EngineErrorKind::LimitExceeded,
+                        format!(
+                            "document pipeline exceeds {MAX_DOCUMENT_REQUEST_BYTES} encoded BSON bytes"
+                        ),
+                    )
+                })?;
+        }
+        Ok(Self {
+            stages: stages.into_boxed_slice(),
+        })
+    }
+
+    pub fn stages(&self) -> &[BsonDocument] {
+        &self.stages
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.stages.is_empty()
+    }
+
+    pub fn into_stages(self) -> Vec<BsonDocument> {
+        self.stages.into_vec()
+    }
+}
+
+impl fmt::Debug for DocumentPipeline {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DocumentPipeline")
+            .field("stage_count", &self.stages.len())
+            .field("stages", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Options applied while reading and materializing document results.
+///
+/// Projection and sort documents remain exact ordered BSON. A missing limit
+/// means unbounded by the caller; engine-wide result limits still apply.
+#[non_exhaustive]
+#[derive(Clone, PartialEq, Eq)]
+pub struct DocumentReadOptions {
+    projection: Option<DocumentProjection>,
+    sort: Option<DocumentSort>,
+    skip: u64,
+    limit: Option<NonZeroU64>,
+    batch_size: NonZeroU64,
+}
+
+impl DocumentReadOptions {
+    /// Construct the default read options.
+    pub const fn new() -> Self {
+        Self {
+            projection: None,
+            sort: None,
+            skip: 0,
+            limit: None,
+            batch_size: NonZeroU64::new(DEFAULT_DOCUMENT_BATCH_SIZE)
+                .expect("the default document batch size is nonzero"),
+        }
+    }
+
+    #[must_use]
+    pub fn with_projection(mut self, projection: DocumentProjection) -> Self {
+        self.projection = Some(projection);
+        self
+    }
+
+    #[must_use]
+    pub fn with_sort(mut self, sort: DocumentSort) -> Self {
+        self.sort = Some(sort);
+        self
+    }
+
+    #[must_use]
+    pub const fn with_skip(mut self, skip: u64) -> Self {
+        self.skip = skip;
+        self
+    }
+
+    /// Set a positive logical result limit.
+    pub fn with_limit(mut self, limit: u64) -> EngineResult<Self> {
+        self.limit = Some(NonZeroU64::new(limit).ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "document result limit must be greater than zero",
+            )
+        })?);
+        Ok(self)
+    }
+
+    /// Request a positive, bounded cursor batch size.
+    pub fn with_batch_size(mut self, batch_size: u64) -> EngineResult<Self> {
+        if batch_size > MAX_DOCUMENT_BATCH_SIZE {
+            return Err(EngineError::new(
+                EngineErrorKind::LimitExceeded,
+                format!("document batch size must not exceed {MAX_DOCUMENT_BATCH_SIZE}"),
+            ));
+        }
+        self.batch_size = NonZeroU64::new(batch_size).ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "document batch size must be greater than zero",
+            )
+        })?;
+        Ok(self)
+    }
+
+    pub const fn projection(&self) -> Option<&DocumentProjection> {
+        self.projection.as_ref()
+    }
+
+    pub const fn sort(&self) -> Option<&DocumentSort> {
+        self.sort.as_ref()
+    }
+
+    pub const fn skip(&self) -> u64 {
+        self.skip
+    }
+
+    pub const fn limit(&self) -> Option<u64> {
+        match self.limit {
+            Some(limit) => Some(limit.get()),
+            None => None,
+        }
+    }
+
+    pub const fn batch_size(&self) -> u64 {
+        self.batch_size.get()
+    }
+
+    pub fn into_parts(
+        self,
+    ) -> (
+        Option<DocumentProjection>,
+        Option<DocumentSort>,
+        u64,
+        Option<u64>,
+        u64,
+    ) {
+        (
+            self.projection,
+            self.sort,
+            self.skip,
+            self.limit.map(NonZeroU64::get),
+            self.batch_size.get(),
+        )
+    }
+}
+
+impl Default for DocumentReadOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Debug for DocumentReadOptions {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DocumentReadOptions")
+            .field(
+                "projection",
+                &self.projection.as_ref().map(|_| "<redacted>"),
+            )
+            .field("sort", &self.sort.as_ref().map(|_| "<redacted>"))
+            .field("skip", &self.skip)
+            .field("limit", &self.limit())
+            .field("batch_size", &self.batch_size())
+            .finish()
+    }
+}
+
+/// Options applied to one logical document write.
+///
+/// `ordered` controls batch failure order. `upsert` is consumed only by
+/// commands that define upsert semantics. Bypassing application validation
+/// never bypasses BriskDB's BSON, `_id`, routing, or storage validation.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct DocumentWriteOptions {
+    ordered: bool,
+    upsert: bool,
+    bypass_document_validation: bool,
+}
+
+impl DocumentWriteOptions {
+    pub const fn new() -> Self {
+        Self {
+            ordered: true,
+            upsert: false,
+            bypass_document_validation: false,
+        }
+    }
+
+    #[must_use]
+    pub const fn with_ordered(mut self, ordered: bool) -> Self {
+        self.ordered = ordered;
+        self
+    }
+
+    #[must_use]
+    pub const fn with_upsert(mut self, upsert: bool) -> Self {
+        self.upsert = upsert;
+        self
+    }
+
+    #[must_use]
+    pub const fn with_bypass_document_validation(mut self, bypass: bool) -> Self {
+        self.bypass_document_validation = bypass;
+        self
+    }
+
+    pub const fn ordered(self) -> bool {
+        self.ordered
+    }
+
+    pub const fn upsert(self) -> bool {
+        self.upsert
+    }
+
+    pub const fn bypass_document_validation(self) -> bool {
+        self.bypass_document_validation
+    }
+}
+
+impl Default for DocumentWriteOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::document::BsonValue;
+
+    fn secret_document() -> BsonDocument {
+        BsonDocument::from_entries([("password", BsonValue::from("correct horse"))]).unwrap()
+    }
+
+    #[test]
+    fn payload_wrappers_preserve_order_and_redact_debug() {
+        let filter = DocumentFilter::new(secret_document()).unwrap();
+        assert_eq!(filter.document().iter().next().unwrap().0, "password");
+        let debug = format!("{filter:?}");
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains("correct horse"));
+    }
+
+    #[test]
+    fn read_options_validate_bounds_and_hide_bson() {
+        let projection = DocumentProjection::new(secret_document()).unwrap();
+        let options = DocumentReadOptions::new()
+            .with_projection(projection)
+            .with_skip(3)
+            .with_limit(7)
+            .unwrap()
+            .with_batch_size(11)
+            .unwrap();
+        assert_eq!(options.skip(), 3);
+        assert_eq!(options.limit(), Some(7));
+        assert_eq!(options.batch_size(), 11);
+        assert!(DocumentReadOptions::new().with_batch_size(0).is_err());
+        assert!(
+            DocumentReadOptions::new()
+                .with_batch_size(MAX_DOCUMENT_BATCH_SIZE + 1)
+                .is_err()
+        );
+        assert!(!format!("{options:?}").contains("correct horse"));
+    }
+
+    #[test]
+    fn pipeline_is_owned_cloneable_and_redacted() {
+        fn assert_owned<T: Clone + Send + Sync + 'static>() {}
+        assert_owned::<DocumentPipeline>();
+        let pipeline = DocumentPipeline::new(vec![secret_document()]).unwrap();
+        assert_eq!(pipeline.stages().len(), 1);
+        assert!(!format!("{pipeline:?}").contains("correct horse"));
+    }
+}

--- a/src/document/plan.rs
+++ b/src/document/plan.rs
@@ -1,0 +1,175 @@
+//! Redaction-safe point and scatter plans for document commands.
+
+use std::fmt;
+
+use crate::core::{EngineError, EngineErrorKind, EngineResult};
+
+use super::{CanonicalBsonKey, DocumentCollectionId};
+
+const MAX_DOCUMENT_SHARDS: usize = 64;
+
+/// A single-shard document plan proven from a canonical BSON identity.
+#[derive(Clone, PartialEq, Eq)]
+pub struct DocumentPointPlan {
+    collection_id: DocumentCollectionId,
+    shard: u16,
+    id_key: CanonicalBsonKey,
+}
+
+impl DocumentPointPlan {
+    pub fn new(
+        collection_id: DocumentCollectionId,
+        shard: u16,
+        id_key: CanonicalBsonKey,
+    ) -> EngineResult<Self> {
+        if usize::from(shard) >= MAX_DOCUMENT_SHARDS {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "document point-plan shard must be in 0..=63",
+            ));
+        }
+        Ok(Self {
+            collection_id,
+            shard,
+            id_key,
+        })
+    }
+
+    pub const fn collection_id(&self) -> DocumentCollectionId {
+        self.collection_id
+    }
+
+    pub const fn shard(&self) -> u16 {
+        self.shard
+    }
+
+    pub const fn id_key(&self) -> &CanonicalBsonKey {
+        &self.id_key
+    }
+
+    pub fn into_parts(self) -> (DocumentCollectionId, u16, CanonicalBsonKey) {
+        (self.collection_id, self.shard, self.id_key)
+    }
+}
+
+impl fmt::Debug for DocumentPointPlan {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DocumentPointPlan")
+            .field("collection_id", &self.collection_id)
+            .field("shard", &self.shard)
+            .field("id_key", &"<redacted>")
+            .finish()
+    }
+}
+
+/// A deterministic set of physical shards for a document command.
+///
+/// Shards are nonempty, unique, and sorted in ascending order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocumentScatterPlan {
+    collection_id: DocumentCollectionId,
+    shards: Box<[u16]>,
+}
+
+impl DocumentScatterPlan {
+    pub fn new(
+        collection_id: DocumentCollectionId,
+        shards: impl Into<Vec<u16>>,
+    ) -> EngineResult<Self> {
+        let mut shards = shards.into();
+        if shards.is_empty() {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "document scatter plan must target at least one shard",
+            ));
+        }
+        if shards.len() > MAX_DOCUMENT_SHARDS
+            || shards
+                .iter()
+                .any(|shard| usize::from(*shard) >= MAX_DOCUMENT_SHARDS)
+        {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "document scatter-plan shards must be unique values in 0..=63",
+            ));
+        }
+        shards.sort_unstable();
+        if shards.windows(2).any(|pair| pair[0] == pair[1]) {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "document scatter-plan shards must be unique values in 0..=63",
+            ));
+        }
+        Ok(Self {
+            collection_id,
+            shards: shards.into_boxed_slice(),
+        })
+    }
+
+    pub const fn collection_id(&self) -> DocumentCollectionId {
+        self.collection_id
+    }
+
+    pub fn shards(&self) -> &[u16] {
+        &self.shards
+    }
+
+    pub fn into_parts(self) -> (DocumentCollectionId, Vec<u16>) {
+        (self.collection_id, self.shards.into_vec())
+    }
+}
+
+/// Physical routing selected for one document command.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DocumentPlan {
+    Point(DocumentPointPlan),
+    Scatter(DocumentScatterPlan),
+}
+
+impl DocumentPlan {
+    pub const fn collection_id(&self) -> DocumentCollectionId {
+        match self {
+            Self::Point(plan) => plan.collection_id(),
+            Self::Scatter(plan) => plan.collection_id(),
+        }
+    }
+
+    pub fn shards(&self) -> &[u16] {
+        match self {
+            Self::Point(plan) => std::slice::from_ref(&plan.shard),
+            Self::Scatter(plan) => plan.shards(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::document::BsonValue;
+
+    fn collection_id() -> DocumentCollectionId {
+        DocumentCollectionId::from_validated(7)
+    }
+
+    #[test]
+    fn point_plan_owns_and_redacts_the_canonical_id() {
+        fn assert_owned<T: Clone + Send + Sync + 'static>() {}
+        assert_owned::<DocumentPlan>();
+        let key = CanonicalBsonKey::encode(&BsonValue::from("private-id")).unwrap();
+        let plan = DocumentPointPlan::new(collection_id(), 3, key).unwrap();
+        assert_eq!(plan.shard(), 3);
+        assert!(!format!("{plan:?}").contains("private-id"));
+        assert!(format!("{plan:?}").contains("<redacted>"));
+    }
+
+    #[test]
+    fn scatter_plan_sorts_and_rejects_invalid_targets() {
+        let plan = DocumentScatterPlan::new(collection_id(), vec![3, 0, 2]).unwrap();
+        assert_eq!(plan.shards(), &[0, 2, 3]);
+        assert!(DocumentScatterPlan::new(collection_id(), Vec::new()).is_err());
+        assert!(DocumentScatterPlan::new(collection_id(), vec![1, 1]).is_err());
+        assert!(DocumentScatterPlan::new(collection_id(), vec![64]).is_err());
+    }
+}

--- a/src/document/result.rs
+++ b/src/document/result.rs
@@ -1,0 +1,466 @@
+//! BSON-preserving results returned by the protocol-neutral document engine.
+
+use std::fmt;
+
+use crate::core::{EngineError, EngineErrorKind, EngineResult};
+
+use super::{
+    BsonDocument, BsonErrorContext, BsonValue, CanonicalBsonKey, DocumentCollectionMetadata,
+    DocumentCursorId, DocumentIndexMetadata, DocumentNamespace, DocumentPlan, DocumentRequestId,
+    MAX_DOCUMENT_BATCH_SIZE, encode_document,
+};
+
+fn validate_result_document(document: &BsonDocument) -> EngineResult<()> {
+    encode_document(document)
+        .map(|_| ())
+        .map_err(|error| error.into_engine_error(BsonErrorContext::StoredData))
+}
+
+/// One ordered batch of independently owned BSON documents.
+///
+/// `cursor_id == None` means this batch exhausted the cursor. A live cursor ID
+/// may accompany an empty batch.
+#[derive(Clone, PartialEq, Eq)]
+pub struct DocumentCursorBatch {
+    namespace: DocumentNamespace,
+    cursor_id: Option<DocumentCursorId>,
+    documents: Box<[BsonDocument]>,
+}
+
+impl DocumentCursorBatch {
+    pub fn new(
+        namespace: DocumentNamespace,
+        cursor_id: Option<DocumentCursorId>,
+        documents: impl Into<Vec<BsonDocument>>,
+    ) -> EngineResult<Self> {
+        let documents = documents.into();
+        if documents.len() as u64 > MAX_DOCUMENT_BATCH_SIZE {
+            return Err(EngineError::new(
+                EngineErrorKind::LimitExceeded,
+                format!("document cursor batch exceeds {MAX_DOCUMENT_BATCH_SIZE} documents"),
+            ));
+        }
+        for document in &documents {
+            validate_result_document(document)?;
+        }
+        Ok(Self {
+            namespace,
+            cursor_id,
+            documents: documents.into_boxed_slice(),
+        })
+    }
+
+    pub(crate) fn from_validated(
+        namespace: DocumentNamespace,
+        cursor_id: Option<DocumentCursorId>,
+        documents: Vec<BsonDocument>,
+    ) -> Self {
+        debug_assert!(documents.len() as u64 <= MAX_DOCUMENT_BATCH_SIZE);
+        Self {
+            namespace,
+            cursor_id,
+            documents: documents.into_boxed_slice(),
+        }
+    }
+
+    pub const fn namespace(&self) -> &DocumentNamespace {
+        &self.namespace
+    }
+
+    pub const fn cursor_id(&self) -> Option<DocumentCursorId> {
+        self.cursor_id
+    }
+
+    pub fn documents(&self) -> &[BsonDocument] {
+        &self.documents
+    }
+
+    pub const fn is_exhausted(&self) -> bool {
+        self.cursor_id.is_none()
+    }
+
+    pub fn into_parts(
+        self,
+    ) -> (
+        DocumentNamespace,
+        Option<DocumentCursorId>,
+        Vec<BsonDocument>,
+    ) {
+        (self.namespace, self.cursor_id, self.documents.into_vec())
+    }
+}
+
+impl fmt::Debug for DocumentCursorBatch {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DocumentCursorBatch")
+            .field("namespace", &self.namespace)
+            .field("cursor_id", &self.cursor_id)
+            .field("document_count", &self.documents.len())
+            .field("documents", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Result of inserting one or more documents in input order.
+#[derive(Clone, PartialEq, Eq)]
+pub struct DocumentInsertResult {
+    inserted_ids: Box<[BsonValue]>,
+    acknowledged: bool,
+}
+
+impl DocumentInsertResult {
+    pub fn new(inserted_ids: impl Into<Vec<BsonValue>>) -> EngineResult<Self> {
+        let inserted_ids = inserted_ids.into();
+        if inserted_ids.is_empty() {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "document insert result must contain at least one inserted ID",
+            ));
+        }
+        if inserted_ids.len() as u64 > MAX_DOCUMENT_BATCH_SIZE {
+            return Err(EngineError::new(
+                EngineErrorKind::LimitExceeded,
+                format!("document insert result exceeds {MAX_DOCUMENT_BATCH_SIZE} IDs"),
+            ));
+        }
+        for id in &inserted_ids {
+            CanonicalBsonKey::encode(id)
+                .map_err(|error| error.into_engine_error(BsonErrorContext::StoredData))?;
+        }
+        Ok(Self {
+            inserted_ids: inserted_ids.into_boxed_slice(),
+            acknowledged: true,
+        })
+    }
+
+    pub(crate) fn from_validated(inserted_ids: Vec<BsonValue>) -> Self {
+        debug_assert!(!inserted_ids.is_empty());
+        debug_assert!(inserted_ids.len() as u64 <= MAX_DOCUMENT_BATCH_SIZE);
+        Self {
+            inserted_ids: inserted_ids.into_boxed_slice(),
+            acknowledged: true,
+        }
+    }
+
+    pub fn inserted_ids(&self) -> &[BsonValue] {
+        &self.inserted_ids
+    }
+
+    pub const fn acknowledged(&self) -> bool {
+        self.acknowledged
+    }
+
+    pub fn into_inserted_ids(self) -> Vec<BsonValue> {
+        self.inserted_ids.into_vec()
+    }
+}
+
+impl fmt::Debug for DocumentInsertResult {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DocumentInsertResult")
+            .field("inserted_count", &self.inserted_ids.len())
+            .field("inserted_ids", &"<redacted>")
+            .field("acknowledged", &self.acknowledged)
+            .finish()
+    }
+}
+
+/// Result of one logical update or replacement command.
+#[derive(Clone, PartialEq, Eq)]
+pub struct DocumentUpdateResult {
+    matched_count: u64,
+    modified_count: u64,
+    upserted_id: Option<BsonValue>,
+    acknowledged: bool,
+}
+
+impl DocumentUpdateResult {
+    pub fn new(
+        matched_count: u64,
+        modified_count: u64,
+        upserted_id: Option<BsonValue>,
+    ) -> EngineResult<Self> {
+        if modified_count > matched_count {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "document modified count cannot exceed matched count",
+            ));
+        }
+        if let Some(id) = &upserted_id {
+            CanonicalBsonKey::encode(id)
+                .map_err(|error| error.into_engine_error(BsonErrorContext::StoredData))?;
+        }
+        Ok(Self {
+            matched_count,
+            modified_count,
+            upserted_id,
+            acknowledged: true,
+        })
+    }
+
+    pub const fn matched_count(&self) -> u64 {
+        self.matched_count
+    }
+
+    pub const fn modified_count(&self) -> u64 {
+        self.modified_count
+    }
+
+    pub const fn upserted_id(&self) -> Option<&BsonValue> {
+        self.upserted_id.as_ref()
+    }
+
+    pub const fn acknowledged(&self) -> bool {
+        self.acknowledged
+    }
+
+    pub fn into_parts(self) -> (u64, u64, Option<BsonValue>) {
+        (self.matched_count, self.modified_count, self.upserted_id)
+    }
+}
+
+impl fmt::Debug for DocumentUpdateResult {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DocumentUpdateResult")
+            .field("matched_count", &self.matched_count)
+            .field("modified_count", &self.modified_count)
+            .field(
+                "upserted_id",
+                &self.upserted_id.as_ref().map(|_| "<redacted>"),
+            )
+            .field("acknowledged", &self.acknowledged)
+            .finish()
+    }
+}
+
+/// Result of one logical delete command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct DocumentDeleteResult {
+    deleted_count: u64,
+    acknowledged: bool,
+}
+
+impl DocumentDeleteResult {
+    pub const fn new(deleted_count: u64) -> Self {
+        Self {
+            deleted_count,
+            acknowledged: true,
+        }
+    }
+
+    pub const fn deleted_count(self) -> u64 {
+        self.deleted_count
+    }
+
+    pub const fn acknowledged(self) -> bool {
+        self.acknowledged
+    }
+}
+
+/// Payload-free classification of a document result.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DocumentResultKind {
+    Acknowledged,
+    Collection,
+    Collections,
+    Document,
+    Cursor,
+    Count,
+    Distinct,
+    Insert,
+    Update,
+    Delete,
+    IndexName,
+    Indexes,
+    CursorKilled,
+}
+
+/// Result of one protocol-neutral document command.
+#[non_exhaustive]
+#[derive(Clone, PartialEq, Eq)]
+pub enum DocumentResult {
+    Acknowledged(bool),
+    Collection(DocumentCollectionMetadata),
+    Collections(Box<[DocumentCollectionMetadata]>),
+    Document(Option<BsonDocument>),
+    Cursor(DocumentCursorBatch),
+    Count(u64),
+    Distinct(Box<[BsonValue]>),
+    Insert(DocumentInsertResult),
+    Update(DocumentUpdateResult),
+    Delete(DocumentDeleteResult),
+    IndexName(String),
+    Indexes(Box<[DocumentIndexMetadata]>),
+    CursorKilled(bool),
+}
+
+impl DocumentResult {
+    pub const fn kind(&self) -> DocumentResultKind {
+        match self {
+            Self::Acknowledged(_) => DocumentResultKind::Acknowledged,
+            Self::Collection(_) => DocumentResultKind::Collection,
+            Self::Collections(_) => DocumentResultKind::Collections,
+            Self::Document(_) => DocumentResultKind::Document,
+            Self::Cursor(_) => DocumentResultKind::Cursor,
+            Self::Count(_) => DocumentResultKind::Count,
+            Self::Distinct(_) => DocumentResultKind::Distinct,
+            Self::Insert(_) => DocumentResultKind::Insert,
+            Self::Update(_) => DocumentResultKind::Update,
+            Self::Delete(_) => DocumentResultKind::Delete,
+            Self::IndexName(_) => DocumentResultKind::IndexName,
+            Self::Indexes(_) => DocumentResultKind::Indexes,
+            Self::CursorKilled(_) => DocumentResultKind::CursorKilled,
+        }
+    }
+}
+
+impl fmt::Debug for DocumentResult {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut debug = formatter.debug_struct("DocumentResult");
+        debug.field("kind", &self.kind());
+        match self {
+            Self::Acknowledged(value) | Self::CursorKilled(value) => {
+                debug.field("value", value);
+            }
+            Self::Collections(values) => {
+                debug.field("collection_count", &values.len());
+            }
+            Self::Document(value) => {
+                debug.field("present", &value.is_some());
+                debug.field("document", &"<redacted>");
+            }
+            Self::Cursor(value) => {
+                debug.field("cursor", value);
+            }
+            Self::Count(value) => {
+                debug.field("count", value);
+            }
+            Self::Distinct(values) => {
+                debug.field("value_count", &values.len());
+                debug.field("values", &"<redacted>");
+            }
+            Self::Insert(value) => {
+                debug.field("result", value);
+            }
+            Self::Update(value) => {
+                debug.field("result", value);
+            }
+            Self::Delete(value) => {
+                debug.field("result", value);
+            }
+            Self::Indexes(values) => {
+                debug.field("index_count", &values.len());
+            }
+            Self::Collection(_) | Self::IndexName(_) => {
+                debug.field("payload", &"<redacted>");
+            }
+        }
+        debug.finish()
+    }
+}
+
+/// Completed document request paired with its route and stable identity.
+#[derive(Clone, PartialEq, Eq)]
+pub struct DocumentExecution {
+    request_id: DocumentRequestId,
+    plan: Option<DocumentPlan>,
+    result: DocumentResult,
+}
+
+impl DocumentExecution {
+    pub fn new(
+        request_id: DocumentRequestId,
+        plan: Option<DocumentPlan>,
+        result: DocumentResult,
+    ) -> Self {
+        Self {
+            request_id,
+            plan,
+            result,
+        }
+    }
+
+    pub const fn request_id(&self) -> DocumentRequestId {
+        self.request_id
+    }
+
+    pub const fn plan(&self) -> Option<&DocumentPlan> {
+        self.plan.as_ref()
+    }
+
+    pub const fn result(&self) -> &DocumentResult {
+        &self.result
+    }
+
+    pub fn into_parts(self) -> (DocumentRequestId, Option<DocumentPlan>, DocumentResult) {
+        (self.request_id, self.plan, self.result)
+    }
+}
+
+impl fmt::Debug for DocumentExecution {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DocumentExecution")
+            .field("request_id", &self.request_id)
+            .field("plan", &self.plan)
+            .field("result_kind", &self.result.kind())
+            .field("result", &"<redacted>")
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn namespace() -> DocumentNamespace {
+        DocumentNamespace::new("database", "records").unwrap()
+    }
+
+    fn secret_document() -> BsonDocument {
+        BsonDocument::from_entries([("secret", BsonValue::from("hidden-value"))]).unwrap()
+    }
+
+    #[test]
+    fn cursor_batch_preserves_bson_order_and_redacts_debug() {
+        let batch = DocumentCursorBatch::new(namespace(), None, vec![secret_document()]).unwrap();
+        assert!(batch.is_exhausted());
+        assert_eq!(batch.documents()[0].iter().next().unwrap().0, "secret");
+        let debug = format!("{batch:?}");
+        assert!(debug.contains("document_count"));
+        assert!(!debug.contains("hidden-value"));
+    }
+
+    #[test]
+    fn write_results_preserve_exact_bson_ids_and_validate_counts() {
+        let id = BsonValue::Int64(42);
+        let inserted = DocumentInsertResult::new(vec![id.clone()]).unwrap();
+        assert!(inserted.acknowledged());
+        assert!(inserted.inserted_ids()[0].representation_eq(&id));
+        assert!(DocumentUpdateResult::new(1, 2, None).is_err());
+        let updated = DocumentUpdateResult::new(0, 0, Some(id.clone())).unwrap();
+        assert!(updated.upserted_id().unwrap().representation_eq(&id));
+        assert_eq!(DocumentDeleteResult::new(3).deleted_count(), 3);
+    }
+
+    #[test]
+    fn execution_carries_identity_and_redacts_result_payload() {
+        fn assert_owned<T: Clone + Send + Sync + 'static>() {}
+        assert_owned::<DocumentExecution>();
+        let request_id = DocumentRequestId::new([5; 16]).unwrap();
+        let execution = DocumentExecution::new(
+            request_id,
+            None,
+            DocumentResult::Document(Some(secret_document())),
+        );
+        assert_eq!(execution.request_id(), request_id);
+        assert_eq!(execution.result().kind(), DocumentResultKind::Document);
+        let debug = format!("{execution:?} {:?}", execution.result());
+        assert!(!debug.contains("hidden-value"));
+        assert!(debug.contains("Document"));
+    }
+}

--- a/src/storage/document.rs
+++ b/src/storage/document.rs
@@ -141,12 +141,15 @@ fn shard_read_error(error: rusqlite::Error, diagnostic: &'static str) -> EngineE
 
 #[cfg(feature = "documents")]
 mod enabled {
-    use std::collections::{HashMap, HashSet};
+    use std::{
+        collections::{HashMap, HashSet},
+        sync::Arc,
+    };
 
     use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params};
 
     use crate::{
-        core::{CancellationToken, EngineError, EngineErrorKind, EngineResult},
+        core::{CancellationToken, EngineError, EngineErrorKind, EngineResult, OperationControl},
         document::{
             BsonDocument, BsonErrorContext, BsonValue, CanonicalBsonKey, DocumentCatalog,
             DocumentCollectionId, DocumentCollectionMetadata, DocumentCollectionOptions,
@@ -158,7 +161,8 @@ mod enabled {
 
     use super::{Storage, corrupt, ensure_schema, require_schema, shard_read_error};
     use crate::storage::{
-        configure_journal_mode, configure_manifest_connection, manifest, open_existing_manifest,
+        SchemaMigrationGuard, configure_journal_mode, configure_manifest_connection,
+        configure_manifest_connection_after_busy_setup, manifest, open_existing_manifest, pool,
     };
 
     const COLLECTION_PROVISIONING: i64 = manifest::DOCUMENT_COLLECTION_PROVISIONING;
@@ -166,6 +170,74 @@ mod enabled {
     const INDEX_READY: i64 = manifest::DOCUMENT_INDEX_READY;
     const INDEX_PENDING_BUILD: i64 = manifest::DOCUMENT_INDEX_PENDING_BUILD;
     const RECORD_CHECKSUM_DOMAIN: &[u8] = b"briskdb.document-record.v1\0";
+    pub(crate) const MAX_DOCUMENT_SHARD_SCAN_RECORDS: usize = 4_096;
+
+    /// Exact, validated bytes prepared for one shard-local document write.
+    ///
+    /// The command engine can retain this value between routing and execution
+    /// without exposing SQLite or re-encoding BSON on a blocking worker.
+    #[derive(Debug, Clone)]
+    pub(crate) struct PreparedDocumentWrite {
+        id_key: CanonicalBsonKey,
+        document_bson: Vec<u8>,
+        shard: u16,
+    }
+
+    impl PreparedDocumentWrite {
+        pub(crate) const fn shard(&self) -> u16 {
+            self.shard
+        }
+
+        pub(crate) const fn id_key(&self) -> &CanonicalBsonKey {
+            &self.id_key
+        }
+
+        pub(crate) fn document_bson_len(&self) -> usize {
+            self.document_bson.len()
+        }
+    }
+
+    /// One checksum-validated shard record returned to the document engine.
+    #[derive(Debug, Clone)]
+    pub(crate) struct DocumentStorageRecord {
+        collection_id: DocumentCollectionId,
+        shard: u16,
+        natural_order: u64,
+        id_key: CanonicalBsonKey,
+        document: BsonDocument,
+        encoded_len: usize,
+    }
+
+    impl DocumentStorageRecord {
+        pub(crate) const fn collection_id(&self) -> DocumentCollectionId {
+            self.collection_id
+        }
+
+        pub(crate) const fn shard(&self) -> u16 {
+            self.shard
+        }
+
+        pub(crate) const fn natural_order(&self) -> u64 {
+            self.natural_order
+        }
+
+        pub(crate) const fn id_key(&self) -> &CanonicalBsonKey {
+            &self.id_key
+        }
+
+        #[cfg(test)]
+        pub(crate) const fn document(&self) -> &BsonDocument {
+            &self.document
+        }
+
+        pub(crate) const fn encoded_len(&self) -> usize {
+            self.encoded_len
+        }
+
+        pub(crate) fn into_document(self) -> BsonDocument {
+            self.document
+        }
+    }
 
     fn require_ready_manifest(connection: &Connection, shard_count: u16) -> EngineResult<()> {
         match manifest::current_integrity(connection, shard_count)?.state() {
@@ -189,25 +261,152 @@ mod enabled {
         next_shard: u16,
     }
 
+    enum CreateCollectionStart {
+        Existing(DocumentCollectionMetadata),
+        Provisioning(Provisioning),
+    }
+
+    fn run_dedicated_controlled<T>(
+        connection: &mut Connection,
+        control: Arc<OperationControl>,
+        work: impl FnOnce(&mut Connection) -> EngineResult<T>,
+    ) -> EngineResult<T> {
+        pool::run_dedicated_connection_controlled(connection, control, work)
+    }
+
+    fn run_manifest_controlled<T>(
+        connection: &mut Connection,
+        control: Arc<OperationControl>,
+        work: impl FnOnce(&mut Connection) -> EngineResult<T>,
+    ) -> EngineResult<T> {
+        run_dedicated_controlled(connection, control, |connection| {
+            // The controlled helper already owns the busy handler. Calling the
+            // ordinary configurator here would replace it with a fixed timeout.
+            configure_manifest_connection_after_busy_setup(connection)?;
+            work(connection)
+        })
+    }
+
+    fn ensure_control_active(
+        control: &OperationControl,
+        boundary: &'static str,
+    ) -> EngineResult<()> {
+        match control.reason() {
+            Some(reason) => Err(reason.error().context(boundary)),
+            None => Ok(()),
+        }
+    }
+
+    fn read_ready_manifest_snapshot<T>(
+        connection: &mut Connection,
+        shard_count: u16,
+        read: impl FnOnce(&Connection) -> EngineResult<T>,
+    ) -> EngineResult<T> {
+        let transaction = connection
+            .transaction_with_behavior(TransactionBehavior::Deferred)
+            .map_err(sqlite_error::storage)?;
+        require_ready_manifest(&transaction, shard_count)?;
+        let value = read(&transaction)?;
+        transaction.commit().map_err(sqlite_error::storage)?;
+        Ok(value)
+    }
+
     impl Storage {
+        #[cfg(any(feature = "tinymongo-import", test))]
         pub(crate) fn document_catalog(&self) -> EngineResult<DocumentCatalog> {
             let result = self.document_catalog_inner();
             self.fail_closed_on_corruption(result)
         }
 
+        #[cfg(test)]
+        pub(crate) fn document_catalog_controlled(
+            &self,
+            control: Arc<OperationControl>,
+        ) -> EngineResult<DocumentCatalog> {
+            // Engine callers already own one schema-operation admission for
+            // the complete logical command. Reacquiring here could fail after
+            // a migration starts behind that admitted command.
+            let result = self.document_catalog_controlled_inner(control);
+            self.fail_closed_on_corruption(result)
+        }
+
+        /// Load one active collection without materializing unrelated catalog
+        /// metadata. Engine callers already own schema-operation admission.
+        pub(crate) fn document_collection_controlled(
+            &self,
+            database: &str,
+            collection: &str,
+            control: Arc<OperationControl>,
+        ) -> EngineResult<Option<DocumentCollectionMetadata>> {
+            let result = self.document_collection_controlled_inner(
+                database,
+                collection,
+                Arc::clone(&control),
+            );
+            self.fail_closed_on_corruption(result)
+        }
+
+        /// Load active collections in one database without decoding metadata
+        /// owned by other namespaces. Engine callers own schema admission.
+        pub(crate) fn document_collections_for_database_controlled(
+            &self,
+            database: &str,
+            control: Arc<OperationControl>,
+        ) -> EngineResult<Vec<DocumentCollectionMetadata>> {
+            let result = self.document_collections_for_database_controlled_inner(database, control);
+            self.fail_closed_on_corruption(result)
+        }
+
+        #[cfg(any(feature = "tinymongo-import", test))]
         fn document_catalog_inner(&self) -> EngineResult<DocumentCatalog> {
             let _operation = self.enter_schema_operation()?;
-            self.load_document_catalog()
+            self.document_catalog_controlled_inner(OperationControl::new(None))
         }
 
-        fn load_document_catalog(&self) -> EngineResult<DocumentCatalog> {
+        #[cfg(any(feature = "tinymongo-import", test))]
+        fn document_catalog_controlled_inner(
+            &self,
+            control: Arc<OperationControl>,
+        ) -> EngineResult<DocumentCatalog> {
             let manifest_path = self.root.join("manifest.sqlite");
-            let connection = open_existing_manifest(&manifest_path)?;
-            configure_manifest_connection(&connection)?;
-            require_ready_manifest(&connection, self.shard_count())?;
-            load_catalog_rows(&connection)
+            let mut connection = open_existing_manifest(&manifest_path)?;
+            run_manifest_controlled(&mut connection, control, |connection| {
+                read_ready_manifest_snapshot(connection, self.shard_count(), load_catalog_rows)
+            })
         }
 
+        fn document_collection_controlled_inner(
+            &self,
+            database: &str,
+            collection: &str,
+            control: Arc<OperationControl>,
+        ) -> EngineResult<Option<DocumentCollectionMetadata>> {
+            let manifest_path = self.root.join("manifest.sqlite");
+            let mut connection = open_existing_manifest(&manifest_path)?;
+            let read_control = Arc::clone(&control);
+            run_manifest_controlled(&mut connection, control, |connection| {
+                read_ready_manifest_snapshot(connection, self.shard_count(), |connection| {
+                    load_collection_row(connection, database, collection, read_control.as_ref())
+                })
+            })
+        }
+
+        fn document_collections_for_database_controlled_inner(
+            &self,
+            database: &str,
+            control: Arc<OperationControl>,
+        ) -> EngineResult<Vec<DocumentCollectionMetadata>> {
+            let manifest_path = self.root.join("manifest.sqlite");
+            let mut connection = open_existing_manifest(&manifest_path)?;
+            let read_control = Arc::clone(&control);
+            run_manifest_controlled(&mut connection, control, |connection| {
+                read_ready_manifest_snapshot(connection, self.shard_count(), |connection| {
+                    load_collection_rows_for_database(connection, database, read_control.as_ref())
+                })
+            })
+        }
+
+        #[cfg(any(feature = "tinymongo-import", test))]
         pub(crate) fn create_document_collection(
             &self,
             database: &str,
@@ -218,12 +417,55 @@ mod enabled {
             self.fail_closed_on_corruption(result)
         }
 
+        #[cfg(any(feature = "tinymongo-import", test))]
         fn create_document_collection_inner(
             &self,
             database: &str,
             collection: &str,
             options: &DocumentCollectionOptions,
         ) -> EngineResult<DocumentCollectionMetadata> {
+            let migration =
+                SchemaMigrationGuard::new(self.schema_coordination.gate.begin_new_migration()?);
+            migration.wait_for_quiescence_blocking();
+            self.create_document_collection_controlled_inner(
+                database,
+                collection,
+                options,
+                migration,
+                OperationControl::new(None),
+            )
+        }
+
+        /// Create and provision a collection under a migration guard acquired
+        /// before an engine session is leased.
+        ///
+        /// The caller must acquire the migration guard while holding no
+        /// session, preflight and release its target session, await
+        /// `migration.wait_for_quiescence()`, then reacquire the session and
+        /// move the guard into this method.
+        pub(crate) fn create_document_collection_controlled(
+            &self,
+            database: &str,
+            collection: &str,
+            options: &DocumentCollectionOptions,
+            migration: SchemaMigrationGuard,
+            control: Arc<OperationControl>,
+        ) -> EngineResult<DocumentCollectionMetadata> {
+            let result = self.create_document_collection_controlled_inner(
+                database, collection, options, migration, control,
+            );
+            self.fail_closed_on_corruption(result)
+        }
+
+        fn create_document_collection_controlled_inner(
+            &self,
+            database: &str,
+            collection: &str,
+            options: &DocumentCollectionOptions,
+            mut migration: SchemaMigrationGuard,
+            control: Arc<OperationControl>,
+        ) -> EngineResult<DocumentCollectionMetadata> {
+            ensure_control_active(&control, "before creating document collection")?;
             crate::document::validate_namespace(database, collection)?;
             let options_bson = encode_document(options.document())
                 .map_err(|error| error.into_engine_error(BsonErrorContext::ClientInput))?;
@@ -231,113 +473,129 @@ mod enabled {
             let id_specification = builtin_id_specification()?;
             let id_specification_bson = encode_document(&id_specification)
                 .map_err(|error| error.into_engine_error(BsonErrorContext::ClientInput))?;
-
-            let mut migration = super::super::SchemaMigrationGuard::new(
-                self.schema_coordination.gate.begin_new_migration()?,
-            );
-            migration.wait_for_quiescence_blocking();
             migration.acquire_process_ownership(&self.schema_coordination.process_lease)?;
 
             let result = (|| {
                 let manifest_path = self.root.join("manifest.sqlite");
                 let mut connection = open_existing_manifest(&manifest_path)?;
-                configure_manifest_connection(&connection)?;
-                configure_journal_mode(&connection)?;
-                require_ready_manifest(&connection, self.shard_count())?;
+                let start = run_manifest_controlled(
+                    &mut connection,
+                    Arc::clone(&control),
+                    |connection| {
+                        configure_journal_mode(connection)?;
+                        require_ready_manifest(connection, self.shard_count())?;
 
-                if let Some(existing) = existing_collection(&connection, database, collection)? {
-                    if existing.1 != options_bson {
-                        return Err(EngineError::new(
-                            EngineErrorKind::FailedPrecondition,
-                            "document collection already exists with different options",
-                        ));
-                    }
-                    if existing.0 != COLLECTION_ACTIVE {
-                        return Err(EngineError::new(
-                            EngineErrorKind::FailedPrecondition,
-                            "document collection has incomplete durable provisioning; reopen the database to recover it",
-                        ));
-                    }
-                    return load_catalog_rows(&connection)?
-                        .collection(database, collection)
-                        .cloned()
-                        .ok_or_else(|| {
-                            corrupt("active document collection disappeared from its catalog")
-                        });
-                }
-                if load_provisioning(&connection)?.is_some() {
-                    return Err(corrupt(
-                        "document catalog retained provisioning after startup recovery",
-                    ));
-                }
+                        if let Some(existing) =
+                            existing_collection(connection, database, collection)?
+                        {
+                            if existing.1 != options_bson {
+                                return Err(EngineError::new(
+                                    EngineErrorKind::FailedPrecondition,
+                                    "document collection already exists with different options",
+                                ));
+                            }
+                            if existing.0 != COLLECTION_ACTIVE {
+                                return Err(EngineError::new(
+                                    EngineErrorKind::FailedPrecondition,
+                                    "document collection has incomplete durable provisioning; reopen the database to recover it",
+                                ));
+                            }
+                            let metadata = load_catalog_rows(connection)?
+                                .collection(database, collection)
+                                .cloned()
+                                .ok_or_else(|| {
+                                    corrupt(
+                                        "active document collection disappeared from its catalog",
+                                    )
+                                })?;
+                            return Ok(CreateCollectionStart::Existing(metadata));
+                        }
+                        if load_provisioning(connection)?.is_some() {
+                            return Err(corrupt(
+                                "document catalog retained provisioning after startup recovery",
+                            ));
+                        }
 
-                let transaction = connection
-                    .transaction_with_behavior(TransactionBehavior::Immediate)
-                    .map_err(sqlite_error::storage)?;
-                require_ready_manifest(&transaction, self.shard_count())?;
-                let database_id = ensure_database(&transaction, database)?;
-                let collection_id = next_positive_id(
-                    &transaction,
-                    "briskdb_document_collections",
-                    "collection_id",
-                    "document collection",
+                        let transaction = connection
+                            .transaction_with_behavior(TransactionBehavior::Immediate)
+                            .map_err(sqlite_error::storage)?;
+                        require_ready_manifest(&transaction, self.shard_count())?;
+                        let database_id = ensure_database(&transaction, database)?;
+                        let collection_id = next_positive_id(
+                            &transaction,
+                            "briskdb_document_collections",
+                            "collection_id",
+                            "document collection",
+                        )?;
+                        let operation_id = provisioning_id(database, collection, &options_bson);
+                        transaction
+                            .execute(
+                                "INSERT INTO briskdb_document_collections (
+                                    collection_id, database_id, collection_name, options_bson,
+                                    bson_schema_version, storage_format_version,
+                                    placement_policy, placement_version, next_natural_order,
+                                    lifecycle_state
+                                 ) VALUES (?1, ?2, ?3, ?4, 1, 1, 1, 1, 1, ?5)",
+                                params![
+                                    collection_id,
+                                    database_id,
+                                    collection,
+                                    options_bson,
+                                    COLLECTION_PROVISIONING
+                                ],
+                            )
+                            .map_err(sqlite_error::storage)?;
+                        transaction
+                            .execute(
+                                "INSERT INTO briskdb_document_indexes (
+                                    collection_id, index_name, spec_bson, is_unique, is_builtin,
+                                    index_format_version, lifecycle_state
+                                 ) VALUES (?1, '_id_', ?2, 1, 1, 1, ?3)",
+                                params![collection_id, id_specification_bson, INDEX_PENDING_BUILD],
+                            )
+                            .map_err(sqlite_error::storage)?;
+                        transaction
+                            .execute(
+                                "INSERT INTO briskdb_document_provisioning (
+                                    singleton, collection_id, operation_id, shard_count, next_shard
+                                 ) VALUES (1, ?1, ?2, ?3, 0)",
+                                params![collection_id, operation_id.as_slice(), self.shard_count()],
+                            )
+                            .map_err(sqlite_error::storage)?;
+                        manifest::validate_document_catalog(&transaction, self.shard_count())?;
+                        manifest::refresh_manifest_digest(&transaction)?;
+                        require_ready_manifest(&transaction, self.shard_count())?;
+                        ensure_control_active(
+                            &control,
+                            "before committing document collection provisioning",
+                        )?;
+                        migration.mark_pending_on_drop();
+                        transaction.commit().map_err(sqlite_error::storage)?;
+
+                        Ok(CreateCollectionStart::Provisioning(Provisioning {
+                            collection_id: DocumentCollectionId::from_validated(
+                                u64::try_from(collection_id)
+                                    .expect("positive SQLite document ID fits u64"),
+                            ),
+                            operation_id,
+                            shard_count: self.shard_count(),
+                            next_shard: 0,
+                        }))
+                    },
                 )?;
-                let operation_id = provisioning_id(database, collection, &options_bson);
-                transaction
-                    .execute(
-                        "INSERT INTO briskdb_document_collections (
-                            collection_id, database_id, collection_name, options_bson,
-                            bson_schema_version, storage_format_version,
-                            placement_policy, placement_version, next_natural_order,
-                            lifecycle_state
-                         ) VALUES (?1, ?2, ?3, ?4, 1, 1, 1, 1, 1, ?5)",
-                        params![
-                            collection_id,
-                            database_id,
-                            collection,
-                            options_bson,
-                            COLLECTION_PROVISIONING
-                        ],
-                    )
-                    .map_err(sqlite_error::storage)?;
-                transaction
-                    .execute(
-                        "INSERT INTO briskdb_document_indexes (
-                            collection_id, index_name, spec_bson, is_unique, is_builtin,
-                            index_format_version, lifecycle_state
-                         ) VALUES (?1, '_id_', ?2, 1, 1, 1, ?3)",
-                        params![collection_id, id_specification_bson, INDEX_PENDING_BUILD],
-                    )
-                    .map_err(sqlite_error::storage)?;
-                transaction
-                    .execute(
-                        "INSERT INTO briskdb_document_provisioning (
-                            singleton, collection_id, operation_id, shard_count, next_shard
-                         ) VALUES (1, ?1, ?2, ?3, 0)",
-                        params![collection_id, operation_id.as_slice(), self.shard_count()],
-                    )
-                    .map_err(sqlite_error::storage)?;
-                manifest::validate_document_catalog(&transaction, self.shard_count())?;
-                manifest::refresh_manifest_digest(&transaction)?;
-                require_ready_manifest(&transaction, self.shard_count())?;
-                migration.mark_pending_on_drop();
-                transaction.commit().map_err(sqlite_error::storage)?;
 
-                let provisioning = Provisioning {
-                    collection_id: DocumentCollectionId::from_validated(
-                        u64::try_from(collection_id).expect("positive SQLite document ID fits u64"),
-                    ),
-                    operation_id,
-                    shard_count: self.shard_count(),
-                    next_shard: 0,
+                let metadata = match start {
+                    CreateCollectionStart::Existing(metadata) => metadata,
+                    CreateCollectionStart::Provisioning(provisioning) => {
+                        recover_provisioning_controlled(
+                            self,
+                            &mut connection,
+                            provisioning,
+                            &control,
+                        )?
+                    }
                 };
-                recover_provisioning(self, &mut connection, provisioning)?;
-                load_catalog_rows(&connection)?
-                    .collection(database, collection)
-                    .cloned()
-                    .ok_or_else(|| {
-                        corrupt("completed document collection is missing from its catalog")
-                    })
+                Ok(metadata)
             })();
 
             match result {
@@ -349,6 +607,7 @@ mod enabled {
             }
         }
 
+        #[cfg(any(feature = "tinymongo-import", test))]
         pub(crate) fn declare_document_index(
             &self,
             collection_id: DocumentCollectionId,
@@ -361,6 +620,7 @@ mod enabled {
             self.fail_closed_on_corruption(result)
         }
 
+        #[cfg(any(feature = "tinymongo-import", test))]
         fn declare_document_index_inner(
             &self,
             collection_id: DocumentCollectionId,
@@ -368,6 +628,46 @@ mod enabled {
             specification: &BsonDocument,
             unique: bool,
         ) -> EngineResult<DocumentIndexMetadata> {
+            let _operation = self.enter_schema_operation()?;
+            self.declare_document_index_controlled_inner(
+                collection_id,
+                name,
+                specification,
+                unique,
+                OperationControl::new(None),
+            )
+        }
+
+        pub(crate) fn declare_document_index_controlled(
+            &self,
+            collection_id: DocumentCollectionId,
+            name: &str,
+            specification: &BsonDocument,
+            unique: bool,
+            control: Arc<OperationControl>,
+        ) -> EngineResult<DocumentIndexMetadata> {
+            // The Engine retains schema admission across catalog resolution
+            // and this manifest mutation; standalone wrappers acquire it once
+            // before delegating to the same controlled implementation.
+            let result = self.declare_document_index_controlled_inner(
+                collection_id,
+                name,
+                specification,
+                unique,
+                control,
+            );
+            self.fail_closed_on_corruption(result)
+        }
+
+        fn declare_document_index_controlled_inner(
+            &self,
+            collection_id: DocumentCollectionId,
+            name: &str,
+            specification: &BsonDocument,
+            unique: bool,
+            control: Arc<OperationControl>,
+        ) -> EngineResult<DocumentIndexMetadata> {
+            ensure_control_active(&control, "before declaring document index")?;
             if name.is_empty()
                 || name.len() > manifest::MAX_DOCUMENT_INDEX_NAME_BYTES
                 || name.contains('\0')
@@ -381,65 +681,64 @@ mod enabled {
             let spec_bson = encode_document(specification)
                 .map_err(|error| error.into_engine_error(BsonErrorContext::ClientInput))?;
             debug_assert!(spec_bson.len() <= manifest::MAX_DOCUMENT_METADATA_BSON_BYTES);
-            let _operation = self.enter_schema_operation()?;
             let manifest_path = self.root.join("manifest.sqlite");
             let mut connection = open_existing_manifest(&manifest_path)?;
-            configure_manifest_connection(&connection)?;
-            configure_journal_mode(&connection)?;
-            require_ready_manifest(&connection, self.shard_count())?;
-            require_active_collection(&connection, collection_id)?;
-            let transaction = connection
-                .transaction_with_behavior(TransactionBehavior::Immediate)
-                .map_err(sqlite_error::storage)?;
-            require_ready_manifest(&transaction, self.shard_count())?;
-            require_active_collection(&transaction, collection_id)?;
-            let existing = transaction
-                .query_row(
-                    "SELECT spec_bson, is_unique, lifecycle_state
-                     FROM briskdb_document_indexes
-                     WHERE collection_id = ?1 AND index_name = ?2",
-                    params![to_sqlite_id(collection_id)?, name],
-                    |row| {
-                        Ok((
-                            row.get::<_, Vec<u8>>(0)?,
-                            row.get::<_, i64>(1)?,
-                            row.get::<_, i64>(2)?,
-                        ))
-                    },
-                )
-                .optional()
-                .map_err(sqlite_error::storage)?;
-            if let Some((existing_spec, existing_unique, lifecycle)) = existing {
-                if existing_spec != spec_bson
-                    || existing_unique != i64::from(unique)
-                    || lifecycle != INDEX_PENDING_BUILD
-                {
-                    return Err(EngineError::new(
-                        EngineErrorKind::FailedPrecondition,
-                        "document index name already has a different declaration",
-                    ));
-                }
-            } else {
-                transaction
-                    .execute(
-                        "INSERT INTO briskdb_document_indexes (
-                            collection_id, index_name, spec_bson, is_unique, is_builtin,
-                            index_format_version, lifecycle_state
-                         ) VALUES (?1, ?2, ?3, ?4, 0, 1, ?5)",
-                        params![
-                            to_sqlite_id(collection_id)?,
-                            name,
-                            spec_bson,
-                            i64::from(unique),
-                            INDEX_PENDING_BUILD
-                        ],
-                    )
+            run_manifest_controlled(&mut connection, control.clone(), |connection| {
+                configure_journal_mode(connection)?;
+                let transaction = connection
+                    .transaction_with_behavior(TransactionBehavior::Immediate)
                     .map_err(sqlite_error::storage)?;
-                manifest::validate_document_catalog(&transaction, self.shard_count())?;
-                manifest::refresh_manifest_digest(&transaction)?;
                 require_ready_manifest(&transaction, self.shard_count())?;
-            }
-            transaction.commit().map_err(sqlite_error::storage)?;
+                require_active_collection(&transaction, collection_id)?;
+                let existing = transaction
+                    .query_row(
+                        "SELECT spec_bson, is_unique, lifecycle_state
+                         FROM briskdb_document_indexes
+                         WHERE collection_id = ?1 AND index_name = ?2",
+                        params![to_sqlite_id(collection_id)?, name],
+                        |row| {
+                            Ok((
+                                row.get::<_, Vec<u8>>(0)?,
+                                row.get::<_, i64>(1)?,
+                                row.get::<_, i64>(2)?,
+                            ))
+                        },
+                    )
+                    .optional()
+                    .map_err(sqlite_error::storage)?;
+                if let Some((existing_spec, existing_unique, lifecycle)) = existing {
+                    if existing_spec != spec_bson
+                        || existing_unique != i64::from(unique)
+                        || lifecycle != INDEX_PENDING_BUILD
+                    {
+                        return Err(EngineError::new(
+                            EngineErrorKind::FailedPrecondition,
+                            "document index name already has a different declaration",
+                        ));
+                    }
+                } else {
+                    transaction
+                        .execute(
+                            "INSERT INTO briskdb_document_indexes (
+                                collection_id, index_name, spec_bson, is_unique, is_builtin,
+                                index_format_version, lifecycle_state
+                             ) VALUES (?1, ?2, ?3, ?4, 0, 1, ?5)",
+                            params![
+                                to_sqlite_id(collection_id)?,
+                                name,
+                                spec_bson,
+                                i64::from(unique),
+                                INDEX_PENDING_BUILD
+                            ],
+                        )
+                        .map_err(sqlite_error::storage)?;
+                    manifest::validate_document_catalog(&transaction, self.shard_count())?;
+                    manifest::refresh_manifest_digest(&transaction)?;
+                    require_ready_manifest(&transaction, self.shard_count())?;
+                }
+                ensure_control_active(&control, "before committing document index declaration")?;
+                transaction.commit().map_err(sqlite_error::storage)
+            })?;
             let decoded = decode_metadata_document(&spec_bson, "document index specification")?;
             Ok(DocumentIndexMetadata::from_validated_parts(
                 name.to_owned(),
@@ -450,6 +749,26 @@ mod enabled {
             ))
         }
 
+        /// Validate and encode one document once before routing its write.
+        pub(crate) fn prepare_document_write(
+            &self,
+            document: &BsonDocument,
+        ) -> EngineResult<PreparedDocumentWrite> {
+            prepare_document(self, document)
+        }
+
+        /// Canonicalize an exact `_id` value and return its one owning shard.
+        pub(crate) fn prepare_document_id(
+            &self,
+            id: &BsonValue,
+        ) -> EngineResult<(CanonicalBsonKey, u16)> {
+            let id_key = CanonicalBsonKey::encode(id)
+                .map_err(|error| error.into_engine_error(BsonErrorContext::ClientInput))?;
+            let shard = self.shard_for_key(id_key.as_bytes());
+            Ok((id_key, shard))
+        }
+
+        #[cfg(any(feature = "tinymongo-import", test))]
         pub(crate) fn insert_document(
             &self,
             collection_id: DocumentCollectionId,
@@ -459,24 +778,22 @@ mod enabled {
             self.fail_closed_on_corruption(result)
         }
 
+        #[cfg(any(feature = "tinymongo-import", test))]
         fn insert_document_inner(
             &self,
             collection_id: DocumentCollectionId,
             document: &BsonDocument,
         ) -> EngineResult<u16> {
             let _operation = self.enter_schema_operation()?;
-            let (id_key, document_bson, shard) = prepare_document(self, document)?;
-            let natural_order = self.reserve_document_natural_orders(collection_id, 1)?;
-            self.insert_prepared_document(
-                collection_id,
-                natural_order,
-                shard,
-                &id_key,
-                &document_bson,
-            )?;
-            Ok(shard)
+            let cancellation = CancellationToken::new();
+            let prepared = self.prepare_document_write(document)?;
+            let natural_order =
+                self.reserve_document_natural_orders_for_engine(collection_id, 1, &cancellation)?;
+            self.insert_prepared_document(collection_id, natural_order, &prepared, &cancellation)?;
+            Ok(prepared.shard())
         }
 
+        #[cfg(any(feature = "tinymongo-import", test))]
         pub(crate) fn insert_documents(
             &self,
             collection_id: DocumentCollectionId,
@@ -487,6 +804,7 @@ mod enabled {
             self.fail_closed_on_corruption(result)
         }
 
+        #[cfg(any(feature = "tinymongo-import", test))]
         fn insert_documents_inner(
             &self,
             collection_id: DocumentCollectionId,
@@ -499,7 +817,7 @@ mod enabled {
                 self.require_active_document_collection(collection_id)?;
                 return Ok(());
             }
-            let natural_order = self.reserve_document_natural_orders(
+            let natural_order = self.reserve_document_natural_orders_for_engine(
                 collection_id,
                 u64::try_from(documents.len()).map_err(|error| {
                     EngineError::from_source(
@@ -508,12 +826,13 @@ mod enabled {
                         error,
                     )
                 })?,
+                cancellation,
             )?;
             // A committed range is never reused. Cancellation or a later shard
             // failure may leave gaps, preserving monotonic order after retry.
             for (offset, document) in documents.iter().enumerate() {
                 ensure_document_write_not_cancelled(cancellation)?;
-                let offset = i64::try_from(offset).map_err(|error| {
+                let offset = u64::try_from(offset).map_err(|error| {
                     EngineError::from_source(
                         EngineErrorKind::LimitExceeded,
                         "document batch offset exceeds its supported range",
@@ -526,35 +845,118 @@ mod enabled {
                         "document natural-order identity space is exhausted",
                     )
                 })?;
-                let (id_key, document_bson, shard) = prepare_document(self, document)?;
-                self.insert_prepared_document(
-                    collection_id,
-                    order,
-                    shard,
-                    &id_key,
-                    &document_bson,
-                )?;
+                let prepared = self.prepare_document_write(document)?;
+                self.insert_prepared_document(collection_id, order, &prepared, cancellation)?;
             }
             Ok(())
         }
 
-        fn reserve_document_natural_orders(
+        /// Reserve a durable, never-reused natural-order range for engine writes.
+        ///
+        /// The caller must hold the request's schema-operation guard while this
+        /// manifest transaction runs. Cancellation is checked before the lock,
+        /// by SQLite's progress hook, and immediately before commit.
+        #[cfg(any(feature = "tinymongo-import", test))]
+        pub(crate) fn reserve_document_natural_orders_for_engine(
             &self,
             collection_id: DocumentCollectionId,
             count: u64,
-        ) -> EngineResult<i64> {
-            debug_assert!(count > 0);
-            let count = i64::try_from(count).map_err(|error| {
-                EngineError::from_source(
-                    EngineErrorKind::LimitExceeded,
-                    "document natural-order reservation exceeds SQLite's supported range",
-                    error,
+            cancellation: &CancellationToken,
+        ) -> EngineResult<u64> {
+            let result =
+                self.reserve_document_natural_orders_inner(collection_id, count, cancellation);
+            self.fail_closed_on_corruption(result)
+        }
+
+        pub(crate) fn reserve_document_natural_orders_controlled(
+            &self,
+            collection_id: DocumentCollectionId,
+            count: u64,
+            control: Arc<OperationControl>,
+        ) -> EngineResult<u64> {
+            let result = self.reserve_document_natural_orders_controlled_inner(
+                collection_id,
+                count,
+                control,
+            );
+            self.fail_closed_on_corruption(result)
+        }
+
+        fn reserve_document_natural_orders_controlled_inner(
+            &self,
+            collection_id: DocumentCollectionId,
+            count: u64,
+            control: Arc<OperationControl>,
+        ) -> EngineResult<u64> {
+            ensure_control_active(&control, "before reserving document natural order")?;
+            let count = validate_natural_order_reservation_count(count)?;
+            let manifest_path = self.root.join("manifest.sqlite");
+            let mut connection = open_existing_manifest(&manifest_path)?;
+            run_manifest_controlled(&mut connection, control.clone(), |connection| {
+                configure_journal_mode(connection)?;
+                self.reserve_document_natural_orders_on_connection(
+                    connection,
+                    collection_id,
+                    count,
+                    || {
+                        ensure_control_active(
+                            &control,
+                            "before committing document natural-order reservation",
+                        )
+                    },
                 )
-            })?;
+            })
+        }
+
+        #[cfg(any(feature = "tinymongo-import", test))]
+        fn reserve_document_natural_orders_inner(
+            &self,
+            collection_id: DocumentCollectionId,
+            count: u64,
+            cancellation: &CancellationToken,
+        ) -> EngineResult<u64> {
+            ensure_document_operation_not_cancelled(
+                cancellation,
+                "before reserving document natural order",
+            )?;
+            let count = validate_natural_order_reservation_count(count)?;
             let manifest_path = self.root.join("manifest.sqlite");
             let mut connection = open_existing_manifest(&manifest_path)?;
             configure_manifest_connection(&connection)?;
             configure_journal_mode(&connection)?;
+            let progress_cancellation = cancellation.clone();
+            connection
+                .progress_handler(1_000, Some(move || progress_cancellation.is_cancelled()))
+                .map_err(sqlite_error::storage)?;
+            let result = self.reserve_document_natural_orders_on_connection(
+                &mut connection,
+                collection_id,
+                count,
+                || {
+                    ensure_document_operation_not_cancelled(
+                        cancellation,
+                        "before committing document natural-order reservation",
+                    )
+                },
+            );
+            let cleanup = connection
+                .progress_handler(0, None::<fn() -> bool>)
+                .map_err(sqlite_error::storage);
+            match (result, cleanup) {
+                (Ok(first), Ok(())) => Ok(first),
+                (Ok(_), Err(error)) => Err(error
+                    .context("failed to remove the document allocator cancellation progress hook")),
+                (Err(error), _) => Err(error),
+            }
+        }
+
+        fn reserve_document_natural_orders_on_connection(
+            &self,
+            connection: &mut Connection,
+            collection_id: DocumentCollectionId,
+            count: i64,
+            before_commit: impl FnOnce() -> EngineResult<()>,
+        ) -> EngineResult<u64> {
             let transaction = connection
                 .transaction_with_behavior(TransactionBehavior::Immediate)
                 .map_err(sqlite_error::storage)?;
@@ -602,33 +1004,65 @@ mod enabled {
             manifest::validate_document_catalog(&transaction, self.shard_count())?;
             manifest::refresh_manifest_digest(&transaction)?;
             require_ready_manifest(&transaction, self.shard_count())?;
+            before_commit()?;
             transaction.commit().map_err(sqlite_error::storage)?;
-            Ok(first)
+            document_natural_order_from_sqlite(first)
         }
 
+        #[cfg(any(feature = "tinymongo-import", test))]
         fn insert_prepared_document(
             &self,
             collection_id: DocumentCollectionId,
-            natural_order: i64,
-            shard: u16,
-            id_key: &CanonicalBsonKey,
-            document_bson: &[u8],
+            natural_order: u64,
+            prepared: &PreparedDocumentWrite,
+            cancellation: &CancellationToken,
         ) -> EngineResult<()> {
-            debug_assert_eq!(self.shard_for_key(id_key.as_bytes()), shard);
+            let shard = prepared.shard();
             let mut connection = self.open_unconfigured_shard(shard)?;
             self.validate_unconfigured_shard(&connection, shard)?;
             require_schema(&connection)?;
+            let transaction = connection
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .map_err(sqlite_error::storage)?;
+            self.insert_prepared_document_on_connection(
+                &transaction,
+                collection_id,
+                natural_order,
+                shard,
+                prepared,
+                cancellation,
+            )?;
+            transaction.commit().map_err(sqlite_error::storage)?;
+            Ok(())
+        }
+
+        /// Insert one prepared record through an already-leased shard handle.
+        ///
+        /// Transaction ownership remains with the engine. The caller supplies
+        /// the lease's physical shard identity and arms SQLite's progress and
+        /// interrupt hooks around this call.
+        #[allow(clippy::too_many_arguments)]
+        pub(crate) fn insert_prepared_document_on_connection(
+            &self,
+            connection: &Connection,
+            collection_id: DocumentCollectionId,
+            natural_order: u64,
+            shard: u16,
+            prepared: &PreparedDocumentWrite,
+            cancellation: &CancellationToken,
+        ) -> EngineResult<()> {
+            ensure_document_operation_not_cancelled(cancellation, "before inserting document")?;
+            self.validate_prepared_document_route(shard, prepared)?;
+            require_schema(connection)?;
+            let natural_order = document_natural_order_to_sqlite(natural_order)?;
             let checksum = record_checksum(
                 collection_id,
                 shard,
                 natural_order,
-                id_key.as_bytes(),
-                document_bson,
+                prepared.id_key.as_bytes(),
+                &prepared.document_bson,
             );
-            let transaction = connection
-                .transaction_with_behavior(TransactionBehavior::Immediate)
-                .map_err(sqlite_error::storage)?;
-            transaction
+            connection
                 .execute(
                     "INSERT INTO briskdb_documents_v1 (
                         collection_id, id_key, natural_order, document_bson,
@@ -636,17 +1070,131 @@ mod enabled {
                      ) VALUES (?1, ?2, ?3, ?4, ?5, 1)",
                     params![
                         to_sqlite_id(collection_id)?,
-                        id_key.as_bytes(),
+                        prepared.id_key.as_bytes(),
                         natural_order,
-                        document_bson,
+                        prepared.document_bson,
                         checksum.as_slice()
                     ],
                 )
                 .map_err(sqlite_error::statement)?;
-            transaction.commit().map_err(sqlite_error::storage)?;
             Ok(())
         }
 
+        /// Replace one exact `_id` record while preserving its natural order.
+        ///
+        /// `false` means the target record no longer exists at the supplied
+        /// natural order. A replacement cannot change the semantic `_id`.
+        #[allow(clippy::too_many_arguments)]
+        // The protocol-neutral command model already reserves replacement;
+        // matcher/update semantics will consume this atomic storage primitive.
+        #[allow(dead_code)]
+        pub(crate) fn replace_document_on_connection(
+            &self,
+            connection: &Connection,
+            collection_id: DocumentCollectionId,
+            shard: u16,
+            id_key: &CanonicalBsonKey,
+            natural_order: u64,
+            replacement: &PreparedDocumentWrite,
+            cancellation: &CancellationToken,
+        ) -> EngineResult<bool> {
+            ensure_document_operation_not_cancelled(cancellation, "before replacing document")?;
+            self.validate_document_key_route(shard, id_key)?;
+            if replacement.id_key != *id_key {
+                return Err(EngineError::new(
+                    EngineErrorKind::InvalidArgument,
+                    "document replacement cannot change the semantic _id",
+                ));
+            }
+            self.validate_prepared_document_route(shard, replacement)?;
+            require_schema(connection)?;
+            let natural_order = document_natural_order_to_sqlite(natural_order)?;
+            let checksum = record_checksum(
+                collection_id,
+                shard,
+                natural_order,
+                id_key.as_bytes(),
+                &replacement.document_bson,
+            );
+            let changed = connection
+                .execute(
+                    "UPDATE briskdb_documents_v1
+                     SET document_bson = ?1, document_checksum = ?2
+                     WHERE collection_id = ?3 AND id_key = ?4 AND natural_order = ?5",
+                    params![
+                        replacement.document_bson,
+                        checksum.as_slice(),
+                        to_sqlite_id(collection_id)?,
+                        id_key.as_bytes(),
+                        natural_order
+                    ],
+                )
+                .map_err(sqlite_error::statement)?;
+            if changed > 1 {
+                return Err(corrupt(
+                    "exact document replacement changed more than one stored record",
+                ));
+            }
+            Ok(changed == 1)
+        }
+
+        /// Delete one exact canonical `_id` through an already-leased handle.
+        pub(crate) fn delete_document_on_connection(
+            &self,
+            connection: &Connection,
+            collection_id: DocumentCollectionId,
+            shard: u16,
+            id_key: &CanonicalBsonKey,
+            cancellation: &CancellationToken,
+        ) -> EngineResult<bool> {
+            ensure_document_operation_not_cancelled(cancellation, "before deleting document")?;
+            self.validate_document_key_route(shard, id_key)?;
+            require_schema(connection)?;
+            let changed = connection
+                .execute(
+                    "DELETE FROM briskdb_documents_v1
+                     WHERE collection_id = ?1 AND id_key = ?2",
+                    params![to_sqlite_id(collection_id)?, id_key.as_bytes()],
+                )
+                .map_err(sqlite_error::statement)?;
+            if changed > 1 {
+                return Err(corrupt(
+                    "exact document deletion changed more than one stored record",
+                ));
+            }
+            Ok(changed == 1)
+        }
+
+        fn validate_prepared_document_route(
+            &self,
+            shard: u16,
+            prepared: &PreparedDocumentWrite,
+        ) -> EngineResult<()> {
+            if prepared.shard != shard {
+                return Err(EngineError::new(
+                    EngineErrorKind::Internal,
+                    "prepared document was sent to a different shard lease",
+                ));
+            }
+            self.validate_document_key_route(shard, &prepared.id_key)
+        }
+
+        fn validate_document_key_route(
+            &self,
+            shard: u16,
+            id_key: &CanonicalBsonKey,
+        ) -> EngineResult<()> {
+            self.ensure_shard_in_range(shard)?;
+            if self.shard_for_key(id_key.as_bytes()) != shard {
+                return Err(EngineError::new(
+                    EngineErrorKind::Internal,
+                    "canonical document _id was sent to a non-owning shard lease",
+                ));
+            }
+            Ok(())
+        }
+
+        #[cfg(any(feature = "tinymongo-import", test))]
         pub(crate) fn get_document(
             &self,
             collection_id: DocumentCollectionId,
@@ -656,6 +1204,7 @@ mod enabled {
             self.fail_closed_on_corruption(result)
         }
 
+        #[cfg(any(feature = "tinymongo-import", test))]
         fn get_document_inner(
             &self,
             collection_id: DocumentCollectionId,
@@ -663,12 +1212,32 @@ mod enabled {
         ) -> EngineResult<Option<BsonDocument>> {
             let _operation = self.enter_schema_operation()?;
             self.require_active_document_collection(collection_id)?;
-            let id_key = CanonicalBsonKey::encode(id)
-                .map_err(|error| error.into_engine_error(BsonErrorContext::ClientInput))?;
-            let shard = self.shard_for_key(id_key.as_bytes());
+            let cancellation = CancellationToken::new();
+            let (id_key, shard) = self.prepare_document_id(id)?;
             let connection = self.open_unconfigured_shard(shard)?;
             self.validate_unconfigured_shard(&connection, shard)?;
-            require_schema(&connection)?;
+            self.get_document_on_connection(
+                &connection,
+                collection_id,
+                shard,
+                &id_key,
+                &cancellation,
+            )
+            .map(|record| record.map(DocumentStorageRecord::into_document))
+        }
+
+        /// Read one exact canonical `_id` through an already-leased shard.
+        pub(crate) fn get_document_on_connection(
+            &self,
+            connection: &Connection,
+            collection_id: DocumentCollectionId,
+            shard: u16,
+            id_key: &CanonicalBsonKey,
+            cancellation: &CancellationToken,
+        ) -> EngineResult<Option<DocumentStorageRecord>> {
+            ensure_document_operation_not_cancelled(cancellation, "before reading document")?;
+            self.validate_document_key_route(shard, id_key)?;
+            require_schema(connection)?;
             let row = connection
                 .query_row(
                     "SELECT natural_order, document_bson, document_checksum,
@@ -687,18 +1256,138 @@ mod enabled {
                 )
                 .optional()
                 .map_err(|error| shard_read_error(error, "failed to read stored BSON document"))?;
-            row.map(|(natural_order, bson, checksum, version)| {
-                decode_record(
+            let record = row
+                .map(|(natural_order, bson, checksum, version)| {
+                    decode_storage_record(
+                        collection_id,
+                        shard,
+                        natural_order,
+                        id_key.as_bytes().to_vec(),
+                        bson,
+                        checksum,
+                        version,
+                    )
+                })
+                .transpose()?;
+            ensure_document_operation_not_cancelled(cancellation, "after reading document")?;
+            Ok(record)
+        }
+
+        /// Count one collection on one already-leased shard.
+        ///
+        /// This deliberately counts rows without decoding every BSON payload.
+        /// Startup validation and point/scan reads remain the checksum boundary.
+        pub(crate) fn count_document_shard_on_connection(
+            &self,
+            connection: &Connection,
+            collection_id: DocumentCollectionId,
+            shard: u16,
+            cancellation: &CancellationToken,
+        ) -> EngineResult<u64> {
+            ensure_document_operation_not_cancelled(cancellation, "before counting documents")?;
+            self.ensure_shard_in_range(shard)?;
+            require_schema(connection)?;
+            let count = connection
+                .query_row(
+                    "SELECT count(*) FROM briskdb_documents_v1
+                     WHERE collection_id = ?1",
+                    [to_sqlite_id(collection_id)?],
+                    |row| row.get::<_, i64>(0),
+                )
+                .map_err(|error| {
+                    shard_read_error(error, "failed to count stored BSON documents")
+                })?;
+            ensure_document_operation_not_cancelled(cancellation, "after counting documents")?;
+            u64::try_from(count)
+                .map_err(|_| corrupt("stored BSON document count is outside its range"))
+        }
+
+        /// Return one bounded, ascending shard-local natural-order page.
+        pub(crate) fn scan_document_shard_on_connection(
+            &self,
+            connection: &Connection,
+            collection_id: DocumentCollectionId,
+            shard: u16,
+            after_natural_order: Option<u64>,
+            limit: usize,
+            cancellation: &CancellationToken,
+        ) -> EngineResult<Vec<DocumentStorageRecord>> {
+            ensure_document_operation_not_cancelled(cancellation, "before scanning documents")?;
+            self.ensure_shard_in_range(shard)?;
+            if !(1..=MAX_DOCUMENT_SHARD_SCAN_RECORDS).contains(&limit) {
+                return Err(EngineError::new(
+                    EngineErrorKind::InvalidArgument,
+                    format!(
+                        "document shard scan limit must be between 1 and {MAX_DOCUMENT_SHARD_SCAN_RECORDS}"
+                    ),
+                ));
+            }
+            let after_natural_order = after_natural_order
+                .map(document_natural_order_to_sqlite)
+                .transpose()?
+                .unwrap_or(0);
+            let sqlite_limit =
+                i64::try_from(limit).expect("bounded document scan limit fits SQLite");
+            require_schema(connection)?;
+            let mut statement = connection
+                .prepare(
+                    "SELECT natural_order, id_key, document_bson, document_checksum,
+                            storage_format_version
+                     FROM briskdb_documents_v1
+                     WHERE collection_id = ?1 AND natural_order > ?2
+                     ORDER BY natural_order LIMIT ?3",
+                )
+                .map_err(|error| {
+                    shard_read_error(error, "failed to prepare stored BSON document scan")
+                })?;
+            let mut rows = statement
+                .query(params![
+                    to_sqlite_id(collection_id)?,
+                    after_natural_order,
+                    sqlite_limit
+                ])
+                .map_err(|error| {
+                    shard_read_error(error, "failed to start stored BSON document scan")
+                })?;
+            let mut records = Vec::with_capacity(limit);
+            while let Some(row) = rows.next().map_err(|error| {
+                shard_read_error(error, "failed while scanning stored BSON documents")
+            })? {
+                ensure_document_operation_not_cancelled(cancellation, "while scanning documents")?;
+                let natural_order = row.get::<_, i64>(0).map_err(|error| {
+                    shard_read_error(error, "failed to decode stored BSON natural order")
+                })?;
+                let id_key = row.get::<_, Vec<u8>>(1).map_err(|error| {
+                    shard_read_error(error, "failed to decode stored BSON canonical key")
+                })?;
+                let document_bson = row.get::<_, Vec<u8>>(2).map_err(|error| {
+                    shard_read_error(error, "failed to decode stored BSON payload")
+                })?;
+                let checksum = row.get::<_, Vec<u8>>(3).map_err(|error| {
+                    shard_read_error(error, "failed to decode stored BSON checksum")
+                })?;
+                let version = row.get::<_, i64>(4).map_err(|error| {
+                    shard_read_error(error, "failed to decode stored BSON format version")
+                })?;
+                let canonical = CanonicalBsonKey::from_bytes(&id_key)
+                    .map_err(|error| error.into_engine_error(BsonErrorContext::StoredData))?;
+                if self.shard_for_key(canonical.as_bytes()) != shard {
+                    return Err(corrupt(
+                        "stored BSON document is on a shard that disagrees with its canonical _id route",
+                    ));
+                }
+                records.push(decode_storage_record(
                     collection_id,
                     shard,
                     natural_order,
-                    id_key.as_bytes(),
-                    bson,
+                    id_key,
+                    document_bson,
                     checksum,
                     version,
-                )
-            })
-            .transpose()
+                )?);
+            }
+            ensure_document_operation_not_cancelled(cancellation, "after scanning documents")?;
+            Ok(records)
         }
 
         #[cfg(feature = "tinymongo-import")]
@@ -714,23 +1403,17 @@ mod enabled {
         fn document_count_inner(&self, collection_id: DocumentCollectionId) -> EngineResult<u64> {
             let _operation = self.enter_schema_operation()?;
             self.require_active_document_collection(collection_id)?;
+            let cancellation = CancellationToken::new();
             let mut total = 0_u64;
             for shard in 0..self.shard_count() {
                 let connection = self.open_unconfigured_shard(shard)?;
                 self.validate_unconfigured_shard(&connection, shard)?;
-                require_schema(&connection)?;
-                let count = connection
-                    .query_row(
-                        "SELECT count(*) FROM briskdb_documents_v1
-                         WHERE collection_id = ?1",
-                        [to_sqlite_id(collection_id)?],
-                        |row| row.get::<_, i64>(0),
-                    )
-                    .map_err(|error| {
-                        shard_read_error(error, "failed to count stored BSON documents")
-                    })?;
-                let count = u64::try_from(count)
-                    .map_err(|_| corrupt("stored BSON document count is outside its range"))?;
+                let count = self.count_document_shard_on_connection(
+                    &connection,
+                    collection_id,
+                    shard,
+                    &cancellation,
+                )?;
                 total = total.checked_add(count).ok_or_else(|| {
                     corrupt("stored BSON document count exceeds its supported range")
                 })?;
@@ -753,47 +1436,29 @@ mod enabled {
         ) -> EngineResult<Vec<BsonDocument>> {
             let _operation = self.enter_schema_operation()?;
             self.require_active_document_collection(collection_id)?;
+            let cancellation = CancellationToken::new();
             let mut documents = Vec::new();
             for shard in 0..self.shard_count() {
                 let connection = self.open_unconfigured_shard(shard)?;
                 self.validate_unconfigured_shard(&connection, shard)?;
-                require_schema(&connection)?;
-                let mut statement = connection
-                    .prepare(
-                        "SELECT natural_order, id_key, document_bson, document_checksum,
-                                storage_format_version
-                         FROM briskdb_documents_v1 WHERE collection_id = ?1
-                         ORDER BY natural_order",
-                    )
-                    .map_err(sqlite_error::storage)?;
-                let mut rows = statement
-                    .query([to_sqlite_id(collection_id)?])
-                    .map_err(sqlite_error::storage)?;
-                while let Some(row) = rows.next().map_err(sqlite_error::storage)? {
-                    let natural_order = row.get::<_, i64>(0).map_err(sqlite_error::storage)?;
-                    let key = row.get::<_, Vec<u8>>(1).map_err(sqlite_error::storage)?;
-                    let bson = row.get::<_, Vec<u8>>(2).map_err(sqlite_error::storage)?;
-                    let checksum = row.get::<_, Vec<u8>>(3).map_err(sqlite_error::storage)?;
-                    let version = row.get::<_, i64>(4).map_err(sqlite_error::storage)?;
-                    CanonicalBsonKey::from_bytes(&key)
-                        .map_err(|error| error.into_engine_error(BsonErrorContext::StoredData))?;
-                    if self.shard_for_key(&key) != shard {
-                        return Err(corrupt(
-                            "stored BSON document is on a shard that disagrees with its canonical _id route",
-                        ));
+                let mut after = None;
+                loop {
+                    let page = self.scan_document_shard_on_connection(
+                        &connection,
+                        collection_id,
+                        shard,
+                        after,
+                        MAX_DOCUMENT_SHARD_SCAN_RECORDS,
+                        &cancellation,
+                    )?;
+                    if page.is_empty() {
+                        break;
                     }
-                    documents.push((
-                        natural_order,
-                        decode_record(
-                            collection_id,
-                            shard,
-                            natural_order,
-                            &key,
-                            bson,
-                            checksum,
-                            version,
-                        )?,
-                    ));
+                    after = page.last().map(DocumentStorageRecord::natural_order);
+                    documents.extend(
+                        page.into_iter()
+                            .map(|record| (record.natural_order(), record.into_document())),
+                    );
                 }
             }
             documents.sort_by_key(|(natural_order, _)| *natural_order);
@@ -820,12 +1485,12 @@ mod enabled {
         fn next_document_natural_order(
             &self,
             collection_id: DocumentCollectionId,
-        ) -> EngineResult<i64> {
+        ) -> EngineResult<u64> {
             let path = self.root.join("manifest.sqlite");
             let connection = open_existing_manifest(&path)?;
             configure_manifest_connection(&connection)?;
             require_ready_manifest(&connection, self.shard_count())?;
-            connection
+            let next = connection
                 .query_row(
                     "SELECT next_natural_order FROM briskdb_document_collections
                      WHERE collection_id = ?1 AND lifecycle_state = ?2",
@@ -834,7 +1499,13 @@ mod enabled {
                 )
                 .optional()
                 .map_err(sqlite_error::storage)?
-                .ok_or_else(|| corrupt("active document collection disappeared from its catalog"))
+                .ok_or_else(|| {
+                    corrupt("active document collection disappeared from its catalog")
+                })?;
+            u64::try_from(next)
+                .ok()
+                .filter(|next| *next > 0)
+                .ok_or_else(|| corrupt("document natural-order allocator is not positive"))
         }
 
         fn require_active_document_collection(
@@ -877,8 +1548,38 @@ mod enabled {
     fn recover_provisioning(
         storage: &Storage,
         manifest_connection: &mut Connection,
-        mut provisioning: Provisioning,
+        provisioning: Provisioning,
     ) -> EngineResult<()> {
+        recover_provisioning_inner(storage, manifest_connection, provisioning, None).map(|_| ())
+    }
+
+    fn recover_provisioning_controlled(
+        storage: &Storage,
+        manifest_connection: &mut Connection,
+        provisioning: Provisioning,
+        control: &Arc<OperationControl>,
+    ) -> EngineResult<DocumentCollectionMetadata> {
+        ensure_control_active(control, "before provisioning document collection")?;
+        recover_provisioning_inner(storage, manifest_connection, provisioning, Some(control))
+    }
+
+    fn run_provisioning_step<T>(
+        connection: &mut Connection,
+        control: Option<&Arc<OperationControl>>,
+        work: impl FnOnce(&mut Connection) -> EngineResult<T>,
+    ) -> EngineResult<T> {
+        match control {
+            Some(control) => run_dedicated_controlled(connection, Arc::clone(control), work),
+            None => work(connection),
+        }
+    }
+
+    fn recover_provisioning_inner(
+        storage: &Storage,
+        manifest_connection: &mut Connection,
+        mut provisioning: Provisioning,
+        control: Option<&Arc<OperationControl>>,
+    ) -> EngineResult<DocumentCollectionMetadata> {
         if provisioning.shard_count != storage.shard_count() {
             return Err(corrupt(
                 "document provisioning shard count differs from routing metadata",
@@ -887,94 +1588,124 @@ mod enabled {
         while provisioning.next_shard < provisioning.shard_count {
             let shard = provisioning.next_shard;
             let mut connection = storage.open_unconfigured_shard(shard)?;
-            storage.validate_unconfigured_shard(&connection, shard)?;
-            ensure_schema(&mut connection)?;
+            match control {
+                Some(control) => {
+                    run_dedicated_controlled(&mut connection, Arc::clone(control), |connection| {
+                        storage.validate_unconfigured_shard_nonterminal(connection, shard)?;
+                        ensure_schema(connection)
+                    })?
+                }
+                None => {
+                    storage.validate_unconfigured_shard(&connection, shard)?;
+                    ensure_schema(&mut connection)?;
+                }
+            }
+            run_provisioning_step(manifest_connection, control, |manifest_connection| {
+                let transaction = manifest_connection
+                    .transaction_with_behavior(TransactionBehavior::Immediate)
+                    .map_err(sqlite_error::storage)?;
+                manifest::current_integrity(&transaction, storage.shard_count())?;
+                let changed = transaction
+                    .execute(
+                        "UPDATE briskdb_document_provisioning SET next_shard = ?1
+                         WHERE singleton = 1 AND collection_id = ?2
+                           AND operation_id = ?3 AND next_shard = ?4",
+                        params![
+                            shard + 1,
+                            to_sqlite_id(provisioning.collection_id)?,
+                            provisioning.operation_id.as_slice(),
+                            shard
+                        ],
+                    )
+                    .map_err(sqlite_error::storage)?;
+                if changed != 1 {
+                    return Err(corrupt(
+                        "document provisioning journal did not advance exactly once",
+                    ));
+                }
+                manifest::validate_document_catalog(&transaction, storage.shard_count())?;
+                manifest::refresh_manifest_digest(&transaction)?;
+                manifest::current_integrity(&transaction, storage.shard_count())?;
+                if let Some(control) = control {
+                    ensure_control_active(
+                        control,
+                        "before committing document collection provisioning cursor",
+                    )?;
+                }
+                transaction.commit().map_err(sqlite_error::storage)
+            })?;
+            provisioning.next_shard = shard + 1;
+        }
+
+        run_provisioning_step(manifest_connection, control, |manifest_connection| {
             let transaction = manifest_connection
                 .transaction_with_behavior(TransactionBehavior::Immediate)
                 .map_err(sqlite_error::storage)?;
             manifest::current_integrity(&transaction, storage.shard_count())?;
+            let activated_index = transaction
+                .execute(
+                    "UPDATE briskdb_document_indexes SET lifecycle_state = ?1
+                     WHERE collection_id = ?2 AND index_name = '_id_'
+                       AND is_unique = 1 AND is_builtin = 1 AND lifecycle_state = ?3",
+                    params![
+                        INDEX_READY,
+                        to_sqlite_id(provisioning.collection_id)?,
+                        INDEX_PENDING_BUILD
+                    ],
+                )
+                .map_err(sqlite_error::storage)?;
+            if activated_index != 1 {
+                return Err(corrupt(
+                    "document collection activation did not update its built-in _id index",
+                ));
+            }
             let changed = transaction
                 .execute(
-                    "UPDATE briskdb_document_provisioning SET next_shard = ?1
-                     WHERE singleton = 1 AND collection_id = ?2
-                       AND operation_id = ?3 AND next_shard = ?4",
+                    "UPDATE briskdb_document_collections SET lifecycle_state = ?1
+                     WHERE collection_id = ?2 AND lifecycle_state = ?3",
                     params![
-                        shard + 1,
+                        COLLECTION_ACTIVE,
                         to_sqlite_id(provisioning.collection_id)?,
-                        provisioning.operation_id.as_slice(),
-                        shard
+                        COLLECTION_PROVISIONING
                     ],
                 )
                 .map_err(sqlite_error::storage)?;
             if changed != 1 {
                 return Err(corrupt(
-                    "document provisioning journal did not advance exactly once",
+                    "document collection activation did not update exactly one row",
+                ));
+            }
+            let deleted = transaction
+                .execute(
+                    "DELETE FROM briskdb_document_provisioning
+                     WHERE singleton = 1 AND collection_id = ?1 AND operation_id = ?2
+                       AND next_shard = shard_count",
+                    params![
+                        to_sqlite_id(provisioning.collection_id)?,
+                        provisioning.operation_id.as_slice()
+                    ],
+                )
+                .map_err(sqlite_error::storage)?;
+            if deleted != 1 {
+                return Err(corrupt(
+                    "document provisioning journal did not finalize exactly once",
                 ));
             }
             manifest::validate_document_catalog(&transaction, storage.shard_count())?;
             manifest::refresh_manifest_digest(&transaction)?;
             manifest::current_integrity(&transaction, storage.shard_count())?;
+            let metadata = load_catalog_rows(&transaction)?
+                .collection_by_id(provisioning.collection_id)
+                .cloned()
+                .ok_or_else(|| {
+                    corrupt("completed document collection is missing from its catalog")
+                })?;
+            if let Some(control) = control {
+                ensure_control_active(control, "before committing document collection activation")?;
+            }
             transaction.commit().map_err(sqlite_error::storage)?;
-            provisioning.next_shard = shard + 1;
-        }
-
-        let transaction = manifest_connection
-            .transaction_with_behavior(TransactionBehavior::Immediate)
-            .map_err(sqlite_error::storage)?;
-        manifest::current_integrity(&transaction, storage.shard_count())?;
-        let activated_index = transaction
-            .execute(
-                "UPDATE briskdb_document_indexes SET lifecycle_state = ?1
-                 WHERE collection_id = ?2 AND index_name = '_id_'
-                   AND is_unique = 1 AND is_builtin = 1 AND lifecycle_state = ?3",
-                params![
-                    INDEX_READY,
-                    to_sqlite_id(provisioning.collection_id)?,
-                    INDEX_PENDING_BUILD
-                ],
-            )
-            .map_err(sqlite_error::storage)?;
-        if activated_index != 1 {
-            return Err(corrupt(
-                "document collection activation did not update its built-in _id index",
-            ));
-        }
-        let changed = transaction
-            .execute(
-                "UPDATE briskdb_document_collections SET lifecycle_state = ?1
-                 WHERE collection_id = ?2 AND lifecycle_state = ?3",
-                params![
-                    COLLECTION_ACTIVE,
-                    to_sqlite_id(provisioning.collection_id)?,
-                    COLLECTION_PROVISIONING
-                ],
-            )
-            .map_err(sqlite_error::storage)?;
-        if changed != 1 {
-            return Err(corrupt(
-                "document collection activation did not update exactly one row",
-            ));
-        }
-        let deleted = transaction
-            .execute(
-                "DELETE FROM briskdb_document_provisioning
-                 WHERE singleton = 1 AND collection_id = ?1 AND operation_id = ?2
-                   AND next_shard = shard_count",
-                params![
-                    to_sqlite_id(provisioning.collection_id)?,
-                    provisioning.operation_id.as_slice()
-                ],
-            )
-            .map_err(sqlite_error::storage)?;
-        if deleted != 1 {
-            return Err(corrupt(
-                "document provisioning journal did not finalize exactly once",
-            ));
-        }
-        manifest::validate_document_catalog(&transaction, storage.shard_count())?;
-        manifest::refresh_manifest_digest(&transaction)?;
-        manifest::current_integrity(&transaction, storage.shard_count())?;
-        transaction.commit().map_err(sqlite_error::storage)
+            Ok(metadata)
+        })
     }
 
     fn validate_stored_records(
@@ -1233,10 +1964,164 @@ mod enabled {
         ))
     }
 
+    type StoredCollectionRow = (i64, i64, String, String, Vec<u8>, i64, i64);
+
+    fn load_collection_row(
+        connection: &Connection,
+        database: &str,
+        collection: &str,
+        control: &OperationControl,
+    ) -> EngineResult<Option<DocumentCollectionMetadata>> {
+        ensure_control_active(control, "before reading document collection metadata")?;
+        let row = connection
+            .query_row(
+                "SELECT c.collection_id, c.database_id, d.database_name,
+                        c.collection_name, c.options_bson, c.placement_policy,
+                        c.placement_version
+                 FROM briskdb_document_collections AS c
+                 JOIN briskdb_document_databases AS d
+                   ON d.database_id = c.database_id
+                 WHERE c.lifecycle_state = 2
+                   AND d.database_name = ?1
+                   AND c.collection_name = ?2",
+                params![database, collection],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                        row.get(5)?,
+                        row.get(6)?,
+                    ))
+                },
+            )
+            .optional()
+            .map_err(sqlite_error::storage)?;
+        let metadata = row
+            .map(|row| decode_collection_row(connection, row, Some(control)))
+            .transpose()?;
+        ensure_control_active(control, "after reading document collection metadata")?;
+        Ok(metadata)
+    }
+
+    fn load_collection_rows_for_database(
+        connection: &Connection,
+        database: &str,
+        control: &OperationControl,
+    ) -> EngineResult<Vec<DocumentCollectionMetadata>> {
+        ensure_control_active(control, "before listing document collection metadata")?;
+        let mut statement = connection
+            .prepare(
+                "SELECT c.collection_id, c.database_id, d.database_name,
+                        c.collection_name, c.options_bson, c.placement_policy,
+                        c.placement_version
+                 FROM briskdb_document_collections AS c
+                 JOIN briskdb_document_databases AS d
+                   ON d.database_id = c.database_id
+                 WHERE c.lifecycle_state = 2 AND d.database_name = ?1
+                 ORDER BY c.collection_id",
+            )
+            .map_err(sqlite_error::storage)?;
+        let mut rows = statement.query([database]).map_err(sqlite_error::storage)?;
+        let mut stored = Vec::new();
+        while let Some(row) = rows.next().map_err(sqlite_error::storage)? {
+            ensure_control_active(control, "while listing document collection metadata")?;
+            stored.push((
+                row.get(0).map_err(sqlite_error::storage)?,
+                row.get(1).map_err(sqlite_error::storage)?,
+                row.get(2).map_err(sqlite_error::storage)?,
+                row.get(3).map_err(sqlite_error::storage)?,
+                row.get(4).map_err(sqlite_error::storage)?,
+                row.get(5).map_err(sqlite_error::storage)?,
+                row.get(6).map_err(sqlite_error::storage)?,
+            ));
+        }
+        drop(rows);
+        drop(statement);
+        let mut collections = Vec::new();
+        collections
+            .try_reserve_exact(stored.len())
+            .map_err(|error| {
+                EngineError::from_source(
+                    EngineErrorKind::OutOfMemory,
+                    "unable to reserve bounded document collection metadata",
+                    error,
+                )
+            })?;
+        for row in stored {
+            ensure_control_active(control, "while decoding document collection metadata")?;
+            collections.push(decode_collection_row(connection, row, Some(control))?);
+        }
+        ensure_control_active(control, "after listing document collection metadata")?;
+        Ok(collections)
+    }
+
+    fn decode_collection_row(
+        connection: &Connection,
+        row: StoredCollectionRow,
+        control: Option<&OperationControl>,
+    ) -> EngineResult<DocumentCollectionMetadata> {
+        let (
+            collection_id,
+            database_id,
+            database_name,
+            name,
+            options_bson,
+            placement_policy,
+            placement_version,
+        ) = row;
+        if let Some(control) = control {
+            ensure_control_active(control, "before decoding document collection metadata")?;
+        }
+        let collection_id = positive_u64(collection_id, "document collection ID")?;
+        let database_id = positive_u64(database_id, "document database ID")?;
+        if placement_policy != 1 || placement_version != 1 {
+            return Err(corrupt("document collection has an unsupported placement"));
+        }
+        let options = DocumentCollectionOptions::new(decode_metadata_document(
+            &options_bson,
+            "document collection options",
+        )?)
+        .map_err(|error| {
+            EngineError::from_source(
+                EngineErrorKind::DataCorruption,
+                "stored document collection options are invalid",
+                error,
+            )
+        })?;
+        if let Some(control) = control {
+            ensure_control_active(control, "after decoding document collection options")?;
+        }
+        let id = DocumentCollectionId::from_validated(collection_id);
+        let indexes = load_indexes_with_control(connection, id, control)?;
+        Ok(DocumentCollectionMetadata::from_validated_parts(
+            id,
+            DocumentDatabaseId::from_validated(database_id),
+            database_name,
+            name,
+            options,
+            DocumentPlacement::HashByIdV1,
+            indexes,
+        ))
+    }
+
     fn load_indexes(
         connection: &Connection,
         collection_id: DocumentCollectionId,
     ) -> EngineResult<Box<[DocumentIndexMetadata]>> {
+        load_indexes_with_control(connection, collection_id, None)
+    }
+
+    fn load_indexes_with_control(
+        connection: &Connection,
+        collection_id: DocumentCollectionId,
+        control: Option<&OperationControl>,
+    ) -> EngineResult<Box<[DocumentIndexMetadata]>> {
+        if let Some(control) = control {
+            ensure_control_active(control, "before reading document index metadata")?;
+        }
         let mut statement = connection
             .prepare(
                 "SELECT index_name, spec_bson, is_unique, is_builtin, lifecycle_state
@@ -1260,6 +2145,9 @@ mod enabled {
         let expected_id = builtin_id_specification()?;
         let mut indexes = Vec::with_capacity(rows.len());
         for (name, spec_bson, unique, built_in, lifecycle) in rows {
+            if let Some(control) = control {
+                ensure_control_active(control, "while decoding document index metadata")?;
+            }
             let specification =
                 decode_metadata_document(&spec_bson, "document index specification")?;
             let lifecycle = DocumentIndexLifecycle::from_code(
@@ -1288,6 +2176,9 @@ mod enabled {
                 built_in,
                 lifecycle,
             ));
+        }
+        if let Some(control) = control {
+            ensure_control_active(control, "after reading document index metadata")?;
         }
         Ok(indexes.into_boxed_slice())
     }
@@ -1420,25 +2311,76 @@ mod enabled {
     fn prepare_document(
         storage: &Storage,
         document: &BsonDocument,
-    ) -> EngineResult<(CanonicalBsonKey, Vec<u8>, u16)> {
+    ) -> EngineResult<PreparedDocumentWrite> {
         let id = required_document_id(document)?;
         let id_key = CanonicalBsonKey::encode(id)
             .map_err(|error| error.into_engine_error(BsonErrorContext::ClientInput))?;
         let document_bson = encode_document(document)
             .map_err(|error| error.into_engine_error(BsonErrorContext::ClientInput))?;
         let shard = storage.shard_for_key(id_key.as_bytes());
-        Ok((id_key, document_bson, shard))
+        Ok(PreparedDocumentWrite {
+            id_key,
+            document_bson,
+            shard,
+        })
     }
 
+    #[cfg(any(feature = "tinymongo-import", test))]
     fn ensure_document_write_not_cancelled(cancellation: &CancellationToken) -> EngineResult<()> {
+        ensure_document_operation_not_cancelled(cancellation, "while inserting document batch")
+    }
+
+    fn ensure_document_operation_not_cancelled(
+        cancellation: &CancellationToken,
+        boundary: &'static str,
+    ) -> EngineResult<()> {
         if cancellation.is_cancelled() {
             Err(EngineError::new(
                 EngineErrorKind::Cancelled,
-                "document batch insertion was cancelled",
+                format!("document operation was cancelled {boundary}"),
             ))
         } else {
             Ok(())
         }
+    }
+
+    fn validate_natural_order_reservation_count(count: u64) -> EngineResult<i64> {
+        if count == 0 {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "document natural-order reservation count must be greater than zero",
+            ));
+        }
+        i64::try_from(count).map_err(|error| {
+            EngineError::from_source(
+                EngineErrorKind::LimitExceeded,
+                "document natural-order reservation exceeds SQLite's supported range",
+                error,
+            )
+        })
+    }
+
+    fn document_natural_order_to_sqlite(natural_order: u64) -> EngineResult<i64> {
+        if natural_order == 0 {
+            return Err(EngineError::new(
+                EngineErrorKind::InvalidArgument,
+                "document natural order must be greater than zero",
+            ));
+        }
+        i64::try_from(natural_order).map_err(|error| {
+            EngineError::from_source(
+                EngineErrorKind::NumericOutOfRange,
+                "document natural order does not fit SQLite",
+                error,
+            )
+        })
+    }
+
+    fn document_natural_order_from_sqlite(natural_order: i64) -> EngineResult<u64> {
+        u64::try_from(natural_order)
+            .ok()
+            .filter(|order| *order > 0)
+            .ok_or_else(|| corrupt("stored BSON document natural order is not positive"))
     }
 
     fn provisioning_id(database: &str, collection: &str, options: &[u8]) -> [u8; 32] {
@@ -1504,6 +2446,37 @@ mod enabled {
         Ok(document)
     }
 
+    fn decode_storage_record(
+        collection_id: DocumentCollectionId,
+        shard: u16,
+        natural_order: i64,
+        id_key: Vec<u8>,
+        bson: Vec<u8>,
+        checksum: Vec<u8>,
+        version: i64,
+    ) -> EngineResult<DocumentStorageRecord> {
+        let canonical_id = CanonicalBsonKey::from_bytes(&id_key)
+            .map_err(|error| error.into_engine_error(BsonErrorContext::StoredData))?;
+        let encoded_len = bson.len();
+        let document = decode_record(
+            collection_id,
+            shard,
+            natural_order,
+            &id_key,
+            bson,
+            checksum,
+            version,
+        )?;
+        Ok(DocumentStorageRecord {
+            collection_id,
+            shard,
+            natural_order: document_natural_order_from_sqlite(natural_order)?,
+            id_key: canonical_id,
+            document,
+            encoded_len,
+        })
+    }
+
     fn hash_bytes(hasher: &mut blake3::Hasher, bytes: &[u8]) {
         hasher.update(&(bytes.len() as u64).to_le_bytes());
         hasher.update(bytes);
@@ -1536,7 +2509,7 @@ mod enabled {
 
         use super::*;
         use crate::{
-            core::Database,
+            core::{CancellationReason, Database},
             document::{
                 BsonBinary, BsonUuid, DocumentPlacement, UuidRepresentation, encode_document,
             },
@@ -1549,6 +2522,452 @@ mod enabled {
 
         fn document(entries: impl IntoIterator<Item = (&'static str, BsonValue)>) -> BsonDocument {
             BsonDocument::from_entries(entries).unwrap()
+        }
+
+        #[test]
+        fn controlled_catalog_mutations_honor_preaccepted_cancellation() {
+            let temp = tempfile::tempdir().unwrap();
+            let storage = Storage::open(temp.path(), 2).unwrap();
+
+            let migration = storage.begin_schema_migration().unwrap();
+            migration.wait_for_quiescence_blocking();
+            let cancelled_create = OperationControl::new(None);
+            assert!(cancelled_create.request_cancel(CancellationReason::Cancelled));
+            assert_eq!(
+                storage
+                    .create_document_collection_controlled(
+                        "engine_db",
+                        "cancelled",
+                        &DocumentCollectionOptions::empty(),
+                        migration,
+                        cancelled_create,
+                    )
+                    .unwrap_err()
+                    .kind(),
+                EngineErrorKind::Cancelled
+            );
+
+            let migration = storage.begin_schema_migration().unwrap();
+            migration.wait_for_quiescence_blocking();
+            let collection = storage
+                .create_document_collection_controlled(
+                    "engine_db",
+                    "events",
+                    &DocumentCollectionOptions::empty(),
+                    migration,
+                    OperationControl::new(None),
+                )
+                .unwrap();
+
+            for result in [
+                storage
+                    .document_catalog_controlled({
+                        let control = OperationControl::new(None);
+                        assert!(control.request_cancel(CancellationReason::Cancelled));
+                        control
+                    })
+                    .map(|_| ()),
+                storage
+                    .declare_document_index_controlled(
+                        collection.id(),
+                        "value_1",
+                        &document([("value", BsonValue::Int32(1))]),
+                        false,
+                        {
+                            let control = OperationControl::new(None);
+                            assert!(control.request_cancel(CancellationReason::Cancelled));
+                            control
+                        },
+                    )
+                    .map(|_| ()),
+                storage
+                    .reserve_document_natural_orders_controlled(collection.id(), 1, {
+                        let control = OperationControl::new(None);
+                        assert!(control.request_cancel(CancellationReason::Cancelled));
+                        control
+                    })
+                    .map(|_| ()),
+            ] {
+                assert_eq!(result.unwrap_err().kind(), EngineErrorKind::Cancelled);
+            }
+        }
+
+        #[test]
+        fn manifest_snapshot_reads_remain_coherent_across_concurrent_catalog_commit() {
+            let temp = tempfile::tempdir().unwrap();
+            let storage = Storage::open(temp.path(), 2).unwrap();
+            let collection = storage
+                .create_document_collection(
+                    "engine_db",
+                    "snapshot_events",
+                    &DocumentCollectionOptions::empty(),
+                )
+                .unwrap();
+            let manifest_path = temp.path().join("manifest.sqlite");
+            let (snapshot_ready_tx, snapshot_ready_rx) = std::sync::mpsc::sync_channel(0);
+            let (continue_tx, continue_rx) = std::sync::mpsc::sync_channel(0);
+
+            let reader = std::thread::spawn(move || {
+                let mut connection = open_existing_manifest(&manifest_path).unwrap();
+                let control = OperationControl::new(None);
+                read_ready_manifest_snapshot(&mut connection, 2, |connection| {
+                    snapshot_ready_tx.send(()).unwrap();
+                    continue_rx.recv().unwrap();
+                    load_collection_row(
+                        connection,
+                        "engine_db",
+                        "snapshot_events",
+                        control.as_ref(),
+                    )
+                })
+                .unwrap()
+                .unwrap()
+            });
+
+            snapshot_ready_rx.recv().unwrap();
+            storage
+                .declare_document_index(
+                    collection.id(),
+                    "value_1",
+                    &document([("value", BsonValue::Int32(1))]),
+                    false,
+                )
+                .unwrap();
+            continue_tx.send(()).unwrap();
+
+            let snapshot = reader.join().unwrap();
+            assert_eq!(snapshot.indexes().len(), 1);
+            let current = storage
+                .document_collection_controlled(
+                    "engine_db",
+                    "snapshot_events",
+                    OperationControl::new(None),
+                )
+                .unwrap()
+                .unwrap();
+            assert_eq!(current.indexes().len(), 2);
+        }
+
+        #[test]
+        fn controlled_natural_order_reservation_interrupts_manifest_lock_wait() {
+            let temp = tempfile::tempdir().unwrap();
+            let storage = Storage::open(temp.path(), 2).unwrap();
+            let collection = storage
+                .create_document_collection(
+                    "engine_db",
+                    "locked_allocator",
+                    &DocumentCollectionOptions::empty(),
+                )
+                .unwrap();
+            let _operation = storage.enter_schema_operation().unwrap();
+
+            let mut blocker = Connection::open(temp.path().join("manifest.sqlite")).unwrap();
+            let blocker_transaction = blocker
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .unwrap();
+            let worker_storage = storage.clone();
+            let control = OperationControl::new(None);
+            let worker_control = Arc::clone(&control);
+            let collection_id = collection.id();
+            let started = std::time::Instant::now();
+            let worker = std::thread::spawn(move || {
+                worker_storage.reserve_document_natural_orders_controlled(
+                    collection_id,
+                    1,
+                    worker_control,
+                )
+            });
+
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            assert!(control.request_cancel(CancellationReason::Cancelled));
+            let error = worker.join().unwrap().unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::Cancelled);
+            assert!(
+                started.elapsed() < std::time::Duration::from_secs(2),
+                "manifest lock wait did not respond promptly to cancellation"
+            );
+            blocker_transaction.rollback().unwrap();
+
+            assert_eq!(
+                storage
+                    .reserve_document_natural_orders_controlled(
+                        collection.id(),
+                        1,
+                        OperationControl::new(None),
+                    )
+                    .unwrap(),
+                1
+            );
+        }
+
+        #[test]
+        fn connection_bound_point_operations_preserve_identity_order_and_exact_bson() {
+            let temp = tempfile::tempdir().unwrap();
+            let storage = Storage::open(temp.path(), 2).unwrap();
+            let collection = storage
+                .create_document_collection(
+                    "engine_db",
+                    "point_records",
+                    &DocumentCollectionOptions::empty(),
+                )
+                .unwrap();
+            let cancellation = CancellationToken::new();
+            let original = document([
+                ("before_id", BsonValue::String("first".to_owned())),
+                ("_id", BsonValue::Int32(17)),
+                ("number", BsonValue::Double(-0.0)),
+                ("after_id", BsonValue::Int64(17)),
+            ]);
+            let prepared = storage.prepare_document_write(&original).unwrap();
+            let natural_order = storage
+                .reserve_document_natural_orders_for_engine(collection.id(), 1, &cancellation)
+                .unwrap();
+            let mut connection = storage.open_unconfigured_shard(prepared.shard()).unwrap();
+            storage
+                .validate_unconfigured_shard(&connection, prepared.shard())
+                .unwrap();
+            let transaction = connection
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .unwrap();
+
+            storage
+                .insert_prepared_document_on_connection(
+                    &transaction,
+                    collection.id(),
+                    natural_order,
+                    prepared.shard(),
+                    &prepared,
+                    &cancellation,
+                )
+                .unwrap();
+            let stored = storage
+                .get_document_on_connection(
+                    &transaction,
+                    collection.id(),
+                    prepared.shard(),
+                    prepared.id_key(),
+                    &cancellation,
+                )
+                .unwrap()
+                .unwrap();
+            assert_eq!(stored.collection_id(), collection.id());
+            assert_eq!(stored.shard(), prepared.shard());
+            assert_eq!(stored.natural_order(), natural_order);
+            assert_eq!(stored.id_key(), prepared.id_key());
+            assert_eq!(
+                stored.encoded_len(),
+                encode_document(&original).unwrap().len()
+            );
+            assert!(stored.document().representation_eq(&original));
+
+            let replacement = document([
+                ("_id", BsonValue::Int64(17)),
+                ("number", BsonValue::Double(0.0)),
+                ("replacement", BsonValue::Boolean(true)),
+            ]);
+            let prepared_replacement = storage.prepare_document_write(&replacement).unwrap();
+            assert!(
+                storage
+                    .replace_document_on_connection(
+                        &transaction,
+                        collection.id(),
+                        prepared.shard(),
+                        prepared.id_key(),
+                        natural_order,
+                        &prepared_replacement,
+                        &cancellation,
+                    )
+                    .unwrap()
+            );
+            let replaced = storage
+                .get_document_on_connection(
+                    &transaction,
+                    collection.id(),
+                    prepared.shard(),
+                    prepared.id_key(),
+                    &cancellation,
+                )
+                .unwrap()
+                .unwrap();
+            assert_eq!(replaced.natural_order(), natural_order);
+            assert!(replaced.document().representation_eq(&replacement));
+
+            let changed_id = storage
+                .prepare_document_write(&document([
+                    ("_id", BsonValue::Int32(18)),
+                    ("replacement", BsonValue::Boolean(true)),
+                ]))
+                .unwrap();
+            assert_eq!(
+                storage
+                    .replace_document_on_connection(
+                        &transaction,
+                        collection.id(),
+                        prepared.shard(),
+                        prepared.id_key(),
+                        natural_order,
+                        &changed_id,
+                        &cancellation,
+                    )
+                    .unwrap_err()
+                    .kind(),
+                EngineErrorKind::InvalidArgument
+            );
+            assert!(
+                storage
+                    .delete_document_on_connection(
+                        &transaction,
+                        collection.id(),
+                        prepared.shard(),
+                        prepared.id_key(),
+                        &cancellation,
+                    )
+                    .unwrap()
+            );
+            assert!(
+                storage
+                    .get_document_on_connection(
+                        &transaction,
+                        collection.id(),
+                        prepared.shard(),
+                        prepared.id_key(),
+                        &cancellation,
+                    )
+                    .unwrap()
+                    .is_none()
+            );
+            transaction.commit().unwrap();
+        }
+
+        #[test]
+        fn connection_bound_shard_scans_are_bounded_resumable_and_cancellable() {
+            let temp = tempfile::tempdir().unwrap();
+            let storage = Storage::open(temp.path(), 2).unwrap();
+            let collection = storage
+                .create_document_collection(
+                    "engine_db",
+                    "scan_records",
+                    &DocumentCollectionOptions::empty(),
+                )
+                .unwrap();
+            let cancellation = CancellationToken::new();
+            let mut selected_shard = None;
+            let mut prepared = Vec::new();
+            for id in 0..100 {
+                let document = document([
+                    ("_id", BsonValue::Int32(id)),
+                    ("ordinal", BsonValue::Int32(id)),
+                ]);
+                let candidate = storage.prepare_document_write(&document).unwrap();
+                if selected_shard.is_none() {
+                    selected_shard = Some(candidate.shard());
+                }
+                if Some(candidate.shard()) == selected_shard {
+                    prepared.push(candidate);
+                }
+                if prepared.len() == 3 {
+                    break;
+                }
+            }
+            assert_eq!(prepared.len(), 3);
+            let shard = selected_shard.unwrap();
+            let first_order = storage
+                .reserve_document_natural_orders_for_engine(
+                    collection.id(),
+                    prepared.len() as u64,
+                    &cancellation,
+                )
+                .unwrap();
+            let mut connection = storage.open_unconfigured_shard(shard).unwrap();
+            storage
+                .validate_unconfigured_shard(&connection, shard)
+                .unwrap();
+            let transaction = connection
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .unwrap();
+            for (offset, document) in prepared.iter().enumerate() {
+                storage
+                    .insert_prepared_document_on_connection(
+                        &transaction,
+                        collection.id(),
+                        first_order + offset as u64,
+                        shard,
+                        document,
+                        &cancellation,
+                    )
+                    .unwrap();
+            }
+
+            assert_eq!(
+                storage
+                    .count_document_shard_on_connection(
+                        &transaction,
+                        collection.id(),
+                        shard,
+                        &cancellation,
+                    )
+                    .unwrap(),
+                3
+            );
+            let first_page = storage
+                .scan_document_shard_on_connection(
+                    &transaction,
+                    collection.id(),
+                    shard,
+                    None,
+                    2,
+                    &cancellation,
+                )
+                .unwrap();
+            assert_eq!(first_page.len(), 2);
+            assert_eq!(first_page[0].natural_order(), first_order);
+            assert_eq!(first_page[1].natural_order(), first_order + 1);
+            let second_page = storage
+                .scan_document_shard_on_connection(
+                    &transaction,
+                    collection.id(),
+                    shard,
+                    Some(first_page[1].natural_order()),
+                    2,
+                    &cancellation,
+                )
+                .unwrap();
+            assert_eq!(second_page.len(), 1);
+            assert_eq!(second_page[0].natural_order(), first_order + 2);
+
+            for limit in [0, MAX_DOCUMENT_SHARD_SCAN_RECORDS + 1] {
+                assert_eq!(
+                    storage
+                        .scan_document_shard_on_connection(
+                            &transaction,
+                            collection.id(),
+                            shard,
+                            None,
+                            limit,
+                            &cancellation,
+                        )
+                        .unwrap_err()
+                        .kind(),
+                    EngineErrorKind::InvalidArgument
+                );
+            }
+            let cancelled = CancellationToken::new();
+            cancelled.cancel();
+            assert_eq!(
+                storage
+                    .scan_document_shard_on_connection(
+                        &transaction,
+                        collection.id(),
+                        shard,
+                        None,
+                        1,
+                        &cancelled,
+                    )
+                    .unwrap_err()
+                    .kind(),
+                EngineErrorKind::Cancelled
+            );
+            transaction.commit().unwrap();
         }
 
         #[test]
@@ -2435,6 +3854,10 @@ mod enabled {
 
 #[cfg(feature = "documents")]
 pub(super) use enabled::recover_or_validate;
+#[cfg(feature = "documents")]
+pub(crate) use enabled::{
+    DocumentStorageRecord, MAX_DOCUMENT_SHARD_SCAN_RECORDS, PreparedDocumentWrite,
+};
 
 #[cfg(not(feature = "documents"))]
 pub(super) fn recover_or_validate(

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,6 +1,10 @@
 //! SQLite file layout, versioned manifest management, and connection configuration.
 
 mod document;
+#[cfg(feature = "documents")]
+pub(crate) use document::{
+    DocumentStorageRecord, MAX_DOCUMENT_SHARD_SCAN_RECORDS, PreparedDocumentWrite,
+};
 mod global_index;
 mod global_index_async;
 mod hilo;
@@ -3155,7 +3159,9 @@ impl Storage {
         let authorizer_probe_wrote = Arc::clone(&probe_wrote);
         connection
             .authorizer(Some(move |context: AuthContext<'_>| {
-                if shard::denies_client_action(context.action) {
+                if shard::denies_client_action(context.action)
+                    && !document_pool_action_is_allowed(context.action)
+                {
                     return Authorization::Deny;
                 }
                 if action_taints_connection(context.action) {
@@ -3185,6 +3191,21 @@ impl Storage {
                 probe_wrote,
             },
         ))
+    }
+}
+
+fn document_pool_action_is_allowed(action: AuthAction<'_>) -> bool {
+    if !pool::document_storage_operation_active() {
+        return false;
+    }
+    match action {
+        AuthAction::Insert { table_name } | AuthAction::Delete { table_name } => {
+            table_name == document::RECORDS_TABLE
+        }
+        AuthAction::Update { table_name, .. } | AuthAction::Read { table_name, .. } => {
+            table_name == document::RECORDS_TABLE
+        }
+        _ => false,
     }
 }
 

--- a/src/storage/pool.rs
+++ b/src/storage/pool.rs
@@ -1,11 +1,14 @@
 //! Bounded per-shard SQLite connection pools.
 
 use std::{
-    cell::RefCell,
+    cell::{Cell, RefCell},
     ops::Deref,
     sync::{Arc, Mutex, MutexGuard, atomic::Ordering},
     time::{Duration, Instant},
 };
+
+#[cfg(feature = "documents")]
+use std::panic::{AssertUnwindSafe, catch_unwind, resume_unwind};
 
 #[cfg(test)]
 use std::sync::atomic::AtomicU64;
@@ -22,6 +25,32 @@ use super::{CONNECTION_BUSY_TIMEOUT, ConnectionHygiene, Storage};
 
 thread_local! {
     static BUSY_OPERATION: RefCell<Option<BusyOperation>> = const { RefCell::new(None) };
+    static DOCUMENT_STORAGE_OPERATION: Cell<bool> = const { Cell::new(false) };
+}
+
+pub(super) fn document_storage_operation_active() -> bool {
+    DOCUMENT_STORAGE_OPERATION.get()
+}
+
+#[cfg(feature = "documents")]
+struct DocumentStorageOperationGuard;
+
+#[cfg(feature = "documents")]
+impl DocumentStorageOperationGuard {
+    fn install() -> Self {
+        DOCUMENT_STORAGE_OPERATION.with(|active| {
+            let previous = active.replace(true);
+            debug_assert!(!previous, "document storage operations cannot be nested");
+        });
+        Self
+    }
+}
+
+#[cfg(feature = "documents")]
+impl Drop for DocumentStorageOperationGuard {
+    fn drop(&mut self) {
+        DOCUMENT_STORAGE_OPERATION.set(false);
+    }
 }
 
 struct BusyOperation {
@@ -862,6 +891,28 @@ impl PooledConnection {
         self.finish_controlled(result)
     }
 
+    /// Run an engine-owned document operation against the reserved document
+    /// table while retaining the ordinary cancellation and pool-hygiene
+    /// boundary.
+    ///
+    /// The pool authorizer consults the thread-local guard only for the exact
+    /// storage-owned document table. It continues to deny every other reserved
+    /// object, and the guard is cleared on both return and unwind.
+    #[cfg(feature = "documents")]
+    pub(crate) fn run_document_controlled<T, F>(
+        &mut self,
+        control: Arc<OperationControl>,
+        work: F,
+    ) -> EngineResult<T>
+    where
+        F: FnOnce(&mut Self) -> EngineResult<T>,
+    {
+        self.run_controlled(control, |connection| {
+            let _document_operation = DocumentStorageOperationGuard::install();
+            work(connection)
+        })
+    }
+
     fn finish_controlled<T>(&mut self, result: EngineResult<T>) -> EngineResult<T> {
         let control = self
             .operation
@@ -1075,6 +1126,69 @@ fn run_connection_validation_controlled<T>(
     }
 }
 
+/// Run work on one dedicated SQLite handle while the request owns every
+/// blocking and interruptible SQLite boundary.
+///
+/// Unlike [`PooledConnection::run_controlled`], this restores the ordinary
+/// fixed busy timeout for a caller-owned handle instead of deciding whether a
+/// pool should retire it. One [`OperationControl`] may use this helper
+/// repeatedly for sequential manifest and shard work; each invocation arms
+/// exactly the handle currently executing SQLite.
+#[cfg(feature = "documents")]
+pub(super) fn run_dedicated_connection_controlled<T>(
+    connection: &mut Connection,
+    control: Arc<OperationControl>,
+    work: impl FnOnce(&mut Connection) -> EngineResult<T>,
+) -> EngineResult<T> {
+    let _busy_operation = BusyOperationGuard::install(Arc::clone(&control));
+    connection
+        .busy_handler(Some(cancellable_busy_handler))
+        .map_err(sqlite_error::storage)?;
+    let progress_control = Arc::clone(&control);
+    if let Err(error) =
+        connection.progress_handler(1_000, Some(move || progress_control.should_stop()))
+    {
+        let _ = connection.busy_timeout(CONNECTION_BUSY_TIMEOUT);
+        return Err(sqlite_error::storage(error)
+            .context("failed to install the dedicated SQLite request progress hook"));
+    }
+    let interrupt_handle = connection.get_interrupt_handle();
+    if let Err(reason) = control.arm(Arc::new(move || interrupt_handle.interrupt())) {
+        let _ = connection.progress_handler(0, None::<fn() -> bool>);
+        let _ = connection.busy_timeout(CONNECTION_BUSY_TIMEOUT);
+        return Err(reason.error());
+    }
+
+    let outcome = catch_unwind(AssertUnwindSafe(|| work(connection)));
+    let progress_cleanup = connection
+        .progress_handler(0, None::<fn() -> bool>)
+        .map_err(sqlite_error::storage);
+    let busy_cleanup = connection
+        .busy_timeout(CONNECTION_BUSY_TIMEOUT)
+        .map_err(sqlite_error::storage);
+    let reason = control.disarm();
+    let result = match outcome {
+        Ok(result) => result,
+        Err(payload) => {
+            let _ = progress_cleanup;
+            let _ = busy_cleanup;
+            resume_unwind(payload)
+        }
+    };
+    match (result, progress_cleanup, busy_cleanup, reason) {
+        (Ok(_), Err(error), _, _) => {
+            Err(error.context("failed to remove the dedicated SQLite request progress hook"))
+        }
+        (Ok(_), Ok(()), Err(error), _) => {
+            Err(error.context("failed to restore the dedicated SQLite busy timeout"))
+        }
+        (Ok(value), Ok(()), Ok(()), _) => Ok(value),
+        (Err(error), _, _, _) if error.kind() == EngineErrorKind::DataCorruption => Err(error),
+        (Err(_), _, _, Some(reason)) => Err(reason.error()),
+        (Err(error), _, _, None) => Err(error),
+    }
+}
+
 impl Deref for PooledConnection {
     type Target = Connection;
 
@@ -1163,6 +1277,60 @@ mod tests {
         migration.publish_ready().unwrap();
         let pools = ConnectionPools::new(storage, pool_size, queue_capacity).unwrap();
         (temp, pools)
+    }
+
+    #[cfg(feature = "documents")]
+    #[tokio::test]
+    async fn document_authority_is_narrow_and_cleared_before_pool_reuse() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = Storage::open(temp.path(), 2).unwrap();
+        storage
+            .create_document_collection(
+                "app",
+                "events",
+                &crate::document::DocumentCollectionOptions::empty(),
+            )
+            .unwrap();
+        let pools = ConnectionPools::new(storage, 1, 0).unwrap();
+        let mut connection = pools.acquire(0).await.unwrap().checkout().unwrap();
+
+        assert!(
+            connection
+                .query_row("SELECT count(*) FROM briskdb_documents_v1", [], |row| row
+                    .get::<_, i64>(
+                    0
+                ),)
+                .is_err(),
+            "ordinary pooled SQL must not read document storage"
+        );
+
+        let count = connection
+            .run_document_controlled(OperationControl::new(None), |connection| {
+                connection
+                    .query_row("SELECT count(*) FROM briskdb_documents_v1", [], |row| {
+                        row.get::<_, i64>(0)
+                    })
+                    .map_err(sqlite_error::statement)
+            })
+            .unwrap();
+        assert_eq!(count, 0);
+
+        assert!(
+            connection
+                .query_row("SELECT count(*) FROM briskdb_documents_v1", [], |row| row
+                    .get::<_, i64>(
+                    0
+                ),)
+                .is_err(),
+            "document authority must be cleared before the connection is reused"
+        );
+        assert!(
+            connection
+                .query_row("SELECT count(*) FROM briskdb_shard_metadata", [], |row| row
+                    .get::<_, i64>(0),)
+                .is_err(),
+            "document authority must not grant access to other storage tables"
+        );
     }
 
     fn advance_schema_generation(

--- a/tests/document_engine.rs
+++ b/tests/document_engine.rs
@@ -1,0 +1,911 @@
+#![cfg(feature = "documents")]
+
+use std::time::{Duration, Instant};
+
+use briskdb::{
+    core::{CancellationToken, Engine, EngineErrorKind, RequestContext, ResultLimits, Session},
+    document::{
+        BsonDocument, BsonValue, DocumentAggregateRequest, DocumentCollectionMetadata,
+        DocumentCollectionOptions, DocumentCommand, DocumentCountRequest,
+        DocumentCreateCollectionRequest, DocumentCreateIndexRequest, DocumentDeleteRequest,
+        DocumentExecution, DocumentFilter, DocumentFindRequest, DocumentIndexLifecycle,
+        DocumentIndexRequest, DocumentInsertRequest, DocumentListCollectionsRequest,
+        DocumentListIndexesRequest, DocumentMutationScope, DocumentNamespace, DocumentPipeline,
+        DocumentPlan, DocumentProjection, DocumentReadOptions, DocumentRequest, DocumentRequestId,
+        DocumentResult, DocumentWriteOptions,
+    },
+};
+use rusqlite::Connection;
+
+fn namespace() -> DocumentNamespace {
+    DocumentNamespace::new("app", "events").unwrap()
+}
+
+fn request(seed: u8, context: RequestContext, command: DocumentCommand) -> DocumentRequest {
+    DocumentRequest::new(
+        DocumentRequestId::new([seed; 16]).unwrap(),
+        context,
+        command,
+    )
+}
+
+fn document(id: BsonValue, label: &str) -> BsonDocument {
+    BsonDocument::from_entries([
+        ("_id", id),
+        ("label", BsonValue::from(label)),
+        ("sequence", BsonValue::Int64(i64::from(label.as_bytes()[0]))),
+    ])
+    .unwrap()
+}
+
+async fn create_collection(
+    engine: &Engine,
+    session: &Session,
+    request_seed: u8,
+) -> DocumentCollectionMetadata {
+    let command = DocumentCommand::CreateCollection(DocumentCreateCollectionRequest::new(
+        namespace(),
+        DocumentCollectionOptions::empty(),
+        DocumentWriteOptions::new(),
+    ));
+    let execution = engine
+        .execute_document(
+            session,
+            request(request_seed, RequestContext::new(), command),
+        )
+        .await
+        .unwrap();
+    assert!(execution.plan().is_none());
+    match execution.into_parts().2 {
+        DocumentResult::Collection(collection) => collection,
+        result => panic!("expected collection metadata, got {:?}", result.kind()),
+    }
+}
+
+async fn insert(
+    engine: &Engine,
+    session: &Session,
+    request_seed: u8,
+    documents: Vec<BsonDocument>,
+) -> DocumentExecution {
+    let insert =
+        DocumentInsertRequest::new(namespace(), documents, DocumentWriteOptions::new()).unwrap();
+    engine
+        .execute_document(
+            session,
+            request(
+                request_seed,
+                RequestContext::new(),
+                DocumentCommand::Insert(insert),
+            ),
+        )
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn catalog_and_index_commands_run_without_a_listener() {
+    let temp = tempfile::tempdir().unwrap();
+    let engine = Engine::open(temp.path(), 4).await.unwrap();
+    let session = engine.session();
+
+    let created = create_collection(&engine, &session, 1).await;
+    assert_eq!(created.namespace(), "app.events");
+    assert_eq!(created.indexes().len(), 1);
+    assert_eq!(created.indexes()[0].name(), "_id_");
+    assert!(created.indexes()[0].is_built_in());
+    assert_eq!(
+        created.indexes()[0].lifecycle(),
+        DocumentIndexLifecycle::Ready
+    );
+
+    let listed = engine
+        .execute_document(
+            &session,
+            request(
+                2,
+                RequestContext::new(),
+                DocumentCommand::ListCollections(
+                    DocumentListCollectionsRequest::new("app", DocumentReadOptions::new()).unwrap(),
+                ),
+            ),
+        )
+        .await
+        .unwrap();
+    assert!(listed.plan().is_none());
+    match listed.result() {
+        DocumentResult::Collections(collections) => {
+            assert_eq!(collections.len(), 1);
+            assert_eq!(collections[0].id(), created.id());
+            assert_eq!(collections[0].namespace(), "app.events");
+        }
+        result => panic!("expected collections, got {:?}", result.kind()),
+    }
+
+    let keys = BsonDocument::from_entries([("label", BsonValue::Int32(1))]).unwrap();
+    let index = DocumentIndexRequest::new(keys)
+        .unwrap()
+        .with_name("label_1")
+        .unwrap();
+    let created_index = engine
+        .execute_document(
+            &session,
+            request(
+                3,
+                RequestContext::new(),
+                DocumentCommand::CreateIndex(DocumentCreateIndexRequest::new(
+                    namespace(),
+                    index,
+                    DocumentWriteOptions::new(),
+                )),
+            ),
+        )
+        .await
+        .unwrap();
+    match created_index.result() {
+        DocumentResult::IndexName(name) => assert_eq!(name, "label_1"),
+        result => panic!("expected index name, got {:?}", result.kind()),
+    }
+
+    let listed_indexes = engine
+        .execute_document(
+            &session,
+            request(
+                4,
+                RequestContext::new(),
+                DocumentCommand::ListIndexes(DocumentListIndexesRequest::new(
+                    namespace(),
+                    DocumentReadOptions::new(),
+                )),
+            ),
+        )
+        .await
+        .unwrap();
+    match listed_indexes.result() {
+        DocumentResult::Indexes(indexes) => {
+            let secondary = indexes
+                .iter()
+                .find(|index| index.name() == "label_1")
+                .expect("declared secondary index");
+            assert!(!secondary.is_built_in());
+            assert_eq!(secondary.lifecycle(), DocumentIndexLifecycle::PendingBuild);
+            assert_eq!(
+                secondary.specification().iter().next(),
+                Some(("label", &BsonValue::Int32(1)))
+            );
+        }
+        result => panic!("expected indexes, got {:?}", result.kind()),
+    }
+
+    engine.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn insert_find_and_count_preserve_identity_routes_and_bson_order() {
+    let temp = tempfile::tempdir().unwrap();
+    let engine = Engine::open(temp.path(), 4).await.unwrap();
+    let session = engine.session();
+    let collection = create_collection(&engine, &session, 10).await;
+
+    let documents = [
+        document(BsonValue::Int32(1), "a"),
+        document(BsonValue::from("second"), "b"),
+        document(BsonValue::Int64(3), "c"),
+        document(BsonValue::from("fourth"), "d"),
+    ];
+    for (offset, source) in documents.iter().enumerate() {
+        let inserted = insert(
+            &engine,
+            &session,
+            50 + u8::try_from(offset).unwrap(),
+            vec![source.clone()],
+        )
+        .await;
+        match inserted.result() {
+            DocumentResult::Insert(result) => {
+                assert_eq!(result.inserted_ids().len(), 1);
+                assert!(
+                    result.inserted_ids()[0]
+                        .representation_eq(source.get_unique("_id").unwrap().expect("source _id"))
+                );
+            }
+            result => panic!("expected insert result, got {:?}", result.kind()),
+        }
+    }
+
+    // Mongo numeric equality makes this double filter select the Int32 ID,
+    // while the returned document retains its original Int32 representation.
+    let exact_filter =
+        DocumentFilter::new(BsonDocument::from_entries([("_id", BsonValue::Double(1.0))]).unwrap())
+            .unwrap();
+    let exact_request_id = DocumentRequestId::new([12; 16]).unwrap();
+    let exact = engine
+        .execute_document(
+            &session,
+            DocumentRequest::new(
+                exact_request_id,
+                RequestContext::new(),
+                DocumentCommand::Find(DocumentFindRequest::new(
+                    namespace(),
+                    exact_filter,
+                    DocumentReadOptions::new(),
+                )),
+            ),
+        )
+        .await
+        .unwrap();
+    assert_eq!(exact.request_id(), exact_request_id);
+    match exact.plan().expect("exact-ID route") {
+        DocumentPlan::Point(plan) => {
+            assert_eq!(plan.collection_id(), collection.id());
+            assert!(plan.shard() < 4);
+        }
+        plan => panic!("expected a point plan, got {plan:?}"),
+    }
+    match exact.result() {
+        DocumentResult::Cursor(batch) => {
+            assert!(batch.is_exhausted());
+            assert_eq!(batch.namespace(), &namespace());
+            assert_eq!(batch.documents().len(), 1);
+            assert!(batch.documents()[0].representation_eq(&documents[0]));
+            assert!(matches!(
+                batch.documents()[0].get_unique("_id").unwrap(),
+                Some(BsonValue::Int32(1))
+            ));
+            assert_eq!(
+                batch.documents()[0]
+                    .iter()
+                    .map(|(name, _)| name)
+                    .collect::<Vec<_>>(),
+                vec!["_id", "label", "sequence"]
+            );
+        }
+        result => panic!("expected cursor, got {:?}", result.kind()),
+    }
+
+    let options = DocumentReadOptions::new()
+        .with_skip(1)
+        .with_limit(2)
+        .unwrap();
+    let scattered = engine
+        .execute_document(
+            &session,
+            request(
+                13,
+                RequestContext::new(),
+                DocumentCommand::Find(DocumentFindRequest::new(
+                    namespace(),
+                    DocumentFilter::empty(),
+                    options,
+                )),
+            ),
+        )
+        .await
+        .unwrap();
+    match scattered.plan().expect("empty-filter route") {
+        DocumentPlan::Scatter(plan) => assert_eq!(plan.shards(), &[0, 1, 2, 3]),
+        plan => panic!("expected a scatter plan, got {plan:?}"),
+    }
+    match scattered.result() {
+        DocumentResult::Cursor(batch) => {
+            assert_eq!(batch.documents().len(), 2);
+            assert!(batch.documents()[0].representation_eq(&documents[1]));
+            assert!(batch.documents()[1].representation_eq(&documents[2]));
+        }
+        result => panic!("expected cursor, got {:?}", result.kind()),
+    }
+
+    let count = engine
+        .execute_document(
+            &session,
+            request(
+                14,
+                RequestContext::new(),
+                DocumentCommand::Count(DocumentCountRequest::new(
+                    namespace(),
+                    DocumentFilter::empty(),
+                    DocumentReadOptions::new(),
+                )),
+            ),
+        )
+        .await
+        .unwrap();
+    assert!(matches!(count.plan(), Some(DocumentPlan::Scatter(_))));
+    assert!(matches!(count.result(), DocumentResult::Count(4)));
+
+    let deleted = engine
+        .execute_document(
+            &session,
+            request(
+                15,
+                RequestContext::new(),
+                DocumentCommand::Delete(DocumentDeleteRequest::new(
+                    namespace(),
+                    DocumentFilter::new(
+                        BsonDocument::from_entries([("_id", BsonValue::Int32(1))]).unwrap(),
+                    )
+                    .unwrap(),
+                    DocumentMutationScope::One,
+                    DocumentWriteOptions::new(),
+                )),
+            ),
+        )
+        .await
+        .unwrap();
+    assert!(matches!(deleted.plan(), Some(DocumentPlan::Point(_))));
+    match deleted.result() {
+        DocumentResult::Delete(result) => assert_eq!(result.deleted_count(), 1),
+        result => panic!("expected delete result, got {:?}", result.kind()),
+    }
+
+    let missing = engine
+        .execute_document(
+            &session,
+            request(
+                16,
+                RequestContext::new(),
+                DocumentCommand::Find(DocumentFindRequest::new(
+                    namespace(),
+                    DocumentFilter::new(
+                        BsonDocument::from_entries([("_id", BsonValue::Int64(1))]).unwrap(),
+                    )
+                    .unwrap(),
+                    DocumentReadOptions::new(),
+                )),
+            ),
+        )
+        .await
+        .unwrap();
+    match missing.result() {
+        DocumentResult::Cursor(batch) => assert!(batch.documents().is_empty()),
+        result => panic!("expected cursor, got {:?}", result.kind()),
+    }
+
+    engine.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn request_controls_and_session_ownership_are_enforced() {
+    let first_temp = tempfile::tempdir().unwrap();
+    let second_temp = tempfile::tempdir().unwrap();
+    let first = Engine::open(first_temp.path(), 2).await.unwrap();
+    let second = Engine::open(second_temp.path(), 2).await.unwrap();
+    let first_session = first.session();
+    let foreign_session = second.session();
+
+    let cancelled = CancellationToken::new();
+    cancelled.cancel();
+    let error = first
+        .execute_document(
+            &first_session,
+            request(
+                20,
+                RequestContext::new().with_cancellation_token(cancelled),
+                DocumentCommand::ListCollections(
+                    DocumentListCollectionsRequest::new("app", DocumentReadOptions::new()).unwrap(),
+                ),
+            ),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::Cancelled);
+
+    let error = first
+        .execute_document(
+            &first_session,
+            request(
+                21,
+                RequestContext::new().with_deadline(Instant::now() - Duration::from_millis(1)),
+                DocumentCommand::ListCollections(
+                    DocumentListCollectionsRequest::new("app", DocumentReadOptions::new()).unwrap(),
+                ),
+            ),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::DeadlineExceeded);
+
+    let error = first
+        .execute_document(
+            &foreign_session,
+            request(
+                22,
+                RequestContext::new(),
+                DocumentCommand::ListCollections(
+                    DocumentListCollectionsRequest::new("app", DocumentReadOptions::new()).unwrap(),
+                ),
+            ),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+
+    first_session.close().await.unwrap();
+    let error = first
+        .execute_document(
+            &first_session,
+            request(
+                23,
+                RequestContext::new(),
+                DocumentCommand::ListCollections(
+                    DocumentListCollectionsRequest::new("app", DocumentReadOptions::new()).unwrap(),
+                ),
+            ),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+
+    second.begin_shutdown();
+    let error = second
+        .execute_document(
+            &foreign_session,
+            request(
+                24,
+                RequestContext::new(),
+                DocumentCommand::ListCollections(
+                    DocumentListCollectionsRequest::new("app", DocumentReadOptions::new()).unwrap(),
+                ),
+            ),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::ShuttingDown);
+
+    first.shutdown().await.unwrap();
+    second.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn manifest_write_lock_waits_honor_document_deadlines() {
+    let temp = tempfile::tempdir().unwrap();
+    let engine = Engine::open(temp.path(), 2).await.unwrap();
+    let session = engine.session();
+    create_collection(&engine, &session, 25).await;
+
+    let blocker = Connection::open(temp.path().join("manifest.sqlite")).unwrap();
+    blocker.execute_batch("BEGIN IMMEDIATE").unwrap();
+
+    let index = DocumentIndexRequest::new(
+        BsonDocument::from_entries([("label", BsonValue::Int32(1))]).unwrap(),
+    )
+    .unwrap()
+    .with_name("deadline_index")
+    .unwrap();
+    let started = Instant::now();
+    let error = engine
+        .execute_document(
+            &session,
+            request(
+                26,
+                RequestContext::new().with_deadline(Instant::now() + Duration::from_millis(50)),
+                DocumentCommand::CreateIndex(DocumentCreateIndexRequest::new(
+                    namespace(),
+                    index,
+                    DocumentWriteOptions::new(),
+                )),
+            ),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::DeadlineExceeded);
+    assert!(
+        started.elapsed() < Duration::from_secs(1),
+        "document manifest lock wait ignored its deadline"
+    );
+    blocker.execute_batch("ROLLBACK").unwrap();
+
+    let indexes = engine
+        .execute_document(
+            &session,
+            request(
+                27,
+                RequestContext::new(),
+                DocumentCommand::ListIndexes(DocumentListIndexesRequest::new(
+                    namespace(),
+                    DocumentReadOptions::new(),
+                )),
+            ),
+        )
+        .await
+        .unwrap();
+    match indexes.result() {
+        DocumentResult::Indexes(indexes) => {
+            assert!(indexes.iter().all(|index| index.name() != "deadline_index"));
+        }
+        result => panic!("expected indexes, got {:?}", result.kind()),
+    }
+
+    engine.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn document_reads_fail_whole_when_result_limits_are_exceeded() {
+    let temp = tempfile::tempdir().unwrap();
+    let engine = Engine::open(temp.path(), 2).await.unwrap();
+    let session = engine.session();
+    create_collection(&engine, &session, 30).await;
+    insert(
+        &engine,
+        &session,
+        31,
+        vec![document(BsonValue::Int32(1), "a")],
+    )
+    .await;
+    insert(
+        &engine,
+        &session,
+        48,
+        vec![document(BsonValue::Int32(2), "b")],
+    )
+    .await;
+
+    let row_limited =
+        RequestContext::new().with_result_limits(ResultLimits::new(1, 1_000_000).unwrap());
+    let error = engine
+        .execute_document(
+            &session,
+            request(
+                32,
+                row_limited,
+                DocumentCommand::Find(DocumentFindRequest::new(
+                    namespace(),
+                    DocumentFilter::empty(),
+                    DocumentReadOptions::new(),
+                )),
+            ),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+
+    let byte_limited =
+        RequestContext::new().with_result_limits(ResultLimits::new(100, 16).unwrap());
+    let error = engine
+        .execute_document(
+            &session,
+            request(
+                33,
+                byte_limited,
+                DocumentCommand::Find(DocumentFindRequest::new(
+                    namespace(),
+                    DocumentFilter::new(
+                        BsonDocument::from_entries([("_id", BsonValue::Int32(1))]).unwrap(),
+                    )
+                    .unwrap(),
+                    DocumentReadOptions::new(),
+                )),
+            ),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+
+    let mutation_limits =
+        || RequestContext::new().with_result_limits(ResultLimits::new(100, 16).unwrap());
+    let limited_namespace = DocumentNamespace::new("app", "limited").unwrap();
+    let error = engine
+        .execute_document(
+            &session,
+            request(
+                34,
+                mutation_limits(),
+                DocumentCommand::CreateCollection(DocumentCreateCollectionRequest::new(
+                    limited_namespace,
+                    DocumentCollectionOptions::empty(),
+                    DocumentWriteOptions::new(),
+                )),
+            ),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+
+    let index = DocumentIndexRequest::new(
+        BsonDocument::from_entries([("label", BsonValue::Int32(1))]).unwrap(),
+    )
+    .unwrap()
+    .with_name("must_not_be_created")
+    .unwrap();
+    let error = engine
+        .execute_document(
+            &session,
+            request(
+                35,
+                mutation_limits(),
+                DocumentCommand::CreateIndex(DocumentCreateIndexRequest::new(
+                    namespace(),
+                    index,
+                    DocumentWriteOptions::new(),
+                )),
+            ),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+
+    let error = engine
+        .execute_document(
+            &session,
+            request(
+                36,
+                mutation_limits(),
+                DocumentCommand::Delete(DocumentDeleteRequest::new(
+                    namespace(),
+                    DocumentFilter::new(
+                        BsonDocument::from_entries([("_id", BsonValue::Int32(1))]).unwrap(),
+                    )
+                    .unwrap(),
+                    DocumentMutationScope::One,
+                    DocumentWriteOptions::new(),
+                )),
+            ),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+
+    let oversized_plan_filter = DocumentFilter::new(
+        BsonDocument::from_entries([("_id", BsonValue::from("x".repeat(1_024)))]).unwrap(),
+    )
+    .unwrap();
+    let error = engine
+        .execute_document(
+            &session,
+            request(
+                37,
+                RequestContext::new().with_result_limits(ResultLimits::new(100, 128).unwrap()),
+                DocumentCommand::Find(DocumentFindRequest::new(
+                    namespace(),
+                    oversized_plan_filter,
+                    DocumentReadOptions::new(),
+                )),
+            ),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+
+    let catalog = engine
+        .execute_document(
+            &session,
+            request(
+                38,
+                RequestContext::new(),
+                DocumentCommand::ListCollections(
+                    DocumentListCollectionsRequest::new("app", DocumentReadOptions::new()).unwrap(),
+                ),
+            ),
+        )
+        .await
+        .unwrap();
+    match catalog.result() {
+        DocumentResult::Collections(collections) => {
+            assert_eq!(
+                collections.len(),
+                1,
+                "limited create must not mutate catalog"
+            )
+        }
+        result => panic!("expected collections, got {:?}", result.kind()),
+    }
+    let indexes = engine
+        .execute_document(
+            &session,
+            request(
+                39,
+                RequestContext::new(),
+                DocumentCommand::ListIndexes(DocumentListIndexesRequest::new(
+                    namespace(),
+                    DocumentReadOptions::new(),
+                )),
+            ),
+        )
+        .await
+        .unwrap();
+    match indexes.result() {
+        DocumentResult::Indexes(indexes) => assert!(
+            indexes
+                .iter()
+                .all(|index| index.name() != "must_not_be_created"),
+            "limited index creation must not mutate catalog"
+        ),
+        result => panic!("expected indexes, got {:?}", result.kind()),
+    }
+    let retained = engine
+        .execute_document(
+            &session,
+            request(
+                45,
+                RequestContext::new(),
+                DocumentCommand::Count(DocumentCountRequest::new(
+                    namespace(),
+                    DocumentFilter::new(
+                        BsonDocument::from_entries([("_id", BsonValue::Int64(1))]).unwrap(),
+                    )
+                    .unwrap(),
+                    DocumentReadOptions::new(),
+                )),
+            ),
+        )
+        .await
+        .unwrap();
+    assert!(matches!(retained.result(), DocumentResult::Count(1)));
+
+    engine.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn unsupported_document_semantics_fail_at_the_engine_boundary() {
+    let temp = tempfile::tempdir().unwrap();
+    let engine = Engine::open(temp.path(), 2).await.unwrap();
+    let session = engine.session();
+    create_collection(&engine, &session, 40).await;
+
+    let general_filter =
+        DocumentFilter::new(BsonDocument::from_entries([("label", BsonValue::from("a"))]).unwrap())
+            .unwrap();
+    let error = engine
+        .execute_document(
+            &session,
+            request(
+                41,
+                RequestContext::new(),
+                DocumentCommand::Find(DocumentFindRequest::new(
+                    namespace(),
+                    general_filter,
+                    DocumentReadOptions::new(),
+                )),
+            ),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::Unsupported);
+
+    let id_operator = DocumentFilter::new(
+        BsonDocument::from_entries([(
+            "_id",
+            BsonValue::Document(
+                BsonDocument::from_entries([("$eq", BsonValue::Int32(1))]).unwrap(),
+            ),
+        )])
+        .unwrap(),
+    )
+    .unwrap();
+    let error = engine
+        .execute_document(
+            &session,
+            request(
+                44,
+                RequestContext::new(),
+                DocumentCommand::Find(DocumentFindRequest::new(
+                    namespace(),
+                    id_operator,
+                    DocumentReadOptions::new(),
+                )),
+            ),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::Unsupported);
+
+    let multi_insert = DocumentInsertRequest::new(
+        namespace(),
+        vec![
+            document(BsonValue::Int32(97), "x"),
+            document(BsonValue::Int32(98), "y"),
+        ],
+        DocumentWriteOptions::new(),
+    )
+    .unwrap();
+    let error = engine
+        .execute_document(
+            &session,
+            request(
+                47,
+                RequestContext::new(),
+                DocumentCommand::Insert(multi_insert),
+            ),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::Unsupported);
+
+    let insert = DocumentInsertRequest::new(
+        namespace(),
+        vec![document(BsonValue::Int32(99), "z")],
+        DocumentWriteOptions::new().with_bypass_document_validation(true),
+    )
+    .unwrap();
+    let error = engine
+        .execute_document(
+            &session,
+            request(46, RequestContext::new(), DocumentCommand::Insert(insert)),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::Unsupported);
+
+    let projection = DocumentProjection::new(
+        BsonDocument::from_entries([("label", BsonValue::Int32(1))]).unwrap(),
+    )
+    .unwrap();
+    let error = engine
+        .execute_document(
+            &session,
+            request(
+                42,
+                RequestContext::new(),
+                DocumentCommand::Find(DocumentFindRequest::new(
+                    namespace(),
+                    DocumentFilter::empty(),
+                    DocumentReadOptions::new().with_projection(projection),
+                )),
+            ),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::Unsupported);
+
+    let error = engine
+        .execute_document(
+            &session,
+            request(
+                43,
+                RequestContext::new(),
+                DocumentCommand::Aggregate(
+                    DocumentAggregateRequest::new(
+                        namespace(),
+                        DocumentPipeline::new(Vec::<BsonDocument>::new()).unwrap(),
+                        DocumentReadOptions::new(),
+                    )
+                    .unwrap(),
+                ),
+            ),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::Unsupported);
+
+    engine.shutdown().await.unwrap();
+}
+
+#[test]
+fn production_protocol_modules_do_not_bypass_the_engine_for_document_storage() {
+    fn production(source: &str) -> &str {
+        source
+            .split_once("\n#[cfg(test)]\nmod tests {")
+            .map_or(source, |parts| parts.0)
+    }
+
+    let modules = [
+        ("protocol/mod.rs", include_str!("../src/protocol/mod.rs")),
+        (
+            "protocol/error.rs",
+            include_str!("../src/protocol/error.rs"),
+        ),
+        ("protocol/http.rs", include_str!("../src/protocol/http.rs")),
+        (
+            "protocol/http/v1.rs",
+            include_str!("../src/protocol/http/v1.rs"),
+        ),
+        (
+            "protocol/http/admin.rs",
+            include_str!("../src/protocol/http/admin.rs"),
+        ),
+        (
+            "protocol/postgres.rs",
+            include_str!("../src/protocol/postgres.rs"),
+        ),
+    ];
+
+    for (name, source) in modules {
+        let source = production(source);
+        for forbidden in ["rusqlite", "crate::storage", "storage::document"] {
+            assert!(
+                !source.contains(forbidden),
+                "{name} production code contains backend escape hatch {forbidden}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds the protocol-neutral document command boundary required before Rust, Python, and MongoDB adapters can expose document operations. `Engine::execute_document` now owns request identity, session serialization, point/scatter routing, cancellation and deadlines, result limits, pooled SQLite access, and redaction-safe plans/results.

The public typed model covers collection, query, mutation, aggregation, index, and cursor commands. This milestone executes collection/index metadata operations, one explicit-`_id` insert, empty or exact-`_id` find/count, and exact-`_id` single deletion. Deferred matcher, bulk-write, update, aggregation, and retained-cursor shapes fail explicitly as unsupported. Storage access stays behind a narrow engine-only pooled authorizer, manifest metadata reads use coherent transactions, and scatter reads preserve durable cross-shard natural order and exact BSON representation.

## Tests

- [x] Unit tests were added or updated for behavior-changing code.
- [x] Boundary/integration tests were added where the change crosses SQLite,
      HTTP, protocol, filesystem, or process boundaries.
- [x] A regression test accompanies each bug fix.
- [ ] No automated test is applicable; the explanation is included above.
- [x] `cargo fmt --check` passes.
- [x] `cargo test` passes.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes.

Validation run:

- `cargo test --locked --all-targets --all-features` (1,094 library tests passed, 5 ignored; all integration, binary, example, and benchmark targets passed)
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo +1.85.0 check --locked --all-targets --features documents`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --all-features --no-deps`
- `cargo check --locked --manifest-path fuzz/Cargo.toml --bins`
- `cargo package --locked --allow-dirty`
- `/usr/bin/python3 -m unittest discover -s tests -p 'test_mongo*.py'` (61 passed on pinned Python 3.9.6)
- `/usr/bin/python3 scripts/mongo_parity.py validate` (228 cases / 456 reference executions)

## Compatibility and operations

- [x] Public behavior and compatibility documentation were updated where needed.
- [x] Storage-format, migration, security, and recovery effects were considered.

The `documents` feature remains opt-in. This adds no MongoDB listener and no TinyMongo runtime dependency. Existing storage format v14 remains unchanged; the new storage primitives use its versioned document catalog and fixed shard table.

Closes #162
