### PR TITLE
Fix hosted global-index write gate

### DIFF
--- a/.github/workflows/global-index-release-gate.yml
+++ b/.github/workflows/global-index-release-gate.yml
@@ -101,6 +101,7 @@ jobs:
           --ignored --exact --nocapture --test-threads=1
 
       - name: Upload operator evidence
+        if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: global-index-release-gate-${{ github.run_id }}

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -89,7 +89,11 @@ and constraints while indexed hits/misses execute on one shard. It also finds
 that current freshness/summary inspection and write coordination are slower
 than the direct hot-cache baseline. Global indexes therefore remain explicit,
 experimental alpha functionality and are not yet recommended for
-latency-sensitive production use. See `docs/GLOBAL_INDEX_RELEASE_GATE.md`.
+latency-sensitive production use. The first hosted Ubuntu calibration also
+found shard-linear SQLite WAL shared-memory process output during indexed reads
+and bounded it with explicit Linux-tested alpha guardrails;
+[#293](https://github.com/schapman1974/briskdb/issues/293) tracks removing that
+connection churn. See `docs/GLOBAL_INDEX_RELEASE_GATE.md`.
 
 ## Install the Python package
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -23,12 +23,15 @@ file's `PRAGMA quick_check` before accepting timing data.
 
 Every result is a tab-separated record with attempts, successes, constraint
 failures, returned rows, visited shards, throughput, p50/p95/p99 latency,
-process CPU, peak RSS, operating-system-reported physical write bytes, peak WAL
-growth, and SQLite durability mode. `physical_write_bytes` comes from
-`getrusage`; a platform/filesystem may report zero. The harness does not invent
-an fsync count when portable syscall accounting is unavailable. It records the
-production `WAL` plus `synchronous=FULL` policy explicitly, while WAL growth
-provides a portable storage-cost signal.
+process CPU, peak RSS, operating-system-reported process block-output bytes,
+peak WAL growth, and SQLite durability mode. The historical
+`physical_write_bytes` column is `getrusage(RUSAGE_SELF).ru_oublock * 512`; it
+is not an fsync or durable-device-write count. A platform/filesystem may report
+the counter as unavailable (including zero for workloads that do write), while
+Linux can charge transient or later-deleted SQLite WAL shared-memory pages.
+The harness preserves the raw counter instead of inventing an fsync count. It
+records the production `WAL` plus `synchronous=FULL` policy explicitly, while
+WAL growth provides a separate storage-cost signal.
 
 Run the parser/budget unit test and the same short correctness smoke used by CI:
 
@@ -69,6 +72,19 @@ It records the exact engine revision, host, compiler, controls, and all 64
 results. The local SQLite secondary index makes individual child lookups cheap,
 but `indexed_hit` and `indexed_miss` still visit 2/4/10/64 shards respectively;
 future gains therefore cannot be mistaken for cache-only improvements.
+
+The first Ubuntu 24.04 release-gate run made this platform distinction
+observable. Its indexed hit/miss path charged exactly 32 KiB per configured
+shard per attempt while reporting zero WAL growth. That is consistent with
+repeated SQLite `-shm` initialization as the freshness path opened and closed
+every source shard. The hosted release comparator now applies explicit finite
+alpha caps to that counter instead of a ratio whose baseline is zero: 64 KiB
+per source shard for indexed reads and 1 MiB per indexed mutation. Point and
+scatter reads keep their zero-baseline relative guard, and WAL retains its
+existing ratios. See the
+[global-index production gate](GLOBAL_INDEX_RELEASE_GATE.md) for the run
+evidence and release decision; [#293](https://github.com/schapman1974/briskdb/issues/293)
+tracks removal of the per-query shard connection churn.
 
 Issue #239 adds an `after` mode that builds a non-unique lookup index and a
 unique constraint index before running the identical matrix. It includes the

--- a/docs/GLOBAL_INDEX_RELEASE_GATE.md
+++ b/docs/GLOBAL_INDEX_RELEASE_GATE.md
@@ -101,6 +101,34 @@ write-coordination transactions, is required before making a performance
 recommendation. The broad alpha guardrails in the harness prevent silent
 worsening; they are not performance targets.
 
+### Hosted Linux physical-output accounting
+
+The [first Ubuntu 24.04 workflow run](https://github.com/schapman1974/briskdb/actions/runs/34014711881)
+exposed a platform gap in the original Apple M1 calibration. The harness
+records the timed-operation delta of
+`getrusage(RUSAGE_SELF).ru_oublock * 512`. The M1 reports returned zero for
+every case, including mutations, while the hosted Linux result charged output
+consistent with SQLite WAL shared-memory (`-shm`) initialization.
+
+On Linux, a single-process indexed hit or miss produced exactly 32 KiB per
+configured shard per attempt, from 64 KiB at two shards to 2 MiB at 64 shards,
+with zero WAL growth. The current freshness snapshot opens and closes every
+source shard for every non-unique indexed query. Indexed mutations produced at
+most 730,016 bytes per attempt in that run. This is real connection and
+shared-memory churn even though it does not represent the same durable row or
+WAL growth measured by the separate WAL column.
+
+The hosted alpha gate therefore uses explicit finite Linux guardrails for this
+counter: 64 KiB per configured shard per indexed-read attempt and 1 MiB per
+indexed-mutation attempt. Point and scatter reads retain the same relative
+budget and gain no nonzero allowance; WAL growth retains the 4x indexed-read
+and 16x indexed-write ratios. Exact-boundary tests fail on the first byte over
+either physical-output limit. These ceilings record an explicit alpha release
+decision rather than a production target. Issue
+[#293](https://github.com/schapman1974/briskdb/issues/293) tracks removal of the
+per-query shard connection and shared-memory churn. Workflow artifacts upload
+even when enforcement fails so a rejected run retains both TSV reports.
+
 ## Run locally
 
 ```bash

--- a/tests/global_index_baseline.rs
+++ b/tests/global_index_baseline.rs
@@ -1371,10 +1371,19 @@ struct RegressionBudget {
     maximum_p99_ratio: f64,
     maximum_p99_jitter_micros: u64,
     maximum_cpu_per_attempt_ratio: f64,
-    maximum_write_bytes_per_attempt_ratio: f64,
+    physical_write_budget: PhysicalWriteBudget,
     maximum_wal_bytes_per_attempt_ratio: f64,
     maximum_rss_growth_bytes: u64,
 }
+
+#[derive(Clone, Copy)]
+enum PhysicalWriteBudget {
+    RelativeToBaseline(f64),
+    AbsolutePerAttempt(u64),
+}
+
+const INDEXED_READ_PHYSICAL_WRITE_BYTES_PER_SHARD_PER_ATTEMPT: u64 = 64 * 1024;
+const INDEXED_WRITE_PHYSICAL_WRITE_BYTES_PER_ATTEMPT: u64 = 1024 * 1024;
 
 impl RegressionBudget {
     const STABLE_HOST: Self = Self {
@@ -1382,19 +1391,9 @@ impl RegressionBudget {
         maximum_p99_ratio: 3.0,
         maximum_p99_jitter_micros: 5_000,
         maximum_cpu_per_attempt_ratio: 2.0,
-        maximum_write_bytes_per_attempt_ratio: 2.0,
+        physical_write_budget: PhysicalWriteBudget::RelativeToBaseline(2.0),
         maximum_wal_bytes_per_attempt_ratio: 2.0,
         maximum_rss_growth_bytes: 64 * 1024 * 1024,
-    };
-
-    const INDEXED_READ_ALPHA: Self = Self {
-        minimum_throughput_ratio: 0.01,
-        maximum_p99_ratio: 150.0,
-        maximum_p99_jitter_micros: 100_000,
-        maximum_cpu_per_attempt_ratio: 64.0,
-        maximum_write_bytes_per_attempt_ratio: 4.0,
-        maximum_wal_bytes_per_attempt_ratio: 4.0,
-        maximum_rss_growth_bytes: 128 * 1024 * 1024,
     };
 
     const INDEXED_WRITE_ALPHA: Self = Self {
@@ -1402,14 +1401,26 @@ impl RegressionBudget {
         maximum_p99_ratio: 160.0,
         maximum_p99_jitter_micros: 250_000,
         maximum_cpu_per_attempt_ratio: 160.0,
-        maximum_write_bytes_per_attempt_ratio: 16.0,
+        physical_write_budget: PhysicalWriteBudget::AbsolutePerAttempt(
+            INDEXED_WRITE_PHYSICAL_WRITE_BYTES_PER_ATTEMPT,
+        ),
         maximum_wal_bytes_per_attempt_ratio: 16.0,
         maximum_rss_growth_bytes: 128 * 1024 * 1024,
     };
 
-    const fn release_for(workload: Workload) -> Self {
+    const fn release_for(workload: Workload, shard_count: u16) -> Self {
         match workload {
-            Workload::IndexedHit | Workload::IndexedMiss => Self::INDEXED_READ_ALPHA,
+            Workload::IndexedHit | Workload::IndexedMiss => Self {
+                minimum_throughput_ratio: 0.01,
+                maximum_p99_ratio: 150.0,
+                maximum_p99_jitter_micros: 100_000,
+                maximum_cpu_per_attempt_ratio: 64.0,
+                physical_write_budget: PhysicalWriteBudget::AbsolutePerAttempt(
+                    INDEXED_READ_PHYSICAL_WRITE_BYTES_PER_SHARD_PER_ATTEMPT * shard_count as u64,
+                ),
+                maximum_wal_bytes_per_attempt_ratio: 4.0,
+                maximum_rss_growth_bytes: 128 * 1024 * 1024,
+            },
             Workload::Insert
             | Workload::Update
             | Workload::Delete
@@ -1437,10 +1448,15 @@ impl RegressionBudget {
         {
             failures.push("CPU per attempt".to_owned());
         }
-        if per_attempt(candidate.physical_write_bytes, candidate.attempts)
-            > per_attempt(baseline.physical_write_bytes, baseline.attempts)
-                * self.maximum_write_bytes_per_attempt_ratio
-        {
+        let candidate_physical_write_bytes =
+            per_attempt(candidate.physical_write_bytes, candidate.attempts);
+        let physical_write_limit = match self.physical_write_budget {
+            PhysicalWriteBudget::RelativeToBaseline(ratio) => {
+                per_attempt(baseline.physical_write_bytes, baseline.attempts) * ratio
+            }
+            PhysicalWriteBudget::AbsolutePerAttempt(limit) => limit as f64,
+        };
+        if candidate_physical_write_bytes > physical_write_limit {
             failures.push("physical write bytes per attempt".to_owned());
         }
         if per_attempt(candidate.peak_wal_growth_bytes, candidate.attempts)
@@ -1526,7 +1542,7 @@ fn compare_release_reports(baseline: &str, candidate: &str) -> Result<Vec<String
                 after.visited_shards
             ));
         }
-        for metric in RegressionBudget::release_for(key.2).compare(before, after) {
+        for metric in RegressionBudget::release_for(key.2, key.1).compare(before, after) {
             failures.push(format!(
                 "{} shards {} {} exceeded its explicit alpha budget: {metric}",
                 key.1,
@@ -1544,11 +1560,11 @@ fn compare_release_reports(baseline: &str, candidate: &str) -> Result<Vec<String
     );
     decisions.push("unindexed reads: stable-host 50% throughput / 3x p99 budget".to_owned());
     decisions.push(
-        "indexed reads: mandatory 1-shard hit/miss passed; measured latency is accepted only for the experimental opt-in alpha and is not a speed claim"
+        "indexed reads: mandatory 1-shard hit/miss passed; measured latency and at most 64 KiB of Linux physical-output accounting per source shard per attempt are accepted only for the experimental opt-in alpha and are not a speed claim"
             .to_owned(),
     );
     decisions.push(
-        "indexed writes: measured overhead is accepted only for the experimental opt-in alpha; 200x throughput, 160x p99/CPU, and 16x write/WAL are regression guardrails, not targets"
+        "indexed writes: measured overhead is accepted only for the experimental opt-in alpha; 200x throughput, 160x p99/CPU, 1 MiB physical output per attempt, and 16x WAL are regression guardrails, not targets"
             .to_owned(),
     );
     decisions.push(
@@ -1605,6 +1621,77 @@ fn release_comparison_requires_index_pruning_and_explicit_alpha_budgets() {
     let miss_before = "result\tsingle_process\t2\tindexed_miss\t1\t32\t32\t32\t0\t0\t64\t1000\t32000.00\t20\t30\t40\t500\t1000\t0\t0\t2\tFULL";
     let miss_after = "result\tsingle_process\t2\tindexed_miss\t1\t32\t32\t32\t0\t0\t32\t1000\t32000.00\t20\t30\t40\t500\t1000\t0\t0\t1\tFULL";
     assert!(compare_release_reports(miss_before, miss_after).is_ok());
+}
+
+#[test]
+fn release_physical_write_budgets_are_explicit_with_zero_baselines() {
+    let case = |workload, shards, physical_write_bytes| ParsedBaseline {
+        mode: RunMode::SingleProcess,
+        shards,
+        workload,
+        throughput: 1_000.0,
+        p99_micros: 100,
+        cpu_micros: 100,
+        peak_rss_bytes: 1_000,
+        physical_write_bytes,
+        peak_wal_growth_bytes: 0,
+        attempts: 1,
+        successes: 1,
+        constraints: 0,
+        returned_rows: u64::from(workload == Workload::IndexedHit),
+        visited_shards: 1,
+    };
+
+    let zero_read = case(Workload::IndexedHit, 64, 0);
+    let read_limit = INDEXED_READ_PHYSICAL_WRITE_BYTES_PER_SHARD_PER_ATTEMPT * 64;
+    assert!(
+        !RegressionBudget::release_for(Workload::IndexedHit, 64)
+            .compare(&zero_read, &case(Workload::IndexedHit, 64, read_limit))
+            .iter()
+            .any(|failure| failure == "physical write bytes per attempt")
+    );
+    assert!(
+        RegressionBudget::release_for(Workload::IndexedHit, 64)
+            .compare(&zero_read, &case(Workload::IndexedHit, 64, read_limit + 1))
+            .iter()
+            .any(|failure| failure == "physical write bytes per attempt")
+    );
+
+    let zero_write = case(Workload::Insert, 2, 0);
+    assert!(
+        !RegressionBudget::release_for(Workload::Insert, 2)
+            .compare(
+                &zero_write,
+                &case(
+                    Workload::Insert,
+                    2,
+                    INDEXED_WRITE_PHYSICAL_WRITE_BYTES_PER_ATTEMPT
+                )
+            )
+            .iter()
+            .any(|failure| failure == "physical write bytes per attempt")
+    );
+    assert!(
+        RegressionBudget::release_for(Workload::Insert, 2)
+            .compare(
+                &zero_write,
+                &case(
+                    Workload::Insert,
+                    2,
+                    INDEXED_WRITE_PHYSICAL_WRITE_BYTES_PER_ATTEMPT + 1
+                )
+            )
+            .iter()
+            .any(|failure| failure == "physical write bytes per attempt")
+    );
+
+    let zero_point = case(Workload::PointRead, 2, 0);
+    assert!(
+        RegressionBudget::release_for(Workload::PointRead, 2)
+            .compare(&zero_point, &case(Workload::PointRead, 2, 1))
+            .iter()
+            .any(|failure| failure == "physical write bytes per attempt")
+    );
 }
 
 #[test]


### PR DESCRIPTION
The first Ubuntu run of the global-index release gate exposed a zero-baseline bug in its physical-output comparison: the Apple M1 calibration recorded zero for every case, while Linux charged repeated SQLite WAL `-shm` initialization and indexed-write output to `ru_oublock`. The comparator rejected every nonzero indexed read and most mutations even though all correctness, routing, throughput, latency, CPU, WAL, and RSS checks passed.

This replaces that unusable ratio with finite workload-specific alpha limits: 64 KiB per configured shard for indexed reads and 1 MiB per indexed mutation. Point/scatter reads retain their zero-baseline relative guard, WAL keeps its existing ratios, and exact-boundary tests reject the first byte over each limit. The workflow now uploads evidence even after a comparison failure. The docs record the Linux counter semantics, the observed 32 KiB/shard churn, the 730,016-byte mutation maximum, and the explicit experimental-alpha decision; #293 tracks removing the underlying per-query connection churn.

Validation:
- `cargo test --locked --all-targets --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --test global_index_baseline`
- `cargo test --locked --test release_packaging`
- exact 128-row Ubuntu run 34014711881 replayed through the revised release comparator
- one-byte-over rejection independently verified
- `cargo fmt --all -- --check`
- `git diff --check`
- workflow YAML and changed Markdown links validated

Refs #292
