### PR TITLE
release: prepare 0.1.0-alpha.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "briskdb"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "briskdb-python"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.6"
 dependencies = [
  "briskdb",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 
 [package]
 name = "briskdb"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.6"
 edition = "2024"
 rust-version = "1.85"
 default-run = "briskdb"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,12 @@
-# Unreleased
+# BriskDB 0.1.0-alpha.6 — 2026-09-06
+
+Alpha 6 expands the supported PostgreSQL and embedded Python surfaces while
+keeping the same-host, local-filesystem multi-process boundary from alpha 5.
+It adds a bounded extended-query lifecycle for PostgreSQL, single-shard
+transactions, TLS/SCRAM protection for remote PostgreSQL listeners, versioned
+HTTP behavior, experimental global indexes, and an opt-in Rust and Python
+document-command slice. This remains an evaluation and development release,
+not a production claim.
 
 Mongo compatibility now has a versioned, source-locked TinyMongo v1.3.0
 contract. Its manifest inventories the supported document surface, 228 logical
@@ -82,6 +90,59 @@ that current freshness/summary inspection and write coordination are slower
 than the direct hot-cache baseline. Global indexes therefore remain explicit,
 experimental alpha functionality and are not yet recommended for
 latency-sensitive production use. See `docs/GLOBAL_INDEX_RELEASE_GATE.md`.
+
+## Install the Python package
+
+Compiler-free `cp39-abi3` wheels support CPython 3.9 through 3.14 on Linux
+x86-64/ARM64 (`manylinux_2_28`) and macOS Intel/Apple Silicon (macOS 11+):
+
+```bash
+python -m pip install briskdb==0.1.0a6
+```
+
+Each native wheel is dependency-audited and installed for the minimum and
+maximum supported Python versions before publication. The separately built
+source distribution is also installed and tested. Release automation checks
+the Rust, Python, and tag versions, distribution contents, type information,
+checksums, and build provenance before publishing.
+
+## Critical alpha boundaries
+
+- HTTP remains unauthenticated and loopback-only. PostgreSQL may bind remotely
+  only with its configured TLS and SCRAM-SHA-256 boundary; BriskDB does not yet
+  provide general users, roles, or authorization policy.
+- PostgreSQL supports bounded simple and parameterized text/binary extended
+  queries plus single-shard transactions. DDL, `COPY`, broad type coverage,
+  and general PostgreSQL session semantics remain unavailable.
+- PostgreSQL operates only on an imported or registered catalog. It does not
+  provide an online `CREATE TABLE` workflow or full PostgreSQL compatibility.
+- General cross-shard transactions are unsupported. Global ordering,
+  pagination, and aggregation pushdown are incomplete, and BriskDB does not
+  claim full SQL compatibility.
+- Backups require every server and embedder to stop first. The supported
+  procedure is a complete data-directory copy. Online backup/restore,
+  resharding, and online rebalance are unsupported.
+- Global indexes remain experimental and their release-gate measurements do
+  not establish production latency or durability claims for the database as a
+  whole.
+- The Python package does not claim DB-API 2.0 or broad MongoDB compatibility.
+  Its native document API is limited to the
+  collection/index/insert/find/count/delete engine slice: collection and index
+  metadata, `insert_one`, empty-filter or exact-`_id` `find` and
+  `count_documents`, and exact-`_id` `delete_one`. General matchers, updates,
+  aggregation, and retained document cursors remain unavailable.
+
+## Storage compatibility
+
+There is no stable pre-1.0 on-disk compatibility promise. This release writes
+manifest version 14 and accepts the exact documented legacy version-1 shape and
+manifest versions 2 through 13 for automatic, ordered forward migration.
+Unknown, malformed, partially migrated, or newer layouts fail closed.
+
+Before opening existing data, stop every process and make a complete backup as
+described in `docs/OFFLINE_BACKUP.md`. Startup may migrate the data. In-place
+downgrade is unsupported; rollback requires restoring the complete pre-upgrade
+backup. Alpha 6 changes the on-disk format from alpha 5.
 
 # BriskDB 0.1.0-alpha.5
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -423,7 +423,7 @@ requires an earlier dependency:
 4. [x] **Finish the embedded Rust API.** Make sessions, transactions,
    cancellation, concurrency, document commands, and shutdown safe for a host
    process.
-5. [ ] **Finish the Python API and wheels.** Provide matching synchronous and
+5. [x] **Finish the Python API and wheels.** Provide matching synchronous and
    asynchronous APIs, lossless values and exceptions, typing, documentation,
    and tested Linux/macOS ARM64/x86-64 wheels.
 6. [ ] **Complete HTTP administration and the data browser.** Version the API,
@@ -459,7 +459,7 @@ requires an earlier dependency:
       embedded Rust facade over protocol-neutral document commands
     - [x] [#198](https://github.com/schapman1974/briskdb/issues/198) — Python
       BSON conversions and document API
-    - [ ] [#200](https://github.com/schapman1974/briskdb/issues/200) — release
+    - [x] [#200](https://github.com/schapman1974/briskdb/issues/200) — release
       wheels and Mongo smoke coverage
 11. [ ] **Implement online resharding and rebalance.** Add durable bucket
     movement, generation-aware retries, verification, and a supported offline

--- a/docs/BSON.md
+++ b/docs/BSON.md
@@ -7,7 +7,7 @@ start a listener or add document commands by itself.
 
 ```toml
 [dependencies]
-briskdb = { version = "0.1.0-alpha.5", default-features = false, features = ["documents"] }
+briskdb = { git = "https://github.com/schapman1974/briskdb", tag = "v0.1.0-alpha.6", default-features = false, features = ["documents"] }
 ```
 
 The contract follows the source-locked TinyMongo v1.3.0 behavior recorded in

--- a/docs/CRATE_FEATURES.md
+++ b/docs/CRATE_FEATURES.md
@@ -9,14 +9,14 @@ handling dependencies:
 
 ```toml
 [dependencies]
-briskdb = { version = "0.1.0-alpha.5", default-features = false, features = ["embedded"] }
+briskdb = { git = "https://github.com/schapman1974/briskdb", tag = "v0.1.0-alpha.6", default-features = false, features = ["embedded"] }
 ```
 
 For the same facade plus native BSON/document commands:
 
 ```toml
 [dependencies]
-briskdb = { version = "0.1.0-alpha.5", default-features = false, features = ["documents"] }
+briskdb = { git = "https://github.com/schapman1974/briskdb", tag = "v0.1.0-alpha.6", default-features = false, features = ["documents"] }
 ```
 
 The `documents` feature selects `embedded`; each database handle must still be

--- a/docs/DEBIAN_INSTALL.md
+++ b/docs/DEBIAN_INSTALL.md
@@ -12,13 +12,13 @@ the checksum before installation, then install the local package:
 
 ```bash
 sha256sum --check SHA256SUMS --ignore-missing
-sudo apt install ./briskdb_0.1.0.alpha.5-1_amd64.deb
+sudo apt install ./briskdb_0.1.0.alpha.6-1_amd64.deb
 ```
 
 Use the `_arm64.deb` package on 64-bit ARM. `apt` resolves the package's runtime
 dependencies and enables and starts `briskdb.service` during installation.
 The filename uses a GitHub-safe dot, while package metadata uses the Debian
-prerelease version `0.1.0~alpha.5-1` so it sorts before the final release.
+prerelease version `0.1.0~alpha.6-1` so it sorts before the final release.
 
 ## Filesystem contract
 

--- a/docs/EMBEDDED_RUST.md
+++ b/docs/EMBEDDED_RUST.md
@@ -84,7 +84,7 @@ the feature includes the embedded facade and BSON dependencies:
 
 ```toml
 [dependencies]
-briskdb = { version = "0.1.0-alpha.5", default-features = false, features = ["documents"] }
+briskdb = { git = "https://github.com/schapman1974/briskdb", tag = "v0.1.0-alpha.6", default-features = false, features = ["documents"] }
 ```
 
 The embedded document facade must also be enabled on each database handle.

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "briskdb"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.6"
 dependencies = [
  "blake3",
  "bson",

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.1.0-alpha.6 — 2026-09-06
+
 - Added opt-in synchronous and asyncio document commands for the currently
   executable collection, index, insert, find, count, and delete engine slice.
 - Added lossless conversion for ordered mappings and PyMongo's BSON value

--- a/python/COMPATIBILITY.md
+++ b/python/COMPATIBILITY.md
@@ -31,7 +31,7 @@ and test its BSON classes on every supported wheel target.
 
 The `briskdb-python` crate version must exactly equal the root `briskdb` Rust
 crate version. Python metadata and `briskdb.__version__` use the equivalent PEP
-440 spelling (`0.1.0-alpha.5` becomes `0.1.0a5`). Release automation rejects a
+440 spelling (`0.1.0-alpha.6` becomes `0.1.0a6`). Release automation rejects a
 tag or artifact when those versions are not equivalent. A Python alpha package
 supports only its exact bundled Rust engine; mixing an extension and core from
 different releases is unsupported.

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "briskdb-python"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.6"
 edition = "2024"
 rust-version = "1.85"
 description = "Native Python bindings for embedded BriskDB"

--- a/python/PUBLISHING.md
+++ b/python/PUBLISHING.md
@@ -35,7 +35,7 @@ Verify a downloaded artifact with:
 
 ```bash
 sha256sum --check SHA256SUMS
-gh attestation verify briskdb-0.1.0a5-*.whl --repo schapman1974/briskdb
+gh attestation verify briskdb-0.1.0a6-*.whl --repo schapman1974/briskdb
 ```
 
 Do not reuse or move a release tag. Update both Cargo package versions and the

--- a/python/SERVERLESS.md
+++ b/python/SERVERLESS.md
@@ -1,7 +1,7 @@
 # Warm-handler quickstart
 
 BriskDB can run inside one long-lived function/container process because the
-Opening the Python package starts no listener or subprocess. Keep one database handle warm
+Python package starts no listener or subprocess. Keep one database handle warm
 and create one session per request:
 
 ```python

--- a/tests/debian_packaging.rs
+++ b/tests/debian_packaging.rs
@@ -44,7 +44,7 @@ fn cargo_versions_convert_to_debian_versions_without_shell_tilde_expansion() {
         env!("CARGO_MANIFEST_DIR")
     );
 
-    for (cargo_version, expected) in [("0.1.0-alpha.5", "0.1.0~alpha.5-1"), ("0.1.0", "0.1.0-1")] {
+    for (cargo_version, expected) in [("0.1.0-alpha.6", "0.1.0~alpha.6-1"), ("0.1.0", "0.1.0-1")] {
         let output = Command::new(&builder)
             .args(["--print-debian-version", cargo_version])
             .output()
@@ -54,13 +54,13 @@ fn cargo_versions_convert_to_debian_versions_without_shell_tilde_expansion() {
     }
 
     let output = Command::new(&builder)
-        .args(["--print-package-filename", "0.1.0-alpha.5"])
+        .args(["--print-package-filename", "0.1.0-alpha.6"])
         .output()
         .expect("package builder must print its external filename");
     assert!(output.status.success());
     assert_eq!(
         String::from_utf8(output.stdout).unwrap().trim(),
-        "briskdb_0.1.0.alpha.5-1_ARCH.deb"
+        "briskdb_0.1.0.alpha.6-1_ARCH.deb"
     );
 }
 

--- a/tests/release_packaging.rs
+++ b/tests/release_packaging.rs
@@ -1,6 +1,6 @@
 #[test]
 fn alpha_release_contract_covers_every_native_archive_and_safety_boundary() {
-    assert_eq!(env!("CARGO_PKG_VERSION"), "0.1.0-alpha.5");
+    assert_eq!(env!("CARGO_PKG_VERSION"), "0.1.0-alpha.6");
 
     let workflow = include_str!("../.github/workflows/release.yml");
     for required in [
@@ -29,20 +29,36 @@ fn alpha_release_contract_covers_every_native_archive_and_safety_boundary() {
     }
 
     let notes = include_str!("../RELEASE_NOTES.md");
+    let release_heading = format!("# BriskDB {}", env!("CARGO_PKG_VERSION"));
+    let current_release = notes
+        .split_once(&release_heading)
+        .unwrap_or_else(|| panic!("release notes are missing heading: {release_heading}"))
+        .1
+        .split("\n# BriskDB ")
+        .next()
+        .expect("current release section must be present");
+    let current_release = current_release
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
     for required in [
-        "no authentication, authorization, or TLS",
-        "PostgreSQL extended-query protocol is unsupported",
-        "psycopg.ClientCursor",
-        "General cross-shard transactions are unsupported",
+        "TLS and SCRAM-SHA-256",
+        "bounded simple and parameterized text/binary extended queries",
+        "single-shard transactions",
+        "native document API is limited",
+        "collection/index/insert/find/count/delete engine slice",
+        "`insert_one`",
+        "`find` and `count_documents`",
+        "`delete_one`",
         "complete data-directory copy",
         "There is no stable pre-1.0 on-disk compatibility promise",
-        "manifest version 12",
+        "manifest version 14",
+        "manifest versions 2 through 13",
         "In-place downgrade is unsupported",
-        "no on-disk format change",
     ] {
         assert!(
-            notes.contains(required),
-            "release notes are missing critical boundary: {required}"
+            current_release.contains(required),
+            "current release notes are missing critical boundary: {required}"
         );
     }
 }


### PR DESCRIPTION
Alpha 6 packages the PostgreSQL, global-index, embedded document, and Python BSON/document work added since alpha.5. It bumps the Rust and Python package versions in both lock domains, promotes the release notes and Python changelog, updates install/package contracts, preserves the published alpha.5 history, and marks the Python API/wheel roadmap milestone ready for publication.

The Rust dependency examples now use the future Git tag because the root crate is not published on crates.io. The release preparation intentionally references #200 without closing it; #200 remains open until the tagged workflow publishes and the GitHub/PyPI artifacts are verified.

Validation:
- `cargo +1.85.0 test --locked --all-targets --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- rustdoc with warnings denied and all-feature doctests
- root `cargo package --locked --allow-dirty`
- Rust/Python version parity and root/fuzz locked metadata
- release, Debian, and compatibility contract tests
- Python crate tests/check on Rust 1.85
- fresh alpha.6 sdist and macOS ARM64 ABI3 wheel content/metadata/native-library audits
- clean installed-wheel SQL and optional-PyMongo boundary
- installed-wheel Python suite: 39/39
- strict Python 3.9 typing

Refs #200
