### PR TITLE
Add lossless Python BSON and document APIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,7 +283,9 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           cache: pip
-          cache-dependency-path: python/pyproject.toml
+          cache-dependency-path: |
+            python/pyproject.toml
+            python/test-requirements.txt
 
       - name: Restore Rust build cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
@@ -299,6 +301,28 @@ jobs:
       - name: Install wheel and run Python tests
         run: |
           python -m pip install --force-reinstall dist/*.whl
+          python - <<'PY'
+          import importlib.util
+          import tempfile
+
+          assert importlib.util.find_spec("bson") is None
+          assert importlib.util.find_spec("pymongo") is None
+          import briskdb
+
+          with tempfile.TemporaryDirectory() as root:
+              with briskdb.open(root, shards=2) as database:
+                  with database.session(routing_key="sql-only") as session:
+                      assert session.query("SELECT 1")["rows"] == [(1,)]
+              with briskdb.open(root, documents=True) as database:
+                  with database.session(routing_key="sql-after-document-error") as session:
+                      try:
+                          session.create_collection("app", "must_not_commit")
+                      except briskdb.UnsupportedError as error:
+                          assert error.code == "unsupported"
+                      else:
+                          raise AssertionError("document call succeeded without PyMongo")
+                      assert session.query("SELECT 2")["rows"] == [(2,)]
+          PY
           python -m pip install -r python/test-requirements.txt
           python -m unittest discover -s python/tests -v
 

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -41,7 +41,9 @@ jobs:
         with:
           python-version: "3.14"
           cache: pip
-          cache-dependency-path: python/pyproject.toml
+          cache-dependency-path: |
+            python/pyproject.toml
+            python/test-requirements.txt
 
       - name: Install pinned packaging tools
         run: >-
@@ -78,6 +80,28 @@ jobs:
           set -euo pipefail
           python -m venv "$RUNNER_TEMP/briskdb-sdist"
           "$RUNNER_TEMP/briskdb-sdist/bin/python" -m pip install dist/*.tar.gz
+          "$RUNNER_TEMP/briskdb-sdist/bin/python" - <<'PY'
+          import importlib.util
+          import tempfile
+
+          assert importlib.util.find_spec("bson") is None
+          assert importlib.util.find_spec("pymongo") is None
+          import briskdb
+
+          with tempfile.TemporaryDirectory() as root:
+              with briskdb.open(root, shards=2) as database:
+                  with database.session(routing_key="sql-only") as session:
+                      assert session.query("SELECT 1")["rows"] == [(1,)]
+              with briskdb.open(root, documents=True) as database:
+                  with database.session(routing_key="sql-after-document-error") as session:
+                      try:
+                          session.create_collection("app", "must_not_commit")
+                      except briskdb.UnsupportedError as error:
+                          assert error.code == "unsupported"
+                      else:
+                          raise AssertionError("document call succeeded without PyMongo")
+                      assert session.query("SELECT 2")["rows"] == [(2,)]
+          PY
           "$RUNNER_TEMP/briskdb-sdist/bin/python" -m pip install -r python/test-requirements.txt
           "$RUNNER_TEMP/briskdb-sdist/bin/python" -m unittest discover -s python/tests -v
 
@@ -178,6 +202,28 @@ jobs:
       - name: Run minimum-version wheel tests without a source build
         run: |
           python -m pip install --no-index --only-binary=:all: --force-reinstall dist/*.whl
+          python - <<'PY'
+          import importlib.util
+          import tempfile
+
+          assert importlib.util.find_spec("bson") is None
+          assert importlib.util.find_spec("pymongo") is None
+          import briskdb
+
+          with tempfile.TemporaryDirectory() as root:
+              with briskdb.open(root, shards=2) as database:
+                  with database.session(routing_key="sql-only") as session:
+                      assert session.query("SELECT 1")["rows"] == [(1,)]
+              with briskdb.open(root, documents=True) as database:
+                  with database.session(routing_key="sql-after-document-error") as session:
+                      try:
+                          session.create_collection("app", "must_not_commit")
+                      except briskdb.UnsupportedError as error:
+                          assert error.code == "unsupported"
+                      else:
+                          raise AssertionError("document call succeeded without PyMongo")
+                      assert session.query("SELECT 2")["rows"] == [(2,)]
+          PY
           python -m pip install -r python/test-requirements.txt
           python -m unittest discover -s python/tests -v
 
@@ -189,6 +235,28 @@ jobs:
       - name: Run maximum-version wheel tests without a source build
         run: |
           python -m pip install --no-index --only-binary=:all: --force-reinstall dist/*.whl
+          python - <<'PY'
+          import importlib.util
+          import tempfile
+
+          assert importlib.util.find_spec("bson") is None
+          assert importlib.util.find_spec("pymongo") is None
+          import briskdb
+
+          with tempfile.TemporaryDirectory() as root:
+              with briskdb.open(root, shards=2) as database:
+                  with database.session(routing_key="sql-only") as session:
+                      assert session.query("SELECT 1")["rows"] == [(1,)]
+              with briskdb.open(root, documents=True) as database:
+                  with database.session(routing_key="sql-after-document-error") as session:
+                      try:
+                          session.create_collection("app", "must_not_commit")
+                      except briskdb.UnsupportedError as error:
+                          assert error.code == "unsupported"
+                      else:
+                          raise AssertionError("document call succeeded without PyMongo")
+                      assert session.query("SELECT 2")["rows"] == [(2,)]
+          PY
           python -m pip install -r python/test-requirements.txt
           python -m unittest discover -s python/tests -v
           python -m pip install mypy==1.19.1

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ experimental and opt-in; the exact contract lives in
 | Same-host service and embedded processes sharing one ready root | Working on local filesystems |
 | Native MongoDB wire protocol with TinyMongo parity | [Versioned parity contract](docs/MONGO_PARITY.md), [Rust BSON foundation](docs/BSON.md), [document storage/import](docs/DOCUMENT_STORAGE.md), the first [protocol-neutral document commands](docs/DOCUMENT_ENGINE.md), and their embedded Rust facade landed; remaining matcher/write semantics and the listener remain [planned](https://github.com/schapman1974/briskdb/issues/160) |
 | MySQL wire protocol | [Planned](https://github.com/schapman1974/briskdb/issues/40) |
-| Native Python extension | Sync/async API working; tagged releases build audited macOS/Linux ARM/x86 wheels |
+| Native Python extension | Typed sync/async SQL and opt-in BSON document commands; tagged releases build audited macOS/Linux ARM/x86 wheels |
 | Serverless lifecycle | [Planned](https://github.com/schapman1974/briskdb/issues/194) |
 
 ## Where BriskDB fits
@@ -232,8 +232,36 @@ with briskdb.open("./data", shards=4) as db:
         print(server.http_address, server.postgres_address)
 ```
 
+The wheel also exposes the current protocol-neutral document slice through
+sync and asyncio sessions. Install PyMongo for its BSON value classes, then
+enable document commands on the database handle:
+
+```bash
+python -m pip install briskdb pymongo
+```
+
+```python
+from bson import ObjectId
+import briskdb
+
+with briskdb.open("./data", shards=4, documents=True) as db:
+    with db.session() as session:
+        session.create_collection("app", "notes")
+        note_id = ObjectId()
+        session.insert_one("app", "notes", {"_id": note_id, "body": "hello"})
+        print(session.find("app", "notes", {"_id": note_id})["documents"])
+```
+
+PyMongo remains optional and is loaded only when a document method runs, so a
+SQL-only installation has no BSON dependency. The current slice supports
+collection/index metadata, one explicit-ID insert, empty or exact-`_id`
+find/count, and exact-`_id` deletion. Secondary index declarations remain
+`pending_build`.
+
 See the [Python quickstart](python/README.md) for sync and asyncio write/read
-examples. Tagged releases publish compiler-free `cp39-abi3` wheels for the
+examples and the [Python value contract](python/VALUE_CONVERSIONS.md) for BSON,
+datetime, UUID, and error behavior. Tagged releases publish compiler-free
+`cp39-abi3` wheels for the
 [supported platform matrix](python/COMPATIBILITY.md); repository checkouts can
 still be installed from source with Rust 1.85+. Independently spawned Python,
 Rust, and server processes can share a ready local data directory; read the
@@ -301,6 +329,9 @@ more valuable than a star. Start with the
 - Multi-process access is same-host/local-filesystem only. Schema, catalog,
   upgrade, and recovery work requires sole-process ownership.
 - Pre-1.0 storage and public-library compatibility can change between releases.
+- Python document commands currently require explicit `_id` values and only
+  implement empty or exact-`_id` filters. Updates, aggregation, bulk writes,
+  retained document cursors, and built secondary indexes are still planned.
 - Ubuntu 24.04 x86-64 receives the full required Rust CI suite. Python wheels
   receive native build, audit, install, restart, corruption, and concurrency
   checks on Linux/macOS x86-64 and ARM64.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -37,14 +37,28 @@ Differential integration tests compare direct engine execution with both
 facades for point and scatter commands, ordered extended BSON values, request
 controls, session ownership, and shutdown.
 
+The typed Python wheel now exposes the same command slice on `Session` and
+`AsyncSession`, gated by `documents=True`. Ordered mappings and PyMongo BSON
+classes convert without JSON, including exact int32/int64 identity, IEEE-754
+bits, Decimal128 BID payloads, ObjectId, Code with scope, and all five UUID
+representation modes. Datetimes use aware UTC millisecond results, validation
+enforces the 16 MiB and 100-container BSON limits, and conversion failures use
+the existing stable Python exception hierarchy. PyMongo 4.17.0 is the pinned
+compatibility oracle, but remains an optional, lazily imported companion:
+installed-wheel and sdist gates first prove SQL and the missing-BSON failure
+path in an environment without PyMongo.
+
 The facade exposes the exact engine slice above. General matchers, update
 expressions, replacements, aggregation, retained cursors, the MongoDB listener,
-a collection-oriented Rust convenience API, and the Python document API remain
-follow-up work before MongoDB compatibility can be claimed. See the
+a collection-oriented Rust convenience API, and broader Python document
+operations remain follow-up work before MongoDB compatibility can be claimed.
+See the
 [embedded Rust guide](docs/EMBEDDED_RUST.md),
 [the BSON contract](docs/BSON.md),
 [the document storage contract](docs/DOCUMENT_STORAGE.md), and
-[the document engine contract](docs/DOCUMENT_ENGINE.md).
+[the document engine contract](docs/DOCUMENT_ENGINE.md). Python users should
+also read the [document API map](python/API.md) and
+[value-conversion contract](python/VALUE_CONVERSIONS.md).
 
 HTTP now has an explicit version-1 contract, discovery at `/v1`, a versioned
 `/v1/health` alias, and `BriskDB-API-Version: 1` on v1 responses. Existing valid
@@ -149,10 +163,10 @@ The release also provides `briskdb` and `briskdb-import` archives for Ubuntu
 `briskdb` account, administrator configuration under `/etc/default/briskdb`,
 persistent state under `/var/lib/briskdb`, and journald logging.
 
-The disabled-by-default PostgreSQL listener supports one registered-table
-simple-query `SELECT`, `INSERT`, `UPDATE`, or `DELETE` statement at a time.
-Psycopg 3 clients must use `psycopg.ClientCursor`; the ordinary cursor uses the
-unsupported extended-query protocol. See `docs/POSTGRES_QUICKSTART.md`.
+The disabled-by-default PostgreSQL listener supports registered-table
+`SELECT`, `INSERT`, `UPDATE`, and `DELETE` through simple queries and bounded
+text/binary extended queries. It also supports real single-shard transactions
+and optional TLS with SCRAM-SHA-256. See `docs/POSTGRES_QUICKSTART.md`.
 
 Every native archive and wheel is built and smoke-tested on its matching native
 GitHub runner. Wheels are installed and tested under CPython 3.9 and 3.14, and
@@ -161,12 +175,12 @@ GitHub build-provenance attestation.
 
 ## Critical alpha boundaries
 
-- There is no authentication, authorization, or TLS. HTTP and PostgreSQL are
-  restricted to loopback. Do not expose either listener to a network.
-- PostgreSQL extended-query protocol is unsupported. Parameters sent through
-  Parse/Bind/Execute, server-side prepared statements, transactions, DDL,
-  `COPY`, and binary results are unavailable. Psycopg must use
-  `psycopg.ClientCursor`.
+- HTTP remains unauthenticated and loopback-only. PostgreSQL may bind remotely
+  only with its configured TLS and SCRAM-SHA-256 boundary; BriskDB does not yet
+  provide general users, roles, or authorization policy.
+- PostgreSQL supports bounded simple and parameterized text/binary extended
+  queries plus single-shard transactions. DDL, `COPY`, broad type coverage,
+  and general PostgreSQL session semantics remain unavailable.
 - PostgreSQL accepts exactly one simple-query statement per message and only
   operates on an offline imported/registered catalog. It does not provide an
   online `CREATE TABLE` workflow or full PostgreSQL compatibility.
@@ -177,18 +191,19 @@ GitHub build-provenance attestation.
   procedure is a complete data-directory copy. Online backup/restore,
   resharding, and online rebalance are unsupported.
 - There is no production metrics or observability suite.
-- The Python package does not claim DB-API 2.0 compatibility, transaction
-  methods, retained SQLite streaming cursors, or native document operations.
+- The Python package does not claim DB-API 2.0 or broad MongoDB compatibility.
+  Its native document methods expose only the command slice listed above;
+  general matchers, updates, aggregation, and retained document cursors remain
+  unavailable.
 
 ## Storage compatibility
 
 There is no stable pre-1.0 on-disk compatibility promise. This release writes
-manifest version 12 and accepts the exact documented legacy version-1 shape and
-manifest versions 2 through 11 for automatic, ordered forward migration.
+manifest version 14 and accepts the exact documented legacy version-1 shape and
+manifest versions 2 through 13 for automatic, ordered forward migration.
 Unknown, malformed, partially migrated, or newer layouts fail closed.
 
 Before opening existing data, stop every process and make a complete backup as
 described in `docs/OFFLINE_BACKUP.md`. Startup may migrate the data.
 In-place downgrade is unsupported; rollback requires restoring the complete
-pre-upgrade backup. This release has no on-disk format change from alpha 1,
-alpha 2, alpha 3, or alpha 4.
+pre-upgrade backup.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -163,10 +163,10 @@ The release also provides `briskdb` and `briskdb-import` archives for Ubuntu
 `briskdb` account, administrator configuration under `/etc/default/briskdb`,
 persistent state under `/var/lib/briskdb`, and journald logging.
 
-The disabled-by-default PostgreSQL listener supports registered-table
-`SELECT`, `INSERT`, `UPDATE`, and `DELETE` through simple queries and bounded
-text/binary extended queries. It also supports real single-shard transactions
-and optional TLS with SCRAM-SHA-256. See `docs/POSTGRES_QUICKSTART.md`.
+The disabled-by-default PostgreSQL listener supports one registered-table
+simple-query `SELECT`, `INSERT`, `UPDATE`, or `DELETE` statement at a time.
+Psycopg 3 clients must use `psycopg.ClientCursor`; the ordinary cursor uses the
+unsupported extended-query protocol. See `docs/POSTGRES_QUICKSTART.md`.
 
 Every native archive and wheel is built and smoke-tested on its matching native
 GitHub runner. Wheels are installed and tested under CPython 3.9 and 3.14, and
@@ -175,12 +175,12 @@ GitHub build-provenance attestation.
 
 ## Critical alpha boundaries
 
-- HTTP remains unauthenticated and loopback-only. PostgreSQL may bind remotely
-  only with its configured TLS and SCRAM-SHA-256 boundary; BriskDB does not yet
-  provide general users, roles, or authorization policy.
-- PostgreSQL supports bounded simple and parameterized text/binary extended
-  queries plus single-shard transactions. DDL, `COPY`, broad type coverage,
-  and general PostgreSQL session semantics remain unavailable.
+- There is no authentication, authorization, or TLS. HTTP and PostgreSQL are
+  restricted to loopback. Do not expose either listener to a network.
+- PostgreSQL extended-query protocol is unsupported. Parameters sent through
+  Parse/Bind/Execute, server-side prepared statements, transactions, DDL,
+  `COPY`, and binary results are unavailable. Psycopg must use
+  `psycopg.ClientCursor`.
 - PostgreSQL accepts exactly one simple-query statement per message and only
   operates on an offline imported/registered catalog. It does not provide an
   online `CREATE TABLE` workflow or full PostgreSQL compatibility.
@@ -191,19 +191,18 @@ GitHub build-provenance attestation.
   procedure is a complete data-directory copy. Online backup/restore,
   resharding, and online rebalance are unsupported.
 - There is no production metrics or observability suite.
-- The Python package does not claim DB-API 2.0 or broad MongoDB compatibility.
-  Its native document methods expose only the command slice listed above;
-  general matchers, updates, aggregation, and retained document cursors remain
-  unavailable.
+- The Python package does not claim DB-API 2.0 compatibility, transaction
+  methods, retained SQLite streaming cursors, or native document operations.
 
 ## Storage compatibility
 
 There is no stable pre-1.0 on-disk compatibility promise. This release writes
-manifest version 14 and accepts the exact documented legacy version-1 shape and
-manifest versions 2 through 13 for automatic, ordered forward migration.
+manifest version 12 and accepts the exact documented legacy version-1 shape and
+manifest versions 2 through 11 for automatic, ordered forward migration.
 Unknown, malformed, partially migrated, or newer layouts fail closed.
 
 Before opening existing data, stop every process and make a complete backup as
 described in `docs/OFFLINE_BACKUP.md`. Startup may migrate the data.
 In-place downgrade is unsupported; rollback requires restoring the complete
-pre-upgrade backup.
+pre-upgrade backup. This release has no on-disk format change from alpha 1,
+alpha 2, alpha 3, or alpha 4.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -457,7 +457,7 @@ requires an earlier dependency:
       see [`docs/DOCUMENT_ENGINE.md`](docs/DOCUMENT_ENGINE.md)
     - [x] [#191](https://github.com/schapman1974/briskdb/issues/191) — thin
       embedded Rust facade over protocol-neutral document commands
-    - [ ] [#198](https://github.com/schapman1974/briskdb/issues/198) — Python
+    - [x] [#198](https://github.com/schapman1974/briskdb/issues/198) — Python
       BSON conversions and document API
     - [ ] [#200](https://github.com/schapman1974/briskdb/issues/200) — release
       wheels and Mongo smoke coverage

--- a/python/API.md
+++ b/python/API.md
@@ -6,7 +6,7 @@ files; the signatures below are the compact API map.
 
 ## Open and configure
 
-- `open(path, *, shards=None, config=None) -> Database`
+- `open(path, *, shards=None, documents=False, uuid_representation=None, config=None) -> Database`
 - `connect(...) -> Database` is the synchronous ergonomic alias.
 - `await open_async(...) -> AsyncDatabase` and `connect_async(...)` open
   without blocking the event loop.
@@ -22,8 +22,8 @@ always report the resolved count.
 
 `Database` exposes `session()`, `transaction()`, `checkpoint()`, `serve()`, `close()`,
 state/config properties, and a synchronous context manager. `Session` exposes
-routing-key state, `migrate()`, `execute()`, `query()`, `query_logical()`,
-`cursor()`, `logical_cursor()`, `status()`, `close()`, and a context manager.
+routing-key state, SQL and document commands, `status()`, `close()`, and a
+context manager.
 
 `Transaction` provides routed `execute()`/`query()`, explicit
 `commit()`/`rollback()`, and commit-on-success/rollback-on-exception context
@@ -31,6 +31,67 @@ management. The `AsyncDatabase`, `AsyncSession`, `AsyncTransaction`, and
 `AsyncCursor` facades provide the same lifecycle and SQL operations with
 `await`/`async with`. Cancelling a task propagates a native
 `CancellationToken` into the exact Rust request.
+
+## Native document commands
+
+The Python wheel contains BriskDB's document engine, but each database handle
+must enable it explicitly:
+
+- `open(path, *, documents=True, uuid_representation="standard", ...)`
+- `Config(..., documents=True, uuid_representation="standard")`
+
+The accepted UUID modes are `unspecified`, `standard`, `python_legacy`,
+`java_legacy`, and `csharp_legacy`. Pass document settings either as direct
+open options or through `config`; direct `documents=True` or an explicit UUID
+mode cannot be combined with `config`. The document methods require the
+optional `bson` package from PyMongo; SQL-only use has no PyMongo dependency.
+
+`Session` exposes this current protocol-neutral engine slice:
+
+- `create_collection(database, collection, *, options=None, ...)`
+- `list_collections(database, *, skip=0, limit=None, batch_size=101, ...)`
+- `create_index(database, collection, keys, *, name, unique=False, ...)`
+- `list_indexes(database, collection, *, skip=0, limit=None, batch_size=101, ...)`
+- `insert_one(database, collection, document, ...)`
+- `find(database, collection, filter=None, *, skip=0, limit=None, batch_size=101, ...)`
+- `count_documents(database, collection, filter=None, *, skip=0, limit=None, ...)`
+- `delete_one(database, collection, filter, ...)`
+
+Every method also accepts `request_id`, `timeout_ms`, `cancellation`,
+`max_result_rows`, and `max_result_bytes`. A request ID is a nonzero
+`uuid.UUID`; omitting it generates one. `AsyncSession` provides the same
+methods as coroutines and propagates task or explicit-token cancellation to
+the native request.
+
+Each result is an insertion-ordered dictionary containing `request_id`,
+`plan`, and `kind`, followed by the command payload. A point or scatter plan
+has `kind`, `collection_id`, and ordered `shards`; catalog commands have a null
+plan. Payload keys are:
+
+| Result kind | Payload |
+| --- | --- |
+| `collection` | `collection` metadata |
+| `collections` | ordered `collections` list |
+| `index_name` | `index_name` and `lifecycle="pending_build"` |
+| `indexes` | ordered `indexes` list |
+| `insert` | `acknowledged`, `inserted_count`, `inserted_ids` |
+| `cursor` | `namespace`, `cursor_id`, `exhausted`, `documents` |
+| `count` | `count` |
+| `delete` | `acknowledged`, `deleted_count` |
+
+Collection metadata contains `id`, `database_id`, `database`, `name`,
+`namespace`, exact BSON `options`, placement `code`/`version`, and index
+metadata. Each index contains `name`, exact ordered `keys`, `unique`,
+`built_in`, and `lifecycle`. Secondary index declarations currently remain
+`pending_build`; the ready built-in `_id_` index is authoritative.
+
+This API deliberately mirrors the document engine's implemented boundary:
+one inserted document must carry an explicit `_id`; find/count accept an empty
+filter or one literal `_id`; delete accepts one literal `_id`; and a find must
+fit in one batch because cursor continuation has not landed. General matchers,
+updates, replacements, projection, sorting, aggregation, bulk writes, and
+retained cursor operations remain unsupported. There is no Python collection
+object or MongoDB network listener in this slice.
 
 ## Attached listeners
 
@@ -56,5 +117,3 @@ and deterministic cancellation on close.
 All native failures derive from `BriskDBError`; each has stable `code` and
 `retryable` class attributes. See [value and error conversions](VALUE_CONVERSIONS.md)
 and [sync/async lifecycle details](ASYNC_API.md).
-
-Document calls are not claimed until their engine dependencies land.

--- a/python/ASYNC_API.md
+++ b/python/ASYNC_API.md
@@ -73,6 +73,27 @@ Closing the database closes every attached server first. Remote PostgreSQL
 uses the same TLS certificate/key/user/password-file keyword arguments as the
 synchronous `Database.serve()` method.
 
+Native document methods have the same sync/async pairing. Enable the document
+engine on open and install PyMongo for its `bson` value classes:
+
+```python
+from bson import ObjectId
+
+async with await briskdb.open_async("./data", shards=4, documents=True) as db:
+    async with await db.session() as session:
+        await session.create_collection("app", "notes")
+        note_id = ObjectId()
+        await session.insert_one(
+            "app", "notes", {"_id": note_id, "body": "hello"}
+        )
+        result = await session.find("app", "notes", {"_id": note_id})
+```
+
+`AsyncSession` includes create/list collection and index calls plus
+`insert_one`, `find`, `count_documents`, and `delete_one`. They use the same
+request IDs, deadlines, cancellation tokens, result limits, BSON conversion,
+and point/scatter plans as their synchronous `Session` methods.
+
 ## Transactions and DB-API boundaries
 
 `Database.transaction()` returns an owned, single-shard transaction. Its first
@@ -90,7 +111,8 @@ with db.transaction(routing_key="account-1") as transaction:
 
 The asyncio equivalent is `async with await db.transaction(...)`. BriskDB does
 not claim Python DB-API 2.0 compliance; these are explicit native handles, not
-implicit connection transactions. Mongo document CRUD/aggregation waits for
-the native document engine in [#160](https://github.com/schapman1974/briskdb/issues/160),
-and snapshot/fencing helpers remain in
+implicit connection transactions. Document commands run on sessions rather
+than SQL transactions; broader Mongo-compatible CRUD and aggregation remain
+in [#160](https://github.com/schapman1974/briskdb/issues/160), and
+snapshot/fencing helpers remain in
 [#194–#196](https://github.com/schapman1974/briskdb/issues/194).

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- Added opt-in synchronous and asyncio document commands for the currently
+  executable collection, index, insert, find, count, and delete engine slice.
+- Added lossless conversion for ordered mappings and PyMongo's BSON value
+  classes, including explicit datetime and UUID-representation rules, bounded
+  cycle/depth/size validation, and stable conversion errors.
+- Kept PyMongo optional and lazily loaded. Distribution gates now prove a bare
+  wheel or sdist can import, open, and execute SQL without `bson`, while the
+  document matrix runs against pinned PyMongo 4.17.0.
 - Added owned synchronous and asyncio transaction handles with deterministic
   commit/rollback context-manager behavior.
 - Python cursors now consume the engine's bounded SQLite row stream and cancel

--- a/python/COMPATIBILITY.md
+++ b/python/COMPATIBILITY.md
@@ -13,6 +13,20 @@ One `cp39-abi3` wheel per platform supports the stated CPython range. A local
 Rust compiler is not used when installing those wheels. The sdist is tested
 separately and requires Rust 1.85 or newer.
 
+## Optional BSON dependency
+
+SQL-only applications need no BSON package. The wheel does not declare a
+runtime dependency on `bson` or PyMongo, and importing BriskDB, opening a
+database, and executing SQL do not import either package. Calling a document
+method without the optional package raises `UnsupportedError` with code
+`unsupported` before the command can mutate storage; the same database remains
+usable for SQL afterward.
+
+Applications using `documents=True` should install PyMongo, which supplies the
+supported `bson` package. The unrelated package named `bson` on PyPI is not a
+supported substitute. The compatibility and release suites pin PyMongo 4.17.0
+and test its BSON classes on every supported wheel target.
+
 ## Version parity
 
 The `briskdb-python` crate version must exactly equal the root `briskdb` Rust

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -13,7 +13,7 @@ name = "_briskdb"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-briskdb = { path = "..", default-features = false, features = ["listeners"] }
+briskdb = { path = "..", default-features = false, features = ["documents", "listeners"] }
 pyo3 = { version = "=0.29.2", features = ["abi3-py39"] }
 tokio = { version = "1.53.1", features = ["rt-multi-thread", "sync", "time"] }
 

--- a/python/PUBLISHING.md
+++ b/python/PUBLISHING.md
@@ -5,6 +5,15 @@ wheel on each native macOS/Linux ARM/x86 runner, audits native dependencies,
 installs each wheel under CPython 3.9 and 3.14, runs the complete Python suite,
 checks packaged typing, and separately builds/installs the sdist.
 
+Each installed artifact is tested before PyMongo is installed. That first
+smoke test proves the artifact declares no BSON runtime dependency, imports and
+executes SQL in a clean environment, and rejects an enabled document command
+with the stable `UnsupportedError` before mutation. The workflow then installs
+the pinned PyMongo 4.17.0 oracle and runs the full BSON/document matrix. Keep
+that order when reproducing a release gate locally; installing test
+requirements first would hide a regression in the optional-dependency
+boundary.
+
 A `v<crate-version>` tag is publishable only when the root Rust crate,
 `briskdb-python` crate, Python metadata, wheel filenames, and runtime
 `briskdb.__version__` agree. The release workflow then:

--- a/python/README.md
+++ b/python/README.md
@@ -12,6 +12,15 @@ macOS and Linux targets:
 python -m pip install --only-binary=:all: briskdb
 ```
 
+Document commands use PyMongo's public BSON classes as an optional companion:
+
+```bash
+python -m pip install --only-binary=:all: briskdb
+python -m pip install pymongo
+```
+
+The BriskDB wheel does not require or import PyMongo for SQL-only applications.
+
 To build the current checkout from source, use Python 3.9+ and Rust 1.85+:
 
 ```bash
@@ -29,6 +38,31 @@ print(session.query("SELECT body FROM notes WHERE id = ?1", [1]))
 session.close()
 db.close()
 ```
+
+Enable native BSON commands per database handle. The default `standard` UUID
+representation uses subtype 4; legacy and `unspecified` modes are documented
+in the [value conversion contract](VALUE_CONVERSIONS.md).
+
+```python
+from bson import ObjectId
+import briskdb
+
+with briskdb.open("./data", shards=4, documents=True) as db:
+    with db.session() as session:
+        session.create_collection("app", "notes")
+        note_id = ObjectId()
+        session.insert_one(
+            "app", "notes", {"_id": note_id, "body": "hello"}
+        )
+        result = session.find("app", "notes", {"_id": note_id})
+        print(result["documents"])
+```
+
+This first slice supports collection/index metadata, one explicit-ID insert,
+empty or exact-`_id` find/count, and exact-`_id` deletion through synchronous
+and asyncio sessions. Secondary indexes are declared as `pending_build` until
+their physical execution milestone. Broader matchers, updates, aggregation,
+bulk writes, and cursor continuation are still outside the Python API.
 
 Pass `shards` when creating a data directory. Later calls may omit it and use
 the count stored in the manifest. Passing the wrong count raises
@@ -93,6 +127,6 @@ errors when SQLite cannot store a value losslessly. See the executable
 [value and exception contract](VALUE_CONVERSIONS.md) for boundaries and the
 stable `BriskDBError` hierarchy.
 
-Native Mongo/document commands are not claimed until BriskDB's document engine
-lands. The extension uses the host-controlled `listeners` Rust feature and
-does not include the daemon CLI, signal handler, or logging subscriber.
+The extension uses the host-controlled `listeners` and `documents` Rust
+features and does not include the daemon CLI, signal handler, or logging
+subscriber. Enabling documents starts no MongoDB listener.

--- a/python/VALUE_CONVERSIONS.md
+++ b/python/VALUE_CONVERSIONS.md
@@ -38,22 +38,93 @@ Rust `EngineErrorKind`. Constraint-specific errors inherit from both
 `ConstraintViolationError` and `IntegrityError`. Only `BusyError` is currently
 marked retryable.
 
-## BSON status
+## BSON documents
 
-The Python package has no BSON dependency for SQL use. BSON conversion cannot
-be implemented honestly until BriskDB has the ordered, duplicate-safe BSON
-value model tracked by [#164](https://github.com/schapman1974/briskdb/issues/164).
-Once that lands, the Python side will map its native values to the installed
-`bson` package's `ObjectId`, `Binary`, `Decimal128`, `Regex`, `Timestamp`,
-`MinKey`, and `MaxKey`, plus timezone-aware UTC `datetime`, `UUID`, lists, and
-ordered mappings. Document entrypoints remain unavailable until then rather
-than silently coercing those values through JSON.
+Document methods use the `bson` package distributed with PyMongo. Install it
+separately when an application needs document commands:
 
-| BSON-facing Python value | Current behavior |
-| --- | --- |
-| aware or naive `datetime`, at any precision | no document entrypoint; rejected by SQL as `TypeMismatchError` |
-| `UUID`, with any representation | no document entrypoint; rejected by SQL as `TypeMismatchError` |
-| `Decimal128`, including finite values, NaN, and infinity | no document entrypoint; never imported by SQL-only use |
-| `ObjectId`, `Binary`, `Regex`, `Timestamp`, `MinKey`, `MaxKey` | no document entrypoint; never imported by SQL-only use |
-| lists and ordered mappings | no document entrypoint; rejected by SQL as `TypeMismatchError` |
-| cyclic or excessively deep containers | rejected at the SQL boundary without traversal; BSON depth/cycle limits belong to #164 |
+```bash
+python -m pip install briskdb pymongo
+```
+
+PyMongo is deliberately absent from BriskDB's runtime dependencies. Importing
+BriskDB, opening a database, and using every SQL method neither imports nor
+requires `bson`. A document method checks for the optional package before it
+executes and otherwise raises `UnsupportedError` with code `unsupported`. The
+unrelated `bson` distribution on PyPI is not supported; install PyMongo, which
+owns the public `bson` package tested by BriskDB. The release gate currently
+pins PyMongo 4.17.0.
+
+Python mappings become BriskDB's ordered BSON documents directly, without a
+JSON intermediate. Returned documents are ordinary insertion-ordered `dict`
+objects. A mapping cannot express repeated field names, and stored document
+fields must be unique; raw duplicate-preserving BSON remains a Rust codec
+facility.
+
+| Python document value | BSON representation | Returned Python value |
+| --- | --- | --- |
+| `None` | null | `None` |
+| `bool` | Boolean | `bool` |
+| plain `int` in `-2^31..=2^31-1` | int32 | plain `int` |
+| plain `int` in the remaining signed 64-bit range | int64 | `bson.Int64` |
+| `bson.Int64`, including a small value | int64 | `bson.Int64` |
+| other `int` | none | `NumericOutOfRangeError` |
+| `float` | double | exact IEEE-754 bits, including signed zero, infinities, and NaN payloads |
+| `str` | UTF-8 string | exact `str`, including embedded NUL characters |
+| `bytes`, `bytearray`, `memoryview` | binary subtype 0 | immutable `bytes` |
+| `bson.Binary` | binary with its unsigned subtype | subtype 0 becomes `bytes`, a configured matching UUID encoding becomes `uuid.UUID`, and every other subtype remains `bson.Binary` |
+| `bson.Decimal128` | exact 16-byte BID payload | `bson.Decimal128`, including finite values, infinities, quiet NaN, and signaling NaN |
+| `bson.ObjectId` | exact 12 bytes | `bson.ObjectId` |
+| `datetime.datetime` | signed UTC milliseconds | aware UTC `datetime`, or `bson.datetime_ms.DatetimeMS` outside Python's datetime range |
+| `bson.datetime_ms.DatetimeMS` | signed UTC milliseconds | the same date rule as above |
+| `uuid.UUID` | UUID binary selected by the database UUID mode | `uuid.UUID` unless the mode is `unspecified`, which rejects it |
+| `bson.Regex` | pattern plus canonical BSON flags | `bson.Regex` |
+| `bson.Timestamp` | unsigned seconds and increment | `bson.Timestamp` |
+| `bson.Code` | JavaScript source and optional ordered scope | `bson.Code` |
+| `bson.MinKey` / `bson.MaxKey` | BSON sentinels | the matching BSON sentinel |
+| `list`/`tuple` and nested mappings | array and document | `list` and insertion-ordered `dict` recursively |
+
+`decimal.Decimal` is the SQL decimal input type. BSON documents require
+`bson.Decimal128`, which retains its exact representation rather than
+converting through a language decimal.
+
+### Datetimes
+
+A naive `datetime` is interpreted as UTC. An aware value is normalized to UTC.
+BSON stores milliseconds, so conversion floors discarded microseconds toward
+the earlier millisecond; for example, one microsecond before the Unix epoch
+becomes millisecond `-1`. In-range results are timezone-aware and carry
+`datetime.timezone.utc`. BSON millisecond values outside years 1 through 9999
+return `DatetimeMS` instead of clamping or failing.
+
+### UUID representations
+
+`uuid_representation` is fixed on a database handle so inputs, filters, index
+keys, and results use one rule. The default is `standard`; the other modes are
+`unspecified`, `python_legacy`, `java_legacy`, and `csharp_legacy`.
+
+- `standard` stores RFC-4122 bytes in subtype 4.
+- Each legacy mode stores subtype 3 with that driver's historical byte order.
+- `unspecified` rejects native `uuid.UUID` values and leaves subtype 3 and 4
+  values as `bson.Binary`.
+- A configured mode materializes a matching 16-byte subtype as `uuid.UUID`.
+  A nonmatching subtype remains `bson.Binary` with exact bytes and subtype.
+
+BSON wire data does not say whether matching UUID bytes originally came from a
+native UUID or an explicit `bson.Binary`. Consequently, a matching explicit
+Binary also returns as `uuid.UUID`. This is the same representation boundary
+used by PyMongo's `CodecOptions`. The same convergence applies to subtype 0:
+an explicit `bson.Binary(payload, 0)` returns as immutable `bytes`.
+
+### Invalid containers and values
+
+Document conversion rejects non-string keys, keys containing NUL, lone Unicode
+surrogates in keys or values, cyclic containers (including a `Code` scope
+cycle), invalid regular-expression patterns or flags, and structures deeper
+than 100 BSON containers. A structure containing exactly 100 containers is
+valid. One BSON document may be at most 16 MiB. These failures use stable
+BriskDB exception subclasses and fixed diagnostics that do not include
+application values. Unsupported BSON families such as DBRef and deprecated
+BSON wire types are rejected instead of being converted through JSON. Reusing
+one acyclic child mapping in more than one location is valid; cycle detection
+follows the active recursion path.

--- a/python/python/briskdb/_briskdb.pyi
+++ b/python/python/briskdb/_briskdb.pyi
@@ -1,9 +1,17 @@
 from decimal import Decimal
 from os import PathLike
-from typing import Dict, Iterator, List, Optional, Sequence, Tuple, TypedDict, Union
+from typing import Any, Dict, Iterator, List, Literal, Mapping, Optional, Sequence, Tuple, TypedDict, Union
+from uuid import UUID
 
 SqlParameter = Union[None, bool, int, float, Decimal, str, bytes, bytearray, memoryview]
 SqlRow = Tuple[object, ...]
+BsonDocument = Mapping[str, Any]
+BsonResultDocument = Dict[str, Any]
+UuidRepresentation = Literal[
+    "unspecified", "standard", "python_legacy", "java_legacy", "csharp_legacy"
+]
+DocumentPlanKind = Literal["point", "scatter"]
+DocumentIndexLifecycle = Literal["ready", "pending_build"]
 
 class ColumnInfo(TypedDict):
     name: str
@@ -22,6 +30,79 @@ class WriteResult(TypedDict):
     shard: int
     rows_affected: int
     generated_key: Optional[GeneratedKey]
+
+class DocumentPlan(TypedDict):
+    kind: DocumentPlanKind
+    collection_id: int
+    shards: List[int]
+
+class DocumentNamespaceInfo(TypedDict):
+    database: str
+    collection: str
+
+class DocumentPlacementInfo(TypedDict):
+    code: int
+    version: int
+
+class DocumentIndexInfo(TypedDict):
+    name: str
+    keys: BsonResultDocument
+    unique: bool
+    built_in: bool
+    lifecycle: DocumentIndexLifecycle
+
+class DocumentCollectionInfo(TypedDict):
+    id: int
+    database_id: int
+    database: str
+    name: str
+    namespace: str
+    options: BsonResultDocument
+    placement: DocumentPlacementInfo
+    indexes: List[DocumentIndexInfo]
+
+class DocumentExecution(TypedDict):
+    request_id: UUID
+    plan: Optional[DocumentPlan]
+
+class CreateCollectionResult(DocumentExecution):
+    kind: Literal["collection"]
+    collection: DocumentCollectionInfo
+
+class ListCollectionsResult(DocumentExecution):
+    kind: Literal["collections"]
+    collections: List[DocumentCollectionInfo]
+
+class CreateIndexResult(DocumentExecution):
+    kind: Literal["index_name"]
+    index_name: str
+    lifecycle: Literal["pending_build"]
+
+class ListIndexesResult(DocumentExecution):
+    kind: Literal["indexes"]
+    indexes: List[DocumentIndexInfo]
+
+class InsertOneResult(DocumentExecution):
+    kind: Literal["insert"]
+    acknowledged: bool
+    inserted_count: int
+    inserted_ids: List[Any]
+
+class FindResult(DocumentExecution):
+    kind: Literal["cursor"]
+    namespace: DocumentNamespaceInfo
+    cursor_id: Optional[int]
+    exhausted: bool
+    documents: List[BsonResultDocument]
+
+class CountDocumentsResult(DocumentExecution):
+    kind: Literal["count"]
+    count: int
+
+class DeleteOneResult(DocumentExecution):
+    kind: Literal["delete"]
+    acknowledged: bool
+    deleted_count: int
 
 class CloseReport(TypedDict):
     already_closed: bool
@@ -88,6 +169,8 @@ class InternalError(OperationalError): ...
 
 class Config:
     shards: Optional[int]
+    documents: bool
+    uuid_representation: UuidRepresentation
     connections_per_shard: int
     queue_capacity_per_shard: int
     max_result_rows: int
@@ -101,6 +184,8 @@ class Config:
         self,
         *,
         shards: Optional[int] = ...,
+        documents: bool = ...,
+        uuid_representation: UuidRepresentation = ...,
         connections_per_shard: int = ...,
         queue_capacity_per_shard: int = ...,
         max_result_rows: int = ...,
@@ -140,6 +225,8 @@ class Database:
         path: Union[str, PathLike[str]],
         *,
         shards: Optional[int] = None,
+        documents: bool = False,
+        uuid_representation: Optional[UuidRepresentation] = None,
         config: Optional[Config] = None,
     ) -> None: ...
     @property
@@ -251,6 +338,112 @@ class Session:
         timeout_ms: Optional[int] = None,
         cancellation: Optional[CancellationToken] = None,
     ) -> Cursor: ...
+    def create_collection(
+        self,
+        database: str,
+        collection: str,
+        *,
+        options: Optional[BsonDocument] = None,
+        request_id: Optional[UUID] = None,
+        timeout_ms: Optional[int] = None,
+        cancellation: Optional[CancellationToken] = None,
+        max_result_rows: Optional[int] = None,
+        max_result_bytes: Optional[int] = None,
+    ) -> CreateCollectionResult: ...
+    def list_collections(
+        self,
+        database: str,
+        *,
+        skip: int = 0,
+        limit: Optional[int] = None,
+        batch_size: int = 101,
+        request_id: Optional[UUID] = None,
+        timeout_ms: Optional[int] = None,
+        cancellation: Optional[CancellationToken] = None,
+        max_result_rows: Optional[int] = None,
+        max_result_bytes: Optional[int] = None,
+    ) -> ListCollectionsResult: ...
+    def create_index(
+        self,
+        database: str,
+        collection: str,
+        keys: BsonDocument,
+        *,
+        name: str,
+        unique: bool = False,
+        request_id: Optional[UUID] = None,
+        timeout_ms: Optional[int] = None,
+        cancellation: Optional[CancellationToken] = None,
+        max_result_rows: Optional[int] = None,
+        max_result_bytes: Optional[int] = None,
+    ) -> CreateIndexResult: ...
+    def list_indexes(
+        self,
+        database: str,
+        collection: str,
+        *,
+        skip: int = 0,
+        limit: Optional[int] = None,
+        batch_size: int = 101,
+        request_id: Optional[UUID] = None,
+        timeout_ms: Optional[int] = None,
+        cancellation: Optional[CancellationToken] = None,
+        max_result_rows: Optional[int] = None,
+        max_result_bytes: Optional[int] = None,
+    ) -> ListIndexesResult: ...
+    def insert_one(
+        self,
+        database: str,
+        collection: str,
+        document: BsonDocument,
+        *,
+        request_id: Optional[UUID] = None,
+        timeout_ms: Optional[int] = None,
+        cancellation: Optional[CancellationToken] = None,
+        max_result_rows: Optional[int] = None,
+        max_result_bytes: Optional[int] = None,
+    ) -> InsertOneResult: ...
+    def find(
+        self,
+        database: str,
+        collection: str,
+        filter: Optional[BsonDocument] = None,
+        *,
+        skip: int = 0,
+        limit: Optional[int] = None,
+        batch_size: int = 101,
+        request_id: Optional[UUID] = None,
+        timeout_ms: Optional[int] = None,
+        cancellation: Optional[CancellationToken] = None,
+        max_result_rows: Optional[int] = None,
+        max_result_bytes: Optional[int] = None,
+    ) -> FindResult: ...
+    def count_documents(
+        self,
+        database: str,
+        collection: str,
+        filter: Optional[BsonDocument] = None,
+        *,
+        skip: int = 0,
+        limit: Optional[int] = None,
+        request_id: Optional[UUID] = None,
+        timeout_ms: Optional[int] = None,
+        cancellation: Optional[CancellationToken] = None,
+        max_result_rows: Optional[int] = None,
+        max_result_bytes: Optional[int] = None,
+    ) -> CountDocumentsResult: ...
+    def delete_one(
+        self,
+        database: str,
+        collection: str,
+        filter: BsonDocument,
+        *,
+        request_id: Optional[UUID] = None,
+        timeout_ms: Optional[int] = None,
+        cancellation: Optional[CancellationToken] = None,
+        max_result_rows: Optional[int] = None,
+        max_result_bytes: Optional[int] = None,
+    ) -> DeleteOneResult: ...
     def status(self) -> Status: ...
     def close(self) -> None: ...
     def __enter__(self) -> Session: ...
@@ -297,6 +490,8 @@ def open(
     path: Union[str, PathLike[str]],
     *,
     shards: Optional[int] = None,
+    documents: bool = False,
+    uuid_representation: Optional[UuidRepresentation] = None,
     config: Optional[Config] = None,
 ) -> Database: ...
 

--- a/python/python/briskdb/api.py
+++ b/python/python/briskdb/api.py
@@ -7,6 +7,7 @@ import functools
 from collections.abc import AsyncIterator
 from os import PathLike
 from typing import Any, Optional, Union
+from uuid import UUID
 
 from ._briskdb import (
     CancellationToken,
@@ -24,11 +25,19 @@ def connect(
     path: Union[str, PathLike[str]],
     *,
     shards: Optional[int] = None,
+    documents: bool = False,
+    uuid_representation: Optional[str] = None,
     config: Optional[Config] = None,
 ) -> Database:
     """Open an in-process database; no listener starts unless ``serve()`` is called."""
 
-    return _native_open(path, shards=shards, config=config)
+    return _native_open(
+        path,
+        shards=shards,
+        documents=documents,
+        uuid_representation=uuid_representation,
+        config=config,
+    )
 
 
 async def _cancelable_call(
@@ -230,6 +239,218 @@ class AsyncSession:
             cancellation=cancellation,
         )
         return AsyncCursor(cursor)
+
+    async def create_collection(
+        self,
+        database: str,
+        collection: str,
+        *,
+        options: Optional[Any] = None,
+        request_id: Optional[UUID] = None,
+        timeout_ms: Optional[int] = None,
+        cancellation: Optional[CancellationToken] = None,
+        max_result_rows: Optional[int] = None,
+        max_result_bytes: Optional[int] = None,
+    ) -> dict[str, Any]:
+        return await _cancelable_call(
+            self._session.create_collection,
+            database,
+            collection,
+            options=options,
+            request_id=request_id,
+            max_result_rows=max_result_rows,
+            max_result_bytes=max_result_bytes,
+            timeout_ms=timeout_ms,
+            cancellation=cancellation,
+        )
+
+    async def list_collections(
+        self,
+        database: str,
+        *,
+        skip: int = 0,
+        limit: Optional[int] = None,
+        batch_size: int = 101,
+        request_id: Optional[UUID] = None,
+        timeout_ms: Optional[int] = None,
+        cancellation: Optional[CancellationToken] = None,
+        max_result_rows: Optional[int] = None,
+        max_result_bytes: Optional[int] = None,
+    ) -> dict[str, Any]:
+        return await _cancelable_call(
+            self._session.list_collections,
+            database,
+            skip=skip,
+            limit=limit,
+            batch_size=batch_size,
+            request_id=request_id,
+            max_result_rows=max_result_rows,
+            max_result_bytes=max_result_bytes,
+            timeout_ms=timeout_ms,
+            cancellation=cancellation,
+        )
+
+    async def create_index(
+        self,
+        database: str,
+        collection: str,
+        keys: Any,
+        *,
+        name: str,
+        unique: bool = False,
+        request_id: Optional[UUID] = None,
+        timeout_ms: Optional[int] = None,
+        cancellation: Optional[CancellationToken] = None,
+        max_result_rows: Optional[int] = None,
+        max_result_bytes: Optional[int] = None,
+    ) -> dict[str, Any]:
+        return await _cancelable_call(
+            self._session.create_index,
+            database,
+            collection,
+            keys,
+            name=name,
+            unique=unique,
+            request_id=request_id,
+            max_result_rows=max_result_rows,
+            max_result_bytes=max_result_bytes,
+            timeout_ms=timeout_ms,
+            cancellation=cancellation,
+        )
+
+    async def list_indexes(
+        self,
+        database: str,
+        collection: str,
+        *,
+        skip: int = 0,
+        limit: Optional[int] = None,
+        batch_size: int = 101,
+        request_id: Optional[UUID] = None,
+        timeout_ms: Optional[int] = None,
+        cancellation: Optional[CancellationToken] = None,
+        max_result_rows: Optional[int] = None,
+        max_result_bytes: Optional[int] = None,
+    ) -> dict[str, Any]:
+        return await _cancelable_call(
+            self._session.list_indexes,
+            database,
+            collection,
+            skip=skip,
+            limit=limit,
+            batch_size=batch_size,
+            request_id=request_id,
+            max_result_rows=max_result_rows,
+            max_result_bytes=max_result_bytes,
+            timeout_ms=timeout_ms,
+            cancellation=cancellation,
+        )
+
+    async def insert_one(
+        self,
+        database: str,
+        collection: str,
+        document: Any,
+        *,
+        request_id: Optional[UUID] = None,
+        timeout_ms: Optional[int] = None,
+        cancellation: Optional[CancellationToken] = None,
+        max_result_rows: Optional[int] = None,
+        max_result_bytes: Optional[int] = None,
+    ) -> dict[str, Any]:
+        return await _cancelable_call(
+            self._session.insert_one,
+            database,
+            collection,
+            document,
+            request_id=request_id,
+            max_result_rows=max_result_rows,
+            max_result_bytes=max_result_bytes,
+            timeout_ms=timeout_ms,
+            cancellation=cancellation,
+        )
+
+    async def find(
+        self,
+        database: str,
+        collection: str,
+        filter: Optional[Any] = None,
+        *,
+        skip: int = 0,
+        limit: Optional[int] = None,
+        batch_size: int = 101,
+        request_id: Optional[UUID] = None,
+        timeout_ms: Optional[int] = None,
+        cancellation: Optional[CancellationToken] = None,
+        max_result_rows: Optional[int] = None,
+        max_result_bytes: Optional[int] = None,
+    ) -> dict[str, Any]:
+        return await _cancelable_call(
+            self._session.find,
+            database,
+            collection,
+            filter,
+            skip=skip,
+            limit=limit,
+            batch_size=batch_size,
+            request_id=request_id,
+            max_result_rows=max_result_rows,
+            max_result_bytes=max_result_bytes,
+            timeout_ms=timeout_ms,
+            cancellation=cancellation,
+        )
+
+    async def count_documents(
+        self,
+        database: str,
+        collection: str,
+        filter: Optional[Any] = None,
+        *,
+        skip: int = 0,
+        limit: Optional[int] = None,
+        request_id: Optional[UUID] = None,
+        timeout_ms: Optional[int] = None,
+        cancellation: Optional[CancellationToken] = None,
+        max_result_rows: Optional[int] = None,
+        max_result_bytes: Optional[int] = None,
+    ) -> dict[str, Any]:
+        return await _cancelable_call(
+            self._session.count_documents,
+            database,
+            collection,
+            filter,
+            skip=skip,
+            limit=limit,
+            request_id=request_id,
+            max_result_rows=max_result_rows,
+            max_result_bytes=max_result_bytes,
+            timeout_ms=timeout_ms,
+            cancellation=cancellation,
+        )
+
+    async def delete_one(
+        self,
+        database: str,
+        collection: str,
+        filter: Any,
+        *,
+        request_id: Optional[UUID] = None,
+        timeout_ms: Optional[int] = None,
+        cancellation: Optional[CancellationToken] = None,
+        max_result_rows: Optional[int] = None,
+        max_result_bytes: Optional[int] = None,
+    ) -> dict[str, Any]:
+        return await _cancelable_call(
+            self._session.delete_one,
+            database,
+            collection,
+            filter,
+            request_id=request_id,
+            max_result_rows=max_result_rows,
+            max_result_bytes=max_result_bytes,
+            timeout_ms=timeout_ms,
+            cancellation=cancellation,
+        )
 
     async def status(self) -> dict[str, Any]:
         return await asyncio.to_thread(self._session.status)
@@ -467,11 +688,20 @@ async def connect_async(
     path: Union[str, PathLike[str]],
     *,
     shards: Optional[int] = None,
+    documents: bool = False,
+    uuid_representation: Optional[str] = None,
     config: Optional[Config] = None,
 ) -> AsyncDatabase:
     """Open an in-process database without blocking the event loop."""
 
-    database = await asyncio.to_thread(connect, path, shards=shards, config=config)
+    database = await asyncio.to_thread(
+        connect,
+        path,
+        shards=shards,
+        documents=documents,
+        uuid_representation=uuid_representation,
+        config=config,
+    )
     return AsyncDatabase(database)
 
 

--- a/python/python/briskdb/api.pyi
+++ b/python/python/briskdb/api.pyi
@@ -1,14 +1,23 @@
 from os import PathLike
 from typing import AsyncIterator, List, Optional, Sequence, Union
+from uuid import UUID
 
 from ._briskdb import (
+    BsonDocument,
     CancellationToken,
     CloseReport,
     CheckpointReport,
     ColumnInfo,
     Config,
-    Cursor,
+    CountDocumentsResult,
+    CreateCollectionResult,
+    CreateIndexResult,
     Database,
+    DeleteOneResult,
+    FindResult,
+    InsertOneResult,
+    ListCollectionsResult,
+    ListIndexesResult,
     QueryResult,
     Server,
     ServerCloseReport,
@@ -17,6 +26,7 @@ from ._briskdb import (
     SqlRow,
     Status,
     Transaction,
+    UuidRepresentation,
     WriteResult,
 )
 
@@ -24,6 +34,8 @@ def connect(
     path: Union[str, PathLike[str]],
     *,
     shards: Optional[int] = None,
+    documents: bool = False,
+    uuid_representation: Optional[UuidRepresentation] = None,
     config: Optional[Config] = None,
 ) -> Database: ...
 
@@ -103,6 +115,112 @@ class AsyncSession:
         timeout_ms: Optional[int] = None,
         cancellation: Optional[CancellationToken] = None,
     ) -> AsyncCursor: ...
+    async def create_collection(
+        self,
+        database: str,
+        collection: str,
+        *,
+        options: Optional[BsonDocument] = None,
+        request_id: Optional[UUID] = None,
+        timeout_ms: Optional[int] = None,
+        cancellation: Optional[CancellationToken] = None,
+        max_result_rows: Optional[int] = None,
+        max_result_bytes: Optional[int] = None,
+    ) -> CreateCollectionResult: ...
+    async def list_collections(
+        self,
+        database: str,
+        *,
+        skip: int = 0,
+        limit: Optional[int] = None,
+        batch_size: int = 101,
+        request_id: Optional[UUID] = None,
+        timeout_ms: Optional[int] = None,
+        cancellation: Optional[CancellationToken] = None,
+        max_result_rows: Optional[int] = None,
+        max_result_bytes: Optional[int] = None,
+    ) -> ListCollectionsResult: ...
+    async def create_index(
+        self,
+        database: str,
+        collection: str,
+        keys: BsonDocument,
+        *,
+        name: str,
+        unique: bool = False,
+        request_id: Optional[UUID] = None,
+        timeout_ms: Optional[int] = None,
+        cancellation: Optional[CancellationToken] = None,
+        max_result_rows: Optional[int] = None,
+        max_result_bytes: Optional[int] = None,
+    ) -> CreateIndexResult: ...
+    async def list_indexes(
+        self,
+        database: str,
+        collection: str,
+        *,
+        skip: int = 0,
+        limit: Optional[int] = None,
+        batch_size: int = 101,
+        request_id: Optional[UUID] = None,
+        timeout_ms: Optional[int] = None,
+        cancellation: Optional[CancellationToken] = None,
+        max_result_rows: Optional[int] = None,
+        max_result_bytes: Optional[int] = None,
+    ) -> ListIndexesResult: ...
+    async def insert_one(
+        self,
+        database: str,
+        collection: str,
+        document: BsonDocument,
+        *,
+        request_id: Optional[UUID] = None,
+        timeout_ms: Optional[int] = None,
+        cancellation: Optional[CancellationToken] = None,
+        max_result_rows: Optional[int] = None,
+        max_result_bytes: Optional[int] = None,
+    ) -> InsertOneResult: ...
+    async def find(
+        self,
+        database: str,
+        collection: str,
+        filter: Optional[BsonDocument] = None,
+        *,
+        skip: int = 0,
+        limit: Optional[int] = None,
+        batch_size: int = 101,
+        request_id: Optional[UUID] = None,
+        timeout_ms: Optional[int] = None,
+        cancellation: Optional[CancellationToken] = None,
+        max_result_rows: Optional[int] = None,
+        max_result_bytes: Optional[int] = None,
+    ) -> FindResult: ...
+    async def count_documents(
+        self,
+        database: str,
+        collection: str,
+        filter: Optional[BsonDocument] = None,
+        *,
+        skip: int = 0,
+        limit: Optional[int] = None,
+        request_id: Optional[UUID] = None,
+        timeout_ms: Optional[int] = None,
+        cancellation: Optional[CancellationToken] = None,
+        max_result_rows: Optional[int] = None,
+        max_result_bytes: Optional[int] = None,
+    ) -> CountDocumentsResult: ...
+    async def delete_one(
+        self,
+        database: str,
+        collection: str,
+        filter: BsonDocument,
+        *,
+        request_id: Optional[UUID] = None,
+        timeout_ms: Optional[int] = None,
+        cancellation: Optional[CancellationToken] = None,
+        max_result_rows: Optional[int] = None,
+        max_result_bytes: Optional[int] = None,
+    ) -> DeleteOneResult: ...
     async def status(self) -> Status: ...
     async def close(self) -> None: ...
     async def __aenter__(self) -> AsyncSession: ...
@@ -202,6 +320,8 @@ async def connect_async(
     path: Union[str, PathLike[str]],
     *,
     shards: Optional[int] = None,
+    documents: bool = False,
+    uuid_representation: Optional[UuidRepresentation] = None,
     config: Optional[Config] = None,
 ) -> AsyncDatabase: ...
 

--- a/python/scripts/check_dist.py
+++ b/python/scripts/check_dist.py
@@ -58,14 +58,18 @@ def release_version() -> Version:
         text=True,
     )
     packages = json.loads(completed.stdout)["packages"]
-    version = next(package["version"] for package in packages if package["name"] == "briskdb")
+    version = next(
+        package["version"] for package in packages if package["name"] == "briskdb"
+    )
     return Version(version)
 
 
 def require_suffixes(names: Iterable[str], suffixes: Set[str]) -> None:
     available = tuple(names)
     missing = sorted(
-        suffix for suffix in suffixes if not any(name.endswith(suffix) for name in available)
+        suffix
+        for suffix in suffixes
+        if not any(name.endswith(suffix) for name in available)
     )
     if missing:
         raise SystemExit("artifact is missing: {}".format(", ".join(missing)))
@@ -74,11 +78,15 @@ def require_suffixes(names: Iterable[str], suffixes: Set[str]) -> None:
 def check_wheel(path: pathlib.Path, platform: str) -> None:
     distribution, version, _build, tags = parse_wheel_filename(path.name)
     if distribution != "briskdb" or version != release_version():
-        raise SystemExit("wheel name/version does not match the Rust package: {}".format(path.name))
+        raise SystemExit(
+            "wheel name/version does not match the Rust package: {}".format(path.name)
+        )
     expected_tag = "cp39-abi3-{}".format(platform)
     if expected_tag not in {str(tag) for tag in tags}:
         raise SystemExit(
-            "wheel must carry exact supported tag {}: {}".format(expected_tag, path.name)
+            "wheel must carry exact supported tag {}: {}".format(
+                expected_tag, path.name
+            )
         )
 
     with zipfile.ZipFile(path) as archive:
@@ -89,12 +97,20 @@ def check_wheel(path: pathlib.Path, platform: str) -> None:
             for name in names
         ):
             raise SystemExit("wheel does not contain the native extension")
-        metadata_name = next(name for name in names if name.endswith(".dist-info/METADATA"))
+        metadata_name = next(
+            name for name in names if name.endswith(".dist-info/METADATA")
+        )
         metadata = Parser().parsestr(archive.read(metadata_name).decode("utf-8"))
         if metadata["Requires-Python"] != ">=3.9":
             raise SystemExit("wheel has the wrong Requires-Python metadata")
         if metadata["License-Expression"] != "MIT":
             raise SystemExit("wheel has the wrong license expression")
+        dependencies = metadata.get_all("Requires-Dist", [])
+        if any(
+            dependency.partition(";")[0].strip().lower().startswith(("bson", "pymongo"))
+            for dependency in dependencies
+        ):
+            raise SystemExit("wheel must not require bson or PyMongo for SQL-only use")
         if not any(
             name.endswith(".dist-info/licenses/BRISKDB_LICENSE.txt") for name in names
         ):
@@ -106,7 +122,9 @@ def check_wheel(path: pathlib.Path, platform: str) -> None:
 def check_sdist(path: pathlib.Path) -> None:
     expected = release_version()
     if not path.name.startswith("briskdb-{}".format(expected)):
-        raise SystemExit("sdist name/version does not match the Rust package: {}".format(path.name))
+        raise SystemExit(
+            "sdist name/version does not match the Rust package: {}".format(path.name)
+        )
     with tarfile.open(path, "r:gz") as archive:
         require_suffixes(archive.getnames(), SDIST_FILES)
     print("sdist contract passed: {}".format(path.name))

--- a/python/scripts/check_versions.py
+++ b/python/scripts/check_versions.py
@@ -43,9 +43,12 @@ def main() -> None:
     if len(core_dependencies) != 1:
         raise SystemExit("briskdb-python must have exactly one briskdb dependency")
     dependency = core_dependencies[0]
-    if dependency["uses_default_features"] or dependency["features"] != ["listeners"]:
+    if dependency["uses_default_features"] or dependency["features"] != [
+        "documents",
+        "listeners",
+    ]:
         raise SystemExit(
-            "briskdb-python must depend only on the host-controlled listeners feature"
+            "briskdb-python must depend only on the documents and host-controlled listeners features"
         )
     if pathlib.Path(dependency["path"]).resolve() != ROOT:
         raise SystemExit("briskdb-python must bind the workspace's exact briskdb core")

--- a/python/src/bson.rs
+++ b/python/src/bson.rs
@@ -1,0 +1,1031 @@
+use std::{collections::HashSet, mem::size_of};
+
+use briskdb::document::{
+    BSON_MAX_DECODED_BYTES, BSON_MAX_DOCUMENT_BYTES, BSON_MAX_NESTING_DEPTH, BsonBinary,
+    BsonDateTime, BsonDecimal128, BsonDocument, BsonJavaScript, BsonObjectId, BsonRegex,
+    BsonTimestamp, BsonUuid, BsonValue, DocumentRequestId, UuidRepresentation, encode_document,
+};
+use pyo3::{
+    conversion::IntoPyObjectExt,
+    prelude::*,
+    types::{
+        PyAny, PyBool, PyByteArray, PyBytes, PyDict, PyFloat, PyInt, PyList, PyMapping,
+        PyMemoryView, PyString, PyStringMethods, PyTuple,
+    },
+};
+
+use crate::error::{
+    bson_error_to_python, invalid_text_encoding, invalid_value, limit_exceeded,
+    numeric_out_of_range, type_mismatch, unsupported,
+};
+
+const MISSING_BSON: &str = "Python document operations require the optional pymongo package";
+const INVALID_BSON_MAPPING: &str = "BSON documents require an ordered mapping with string keys";
+const INVALID_BSON_VALUE: &str = "unsupported Python value in BSON document";
+const INVALID_BSON_CONTAINER: &str = "unable to read Python BSON container";
+const INVALID_BSON_ATTRIBUTE: &str = "unable to read Python BSON value";
+const BSON_CYCLE: &str = "BSON documents cannot contain cyclic containers";
+const BSON_DEPTH: &str = "BSON container depth exceeds the limit of 100";
+const BSON_SIZE: &str = "BSON document exceeds the 16777216-byte limit";
+const BSON_HEAP: &str = "decoded BSON exceeds the 67108864-byte allocation budget";
+const INVALID_BSON_TEXT: &str =
+    "BSON strings and field names must contain valid Unicode scalar values";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PythonUuidRepresentation {
+    Unspecified,
+    Standard,
+    PythonLegacy,
+    JavaLegacy,
+    CSharpLegacy,
+}
+
+impl PythonUuidRepresentation {
+    const fn into_brisk(self) -> Option<UuidRepresentation> {
+        match self {
+            Self::Unspecified => None,
+            Self::Standard => Some(UuidRepresentation::Standard),
+            Self::PythonLegacy => Some(UuidRepresentation::PythonLegacy),
+            Self::JavaLegacy => Some(UuidRepresentation::JavaLegacy),
+            Self::CSharpLegacy => Some(UuidRepresentation::CSharpLegacy),
+        }
+    }
+}
+
+pub(crate) fn parse_uuid_representation(value: &str) -> PyResult<PythonUuidRepresentation> {
+    match value {
+        "unspecified" => Ok(PythonUuidRepresentation::Unspecified),
+        "standard" => Ok(PythonUuidRepresentation::Standard),
+        "python_legacy" => Ok(PythonUuidRepresentation::PythonLegacy),
+        "java_legacy" => Ok(PythonUuidRepresentation::JavaLegacy),
+        "csharp_legacy" => Ok(PythonUuidRepresentation::CSharpLegacy),
+        _ => Err(crate::error::invalid_value(
+            "uuid_representation must be one of: unspecified, standard, python_legacy, java_legacy, csharp_legacy",
+        )),
+    }
+}
+
+pub(crate) fn ensure_bson_available(py: Python<'_>) -> PyResult<PythonBsonOutputTypes> {
+    PythonBsonTypes::load(py)?.into_output_types()
+}
+
+pub(crate) fn extract_bson_document(
+    py: Python<'_>,
+    value: &Bound<'_, PyAny>,
+    representation: PythonUuidRepresentation,
+) -> PyResult<BsonDocument> {
+    InputConverter::new(PythonBsonTypes::load(py)?, representation).document(value)
+}
+
+pub(crate) fn bson_document_to_python(
+    py: Python<'_>,
+    document: &BsonDocument,
+    representation: PythonUuidRepresentation,
+    types: &PythonBsonOutputTypes,
+) -> PyResult<Py<PyAny>> {
+    OutputConverter::new(py, types, representation).document(document)
+}
+
+pub(crate) fn bson_value_to_python(
+    py: Python<'_>,
+    value: &BsonValue,
+    representation: PythonUuidRepresentation,
+    types: &PythonBsonOutputTypes,
+) -> PyResult<Py<PyAny>> {
+    OutputConverter::new(py, types, representation).value(value)
+}
+
+pub(crate) fn extract_request_id(value: &Bound<'_, PyAny>) -> PyResult<DocumentRequestId> {
+    DocumentRequestId::new(extract_uuid_bytes(value, "request_id")?)
+        .map_err(crate::error::engine_error_to_python)
+}
+
+pub(crate) fn extract_uuid_bytes(
+    value: &Bound<'_, PyAny>,
+    label: &'static str,
+) -> PyResult<[u8; 16]> {
+    if let Ok(bytes) = value.cast::<PyBytes>() {
+        return bytes
+            .as_bytes()
+            .try_into()
+            .map_err(|_| type_mismatch(format!("{label} must be a uuid.UUID or 16-byte value")));
+    }
+    let uuid = value
+        .py()
+        .import("uuid")
+        .and_then(|module| module.getattr("UUID"))
+        .map_err(|_| invalid_value("unable to load Python UUID support"))?;
+    if !value
+        .is_instance(&uuid)
+        .map_err(|_| invalid_value("unable to inspect Python UUID value"))?
+    {
+        return Err(type_mismatch(format!(
+            "{label} must be a uuid.UUID or 16-byte value"
+        )));
+    }
+    required_uuid_bytes(value)
+}
+
+pub(crate) fn uuid_bytes_to_python(
+    py: Python<'_>,
+    bytes: [u8; 16],
+    types: &PythonBsonOutputTypes,
+) -> PyResult<Py<PyAny>> {
+    uuid_to_python(py, types.uuid.bind(py), bytes)
+}
+
+struct PythonBsonTypes<'py> {
+    binary: Bound<'py, PyAny>,
+    code: Bound<'py, PyAny>,
+    datetime_ms: Bound<'py, PyAny>,
+    decimal128: Bound<'py, PyAny>,
+    int64: Bound<'py, PyAny>,
+    max_key: Bound<'py, PyAny>,
+    min_key: Bound<'py, PyAny>,
+    object_id: Bound<'py, PyAny>,
+    regex: Bound<'py, PyAny>,
+    timestamp: Bound<'py, PyAny>,
+    datetime: Bound<'py, PyAny>,
+    timedelta: Bound<'py, PyAny>,
+    timezone_utc: Bound<'py, PyAny>,
+    regex_pattern: Bound<'py, PyAny>,
+    uuid: Bound<'py, PyAny>,
+}
+
+pub(crate) struct PythonBsonOutputTypes {
+    binary: Py<PyAny>,
+    code: Py<PyAny>,
+    datetime_ms: Py<PyAny>,
+    decimal128_from_bid: Py<PyAny>,
+    int64: Py<PyAny>,
+    max_key: Py<PyAny>,
+    min_key: Py<PyAny>,
+    object_id: Py<PyAny>,
+    regex: Py<PyAny>,
+    timestamp: Py<PyAny>,
+    datetime: Py<PyAny>,
+    timedelta: Py<PyAny>,
+    timezone_utc: Py<PyAny>,
+    uuid: Py<PyAny>,
+}
+
+impl<'py> PythonBsonTypes<'py> {
+    fn load(py: Python<'py>) -> PyResult<Self> {
+        let bson = py.import("bson").map_err(|_| unsupported(MISSING_BSON))?;
+        let attr = |name| bson.getattr(name).map_err(|_| unsupported(MISSING_BSON));
+        let datetime_module = py
+            .import("datetime")
+            .map_err(|_| unsupported(MISSING_BSON))?;
+        let re_module = py.import("re").map_err(|_| unsupported(MISSING_BSON))?;
+        let uuid_module = py.import("uuid").map_err(|_| unsupported(MISSING_BSON))?;
+        Ok(Self {
+            binary: attr("Binary")?,
+            code: attr("Code")?,
+            datetime_ms: attr("DatetimeMS")?,
+            decimal128: attr("Decimal128")?,
+            int64: attr("Int64")?,
+            max_key: attr("MaxKey")?,
+            min_key: attr("MinKey")?,
+            object_id: attr("ObjectId")?,
+            regex: attr("Regex")?,
+            timestamp: attr("Timestamp")?,
+            datetime: datetime_module
+                .getattr("datetime")
+                .map_err(|_| unsupported(MISSING_BSON))?,
+            timedelta: datetime_module
+                .getattr("timedelta")
+                .map_err(|_| unsupported(MISSING_BSON))?,
+            timezone_utc: datetime_module
+                .getattr("timezone")
+                .and_then(|timezone| timezone.getattr("utc"))
+                .map_err(|_| unsupported(MISSING_BSON))?,
+            regex_pattern: re_module
+                .getattr("Pattern")
+                .map_err(|_| unsupported(MISSING_BSON))?,
+            uuid: uuid_module
+                .getattr("UUID")
+                .map_err(|_| unsupported(MISSING_BSON))?,
+        })
+    }
+
+    fn into_output_types(self) -> PyResult<PythonBsonOutputTypes> {
+        let decimal128_from_bid = self
+            .decimal128
+            .getattr("from_bid")
+            .map_err(|_| unsupported(MISSING_BSON))?
+            .unbind();
+        Ok(PythonBsonOutputTypes {
+            binary: self.binary.unbind(),
+            code: self.code.unbind(),
+            datetime_ms: self.datetime_ms.unbind(),
+            decimal128_from_bid,
+            int64: self.int64.unbind(),
+            max_key: self.max_key.unbind(),
+            min_key: self.min_key.unbind(),
+            object_id: self.object_id.unbind(),
+            regex: self.regex.unbind(),
+            timestamp: self.timestamp.unbind(),
+            datetime: self.datetime.unbind(),
+            timedelta: self.timedelta.unbind(),
+            timezone_utc: self.timezone_utc.unbind(),
+            uuid: self.uuid.unbind(),
+        })
+    }
+}
+
+struct ConversionBudget {
+    wire_remaining: usize,
+    heap_remaining: usize,
+}
+
+impl ConversionBudget {
+    const fn new() -> Self {
+        Self {
+            wire_remaining: BSON_MAX_DOCUMENT_BYTES,
+            heap_remaining: BSON_MAX_DECODED_BYTES,
+        }
+    }
+
+    fn wire(&mut self, bytes: usize) -> PyResult<()> {
+        self.wire_remaining = self
+            .wire_remaining
+            .checked_sub(bytes)
+            .ok_or_else(|| limit_exceeded(BSON_SIZE))?;
+        Ok(())
+    }
+
+    fn heap(&mut self, bytes: usize) -> PyResult<()> {
+        self.heap_remaining = self
+            .heap_remaining
+            .checked_sub(bytes)
+            .ok_or_else(|| limit_exceeded(BSON_HEAP))?;
+        Ok(())
+    }
+}
+
+struct InputConverter<'py> {
+    types: PythonBsonTypes<'py>,
+    representation: PythonUuidRepresentation,
+    active: HashSet<usize>,
+    budget: ConversionBudget,
+}
+
+impl<'py> InputConverter<'py> {
+    fn new(types: PythonBsonTypes<'py>, representation: PythonUuidRepresentation) -> Self {
+        Self {
+            types,
+            representation,
+            active: HashSet::new(),
+            budget: ConversionBudget::new(),
+        }
+    }
+
+    fn document(mut self, value: &Bound<'py, PyAny>) -> PyResult<BsonDocument> {
+        let document = self.convert_document(value, 1)?;
+        encode_document(&document).map_err(bson_error_to_python)?;
+        Ok(document)
+    }
+
+    fn convert_document(
+        &mut self,
+        value: &Bound<'py, PyAny>,
+        depth: usize,
+    ) -> PyResult<BsonDocument> {
+        self.ensure_depth(depth)?;
+        let mapping = value
+            .cast::<PyMapping>()
+            .map_err(|_| type_mismatch(INVALID_BSON_MAPPING))?;
+        self.enter(value)?;
+        self.budget.wire(5)?;
+
+        let result = (|| {
+            let mut document = BsonDocument::new();
+            let mut names: HashSet<String> = HashSet::new();
+            let iterator = mapping
+                .try_iter()
+                .map_err(|_| invalid_value(INVALID_BSON_CONTAINER))?;
+            for key in iterator {
+                let key = key.map_err(|_| invalid_value(INVALID_BSON_CONTAINER))?;
+                let key_string = key
+                    .cast::<PyString>()
+                    .map_err(|_| type_mismatch(INVALID_BSON_MAPPING))?;
+                let key_len = self.preflight_string(key_string, 2)?;
+                self.budget.wire(
+                    key_len
+                        .checked_add(2)
+                        .ok_or_else(|| limit_exceeded(BSON_SIZE))?,
+                )?;
+                self.budget.heap(
+                    size_of::<(String, BsonValue)>()
+                        .saturating_mul(2)
+                        .saturating_add(size_of::<&str>().saturating_mul(8))
+                        .saturating_add(key_len.saturating_mul(2)),
+                )?;
+                let key_text = key_string
+                    .to_cow()
+                    .map_err(|_| invalid_text_encoding(INVALID_BSON_TEXT))?;
+                if key_text.contains('\0') {
+                    return Err(invalid_value("BSON field names cannot contain NUL"));
+                }
+                debug_assert_eq!(key_text.len(), key_len);
+                let field = mapping
+                    .get_item(&key)
+                    .map_err(|_| invalid_value(INVALID_BSON_CONTAINER))?;
+                let key_text = key_text.into_owned();
+                names
+                    .try_reserve(1)
+                    .map_err(|_| limit_exceeded(BSON_HEAP))?;
+                if !names.insert(key_text.clone()) {
+                    return Err(invalid_value(
+                        "BSON documents cannot contain duplicate field names",
+                    ));
+                }
+                let field = self.convert_value(&field, depth)?;
+                document
+                    .push(key_text, field)
+                    .map_err(bson_error_to_python)?;
+            }
+            Ok(document)
+        })();
+        self.leave(value);
+        result
+    }
+
+    fn convert_array(
+        &mut self,
+        value: &Bound<'py, PyAny>,
+        depth: usize,
+    ) -> PyResult<Vec<BsonValue>> {
+        self.ensure_depth(depth)?;
+        self.enter(value)?;
+        self.budget.wire(5)?;
+        let result = (|| {
+            let len = value
+                .len()
+                .map_err(|_| invalid_value(INVALID_BSON_CONTAINER))?;
+            self.budget
+                .heap(size_of::<BsonValue>().saturating_mul(len).saturating_mul(2))?;
+            let mut values = Vec::new();
+            values
+                .try_reserve_exact(len)
+                .map_err(|_| limit_exceeded(BSON_HEAP))?;
+            for index in 0..len {
+                let index_bytes = decimal_digits(index);
+                self.budget.wire(index_bytes.saturating_add(2))?;
+                let item = value
+                    .get_item(index)
+                    .map_err(|_| invalid_value(INVALID_BSON_CONTAINER))?;
+                values.push(self.convert_value(&item, depth)?);
+            }
+            Ok(values)
+        })();
+        self.leave(value);
+        result
+    }
+
+    fn convert_value(
+        &mut self,
+        value: &Bound<'py, PyAny>,
+        parent_depth: usize,
+    ) -> PyResult<BsonValue> {
+        if value.is_none() {
+            return Ok(BsonValue::Null);
+        }
+        if value.is_instance_of::<PyBool>() {
+            self.budget.wire(1)?;
+            return value.extract::<bool>().map(BsonValue::Boolean);
+        }
+        if value
+            .is_instance(&self.types.int64)
+            .map_err(|_| invalid_value(INVALID_BSON_ATTRIBUTE))?
+        {
+            self.budget.wire(8)?;
+            return value.extract::<i64>().map(BsonValue::Int64).map_err(|_| {
+                numeric_out_of_range("BSON Int64 values must be between -2^63 and 2^63-1")
+            });
+        }
+        if value.is_instance_of::<PyInt>() {
+            if let Ok(integer) = value.extract::<i32>() {
+                self.budget.wire(4)?;
+                return Ok(BsonValue::Int32(integer));
+            }
+            self.budget.wire(8)?;
+            return value.extract::<i64>().map(BsonValue::Int64).map_err(|_| {
+                numeric_out_of_range("BSON integer values must be between -2^63 and 2^63-1")
+            });
+        }
+        if value.is_instance_of::<PyFloat>() {
+            self.budget.wire(8)?;
+            return value.extract::<f64>().map(BsonValue::Double);
+        }
+        if value
+            .is_instance(&self.types.code)
+            .map_err(|_| invalid_value(INVALID_BSON_ATTRIBUTE))?
+        {
+            return self.convert_code(value, parent_depth);
+        }
+        if value
+            .is_instance(&self.types.binary)
+            .map_err(|_| invalid_value(INVALID_BSON_ATTRIBUTE))?
+        {
+            return self.convert_binary(value);
+        }
+        if value.is_instance_of::<PyString>() {
+            return self.convert_string(value).map(BsonValue::String);
+        }
+        if let Ok(bytes) = value.cast::<PyBytes>() {
+            return self.copy_binary(bytes.as_bytes(), 0);
+        }
+        if let Ok(bytes) = value.cast::<PyByteArray>() {
+            self.ensure_binary_len(bytes.len(), 0)?;
+            return Ok(BsonValue::Binary(BsonBinary::new(0, bytes.to_vec())));
+        }
+        if let Ok(memory_view) = value.cast::<PyMemoryView>() {
+            let len = memory_view
+                .getattr("nbytes")
+                .and_then(|length| length.extract::<usize>())
+                .map_err(|_| invalid_value(INVALID_BSON_ATTRIBUTE))?;
+            self.ensure_binary_len(len, 0)?;
+            let bytes = memory_view
+                .call_method0("tobytes")
+                .and_then(|bytes| bytes.cast_into::<PyBytes>().map_err(PyErr::from))
+                .map_err(|_| invalid_value(INVALID_BSON_ATTRIBUTE))?;
+            return self.copy_binary_after_budget(bytes.as_bytes(), 0);
+        }
+        if value
+            .is_instance(&self.types.datetime_ms)
+            .map_err(|_| invalid_value(INVALID_BSON_ATTRIBUTE))?
+        {
+            self.budget.wire(8)?;
+            let integer = value
+                .call_method0("__int__")
+                .and_then(|integer| integer.extract::<i64>())
+                .map_err(|_| {
+                    numeric_out_of_range("BSON DatetimeMS values must be between -2^63 and 2^63-1")
+                })?;
+            return Ok(BsonValue::DateTime(BsonDateTime::from_millis(integer)));
+        }
+        if value
+            .is_instance(&self.types.datetime)
+            .map_err(|_| invalid_value(INVALID_BSON_ATTRIBUTE))?
+        {
+            self.budget.wire(8)?;
+            return self
+                .datetime_millis(value)
+                .map(BsonDateTime::from_millis)
+                .map(BsonValue::DateTime);
+        }
+        if value
+            .is_instance(&self.types.uuid)
+            .map_err(|_| invalid_value(INVALID_BSON_ATTRIBUTE))?
+        {
+            let Some(representation) = self.representation.into_brisk() else {
+                return Err(unsupported(
+                    "native UUID values require an explicit uuid_representation",
+                ));
+            };
+            self.budget.wire(21)?;
+            return Ok(BsonValue::Uuid(BsonUuid::new(
+                required_uuid_bytes(value)?,
+                representation,
+            )));
+        }
+        if value
+            .is_instance(&self.types.object_id)
+            .map_err(|_| invalid_value(INVALID_BSON_ATTRIBUTE))?
+        {
+            self.budget.wire(12)?;
+            let bytes = required_fixed_bytes(&value.getattr("binary"), 12, INVALID_BSON_ATTRIBUTE)?;
+            return Ok(BsonValue::ObjectId(BsonObjectId::from_bytes(bytes)));
+        }
+        if value
+            .is_instance(&self.types.decimal128)
+            .map_err(|_| invalid_value(INVALID_BSON_ATTRIBUTE))?
+        {
+            self.budget.wire(16)?;
+            let bid = required_fixed_bytes(&value.getattr("bid"), 16, INVALID_BSON_ATTRIBUTE)?;
+            return Ok(BsonValue::Decimal128(BsonDecimal128::from_bid(bid)));
+        }
+        if value
+            .is_instance(&self.types.regex)
+            .map_err(|_| invalid_value(INVALID_BSON_ATTRIBUTE))?
+            || value
+                .is_instance(&self.types.regex_pattern)
+                .map_err(|_| invalid_value(INVALID_BSON_ATTRIBUTE))?
+        {
+            return self.convert_regex(value);
+        }
+        if value
+            .is_instance(&self.types.timestamp)
+            .map_err(|_| invalid_value(INVALID_BSON_ATTRIBUTE))?
+        {
+            self.budget.wire(8)?;
+            let time = extract_attr::<u32>(value, "time")?;
+            let increment = extract_attr::<u32>(value, "inc")?;
+            return Ok(BsonValue::Timestamp(BsonTimestamp::new(time, increment)));
+        }
+        if value
+            .is_instance(&self.types.min_key)
+            .map_err(|_| invalid_value(INVALID_BSON_ATTRIBUTE))?
+        {
+            return Ok(BsonValue::MinKey);
+        }
+        if value
+            .is_instance(&self.types.max_key)
+            .map_err(|_| invalid_value(INVALID_BSON_ATTRIBUTE))?
+        {
+            return Ok(BsonValue::MaxKey);
+        }
+        if value.cast::<PyMapping>().is_ok() {
+            return self
+                .convert_document(value, parent_depth + 1)
+                .map(BsonValue::Document);
+        }
+        if value.cast::<PyList>().is_ok() || value.cast::<PyTuple>().is_ok() {
+            return self
+                .convert_array(value, parent_depth + 1)
+                .map(BsonValue::Array);
+        }
+        Err(type_mismatch(INVALID_BSON_VALUE))
+    }
+
+    fn convert_string(&mut self, value: &Bound<'py, PyAny>) -> PyResult<String> {
+        let string = value
+            .cast::<PyString>()
+            .map_err(|_| type_mismatch(INVALID_BSON_VALUE))?;
+        let string_len = self.preflight_string(string, 5)?;
+        self.budget.wire(
+            string_len
+                .checked_add(5)
+                .ok_or_else(|| limit_exceeded(BSON_SIZE))?,
+        )?;
+        self.budget.heap(string_len)?;
+        let string = string
+            .to_cow()
+            .map_err(|_| invalid_text_encoding(INVALID_BSON_TEXT))?;
+        debug_assert_eq!(string.len(), string_len);
+        Ok(string.into_owned())
+    }
+
+    fn convert_binary(&mut self, value: &Bound<'py, PyAny>) -> PyResult<BsonValue> {
+        let subtype = extract_attr::<u8>(value, "subtype")?;
+        let bytes = value
+            .cast::<PyBytes>()
+            .map_err(|_| invalid_value(INVALID_BSON_ATTRIBUTE))?;
+        self.copy_binary(bytes.as_bytes(), subtype)
+    }
+
+    fn copy_binary(&mut self, bytes: &[u8], subtype: u8) -> PyResult<BsonValue> {
+        self.ensure_binary_len(bytes.len(), subtype)?;
+        self.copy_binary_after_budget(bytes, subtype)
+    }
+
+    fn ensure_binary_len(&mut self, len: usize, subtype: u8) -> PyResult<()> {
+        let framing = if subtype == 2 { 9 } else { 5 };
+        self.budget.wire(
+            len.checked_add(framing)
+                .ok_or_else(|| limit_exceeded(BSON_SIZE))?,
+        )?;
+        self.budget.heap(len)
+    }
+
+    fn copy_binary_after_budget(&mut self, bytes: &[u8], subtype: u8) -> PyResult<BsonValue> {
+        let mut owned = Vec::new();
+        owned
+            .try_reserve_exact(bytes.len())
+            .map_err(|_| limit_exceeded(BSON_HEAP))?;
+        owned.extend_from_slice(bytes);
+        Ok(BsonValue::Binary(BsonBinary::new(subtype, owned)))
+    }
+
+    fn convert_regex(&mut self, value: &Bound<'py, PyAny>) -> PyResult<BsonValue> {
+        let pattern = value
+            .getattr("pattern")
+            .map_err(|_| invalid_value(INVALID_BSON_ATTRIBUTE))?;
+        let pattern = pattern
+            .cast::<PyString>()
+            .map_err(|_| type_mismatch("BSON regular expression patterns must be strings"))?;
+        let pattern_len = self.preflight_string(pattern, 2)?;
+        let flags = extract_attr::<u32>(value, "flags")?;
+        const KNOWN_FLAGS: u32 = 2 | 4 | 8 | 16 | 32 | 64;
+        if flags & !KNOWN_FLAGS != 0 {
+            return Err(invalid_value(
+                "BSON regular expression flags may contain only i, l, m, s, u, and x",
+            ));
+        }
+        let mut options = String::new();
+        for (bit, option) in [
+            (2, 'i'),
+            (4, 'l'),
+            (8, 'm'),
+            (16, 's'),
+            (32, 'u'),
+            (64, 'x'),
+        ] {
+            if flags & bit != 0 {
+                options.push(option);
+            }
+        }
+        self.budget.wire(
+            pattern_len
+                .checked_add(options.len())
+                .and_then(|len| len.checked_add(2))
+                .ok_or_else(|| limit_exceeded(BSON_SIZE))?,
+        )?;
+        self.budget
+            .heap(pattern_len.saturating_add(options.len()))?;
+        let pattern = pattern
+            .to_cow()
+            .map_err(|_| invalid_text_encoding(INVALID_BSON_TEXT))?;
+        debug_assert_eq!(pattern.len(), pattern_len);
+        BsonRegex::new(pattern, options)
+            .map(BsonValue::RegularExpression)
+            .map_err(bson_error_to_python)
+    }
+
+    fn convert_code(
+        &mut self,
+        value: &Bound<'py, PyAny>,
+        parent_depth: usize,
+    ) -> PyResult<BsonValue> {
+        self.enter(value)?;
+        let result = (|| {
+            let code = value
+                .cast::<PyString>()
+                .map_err(|_| invalid_value(INVALID_BSON_ATTRIBUTE))?;
+            let code_len = self.preflight_string(code, 5)?;
+            self.budget.wire(
+                code_len
+                    .checked_add(5)
+                    .ok_or_else(|| limit_exceeded(BSON_SIZE))?,
+            )?;
+            self.budget.heap(code_len)?;
+            let code = code
+                .to_cow()
+                .map_err(|_| invalid_text_encoding(INVALID_BSON_TEXT))?;
+            debug_assert_eq!(code.len(), code_len);
+            let scope = value
+                .getattr("scope")
+                .map_err(|_| invalid_value(INVALID_BSON_ATTRIBUTE))?;
+            if scope.is_none() {
+                return Ok(BsonValue::JavaScript(BsonJavaScript::new(code)));
+            }
+            self.budget.wire(4)?;
+            let scope = self.convert_document(&scope, parent_depth + 1)?;
+            Ok(BsonValue::JavaScript(BsonJavaScript::with_scope(
+                code, scope,
+            )))
+        })();
+        self.leave(value);
+        result
+    }
+
+    fn datetime_millis(&self, value: &Bound<'py, PyAny>) -> PyResult<i64> {
+        let ordinal = value
+            .call_method0("toordinal")
+            .and_then(|ordinal| ordinal.extract::<i64>())
+            .map_err(|_| invalid_value("invalid Python datetime value"))?;
+        let hour = extract_attr::<i64>(value, "hour")?;
+        let minute = extract_attr::<i64>(value, "minute")?;
+        let second = extract_attr::<i64>(value, "second")?;
+        let micros = extract_attr::<i64>(value, "microsecond")?;
+        let offset = value
+            .call_method0("utcoffset")
+            .map_err(|_| invalid_value("invalid Python datetime UTC offset"))?;
+        let offset_micros = if offset.is_none() {
+            0_i128
+        } else {
+            timedelta_micros(&offset)?
+        };
+        let local_micros = i128::from(ordinal - 719_163)
+            .checked_mul(86_400_000_000)
+            .and_then(|total| total.checked_add(i128::from(hour) * 3_600_000_000))
+            .and_then(|total| total.checked_add(i128::from(minute) * 60_000_000))
+            .and_then(|total| total.checked_add(i128::from(second) * 1_000_000))
+            .and_then(|total| total.checked_add(i128::from(micros)))
+            .ok_or_else(|| numeric_out_of_range("Python datetime is outside BSON's range"))?;
+        i64::try_from(
+            local_micros
+                .checked_sub(offset_micros)
+                .ok_or_else(|| numeric_out_of_range("Python datetime is outside BSON's range"))?
+                .div_euclid(1_000),
+        )
+        .map_err(|_| numeric_out_of_range("Python datetime is outside BSON's range"))
+    }
+
+    fn ensure_depth(&self, depth: usize) -> PyResult<()> {
+        if depth > BSON_MAX_NESTING_DEPTH {
+            Err(limit_exceeded(BSON_DEPTH))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn preflight_string(&self, value: &Bound<'py, PyString>, framing: usize) -> PyResult<usize> {
+        let characters = value
+            .len()
+            .map_err(|_| invalid_text_encoding(INVALID_BSON_TEXT))?;
+        if characters
+            .checked_add(framing)
+            .is_none_or(|bytes| bytes > self.budget.wire_remaining)
+        {
+            return Err(limit_exceeded(BSON_SIZE));
+        }
+        if characters > self.budget.heap_remaining {
+            return Err(limit_exceeded(BSON_HEAP));
+        }
+        let is_ascii = value
+            .py()
+            .get_type::<PyString>()
+            .getattr("isascii")
+            .and_then(|method| method.call1((value,)))
+            .and_then(|result| result.is_truthy())
+            .map_err(|_| invalid_text_encoding(INVALID_BSON_TEXT))?;
+        if is_ascii {
+            return Ok(characters);
+        }
+        const PREFLIGHT_CHUNK_CHARACTERS: usize = 64 * 1024;
+        let mut encoded_bytes = 0_usize;
+        let mut start = 0_usize;
+        while start < characters {
+            let end = start
+                .saturating_add(PREFLIGHT_CHUNK_CHARACTERS)
+                .min(characters);
+            // SAFETY: `value` is a live Python `str`, the GIL is held for
+            // `'py`, and both indices are bounded by `PyUnicode_GetLength`
+            // through `PyString::len` above. The returned new reference is
+            // immediately owned by `Bound`.
+            let chunk = unsafe {
+                Bound::from_owned_ptr_or_err(
+                    value.py(),
+                    pyo3::ffi::PyUnicode_Substring(
+                        value.as_ptr(),
+                        start as pyo3::ffi::Py_ssize_t,
+                        end as pyo3::ffi::Py_ssize_t,
+                    ),
+                )
+            }
+            .and_then(|chunk| chunk.cast_into::<PyString>().map_err(PyErr::from))
+            .map_err(|_| invalid_text_encoding(INVALID_BSON_TEXT))?;
+            let width = chunk
+                .encode_utf8()
+                .map_err(|_| invalid_text_encoding(INVALID_BSON_TEXT))?
+                .len()
+                .map_err(|_| invalid_text_encoding(INVALID_BSON_TEXT))?;
+            encoded_bytes = encoded_bytes
+                .checked_add(width)
+                .ok_or_else(|| limit_exceeded(BSON_SIZE))?;
+            if encoded_bytes
+                .checked_add(framing)
+                .is_none_or(|bytes| bytes > self.budget.wire_remaining)
+            {
+                return Err(limit_exceeded(BSON_SIZE));
+            }
+            if encoded_bytes > self.budget.heap_remaining {
+                return Err(limit_exceeded(BSON_HEAP));
+            }
+            start = end;
+        }
+        Ok(encoded_bytes)
+    }
+
+    fn enter(&mut self, value: &Bound<'py, PyAny>) -> PyResult<()> {
+        if self.active.insert(value.as_ptr() as usize) {
+            Ok(())
+        } else {
+            Err(invalid_value(BSON_CYCLE))
+        }
+    }
+
+    fn leave(&mut self, value: &Bound<'py, PyAny>) {
+        self.active.remove(&(value.as_ptr() as usize));
+    }
+}
+
+struct OutputConverter<'types, 'py> {
+    py: Python<'py>,
+    types: &'types PythonBsonOutputTypes,
+    representation: PythonUuidRepresentation,
+}
+
+impl<'types, 'py> OutputConverter<'types, 'py> {
+    fn new(
+        py: Python<'py>,
+        types: &'types PythonBsonOutputTypes,
+        representation: PythonUuidRepresentation,
+    ) -> Self {
+        Self {
+            py,
+            types,
+            representation,
+        }
+    }
+
+    fn document(self, document: &BsonDocument) -> PyResult<Py<PyAny>> {
+        encode_document(document).map_err(bson_error_to_python)?;
+        self.document_unchecked(document)
+            .map(|document| document.into_any().unbind())
+    }
+
+    fn value(self, value: &BsonValue) -> PyResult<Py<PyAny>> {
+        let wrapper =
+            BsonDocument::from_entries([("value", value.clone())]).map_err(bson_error_to_python)?;
+        encode_document(&wrapper).map_err(bson_error_to_python)?;
+        self.value_unchecked(value)
+    }
+
+    fn document_unchecked(&self, document: &BsonDocument) -> PyResult<Bound<'py, PyDict>> {
+        let output = PyDict::new(self.py);
+        for (name, value) in document.iter() {
+            output.set_item(name, self.value_unchecked(value)?)?;
+        }
+        Ok(output)
+    }
+
+    fn value_unchecked(&self, value: &BsonValue) -> PyResult<Py<PyAny>> {
+        let py = self.py;
+        match value {
+            BsonValue::Double(value) => value.into_py_any(py),
+            BsonValue::String(value) => value.into_py_any(py),
+            BsonValue::Document(value) => Ok(self.document_unchecked(value)?.into_any().unbind()),
+            BsonValue::Array(values) => {
+                let output = PyList::empty(py);
+                for value in values {
+                    output.append(self.value_unchecked(value)?)?;
+                }
+                Ok(output.into_any().unbind())
+            }
+            BsonValue::Binary(value) => self.binary_to_python(value),
+            BsonValue::Uuid(value) => self.binary_to_python(&value.to_binary()),
+            BsonValue::ObjectId(value) => self
+                .types
+                .object_id
+                .bind(py)
+                .call1((PyBytes::new(py, &value.bytes()),))
+                .map(|value| value.unbind()),
+            BsonValue::Boolean(value) => value.into_py_any(py),
+            BsonValue::DateTime(value) => self.datetime_to_python(*value),
+            BsonValue::Null => Ok(py.None()),
+            BsonValue::RegularExpression(value) => self
+                .types
+                .regex
+                .bind(py)
+                .call1((value.pattern(), value.options()))
+                .map(|value| value.unbind()),
+            BsonValue::JavaScript(value) => {
+                if let Some(scope) = value.scope() {
+                    self.types
+                        .code
+                        .bind(py)
+                        .call1((value.code(), self.document_unchecked(scope)?))
+                        .map(|value| value.unbind())
+                } else {
+                    self.types
+                        .code
+                        .bind(py)
+                        .call1((value.code(),))
+                        .map(|value| value.unbind())
+                }
+            }
+            BsonValue::Int32(value) => value.into_py_any(py),
+            BsonValue::Timestamp(value) => self
+                .types
+                .timestamp
+                .bind(py)
+                .call1((value.time(), value.increment()))
+                .map(|value| value.unbind()),
+            BsonValue::Int64(value) => self
+                .types
+                .int64
+                .bind(py)
+                .call1((*value,))
+                .map(|value| value.unbind()),
+            BsonValue::Decimal128(value) => self
+                .types
+                .decimal128_from_bid
+                .bind(py)
+                .call1((PyBytes::new(py, &value.bid()),))
+                .map(|value| value.unbind()),
+            BsonValue::MinKey => self
+                .types
+                .min_key
+                .bind(py)
+                .call0()
+                .map(|value| value.unbind()),
+            BsonValue::MaxKey => self
+                .types
+                .max_key
+                .bind(py)
+                .call0()
+                .map(|value| value.unbind()),
+            _ => Err(unsupported("unsupported BriskDB BSON value")),
+        }
+    }
+
+    fn binary_to_python(&self, binary: &BsonBinary) -> PyResult<Py<PyAny>> {
+        let py = self.py;
+        if binary.subtype() == 0 {
+            return Ok(PyBytes::new(py, binary.bytes()).into_any().unbind());
+        }
+        if let Some(representation) = self.representation.into_brisk() {
+            if let Ok(uuid) = BsonUuid::from_binary(binary, representation) {
+                return uuid_to_python(py, self.types.uuid.bind(py), uuid.bytes());
+            }
+        }
+        self.types
+            .binary
+            .bind(py)
+            .call1((PyBytes::new(py, binary.bytes()), binary.subtype()))
+            .map(|value| value.unbind())
+    }
+
+    fn datetime_to_python(&self, value: BsonDateTime) -> PyResult<Py<PyAny>> {
+        let py = self.py;
+        let kwargs = PyDict::new(py);
+        kwargs.set_item("tzinfo", self.types.timezone_utc.bind(py))?;
+        let epoch = self
+            .types
+            .datetime
+            .bind(py)
+            .call((1970, 1, 1), Some(&kwargs))
+            .map_err(|_| invalid_value("unable to construct UTC datetime"))?;
+        let delta_kwargs = PyDict::new(py);
+        delta_kwargs.set_item("milliseconds", value.timestamp_millis())?;
+        let converted = self
+            .types
+            .timedelta
+            .bind(py)
+            .call((), Some(&delta_kwargs))
+            .and_then(|delta| epoch.call_method1("__add__", (delta,)));
+        match converted {
+            Ok(datetime) => Ok(datetime.unbind()),
+            Err(_) => self
+                .types
+                .datetime_ms
+                .bind(py)
+                .call1((value.timestamp_millis(),))
+                .map(|value| value.unbind())
+                .map_err(|_| invalid_value("unable to construct BSON DatetimeMS value")),
+        }
+    }
+}
+
+fn required_fixed_bytes<const N: usize>(
+    value: &PyResult<Bound<'_, PyAny>>,
+    expected: usize,
+    message: &'static str,
+) -> PyResult<[u8; N]> {
+    let value = value.as_ref().map_err(|_| invalid_value(message))?;
+    let bytes = value
+        .cast::<PyBytes>()
+        .map_err(|_| invalid_value(message))?
+        .as_bytes();
+    if bytes.len() != expected || expected != N {
+        return Err(invalid_value(message));
+    }
+    let mut output = [0; N];
+    output.copy_from_slice(bytes);
+    Ok(output)
+}
+
+fn required_uuid_bytes(value: &Bound<'_, PyAny>) -> PyResult<[u8; 16]> {
+    required_fixed_bytes(&value.getattr("bytes"), 16, "invalid Python UUID value")
+}
+
+fn uuid_to_python(py: Python<'_>, uuid: &Bound<'_, PyAny>, bytes: [u8; 16]) -> PyResult<Py<PyAny>> {
+    let kwargs = PyDict::new(py);
+    kwargs.set_item("bytes", PyBytes::new(py, &bytes))?;
+    uuid.call((), Some(&kwargs)).map(|value| value.unbind())
+}
+
+fn extract_attr<'py, T>(value: &Bound<'py, PyAny>, name: &str) -> PyResult<T>
+where
+    T: FromPyObjectOwned<'py>,
+{
+    let attribute = value
+        .getattr(name)
+        .map_err(|_| invalid_value(INVALID_BSON_ATTRIBUTE))?;
+    attribute
+        .extract::<T>()
+        .map_err(|_| invalid_value(INVALID_BSON_ATTRIBUTE))
+}
+
+fn timedelta_micros(value: &Bound<'_, PyAny>) -> PyResult<i128> {
+    let days = extract_attr::<i64>(value, "days")?;
+    let seconds = extract_attr::<i64>(value, "seconds")?;
+    let micros = extract_attr::<i64>(value, "microseconds")?;
+    i128::from(days)
+        .checked_mul(86_400_000_000)
+        .and_then(|total| total.checked_add(i128::from(seconds) * 1_000_000))
+        .and_then(|total| total.checked_add(i128::from(micros)))
+        .ok_or_else(|| numeric_out_of_range("Python datetime UTC offset is outside BSON's range"))
+}
+
+fn decimal_digits(mut value: usize) -> usize {
+    let mut digits = 1;
+    while value >= 10 {
+        value /= 10;
+        digits += 1;
+    }
+    digits
+}

--- a/python/src/document_api.rs
+++ b/python/src/document_api.rs
@@ -1,0 +1,236 @@
+use briskdb::document::{
+    BsonValue, DocumentCollectionMetadata, DocumentExecution, DocumentIndexLifecycle,
+    DocumentIndexMetadata, DocumentPlan, DocumentRequestId, DocumentResult,
+};
+use pyo3::{
+    prelude::*,
+    types::{PyDict, PyList},
+};
+
+use crate::bson::{
+    PythonBsonOutputTypes, PythonUuidRepresentation, bson_document_to_python, bson_value_to_python,
+    uuid_bytes_to_python,
+};
+
+pub(crate) fn execution_to_python(
+    py: Python<'_>,
+    execution: DocumentExecution,
+    uuid_representation: PythonUuidRepresentation,
+    bson_types: &PythonBsonOutputTypes,
+) -> PyResult<Py<PyAny>> {
+    let (request_id, plan, result) = execution.into_parts();
+    let output = PyDict::new(py);
+    output.set_item(
+        "request_id",
+        request_id_to_python(py, request_id, bson_types)?,
+    )?;
+    match plan {
+        Some(plan) => output.set_item("plan", plan_to_python(py, &plan)?)?,
+        None => output.set_item("plan", py.None())?,
+    }
+
+    match result {
+        DocumentResult::Collection(collection) => {
+            output.set_item("kind", "collection")?;
+            output.set_item(
+                "collection",
+                collection_to_python(py, &collection, uuid_representation, bson_types)?,
+            )?;
+        }
+        DocumentResult::Collections(collections) => {
+            output.set_item("kind", "collections")?;
+            let values = PyList::empty(py);
+            for collection in &collections {
+                values.append(collection_to_python(
+                    py,
+                    collection,
+                    uuid_representation,
+                    bson_types,
+                )?)?;
+            }
+            output.set_item("collections", values)?;
+        }
+        DocumentResult::Cursor(batch) => {
+            output.set_item("kind", "cursor")?;
+            output.set_item("namespace", namespace_to_python(py, batch.namespace())?)?;
+            match batch.cursor_id() {
+                Some(cursor_id) => output.set_item("cursor_id", cursor_id.get())?,
+                None => output.set_item("cursor_id", py.None())?,
+            }
+            output.set_item("exhausted", batch.is_exhausted())?;
+            let documents = PyList::empty(py);
+            for document in batch.documents() {
+                documents.append(bson_document_to_python(
+                    py,
+                    document,
+                    uuid_representation,
+                    bson_types,
+                )?)?;
+            }
+            output.set_item("documents", documents)?;
+        }
+        DocumentResult::Count(count) => {
+            output.set_item("kind", "count")?;
+            output.set_item("count", count)?;
+        }
+        DocumentResult::Insert(result) => {
+            output.set_item("kind", "insert")?;
+            output.set_item("acknowledged", result.acknowledged())?;
+            output.set_item("inserted_count", result.inserted_ids().len())?;
+            let ids = PyList::empty(py);
+            for value in result.inserted_ids() {
+                ids.append(bson_value_to_python(
+                    py,
+                    value,
+                    uuid_representation,
+                    bson_types,
+                )?)?;
+            }
+            output.set_item("inserted_ids", ids)?;
+        }
+        DocumentResult::Delete(result) => {
+            output.set_item("kind", "delete")?;
+            output.set_item("acknowledged", result.acknowledged())?;
+            output.set_item("deleted_count", result.deleted_count())?;
+        }
+        DocumentResult::IndexName(name) => {
+            output.set_item("kind", "index_name")?;
+            output.set_item("index_name", name)?;
+            output.set_item("lifecycle", "pending_build")?;
+        }
+        DocumentResult::Indexes(indexes) => {
+            output.set_item("kind", "indexes")?;
+            let values = PyList::empty(py);
+            for index in &indexes {
+                values.append(index_to_python(py, index, uuid_representation, bson_types)?)?;
+            }
+            output.set_item("indexes", values)?;
+        }
+        // The Python surface only constructs commands from the currently
+        // executable engine slice. Keep future result variants explicit if a
+        // core change accidentally routes one through these methods.
+        DocumentResult::Acknowledged(_)
+        | DocumentResult::Document(_)
+        | DocumentResult::Distinct(_)
+        | DocumentResult::Update(_)
+        | DocumentResult::CursorKilled(_) => {
+            return Err(crate::error::unsupported(
+                "this document result is not exposed by the current Python API",
+            ));
+        }
+        _ => {
+            return Err(crate::error::unsupported(
+                "this document result is unknown to the current Python API",
+            ));
+        }
+    }
+    Ok(output.into_any().unbind())
+}
+
+fn request_id_to_python(
+    py: Python<'_>,
+    request_id: DocumentRequestId,
+    bson_types: &PythonBsonOutputTypes,
+) -> PyResult<Py<PyAny>> {
+    uuid_bytes_to_python(py, request_id.as_bytes(), bson_types)
+}
+
+fn plan_to_python(py: Python<'_>, plan: &DocumentPlan) -> PyResult<Py<PyAny>> {
+    let output = PyDict::new(py);
+    match plan {
+        DocumentPlan::Point(point) => {
+            output.set_item("kind", "point")?;
+            output.set_item("collection_id", point.collection_id().get())?;
+            output.set_item("shards", vec![point.shard()])?;
+        }
+        DocumentPlan::Scatter(scatter) => {
+            output.set_item("kind", "scatter")?;
+            output.set_item("collection_id", scatter.collection_id().get())?;
+            output.set_item("shards", scatter.shards().to_vec())?;
+        }
+        _ => {
+            return Err(crate::error::unsupported(
+                "this document plan is unknown to the current Python API",
+            ));
+        }
+    }
+    Ok(output.into_any().unbind())
+}
+
+fn namespace_to_python(
+    py: Python<'_>,
+    namespace: &briskdb::document::DocumentNamespace,
+) -> PyResult<Py<PyAny>> {
+    let output = PyDict::new(py);
+    output.set_item("database", namespace.database())?;
+    output.set_item("collection", namespace.collection())?;
+    Ok(output.into_any().unbind())
+}
+
+fn collection_to_python(
+    py: Python<'_>,
+    collection: &DocumentCollectionMetadata,
+    uuid_representation: PythonUuidRepresentation,
+    bson_types: &PythonBsonOutputTypes,
+) -> PyResult<Py<PyAny>> {
+    let output = PyDict::new(py);
+    output.set_item("id", collection.id().get())?;
+    output.set_item("database_id", collection.database_id().get())?;
+    output.set_item("database", collection.database_name())?;
+    output.set_item("name", collection.name())?;
+    output.set_item("namespace", collection.namespace())?;
+    output.set_item(
+        "options",
+        bson_document_to_python(
+            py,
+            collection.options().document(),
+            uuid_representation,
+            bson_types,
+        )?,
+    )?;
+    let placement = PyDict::new(py);
+    placement.set_item("code", collection.placement().code())?;
+    placement.set_item("version", collection.placement().version())?;
+    output.set_item("placement", placement)?;
+    let indexes = PyList::empty(py);
+    for index in collection.indexes() {
+        indexes.append(index_to_python(py, index, uuid_representation, bson_types)?)?;
+    }
+    output.set_item("indexes", indexes)?;
+    Ok(output.into_any().unbind())
+}
+
+fn index_to_python(
+    py: Python<'_>,
+    index: &DocumentIndexMetadata,
+    uuid_representation: PythonUuidRepresentation,
+    bson_types: &PythonBsonOutputTypes,
+) -> PyResult<Py<PyAny>> {
+    let output = PyDict::new(py);
+    output.set_item("name", index.name())?;
+    let keys = if index.is_built_in() {
+        match index.specification().get_first("key") {
+            Some(BsonValue::Document(keys)) => keys,
+            _ => index.specification(),
+        }
+    } else {
+        index.specification()
+    };
+    output.set_item(
+        "keys",
+        bson_document_to_python(py, keys, uuid_representation, bson_types)?,
+    )?;
+    output.set_item("unique", index.is_unique())?;
+    output.set_item("built_in", index.is_built_in())?;
+    let lifecycle = match index.lifecycle() {
+        DocumentIndexLifecycle::Ready => "ready",
+        DocumentIndexLifecycle::PendingBuild => "pending_build",
+        _ => {
+            return Err(crate::error::unsupported(
+                "this document index lifecycle is unknown to the current Python API",
+            ));
+        }
+    };
+    output.set_item("lifecycle", lifecycle)?;
+    Ok(output.into_any().unbind())
+}

--- a/python/src/error.rs
+++ b/python/src/error.rs
@@ -1,5 +1,6 @@
 use std::{panic::AssertUnwindSafe, sync::PoisonError};
 
+use briskdb::document::{BsonError, BsonErrorContext};
 use briskdb::{EngineError, EngineErrorKind};
 use pyo3::{create_exception, exceptions::PyException, marker::Ungil, prelude::*, types::PyModule};
 
@@ -97,7 +98,7 @@ impl From<NativeError> for PyErr {
     }
 }
 
-fn engine_error_to_python(error: EngineError) -> PyErr {
+pub(crate) fn engine_error_to_python(error: EngineError) -> PyErr {
     let diagnostic = error.diagnostic().to_owned();
     match error.kind() {
         EngineErrorKind::InvalidArgument => InvalidArgumentError::new_err(diagnostic),
@@ -143,6 +144,18 @@ where
 
 pub(crate) fn invalid_value(message: impl Into<String>) -> PyErr {
     InvalidArgumentError::new_err(message.into())
+}
+
+pub(crate) fn invalid_text_encoding(message: impl Into<String>) -> PyErr {
+    InvalidTextEncodingError::new_err(message.into())
+}
+
+pub(crate) fn limit_exceeded(message: impl Into<String>) -> PyErr {
+    LimitExceededError::new_err(message.into())
+}
+
+pub(crate) fn bson_error_to_python(error: BsonError) -> PyErr {
+    engine_error_to_python(error.into_engine_error(BsonErrorContext::ClientInput))
 }
 
 pub(crate) fn numeric_out_of_range(message: impl Into<String>) -> PyErr {

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,3 +1,5 @@
+mod bson;
+mod document_api;
 mod error;
 mod value;
 
@@ -8,11 +10,19 @@ use std::{
     time::Duration,
 };
 
+use briskdb::document::{
+    DocumentCollectionOptions, DocumentCommand, DocumentCountRequest,
+    DocumentCreateCollectionRequest, DocumentCreateIndexRequest, DocumentDeleteRequest,
+    DocumentFilter, DocumentFindRequest, DocumentIndexRequest, DocumentInsertRequest,
+    DocumentListCollectionsRequest, DocumentListIndexesRequest, DocumentMutationScope,
+    DocumentNamespace, DocumentReadOptions, DocumentRequest, DocumentRequestId,
+    DocumentWriteOptions,
+};
 use briskdb::{
     BriskCursor, BriskDb, BriskSession, BriskTransaction,
-    CancellationToken as EngineCancellationToken, CheckpointReport, Column, EngineOptions,
-    EngineState, EngineStatus, PreparedStatementLimits, RequestContext, ResultLimits, SessionState,
-    Statement, TransactionExecution, Value,
+    CancellationToken as EngineCancellationToken, CheckpointReport, Column, DocumentSupport,
+    EngineOptions, EngineState, EngineStatus, PreparedStatementLimits, RequestContext,
+    ResultLimits, SessionState, Statement, TransactionExecution, Value,
     protocol::postgres::SecurityConfig as PostgresSecurityConfig,
     server::{AttachedServer, ListenerAddresses, ListenerConfig},
 };
@@ -23,6 +33,11 @@ use pyo3::{
 use tokio::runtime::{Builder as RuntimeBuilder, Runtime};
 
 use crate::{
+    bson::{
+        PythonUuidRepresentation, ensure_bson_available, extract_bson_document, extract_request_id,
+        parse_uuid_representation,
+    },
+    document_api::execution_to_python as document_execution_to_python,
     error::{NativeError, NativeResult, listener_error, run_native},
     value::{
         data_type_name, extract_params, logical_result_to_python, routed_result_to_python,
@@ -84,6 +99,7 @@ struct DatabaseShared {
     runtime: Arc<RuntimeOwner>,
     root: PathBuf,
     config: Config,
+    uuid_representation: PythonUuidRepresentation,
 }
 
 impl DatabaseShared {
@@ -114,6 +130,8 @@ impl Drop for DatabaseShared {
 #[derive(Clone, Debug)]
 struct Config {
     shards: Option<u16>,
+    documents: bool,
+    uuid_representation: String,
     connections_per_shard: usize,
     queue_capacity_per_shard: usize,
     max_result_rows: u64,
@@ -129,6 +147,8 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             shards: None,
+            documents: false,
+            uuid_representation: "standard".to_owned(),
             connections_per_shard: briskdb::core::DEFAULT_CONNECTIONS_PER_SHARD,
             queue_capacity_per_shard: briskdb::core::DEFAULT_QUEUE_CAPACITY_PER_SHARD,
             max_result_rows: briskdb::core::DEFAULT_MAX_RESULT_ROWS,
@@ -172,6 +192,8 @@ impl Config {
     #[pyo3(signature = (
         *,
         shards = None,
+        documents = false,
+        uuid_representation = "standard",
         connections_per_shard = briskdb::core::DEFAULT_CONNECTIONS_PER_SHARD,
         queue_capacity_per_shard = briskdb::core::DEFAULT_QUEUE_CAPACITY_PER_SHARD,
         max_result_rows = briskdb::core::DEFAULT_MAX_RESULT_ROWS,
@@ -185,6 +207,8 @@ impl Config {
     #[allow(clippy::too_many_arguments)]
     fn new(
         shards: Option<u16>,
+        documents: bool,
+        uuid_representation: &str,
         connections_per_shard: usize,
         queue_capacity_per_shard: usize,
         max_result_rows: u64,
@@ -197,6 +221,8 @@ impl Config {
     ) -> PyResult<Self> {
         let config = Self {
             shards,
+            documents,
+            uuid_representation: uuid_representation.to_owned(),
             connections_per_shard,
             queue_capacity_per_shard,
             max_result_rows,
@@ -208,6 +234,7 @@ impl Config {
             shutdown_grace_ms,
         };
         config.engine_options()?;
+        parse_uuid_representation(&config.uuid_representation)?;
         Ok(config)
     }
 
@@ -216,8 +243,11 @@ impl Config {
             .shards
             .map_or_else(|| "None".to_owned(), |shards| shards.to_string());
         format!(
-            "Config(shards={shards}, connections_per_shard={}, queue_capacity_per_shard={})",
-            self.connections_per_shard, self.queue_capacity_per_shard
+            "Config(shards={shards}, documents={}, uuid_representation={:?}, connections_per_shard={}, queue_capacity_per_shard={})",
+            self.documents,
+            self.uuid_representation,
+            self.connections_per_shard,
+            self.queue_capacity_per_shard
         )
     }
 }
@@ -449,6 +479,8 @@ impl Cursor {
 struct SessionShared {
     session: Mutex<Option<BriskSession>>,
     runtime: Arc<RuntimeOwner>,
+    documents: bool,
+    uuid_representation: PythonUuidRepresentation,
 }
 
 impl SessionShared {
@@ -658,6 +690,7 @@ struct Database {
 
 impl Database {
     fn create(py: Python<'_>, root: PathBuf, config: Config) -> PyResult<Self> {
+        let uuid_representation = parse_uuid_representation(&config.uuid_representation)?;
         run_native(py, move || {
             let engine_options = config.engine_options()?;
             let runtime = RuntimeBuilder::new_multi_thread()
@@ -665,7 +698,13 @@ impl Database {
                 .thread_name("briskdb-python")
                 .build()
                 .map_err(|error| NativeError::Runtime(error.to_string()))?;
-            let builder = BriskDb::builder(&root).with_engine_options(engine_options);
+            let builder = BriskDb::builder(&root)
+                .with_engine_options(engine_options)
+                .with_document_support(if config.documents {
+                    DocumentSupport::Enabled
+                } else {
+                    DocumentSupport::Disabled
+                });
             let builder = match config.shards {
                 Some(shards) => builder.with_shard_count(shards),
                 None => builder,
@@ -681,6 +720,7 @@ impl Database {
                     runtime,
                     root,
                     config,
+                    uuid_representation,
                 }),
             })
         })
@@ -690,14 +730,16 @@ impl Database {
 #[pymethods]
 impl Database {
     #[new]
-    #[pyo3(signature = (path, *, shards = None, config = None))]
+    #[pyo3(signature = (path, *, shards = None, documents = false, uuid_representation = None, config = None))]
     fn new(
         py: Python<'_>,
         path: PathBuf,
         shards: Option<u16>,
+        documents: bool,
+        uuid_representation: Option<&str>,
         config: Option<PyRef<'_, Config>>,
     ) -> PyResult<Self> {
-        let config = resolve_config(shards, config.as_deref())?;
+        let config = resolve_config(shards, documents, uuid_representation, config.as_deref())?;
         Self::create(py, path, config)
     }
 
@@ -757,6 +799,8 @@ impl Database {
                 shared: Arc::new(SessionShared {
                     session: Mutex::new(Some(session)),
                     runtime: Arc::clone(&shared.runtime),
+                    documents: shared.config.documents,
+                    uuid_representation: shared.uuid_representation,
                 }),
             })
         })
@@ -1020,6 +1064,49 @@ struct Session {
     shared: Arc<SessionShared>,
 }
 
+impl Session {
+    fn require_document_support(&self) -> PyResult<()> {
+        if !self.shared.documents {
+            return python_engine_result(Err(briskdb::EngineError::new(
+                briskdb::EngineErrorKind::FailedPrecondition,
+                "native document support is disabled for this embedded database",
+            )));
+        }
+        self.shared.session().map(|_| ()).map_err(PyErr::from)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn execute_document_command(
+        &self,
+        py: Python<'_>,
+        command: DocumentCommand,
+        request_id: Option<Py<PyAny>>,
+        timeout_ms: Option<u64>,
+        cancellation: Option<&CancellationToken>,
+        max_result_rows: Option<u64>,
+        max_result_bytes: Option<u64>,
+    ) -> PyResult<Py<PyAny>> {
+        self.require_document_support()?;
+        // Resolve the optional dependency and retain the exact output
+        // constructors before engine execution. This keeps module-level type
+        // replacement while the GIL is released from changing result lookup
+        // after a mutation commits.
+        let bson_types = ensure_bson_available(py)?;
+        let request_id = python_document_request_id(py, request_id.as_ref())?;
+        let context =
+            document_request_context(timeout_ms, cancellation, max_result_rows, max_result_bytes)?;
+        let uuid_representation = self.shared.uuid_representation;
+        let shared = Arc::clone(&self.shared);
+        let execution = run_native(py, move || {
+            let session = shared.session()?;
+            Ok(shared.runtime.runtime.block_on(
+                session.execute_document(DocumentRequest::new(request_id, context, command)),
+            )?)
+        })?;
+        document_execution_to_python(py, execution, uuid_representation, &bson_types)
+    }
+}
+
 #[pymethods]
 impl Session {
     #[getter]
@@ -1217,6 +1304,377 @@ impl Session {
         ))
     }
 
+    #[pyo3(signature = (
+        database,
+        collection,
+        *,
+        options = None,
+        request_id = None,
+        timeout_ms = None,
+        cancellation = None,
+        max_result_rows = None,
+        max_result_bytes = None,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn create_collection(
+        &self,
+        py: Python<'_>,
+        database: String,
+        collection: String,
+        options: Option<Py<PyAny>>,
+        request_id: Option<Py<PyAny>>,
+        timeout_ms: Option<u64>,
+        cancellation: Option<PyRef<'_, CancellationToken>>,
+        max_result_rows: Option<u64>,
+        max_result_bytes: Option<u64>,
+    ) -> PyResult<Py<PyAny>> {
+        self.require_document_support()?;
+        let representation = self.shared.uuid_representation;
+        let options = match options {
+            Some(options) => DocumentCollectionOptions::new(extract_bson_document(
+                py,
+                options.bind(py),
+                representation,
+            )?),
+            None => Ok(DocumentCollectionOptions::empty()),
+        };
+        let command = DocumentCommand::CreateCollection(DocumentCreateCollectionRequest::new(
+            python_engine_result(DocumentNamespace::new(database, collection))?,
+            python_engine_result(options)?,
+            DocumentWriteOptions::new(),
+        ));
+        self.execute_document_command(
+            py,
+            command,
+            request_id,
+            timeout_ms,
+            cancellation.as_deref(),
+            max_result_rows,
+            max_result_bytes,
+        )
+    }
+
+    #[pyo3(signature = (
+        database,
+        *,
+        skip = 0,
+        limit = None,
+        batch_size = 101,
+        request_id = None,
+        timeout_ms = None,
+        cancellation = None,
+        max_result_rows = None,
+        max_result_bytes = None,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn list_collections(
+        &self,
+        py: Python<'_>,
+        database: String,
+        skip: u64,
+        limit: Option<u64>,
+        batch_size: u64,
+        request_id: Option<Py<PyAny>>,
+        timeout_ms: Option<u64>,
+        cancellation: Option<PyRef<'_, CancellationToken>>,
+        max_result_rows: Option<u64>,
+        max_result_bytes: Option<u64>,
+    ) -> PyResult<Py<PyAny>> {
+        self.require_document_support()?;
+        let command = DocumentCommand::ListCollections(python_engine_result(
+            DocumentListCollectionsRequest::new(
+                database,
+                document_read_options(skip, limit, batch_size)?,
+            ),
+        )?);
+        self.execute_document_command(
+            py,
+            command,
+            request_id,
+            timeout_ms,
+            cancellation.as_deref(),
+            max_result_rows,
+            max_result_bytes,
+        )
+    }
+
+    #[pyo3(signature = (
+        database,
+        collection,
+        keys,
+        *,
+        name,
+        unique = false,
+        request_id = None,
+        timeout_ms = None,
+        cancellation = None,
+        max_result_rows = None,
+        max_result_bytes = None,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn create_index(
+        &self,
+        py: Python<'_>,
+        database: String,
+        collection: String,
+        keys: Py<PyAny>,
+        name: String,
+        unique: bool,
+        request_id: Option<Py<PyAny>>,
+        timeout_ms: Option<u64>,
+        cancellation: Option<PyRef<'_, CancellationToken>>,
+        max_result_rows: Option<u64>,
+        max_result_bytes: Option<u64>,
+    ) -> PyResult<Py<PyAny>> {
+        self.require_document_support()?;
+        let namespace = python_engine_result(DocumentNamespace::new(database, collection))?;
+        let keys = extract_bson_document(py, keys.bind(py), self.shared.uuid_representation)?;
+        let index = python_engine_result(DocumentIndexRequest::new(keys))?;
+        let index = python_engine_result(index.with_name(name))?.with_unique(unique);
+        let command = DocumentCommand::CreateIndex(DocumentCreateIndexRequest::new(
+            namespace,
+            index,
+            DocumentWriteOptions::new(),
+        ));
+        self.execute_document_command(
+            py,
+            command,
+            request_id,
+            timeout_ms,
+            cancellation.as_deref(),
+            max_result_rows,
+            max_result_bytes,
+        )
+    }
+
+    #[pyo3(signature = (
+        database,
+        collection,
+        *,
+        skip = 0,
+        limit = None,
+        batch_size = 101,
+        request_id = None,
+        timeout_ms = None,
+        cancellation = None,
+        max_result_rows = None,
+        max_result_bytes = None,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn list_indexes(
+        &self,
+        py: Python<'_>,
+        database: String,
+        collection: String,
+        skip: u64,
+        limit: Option<u64>,
+        batch_size: u64,
+        request_id: Option<Py<PyAny>>,
+        timeout_ms: Option<u64>,
+        cancellation: Option<PyRef<'_, CancellationToken>>,
+        max_result_rows: Option<u64>,
+        max_result_bytes: Option<u64>,
+    ) -> PyResult<Py<PyAny>> {
+        self.require_document_support()?;
+        let command = DocumentCommand::ListIndexes(DocumentListIndexesRequest::new(
+            python_engine_result(DocumentNamespace::new(database, collection))?,
+            document_read_options(skip, limit, batch_size)?,
+        ));
+        self.execute_document_command(
+            py,
+            command,
+            request_id,
+            timeout_ms,
+            cancellation.as_deref(),
+            max_result_rows,
+            max_result_bytes,
+        )
+    }
+
+    #[pyo3(signature = (
+        database,
+        collection,
+        document,
+        *,
+        request_id = None,
+        timeout_ms = None,
+        cancellation = None,
+        max_result_rows = None,
+        max_result_bytes = None,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn insert_one(
+        &self,
+        py: Python<'_>,
+        database: String,
+        collection: String,
+        document: Py<PyAny>,
+        request_id: Option<Py<PyAny>>,
+        timeout_ms: Option<u64>,
+        cancellation: Option<PyRef<'_, CancellationToken>>,
+        max_result_rows: Option<u64>,
+        max_result_bytes: Option<u64>,
+    ) -> PyResult<Py<PyAny>> {
+        self.require_document_support()?;
+        let document =
+            extract_bson_document(py, document.bind(py), self.shared.uuid_representation)?;
+        let request = python_engine_result(DocumentInsertRequest::new(
+            python_engine_result(DocumentNamespace::new(database, collection))?,
+            [document],
+            DocumentWriteOptions::new(),
+        ))?;
+        self.execute_document_command(
+            py,
+            DocumentCommand::Insert(request),
+            request_id,
+            timeout_ms,
+            cancellation.as_deref(),
+            max_result_rows,
+            max_result_bytes,
+        )
+    }
+
+    #[pyo3(signature = (
+        database,
+        collection,
+        filter = None,
+        *,
+        skip = 0,
+        limit = None,
+        batch_size = 101,
+        request_id = None,
+        timeout_ms = None,
+        cancellation = None,
+        max_result_rows = None,
+        max_result_bytes = None,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn find(
+        &self,
+        py: Python<'_>,
+        database: String,
+        collection: String,
+        filter: Option<Py<PyAny>>,
+        skip: u64,
+        limit: Option<u64>,
+        batch_size: u64,
+        request_id: Option<Py<PyAny>>,
+        timeout_ms: Option<u64>,
+        cancellation: Option<PyRef<'_, CancellationToken>>,
+        max_result_rows: Option<u64>,
+        max_result_bytes: Option<u64>,
+    ) -> PyResult<Py<PyAny>> {
+        self.require_document_support()?;
+        let filter = document_filter(py, filter.as_ref(), self.shared.uuid_representation)?;
+        let request = DocumentFindRequest::new(
+            python_engine_result(DocumentNamespace::new(database, collection))?,
+            filter,
+            document_read_options(skip, limit, batch_size)?,
+        );
+        self.execute_document_command(
+            py,
+            DocumentCommand::Find(request),
+            request_id,
+            timeout_ms,
+            cancellation.as_deref(),
+            max_result_rows,
+            max_result_bytes,
+        )
+    }
+
+    #[pyo3(signature = (
+        database,
+        collection,
+        filter = None,
+        *,
+        skip = 0,
+        limit = None,
+        request_id = None,
+        timeout_ms = None,
+        cancellation = None,
+        max_result_rows = None,
+        max_result_bytes = None,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn count_documents(
+        &self,
+        py: Python<'_>,
+        database: String,
+        collection: String,
+        filter: Option<Py<PyAny>>,
+        skip: u64,
+        limit: Option<u64>,
+        request_id: Option<Py<PyAny>>,
+        timeout_ms: Option<u64>,
+        cancellation: Option<PyRef<'_, CancellationToken>>,
+        max_result_rows: Option<u64>,
+        max_result_bytes: Option<u64>,
+    ) -> PyResult<Py<PyAny>> {
+        self.require_document_support()?;
+        let filter = document_filter(py, filter.as_ref(), self.shared.uuid_representation)?;
+        let request = DocumentCountRequest::new(
+            python_engine_result(DocumentNamespace::new(database, collection))?,
+            filter,
+            document_read_options(skip, limit, briskdb::document::DEFAULT_DOCUMENT_BATCH_SIZE)?,
+        );
+        self.execute_document_command(
+            py,
+            DocumentCommand::Count(request),
+            request_id,
+            timeout_ms,
+            cancellation.as_deref(),
+            max_result_rows,
+            max_result_bytes,
+        )
+    }
+
+    #[pyo3(signature = (
+        database,
+        collection,
+        filter,
+        *,
+        request_id = None,
+        timeout_ms = None,
+        cancellation = None,
+        max_result_rows = None,
+        max_result_bytes = None,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn delete_one(
+        &self,
+        py: Python<'_>,
+        database: String,
+        collection: String,
+        filter: Py<PyAny>,
+        request_id: Option<Py<PyAny>>,
+        timeout_ms: Option<u64>,
+        cancellation: Option<PyRef<'_, CancellationToken>>,
+        max_result_rows: Option<u64>,
+        max_result_bytes: Option<u64>,
+    ) -> PyResult<Py<PyAny>> {
+        self.require_document_support()?;
+        let filter = DocumentFilter::new(extract_bson_document(
+            py,
+            filter.bind(py),
+            self.shared.uuid_representation,
+        )?);
+        let request = DocumentDeleteRequest::new(
+            python_engine_result(DocumentNamespace::new(database, collection))?,
+            python_engine_result(filter)?,
+            DocumentMutationScope::One,
+            DocumentWriteOptions::new(),
+        );
+        self.execute_document_command(
+            py,
+            DocumentCommand::Delete(request),
+            request_id,
+            timeout_ms,
+            cancellation.as_deref(),
+            max_result_rows,
+            max_result_bytes,
+        )
+    }
+
     fn status(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let shared = Arc::clone(&self.shared);
         let status = run_native(py, move || {
@@ -1258,33 +1716,49 @@ impl Session {
     }
 }
 
-#[pyfunction(name = "open", signature = (path, *, shards = None, config = None))]
+#[pyfunction(name = "open", signature = (path, *, shards = None, documents = false, uuid_representation = None, config = None))]
 fn open_database(
     py: Python<'_>,
     path: PathBuf,
     shards: Option<u16>,
+    documents: bool,
+    uuid_representation: Option<&str>,
     config: Option<PyRef<'_, Config>>,
 ) -> PyResult<Database> {
-    let config = resolve_config(shards, config.as_deref())?;
+    let config = resolve_config(shards, documents, uuid_representation, config.as_deref())?;
     Database::create(py, path, config)
 }
 
-fn resolve_config(shards: Option<u16>, config: Option<&Config>) -> PyResult<Config> {
-    match (shards, config) {
-        (Some(_), Some(_)) => Err(crate::error::invalid_value(
-            "pass either shards or config to open a database, not both",
-        )),
-        (Some(shards), None) => {
-            let config = Config {
-                shards: Some(shards),
-                ..Config::default()
-            };
-            config.engine_options()?;
-            Ok(config)
-        }
-        (None, Some(config)) => Ok(config.clone()),
-        (None, None) => Ok(Config::default()),
+fn resolve_config(
+    shards: Option<u16>,
+    documents: bool,
+    uuid_representation: Option<&str>,
+    config: Option<&Config>,
+) -> PyResult<Config> {
+    if let Some(uuid_representation) = uuid_representation {
+        parse_uuid_representation(uuid_representation)?;
     }
+    if let Some(config) = config {
+        if shards.is_some() {
+            return Err(crate::error::invalid_value(
+                "pass either shards or config to open a database, not both",
+            ));
+        }
+        if documents || uuid_representation.is_some() {
+            return Err(crate::error::invalid_value(
+                "pass document options through either direct open options or config, not both",
+            ));
+        }
+        return Ok(config.clone());
+    }
+    let config = Config {
+        shards,
+        documents,
+        uuid_representation: uuid_representation.unwrap_or("standard").to_owned(),
+        ..Config::default()
+    };
+    config.engine_options()?;
+    Ok(config)
 }
 
 fn parse_listener_address(value: &str, label: &str) -> PyResult<SocketAddr> {
@@ -1320,6 +1794,71 @@ fn request_context(
             .map_err(PyErr::from),
         None => Ok(context),
     }
+}
+
+fn document_request_context(
+    timeout_ms: Option<u64>,
+    cancellation: Option<&CancellationToken>,
+    max_result_rows: Option<u64>,
+    max_result_bytes: Option<u64>,
+) -> PyResult<RequestContext> {
+    let mut context = request_context(timeout_ms, cancellation)?;
+    if max_result_rows.is_some() || max_result_bytes.is_some() {
+        let limits = ResultLimits::new(
+            max_result_rows.unwrap_or(briskdb::core::MAX_RESULT_ROWS),
+            max_result_bytes.unwrap_or(briskdb::core::MAX_RESULT_BYTES),
+        );
+        context = context.with_result_limits(python_engine_result(limits)?);
+    }
+    Ok(context)
+}
+
+fn python_document_request_id(
+    py: Python<'_>,
+    request_id: Option<&Py<PyAny>>,
+) -> PyResult<DocumentRequestId> {
+    match request_id {
+        Some(request_id) => extract_request_id(request_id.bind(py)),
+        None => {
+            let generated = py.import("uuid")?.getattr("uuid4")?.call0()?;
+            extract_request_id(&generated)
+        }
+    }
+}
+
+fn document_filter(
+    py: Python<'_>,
+    filter: Option<&Py<PyAny>>,
+    uuid_representation: PythonUuidRepresentation,
+) -> PyResult<DocumentFilter> {
+    match filter {
+        Some(filter) => python_engine_result(DocumentFilter::new(extract_bson_document(
+            py,
+            filter.bind(py),
+            uuid_representation,
+        )?)),
+        None => Ok(DocumentFilter::empty()),
+    }
+}
+
+fn document_read_options(
+    skip: u64,
+    limit: Option<u64>,
+    batch_size: u64,
+) -> PyResult<DocumentReadOptions> {
+    let mut options = python_engine_result(
+        DocumentReadOptions::new()
+            .with_skip(skip)
+            .with_batch_size(batch_size),
+    )?;
+    if let Some(limit) = limit {
+        options = python_engine_result(options.with_limit(limit))?;
+    }
+    Ok(options)
+}
+
+fn python_engine_result<T>(result: briskdb::EngineResult<T>) -> PyResult<T> {
+    result.map_err(NativeError::from).map_err(PyErr::from)
 }
 
 fn validate_cursor_batch_size(batch_size: usize) -> PyResult<()> {

--- a/python/src/value.rs
+++ b/python/src/value.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+use briskdb::GeneratedKey;
 use briskdb::{DataType, Decimal, Executed, ResultSet, Routed, Value, WriteResult};
 use pyo3::{
     conversion::IntoPyObjectExt,
@@ -217,6 +219,65 @@ mod tests {
             assert_eq!(
                 CanonicalIndexKey::encode_values(&through_python).unwrap(),
                 CanonicalIndexKey::encode_values(&direct).unwrap()
+            );
+        });
+    }
+
+    #[test]
+    fn generated_write_keys_keep_their_column_and_typed_value() {
+        Python::initialize();
+        Python::attach(|py| {
+            let output = write_result_parts_to_python(
+                py,
+                3,
+                WriteResult::with_generated_key(
+                    1,
+                    GeneratedKey::new("event_id", Value::Int64(4_620_693_217_682_128_897)),
+                ),
+            )
+            .unwrap();
+            let output = output.bind(py).cast::<PyDict>().unwrap();
+            assert_eq!(
+                output
+                    .get_item("shard")
+                    .unwrap()
+                    .unwrap()
+                    .extract::<u16>()
+                    .unwrap(),
+                3
+            );
+            assert_eq!(
+                output
+                    .get_item("rows_affected")
+                    .unwrap()
+                    .unwrap()
+                    .extract::<usize>()
+                    .unwrap(),
+                1
+            );
+            let generated = output
+                .get_item("generated_key")
+                .unwrap()
+                .unwrap()
+                .cast_into::<PyDict>()
+                .unwrap();
+            assert_eq!(
+                generated
+                    .get_item("column")
+                    .unwrap()
+                    .unwrap()
+                    .extract::<String>()
+                    .unwrap(),
+                "event_id"
+            );
+            assert_eq!(
+                generated
+                    .get_item("value")
+                    .unwrap()
+                    .unwrap()
+                    .extract::<i64>()
+                    .unwrap(),
+                4_620_693_217_682_128_897
             );
         });
     }

--- a/python/test-requirements.txt
+++ b/python/test-requirements.txt
@@ -1,1 +1,2 @@
+pymongo==4.17.0
 psycopg[binary]==3.2.13

--- a/python/tests/test_documents.py
+++ b/python/tests/test_documents.py
@@ -1,0 +1,816 @@
+import datetime
+import decimal
+import inspect
+import math
+import random
+import struct
+import subprocess
+import sys
+import tempfile
+import unittest
+import uuid
+from collections import OrderedDict
+
+import briskdb
+from bson import (
+    BSON,
+    Binary,
+    Code,
+    DBRef,
+    Decimal128,
+    Int64,
+    MaxKey,
+    MinKey,
+    ObjectId,
+    Regex,
+    SON,
+    Timestamp,
+)
+from bson.binary import UuidRepresentation
+from bson.codec_options import CodecOptions, DatetimeConversion
+from bson.datetime_ms import DatetimeMS
+
+
+DATABASE = "app"
+COLLECTION = "values"
+UUID_VALUE = uuid.UUID("00112233-4455-6677-8899-aabbccddeeff")
+
+
+def codec_options(representation: int = UuidRepresentation.STANDARD) -> CodecOptions:
+    return CodecOptions(
+        tz_aware=True,
+        tzinfo=datetime.timezone.utc,
+        uuid_representation=representation,
+        datetime_conversion=DatetimeConversion.DATETIME_AUTO,
+    )
+
+
+def bson_bytes(
+    document: dict, representation: int = UuidRepresentation.STANDARD
+) -> bytes:
+    return BSON.encode(document, codec_options=codec_options(representation))
+
+
+class PythonDocumentApiTests(unittest.TestCase):
+    def test_native_document_signatures_match_the_typed_api(self) -> None:
+        for method_name in ("find", "list_collections", "list_indexes"):
+            with self.subTest(method=method_name):
+                signature = inspect.signature(getattr(briskdb.Session, method_name))
+                self.assertEqual(signature.parameters["batch_size"].default, 101)
+
+    def open_session(
+        self,
+        root: str,
+        *,
+        uuid_representation: str = "standard",
+        collection: str = COLLECTION,
+    ):
+        database = briskdb.open(
+            root,
+            shards=4,
+            documents=True,
+            uuid_representation=uuid_representation,
+        )
+        session = database.session()
+        session.create_collection(DATABASE, collection)
+        return database, session
+
+    def test_document_commands_share_plans_identity_and_lifecycle(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            database = briskdb.open(root, shards=4)
+            disabled = database.session()
+            with self.assertRaises(briskdb.FailedPreconditionError) as raised:
+                disabled.create_collection(DATABASE, COLLECTION)
+            self.assertEqual(raised.exception.code, "failed_precondition")
+            disabled.close()
+            database.close()
+
+            database = briskdb.open(root, documents=True)
+            session = database.session()
+            self.assertEqual(session.list_collections(DATABASE)["collections"], [])
+
+            request_id = uuid.UUID("f47ac10b-58cc-4372-a567-0e02b2c3d479")
+            created = session.create_collection(
+                DATABASE,
+                COLLECTION,
+                options=OrderedDict([("first", 1), ("second", "two")]),
+                request_id=request_id,
+            )
+            self.assertEqual(set(created), {"request_id", "plan", "kind", "collection"})
+            self.assertEqual(created["request_id"], request_id)
+            self.assertIsNone(created["plan"])
+            self.assertEqual(created["kind"], "collection")
+            collection = created["collection"]
+            self.assertEqual(collection["namespace"], "app.values")
+            self.assertEqual(list(collection["options"]), ["first", "second"])
+            self.assertEqual(collection["placement"], {"code": 1, "version": 1})
+            self.assertEqual(
+                collection["indexes"],
+                [
+                    {
+                        "name": "_id_",
+                        "keys": {"_id": 1},
+                        "unique": True,
+                        "built_in": True,
+                        "lifecycle": "ready",
+                    }
+                ],
+            )
+
+            generated_request_id = session.list_collections(DATABASE)["request_id"]
+            self.assertIsInstance(generated_request_id, uuid.UUID)
+            self.assertNotEqual(generated_request_id.int, 0)
+
+            declared = session.create_index(
+                DATABASE,
+                COLLECTION,
+                OrderedDict([("body", 1), ("rank", -1)]),
+                name="body_rank",
+                unique=True,
+            )
+            self.assertEqual(
+                set(declared),
+                {"request_id", "plan", "kind", "index_name", "lifecycle"},
+            )
+            self.assertEqual(declared["kind"], "index_name")
+            self.assertEqual(declared["index_name"], "body_rank")
+            self.assertEqual(declared["lifecycle"], "pending_build")
+            self.assertIsNone(declared["plan"])
+            indexes = session.list_indexes(DATABASE, COLLECTION)["indexes"]
+            self.assertEqual(
+                [index["name"] for index in indexes], ["_id_", "body_rank"]
+            )
+            self.assertEqual(list(indexes[1]["keys"]), ["body", "rank"])
+            self.assertTrue(indexes[1]["unique"])
+            self.assertFalse(indexes[1]["built_in"])
+            self.assertEqual(indexes[1]["lifecycle"], "pending_build")
+
+            first = OrderedDict([("_id", "first"), ("body", "one")])
+            second = OrderedDict([("_id", "second"), ("body", "two")])
+            inserted = session.insert_one(DATABASE, COLLECTION, first)
+            session.insert_one(DATABASE, COLLECTION, second)
+            self.assertEqual(inserted["kind"], "insert")
+            self.assertTrue(inserted["acknowledged"])
+            self.assertEqual(inserted["inserted_count"], 1)
+            self.assertEqual(inserted["inserted_ids"], ["first"])
+            self.assertEqual(inserted["plan"]["kind"], "point")
+            self.assertEqual(len(inserted["plan"]["shards"]), 1)
+
+            exact = session.find(DATABASE, COLLECTION, {"_id": "second"})
+            self.assertEqual(exact["documents"], [second])
+            self.assertEqual(exact["plan"]["kind"], "point")
+            self.assertEqual(
+                exact["namespace"], {"database": DATABASE, "collection": COLLECTION}
+            )
+            self.assertIsNone(exact["cursor_id"])
+            self.assertTrue(exact["exhausted"])
+
+            scatter = session.find(DATABASE, COLLECTION, limit=2, batch_size=2)
+            self.assertEqual(scatter["documents"], [first, second])
+            self.assertEqual(scatter["plan"]["kind"], "scatter")
+            self.assertEqual(scatter["plan"]["shards"], [0, 1, 2, 3])
+            count = session.count_documents(DATABASE, COLLECTION)
+            self.assertEqual(count["count"], 2)
+            self.assertEqual(count["plan"]["kind"], "scatter")
+            exact_count = session.count_documents(
+                DATABASE, COLLECTION, {"_id": "first"}
+            )
+            self.assertEqual(exact_count["count"], 1)
+            self.assertEqual(exact_count["plan"]["kind"], "point")
+
+            deleted = session.delete_one(DATABASE, COLLECTION, {"_id": "first"})
+            self.assertTrue(deleted["acknowledged"])
+            self.assertEqual(deleted["deleted_count"], 1)
+            self.assertEqual(deleted["plan"]["kind"], "point")
+            self.assertEqual(session.count_documents(DATABASE, COLLECTION)["count"], 1)
+
+            with self.assertRaisesRegex(briskdb.InvalidArgumentError, "explicit _id"):
+                session.insert_one(DATABASE, COLLECTION, {"body": "missing"})
+
+            session.close()
+            database.close()
+
+    def test_every_bson_family_round_trips_with_exact_wire_representation(self) -> None:
+        nan = struct.unpack("<d", bytes.fromhex("010000000000f87f"))[0]
+        document = OrderedDict(
+            [
+                ("_id", ObjectId("64b000000000000000000001")),
+                ("null", None),
+                ("boolean", True),
+                ("int32_min", -(2**31)),
+                ("int32_max", 2**31 - 1),
+                ("plain_int64_low", -(2**31) - 1),
+                ("plain_int64_high", 2**31),
+                ("plain_int64_min", -(2**63)),
+                ("plain_int64_max", 2**63 - 1),
+                ("int64_min", Int64(-(2**63))),
+                ("int64_max", Int64(2**63 - 1)),
+                ("forced_int64", Int64(7)),
+                ("negative_zero", -0.0),
+                ("nan", nan),
+                ("infinity", float("inf")),
+                ("text", "snowman ☃ and nul \x00"),
+                ("bytes", b"\x00\xffbytes"),
+                ("binary_zero", Binary(b"zero", 0)),
+                ("bytearray", bytearray(b"mutable")),
+                ("memoryview", memoryview(b"view")),
+                ("binary_old", Binary(b"old-binary", 2)),
+                ("binary_user", Binary(b"user", 128)),
+                ("uuid", UUID_VALUE),
+                (
+                    "binary_uuid",
+                    Binary.from_uuid(UUID_VALUE, UuidRepresentation.STANDARD),
+                ),
+                (
+                    "binary_legacy",
+                    Binary.from_uuid(UUID_VALUE, UuidRepresentation.JAVA_LEGACY),
+                ),
+                ("binary_legacy_short", Binary(b"not-a-uuid", 3)),
+                ("object_id", ObjectId("64b000000000000000000002")),
+                ("date_naive", datetime.datetime(1969, 12, 31, 23, 59, 59, 999999)),
+                (
+                    "date_offset",
+                    datetime.datetime(
+                        2024,
+                        1,
+                        2,
+                        3,
+                        4,
+                        5,
+                        678999,
+                        tzinfo=datetime.timezone(
+                            datetime.timedelta(hours=5, minutes=30)
+                        ),
+                    ),
+                ),
+                ("date_out_of_range", DatetimeMS(2**62)),
+                ("decimal", Decimal128("123456789.0012300")),
+                (
+                    "decimal_nan",
+                    Decimal128.from_bid(bytes.fromhex("01" + "00" * 14 + "7c")),
+                ),
+                (
+                    "decimal_noncanonical_zero",
+                    Decimal128.from_bid(
+                        bytes.fromhex("00000000648e8d37c087adbe09ed4130")
+                    ),
+                ),
+                ("decimal_snan", Decimal128("sNaN")),
+                ("decimal_infinity", Decimal128("-Infinity")),
+                ("regex", Regex("^a.*z$", "mi")),
+                ("timestamp", Timestamp(2**32 - 1, 2**32 - 1)),
+                ("minimum", MinKey()),
+                ("maximum", MaxKey()),
+                ("code", Code("return 1;")),
+                (
+                    "scoped_code",
+                    Code("return value;", SON([("value", Int64(2)), ("other", 1)])),
+                ),
+                ("array", [None, Int64(9), {"nested": Binary(b"x", 42)}]),
+                ("tuple", (1, Int64(2))),
+                ("ordered", SON([("z", 1), ("a", 2)])),
+            ]
+        )
+        expected_document = OrderedDict(document)
+        expected_document["bytearray"] = bytes(document["bytearray"])
+        expected_document["memoryview"] = bytes(document["memoryview"])
+
+        with tempfile.TemporaryDirectory() as root:
+            database, session = self.open_session(root)
+            inserted = session.insert_one(DATABASE, COLLECTION, document)
+            self.assertEqual(inserted["inserted_ids"], [document["_id"]])
+            returned = session.find(DATABASE, COLLECTION, {"_id": document["_id"]})[
+                "documents"
+            ][0]
+
+            self.assertEqual(bson_bytes(returned), bson_bytes(expected_document))
+            self.assertEqual(list(returned), list(document))
+            self.assertIs(type(returned["int32_min"]), int)
+            self.assertIsInstance(returned["plain_int64_low"], Int64)
+            self.assertIsInstance(returned["plain_int64_high"], Int64)
+            self.assertIsInstance(returned["plain_int64_min"], Int64)
+            self.assertIsInstance(returned["plain_int64_max"], Int64)
+            self.assertIsInstance(returned["int64_min"], Int64)
+            self.assertIsInstance(returned["forced_int64"], Int64)
+            self.assertEqual(
+                struct.pack("<d", returned["negative_zero"]),
+                struct.pack("<d", -0.0),
+            )
+            self.assertTrue(math.isnan(returned["nan"]))
+            self.assertEqual(struct.pack("<d", returned["nan"]), struct.pack("<d", nan))
+            self.assertIsInstance(returned["bytes"], bytes)
+            self.assertIs(type(returned["binary_zero"]), bytes)
+            self.assertEqual(returned["binary_zero"], b"zero")
+            self.assertIs(type(returned["bytearray"]), bytes)
+            self.assertEqual(returned["bytearray"], b"mutable")
+            self.assertIs(type(returned["memoryview"]), bytes)
+            self.assertEqual(returned["memoryview"], b"view")
+            self.assertIsInstance(returned["binary_old"], Binary)
+            self.assertEqual(returned["binary_old"].subtype, 2)
+            self.assertEqual(bytes(returned["binary_old"]), b"old-binary")
+            self.assertIsInstance(returned["binary_user"], Binary)
+            self.assertEqual(returned["binary_user"].subtype, 128)
+            self.assertEqual(returned["uuid"], UUID_VALUE)
+            self.assertEqual(returned["binary_uuid"], UUID_VALUE)
+            self.assertIsInstance(returned["binary_legacy"], Binary)
+            self.assertEqual(returned["binary_legacy"].subtype, 3)
+            self.assertIsInstance(returned["binary_legacy_short"], Binary)
+            self.assertEqual(returned["binary_legacy_short"].subtype, 3)
+            self.assertEqual(returned["decimal"].bid, document["decimal"].bid)
+            self.assertEqual(returned["decimal_nan"].bid, document["decimal_nan"].bid)
+            self.assertEqual(
+                returned["decimal_noncanonical_zero"].bid,
+                document["decimal_noncanonical_zero"].bid,
+            )
+            self.assertEqual(returned["decimal_snan"].bid, document["decimal_snan"].bid)
+            self.assertEqual(
+                returned["decimal_infinity"].bid, document["decimal_infinity"].bid
+            )
+            self.assertEqual(returned["date_naive"].tzinfo, datetime.timezone.utc)
+            self.assertEqual(
+                returned["date_naive"],
+                datetime.datetime(
+                    1969, 12, 31, 23, 59, 59, 999000, tzinfo=datetime.timezone.utc
+                ),
+            )
+            self.assertEqual(returned["date_offset"].tzinfo, datetime.timezone.utc)
+            self.assertIsInstance(returned["date_out_of_range"], DatetimeMS)
+            self.assertEqual(int(returned["date_out_of_range"]), 2**62)
+            self.assertEqual(list(returned["ordered"]), ["z", "a"])
+            self.assertEqual(returned["tuple"], [1, Int64(2)])
+            self.assertIsInstance(returned["regex"], Regex)
+            self.assertIsInstance(returned["timestamp"], Timestamp)
+            self.assertIsInstance(returned["minimum"], MinKey)
+            self.assertIsInstance(returned["maximum"], MaxKey)
+            self.assertIsInstance(returned["code"], Code)
+            self.assertIsInstance(returned["scoped_code"], Code)
+            self.assertEqual(list(returned["scoped_code"].scope), ["value", "other"])
+
+            session.close()
+            database.close()
+
+    def test_semantic_id_aliases_route_without_losing_stored_representation(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            database, session = self.open_session(root)
+
+            stored_integer_id = Int64(1)
+            session.insert_one(
+                DATABASE,
+                COLLECTION,
+                {"_id": stored_integer_id, "kind": "int64"},
+            )
+            integer_match = session.find(DATABASE, COLLECTION, {"_id": 1})
+            self.assertEqual(integer_match["plan"]["kind"], "point")
+            self.assertIsInstance(integer_match["documents"][0]["_id"], Int64)
+            self.assertEqual(integer_match["documents"][0]["_id"], 1)
+            self.assertEqual(
+                session.delete_one(DATABASE, COLLECTION, {"_id": 1})["deleted_count"],
+                1,
+            )
+
+            matching_binary = Binary.from_uuid(UUID_VALUE, UuidRepresentation.STANDARD)
+            session.insert_one(
+                DATABASE,
+                COLLECTION,
+                {"_id": UUID_VALUE, "kind": "uuid"},
+            )
+            uuid_match = session.find(DATABASE, COLLECTION, {"_id": matching_binary})
+            self.assertEqual(uuid_match["plan"]["kind"], "point")
+            self.assertEqual(uuid_match["documents"][0]["_id"], UUID_VALUE)
+            self.assertEqual(
+                session.delete_one(DATABASE, COLLECTION, {"_id": matching_binary})[
+                    "deleted_count"
+                ],
+                1,
+            )
+            session.close()
+            database.close()
+
+    def test_all_uuid_representations_match_pymongo_binary_rules(self) -> None:
+        representations = {
+            "standard": (
+                UuidRepresentation.STANDARD,
+                4,
+                "00112233445566778899aabbccddeeff",
+            ),
+            "python_legacy": (
+                UuidRepresentation.PYTHON_LEGACY,
+                3,
+                "00112233445566778899aabbccddeeff",
+            ),
+            "java_legacy": (
+                UuidRepresentation.JAVA_LEGACY,
+                3,
+                "7766554433221100ffeeddccbbaa9988",
+            ),
+            "csharp_legacy": (
+                UuidRepresentation.CSHARP_LEGACY,
+                3,
+                "33221100554477668899aabbccddeeff",
+            ),
+        }
+        for name, (
+            representation,
+            expected_subtype,
+            expected_hex,
+        ) in representations.items():
+            with (
+                self.subTest(representation=name),
+                tempfile.TemporaryDirectory() as root,
+            ):
+                database, session = self.open_session(root, uuid_representation=name)
+                matching = Binary.from_uuid(UUID_VALUE, representation)
+                self.assertEqual(matching.subtype, expected_subtype)
+                self.assertEqual(bytes(matching).hex(), expected_hex)
+                mismatch_representation = (
+                    UuidRepresentation.PYTHON_LEGACY
+                    if representation == UuidRepresentation.STANDARD
+                    else UuidRepresentation.STANDARD
+                )
+                mismatching = Binary.from_uuid(UUID_VALUE, mismatch_representation)
+                document = {
+                    "_id": name,
+                    "native": UUID_VALUE,
+                    "matching_binary": matching,
+                    "mismatching_binary": mismatching,
+                }
+                session.insert_one(DATABASE, COLLECTION, document)
+                returned = session.find(DATABASE, COLLECTION, {"_id": name})[
+                    "documents"
+                ][0]
+                self.assertEqual(returned["native"], UUID_VALUE)
+                self.assertEqual(returned["matching_binary"], UUID_VALUE)
+                self.assertIsInstance(returned["mismatching_binary"], Binary)
+                self.assertEqual(
+                    bytes(returned["mismatching_binary"]), bytes(mismatching)
+                )
+                self.assertEqual(
+                    returned["mismatching_binary"].subtype, mismatching.subtype
+                )
+                self.assertEqual(
+                    bson_bytes(returned, representation),
+                    bson_bytes(document, representation),
+                )
+                session.close()
+                database.close()
+
+        with tempfile.TemporaryDirectory() as root:
+            database, session = self.open_session(
+                root, uuid_representation="unspecified"
+            )
+            with self.assertRaises(briskdb.UnsupportedError) as raised:
+                session.insert_one(
+                    DATABASE, COLLECTION, {"_id": "native", "uuid": UUID_VALUE}
+                )
+            self.assertEqual(raised.exception.code, "unsupported")
+
+            standard = Binary.from_uuid(UUID_VALUE, UuidRepresentation.STANDARD)
+            legacy = Binary.from_uuid(UUID_VALUE, UuidRepresentation.JAVA_LEGACY)
+            session.insert_one(
+                DATABASE,
+                COLLECTION,
+                {"_id": "binary", "standard": standard, "legacy": legacy},
+            )
+            returned = session.find(DATABASE, COLLECTION, {"_id": "binary"})[
+                "documents"
+            ][0]
+            self.assertIsInstance(returned["standard"], Binary)
+            self.assertIsInstance(returned["legacy"], Binary)
+            self.assertEqual(bytes(returned["standard"]), bytes(standard))
+            self.assertEqual(bytes(returned["legacy"]), bytes(legacy))
+            self.assertEqual(returned["standard"].subtype, 4)
+            self.assertEqual(returned["legacy"].subtype, 3)
+            session.close()
+            database.close()
+
+    def test_random_ordered_documents_round_trip_as_bson(self) -> None:
+        generator = random.Random(198)
+        with tempfile.TemporaryDirectory() as root:
+            database, session = self.open_session(root)
+            for index in range(40):
+                values = [
+                    None,
+                    generator.choice([True, False]),
+                    generator.randint(-(2**31), 2**31 - 1),
+                    Int64(generator.randint(-(2**63), 2**63 - 1)),
+                    struct.unpack("<d", generator.randbytes(8))[0],
+                    "".join(
+                        chr(generator.randint(0x20, 0x7E))
+                        for _ in range(generator.randint(0, 32))
+                    ),
+                    generator.randbytes(generator.randint(0, 32)),
+                    Binary(generator.randbytes(generator.randint(0, 16)), 128),
+                    ObjectId(generator.randbytes(12)),
+                    Decimal128(str(generator.randint(-(10**20), 10**20))),
+                    Timestamp(generator.randrange(2**32), generator.randrange(2**32)),
+                    Regex("item-{}".format(index), "im"),
+                    [Int64(index), SON([("b", 2), ("a", 1)])],
+                ]
+                generator.shuffle(values)
+                document = OrderedDict([("_id", "random-{}".format(index))])
+                document.update(
+                    ("value-{}".format(i), value) for i, value in enumerate(values)
+                )
+                session.insert_one(DATABASE, COLLECTION, document)
+                returned = session.find(DATABASE, COLLECTION, {"_id": document["_id"]})[
+                    "documents"
+                ][0]
+                self.assertEqual(bson_bytes(returned), bson_bytes(document))
+                self.assertEqual(list(returned), list(document))
+            session.close()
+            database.close()
+
+    def test_invalid_bson_values_fail_deterministically_and_recover(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            database, session = self.open_session(root)
+
+            for value in [-(2**63) - 1, 2**63]:
+                with (
+                    self.subTest(integer=value),
+                    self.assertRaises(briskdb.NumericOutOfRangeError) as raised,
+                ):
+                    session.insert_one(
+                        DATABASE, COLLECTION, {"_id": "integer", "value": value}
+                    )
+                self.assertEqual(raised.exception.code, "numeric_out_of_range")
+
+            cyclic = {"_id": "cyclic", "secret": "must-not-leak"}
+            cyclic["cycle"] = cyclic
+            with self.assertRaises(briskdb.InvalidArgumentError) as raised:
+                session.insert_one(DATABASE, COLLECTION, cyclic)
+            self.assertEqual(raised.exception.code, "invalid_argument")
+            self.assertNotIn("must-not-leak", str(raised.exception))
+
+            accepted_depth = {"_id": "depth-100"}
+            cursor = accepted_depth
+            for _ in range(99):
+                child = {}
+                cursor["nested"] = child
+                cursor = child
+            cursor["value"] = 1
+            session.insert_one(DATABASE, COLLECTION, accepted_depth)
+
+            deep = {"_id": "depth-101"}
+            cursor = deep
+            for _ in range(100):
+                child = {}
+                cursor["nested"] = child
+                cursor = child
+            cursor["value"] = 1
+            with self.assertRaises(briskdb.LimitExceededError) as raised:
+                session.insert_one(DATABASE, COLLECTION, deep)
+            self.assertEqual(raised.exception.code, "limit_exceeded")
+
+            code_scope = {}
+            cyclic_code = Code("return self;", code_scope)
+            code_scope["self"] = cyclic_code
+            with self.assertRaises(briskdb.InvalidArgumentError):
+                session.insert_one(
+                    DATABASE,
+                    COLLECTION,
+                    {"_id": "cyclic-code", "value": cyclic_code},
+                )
+
+            invalid_documents = [
+                ({"_id": "key", 1: "not a string"}, briskdb.TypeMismatchError),
+                ({"_id": "nul", "bad\x00key": 1}, briskdb.InvalidArgumentError),
+                (
+                    {"_id": "surrogate-value", "value": "\ud800"},
+                    briskdb.InvalidTextEncodingError,
+                ),
+                (
+                    {"_id": "surrogate-key", "\ud800": 1},
+                    briskdb.InvalidTextEncodingError,
+                ),
+                ({"_id": "set", "value": {1, 2}}, briskdb.TypeMismatchError),
+                (
+                    {"_id": "dbref", "value": DBRef("values", "private-id")},
+                    briskdb.TypeMismatchError,
+                ),
+                (
+                    {"_id": "decimal", "value": decimal.Decimal("1.25")},
+                    briskdb.TypeMismatchError,
+                ),
+                (
+                    {"_id": "regex-bytes", "value": Regex(b"bytes", 0)},
+                    briskdb.TypeMismatchError,
+                ),
+                (
+                    {"_id": "regex-flags", "value": Regex("flags", 256)},
+                    briskdb.InvalidArgumentError,
+                ),
+            ]
+            for document, error_type in invalid_documents:
+                with (
+                    self.subTest(document_id=document["_id"]),
+                    self.assertRaises(error_type),
+                ):
+                    session.insert_one(DATABASE, COLLECTION, document)
+
+            oversized = {"_id": "oversized", "value": "x" * (16 * 1024 * 1024)}
+            with self.assertRaises(briskdb.LimitExceededError):
+                session.insert_one(DATABASE, COLLECTION, oversized)
+            del oversized
+
+            class MisleadingAstralString(str):
+                def isascii(self) -> bool:
+                    return True
+
+            oversized_astral = MisleadingAstralString("😀" * (4 * 1024 * 1024))
+            with self.assertRaises(briskdb.LimitExceededError):
+                session.insert_one(
+                    DATABASE,
+                    COLLECTION,
+                    {"_id": "oversized-astral", "value": oversized_astral},
+                )
+            del oversized_astral
+
+            shared = {"child": 1}
+            valid = {"_id": "shared", "left": shared, "right": shared}
+            session.insert_one(DATABASE, COLLECTION, valid)
+            self.assertEqual(
+                session.find(DATABASE, COLLECTION, {"_id": "shared"})["documents"],
+                [{"_id": "shared", "left": {"child": 1}, "right": {"child": 1}}],
+            )
+
+            self.assertEqual(session.count_documents(DATABASE, COLLECTION)["count"], 2)
+            session.close()
+            database.close()
+
+    def test_request_controls_errors_and_reopen(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            config = briskdb.Config(
+                shards=4, documents=True, uuid_representation="standard"
+            )
+            database = briskdb.open(root, config=config)
+            self.assertTrue(database.config.documents)
+            self.assertEqual(database.config.uuid_representation, "standard")
+            session = database.session()
+            session.create_collection(DATABASE, COLLECTION)
+            session.insert_one(DATABASE, COLLECTION, {"_id": 1})
+            session.insert_one(DATABASE, COLLECTION, {"_id": 2})
+
+            token = briskdb.CancellationToken()
+            token.cancel()
+            with self.assertRaises(briskdb.CancelledError) as cancelled:
+                session.list_collections(DATABASE, cancellation=token)
+            self.assertEqual(cancelled.exception.code, "cancelled")
+
+            with self.assertRaises(briskdb.LimitExceededError):
+                session.find(DATABASE, COLLECTION, max_result_rows=1)
+            with self.assertRaises(briskdb.LimitExceededError):
+                session.count_documents(DATABASE, COLLECTION, max_result_bytes=1)
+            with self.assertRaises(briskdb.InvalidArgumentError):
+                session.find(DATABASE, COLLECTION, limit=0)
+            with self.assertRaises(briskdb.InvalidArgumentError):
+                session.find(DATABASE, COLLECTION, batch_size=0)
+            with self.assertRaises(briskdb.InvalidArgumentError):
+                session.list_collections(DATABASE, timeout_ms=0)
+            with self.assertRaises(briskdb.InvalidArgumentError):
+                session.list_collections(DATABASE, request_id=uuid.UUID(int=0))
+
+            self.assertEqual(session.count_documents(DATABASE, COLLECTION)["count"], 2)
+            session.close()
+            with self.assertRaises(briskdb.FailedPreconditionError):
+                session.list_collections(DATABASE)
+            database.close()
+
+            reopened = briskdb.open(root, documents=True)
+            reopened_session = reopened.session()
+            self.assertEqual(
+                reopened_session.count_documents(DATABASE, COLLECTION)["count"], 2
+            )
+            reopened_session.close()
+            reopened.close()
+
+        with tempfile.TemporaryDirectory() as parent:
+            invalid_root = "{}/invalid".format(parent)
+            with self.assertRaises(briskdb.InvalidArgumentError):
+                briskdb.open(
+                    invalid_root,
+                    shards=2,
+                    documents=True,
+                    uuid_representation="not-a-representation",
+                )
+            with self.assertRaisesRegex(
+                briskdb.InvalidArgumentError, "either direct open options or config"
+            ):
+                briskdb.open(
+                    invalid_root,
+                    config=briskdb.Config(shards=2, documents=True),
+                    uuid_representation="standard",
+                )
+
+    def test_sql_only_use_does_not_import_or_require_bson(self) -> None:
+        script = r"""
+import importlib.abc
+import pathlib
+import sys
+import tempfile
+
+attempts = []
+
+class BlockBson(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "bson" or fullname.startswith("bson.") or fullname == "pymongo" or fullname.startswith("pymongo."):
+            attempts.append(fullname)
+            raise ModuleNotFoundError("optional BSON dependency blocked for test")
+        return None
+
+blocker = BlockBson()
+sys.meta_path.insert(0, blocker)
+import briskdb
+
+assert attempts == [], attempts
+with tempfile.TemporaryDirectory() as parent:
+    sql_root = pathlib.Path(parent) / "sql"
+    with briskdb.open(sql_root, shards=2) as database:
+        with database.session(routing_key="sql-only") as session:
+            assert session.query("SELECT 1")["rows"] == [(1,)]
+            try:
+                session.create_collection("app", "disabled")
+            except briskdb.FailedPreconditionError as error:
+                assert error.code == "failed_precondition"
+            else:
+                raise AssertionError("disabled document support unexpectedly accepted work")
+    assert attempts == [], attempts
+
+    document_root = pathlib.Path(parent) / "documents"
+    with briskdb.open(document_root, shards=2, documents=True) as database:
+        with database.session(routing_key="sql-after-document-error") as session:
+            try:
+                session.create_collection("app", "must_not_commit")
+            except briskdb.UnsupportedError as error:
+                assert error.code == "unsupported"
+                assert error.retryable is False
+                assert str(error) == "Python document operations require the optional pymongo package"
+            else:
+                raise AssertionError("document command unexpectedly succeeded without bson")
+
+            assert session.query("SELECT 2")["rows"] == [(2,)]
+
+            sys.meta_path.remove(blocker)
+            import bson
+            assert session.list_collections("app")["collections"] == []
+assert attempts and attempts[0] == "bson", attempts
+"""
+        completed = subprocess.run(
+            [sys.executable, "-c", script],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+
+
+class AsyncPythonDocumentApiTests(unittest.IsolatedAsyncioTestCase):
+    async def test_async_document_methods_forward_values_and_controls(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            async with await briskdb.open_async(
+                root,
+                shards=4,
+                documents=True,
+                uuid_representation="java_legacy",
+            ) as database:
+                async with await database.session() as session:
+                    created = await session.create_collection(DATABASE, COLLECTION)
+                    self.assertEqual(created["kind"], "collection")
+                    inserted = await session.insert_one(
+                        DATABASE,
+                        COLLECTION,
+                        {"_id": UUID_VALUE, "body": Decimal128("1.25")},
+                    )
+                    self.assertEqual(inserted["inserted_ids"], [UUID_VALUE])
+                    found = await session.find(
+                        DATABASE, COLLECTION, {"_id": UUID_VALUE}
+                    )
+                    self.assertEqual(
+                        found["documents"][0]["body"].bid, Decimal128("1.25").bid
+                    )
+                    self.assertEqual(
+                        (await session.count_documents(DATABASE, COLLECTION))["count"],
+                        1,
+                    )
+
+                    token = briskdb.CancellationToken()
+                    token.cancel()
+                    with self.assertRaises(briskdb.CancelledError):
+                        await session.list_indexes(
+                            DATABASE, COLLECTION, cancellation=token
+                        )
+
+                    deleted = await session.delete_one(
+                        DATABASE, COLLECTION, {"_id": UUID_VALUE}
+                    )
+                    self.assertEqual(deleted["deleted_count"], 1)
+                    self.assertEqual(
+                        (await session.count_documents(DATABASE, COLLECTION))["count"],
+                        0,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/typing_contract.py
+++ b/python/tests/typing_contract.py
@@ -1,4 +1,5 @@
-from typing import List, Optional, Tuple
+from typing import List, Literal, Optional, Tuple
+from uuid import UUID
 
 import briskdb
 
@@ -18,7 +19,40 @@ def sync_contract(path: str) -> None:
     row: Optional[Tuple[object, ...]] = cursor.fetchone()
     transaction: briskdb.Transaction = database.transaction(routing_key="typed")
     outcome: str = transaction.rollback()
-    print(affected, rows, row, outcome)
+    document_database: briskdb.Database = briskdb.open(
+        path, documents=True, uuid_representation="standard"
+    )
+    document_session: briskdb.Session = document_database.session()
+    request_id = UUID("00112233-4455-6677-8899-aabbccddeeff")
+    collection_id: int = document_session.create_collection(
+        "app", "notes", request_id=request_id
+    )["collection"]["id"]
+    index_lifecycle: Literal["pending_build"] = document_session.create_index(
+        "app", "notes", {"body": 1}, name="body_1"
+    )["lifecycle"]
+    inserted: int = document_session.insert_one(
+        "app", "notes", {"_id": 1, "body": "typed"}
+    )["inserted_count"]
+    documents: List[dict[str, object]] = document_session.find(
+        "app", "notes", {"_id": 1}
+    )["documents"]
+    count: int = document_session.count_documents("app", "notes")["count"]
+    deleted: int = document_session.delete_one("app", "notes", {"_id": 1})[
+        "deleted_count"
+    ]
+    print(
+        address,
+        affected,
+        rows,
+        row,
+        outcome,
+        collection_id,
+        index_lifecycle,
+        inserted,
+        documents,
+        count,
+        deleted,
+    )
 
 
 async def async_contract(path: str) -> None:
@@ -33,4 +67,8 @@ async def async_contract(path: str) -> None:
         routing_key="typed"
     )
     outcome: str = await transaction.rollback()
-    print(address, rows, outcome)
+    created = await session.create_collection("app", "typed")
+    namespace: str = created["collection"]["namespace"]
+    await session.insert_one("app", "typed", {"_id": 1})
+    document_count: int = (await session.count_documents("app", "typed"))["count"]
+    print(address, rows, outcome, namespace, document_count)

--- a/tests/release_packaging.rs
+++ b/tests/release_packaging.rs
@@ -30,15 +30,16 @@ fn alpha_release_contract_covers_every_native_archive_and_safety_boundary() {
 
     let notes = include_str!("../RELEASE_NOTES.md");
     for required in [
-        "no authentication, authorization, or TLS",
-        "PostgreSQL extended-query protocol is unsupported",
-        "psycopg.ClientCursor",
+        "HTTP remains unauthenticated and loopback-only",
+        "general users, roles, or authorization policy",
+        "PostgreSQL supports bounded simple and parameterized text/binary extended",
+        "DDL, `COPY`, broad type coverage",
         "General cross-shard transactions are unsupported",
         "complete data-directory copy",
         "There is no stable pre-1.0 on-disk compatibility promise",
-        "manifest version 12",
+        "manifest version 14",
         "In-place downgrade is unsupported",
-        "no on-disk format change",
+        "Unknown, malformed, partially migrated, or newer layouts fail closed",
     ] {
         assert!(
             notes.contains(required),

--- a/tests/release_packaging.rs
+++ b/tests/release_packaging.rs
@@ -30,16 +30,15 @@ fn alpha_release_contract_covers_every_native_archive_and_safety_boundary() {
 
     let notes = include_str!("../RELEASE_NOTES.md");
     for required in [
-        "HTTP remains unauthenticated and loopback-only",
-        "general users, roles, or authorization policy",
-        "PostgreSQL supports bounded simple and parameterized text/binary extended",
-        "DDL, `COPY`, broad type coverage",
+        "no authentication, authorization, or TLS",
+        "PostgreSQL extended-query protocol is unsupported",
+        "psycopg.ClientCursor",
         "General cross-shard transactions are unsupported",
         "complete data-directory copy",
         "There is no stable pre-1.0 on-disk compatibility promise",
-        "manifest version 14",
+        "manifest version 12",
         "In-place downgrade is unsupported",
-        "Unknown, malformed, partially migrated, or newer layouts fail closed",
+        "no on-disk format change",
     ] {
         assert!(
             notes.contains(required),


### PR DESCRIPTION
The Python extension could execute SQL values but had no lossless BSON conversion boundary or document-command facade. This adds bounded, ordered Python↔BSON conversion and exposes the protocol-neutral document engine through synchronous and asyncio sessions while keeping PyMongo optional for SQL-only installations.

The implementation preserves BSON representation for Int64, floating-point bits, Decimal128 BID payloads, binary subtypes, ObjectId, datetime milliseconds, UUID representations, regex, timestamp, Code/scope, MinKey/MaxKey, arrays, and ordered mappings. It enforces the BSON depth, wire-size, retained-memory, cycle, text, and numeric limits before engine mutation. `documents=True` enables the eight currently executable collection/index/insert/find/count/delete methods; unsupported engine semantics remain explicit. Runtime signatures, stubs, API docs, wheel/sdist metadata, and CI now cover the same surface, including a bare install with no `bson` or PyMongo dependency.

Validation:
- Rust 1.85 all-target/all-feature suite: 1,095 library tests plus all integration, benchmark, and example targets passed
- Python installed-extension suite: 39/39 passed; focused document suite: 10/10 passed
- Native Python crate tests: 6/6 passed
- Stable Clippy with warnings denied, rustfmt, rustdoc, doctests, strict mypy for Python 3.9, and fuzz-bin compilation passed
- Fresh CPython 3.9/3.14 `cp39-abi3` wheel and sdist inspections passed with no runtime PyMongo dependency
- PyMongo 4.17/4.18 compatibility probes and randomized byte-exact BSON/Decimal128 differentials passed

Closes #198
