### PR TITLE
Bound global-index write tail latency

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -84,6 +84,16 @@ restore test covering reservations, value sequences, outboxes, watermarks, and
 summaries. Dedicated fault, clock, disk-full, crash-boundary, and mixed
 multi-process soak suites run through a manual GitHub workflow.
 
+Indexed writes continue to omit unchanged non-unique outbox events and now also
+omit summary and unique-snapshot mutations when a captured update leaves every
+canonical index key and row locator unchanged.
+Unique snapshot publication validates the existing ordered prefix and appends
+only a new suffix, while deletions and middle/key/locator changes retain the
+full rebuild fallback. This removes repeated whole-shard snapshot rewrites from
+append-heavy inserts. Unchanged unique indexes receive a compare-first coherence
+check that starts no global write transaction when clean and repairs markerless
+snapshot-only crash residue when stale, preserving recovery and rollback.
+
 The same-host 2/4/10/64-shard before/after matrix confirms identical results
 and constraints while indexed hits/misses execute on one shard. It also finds
 that current freshness/summary inspection and write coordination are slower

--- a/docs/GLOBAL_INDEX_AUTHORITY.md
+++ b/docs/GLOBAL_INDEX_AUTHORITY.md
@@ -44,6 +44,19 @@ an event for a rolled-back row. Fenced asynchronous consumers now apply those
 events and publish durable per-shard freshness watermarks; see
 [asynchronous global indexes](GLOBAL_INDEX_ASYNC.md).
 
+The write planner compares each captured row's old and new canonical index key
+and stable locator. A payload-only update still performs the orphan probe shown
+above and checks every touched unchanged unique snapshot against a frozen source
+scan. A coherent check starts no global write transaction; a mismatch left by a
+markerless crash is repaired before the new shard write commits. The update does
+not rewrite shard summaries or enqueue an outbox event. When a unique snapshot
+does change, the publisher streams and validates its existing rows against one
+frozen source scan. An exact prefix is extended with only the new suffix; a
+deletion, middle insertion, key change, or locator change falls back to a bounded
+second scan and full snapshot rebuild. Publication and repair writes remain
+inside immediate global transactions, so a failed write never exposes a partial
+snapshot.
+
 ## Transactional non-unique outbox
 
 ```mermaid

--- a/src/storage/global_index.rs
+++ b/src/storage/global_index.rs
@@ -397,6 +397,20 @@ struct SourceEntry {
 }
 
 #[derive(Debug)]
+struct SnapshotEntry {
+    source_ordinal: u64,
+    encoded_key: Vec<u8>,
+    source_locator: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SnapshotRefresh {
+    Unchanged,
+    Appended(u64),
+    Rebuilt,
+}
+
+#[derive(Debug)]
 struct PhysicalEntry {
     source_shard: u16,
     source_ordinal: u64,
@@ -1427,6 +1441,161 @@ pub(super) fn refresh_unique_write_indexes(
     transaction.commit().map_err(sqlite_error::storage)
 }
 
+/// Repair snapshot-only unique-index changes left behind when a writer dies
+/// after committing its shard transaction but before refreshing global
+/// storage. Coherent checkpoints return without starting a global write
+/// transaction; only observed mismatches enter the serialized repair path.
+pub(super) fn repair_stale_unique_write_snapshots(
+    storage: &Storage,
+    index_ids: &[GlobalIndexId],
+    shard: u16,
+    cancellation: &CancellationToken,
+) -> EngineResult<usize> {
+    if index_ids.is_empty() {
+        return Ok(0);
+    }
+    ensure_authority_not_cancelled(cancellation, "before checking indexed write snapshots")?;
+    if shard >= storage.shard_count() {
+        return Err(EngineError::new(
+            EngineErrorKind::InvalidArgument,
+            format!(
+                "global-index snapshot shard {shard} is outside 0..{}",
+                storage.shard_count()
+            ),
+        ));
+    }
+    let (mut connection, _) = open_existing(&storage.root)?
+        .ok_or_else(|| corrupt("ready global index has no physical storage"))?;
+    let mut stale = Vec::new();
+    let mut seen = HashSet::new();
+    for index_id in index_ids {
+        if !seen.insert(*index_id) {
+            continue;
+        }
+        ensure_authority_not_cancelled(cancellation, "while checking indexed write snapshots")?;
+        let index = ready_unique_write_index(storage, *index_id)?;
+        validate_physical_authority(&connection, index, storage.shard_count())?;
+        if !source_snapshot_matches(storage, &connection, index, shard, cancellation)? {
+            stale.push(*index_id);
+        }
+    }
+    ensure_authority_not_cancelled(cancellation, "after checking indexed write snapshots")?;
+    if stale.is_empty() {
+        return Ok(0);
+    }
+
+    ensure_authority_not_cancelled(cancellation, "before repairing indexed write snapshots")?;
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error::storage)?;
+    for index_id in &stale {
+        let index = ready_unique_write_index(storage, *index_id)?;
+        validate_physical_authority(&transaction, index, storage.shard_count())?;
+        refresh_unique_shard_snapshot(storage, &transaction, index, shard, cancellation)?;
+    }
+    ensure_authority_not_cancelled(cancellation, "before committing indexed snapshot repairs")?;
+    transaction.commit().map_err(sqlite_error::storage)?;
+    Ok(stale.len())
+}
+
+fn ready_unique_write_index(
+    storage: &Storage,
+    index_id: GlobalIndexId,
+) -> EngineResult<&GlobalIndexMetadata> {
+    let index = storage
+        .catalog
+        .logical()
+        .global_index_by_id(index_id)
+        .ok_or_else(|| corrupt("indexed write references a missing global index"))?;
+    if !index.is_unique() || index.lifecycle() != GlobalIndexLifecycle::Ready {
+        return Err(EngineError::new(
+            EngineErrorKind::FailedPrecondition,
+            format!(
+                "global index {} is not ready for authoritative snapshot maintenance",
+                index.id()
+            ),
+        ));
+    }
+    Ok(index)
+}
+
+fn source_snapshot_matches(
+    storage: &Storage,
+    connection: &Connection,
+    index: &GlobalIndexMetadata,
+    shard: u16,
+    cancellation: &CancellationToken,
+) -> EngineResult<bool> {
+    let checkpoint = connection
+        .query_row(
+            "SELECT source_digest, indexed_rows, unique_rows
+             FROM briskdb_global_index_checkpoints
+             WHERE index_id = ?1 AND source_shard = ?2",
+            params![to_sqlite_id(index.id())?, i64::from(shard)],
+            |row| {
+                Ok((
+                    row.get::<_, Vec<u8>>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, i64>(2)?,
+                ))
+            },
+        )
+        .optional()
+        .map_err(sqlite_error::storage)?;
+    let Some((digest, indexed_rows, unique_rows)) = checkpoint else {
+        return Ok(false);
+    };
+    let source_digest: [u8; 32] = digest
+        .try_into()
+        .map_err(|_| corrupt("global-index checkpoint has an invalid source digest"))?;
+    let mut statement = connection
+        .prepare(
+            "SELECT source_ordinal, encoded_key, source_locator
+             FROM briskdb_global_index_entries
+             WHERE index_id = ?1 AND source_shard = ?2
+             ORDER BY source_ordinal",
+        )
+        .map_err(sqlite_error::storage)?;
+    let mut stored = statement
+        .query(params![to_sqlite_id(index.id())?, i64::from(shard)])
+        .map_err(sqlite_error::storage)?;
+    let mut entries_match = true;
+    let observed = scan_source_shard_with_visitor(
+        storage,
+        index,
+        shard,
+        cancellation,
+        |source_ordinal, source| {
+            ensure_authority_not_cancelled(
+                cancellation,
+                "while checking an indexed write snapshot",
+            )?;
+            if !entries_match {
+                return Ok(());
+            }
+            let entry = stored
+                .next()
+                .map_err(sqlite_error::storage)?
+                .map(read_snapshot_entry)
+                .transpose()?;
+            entries_match = entry.is_some_and(|entry| {
+                entry.source_ordinal == source_ordinal
+                    && entry.encoded_key.as_slice() == source.encoded_key.as_bytes()
+                    && entry.source_locator == source.encoded_locator
+            });
+            Ok(())
+        },
+    )?;
+    if entries_match {
+        ensure_authority_not_cancelled(cancellation, "while checking an indexed write snapshot")?;
+        entries_match = stored.next().map_err(sqlite_error::storage)?.is_none();
+    }
+    Ok(entries_match
+        && source_digest == observed.source_digest
+        && from_sqlite_u64(indexed_rows, "checkpoint row count")? == observed.indexed_rows
+        && from_sqlite_u64(unique_rows, "checkpoint unique row count")? == observed.unique_rows)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum OrphanedUniqueWriteDecision {
     Finalize,
@@ -2163,11 +2332,11 @@ fn validate_physical_build_complete(
 }
 
 pub(super) fn validate_physical_authority(
-    transaction: &Transaction<'_>,
+    connection: &Connection,
     index: &GlobalIndexMetadata,
     shard_count: u16,
 ) -> EngineResult<()> {
-    let build = transaction
+    let build = connection
         .query_row(
             "SELECT definition_digest, schema_generation, shard_count, build_state
              FROM briskdb_global_index_builds WHERE index_id = ?1",
@@ -4213,6 +4382,119 @@ fn refresh_unique_shard_snapshot(
     shard: u16,
     cancellation: &CancellationToken,
 ) -> EngineResult<()> {
+    refresh_unique_shard_snapshot_with_scan(transaction, index, shard, cancellation, |visitor| {
+        scan_source_shard_with_visitor(storage, index, shard, cancellation, visitor)
+    })?;
+    Ok(())
+}
+
+fn refresh_unique_shard_snapshot_with_scan<S>(
+    transaction: &Transaction<'_>,
+    index: &GlobalIndexMetadata,
+    shard: u16,
+    cancellation: &CancellationToken,
+    mut scan: S,
+) -> EngineResult<SnapshotRefresh>
+where
+    S: FnMut(&mut dyn FnMut(u64, &SourceEntry) -> EngineResult<()>) -> EngineResult<ScanOutcome>,
+{
+    let mut statement = transaction
+        .prepare(
+            "SELECT source_ordinal, encoded_key, source_locator
+             FROM briskdb_global_index_entries
+             WHERE index_id = ?1 AND source_shard = ?2
+             ORDER BY source_ordinal",
+        )
+        .map_err(sqlite_error::storage)?;
+    let mut current = statement
+        .query(params![to_sqlite_id(index.id())?, i64::from(shard)])
+        .map_err(sqlite_error::storage)?;
+    let mut stored_exhausted = false;
+    let mut mismatch = false;
+    let mut appended = 0_u64;
+    // Keep comparison streaming and the target untouched until the stored
+    // cursor is exhausted. A non-append mutation intentionally pays for a
+    // second frozen source scan so fallback remains bounded in memory.
+    let outcome = scan(&mut |source_ordinal, entry| {
+        ensure_authority_not_cancelled(
+            cancellation,
+            "while validating an indexed write snapshot prefix",
+        )?;
+        if mismatch {
+            return Ok(());
+        }
+        if !stored_exhausted {
+            let stored = current
+                .next()
+                .map_err(sqlite_error::storage)?
+                .map(read_snapshot_entry)
+                .transpose()?;
+            if let Some(stored) = stored {
+                if stored.source_ordinal != source_ordinal
+                    || stored.encoded_key.as_slice() != entry.encoded_key.as_bytes()
+                    || stored.source_locator != entry.encoded_locator
+                {
+                    mismatch = true;
+                }
+                return Ok(());
+            }
+            stored_exhausted = true;
+        }
+        insert_snapshot_entry(transaction, index, shard, source_ordinal, entry)?;
+        appended = appended.checked_add(1).ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::NumericOutOfRange,
+                "global-index appended row count overflowed",
+            )
+        })?;
+        Ok(())
+    })?;
+    if !mismatch && !stored_exhausted {
+        ensure_authority_not_cancelled(
+            cancellation,
+            "while validating an indexed write snapshot prefix",
+        )?;
+        mismatch = current.next().map_err(sqlite_error::storage)?.is_some();
+    }
+    drop(current);
+    drop(statement);
+    let refresh = if !mismatch {
+        if appended == 0 {
+            SnapshotRefresh::Unchanged
+        } else {
+            SnapshotRefresh::Appended(appended)
+        }
+    } else {
+        debug_assert_eq!(appended, 0);
+        rebuild_unique_shard_snapshot(transaction, index, shard, cancellation, &mut scan)?;
+        return Ok(SnapshotRefresh::Rebuilt);
+    };
+    write_refreshed_checkpoint(transaction, index.id(), shard, &outcome)?;
+    update_build_indexed_rows(transaction, index.id())?;
+    Ok(refresh)
+}
+
+fn read_snapshot_entry(row: &rusqlite::Row<'_>) -> EngineResult<SnapshotEntry> {
+    Ok(SnapshotEntry {
+        source_ordinal: from_sqlite_u64(
+            row.get::<_, i64>(0).map_err(sqlite_error::storage)?,
+            "global-index source ordinal",
+        )?,
+        encoded_key: row.get(1).map_err(sqlite_error::storage)?,
+        source_locator: row.get(2).map_err(sqlite_error::storage)?,
+    })
+}
+
+fn rebuild_unique_shard_snapshot<S>(
+    transaction: &Transaction<'_>,
+    index: &GlobalIndexMetadata,
+    shard: u16,
+    cancellation: &CancellationToken,
+    scan: &mut S,
+) -> EngineResult<()>
+where
+    S: FnMut(&mut dyn FnMut(u64, &SourceEntry) -> EngineResult<()>) -> EngineResult<ScanOutcome>,
+{
     transaction
         .execute(
             "DELETE FROM briskdb_global_index_entries
@@ -4227,29 +4509,61 @@ fn refresh_unique_shard_snapshot(
             params![to_sqlite_id(index.id())?, i64::from(shard)],
         )
         .map_err(sqlite_error::storage)?;
-    let outcome = scan_source_shard_with_visitor(
-        storage,
-        index,
-        shard,
-        cancellation,
-        |source_ordinal, entry| {
-            insert_snapshot_entry(transaction, index, shard, source_ordinal, entry)
-        },
-    )?;
+    let outcome = scan(&mut |source_ordinal, entry| {
+        ensure_authority_not_cancelled(cancellation, "while rebuilding an indexed write snapshot")?;
+        insert_snapshot_entry(transaction, index, shard, source_ordinal, entry)
+    })?;
     write_checkpoint(transaction, index.id(), shard, &outcome)?;
+    update_build_indexed_rows(transaction, index.id())
+}
+
+fn write_refreshed_checkpoint(
+    transaction: &Transaction<'_>,
+    index_id: GlobalIndexId,
+    shard: u16,
+    outcome: &ScanOutcome,
+) -> EngineResult<()> {
+    transaction
+        .execute(
+            "INSERT INTO briskdb_global_index_checkpoints (
+                 index_id, source_shard, source_digest, indexed_rows, unique_rows
+             ) VALUES (?1, ?2, ?3, ?4, ?5)
+             ON CONFLICT (index_id, source_shard) DO UPDATE SET
+                 source_digest = excluded.source_digest,
+                 indexed_rows = excluded.indexed_rows,
+                 unique_rows = excluded.unique_rows
+             WHERE source_digest != excluded.source_digest
+                OR indexed_rows != excluded.indexed_rows
+                OR unique_rows != excluded.unique_rows",
+            params![
+                to_sqlite_id(index_id)?,
+                i64::from(shard),
+                outcome.source_digest.as_slice(),
+                to_sqlite_u64(outcome.indexed_rows, "checkpoint row count")?,
+                to_sqlite_u64(outcome.unique_rows, "checkpoint unique row count")?,
+            ],
+        )
+        .map_err(sqlite_error::storage)?;
+    Ok(())
+}
+
+fn update_build_indexed_rows(
+    transaction: &Transaction<'_>,
+    index_id: GlobalIndexId,
+) -> EngineResult<()> {
     let indexed_rows = transaction
         .query_row(
             "SELECT COALESCE(SUM(indexed_rows), 0)
              FROM briskdb_global_index_checkpoints WHERE index_id = ?1",
-            [to_sqlite_id(index.id())?],
+            [to_sqlite_id(index_id)?],
             |row| row.get::<_, i64>(0),
         )
         .map_err(sqlite_error::storage)?;
     transaction
         .execute(
             "UPDATE briskdb_global_index_builds SET indexed_rows = ?1
-             WHERE index_id = ?2 AND build_state = ?3",
-            params![indexed_rows, to_sqlite_id(index.id())?, COMPLETE],
+             WHERE index_id = ?2 AND build_state = ?3 AND indexed_rows != ?1",
+            params![indexed_rows, to_sqlite_id(index_id)?, COMPLETE],
         )
         .map_err(sqlite_error::storage)?;
     Ok(())
@@ -5376,6 +5690,94 @@ mod tests {
         )
     }
 
+    fn snapshot_source_entry(label: &str, locator: i64, reserves_unique_key: bool) -> SourceEntry {
+        let value = IndexKeyValue::Text(label.to_owned());
+        let encoded_key = CanonicalIndexKey::encode(&[IndexKeyPart::ascending(value.as_ref())])
+            .expect("encode snapshot test key");
+        SourceEntry {
+            encoded_key,
+            encoded_locator: encode_locator(&[ValueRef::Integer(locator)])
+                .expect("encode snapshot test locator"),
+            reserves_unique_key,
+        }
+    }
+
+    fn scan_snapshot_entries(
+        index: &GlobalIndexMetadata,
+        shard: u16,
+        entries: &[SourceEntry],
+        visitor: &mut dyn FnMut(u64, &SourceEntry) -> EngineResult<()>,
+    ) -> EngineResult<ScanOutcome> {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(SOURCE_DIGEST_DOMAIN);
+        hasher.update(&index.id().get().to_le_bytes());
+        hasher.update(&shard.to_le_bytes());
+        let mut unique_rows = 0_u64;
+        for (source_ordinal, entry) in entries.iter().enumerate() {
+            update_framed(&mut hasher, entry.encoded_key.as_bytes());
+            update_framed(&mut hasher, &entry.encoded_locator);
+            visitor(source_ordinal as u64, entry)?;
+            unique_rows += u64::from(entry.reserves_unique_key);
+        }
+        Ok(ScanOutcome {
+            source_digest: *hasher.finalize().as_bytes(),
+            indexed_rows: entries.len() as u64,
+            unique_rows,
+        })
+    }
+
+    fn seed_snapshot(
+        connection: &mut Connection,
+        index: &GlobalIndexMetadata,
+        entries: &[SourceEntry],
+    ) {
+        connection.execute_batch(SCHEMA_SQL).unwrap();
+        connection
+            .execute(
+                "INSERT INTO briskdb_global_index_builds (
+                     index_id, definition_digest, schema_generation, shard_count,
+                     build_state, indexed_rows
+                 ) VALUES (?1, ?2, ?3, 2, ?4, 0)",
+                params![
+                    to_sqlite_id(index.id()).unwrap(),
+                    definition_digest(index).as_slice(),
+                    to_sqlite_u64(index.schema_generation(), "schema generation").unwrap(),
+                    COMPLETE,
+                ],
+            )
+            .unwrap();
+        let transaction = connection.transaction().unwrap();
+        let outcome = scan_snapshot_entries(index, 0, entries, &mut |ordinal, entry| {
+            insert_entry(&transaction, index, 0, ordinal, entry)
+        })
+        .unwrap();
+        write_checkpoint(&transaction, index.id(), 0, &outcome).unwrap();
+        update_build_indexed_rows(&transaction, index.id()).unwrap();
+        transaction.commit().unwrap();
+    }
+
+    fn total_changes(transaction: &Transaction<'_>) -> i64 {
+        transaction
+            .query_row("SELECT total_changes()", [], |row| row.get(0))
+            .unwrap()
+    }
+
+    fn stored_snapshot_rows(connection: &Connection) -> Vec<(i64, Vec<u8>, Vec<u8>)> {
+        let mut statement = connection
+            .prepare(
+                "SELECT source_ordinal, encoded_key, source_locator
+                 FROM briskdb_global_index_entries
+                 WHERE index_id = 1 AND source_shard = 0
+                 ORDER BY source_ordinal",
+            )
+            .unwrap();
+        statement
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+    }
+
     #[test]
     fn source_locator_encoding_is_typed_framed_and_stable() {
         let encoded = encode_locator(&[
@@ -5494,6 +5896,315 @@ mod tests {
                 )
                 .unwrap(),
             0
+        );
+    }
+
+    #[test]
+    fn append_snapshot_refresh_changes_only_the_suffix_and_metadata() {
+        let index = unique_metadata();
+        let initial = vec![
+            snapshot_source_entry("a", 1, true),
+            snapshot_source_entry("b", 2, true),
+        ];
+        let mut connection = Connection::open_in_memory().unwrap();
+        seed_snapshot(&mut connection, &index, &initial);
+        let transaction = connection.transaction().unwrap();
+        let cancellation = CancellationToken::new();
+
+        let before = total_changes(&transaction);
+        let unchanged = refresh_unique_shard_snapshot_with_scan(
+            &transaction,
+            &index,
+            0,
+            &cancellation,
+            |visitor| scan_snapshot_entries(&index, 0, &initial, visitor),
+        )
+        .unwrap();
+        assert_eq!(unchanged, SnapshotRefresh::Unchanged);
+        assert_eq!(total_changes(&transaction) - before, 0);
+
+        // This models a NULL-distinct or newly qualifying partial-index row:
+        // it belongs in the physical snapshot without changing unique authority.
+        let appended = vec![
+            snapshot_source_entry("a", 1, true),
+            snapshot_source_entry("b", 2, true),
+            snapshot_source_entry("null", 3, false),
+        ];
+        let before = total_changes(&transaction);
+        let refresh = refresh_unique_shard_snapshot_with_scan(
+            &transaction,
+            &index,
+            0,
+            &cancellation,
+            |visitor| scan_snapshot_entries(&index, 0, &appended, visitor),
+        )
+        .unwrap();
+        assert_eq!(refresh, SnapshotRefresh::Appended(1));
+        assert_eq!(
+            total_changes(&transaction) - before,
+            3,
+            "one suffix insert, one checkpoint update, and one build-count update"
+        );
+        assert_eq!(
+            transaction
+                .query_row(
+                    "SELECT COUNT(*) FROM briskdb_global_index_unique_keys WHERE index_id = 1",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            2
+        );
+        transaction.commit().unwrap();
+        assert_eq!(stored_snapshot_rows(&connection).len(), 3);
+    }
+
+    #[test]
+    fn non_append_snapshot_changes_fall_back_to_a_full_rebuild() {
+        let cases = [
+            (
+                "middle insert",
+                vec![
+                    snapshot_source_entry("a", 1, false),
+                    snapshot_source_entry("b", 2, false),
+                    snapshot_source_entry("c", 3, false),
+                ],
+                8,
+            ),
+            ("delete", vec![snapshot_source_entry("a", 1, false)], 6),
+            (
+                "key move",
+                vec![
+                    snapshot_source_entry("a", 1, false),
+                    snapshot_source_entry("moved", 3, false),
+                ],
+                6,
+            ),
+        ];
+        for (name, source, expected_changes) in cases {
+            let index = unique_metadata();
+            let initial = vec![
+                snapshot_source_entry("a", 1, false),
+                snapshot_source_entry("c", 3, false),
+            ];
+            let mut connection = Connection::open_in_memory().unwrap();
+            seed_snapshot(&mut connection, &index, &initial);
+            let transaction = connection.transaction().unwrap();
+            let mut scans = 0;
+            let before = total_changes(&transaction);
+            let refresh = refresh_unique_shard_snapshot_with_scan(
+                &transaction,
+                &index,
+                0,
+                &CancellationToken::new(),
+                |visitor| {
+                    scans += 1;
+                    scan_snapshot_entries(&index, 0, &source, visitor)
+                },
+            )
+            .unwrap();
+            assert_eq!(refresh, SnapshotRefresh::Rebuilt, "{name}");
+            assert_eq!(scans, 2, "{name}");
+            assert_eq!(
+                total_changes(&transaction) - before,
+                expected_changes,
+                "{name} made writes before fallback or outside its exact rebuild"
+            );
+            transaction.commit().unwrap();
+
+            let stored = stored_snapshot_rows(&connection);
+            assert_eq!(stored.len(), source.len(), "{name}");
+            for ((ordinal, key, locator), expected) in stored.iter().zip(&source) {
+                assert_eq!(
+                    *ordinal as usize,
+                    stored.iter().position(|row| row.0 == *ordinal).unwrap()
+                );
+                assert_eq!(key.as_slice(), expected.encoded_key.as_bytes(), "{name}");
+                assert_eq!(locator, &expected.encoded_locator, "{name}");
+            }
+        }
+    }
+
+    #[test]
+    fn appended_snapshot_rows_roll_back_with_the_authority_transaction() {
+        let index = unique_metadata();
+        let initial = vec![snapshot_source_entry("a", 1, false)];
+        let appended = [
+            snapshot_source_entry("a", 1, false),
+            snapshot_source_entry("b", 2, false),
+        ];
+        let mut connection = Connection::open_in_memory().unwrap();
+        seed_snapshot(&mut connection, &index, &initial);
+        {
+            let transaction = connection.transaction().unwrap();
+            assert_eq!(
+                refresh_unique_shard_snapshot_with_scan(
+                    &transaction,
+                    &index,
+                    0,
+                    &CancellationToken::new(),
+                    |visitor| scan_snapshot_entries(&index, 0, &appended, visitor),
+                )
+                .unwrap(),
+                SnapshotRefresh::Appended(1)
+            );
+            assert_eq!(stored_snapshot_rows(&transaction).len(), 2);
+        }
+        assert_eq!(stored_snapshot_rows(&connection).len(), 1);
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT indexed_rows FROM briskdb_global_index_builds WHERE index_id = 1",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn snapshot_prefix_scan_honors_cancellation_without_writes() {
+        let index = unique_metadata();
+        let initial = vec![snapshot_source_entry("a", 1, false)];
+        let mut connection = Connection::open_in_memory().unwrap();
+        seed_snapshot(&mut connection, &index, &initial);
+        let transaction = connection.transaction().unwrap();
+        let cancellation = CancellationToken::new();
+        assert!(cancellation.cancel());
+        let before = total_changes(&transaction);
+        let error = refresh_unique_shard_snapshot_with_scan(
+            &transaction,
+            &index,
+            0,
+            &cancellation,
+            |visitor| scan_snapshot_entries(&index, 0, &initial, visitor),
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Cancelled);
+        assert_eq!(total_changes(&transaction) - before, 0);
+    }
+
+    #[test]
+    fn snapshot_scan_error_rolls_back_an_inserted_suffix() {
+        let index = unique_metadata();
+        let initial = vec![snapshot_source_entry("a", 1, false)];
+        let appended = [
+            snapshot_source_entry("a", 1, false),
+            snapshot_source_entry("b", 2, false),
+        ];
+        let mut connection = Connection::open_in_memory().unwrap();
+        seed_snapshot(&mut connection, &index, &initial);
+        {
+            let transaction = connection.transaction().unwrap();
+            let error = refresh_unique_shard_snapshot_with_scan(
+                &transaction,
+                &index,
+                0,
+                &CancellationToken::new(),
+                |visitor| {
+                    visitor(0, &appended[0])?;
+                    visitor(1, &appended[1])?;
+                    Err(EngineError::new(
+                        EngineErrorKind::Internal,
+                        "injected source scan failure",
+                    ))
+                },
+            )
+            .unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::Internal);
+            assert_eq!(stored_snapshot_rows(&transaction).len(), 2);
+        }
+        assert_eq!(stored_snapshot_rows(&connection).len(), 1);
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT indexed_rows FROM briskdb_global_index_checkpoints
+                     WHERE index_id = 1 AND source_shard = 0",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn concurrent_snapshot_refreshes_serialize_before_extending_the_prefix() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("authority.sqlite");
+        let index = unique_metadata();
+        let initial = vec![snapshot_source_entry("a", 1, false)];
+        let mut setup = Connection::open(&path).unwrap();
+        seed_snapshot(&mut setup, &index, &initial);
+        drop(setup);
+
+        let mut first = Connection::open(&path).unwrap();
+        first
+            .busy_timeout(std::time::Duration::from_secs(5))
+            .unwrap();
+        let first_transaction = first
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .unwrap();
+        let first_source = vec![
+            snapshot_source_entry("a", 1, false),
+            snapshot_source_entry("b", 2, false),
+        ];
+        assert_eq!(
+            refresh_unique_shard_snapshot_with_scan(
+                &first_transaction,
+                &index,
+                0,
+                &CancellationToken::new(),
+                |visitor| scan_snapshot_entries(&index, 0, &first_source, visitor),
+            )
+            .unwrap(),
+            SnapshotRefresh::Appended(1)
+        );
+
+        let path_for_second = path.clone();
+        let (started_tx, started_rx) = std::sync::mpsc::sync_channel(0);
+        let second = std::thread::spawn(move || {
+            let mut connection = Connection::open(path_for_second).unwrap();
+            connection
+                .busy_timeout(std::time::Duration::from_secs(5))
+                .unwrap();
+            started_tx.send(()).unwrap();
+            let transaction = connection
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .unwrap();
+            let index = unique_metadata();
+            let source = vec![
+                snapshot_source_entry("a", 1, false),
+                snapshot_source_entry("b", 2, false),
+                snapshot_source_entry("c", 3, false),
+            ];
+            let refresh = refresh_unique_shard_snapshot_with_scan(
+                &transaction,
+                &index,
+                0,
+                &CancellationToken::new(),
+                |visitor| scan_snapshot_entries(&index, 0, &source, visitor),
+            )
+            .unwrap();
+            transaction.commit().unwrap();
+            refresh
+        });
+        started_rx.recv().unwrap();
+        first_transaction.commit().unwrap();
+        assert_eq!(second.join().unwrap(), SnapshotRefresh::Appended(1));
+
+        let connection = Connection::open(path).unwrap();
+        assert_eq!(stored_snapshot_rows(&connection).len(), 3);
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT indexed_rows FROM briskdb_global_index_builds WHERE index_id = 1",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            3
         );
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1700,6 +1700,17 @@ impl Storage {
         self.fail_closed_on_corruption(result)
     }
 
+    pub(crate) fn repair_stale_global_unique_write_snapshots(
+        &self,
+        index_ids: &[GlobalIndexId],
+        shard: u16,
+        cancellation: &crate::core::CancellationToken,
+    ) -> EngineResult<usize> {
+        let result =
+            global_index::repair_stale_unique_write_snapshots(self, index_ids, shard, cancellation);
+        self.fail_closed_on_corruption(result)
+    }
+
     pub(crate) fn global_index_read_resolution(
         &self,
         index_id: GlobalIndexId,
@@ -7263,6 +7274,30 @@ mod tests {
         (unique_id, value_id)
     }
 
+    fn setup_snapshot_only_authority_crash_root(root: &Path) -> GlobalIndexId {
+        let mut database = setup_global_index_root(root);
+        let table_id = database
+            .catalog()
+            .table("default", "events")
+            .unwrap()
+            .unwrap()
+            .id();
+        let declaration = crate::core::GlobalIndexDeclaration::new(
+            table_id,
+            "events_null_distinct_unique",
+            vec![crate::core::GlobalIndexKeyPart::new(
+                crate::core::GlobalIndexKeySource::expression("NULL").unwrap(),
+                crate::core::GlobalIndexKeyType::Binary,
+            )],
+        )
+        .unwrap()
+        .unique(crate::core::UniqueNullSemantics::Distinct)
+        .with_topology(crate::core::GlobalIndexStorageTopology::SharedSqliteV1);
+        let index_id = database.create_global_index(declaration).unwrap();
+        database.build_global_index(index_id).unwrap();
+        index_id
+    }
+
     fn authority_operation_state(root: &Path) -> Option<i64> {
         Connection::open(root.join("global-indexes/global.sqlite"))
             .unwrap()
@@ -7479,6 +7514,151 @@ mod tests {
                 })
             );
         }
+    }
+
+    #[test]
+    fn markerless_null_distinct_snapshot_crash_is_repaired_on_the_next_write() {
+        let temp = tempfile::tempdir().unwrap();
+        let index_id = setup_snapshot_only_authority_crash_root(temp.path());
+        abort_global_index_child(
+            temp.path(),
+            "authority-coordinator-write",
+            "unique-write-physical-after-commit",
+            Some(index_id),
+        );
+
+        let storage = Storage::open(temp.path(), 2).unwrap();
+        let cancellation = crate::core::CancellationToken::new();
+        assert_eq!(
+            storage.recover_global_unique_writes(&cancellation).unwrap(),
+            0,
+            "NULL-distinct snapshot changes have no unique-operation marker"
+        );
+        drop(storage);
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime
+            .block_on(async {
+                let brisk = crate::BriskDb::open(temp.path()).await?;
+                let session = brisk.session();
+                session.set_routing_key("crash-writer").await?;
+                brisk
+                    .execute_write(
+                        &session,
+                        crate::Statement::new(
+                            "UPDATE events SET payload = ?1
+                             WHERE id = 1 AND tenant_id = ?2",
+                            vec![
+                                crate::core::Value::from(vec![9_u8, 8, 7]),
+                                crate::core::Value::from("crash-writer"),
+                            ],
+                        ),
+                    )
+                    .await?;
+                EngineResult::Ok(())
+            })
+            .unwrap();
+
+        let mut database = Database::open(temp.path(), 2).unwrap();
+        let report = database.validate_global_index(index_id).unwrap();
+        assert!(report.is_valid(), "{report:?}");
+        let result = database
+            .query(
+                "crash-writer",
+                "SELECT payload FROM events WHERE id = 1 AND tenant_id = ?1",
+                &[crate::core::Value::from("crash-writer")],
+            )
+            .unwrap();
+        assert_eq!(
+            result.rows().len(),
+            1,
+            "the crashed insert must remain committed"
+        );
+        assert_eq!(
+            result.rows()[0].get(0).unwrap().as_bytes(),
+            Some(&[9_u8, 8, 7][..]),
+            "the next payload-only write must commit after repairing the stale snapshot"
+        );
+    }
+
+    #[test]
+    fn stale_snapshot_probe_skips_coherent_state_and_repairs_entry_only_divergence() {
+        let temp = tempfile::tempdir().unwrap();
+        let index_id = setup_snapshot_only_authority_crash_root(temp.path());
+        let storage = Storage::open(temp.path(), 2).unwrap();
+        let cancellation = crate::core::CancellationToken::new();
+        let shard = storage.shard_for_key(&crate::core::canonical_shard_key_bytes(
+            crate::core::CanonicalShardKeyRef::Text("crash-writer"),
+        ));
+        storage
+            .open_shard(shard)
+            .unwrap()
+            .execute(
+                "INSERT INTO events (id, tenant_id, payload) VALUES (1, ?1, X'01')",
+                ["crash-writer"],
+            )
+            .unwrap();
+        assert_eq!(
+            storage
+                .repair_stale_global_unique_write_snapshots(&[index_id], shard, &cancellation)
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            storage
+                .repair_stale_global_unique_write_snapshots(&[index_id], shard, &cancellation)
+                .unwrap(),
+            0,
+            "a coherent snapshot check must not enter the repair path"
+        );
+        let sqlite_index_id = i64::try_from(index_id.get()).unwrap();
+        let authority = Connection::open(temp.path().join("global-indexes/global.sqlite")).unwrap();
+        authority
+            .execute(
+                "UPDATE briskdb_global_index_entries SET encoded_key = X'00'
+                 WHERE index_id = ?1",
+                [sqlite_index_id],
+            )
+            .unwrap();
+        drop(authority);
+        assert_eq!(
+            storage
+                .repair_stale_global_unique_write_snapshots(&[index_id], shard, &cancellation)
+                .unwrap(),
+            1,
+            "stored entries must be compared even when checkpoint and source agree"
+        );
+
+        let authority = Connection::open(temp.path().join("global-indexes/global.sqlite")).unwrap();
+        assert_eq!(
+            authority
+                .query_row(
+                    "SELECT COUNT(*) FROM briskdb_global_index_entries WHERE index_id = ?1",
+                    [sqlite_index_id],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            authority
+                .query_row(
+                    "SELECT COUNT(*) FROM briskdb_global_index_unique_keys WHERE index_id = ?1",
+                    [sqlite_index_id],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            0
+        );
+        drop(authority);
+        drop(storage);
+
+        let mut database = Database::open(temp.path(), 2).unwrap();
+        let report = database.validate_global_index(index_id).unwrap();
+        assert!(report.is_valid(), "{report:?}");
     }
 
     const fn target_code(state: crate::core::GlobalOperationState) -> i64 {

--- a/src/storage/sharded_vtab/write.rs
+++ b/src/storage/sharded_vtab/write.rs
@@ -1,5 +1,7 @@
 //! Writable coordinator execution and one-shard transaction state.
 
+#[cfg(test)]
+use std::cell::Cell;
 use std::{
     collections::{BTreeMap, BTreeSet},
     sync::{
@@ -76,6 +78,67 @@ fn abort_at_global_write_test_boundary(boundary: &str) {
 
 #[cfg(not(test))]
 fn abort_at_global_write_test_boundary(_boundary: &str) {}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct GlobalAuthorityCallCounts {
+    unique_recoveries: usize,
+    unique_snapshot_repair_checks: usize,
+    unique_snapshot_refreshes: usize,
+}
+
+#[cfg(test)]
+thread_local! {
+    static GLOBAL_AUTHORITY_CALL_COUNTS: Cell<GlobalAuthorityCallCounts> =
+        const { Cell::new(GlobalAuthorityCallCounts {
+            unique_recoveries: 0,
+            unique_snapshot_repair_checks: 0,
+            unique_snapshot_refreshes: 0,
+        }) };
+}
+
+#[cfg(test)]
+fn reset_global_authority_call_counts() {
+    GLOBAL_AUTHORITY_CALL_COUNTS.set(GlobalAuthorityCallCounts::default());
+}
+
+#[cfg(test)]
+fn global_authority_call_counts() -> GlobalAuthorityCallCounts {
+    GLOBAL_AUTHORITY_CALL_COUNTS.get()
+}
+
+#[cfg(test)]
+fn record_global_unique_recovery_call() {
+    GLOBAL_AUTHORITY_CALL_COUNTS.with(|slot| {
+        let counts = slot.get();
+        slot.set(GlobalAuthorityCallCounts {
+            unique_recoveries: counts.unique_recoveries + 1,
+            ..counts
+        });
+    });
+}
+
+#[cfg(test)]
+fn record_global_unique_snapshot_repair_check() {
+    GLOBAL_AUTHORITY_CALL_COUNTS.with(|slot| {
+        let counts = slot.get();
+        slot.set(GlobalAuthorityCallCounts {
+            unique_snapshot_repair_checks: counts.unique_snapshot_repair_checks + 1,
+            ..counts
+        });
+    });
+}
+
+#[cfg(test)]
+fn record_global_unique_snapshot_refresh_call() {
+    GLOBAL_AUTHORITY_CALL_COUNTS.with(|slot| {
+        let counts = slot.get();
+        slot.set(GlobalAuthorityCallCounts {
+            unique_snapshot_refreshes: counts.unique_snapshot_refreshes + 1,
+            ..counts
+        });
+    });
+}
 
 #[derive(Debug, Clone)]
 struct CapturedPhysicalRow {
@@ -198,11 +261,27 @@ struct CapturedOwnerState {
     current: Option<CanonicalIndexKey>,
 }
 
-fn touched_global_unique_indexes(
+#[derive(Debug)]
+struct CapturedIndexStates {
+    unique: bool,
+    owners: BTreeMap<Vec<u8>, CapturedOwnerState>,
+}
+
+#[derive(Debug, Default, PartialEq)]
+struct GlobalIndexWriteImpact {
+    summary_additions: Vec<(GlobalIndexId, CanonicalIndexKey)>,
+    unique_snapshot_indexes: Vec<GlobalIndexId>,
+    unchanged_unique_indexes: Vec<GlobalIndexId>,
+    needs_unique_recovery: bool,
+}
+
+fn plan_global_index_write_impact(
     registry: &Registry,
+    shard: u16,
+    connection: &Connection,
     changes: &[CapturedPhysicalChange],
-) -> EngineResult<Vec<GlobalIndexId>> {
-    let mut touched = BTreeSet::new();
+) -> EngineResult<GlobalIndexWriteImpact> {
+    let mut by_index = BTreeMap::<GlobalIndexId, CapturedIndexStates>::new();
     for change in changes {
         let spec = registry.table_named(&change.table).ok_or_else(|| {
             EngineError::new(
@@ -213,14 +292,82 @@ fn touched_global_unique_indexes(
                 ),
             )
         })?;
-        touched.extend(
-            spec.global_indexes
-                .iter()
-                .filter(|index| index.metadata.is_unique())
-                .map(|index| index.metadata.id()),
-        );
+        if change
+            .old
+            .iter()
+            .chain(change.new.iter())
+            .any(|row| row.values.len() != spec.columns.len())
+        {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                format!(
+                    "physical table {} changed column count during global-index impact capture",
+                    spec.name
+                ),
+            ));
+        }
+        for index in &spec.global_indexes {
+            let index_id = index.metadata.id();
+            let unique = index.metadata.is_unique();
+            let states = &mut by_index
+                .entry(index_id)
+                .or_insert_with(|| CapturedIndexStates {
+                    unique,
+                    owners: BTreeMap::new(),
+                })
+                .owners;
+            if let Some(old) = &change.old {
+                if let Some(key) = evaluate_captured_index_key(connection, index, shard, old)? {
+                    apply_captured_old(
+                        states,
+                        captured_global_owner(spec, shard, old)?,
+                        Some(key),
+                    )?;
+                }
+            }
+            if let Some(new) = &change.new {
+                if let Some(key) = evaluate_captured_index_key(connection, index, shard, new)? {
+                    apply_captured_new(
+                        states,
+                        captured_global_owner(spec, shard, new)?,
+                        Some(key),
+                    )?;
+                }
+            }
+        }
     }
-    Ok(touched.into_iter().collect())
+    Ok(collapse_global_index_write_impact(by_index))
+}
+
+fn collapse_global_index_write_impact(
+    by_index: BTreeMap<GlobalIndexId, CapturedIndexStates>,
+) -> GlobalIndexWriteImpact {
+    let mut impact = GlobalIndexWriteImpact::default();
+    for (index_id, states) in by_index {
+        impact.needs_unique_recovery |= states.unique;
+        let mut changed = false;
+        for state in states.owners.into_values() {
+            if state.initial == state.current {
+                continue;
+            }
+            changed = true;
+            if let Some(key) = state.current {
+                impact.summary_additions.push((index_id, key));
+            }
+        }
+        if changed && states.unique {
+            impact.unique_snapshot_indexes.push(index_id);
+        } else if states.unique {
+            impact.unchanged_unique_indexes.push(index_id);
+        }
+    }
+    impact.summary_additions.sort_by(|left, right| {
+        left.0
+            .cmp(&right.0)
+            .then_with(|| left.1.as_bytes().cmp(right.1.as_bytes()))
+    });
+    impact.summary_additions.dedup();
+    impact
 }
 
 fn plan_global_unique_mutations(
@@ -578,50 +725,6 @@ fn plan_global_nonunique_outbox_events(
         }
     }
     Ok(events)
-}
-
-fn plan_global_summary_additions(
-    registry: &Registry,
-    shard: u16,
-    connection: &Connection,
-    changes: &[CapturedPhysicalChange],
-) -> EngineResult<Vec<(GlobalIndexId, CanonicalIndexKey)>> {
-    let mut additions = Vec::new();
-    for change in changes {
-        let Some(row) = change.new.as_ref() else {
-            continue;
-        };
-        let spec = registry.table_named(&change.table).ok_or_else(|| {
-            EngineError::new(
-                EngineErrorKind::DataCorruption,
-                format!(
-                    "global-index capture references unregistered physical table {}",
-                    change.table
-                ),
-            )
-        })?;
-        if row.values.len() != spec.columns.len() {
-            return Err(EngineError::new(
-                EngineErrorKind::DataCorruption,
-                format!(
-                    "physical table {} changed column count during shard-summary capture",
-                    spec.name
-                ),
-            ));
-        }
-        for index in &spec.global_indexes {
-            if let Some(key) = evaluate_captured_index_key(connection, index, shard, row)? {
-                additions.push((index.metadata.id(), key));
-            }
-        }
-    }
-    additions.sort_by(|left, right| {
-        left.0
-            .cmp(&right.0)
-            .then_with(|| left.1.as_bytes().cmp(right.1.as_bytes()))
-    });
-    additions.dedup();
-    Ok(additions)
 }
 
 fn validate_allocation_sequence_capacity(
@@ -2779,9 +2882,9 @@ impl WriteTransaction {
             return Err(cancelled_error());
         }
 
-        let summary_additions =
-            plan_global_summary_additions(registry, child.shard, &child.connection, &changes)?;
-        shard_summary::record_additions(&child.connection, &summary_additions)?;
+        let impact =
+            plan_global_index_write_impact(registry, child.shard, &child.connection, &changes)?;
+        shard_summary::record_additions(&child.connection, &impact.summary_additions)?;
 
         let outbox_events = plan_global_nonunique_outbox_events(
             registry,
@@ -2809,16 +2912,35 @@ impl WriteTransaction {
                 &outbox_events,
             )?;
         }
-        self.global_snapshot_indexes = touched_global_unique_indexes(registry, &changes)?;
+        if impact.needs_unique_recovery {
+            #[cfg(test)]
+            record_global_unique_recovery_call();
+            registry
+                .storage
+                .recover_global_unique_writes(&self.authority_cancellation)?;
+        }
+        if !impact.unchanged_unique_indexes.is_empty() {
+            #[cfg(test)]
+            record_global_unique_snapshot_repair_check();
+            registry
+                .storage
+                .repair_stale_global_unique_write_snapshots(
+                    &impact.unchanged_unique_indexes,
+                    child.shard,
+                    &self.authority_cancellation,
+                )?;
+        }
+        self.global_snapshot_indexes = impact.unique_snapshot_indexes;
         if self.global_snapshot_indexes.is_empty() {
             self.global_authority_prepared = true;
             return Ok(());
         }
-        registry
-            .storage
-            .recover_global_unique_writes(&self.authority_cancellation)?;
         let mutations =
             plan_global_unique_mutations(registry, child.shard, &child.connection, &changes)?;
+        if mutations.is_empty() {
+            self.global_authority_prepared = true;
+            return Ok(());
+        }
         let mut reservations = Vec::new();
         reservations
             .try_reserve_exact(mutations.len())
@@ -3892,12 +4014,16 @@ impl WriteTransaction {
         self.global_snapshot_indexes
             .retain(|index| !self.global_reserved_indexes.contains(index));
         self.global_reserved_indexes.clear();
-        if let Some(shard) = self.statement_shard {
-            self.authority_storage.refresh_global_unique_write_indexes(
-                &self.global_snapshot_indexes,
-                shard,
-                &completion,
-            )?;
+        if !self.global_snapshot_indexes.is_empty() {
+            if let Some(shard) = self.statement_shard {
+                #[cfg(test)]
+                record_global_unique_snapshot_refresh_call();
+                self.authority_storage.refresh_global_unique_write_indexes(
+                    &self.global_snapshot_indexes,
+                    shard,
+                    &completion,
+                )?;
+            }
         }
         self.global_snapshot_indexes.clear();
         Ok(WriteOutcome {
@@ -4013,7 +4139,189 @@ mod tests {
         thread,
     };
 
+    use crate::core::{
+        GlobalIndexDeclaration, GlobalIndexKeyPart, GlobalIndexKeySource, GlobalIndexKeyType,
+        GlobalIndexStorageTopology, ShardKeyMetadata, ShardKeyType, TableDeclaration,
+        UniqueNullSemantics,
+    };
+
     use super::*;
+
+    type SqliteRows = Vec<Vec<rusqlite::types::Value>>;
+
+    #[derive(Debug, PartialEq)]
+    struct DurableGlobalIndexState {
+        builds: SqliteRows,
+        checkpoints: SqliteRows,
+        entries: SqliteRows,
+        unique_keys: SqliteRows,
+        operations: SqliteRows,
+        unique_mutations: SqliteRows,
+        unique_reservations: SqliteRows,
+        shard_summaries: Vec<SqliteRows>,
+    }
+
+    struct IndexedWriteFixture {
+        temp: tempfile::TempDir,
+        storage: Storage,
+        index_id: GlobalIndexId,
+        tenant: String,
+        shard: u16,
+    }
+
+    impl IndexedWriteFixture {
+        fn new() -> Self {
+            let temp = tempfile::tempdir().unwrap();
+            let mut storage = Storage::open(temp.path(), 2).unwrap();
+            let mut migration = storage.begin_schema_migration().unwrap();
+            migration.wait_for_quiescence_blocking();
+            storage
+                .apply_schema_migration(
+                    "CREATE TABLE indexed_accounts (
+                         tenant_id TEXT PRIMARY KEY NOT NULL,
+                         email TEXT,
+                         active INTEGER NOT NULL,
+                         payload TEXT NOT NULL
+                     ) STRICT;",
+                    &mut migration,
+                    None,
+                )
+                .unwrap();
+            migration.publish_ready().unwrap();
+            let database_id = storage.logical_catalog().default_database().id();
+            storage
+                .register_tables(vec![
+                    TableDeclaration::sharded(
+                        database_id,
+                        "indexed_accounts",
+                        ShardKeyMetadata::new("tenant_id", ShardKeyType::Text).unwrap(),
+                    )
+                    .unwrap(),
+                ])
+                .unwrap();
+            let table_id = storage
+                .logical_catalog()
+                .table("default", "indexed_accounts")
+                .unwrap()
+                .unwrap()
+                .id();
+            let declaration = GlobalIndexDeclaration::new(
+                table_id,
+                "indexed_accounts_email_unique",
+                vec![GlobalIndexKeyPart::new(
+                    GlobalIndexKeySource::column("email").unwrap(),
+                    GlobalIndexKeyType::Text,
+                )],
+            )
+            .unwrap()
+            .unique(UniqueNullSemantics::Distinct)
+            .with_predicate("active = 1")
+            .unwrap()
+            .with_topology(GlobalIndexStorageTopology::selected_v1());
+            let index_id = storage.create_global_index(declaration).unwrap();
+            let tenant = "payload-only-tenant".to_owned();
+            let shard = storage.shard_for_key(tenant.as_bytes());
+            storage
+                .open_shard(shard)
+                .unwrap()
+                .execute(
+                    "INSERT INTO indexed_accounts
+                     (tenant_id, email, active, payload)
+                     VALUES (?1, 'same@example.test', 1, 'before')",
+                    [&tenant],
+                )
+                .unwrap();
+            storage
+                .build_global_index(index_id, &CancellationToken::new())
+                .unwrap();
+            Self {
+                temp,
+                storage,
+                index_id,
+                tenant,
+                shard,
+            }
+        }
+
+        fn durable_state(&self) -> DurableGlobalIndexState {
+            let authority =
+                Connection::open(self.temp.path().join("global-indexes/global.sqlite")).unwrap();
+            let index_id = i64::try_from(self.index_id.get()).unwrap();
+            let shard_summaries = (0..self.storage.shard_count())
+                .map(|shard| {
+                    let connection = self.storage.open_shard(shard).unwrap();
+                    sqlite_rows(
+                        &connection,
+                        "SELECT * FROM briskdb_global_index_shard_summaries
+                         WHERE index_id = ?1 ORDER BY index_id",
+                        [index_id],
+                    )
+                })
+                .collect();
+            DurableGlobalIndexState {
+                builds: sqlite_rows(
+                    &authority,
+                    "SELECT * FROM briskdb_global_index_builds
+                     WHERE index_id = ?1 ORDER BY index_id",
+                    [index_id],
+                ),
+                checkpoints: sqlite_rows(
+                    &authority,
+                    "SELECT * FROM briskdb_global_index_checkpoints
+                     WHERE index_id = ?1 ORDER BY index_id, source_shard",
+                    [index_id],
+                ),
+                entries: sqlite_rows(
+                    &authority,
+                    "SELECT * FROM briskdb_global_index_entries
+                     WHERE index_id = ?1
+                     ORDER BY index_id, encoded_key, source_shard, source_locator",
+                    [index_id],
+                ),
+                unique_keys: sqlite_rows(
+                    &authority,
+                    "SELECT * FROM briskdb_global_index_unique_keys
+                     WHERE index_id = ?1 ORDER BY index_id, encoded_key",
+                    [index_id],
+                ),
+                operations: sqlite_rows(
+                    &authority,
+                    "SELECT * FROM briskdb_global_operations ORDER BY operation_id",
+                    [],
+                ),
+                unique_mutations: sqlite_rows(
+                    &authority,
+                    "SELECT * FROM briskdb_global_unique_mutations ORDER BY operation_id",
+                    [],
+                ),
+                unique_reservations: sqlite_rows(
+                    &authority,
+                    "SELECT * FROM briskdb_global_unique_reservations
+                     ORDER BY index_id, encoded_key",
+                    [],
+                ),
+                shard_summaries,
+            }
+        }
+
+        fn coordinator(&self) -> WriteCoordinator {
+            WriteCoordinator::open(self.storage.clone()).unwrap()
+        }
+    }
+
+    fn sqlite_rows<P: Params>(connection: &Connection, sql: &str, parameters: P) -> SqliteRows {
+        let mut statement = connection.prepare(sql).unwrap();
+        let column_count = statement.column_count();
+        statement
+            .query_map(parameters, move |row| {
+                (0..column_count)
+                    .map(|column| row.get::<_, rusqlite::types::Value>(column))
+                    .collect::<rusqlite::Result<Vec<_>>>()
+            })
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap()
+    }
 
     fn write_cancellation_fixture() -> (
         Connection,
@@ -4181,6 +4489,272 @@ mod tests {
             Some((&released_key, &released_owner))
         );
         assert_eq!(planned[0].new_entry(), None);
+    }
+
+    fn captured_index_states(
+        unique: bool,
+        states: impl IntoIterator<Item = CapturedOwnerState>,
+    ) -> CapturedIndexStates {
+        CapturedIndexStates {
+            unique,
+            owners: states
+                .into_iter()
+                .map(|state| (state.owner.locator().to_vec(), state))
+                .collect(),
+        }
+    }
+
+    fn captured_owner_state(
+        owner: GlobalIndexOwner,
+        initial: Option<CanonicalIndexKey>,
+        current: Option<CanonicalIndexKey>,
+    ) -> CapturedOwnerState {
+        CapturedOwnerState {
+            owner,
+            initial,
+            current,
+        }
+    }
+
+    #[test]
+    fn unchanged_index_keys_and_owners_have_no_write_impact() {
+        let unique_id = GlobalIndexId::new(11).unwrap();
+        let nonunique_id = GlobalIndexId::new(12).unwrap();
+        let key = CanonicalIndexKey::encode_values(&[Value::from("same")]).unwrap();
+        let owner = GlobalIndexOwner::new(1, b"row".to_vec()).unwrap();
+        let mut by_index = BTreeMap::new();
+        by_index.insert(
+            unique_id,
+            captured_index_states(
+                true,
+                [captured_owner_state(
+                    owner.clone(),
+                    Some(key.clone()),
+                    Some(key.clone()),
+                )],
+            ),
+        );
+        by_index.insert(
+            nonunique_id,
+            captured_index_states(
+                false,
+                [captured_owner_state(owner, Some(key.clone()), Some(key))],
+            ),
+        );
+
+        assert_eq!(
+            collapse_global_index_write_impact(by_index),
+            GlobalIndexWriteImpact {
+                unchanged_unique_indexes: vec![unique_id],
+                needs_unique_recovery: true,
+                ..GlobalIndexWriteImpact::default()
+            }
+        );
+    }
+
+    #[test]
+    fn partial_and_null_distinct_entries_keep_required_snapshot_impacts() {
+        let excluded_id = GlobalIndexId::new(13).unwrap();
+        let included_id = GlobalIndexId::new(14).unwrap();
+        let null_distinct_id = GlobalIndexId::new(15).unwrap();
+        let included_key = CanonicalIndexKey::encode_values(&[Value::from("included")]).unwrap();
+        let null_key = CanonicalIndexKey::encode_values(&[Value::Null]).unwrap();
+        let changed_null_key =
+            CanonicalIndexKey::encode_values(&[Value::Null, Value::from("changed")]).unwrap();
+        let owner = GlobalIndexOwner::new(2, b"row".to_vec()).unwrap();
+        let mut by_index = BTreeMap::new();
+        by_index.insert(excluded_id, captured_index_states(true, []));
+        by_index.insert(
+            included_id,
+            captured_index_states(
+                true,
+                [captured_owner_state(
+                    owner.clone(),
+                    None,
+                    Some(included_key.clone()),
+                )],
+            ),
+        );
+        by_index.insert(
+            null_distinct_id,
+            captured_index_states(
+                true,
+                [captured_owner_state(
+                    owner,
+                    Some(null_key),
+                    Some(changed_null_key.clone()),
+                )],
+            ),
+        );
+
+        let impact = collapse_global_index_write_impact(by_index);
+        assert_eq!(
+            impact.summary_additions,
+            vec![
+                (included_id, included_key),
+                (null_distinct_id, changed_null_key),
+            ]
+        );
+        assert_eq!(
+            impact.unique_snapshot_indexes,
+            vec![included_id, null_distinct_id]
+        );
+        assert_eq!(impact.unchanged_unique_indexes, vec![excluded_id]);
+        assert!(impact.needs_unique_recovery);
+    }
+
+    #[test]
+    fn locator_changes_remain_index_relevant_even_when_the_key_is_unchanged() {
+        let index_id = GlobalIndexId::new(16).unwrap();
+        let key = CanonicalIndexKey::encode_values(&[Value::from("same")]).unwrap();
+        let old_owner = GlobalIndexOwner::new(3, b"old-row".to_vec()).unwrap();
+        let new_owner = GlobalIndexOwner::new(3, b"new-row".to_vec()).unwrap();
+        let mut by_index = BTreeMap::new();
+        by_index.insert(
+            index_id,
+            captured_index_states(
+                true,
+                [
+                    captured_owner_state(old_owner, Some(key.clone()), None),
+                    captured_owner_state(new_owner, None, Some(key.clone())),
+                ],
+            ),
+        );
+
+        let impact = collapse_global_index_write_impact(by_index);
+        assert_eq!(impact.summary_additions, vec![(index_id, key)]);
+        assert_eq!(impact.unique_snapshot_indexes, vec![index_id]);
+        assert!(impact.unchanged_unique_indexes.is_empty());
+        assert!(impact.needs_unique_recovery);
+    }
+
+    #[test]
+    fn multi_change_history_collapses_back_to_no_index_impact() {
+        let index_id = GlobalIndexId::new(17).unwrap();
+        let first_key = CanonicalIndexKey::encode_values(&[Value::from("first")]).unwrap();
+        let second_key = CanonicalIndexKey::encode_values(&[Value::from("second")]).unwrap();
+        let owner = GlobalIndexOwner::new(4, b"row".to_vec()).unwrap();
+        let mut owners = BTreeMap::new();
+        apply_captured_old(&mut owners, owner.clone(), Some(first_key.clone())).unwrap();
+        apply_captured_new(&mut owners, owner.clone(), Some(second_key.clone())).unwrap();
+        apply_captured_old(&mut owners, owner.clone(), Some(second_key)).unwrap();
+        apply_captured_new(&mut owners, owner, Some(first_key)).unwrap();
+        let mut by_index = BTreeMap::new();
+        by_index.insert(
+            index_id,
+            CapturedIndexStates {
+                unique: true,
+                owners,
+            },
+        );
+
+        assert_eq!(
+            collapse_global_index_write_impact(by_index),
+            GlobalIndexWriteImpact {
+                unchanged_unique_indexes: vec![index_id],
+                needs_unique_recovery: true,
+                ..GlobalIndexWriteImpact::default()
+            }
+        );
+    }
+
+    #[test]
+    fn payload_only_update_leaves_global_authority_and_summary_bytes_unchanged() {
+        let fixture = IndexedWriteFixture::new();
+        let before = fixture.durable_state();
+        let mut coordinator = fixture.coordinator();
+        reset_global_authority_call_counts();
+
+        let result = coordinator
+            .execute_dml(
+                "UPDATE indexed_accounts SET payload = 'after'
+                 WHERE tenant_id = ?1",
+                [&fixture.tenant],
+            )
+            .unwrap();
+
+        assert_eq!(result.affected_rows(), 1);
+        assert_eq!(result.shard(), Some(fixture.shard));
+        assert_eq!(
+            global_authority_call_counts(),
+            GlobalAuthorityCallCounts {
+                unique_recoveries: 1,
+                unique_snapshot_repair_checks: 1,
+                unique_snapshot_refreshes: 0,
+            },
+            "an index-irrelevant update must preserve orphan recovery without refreshing a snapshot"
+        );
+        assert_eq!(fixture.durable_state(), before);
+        assert_eq!(
+            fixture
+                .storage
+                .open_shard(fixture.shard)
+                .unwrap()
+                .query_row(
+                    "SELECT payload FROM indexed_accounts WHERE tenant_id = ?1",
+                    [&fixture.tenant],
+                    |row| row.get::<_, String>(0),
+                )
+                .unwrap(),
+            "after"
+        );
+    }
+
+    #[test]
+    fn coordinator_preserves_partial_membership_and_null_distinct_snapshots() {
+        let fixture = IndexedWriteFixture::new();
+        let mut coordinator = fixture.coordinator();
+
+        coordinator
+            .execute_dml(
+                "UPDATE indexed_accounts SET active = 0 WHERE tenant_id = ?1",
+                [&fixture.tenant],
+            )
+            .unwrap();
+        let excluded = fixture.durable_state();
+        assert!(excluded.entries.is_empty());
+        assert!(excluded.unique_keys.is_empty());
+
+        reset_global_authority_call_counts();
+        coordinator
+            .execute_dml(
+                "UPDATE indexed_accounts SET active = 1, email = NULL
+                 WHERE tenant_id = ?1",
+                [&fixture.tenant],
+            )
+            .unwrap();
+        assert_eq!(
+            global_authority_call_counts(),
+            GlobalAuthorityCallCounts {
+                unique_recoveries: 1,
+                unique_snapshot_repair_checks: 0,
+                unique_snapshot_refreshes: 1,
+            },
+            "a NULL-distinct entry needs a snapshot refresh and preserves orphan recovery"
+        );
+        let null_distinct = fixture.durable_state();
+        assert_eq!(null_distinct.entries.len(), 1);
+        assert!(null_distinct.unique_keys.is_empty());
+        assert_ne!(null_distinct.checkpoints, excluded.checkpoints);
+
+        let before_payload = fixture.durable_state();
+        reset_global_authority_call_counts();
+        coordinator
+            .execute_dml(
+                "UPDATE indexed_accounts SET payload = 'null-payload'
+                 WHERE tenant_id = ?1",
+                [&fixture.tenant],
+            )
+            .unwrap();
+        assert_eq!(
+            global_authority_call_counts(),
+            GlobalAuthorityCallCounts {
+                unique_recoveries: 1,
+                unique_snapshot_repair_checks: 1,
+                unique_snapshot_refreshes: 0,
+            }
+        );
+        assert_eq!(fixture.durable_state(), before_payload);
     }
 
     #[test]


### PR DESCRIPTION
A payload-only update to a table with a ready unique global index rebuilt the entire shard snapshot and rewrote summary rows even when the canonical key and owner were unchanged. Append inserts also deleted and reinserted the complete growing snapshot, which produced the multi-process p99 failures recorded in #296.

This change collapses captured old/new rows into their net canonical index impact. Unchanged keys skip summary and snapshot mutations while retaining orphan recovery, and a read-first coherence check repairs markerless snapshot-only crash residue before the next write commits. Changed unique snapshots now validate their stored ordered prefix and append only a true suffix; deletes, middle inserts, key moves, and locator moves use the existing atomic full-rebuild fallback.

Local release-mode probes on the final implementation measured:

- 10-shard, four-process payload update: 24.930 ms p99 and 535.89 ops/s, versus 123.676 ms p99 on the base implementation.
- 64-shard, four-process insert: 86.312 ms p99 and 233.36 ops/s, versus a 166.374 ms base median p99 and 131.34 ops/s.

Crash coverage includes a real process abort after a NULL-distinct physical commit with no reservation marker, followed by a payload-only coordinator update and full index validation after reopen.

Validation:

- `cargo test --locked --all-targets --all-features` (1,109 passed; 5 expected ignored; all other targets green)
- release-mode global-index authority/write/async/candidate/recovery/shard-summary/topology/backup suites (45 passed; 2 expected ignored)
- all eight release-mode crash/recovery filters
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- all nine Rust 1.85 feature surfaces
- `cargo fmt --all -- --check`
- `git diff --check`

Refs #296. The issue remains open until the merged SHA passes the manual hosted global-index release gate under the existing p99 limits.
