### PR TITLE
Add embedded document command facade

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ experimental and opt-in; the exact contract lives in
 | Global-index health and Prometheus metrics | `/health`, `/v1/admin/global-indexes`, `/metrics`, plus Rust operational reports |
 | Ubuntu/macOS x86-64 and ARM64 release artifacts | Published |
 | Debian package and hardened systemd service | Published |
-| Rust library entrypoint with optional attached listeners | Working |
+| Rust library entrypoint with optional attached listeners | Working; the opt-in `documents` feature adds a thin native document-command facade |
 | Same-host service and embedded processes sharing one ready root | Working on local filesystems |
-| Native MongoDB wire protocol with TinyMongo parity | [Versioned parity contract](docs/MONGO_PARITY.md), [Rust BSON foundation](docs/BSON.md), [document storage/import](docs/DOCUMENT_STORAGE.md), and the first [protocol-neutral document commands](docs/DOCUMENT_ENGINE.md) landed; remaining matcher/write semantics and the listener remain [planned](https://github.com/schapman1974/briskdb/issues/160) |
+| Native MongoDB wire protocol with TinyMongo parity | [Versioned parity contract](docs/MONGO_PARITY.md), [Rust BSON foundation](docs/BSON.md), [document storage/import](docs/DOCUMENT_STORAGE.md), the first [protocol-neutral document commands](docs/DOCUMENT_ENGINE.md), and their embedded Rust facade landed; remaining matcher/write semantics and the listener remain [planned](https://github.com/schapman1974/briskdb/issues/160) |
 | MySQL wire protocol | [Planned](https://github.com/schapman1974/briskdb/issues/40) |
 | Native Python extension | Sync/async API working; tagged releases build audited macOS/Linux ARM/x86 wheels |
 | Serverless lifecycle | [Planned](https://github.com/schapman1974/briskdb/issues/194) |
@@ -215,8 +215,11 @@ packages with a hardened systemd service.
 Embedding in Rust starts with `BriskDb::open()` or the validated builder. The
 [embedded Rust guide](docs/EMBEDDED_RUST.md) includes a complete listener-free
 example. Choose a shard count when creating data; later opens detect it from
-the manifest and reject explicit mismatches. Use `default-features = false` with the
-`embedded` feature to leave the network and CLI stacks out; see the
+the manifest and reject explicit mismatches. Use `default-features = false`
+with the `embedded` feature for SQL-only embedding. Select `documents` and
+explicitly enable `DocumentSupport` to submit native BSON commands through
+`BriskDb` or an owned `BriskSession`. Both forms use the same document engine
+and routing plans as future protocol adapters; see the
 [crate feature map](docs/CRATE_FEATURES.md).
 
 Python runs the same engine directly in-process. It starts no listener by
@@ -257,8 +260,9 @@ and integrity metadata. Application rows stay in ordinary SQLite files.
 
 ## Where this is going
 
-- **MongoDB:** a native Rust Mongo listener with BSON, queries, updates,
-  indexes, cursors, aggregation, and differential TinyMongo parity.
+- **MongoDB:** complete the matcher, write, index, cursor, and aggregation
+  semantics behind the native embedded command facade, then add a Rust Mongo
+  listener and differential TinyMongo parity.
 - **More wire protocols:** broader PostgreSQL client compatibility and a MySQL
   listener, all sharing the same engine behavior.
 - **Serverless storage:** atomic snapshots, object-store adapters, and fenced

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,9 +22,27 @@ inserts, empty-filter or exact-`_id` find/count commands, and exact-`_id`
 single-document deletion through the same session, pool, routing, cancellation,
 deadline, shutdown, and result-limit boundaries as SQL. Point plans target one
 shard; scatter reads merge in durable natural order while preserving exact
-ordered BSON. General matchers, update expressions, replacements, aggregation,
-retained cursors, the MongoDB listener, and public Rust/Python collection APIs
-remain follow-up work. See [the BSON contract](docs/BSON.md),
+ordered BSON.
+
+The embedded Rust surface now exposes that engine through thin
+`BriskDb::execute_document` and `BriskSession::execute_document` methods. A
+document-enabled handle forwards the caller's owned `DocumentRequest`
+unchanged, preserving ordered BSON, typed results, request identity, point or
+scatter plans, cancellation, deadlines, result limits, and classified engine
+errors. Document support remains opt-in twice: compile with the `documents`
+feature and open with `DocumentSupport::Enabled`. A disabled handle rejects a
+facade call with `FailedPrecondition`; a build without `documents` rejects the
+enabled builder setting with `Unsupported` before accessing storage.
+Differential integration tests compare direct engine execution with both
+facades for point and scatter commands, ordered extended BSON values, request
+controls, session ownership, and shutdown.
+
+The facade exposes the exact engine slice above. General matchers, update
+expressions, replacements, aggregation, retained cursors, the MongoDB listener,
+a collection-oriented Rust convenience API, and the Python document API remain
+follow-up work before MongoDB compatibility can be claimed. See the
+[embedded Rust guide](docs/EMBEDDED_RUST.md),
+[the BSON contract](docs/BSON.md),
 [the document storage contract](docs/DOCUMENT_STORAGE.md), and
 [the document engine contract](docs/DOCUMENT_ENGINE.md).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -420,7 +420,7 @@ requires an earlier dependency:
    - [x] [#237](https://github.com/schapman1974/briskdb/issues/237) — asynchronous indexing and watermarks
    - [x] [#238](https://github.com/schapman1974/briskdb/issues/238) — Bloom/min-max shard summaries
    - [x] [#239](https://github.com/schapman1974/briskdb/issues/239) — production/release gates
-4. [ ] **Finish the embedded Rust API.** Make sessions, transactions,
+4. [x] **Finish the embedded Rust API.** Make sessions, transactions,
    cancellation, concurrency, document commands, and shutdown safe for a host
    process.
 5. [ ] **Finish the Python API and wheels.** Provide matching synchronous and
@@ -455,8 +455,8 @@ requires an earlier dependency:
     - [x] [#162](https://github.com/schapman1974/briskdb/issues/162) —
       protocol-neutral document engine with controlled point/scatter commands;
       see [`docs/DOCUMENT_ENGINE.md`](docs/DOCUMENT_ENGINE.md)
-    - [ ] [#191](https://github.com/schapman1974/briskdb/issues/191) — embedded
-      Rust document API
+    - [x] [#191](https://github.com/schapman1974/briskdb/issues/191) — thin
+      embedded Rust facade over protocol-neutral document commands
     - [ ] [#198](https://github.com/schapman1974/briskdb/issues/198) — Python
       BSON conversions and document API
     - [ ] [#200](https://github.com/schapman1974/briskdb/issues/200) — release

--- a/docs/CRATE_FEATURES.md
+++ b/docs/CRATE_FEATURES.md
@@ -12,11 +12,22 @@ handling dependencies:
 briskdb = { version = "0.1.0-alpha.5", default-features = false, features = ["embedded"] }
 ```
 
+For the same facade plus native BSON/document commands:
+
+```toml
+[dependencies]
+briskdb = { version = "0.1.0-alpha.5", default-features = false, features = ["documents"] }
+```
+
+The `documents` feature selects `embedded`; each database handle must still be
+opened with `DocumentSupport::Enabled` before its document facade accepts work.
+Command, BSON, plan, and result types live under `briskdb::document`.
+
 ## Feature map
 
 | Feature | Adds | Tier |
 | --- | --- | --- |
-| `embedded` | Listener-free `BriskDb` and `BriskSession` APIs | Alpha-supported |
+| `embedded` | Listener-free `BriskDb` and `BriskSession` SQL APIs | Alpha-supported |
 | `http` | Axum HTTP API and admin browser | Alpha-supported |
 | `postgres` | PostgreSQL wire adapter, including TLS/SCRAM implementation | Alpha-supported, bounded SQL subset |
 | `listeners` | Host-controlled HTTP/PostgreSQL listeners, selecting `tls`, without signals or engine ownership | Alpha-supported |
@@ -26,7 +37,7 @@ briskdb = { version = "0.1.0-alpha.5", default-features = false, features = ["em
 | `sqlite-import-cli` | `briskdb-import` binary | Process integration |
 | `tinymongo-import` | Strict TinyMongo v1.3 SQLite reader and atomic document import; selects `documents` and `sqlite-import` | Experimental migration API |
 | `experimental-vtab` | Sharded virtual-table prototype | Experimental |
-| `documents` | BSON values and codec, catalog/storage, TinyMongo-ready semantic keys, and protocol-neutral document commands; also selects `embedded` | Experimental document engine; no MongoDB listener yet |
+| `documents` | BSON values and codec, catalog/storage, TinyMongo-ready semantic keys, protocol-neutral document commands, and their `BriskDb`/`BriskSession` facade; also selects `embedded` | Experimental document engine; no MongoDB listener yet |
 | `mysql` | Reserved MySQL boundary | Reserved; no listener yet |
 | `tls` | Compatibility alias for the secure `postgres` surface | Alpha-supported; selected by `listeners` |
 
@@ -46,12 +57,15 @@ listener assembly.
   building blocks used by current adapters. Prefer crate-root and `embedded`
   APIs unless implementing a BriskDB adapter.
 - The `documents` feature exposes the protocol-neutral BSON foundation,
-  versioned persistence, and first document-engine commands documented in
-  [BSON value and codec contract](BSON.md) and
-  [document storage](DOCUMENT_STORAGE.md), and
+  versioned persistence, first document-engine commands, and the thin embedded
+  facade documented in the
+  [BSON value and codec contract](BSON.md),
+  [document storage contract](DOCUMENT_STORAGE.md), and
   [protocol-neutral document engine](DOCUMENT_ENGINE.md). Its public value,
   command, result, and metadata APIs remain experimental while Mongo semantics
-  are completed. It does not expose a MongoDB listener.
+  are completed. Callers must also open with `DocumentSupport::Enabled`; merely
+  compiling the feature does not enable document commands on a handle. It does
+  not expose a MongoDB listener or a collection-oriented convenience API.
 - The `mysql` reserved feature compiles but intentionally exposes no claimed
   implementation.
 

--- a/docs/DOCUMENT_ENGINE.md
+++ b/docs/DOCUMENT_ENGINE.md
@@ -1,12 +1,14 @@
 # Protocol-neutral document engine
 
-Status: implemented by roadmap issue #162
+Status: engine slice implemented by roadmap issue #162; embedded facade
+implemented by issue #191
 
 The opt-in `documents` feature adds an asynchronous document command boundary
 to `core::Engine`. A caller submits an owned `DocumentRequest` to
 `Engine::execute_document`; no HTTP, PostgreSQL, MongoDB, or other network
-listener participates. This is the shared execution boundary for future Rust,
-Python, and MongoDB adapters.
+listener participates. `BriskDb` and `BriskSession` expose the same operation
+to embedded Rust callers. This is the shared execution boundary for future
+Python and MongoDB adapters.
 
 Every request carries a nonzero 128-bit request identity and the same
 `RequestContext` controls as SQL operations: cancellation, an absolute
@@ -14,6 +16,40 @@ deadline, and result limits that may narrow the engine defaults. The returned
 `DocumentExecution` echoes the request identity and, for routed data commands,
 the selected point or scatter plan. Reusing an identity helps correlate logs;
 it does not make a write idempotent.
+
+## Embedded facade
+
+With the `documents` feature, the listener-free API adds these exact methods:
+
+```text
+BriskDb::execute_document(
+    &self,
+    session: &Session,
+    request: DocumentRequest,
+) -> EngineResult<DocumentExecution>
+
+BriskSession::execute_document(
+    &self,
+    request: DocumentRequest,
+) -> EngineResult<DocumentExecution>
+```
+
+The database form is useful to hosts that already manage core `Session`
+values. The owned-session form keeps the database identity and shared
+serialized session state in one cloneable handle. Neither method translates
+BSON, reconstructs requests, or owns document semantics; after checking
+per-handle enablement, it forwards the request unchanged to
+`Engine::execute_document`.
+
+The embedded facade has a build-time and a per-handle gate. Applications
+compile with `default-features = false, features = ["documents"]`, then open
+through `BriskDb::builder(...)` with `DocumentSupport::Enabled`.
+Without the Cargo feature, these methods are not compiled and builder
+validation of the enabled setting returns `Unsupported` before filesystem
+access. With the feature present but support disabled on the handle, a facade
+call returns `FailedPrecondition` before engine admission. See
+[Embedded Rust](EMBEDDED_RUST.md#native-document-commands) for a complete
+example.
 
 ## Implemented commands
 
@@ -65,8 +101,9 @@ Unsupported command shapes return the stable `EngineErrorKind::Unsupported`
 category. Inserts require caller-supplied `_id` values until generated document
 IDs land.
 
-This release does not add a MongoDB listener or the higher-level embedded Rust
-and Python collection APIs. Those adapters will translate into this engine
-boundary instead of implementing routing or storage behavior themselves. See
-[the Mongo parity contract](MONGO_PARITY.md), [the BSON contract](BSON.md), and
-[document storage](DOCUMENT_STORAGE.md) for the adjacent contracts.
+This release does not add a MongoDB listener, a collection-oriented Rust
+convenience API, or the Python document API. Those later adapters will
+translate into this engine boundary instead of implementing routing or storage
+behavior themselves. See [the Mongo parity contract](MONGO_PARITY.md),
+[the BSON contract](BSON.md), and [document storage](DOCUMENT_STORAGE.md) for
+the adjacent contracts.

--- a/docs/EMBEDDED_RUST.md
+++ b/docs/EMBEDDED_RUST.md
@@ -1,13 +1,15 @@
 # Embedded Rust
 
-Status: implemented by issue #189
+Status: library entrypoint implemented by issue #189; native document-command
+facade implemented by issue #191
 
 `BriskDb` is the listener-free entrypoint for using the same protocol-neutral
 engine inside a Rust application. Opening it does not bind sockets, install
 signal handlers, configure tracing, or change process-global state.
 
-See [Embedded SQL](EMBEDDED_SQL.md) for direct and prepared command APIs,
-value guarantees, and the foreign-language runtime boundary.
+See [Embedded SQL](EMBEDDED_SQL.md) for direct and prepared SQL APIs, value
+guarantees, and the foreign-language runtime boundary. The opt-in native
+document facade is covered below.
 
 ```rust
 use briskdb::{BriskDb, Statement, Value};
@@ -67,12 +69,95 @@ the data under the wrong layout.
 | Request timeout | 30 seconds |
 | Shutdown grace | 30 seconds |
 | Runtime | Caller-managed Tokio runtime |
-| Native document support | Disabled |
+| Native document support | Disabled; requires the `documents` feature and explicit per-handle enablement |
 
 Use `EngineOptions`, `ResultLimits`, and `PreparedStatementLimits` to replace
 resource defaults. Explicit shard counts are validated before storage is
 created; count-dependent limits are validated after an existing manifest is
 detected.
+
+## Native document commands
+
+Document embedding uses the same owned commands and results as the
+protocol-neutral document engine. Select `documents` instead of `embedded`;
+the feature includes the embedded facade and BSON dependencies:
+
+```toml
+[dependencies]
+briskdb = { version = "0.1.0-alpha.5", default-features = false, features = ["documents"] }
+```
+
+The embedded document facade must also be enabled on each database handle.
+This example uses the owned session facade; `BriskDb::execute_document`
+accepts the same request together with a borrowed core `Session`.
+
+```rust
+use briskdb::{BriskDb, DocumentSupport, RequestContext};
+use briskdb::document::{
+    DocumentCollectionOptions, DocumentCommand, DocumentCreateCollectionRequest,
+    DocumentNamespace, DocumentRequest, DocumentRequestId, DocumentResult,
+    DocumentWriteOptions,
+};
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let db = BriskDb::builder("./data")
+    .with_shard_count(4)
+    .with_document_support(DocumentSupport::Enabled)
+    .open()
+    .await?;
+let session = db.owned_session();
+let namespace = DocumentNamespace::new("app", "notes")?;
+
+// Use a fresh caller-generated value for each logical request.
+let request_id = DocumentRequestId::new([1; 16])?;
+let execution = session
+    .execute_document(DocumentRequest::new(
+        request_id,
+        RequestContext::new(),
+        DocumentCommand::CreateCollection(DocumentCreateCollectionRequest::new(
+            namespace,
+            DocumentCollectionOptions::empty(),
+            DocumentWriteOptions::new(),
+        )),
+    ))
+    .await?;
+
+assert_eq!(execution.request_id(), request_id);
+assert!(matches!(execution.result(), DocumentResult::Collection(_)));
+
+session.close().await?;
+db.close().await?;
+# Ok(())
+# }
+```
+
+`BriskSession::execute_document` and `BriskDb::execute_document` are thin
+facades: they pass `DocumentRequest` to the engine entrypoint defined for
+adapters and return its `DocumentExecution` unchanged. The request owns its
+nonzero identity and `RequestContext`, including cancellation, deadline, and
+narrower result limits. Reusing a request identity helps correlate retries; it
+does not make a write idempotent.
+
+The current command slice is listed in the
+[document engine contract](DOCUMENT_ENGINE.md#implemented-commands). It
+preserves ordered BSON documents, exact BSON representations, typed document
+results, and point/scatter routing plans. It is deliberately command-shaped;
+there is no collection-oriented convenience API in this release.
+
+The two enablement checks fail closed:
+
+- Without the `documents` Cargo feature,
+  the document facade methods are absent and
+  `with_document_support(DocumentSupport::Enabled)` returns `Unsupported`
+  during builder validation, before opening or creating storage.
+- With the feature compiled but the handle left at its default
+  `DocumentSupport::Disabled`, either facade method returns
+  `FailedPrecondition` before submitting the request to the engine.
+
+Enabling the facade does not expand the engine's supported Mongo semantics.
+Requests for general matchers, updates, replacements, aggregation, distinct,
+and retained cursors remain `Unsupported` as described by the engine contract.
+There is no MongoDB listener in this release.
 
 ## Lifecycle and errors
 
@@ -113,10 +198,10 @@ bounded WAL checkpoint on every shard and reports incomplete progress without
 blocking active writers.
 
 The initial library is async and requires a caller-managed Tokio runtime. The
-typed dedicated-runtime and document-support modes are reserved and fail with
-`unsupported` before storage is touched until their implementations land.
-The host may install any tracing subscriber it wants; the library emits through
-the normal `tracing` facade and never configures global logging itself.
+typed dedicated-runtime mode remains reserved and fails with `Unsupported`
+before storage is touched. The host may install any tracing subscriber it
+wants; the library emits through the normal `tracing` facade and never
+configures global logging itself.
 
 `BriskDb::begin_transaction()` returns an owned `BriskTransaction` backed by a
 private core session. Its first routed statement pins one physical shard;

--- a/docs/EMBEDDED_SQL.md
+++ b/docs/EMBEDDED_SQL.md
@@ -77,9 +77,9 @@ one finite runtime outside the GIL/host lock, submit these async calls to it,
 and map cancellation back through `RequestContext`; they must not create a new
 runtime per query.
 
-The opt-in `documents` feature now exposes protocol-neutral document commands
-on `core::Engine`; see [the document engine contract](DOCUMENT_ENGINE.md).
-`BriskDb` does not yet wrap those commands as a high-level collection API.
-Selecting `DocumentSupport::Enabled` therefore still fails before storage is
-touched until issue #191 lands, so SQL-only embedding cannot accidentally claim
-Mongo compatibility.
+The opt-in `documents` feature also exposes protocol-neutral document commands
+through `BriskDb` and `BriskSession`. It does not change these SQL methods or
+enable document execution implicitly: the builder must select
+`DocumentSupport::Enabled`. See the
+[embedded Rust document example](EMBEDDED_RUST.md#native-document-commands) and
+[document engine contract](DOCUMENT_ENGINE.md).

--- a/src/embedded.rs
+++ b/src/embedded.rs
@@ -18,6 +18,8 @@ use crate::core::{
     RequestContext, ResultSet, Routed, Row, RowStream, Session, SessionId, SessionState,
     ShutdownReport, Statement, TransactionExecution, Value, WriteResult,
 };
+#[cfg(feature = "documents")]
+use crate::document::{DocumentExecution, DocumentRequest};
 use crate::{EngineError, EngineErrorKind};
 use crate::{SqlDialect, SqlTranslationMode};
 
@@ -45,8 +47,9 @@ pub enum RuntimeBehavior {
 /// Optional native document-command surface for an embedded database.
 ///
 /// Document support is an explicit configuration choice so enabling it later
-/// cannot silently change a SQL-only application's storage contract. The
-/// current build rejects [`DocumentSupport::Enabled`] before touching storage.
+/// cannot silently change a SQL-only application's storage contract. Builds
+/// without the `documents` feature reject [`DocumentSupport::Enabled`] before
+/// touching storage.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum DocumentSupport {
@@ -147,10 +150,11 @@ impl BriskDbBuilder {
                 "a dedicated embedded runtime is not implemented; use CallerManaged",
             ));
         }
+        #[cfg(not(feature = "documents"))]
         if self.document_support != DocumentSupport::Disabled {
             return Err(EngineError::new(
                 EngineErrorKind::Unsupported,
-                "native embedded document support is not implemented in this build",
+                "native embedded document support requires the `documents` Cargo feature",
             ));
         }
         Ok(())
@@ -255,6 +259,17 @@ impl fmt::Debug for BriskCursor {
 }
 
 impl BriskDb {
+    #[cfg(feature = "documents")]
+    fn require_document_support(&self) -> EngineResult<()> {
+        if self.document_support != DocumentSupport::Enabled {
+            return Err(EngineError::new(
+                EngineErrorKind::FailedPrecondition,
+                "native document support is disabled for this embedded database",
+            ));
+        }
+        Ok(())
+    }
+
     /// Start a builder for one data directory.
     pub fn builder(root: impl Into<PathBuf>) -> BriskDbBuilder {
         BriskDbBuilder::new(root)
@@ -334,6 +349,20 @@ impl BriskDb {
     /// Return immutable engine and resource-limit status.
     pub async fn status(&self, session: &Session) -> EngineResult<EngineStatus> {
         self.engine.status(session).await
+    }
+
+    /// Execute one native document request through the protocol-neutral engine.
+    ///
+    /// The database must be opened with [`DocumentSupport::Enabled`]. The
+    /// request and engine outcome are otherwise forwarded unchanged.
+    #[cfg(feature = "documents")]
+    pub async fn execute_document(
+        &self,
+        session: &Session,
+        request: DocumentRequest,
+    ) -> EngineResult<DocumentExecution> {
+        self.require_document_support()?;
+        self.engine.execute_document(session, request).await
     }
 
     /// Execute one routed write and return only its affected-row count.
@@ -796,6 +825,20 @@ impl BriskSession {
         self.database.status(self.session.as_ref()).await
     }
 
+    /// Execute one native document request on this owned session.
+    ///
+    /// The owning database must have been opened with
+    /// [`DocumentSupport::Enabled`].
+    #[cfg(feature = "documents")]
+    pub async fn execute_document(
+        &self,
+        request: DocumentRequest,
+    ) -> EngineResult<DocumentExecution> {
+        self.database
+            .execute_document(self.session.as_ref(), request)
+            .await
+    }
+
     /// Execute one routed write and return only its affected-row count.
     pub async fn execute(&self, statement: Statement) -> EngineResult<Routed<usize>> {
         self.database
@@ -1234,5 +1277,121 @@ impl BriskCursor {
     /// Wait for the next row, terminal query error, or clean end of stream.
     pub async fn next_row(&mut self) -> Option<EngineResult<Row>> {
         self.stream.next_row().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(not(feature = "documents"))]
+    #[test]
+    fn document_support_fails_closed_without_documents_feature() {
+        let error = BriskDb::builder("unused")
+            .with_document_support(DocumentSupport::Enabled)
+            .validate()
+            .unwrap_err();
+
+        assert_eq!(error.kind(), EngineErrorKind::Unsupported);
+        assert_eq!(
+            error.to_string(),
+            "native embedded document support requires the `documents` Cargo feature"
+        );
+    }
+
+    #[cfg(feature = "documents")]
+    mod documents {
+        use super::*;
+        use crate::document::{
+            DocumentCollectionOptions, DocumentCommand, DocumentCreateCollectionRequest,
+            DocumentListCollectionsRequest, DocumentNamespace, DocumentReadOptions,
+            DocumentRequestId, DocumentResult, DocumentWriteOptions,
+        };
+
+        fn request(seed: u8, command: DocumentCommand) -> DocumentRequest {
+            DocumentRequest::new(
+                DocumentRequestId::new([seed; 16]).unwrap(),
+                RequestContext::new(),
+                command,
+            )
+        }
+
+        #[tokio::test]
+        async fn document_facades_require_opt_in_and_preserve_engine_outcomes() {
+            let temp = tempfile::tempdir().unwrap();
+            let disabled = BriskDb::builder(temp.path())
+                .with_shard_count(2)
+                .open()
+                .await
+                .unwrap();
+            let disabled_session = disabled.session();
+            let namespace = DocumentNamespace::new("app", "events").unwrap();
+            let create = DocumentCommand::CreateCollection(DocumentCreateCollectionRequest::new(
+                namespace.clone(),
+                DocumentCollectionOptions::empty(),
+                DocumentWriteOptions::new(),
+            ));
+
+            let error = disabled
+                .execute_document(&disabled_session, request(1, create))
+                .await
+                .unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+            assert_eq!(
+                error.to_string(),
+                "native document support is disabled for this embedded database"
+            );
+            disabled_session.close().await.unwrap();
+            disabled.close().await.unwrap();
+
+            let enabled = BriskDb::builder(temp.path())
+                .with_document_support(DocumentSupport::Enabled)
+                .open()
+                .await
+                .unwrap();
+            assert_eq!(enabled.document_support(), DocumentSupport::Enabled);
+            let session = enabled.session();
+            let create_id = DocumentRequestId::new([2; 16]).unwrap();
+            let created = enabled
+                .execute_document(
+                    &session,
+                    DocumentRequest::new(
+                        create_id,
+                        RequestContext::new(),
+                        DocumentCommand::CreateCollection(DocumentCreateCollectionRequest::new(
+                            namespace,
+                            DocumentCollectionOptions::empty(),
+                            DocumentWriteOptions::new(),
+                        )),
+                    ),
+                )
+                .await
+                .unwrap();
+            assert_eq!(created.request_id(), create_id);
+            assert!(matches!(created.result(), DocumentResult::Collection(_)));
+            session.close().await.unwrap();
+
+            let owned = enabled.owned_session();
+            let list_id = DocumentRequestId::new([3; 16]).unwrap();
+            let listed = owned
+                .execute_document(DocumentRequest::new(
+                    list_id,
+                    RequestContext::new(),
+                    DocumentCommand::ListCollections(
+                        DocumentListCollectionsRequest::new("app", DocumentReadOptions::new())
+                            .unwrap(),
+                    ),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(listed.request_id(), list_id);
+            match listed.result() {
+                DocumentResult::Collections(collections) => assert_eq!(collections.len(), 1),
+                result => panic!("expected collections, got {:?}", result.kind()),
+            }
+
+            owned.close().await.unwrap();
+            enabled.close().await.unwrap();
+        }
     }
 }

--- a/tests/embedded_api.rs
+++ b/tests/embedded_api.rs
@@ -184,14 +184,30 @@ async fn invalid_complete_configuration_fails_before_creating_storage() {
     assert_eq!(error.kind(), EngineErrorKind::Unsupported);
     assert!(!unsupported_runtime.exists());
 
-    let unsupported_documents = parent.path().join("unsupported-documents");
-    let error = BriskDb::builder(&unsupported_documents)
-        .with_document_support(DocumentSupport::Enabled)
-        .open()
-        .await
-        .unwrap_err();
-    assert_eq!(error.kind(), EngineErrorKind::Unsupported);
-    assert!(!unsupported_documents.exists());
+    #[cfg(not(feature = "documents"))]
+    {
+        let unsupported_documents = parent.path().join("unsupported-documents");
+        let error = BriskDb::builder(&unsupported_documents)
+            .with_document_support(DocumentSupport::Enabled)
+            .open()
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Unsupported);
+        assert!(!unsupported_documents.exists());
+    }
+
+    #[cfg(feature = "documents")]
+    {
+        let supported_documents = parent.path().join("supported-documents");
+        let database = BriskDb::builder(&supported_documents)
+            .with_shard_count(2)
+            .with_document_support(DocumentSupport::Enabled)
+            .open()
+            .await
+            .unwrap();
+        assert_eq!(database.document_support(), DocumentSupport::Enabled);
+        database.close().await.unwrap();
+    }
 
     let empty = BriskDb::builder("").validate().unwrap_err();
     assert_eq!(empty.kind(), EngineErrorKind::InvalidArgument);

--- a/tests/embedded_document_api.rs
+++ b/tests/embedded_document_api.rs
@@ -1,0 +1,358 @@
+#![cfg(feature = "documents")]
+
+use std::time::{Duration, Instant};
+
+use briskdb::{
+    BriskDb, CancellationToken, DocumentSupport, EngineErrorKind, RequestContext,
+    document::{
+        BsonBinary, BsonDateTime, BsonDecimal128, BsonDocument, BsonValue, DocumentCommand,
+        DocumentCountRequest, DocumentCreateCollectionRequest, DocumentFilter, DocumentFindRequest,
+        DocumentInsertRequest, DocumentListCollectionsRequest, DocumentPlan, DocumentReadOptions,
+        DocumentRequest, DocumentRequestId, DocumentResult, DocumentWriteOptions,
+    },
+};
+
+fn namespace() -> briskdb::document::DocumentNamespace {
+    briskdb::document::DocumentNamespace::new("app", "records").unwrap()
+}
+
+fn request(seed: u8, command: DocumentCommand) -> DocumentRequest {
+    request_with_context(seed, RequestContext::new(), command)
+}
+
+fn request_with_context(
+    seed: u8,
+    context: RequestContext,
+    command: DocumentCommand,
+) -> DocumentRequest {
+    DocumentRequest::new(
+        DocumentRequestId::new([seed; 16]).unwrap(),
+        context,
+        command,
+    )
+}
+
+fn create_collection_command() -> DocumentCommand {
+    DocumentCommand::CreateCollection(DocumentCreateCollectionRequest::new(
+        namespace(),
+        Default::default(),
+        DocumentWriteOptions::new(),
+    ))
+}
+
+fn list_collections_command() -> DocumentCommand {
+    DocumentCommand::ListCollections(
+        DocumentListCollectionsRequest::new("app", DocumentReadOptions::new()).unwrap(),
+    )
+}
+
+fn exact_filter(id: BsonValue) -> DocumentFilter {
+    DocumentFilter::new(BsonDocument::from_entries([("_id", id)]).unwrap()).unwrap()
+}
+
+fn fidelity_document() -> BsonDocument {
+    let nested = BsonDocument::from_entries([
+        ("first", BsonValue::Int32(1)),
+        ("second", BsonValue::Int64(2)),
+    ])
+    .unwrap();
+    BsonDocument::from_entries([
+        ("_id", BsonValue::from("typed-id")),
+        ("int32", BsonValue::Int32(7)),
+        ("int64", BsonValue::Int64(7)),
+        ("double", BsonValue::Double(-0.0)),
+        ("null", BsonValue::Null),
+        ("boolean", BsonValue::Boolean(true)),
+        (
+            "binary",
+            BsonValue::Binary(BsonBinary::new(0, [0x00, 0x7f, 0xff])),
+        ),
+        ("date", BsonValue::DateTime(BsonDateTime::from_millis(-1))),
+        (
+            "decimal",
+            BsonValue::Decimal128(BsonDecimal128::parse("123.4500").unwrap()),
+        ),
+        ("nested", BsonValue::Document(nested)),
+        (
+            "array",
+            BsonValue::Array(vec![BsonValue::Int32(3), BsonValue::from("four")]),
+        ),
+    ])
+    .unwrap()
+}
+
+#[tokio::test]
+async fn document_support_is_an_enforced_runtime_opt_in() {
+    let temp = tempfile::tempdir().unwrap();
+    let database = BriskDb::builder(temp.path())
+        .with_shard_count(2)
+        .open()
+        .await
+        .unwrap();
+    assert_eq!(database.document_support(), DocumentSupport::Disabled);
+    let session = database.session();
+
+    let error = database
+        .execute_document(&session, request(1, create_collection_command()))
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), EngineErrorKind::FailedPrecondition);
+    assert!(error.to_string().contains("document support is disabled"));
+
+    // The facade rejects the request before forwarding it to the document
+    // engine, so the failed opt-in check cannot leave catalog mutations behind.
+    let listed = database
+        .engine()
+        .execute_document(&session, request(2, list_collections_command()))
+        .await
+        .unwrap();
+    match listed.result() {
+        DocumentResult::Collections(collections) => assert!(collections.is_empty()),
+        result => panic!("expected collections, got {:?}", result.kind()),
+    }
+
+    session.close().await.unwrap();
+    database.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn raw_and_owned_facades_preserve_engine_document_outcomes_and_bson() {
+    let temp = tempfile::tempdir().unwrap();
+    let database = BriskDb::builder(temp.path())
+        .with_shard_count(4)
+        .with_document_support(DocumentSupport::Enabled)
+        .open()
+        .await
+        .unwrap();
+    assert_eq!(database.document_support(), DocumentSupport::Enabled);
+    let raw = database.session();
+    let owned = database.owned_session();
+
+    let created = database
+        .execute_document(&raw, request(10, create_collection_command()))
+        .await
+        .unwrap();
+    assert_eq!(
+        created.request_id(),
+        DocumentRequestId::new([10; 16]).unwrap()
+    );
+    assert!(created.plan().is_none());
+    assert!(matches!(created.result(), DocumentResult::Collection(_)));
+
+    let source = fidelity_document();
+    let insert = DocumentInsertRequest::new(
+        namespace(),
+        vec![source.clone()],
+        DocumentWriteOptions::new(),
+    )
+    .unwrap();
+    let inserted = owned
+        .execute_document(request(11, DocumentCommand::Insert(insert)))
+        .await
+        .unwrap();
+    assert_eq!(
+        inserted.request_id(),
+        DocumentRequestId::new([11; 16]).unwrap()
+    );
+    assert!(matches!(inserted.plan(), Some(DocumentPlan::Point(_))));
+    match inserted.result() {
+        DocumentResult::Insert(result) => {
+            assert_eq!(result.inserted_ids().len(), 1);
+            assert!(result.inserted_ids()[0].representation_eq(&BsonValue::from("typed-id")));
+        }
+        result => panic!("expected insert result, got {:?}", result.kind()),
+    }
+
+    let exact_find = request(
+        12,
+        DocumentCommand::Find(DocumentFindRequest::new(
+            namespace(),
+            exact_filter(BsonValue::from("typed-id")),
+            DocumentReadOptions::new(),
+        )),
+    );
+    let direct_exact = database
+        .engine()
+        .execute_document(&raw, exact_find.clone())
+        .await
+        .unwrap();
+    let facade_exact = database.execute_document(&raw, exact_find).await.unwrap();
+    assert_eq!(facade_exact, direct_exact);
+    assert!(matches!(facade_exact.plan(), Some(DocumentPlan::Point(_))));
+    match facade_exact.result() {
+        DocumentResult::Cursor(batch) => {
+            assert_eq!(batch.documents().len(), 1);
+            let returned = &batch.documents()[0];
+            assert!(returned.representation_eq(&source));
+            assert_eq!(
+                returned.iter().map(|(name, _)| name).collect::<Vec<_>>(),
+                vec![
+                    "_id", "int32", "int64", "double", "null", "boolean", "binary", "date",
+                    "decimal", "nested", "array",
+                ]
+            );
+            assert!(matches!(
+                returned.get_unique("int32").unwrap(),
+                Some(BsonValue::Int32(7))
+            ));
+            assert!(matches!(
+                returned.get_unique("int64").unwrap(),
+                Some(BsonValue::Int64(7))
+            ));
+            assert!(matches!(
+                returned.get_unique("double").unwrap(),
+                Some(BsonValue::Double(value)) if value.to_bits() == (-0.0_f64).to_bits()
+            ));
+        }
+        result => panic!("expected cursor, got {:?}", result.kind()),
+    }
+
+    let scatter_find = request(
+        13,
+        DocumentCommand::Find(DocumentFindRequest::new(
+            namespace(),
+            DocumentFilter::empty(),
+            DocumentReadOptions::new(),
+        )),
+    );
+    let direct_scatter = database
+        .engine()
+        .execute_document(&raw, scatter_find.clone())
+        .await
+        .unwrap();
+    let facade_scatter = owned.execute_document(scatter_find).await.unwrap();
+    assert_eq!(facade_scatter, direct_scatter);
+    match facade_scatter.plan().expect("scatter find plan") {
+        DocumentPlan::Scatter(plan) => assert_eq!(plan.shards(), &[0, 1, 2, 3]),
+        plan => panic!("expected scatter plan, got {plan:?}"),
+    }
+
+    let exact_count = request(
+        14,
+        DocumentCommand::Count(DocumentCountRequest::new(
+            namespace(),
+            exact_filter(BsonValue::from("typed-id")),
+            DocumentReadOptions::new(),
+        )),
+    );
+    let direct_exact_count = database
+        .engine()
+        .execute_document(&raw, exact_count.clone())
+        .await
+        .unwrap();
+    let facade_exact_count = database.execute_document(&raw, exact_count).await.unwrap();
+    assert_eq!(facade_exact_count, direct_exact_count);
+    assert!(matches!(
+        facade_exact_count.plan(),
+        Some(DocumentPlan::Point(_))
+    ));
+    assert!(matches!(
+        facade_exact_count.result(),
+        DocumentResult::Count(1)
+    ));
+
+    let scatter_count = request(
+        15,
+        DocumentCommand::Count(DocumentCountRequest::new(
+            namespace(),
+            DocumentFilter::empty(),
+            DocumentReadOptions::new(),
+        )),
+    );
+    let direct_scatter_count = database
+        .engine()
+        .execute_document(&raw, scatter_count.clone())
+        .await
+        .unwrap();
+    let facade_scatter_count = owned.execute_document(scatter_count).await.unwrap();
+    assert_eq!(facade_scatter_count, direct_scatter_count);
+    assert!(matches!(
+        facade_scatter_count.plan(),
+        Some(DocumentPlan::Scatter(_))
+    ));
+    assert!(matches!(
+        facade_scatter_count.result(),
+        DocumentResult::Count(1)
+    ));
+
+    raw.close().await.unwrap();
+    owned.close().await.unwrap();
+    database.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn document_facades_preserve_controls_session_ownership_and_shutdown() {
+    let parent = tempfile::tempdir().unwrap();
+    let first = BriskDb::builder(parent.path().join("first"))
+        .with_shard_count(2)
+        .with_document_support(DocumentSupport::Enabled)
+        .open()
+        .await
+        .unwrap();
+    let second = BriskDb::builder(parent.path().join("second"))
+        .with_shard_count(2)
+        .with_document_support(DocumentSupport::Enabled)
+        .open()
+        .await
+        .unwrap();
+    let first_raw = first.session();
+    let foreign_raw = second.session();
+
+    let cancellation = CancellationToken::new();
+    cancellation.cancel();
+    let cancelled = first
+        .execute_document(
+            &first_raw,
+            request_with_context(
+                20,
+                RequestContext::new().with_cancellation_token(cancellation),
+                list_collections_command(),
+            ),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(cancelled.kind(), EngineErrorKind::Cancelled);
+
+    let owned = first.owned_session();
+    let deadline = owned
+        .execute_document(request_with_context(
+            21,
+            RequestContext::new().with_deadline(Instant::now() - Duration::from_millis(1)),
+            list_collections_command(),
+        ))
+        .await
+        .unwrap_err();
+    assert_eq!(deadline.kind(), EngineErrorKind::DeadlineExceeded);
+
+    let foreign = first
+        .execute_document(&foreign_raw, request(22, list_collections_command()))
+        .await
+        .unwrap_err();
+    assert_eq!(foreign.kind(), EngineErrorKind::FailedPrecondition);
+
+    first_raw.close().await.unwrap();
+    let closed_raw = first
+        .execute_document(&first_raw, request(23, list_collections_command()))
+        .await
+        .unwrap_err();
+    assert_eq!(closed_raw.kind(), EngineErrorKind::FailedPrecondition);
+
+    owned.close().await.unwrap();
+    let closed_owned = owned
+        .execute_document(request(24, list_collections_command()))
+        .await
+        .unwrap_err();
+    assert_eq!(closed_owned.kind(), EngineErrorKind::FailedPrecondition);
+
+    let leaked = first.owned_session();
+    first.close().await.unwrap();
+    let stopped = leaked
+        .execute_document(request(25, list_collections_command()))
+        .await
+        .unwrap_err();
+    assert_eq!(stopped.kind(), EngineErrorKind::ShuttingDown);
+    leaked.close().await.unwrap();
+
+    foreign_raw.close().await.unwrap();
+    second.close().await.unwrap();
+}


### PR DESCRIPTION
The embedded Rust API exposed the completed SQL path, but native document callers still had to reach into `Engine` directly and `DocumentSupport::Enabled` was rejected in every build. This adds feature-gated `BriskDb::execute_document` and `BriskSession::execute_document` facades that forward `DocumentRequest` and `DocumentExecution` unchanged through the protocol-neutral engine.

Document execution now requires both the `documents` Cargo feature and explicit per-handle `DocumentSupport::Enabled`. Builds without the feature fail builder validation before filesystem access; handles that leave support disabled fail before engine admission. Integration coverage compares both facades with direct engine outcomes for point and scatter plans, ordered extended BSON, request identity, cancellation, deadlines, session ownership, and shutdown. Documentation records the exact currently implemented command slice and keeps Mongo listener, broader matcher/write behavior, collection conveniences, and Python bindings in their owning follow-up issues.

Validation:
- `cargo +1.85.0 test --locked --all-targets --all-features`
- `cargo +1.85.0 test --locked --doc --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo +1.85.0 check --locked --lib --no-default-features --features embedded`
- `cargo +1.85.0 check --locked --lib --no-default-features --features documents`
- feature-on/off embedded integration tests
- locked fuzz-bin compilation
- package, rustfmt, and diff checks

Closes #191
