### PR TITLE
Add lossless HTTP JSON value encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,6 +300,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "base64",
  "blake3",
  "bson",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ embedded = ["experimental-vtab"]
 # Network adapters can be selected independently by downstream applications.
 http = [
     "dep:axum",
+    "dep:base64",
     "dep:futures",
     "dep:serde",
     "dep:serde_json",
@@ -94,6 +95,7 @@ experimental-vtab = ["rusqlite/vtab"]
 anyhow = { version = "1.0", optional = true }
 async-trait = { version = "0.1", optional = true }
 axum = { version = "0.8.9", optional = true }
+base64 = { version = "0.22.1", optional = true }
 blake3 = "1.8"
 bson = { version = "=3.1.0", default-features = false, features = ["compat-3-0-0"], optional = true }
 bytes = { version = "1.12", optional = true }
@@ -117,7 +119,7 @@ rustls-pemfile = { version = "2.2", optional = true }
 rusqlite = { version = "0.39.0", features = ["bundled", "column_decltype", "column_metadata", "hooks", "limits", "preupdate_hook"] }
 same-file = "1.0"
 serde = { version = "1.0.229", features = ["derive"], optional = true }
-serde_json = { version = "1.0", features = ["arbitrary_precision", "preserve_order"], optional = true }
+serde_json = { version = "1.0", features = ["arbitrary_precision", "preserve_order", "raw_value"], optional = true }
 sqlparser = { version = "=0.62.0", default-features = false, features = ["std", "recursive-protection", "visitor"] }
 # `recursive` admits newer `psm` releases whose build dependencies require
 # Rust 1.88. The direct exact constraint preserves BriskDB's Rust 1.85 MSRV for

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,22 @@
+# Unreleased
+
+HTTP v1 now offers the opt-in `lossless-json-v1` value encoding while retaining
+`legacy-json-v1` as the byte-compatible default. Lossless query rows keep the
+existing ordered columns and positional arrays, tag every signed and unsigned
+integer with exact decimal text, preserve binary64 values as their 16-digit
+lowercase hexadecimal bits, and carry blobs or invalid SQLite text as canonical
+padded base64. The same tags are accepted as execute/query parameters, so a
+returned blob can be reused without becoming JSON text. Discovery advertises
+both encodings, and malformed or unknown selections and tags fail before engine
+execution.
+
+The codec preserves the current protocol-neutral values; it does not add a
+SQLite storage class. Existing decimal, oversized unsigned-integer,
+invalid-text, and NaN binding rejections remain. Relational timestamps still use
+an application-chosen ordinary `Text` or `Int64` representation and have no
+native BriskDB HTTP tag. The change adds no manifest, shard-file, listener,
+routing, or other on-disk change.
+
 # BriskDB 0.1.0-alpha.6 — 2026-09-06
 
 Alpha 6 expands the supported PostgreSQL and embedded Python surfaces while

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -318,11 +318,14 @@ protocol-specific golden tests only for encoding and state-machine behavior.
   authentication/role, pagination, or scatter/gather items below.
 - [x] Replace the experimental endpoints with a versioned `/v1` contract built
   on the shared session/engine types, with discovery, strict envelopes, and
-  fixed transport errors; see [the HTTP contract](docs/HTTP_API.md). The default
-  `legacy-json-v1` value encoding is preserved; lossless encoding remains #51.
-- [ ] Return ordered columns and row arrays so duplicate names and binary values
-  round-trip without loss; define JSON encodings for integers, decimals,
-  timestamps, and blobs.
+  fixed transport errors; see [the HTTP contract](docs/HTTP_API.md).
+- [x] Preserve ordered columns and positional row arrays and add the explicitly
+  selected `lossless-json-v1` encoding for integers, decimals, binary64 bits,
+  blobs, and invalid SQLite text (issue #51). `legacy-json-v1` remains the
+  default. Relational timestamps remain application-defined `Text` or `Int64`
+  because the shared SQL value system has no timestamp type or storage policy;
+  [#298](https://github.com/schapman1974/briskdb/issues/298) tracks that shared
+  contract.
 - [ ] Separate data-plane and admin-plane routers/listeners.
 - [ ] Add endpoints for health, readiness, catalog inspection, migrations,
   shard state, query cancellation, backup, and maintenance.

--- a/docs/ADMIN_BROWSER.md
+++ b/docs/ADMIN_BROWSER.md
@@ -150,8 +150,12 @@ unsigned integers use
 `uint64` tag in this admin-only response so the browser never rounds the
 displayed value. Blobs are
 arrays of byte-valued integers; decimals use strings; invalid UTF-8 text is
-rendered lossily; and non-finite floats become JSON `null`. This tagged integer
-addition does not change the experimental `/v1/query` response.
+rendered lossily; and non-finite floats become JSON `null`.
+
+This browser representation is separate from the public API's opt-in
+`lossless-json-v1` codec. The browser neither accepts a `value_encoding`
+selection nor returns its fully tagged integers, float bits, or base64 byte
+values. Adding the public codec changes no `/admin/api/*` request or response.
 
 Engine failures use the same fixed, redacted HTTP problem details as other HTTP
 operations. Login or session rejection returns HTTP 401 without echoing the

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,9 +1,9 @@
 # Architecture
 
 BriskDB is organized so network protocols can share one routing and execution
-core. The module layout preserves the experimental HTTP contract and existing
-Rust module paths while making the active PostgreSQL startup adapter and the
-planned MySQL adapter explicit peers.
+core. The module layout preserves the versioned HTTP contract and existing Rust
+module paths while making the active PostgreSQL startup adapter and the planned
+MySQL adapter explicit peers.
 
 ```text
 binary (main)
@@ -33,7 +33,7 @@ server ---------> protocol::http
 | `storage` | Versioned routing and authoritative logical/global-index manifest, persisted generated-ID policy/activation, stable active/retired allocation-owner slots, durable per-table hi/lo block leases, recoverable one-time table provisioning, shard layout, migration journals and recovery, SQLite connection opening, WAL/durability configuration | Network requests or response serialization |
 | `import` | Offline source-schema preflight, explicit placement and generated-ID plan validation, exact-value row routing into private staging, independent verification, durable receipt creation, and atomic publication | Network handlers, live/incremental migration, generated-ID inference, implicit Global placement, or protocol-specific behavior |
 | `sql` | Dialect-explicit SQL syntax parsing, recursive common-subset validation, protocol-neutral statement/batch classification, source-preserving placeholder normalization, explicit strict/compatibility translation, catalog-aware typed shard-key inference, and narrow crate-private DML-shape inspection behind BriskDB-owned boundaries; exact source retention; SQLite statement execution and conversion between SQLite storage classes and BriskDB values | JSON, key hashing or shard selection, mutable session state, physical write-routing policy, filesystem layout, protocol responses, protocol-buffer ownership, or protocol-specific support policy |
-| `protocol::http` | Existing HTTP request extraction, shared JSON/BriskDB value and RFC 9457 problem-detail encoding, and the embedded admin shell/assets, temporary browser sessions, metadata-driven logical discovery, exact logical counts, and bounded shard-major page handlers | BLAKE3 routing, shard files, direct SQLite access, or rusqlite calls |
+| `protocol::http` | Versioned HTTP request extraction, legacy and lossless JSON/BriskDB value codecs, RFC 9457 problem-detail encoding, and the embedded admin shell/assets, temporary browser sessions, metadata-driven logical discovery, exact logical counts, and bounded shard-major page handlers | BLAKE3 routing, shard files, direct SQLite access, or rusqlite calls |
 | `protocol::postgres` | BriskDB-owned bounded protocol-3.0 baseline and newer-minor downgrade, selected identity/status, per-connection core-session ownership, simple query execution, bounded parameterized text/binary extended lifecycle, fixed error recovery, and private compile/query-parser seam around exactly pinned `pgwire` | Listener binding, direct SQLite access, routing, unbounded authoritative prepared state, or public dependency-owned types |
 | `protocol::error` | Exhaustive HTTP, PostgreSQL, and MySQL mappings from stable engine error kinds | SQLite errors, routing decisions, or wire-protocol session state |
 | `server` | Process configuration, database assembly, loopback validation, separate HTTP/PostgreSQL listener binding, finite connection-task supervision, and shared graceful/forced draining | SQL parsing, PostgreSQL wire framing, or storage implementation details |
@@ -56,8 +56,8 @@ The module split deliberately preserved:
   shapes, and current error statuses;
 - BLAKE3 routing, shard filenames, manifest schema, WAL and synchronous modes;
 - legacy SQLite pass-through semantics while the table catalog is empty,
-  authoritative catalog gating after registration, and cell-level HTTP JSON
-  encoding behavior; and
+  authoritative catalog gating after registration, and the default cell-level
+  HTTP JSON encoding behavior; and
 - the existing `briskdb::api::router` and `briskdb::storage::Database` Rust
   paths through compatibility re-exports.
 
@@ -102,9 +102,10 @@ address or `None`.
 
 HTTP routes under `/v1` have an explicit transport contract in
 [HTTP_API.md](HTTP_API.md). `protocol::http::v1` owns version discovery, the
-shared strict SQL envelope, body extraction, version headers, and transport
-errors. Existing handlers still create core sessions and send typed statements
-through the shared engine; versioning adds no routing or SQLite implementation.
+shared strict SQL envelope, selected value codec, body extraction, version
+headers, and transport errors. Existing handlers still create core sessions and
+send typed statements through the shared engine; versioning and JSON conversion
+add no routing or SQLite implementation.
 
 The HTTP address remains `Config::listen`. The independent
 `Config::postgres_listen` is either a numeric socket address or disabled with
@@ -1358,23 +1359,37 @@ exact decimals, invalid UTF-8 text, and `NaN` are rejected rather than coerced
 to another SQLite storage class. SQLite `TEXT` results preserve invalid bytes as
 `Value::InvalidText` inside the core.
 
-The experimental HTTP adapter is the only JSON conversion boundary.
-`/v1/query` and the admin row-page response use the same ordered `columns` array
-of `name` and `data_type` metadata objects plus positional arrays in `rows`.
-Column and row indices correspond exactly. Duplicate and empty names are valid,
-and metadata is returned even when there are zero rows. The admin response adds
-physical-shard, table, and finite pagination metadata. It also tags signed or
-unsigned integers outside JavaScript's exact range with their decimal text so
-the browser cannot round them; the experimental `/v1/query` cell encoding is
-unchanged.
+The HTTP adapter is the only relational JSON conversion boundary. `/v1/query`
+and the admin row-page response use the same ordered `columns` array of `name`
+and `data_type` metadata objects plus positional arrays in `rows`. Column and
+row indices correspond exactly. Duplicate and empty names are valid, and
+metadata is returned even when there are zero rows. The admin response adds
+physical-shard, table, and finite pagination metadata and retains its separate
+browser display codec.
 
-The adapter renders exact decimals as JSON strings, converts `InvalidText` to a
-JSON string with invalid byte sequences replaced by U+FFFD, and maps non-finite
-floats to JSON `null`; these losses are explicit adapter policy rather than
-storage behavior. HTTP parameters that cannot bind to SQLite without loss fail
-instead of being rounded or rewritten. The ordered response change affects only
-HTTP query serialization: it does not change routing, configuration, the
-manifest, shard files, or any other on-disk data.
+Version 1 keeps `legacy-json-v1` as its default value conversion. That codec
+renders exact decimals as JSON strings, converts `InvalidText` to a string with
+U+FFFD replacement, represents blobs as byte arrays, exposes integers as JSON
+numbers, and maps non-finite floats to JSON null. These losses remain explicit
+adapter policy rather than storage behavior.
+
+An execute or query request may instead select `lossless-json-v1`. Nulls,
+Booleans, and valid text stay native JSON; every integer, decimal, binary64
+float, blob, and invalid-text value uses an exact two-field `$briskdb_type` tag.
+Integers use canonical decimal strings, floats use 16 lowercase hexadecimal
+IEEE-754 bits, and byte sequences use canonical padded standard base64. The
+adapter validates the complete tagged parameter set before invoking the engine,
+so malformed tags cannot partially execute a request. A returned binary tag can
+be reused as a parameter and reaches SQLite as the same BLOB bytes.
+
+Lossless JSON does not add a SQLite type or change which core values SQLite can
+bind. The SQL layer continues to reject oversized unsigned integers, decimals,
+invalid-text parameters, and NaN rather than coercing them. Relational
+timestamps likewise remain application-managed `Text` or `Int64`; there is no
+timestamp query value or HTTP tag. Engine byte limits account the
+protocol-neutral result before base64 and tag expansion. The optional codec
+changes only HTTP serialization and adds no routing, configuration, manifest,
+shard-file, or other on-disk change.
 
 The pre-1.0 Rust `Database::execute` and `Database::query` signatures now use
 BriskDB `Value` and `ResultSet` directly instead of `serde_json::Value`. This is

--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -1,8 +1,8 @@
 # HTTP API version 1
 
-Status: implemented for issue #50. BriskDB remains an alpha database; HTTP is
-loopback-only and has no data/admin authorization. The `/admin` browser login
-does not authenticate `/v1` requests.
+Status: implemented for issues #50 and #51. BriskDB remains an alpha database;
+HTTP is loopback-only and has no data/admin authorization. The `/admin` browser
+login does not authenticate `/v1` requests.
 
 ## Version and compatibility
 
@@ -12,6 +12,7 @@ does not authenticate `/v1` requests.
 {
   "api_version": "1",
   "value_encoding": "legacy-json-v1",
+  "supported_value_encodings": ["legacy-json-v1", "lossless-json-v1"],
   "session_scope": "request",
   "sql_dialect": "sqlite",
   "max_request_bytes": 2097152
@@ -35,11 +36,10 @@ requires a new API major version and a documented migration; it must not
 silently reinterpret a v1 request. SQL support and storage compatibility still
 follow their separately documented alpha contracts.
 
-`legacy-json-v1` names the existing cell conversion, including its losses. It
-does not claim lossless binary, decimal, or timestamp round trips. Issue #51
-will define an explicitly selected lossless encoding or a new API major
-version; it must preserve this default. A `value_encoding` request field is
-not accepted yet.
+`legacy-json-v1` remains the default and retains the original cell conversion,
+including its losses. `lossless-json-v1` is an explicitly selected, tagged
+encoding for the complete current protocol-neutral value model. Adding that
+choice does not reinterpret an omitted v1 field or change the default response.
 
 ## Routes
 
@@ -65,7 +65,8 @@ Both SQL endpoints accept this exact envelope:
 {
   "sql": "SELECT id, name FROM widgets WHERE id = ?1",
   "params": ["widget-1"],
-  "shard_key": "widget-1"
+  "shard_key": "widget-1",
+  "value_encoding": "lossless-json-v1"
 }
 ```
 
@@ -73,6 +74,10 @@ Both SQL endpoints accept this exact envelope:
   values are bound through the engine and never interpolated.
 - `params` is an optional array, defaulting to `[]`; explicit `null` is invalid.
 - `shard_key` is an optional string; omission or `null` means no explicit key.
+- `value_encoding` is optional. Omission and the exact string
+  `legacy-json-v1` select the established conversion. The exact string
+  `lossless-json-v1` selects the tagged conversion described below. Explicit
+  `null`, any other type, and an unknown name are invalid.
 - Unknown and duplicate envelope fields, missing required fields, and wrong
   field types are rejected before any engine operation.
 - Supply `Content-Type: application/json`, optionally with a charset. JSON
@@ -99,8 +104,9 @@ The engine retains its existing catalog-dependent behavior:
   are rejected before mutation, apart from explicitly supported generated-key
   operations.
 
-The adapter does not parse SQL, hash keys, open files, or implement transaction
-or migration coordination. See [SQL compatibility](SQL_COMPATIBILITY.md),
+The adapter validates and converts the selected JSON value encoding, but does
+not parse SQL, hash keys, open files, or implement transaction or migration
+coordination. See [SQL compatibility](SQL_COMPATIBILITY.md),
 [generated keys](GENERATED_KEYS.md), and [request controls](REQUEST_CONTROLS.md).
 Engine deadlines, cancellation, admission, and result limits still apply.
 This API buffers bounded results; it does not expose an HTTP row stream or a
@@ -118,6 +124,8 @@ When generated-key execution is enabled and the engine returns a key, it also
 includes `generated_key`, for example
 `{"column":"id","data_type":"int64","value":"9007199254740993"}`.
 The value is exact decimal text. An absent generated key is omitted, not null.
+The execute response does not echo `value_encoding`; its generated-key shape is
+already exact and remains unchanged for both encodings.
 
 Query returns one shard or the complete visited-shard array, never both:
 
@@ -143,6 +151,103 @@ non-finite floats as null. JavaScript can round integers outside its safe
 range; returning such a number does not claim JavaScript-safe precision. The
 browser's tagged large-integer representation is a different contract.
 
+### Lossless value encoding
+
+A request that selects `lossless-json-v1` receives the same ordered columns and
+positional rows, with the selected encoding named in the response:
+
+```json
+{
+  "shard": 2,
+  "value_encoding": "lossless-json-v1",
+  "columns": [
+    {"name":"id","data_type":"int64"},
+    {"name":"payload","data_type":"binary"}
+  ],
+  "rows": [[
+    {"$briskdb_type":"int64","value":"9007199254740993"},
+    {"$briskdb_type":"binary","value":"AP8="}
+  ]]
+}
+```
+
+The response omits `value_encoding` for the default legacy selection, including
+when a request names `legacy-json-v1` explicitly. Column metadata describes the
+result shape; every lossless cell remains self-describing even when SQLite marks
+an expression's column type `unknown`.
+
+The lossless encoding has one canonical JSON form for each current BriskDB
+`Value` variant:
+
+| BriskDB value | JSON form |
+| --- | --- |
+| `Null` | `null` |
+| `Boolean` | `true` or `false` |
+| `Text` | JSON string |
+| `Int64` | `{"$briskdb_type":"int64","value":"-9223372036854775808"}` |
+| `UInt64` | `{"$briskdb_type":"uint64","value":"18446744073709551615"}` |
+| `Float64` | `{"$briskdb_type":"float64","value":"3ff8000000000000"}` |
+| `Decimal` | `{"$briskdb_type":"decimal","value":"12.3400"}` |
+| `Binary` | `{"$briskdb_type":"binary","value":"AP8="}` |
+| `InvalidText` | `{"$briskdb_type":"invalid_text","value":"ZoA="}` |
+
+Signed and unsigned integer tags are used at every magnitude, including values
+inside JavaScript's exact range. Their `value` is the type's canonical base-10
+text: no leading plus, no unnecessary leading zero, and no negative zero.
+Decimal `value` text matches
+`[+-]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?` and deliberately
+preserves the caller's valid sign, digits, scale, exponent case, and exponent
+sign.
+
+The `float64` `value` is exactly 16 lowercase hexadecimal digits containing the
+IEEE-754 binary64 bits in most-significant-byte-first display order. This keeps
+finite values, signed zero, infinities, and individual NaN representations
+distinct without relying on JSON number behavior.
+
+The `binary` and `invalid_text` values use canonical RFC 4648 standard-alphabet
+base64, including `=` padding whenever the encoded length requires it and no
+whitespace. `""` represents zero bytes. `InvalidText` is separate from `Binary`
+because the core records that those bytes came from SQLite's `TEXT` storage
+class.
+
+For lossless parameters, JSON nulls, Booleans, and strings decode directly.
+Numbers, arrays, and untagged objects are rejected because none is a canonical
+lossless value. Every tag object contains exactly two fields,
+`$briskdb_type` and string `value`; unknown tags, duplicate, missing, or extra
+members, wrong member types, noncanonical integers, malformed float bits, and
+malformed or noncanonical base64 fail as `invalid_argument` before the engine
+can execute or mutate data. Object-member order and insignificant JSON
+whitespace are not significant.
+
+The tagged codec preserves the HTTP representation of a protocol-neutral value;
+it does not expand SQLite's storage classes. SQL binding still rejects decimal
+parameters, unsigned integers greater than `i64::MAX`, invalid-text parameters,
+and `Float64` NaN rather than coercing them. Those engine failures retain their
+existing problem codes.
+
+Relational timestamps have no native BriskDB `Value`, `DataType`, SQL binding,
+or HTTP tag. SQLite has no timestamp storage class, so applications currently
+store their chosen representation as ordinary `Text` or `Int64` and own its
+units, precision, time-zone, and normalization rules. In particular,
+`{"$briskdb_type":"timestamp",...}` is invalid. The signed-microsecond
+timestamp domain used by canonical global-index keys does not itself establish
+a relational query-value or cross-protocol timestamp contract. Issue #298
+tracks that shared temporal contract.
+
+The 2 MiB request limit counts the encoded JSON body, including tag and base64
+expansion. Engine result limits count protocol-neutral column, row, and value
+bytes before JSON serialization. Base64 expands a binary payload and tag objects
+add response bytes beyond that logical accounting; v1 still buffers the bounded
+result and has no separate encoded-response-byte or streaming contract. Those
+transport controls remain later roadmap work. A result-budget failure returns
+only the standard problem document, without partial columns, rows, or an
+encoding echo.
+
+Binary values can make a storage round trip without becoming JSON text. For
+example, insert the canonical base64 tag with `lossless-json-v1`, query the BLOB
+with the same selection, and reuse the returned tag as another parameter. The
+second parameter decodes to `Value::Binary`, not to a JSON array or text value.
+
 Broadcast accepts only `{"sql":"CREATE TABLE ..."}` and returns
 `{"completed_shards":[0,1]}`. It is the existing journaled schema migration
 operation, with preflight and resumable application across every shard. It
@@ -157,7 +262,7 @@ names, query text, filesystem paths, and decoder diagnostics are not echoed.
 
 | Failure | HTTP | Code |
 | --- | ---: | --- |
-| Malformed JSON or invalid request envelope | 400 | `invalid_argument` |
+| Malformed JSON, invalid request envelope, or invalid value encoding/tag | 400 | `invalid_argument` |
 | Unknown v1 endpoint | 404 | `not_found` |
 | Unsupported method on a known endpoint | 405 | `method_not_allowed` |
 | Body exceeds 2 MiB | 413 | `request_too_large` |
@@ -173,15 +278,19 @@ exactly-once delivery guarantee.
 
 ## Migration from the experimental endpoints
 
-Existing route names, valid request bodies, successful result shapes, and cell
-encodings continue to work. Unknown fields were previously ignored and now
-return 400. Malformed-body responses previously used framework-specific text
-and statuses; they now use the fixed problems above. Clients must remove
-unused envelope fields and consume `code` instead of decoder text. No storage
-format, Rust engine behavior, or startup configuration changes are involved.
+Existing route names, valid legacy request bodies, successful legacy result
+shapes, and legacy cell encodings continue to work. Unknown fields were
+previously ignored and now return 400. Malformed-body responses previously used
+framework-specific text and statuses; they now use the fixed problems above.
+Clients must remove unused envelope fields and consume `code` instead of decoder
+text. Clients may adopt lossless cells one request at a time by adding
+`"value_encoding":"lossless-json-v1"`; no API-major or storage migration is
+involved. No storage format, Rust engine behavior, or startup configuration
+changes are involved.
 
 `tests/http_v1.rs` exercises discovery, schema rejection before mutation, body
 limits, routing errors, method headers, version isolation, and session isolation.
 Existing HTTP tests cover catalog routing, generated keys, concurrent requests,
-deadlines, result limits, and exact response shapes; embedded differential tests
-verify shared-engine outcomes.
+deadlines, result limits, and exact response shapes. Lossless-codec tests cover
+every tag, canonical validation, binary reuse, and unchanged legacy responses;
+embedded differential tests verify shared-engine outcomes.

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -343,20 +343,24 @@ is reconciled from the retained journal prefix.
 
 ### Current HTTP parameter and result conversion
 
-The [HTTP v1 contract](HTTP_API.md) versions the existing representation as
-`legacy-json-v1`. Request envelopes are strict and decoding failures use fixed
-problem details. Versioning this encoding does not make it lossless; the
-conversion rules and limitations below remain part of v1.
+The [HTTP v1 contract](HTTP_API.md) supports two explicitly named value
+encodings. `legacy-json-v1` remains the default and preserves the original
+conversion exactly. A request may select `lossless-json-v1` to use a canonical
+tagged representation for every current protocol-neutral value that JSON cannot
+otherwise distinguish or preserve. Request envelopes and tag objects are
+strict, and decoding failures use fixed problem details before engine work.
 
 Use SQLite positional placeholders such as `?1` and `?2`. Values are never
-interpolated into SQL text. The HTTP adapter converts JSON parameters into
-protocol-neutral BriskDB values; the SQL layer binds only those typed values.
-An empty catalog binds the caller's SQLite markers on the legacy path. A
-populated catalog runs `normalize_placeholders(CommonSql)` and executes its
-strict translated `?N` SQL; named SQLite markers accepted by the legacy path
-are therefore not part of the registered-catalog contract.
+interpolated into SQL text. The HTTP adapter converts the selected JSON
+representation into protocol-neutral BriskDB values; the SQL layer binds only
+those typed values. An empty catalog binds the caller's SQLite markers on the
+legacy path. A populated catalog runs `normalize_placeholders(CommonSql)` and
+executes its strict translated `?N` SQL; named SQLite markers accepted by the
+legacy path are therefore not part of the registered-catalog contract.
 
-| JSON input | SQLite binding |
+The default legacy parameter conversion is:
+
+| `legacy-json-v1` input | SQLite binding |
 | --- | --- |
 | `null` | `NULL` |
 | `true` / `false` | `INTEGER` `1` / `0` |
@@ -373,67 +377,80 @@ SQLite results map to protocol-neutral BriskDB `Null`, `Int64`, `Float64`,
 UTF-8 remains byte-for-byte intact in `InvalidText`. The wider value model also
 has `UInt64` and a validated, exact string-backed `Decimal` variant for protocol
 inputs. Decimal construction accepts SQL-style signed decimal and exponent
-syntax and preserves its original digits and scale.
-SQLite binding accepts `UInt64` only through a checked conversion to `i64` and
-rejects larger values, `Decimal`, `InvalidText`, and `Float64(NaN)` instead of
-rounding, rewriting, or allowing SQLite to turn `NaN` into `NULL`. Infinite
-`Float64` values remain SQLite `REAL` values. Ordered column metadata and
-positional rows are preserved inside `ResultSet`; SQLite result-column metadata
-is marked `Unknown` because dynamic SQLite values do not guarantee one static
-type.
+syntax and preserves its original digits and scale. SQLite binding accepts
+`UInt64` only through a checked conversion to `i64` and rejects larger values,
+`Decimal`, `InvalidText`, and `Float64(NaN)` instead of rounding, rewriting, or
+allowing SQLite to turn `NaN` into `NULL`. Infinite `Float64` values remain
+SQLite `REAL` values.
 
-The experimental `/v1/query` response exposes the ordered result directly. The
-admin row-page endpoint reuses the same ordered columns and positional rows and
-wraps them with physical-shard and pagination metadata. Its large-integer
-display encoding differs as described below. For example, the existing query
-shape is:
+Both HTTP encodings expose the same ordered query shape. A successful one-target
+query contains `"shard": N`; a logical query that visits multiple targets uses
+the unique, sorted `"shards": [N, ...]` array and concatenates rows in that
+physical-shard order. For every row,
+`rows[row_index][column_index]` is described by `columns[column_index]`. Column
+names may be duplicated or empty and are never used as JSON object keys. A
+query that produces no rows still returns all ordered column metadata with
+`"rows": []`. The `data_type` label is one of `unknown`, `null`, `boolean`,
+`int64`, `uint64`, `float64`, `decimal`, `text`, or `binary`. Direct SQLite
+columns retain the conservative declared-type mapping documented for
+PostgreSQL; expressions and unrecognized declarations remain `unknown` because
+SQLite does not guarantee one static result type.
 
-```json
-{
-  "shard": 0,
-  "columns": [
-    {"name": "value", "data_type": "unknown"},
-    {"name": "value", "data_type": "unknown"}
-  ],
-  "rows": [[1, 2]]
-}
-```
+Legacy results use direct JSON for nulls, Booleans, integers, finite floats, and
+valid text. Binary data is an array of byte-valued integers, exact decimals are
+strings, invalid UTF-8 is rendered with U+FFFD replacement, and non-finite
+floats become null. This is intentionally lossy and remains unchanged.
 
-A successful one-target query contains `"shard": N`. A logical query that
-visits multiple targets replaces that member with `"shards": [N, ...]`; the
-array is unique and sorted in physical-shard order, matching the order used to
-concatenate its per-shard rows.
+Lossless nulls, Booleans, and valid text remain native JSON. Every other value
+uses an object containing exactly `$briskdb_type` and a string `value`:
 
-For every row, `rows[row_index][column_index]` is described by
-`columns[column_index]`. Column names may be duplicated or empty and are never
-used as JSON object keys. A query that produces no rows still returns all of its
-ordered column metadata with `"rows": []`. The `data_type` label is one of
-`unknown`, `null`, `boolean`, `int64`, `uint64`, `float64`, `decimal`, `text`,
-or `binary`. Direct SQLite columns now retain the conservative declared-type
-mapping documented for PostgreSQL; expressions and unrecognized declarations
-remain `unknown` because SQLite does not guarantee one static result type.
+| Type | `lossless-json-v1` value |
+| --- | --- |
+| Signed integer | `{"$briskdb_type":"int64","value":"-9223372036854775808"}` |
+| Unsigned integer | `{"$briskdb_type":"uint64","value":"18446744073709551615"}` |
+| Decimal | `{"$briskdb_type":"decimal","value":"12.3400"}` |
+| Binary64 float | `{"$briskdb_type":"float64","value":"3ff8000000000000"}` |
+| BLOB bytes | `{"$briskdb_type":"binary","value":"AP8="}` |
+| Invalid SQLite `TEXT` bytes | `{"$briskdb_type":"invalid_text","value":"ZoA="}` |
 
-The `/v1/query` cell encoding retains the existing HTTP policy: nulls, booleans,
-signed and unsigned integers, finite floats, and valid text use their direct
-JSON forms; binary data is an array of byte-valued JSON integers; and exact
-decimals are JSON strings. `InvalidText` is rendered lossily with invalid UTF-8
-byte sequences replaced by U+FFFD. Because JSON has no non-finite number syntax,
-infinite or `NaN` `Float64` values become `null`. Consumers that decode every
-`/v1/query` JSON number through binary floating point must also account for
-precision loss when reading large integer cells.
+Integer strings are canonical base-10 values. Float strings are exactly 16
+lowercase hexadecimal digits containing the IEEE-754 bits, which preserves
+signed zero, infinities, and NaN payloads. Binary strings use canonical RFC 4648
+standard-alphabet base64, with `=` padding whenever required and no whitespace.
+Decimal strings retain their valid source representation, including sign,
+scale, exponent case, and exponent sign. Raw numbers, arrays, untagged objects,
+and malformed or noncanonical tags are not lossless parameter forms and fail
+before execution.
+The complete tag grammar and negotiation rules are in
+[HTTP_API.md](HTTP_API.md#lossless-value-encoding).
 
-The admin row-page response keeps direct JSON integers within
-`-9007199254740991..=9007199254740991`. It represents larger signed or unsigned
-values as
-`{"$briskdb_type":"int64","value":"exact decimal text"}` or the equivalent
-`uint64` tag, and the embedded browser displays that text verbatim. This
-admin-only tag avoids JavaScript rounding without changing `/v1/query`.
+The codec is lossless at the HTTP/core boundary; it does not add SQLite storage
+classes. In particular, SQL binding still rejects decimal parameters, unsigned
+integers above `i64::MAX`, invalid-text parameters, and NaN. Binary is supported:
+a returned `binary` tag can be reused as a parameter and binds to BLOB bytes
+rather than JSON text.
 
-This ordered response intentionally replaces the earlier experimental
-object-per-row shape, which collapsed duplicate names. Admin pages preserve the
-same indexed relationship instead of converting rows into name-keyed objects.
-The conversion changes only HTTP serialization; request fields, routing,
-configuration, the manifest, shard files, and stored data are unchanged.
+There is no relational timestamp `Value`, `DataType`, or HTTP tag. SQLite has no
+dedicated temporal storage class, so applications store a documented canonical
+timestamp as ordinary `Text` or `Int64`. An application choosing integer Unix
+microseconds can use the ordinary lossless `int64` tag, but BriskDB does not
+infer that semantic type, normalize time zones, or promise cross-protocol
+temporal compatibility. Issue #298 tracks the shared relational timestamp
+contract.
+
+The 2 MiB request-body limit counts encoded JSON. Engine result limits account
+protocol-neutral values before tag and base64 expansion, so encoded response
+size can exceed the logical byte count. The current response remains buffered;
+HTTP output-byte limits and streaming are separate roadmap work.
+
+The admin row-page response keeps its separate browser-oriented encoding. It
+uses direct JSON integers within `-9007199254740991..=9007199254740991` and
+tags only larger signed or unsigned values with exact decimal text. Blobs remain
+byte arrays there. The browser does not select or expose the public
+`lossless-json-v1` codec.
+
+These conversions change only HTTP serialization. Routing, configuration, the
+manifest, shard files, and stored data are unchanged.
 
 ### Current error contract
 

--- a/src/protocol/http.rs
+++ b/src/protocol/http.rs
@@ -12,13 +12,17 @@ use axum::{
     response::{IntoResponse, Response},
     routing::get,
 };
-use serde::Serialize;
+use base64::{Engine as _, engine::general_purpose::STANDARD as STANDARD_BASE64};
+use serde::{Deserialize, Serialize};
 use serde_json::{Value as JsonValue, json};
-use v1::{BroadcastRequest, SqlRequest as QueryRequest, SqlRequest as RoutedSqlRequest, V1Json};
+use v1::{
+    BroadcastRequest, RawJsonParameter, SqlRequest as QueryRequest, SqlRequest as RoutedSqlRequest,
+    V1Json, ValueEncoding,
+};
 
 use crate::{
     core::{
-        DataType, Database, Engine, EngineError, EngineErrorKind, Executed, GeneratedKey,
+        DataType, Database, Decimal, Engine, EngineError, EngineErrorKind, Executed, GeneratedKey,
         GlobalIndexHealthState, GlobalIndexLifecycle, GlobalIndexOperationalReport,
         GlobalIndexOperationalStatus, ResultSet, Routed, Statement, Value,
     },
@@ -160,6 +164,8 @@ struct QueryResponse {
     shard: Option<u16>,
     #[serde(skip_serializing_if = "Option::is_none")]
     shards: Option<Vec<u16>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    value_encoding: Option<ValueEncoding>,
     columns: Vec<QueryColumn>,
     rows: Vec<Vec<JsonValue>>,
 }
@@ -175,10 +181,11 @@ async fn execute(
     V1Json(request): V1Json<RoutedSqlRequest>,
 ) -> Result<Json<ExecuteResponse>, ApiError> {
     let engine = state.engine;
+    let value_encoding = request.value_encoding;
     let params = request
         .params
         .into_iter()
-        .map(json_to_value)
+        .map(|value| parameter_to_value(value, value_encoding))
         .collect::<Result<Vec<_>, _>>()?;
     let session = engine.session();
     if let Some(shard_key) = request.shard_key {
@@ -226,10 +233,11 @@ async fn query(
     V1Json(request): V1Json<QueryRequest>,
 ) -> Result<Json<QueryResponse>, ApiError> {
     let engine = state.engine;
+    let value_encoding = request.value_encoding;
     let params = request
         .params
         .into_iter()
-        .map(json_to_value)
+        .map(|value| parameter_to_value(value, value_encoding))
         .collect::<Result<Vec<_>, _>>()?;
     let session = engine.session();
     if engine.catalog().tables().is_empty() {
@@ -243,7 +251,7 @@ async fn query(
     } = engine
         .query_logical(&session, Statement::new(request.sql, params))
         .await?;
-    let response = result_set_to_query_response(shards, result);
+    let response = result_set_to_query_response(shards, result, value_encoding);
 
     Ok(Json(response))
 }
@@ -419,6 +427,41 @@ fn write_index_metrics(output: &mut String, index: &GlobalIndexOperationalStatus
     );
 }
 
+fn parameter_to_value(
+    value: RawJsonParameter,
+    encoding: ValueEncoding,
+) -> Result<Value, EngineError> {
+    match encoding {
+        ValueEncoding::LegacyJsonV1 => legacy_json_to_value(value.get()),
+        ValueEncoding::LosslessJsonV1 => lossless_json_to_value(value.get()),
+    }
+}
+
+#[derive(Deserialize)]
+struct LegacyParameterEnvelope {
+    params: [JsonValue; 1],
+}
+
+fn legacy_json_to_value(raw: &str) -> Result<Value, EngineError> {
+    // RawValue is required so lossless tags retain duplicate members for strict
+    // rejection. Reparse each legacy value beneath the same root-object and
+    // params-array nesting as the original Vec<JsonValue> envelope so opting
+    // into RawValue does not relax serde_json's established recursion limit.
+    let mut envelope = String::with_capacity(raw.len().saturating_add(13));
+    envelope.push_str("{\"params\":[");
+    envelope.push_str(raw);
+    envelope.push_str("]}");
+    let LegacyParameterEnvelope { params: [value] } =
+        serde_json::from_str(&envelope).map_err(|error| {
+            EngineError::from_source(
+                EngineErrorKind::InvalidArgument,
+                "an HTTP JSON parameter could not be decoded",
+                error,
+            )
+        })?;
+    json_to_value(value)
+}
+
 fn json_to_value(value: JsonValue) -> Result<Value, EngineError> {
     validate_json_numbers(&value)?;
     Ok(match value {
@@ -506,7 +549,139 @@ fn value_to_json(value: Value) -> JsonValue {
     }
 }
 
-fn result_set_to_query_response(shards: Vec<u16>, result: ResultSet) -> QueryResponse {
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LosslessTaggedValue {
+    #[serde(rename = "$briskdb_type")]
+    kind: LosslessValueKind,
+    value: String,
+}
+
+#[derive(Debug, Deserialize)]
+enum LosslessValueKind {
+    #[serde(rename = "int64")]
+    Int64,
+    #[serde(rename = "uint64")]
+    UInt64,
+    #[serde(rename = "float64")]
+    Float64,
+    #[serde(rename = "decimal")]
+    Decimal,
+    #[serde(rename = "binary")]
+    Binary,
+    #[serde(rename = "invalid_text")]
+    InvalidText,
+}
+
+fn lossless_json_to_value(raw: &str) -> Result<Value, EngineError> {
+    let value = serde_json::from_str::<JsonValue>(raw).map_err(|_| invalid_lossless_value())?;
+    match value {
+        JsonValue::Null => Ok(Value::Null),
+        JsonValue::Bool(value) => Ok(Value::Boolean(value)),
+        JsonValue::String(value) => Ok(Value::Text(value)),
+        JsonValue::Object(_) => {
+            // Deserialize the raw object again so serde observes repeated fields
+            // instead of accepting serde_json::Map's last-value-wins projection.
+            let tagged = serde_json::from_str::<LosslessTaggedValue>(raw)
+                .map_err(|_| invalid_lossless_value())?;
+            decode_lossless_tag(tagged)
+        }
+        JsonValue::Number(_) | JsonValue::Array(_) => Err(invalid_lossless_value()),
+    }
+}
+
+fn decode_lossless_tag(tagged: LosslessTaggedValue) -> Result<Value, EngineError> {
+    let LosslessTaggedValue { kind, value } = tagged;
+    match kind {
+        LosslessValueKind::Int64 => value
+            .parse::<i64>()
+            .ok()
+            .filter(|parsed| parsed.to_string() == value)
+            .map(Value::Int64)
+            .ok_or_else(invalid_lossless_value),
+        LosslessValueKind::UInt64 => value
+            .parse::<u64>()
+            .ok()
+            .filter(|parsed| parsed.to_string() == value)
+            .map(Value::UInt64)
+            .ok_or_else(invalid_lossless_value),
+        LosslessValueKind::Float64 => decode_float64_bits(&value).map(Value::Float64),
+        LosslessValueKind::Decimal => Decimal::parse(value)
+            .map(Value::Decimal)
+            .map_err(|_| invalid_lossless_value()),
+        LosslessValueKind::Binary => decode_canonical_base64(&value).map(Value::Binary),
+        LosslessValueKind::InvalidText => decode_canonical_base64(&value).map(Value::InvalidText),
+    }
+}
+
+fn decode_float64_bits(value: &str) -> Result<f64, EngineError> {
+    if value.len() != 16
+        || !value
+            .as_bytes()
+            .iter()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
+        return Err(invalid_lossless_value());
+    }
+    u64::from_str_radix(value, 16)
+        .map(f64::from_bits)
+        .map_err(|_| invalid_lossless_value())
+}
+
+fn decode_canonical_base64(value: &str) -> Result<Vec<u8>, EngineError> {
+    let decoded = STANDARD_BASE64
+        .decode(value)
+        .map_err(|_| invalid_lossless_value())?;
+    if STANDARD_BASE64.encode(&decoded) != value {
+        return Err(invalid_lossless_value());
+    }
+    Ok(decoded)
+}
+
+fn invalid_lossless_value() -> EngineError {
+    EngineError::new(
+        EngineErrorKind::InvalidArgument,
+        "an HTTP JSON parameter does not match lossless-json-v1",
+    )
+}
+
+fn lossless_value_to_json(value: Value) -> JsonValue {
+    match value {
+        Value::Null => JsonValue::Null,
+        Value::Boolean(value) => JsonValue::Bool(value),
+        Value::Text(value) => JsonValue::String(value),
+        Value::Int64(value) => tagged_lossless_value("int64", value.to_string()),
+        Value::UInt64(value) => tagged_lossless_value("uint64", value.to_string()),
+        Value::Float64(value) => {
+            tagged_lossless_value("float64", format!("{:016x}", value.to_bits()))
+        }
+        Value::Decimal(value) => tagged_lossless_value("decimal", value.into_string()),
+        Value::Binary(value) => tagged_lossless_value("binary", STANDARD_BASE64.encode(value)),
+        Value::InvalidText(value) => {
+            tagged_lossless_value("invalid_text", STANDARD_BASE64.encode(value))
+        }
+    }
+}
+
+fn tagged_lossless_value(kind: &'static str, value: String) -> JsonValue {
+    json!({
+        "$briskdb_type": kind,
+        "value": value,
+    })
+}
+
+fn value_to_json_with_encoding(value: Value, encoding: ValueEncoding) -> JsonValue {
+    match encoding {
+        ValueEncoding::LegacyJsonV1 => value_to_json(value),
+        ValueEncoding::LosslessJsonV1 => lossless_value_to_json(value),
+    }
+}
+
+fn result_set_to_query_response(
+    shards: Vec<u16>,
+    result: ResultSet,
+    value_encoding: ValueEncoding,
+) -> QueryResponse {
     let (shard, shards) = match shards.as_slice() {
         [shard] => (Some(*shard), None),
         _ => (None, Some(shards)),
@@ -521,12 +696,18 @@ fn result_set_to_query_response(shards: Vec<u16>, result: ResultSet) -> QueryRes
         .collect();
     let rows = rows
         .into_iter()
-        .map(|row| row.into_values().into_iter().map(value_to_json).collect())
+        .map(|row| {
+            row.into_values()
+                .into_iter()
+                .map(|value| value_to_json_with_encoding(value, value_encoding))
+                .collect()
+        })
         .collect();
 
     QueryResponse {
         shard,
         shards,
+        value_encoding: (!value_encoding.is_legacy()).then_some(value_encoding),
         columns,
         rows,
     }
@@ -2338,6 +2519,34 @@ mod tests {
     }
 
     #[test]
+    fn raw_parameter_capture_preserves_the_legacy_envelope_recursion_limit() {
+        #[derive(Deserialize)]
+        struct PreviousSqlRequest {
+            #[serde(rename = "sql")]
+            _sql: String,
+            params: Vec<JsonValue>,
+        }
+
+        for depth in 120..=132 {
+            let nested = format!("{}null{}", "[".repeat(depth), "]".repeat(depth));
+            let body = format!(r#"{{"sql":"SELECT ?1","params":[{nested}]}}"#);
+            let previous_accepts = serde_json::from_str::<PreviousSqlRequest>(&body)
+                .is_ok_and(|request| request.params.len() == 1);
+            let current_accepts = serde_json::from_str::<RoutedSqlRequest>(&body)
+                .ok()
+                .and_then(|mut request| request.params.pop())
+                .is_some_and(|parameter| {
+                    parameter_to_value(parameter, ValueEncoding::LegacyJsonV1).is_ok()
+                });
+
+            assert_eq!(
+                current_accepts, previous_accepts,
+                "legacy recursion-depth behavior changed at parameter depth {depth}"
+            );
+        }
+    }
+
+    #[test]
     fn http_parameters_use_the_shared_canonical_index_key_encoding() {
         let through_http = [
             json_to_value(json!(true)).unwrap(),
@@ -2455,6 +2664,155 @@ mod tests {
         );
     }
 
+    fn decode_lossless_parameter(raw: &str) -> Result<Value, EngineError> {
+        let parameter = serde_json::from_str::<RawJsonParameter>(raw).unwrap();
+        parameter_to_value(parameter, ValueEncoding::LosslessJsonV1)
+    }
+
+    #[test]
+    fn lossless_json_round_trips_every_protocol_neutral_value_representation() {
+        for value in [
+            Value::Null,
+            Value::Boolean(false),
+            Value::Boolean(true),
+            Value::Int64(i64::MIN),
+            Value::Int64(i64::MAX),
+            Value::UInt64(u64::MAX),
+            Value::decimal("+0012.3400E-02").unwrap(),
+            Value::Text("plain text".to_owned()),
+            Value::Text("{\"$briskdb_type\":\"binary\"}".to_owned()),
+            Value::InvalidText(vec![b'f', 0x80, 0xff]),
+            Value::Binary(vec![]),
+            Value::Binary(vec![0, 0xff]),
+            Value::Binary((0..=u8::MAX).collect()),
+        ] {
+            let encoded = lossless_value_to_json(value.clone()).to_string();
+            let decoded = decode_lossless_parameter(&encoded)
+                .unwrap_or_else(|error| panic!("failed to decode {encoded}: {error:?}"));
+            assert_eq!(decoded, value);
+        }
+
+        for bits in [
+            0_u64,
+            (-0.0_f64).to_bits(),
+            1.5_f64.to_bits(),
+            f64::INFINITY.to_bits(),
+            f64::NEG_INFINITY.to_bits(),
+            0x7ff8_0000_0000_0042,
+        ] {
+            let encoded = lossless_value_to_json(Value::Float64(f64::from_bits(bits))).to_string();
+            let Value::Float64(decoded) = decode_lossless_parameter(&encoded).unwrap() else {
+                panic!("float64 tag decoded as another value type");
+            };
+            assert_eq!(decoded.to_bits(), bits);
+        }
+    }
+
+    #[test]
+    fn lossless_json_has_stable_exact_tag_shapes() {
+        for (value, expected) in [
+            (
+                Value::Int64(i64::MIN),
+                json!({"$briskdb_type": "int64", "value": "-9223372036854775808"}),
+            ),
+            (
+                Value::UInt64(u64::MAX),
+                json!({"$briskdb_type": "uint64", "value": "18446744073709551615"}),
+            ),
+            (
+                Value::Float64(-0.0),
+                json!({"$briskdb_type": "float64", "value": "8000000000000000"}),
+            ),
+            (
+                Value::decimal("12.3400").unwrap(),
+                json!({"$briskdb_type": "decimal", "value": "12.3400"}),
+            ),
+            (
+                Value::Binary(vec![0, 255]),
+                json!({"$briskdb_type": "binary", "value": "AP8="}),
+            ),
+            (
+                Value::InvalidText(vec![b'f', 0x80]),
+                json!({"$briskdb_type": "invalid_text", "value": "ZoA="}),
+            ),
+        ] {
+            assert_eq!(lossless_value_to_json(value), expected);
+        }
+    }
+
+    #[test]
+    fn lossless_json_rejects_ambiguous_or_noncanonical_parameters() {
+        for raw in [
+            "0",
+            "1.5",
+            "[]",
+            "{}",
+            r#"{"value":"0","$briskdb_type":"int64","extra":true}"#,
+            r#"{"$briskdb_type":"int64"}"#,
+            r#"{"value":"0"}"#,
+            r#"{"$briskdb_type":"unknown","value":"0"}"#,
+            r#"{"$briskdb_type":1,"value":"0"}"#,
+            r#"{"$briskdb_type":"int64","value":0}"#,
+            r#"{"$briskdb_type":"int64","$briskdb_type":"int64","value":"0"}"#,
+            r#"{"$briskdb_type":"int64","value":"0","value":"0"}"#,
+            r#"{"$briskdb_type":"int64","value":"00"}"#,
+            r#"{"$briskdb_type":"int64","value":"-0"}"#,
+            r#"{"$briskdb_type":"int64","value":"9223372036854775808"}"#,
+            r#"{"$briskdb_type":"uint64","value":"+1"}"#,
+            r#"{"$briskdb_type":"uint64","value":"18446744073709551616"}"#,
+            r#"{"$briskdb_type":"decimal","value":"NaN"}"#,
+            r#"{"$briskdb_type":"float64","value":"000000000000000"}"#,
+            r#"{"$briskdb_type":"float64","value":"3FF0000000000000"}"#,
+            r#"{"$briskdb_type":"float64","value":"xxxxxxxxxxxxxxxx"}"#,
+            r#"{"$briskdb_type":"binary","value":"AA"}"#,
+            r#"{"$briskdb_type":"binary","value":"AB=="}"#,
+            r#"{"$briskdb_type":"invalid_text","value":"!"}"#,
+        ] {
+            let error = decode_lossless_parameter(raw).unwrap_err();
+            assert_eq!(error.kind(), EngineErrorKind::InvalidArgument, "{raw}");
+            assert_eq!(
+                error.diagnostic(),
+                "an HTTP JSON parameter does not match lossless-json-v1"
+            );
+        }
+    }
+
+    #[test]
+    fn lossless_query_response_echoes_encoding_and_keeps_ordered_rows() {
+        let result = ResultSet::new(
+            vec![
+                Column::new("duplicate", DataType::Int64),
+                Column::new("duplicate", DataType::Binary),
+            ],
+            vec![Row::new(vec![
+                Value::Int64(9_007_199_254_740_993),
+                Value::Binary(vec![0, 255]),
+            ])],
+        )
+        .unwrap();
+
+        assert_eq!(
+            serde_json::to_value(result_set_to_query_response(
+                vec![3],
+                result,
+                ValueEncoding::LosslessJsonV1,
+            ))
+            .unwrap(),
+            json!({
+                "shard": 3,
+                "value_encoding": "lossless-json-v1",
+                "columns": [
+                    {"name": "duplicate", "data_type": "int64"},
+                    {"name": "duplicate", "data_type": "binary"}
+                ],
+                "rows": [[
+                    {"$briskdb_type": "int64", "value": "9007199254740993"},
+                    {"$briskdb_type": "binary", "value": "AP8="}
+                ]]
+            })
+        );
+    }
+
     #[test]
     fn every_data_type_has_a_stable_http_metadata_name() {
         assert_eq!(
@@ -2507,7 +2865,12 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            serde_json::to_value(result_set_to_query_response(vec![3], result)).unwrap(),
+            serde_json::to_value(result_set_to_query_response(
+                vec![3],
+                result,
+                ValueEncoding::LegacyJsonV1,
+            ))
+            .unwrap(),
             json!({
                 "shard": 3,
                 "columns": [
@@ -2529,13 +2892,23 @@ mod tests {
     fn result_encoding_keeps_valid_zero_column_shapes() {
         let empty = ResultSet::new(Vec::new(), Vec::new()).unwrap();
         assert_eq!(
-            serde_json::to_value(result_set_to_query_response(vec![1], empty)).unwrap(),
+            serde_json::to_value(result_set_to_query_response(
+                vec![1],
+                empty,
+                ValueEncoding::LegacyJsonV1,
+            ))
+            .unwrap(),
             json!({"shard": 1, "columns": [], "rows": []})
         );
 
         let empty_row = ResultSet::new(Vec::new(), vec![Row::new(Vec::new())]).unwrap();
         assert_eq!(
-            serde_json::to_value(result_set_to_query_response(vec![2], empty_row)).unwrap(),
+            serde_json::to_value(result_set_to_query_response(
+                vec![2],
+                empty_row,
+                ValueEncoding::LegacyJsonV1,
+            ))
+            .unwrap(),
             json!({"shard": 2, "columns": [], "rows": [[]]})
         );
     }
@@ -2552,7 +2925,12 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            serde_json::to_value(result_set_to_query_response(vec![0, 1], result)).unwrap(),
+            serde_json::to_value(result_set_to_query_response(
+                vec![0, 1],
+                result,
+                ValueEncoding::LegacyJsonV1,
+            ))
+            .unwrap(),
             json!({
                 "shards": [0, 1],
                 "columns": [{"name": "payload", "data_type": "text"}],

--- a/src/protocol/http/v1.rs
+++ b/src/protocol/http/v1.rs
@@ -9,7 +9,7 @@ use axum::{
     routing::{get, post},
 };
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
-use serde_json::Value as JsonValue;
+use serde_json::value::RawValue;
 
 use super::{
     HttpState, ProblemDetails, broadcast, execute, global_indexes, health, problem_response, query,
@@ -45,7 +45,8 @@ async fn version_header(mut response: Response) -> Response {
 #[derive(Serialize)]
 struct ApiVersion {
     api_version: &'static str,
-    value_encoding: &'static str,
+    value_encoding: ValueEncoding,
+    supported_value_encodings: [ValueEncoding; 2],
     session_scope: &'static str,
     sql_dialect: &'static str,
     max_request_bytes: usize,
@@ -54,11 +55,39 @@ struct ApiVersion {
 async fn discovery() -> Json<ApiVersion> {
     Json(ApiVersion {
         api_version: "1",
-        value_encoding: "legacy-json-v1",
+        value_encoding: ValueEncoding::LegacyJsonV1,
+        supported_value_encodings: ValueEncoding::ALL,
         session_scope: "request",
         sql_dialect: "sqlite",
         max_request_bytes: MAX_REQUEST_BYTES,
     })
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
+pub(super) enum ValueEncoding {
+    #[default]
+    #[serde(rename = "legacy-json-v1")]
+    LegacyJsonV1,
+    #[serde(rename = "lossless-json-v1")]
+    LosslessJsonV1,
+}
+
+impl ValueEncoding {
+    pub(super) const ALL: [Self; 2] = [Self::LegacyJsonV1, Self::LosslessJsonV1];
+
+    pub(super) const fn is_legacy(self) -> bool {
+        matches!(self, Self::LegacyJsonV1)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(transparent)]
+pub(super) struct RawJsonParameter(Box<RawValue>);
+
+impl RawJsonParameter {
+    pub(super) fn get(&self) -> &str {
+        self.0.get()
+    }
 }
 
 /// Shared SQL envelope; each handler creates a fresh core Session and Statement.
@@ -71,7 +100,9 @@ pub(super) struct SqlRequest {
     pub(super) shard_key: Option<String>,
     pub(super) sql: String,
     #[serde(default)]
-    pub(super) params: Vec<JsonValue>,
+    pub(super) params: Vec<RawJsonParameter>,
+    #[serde(default)]
+    pub(super) value_encoding: ValueEncoding,
 }
 
 #[derive(Debug, Deserialize)]
@@ -168,4 +199,29 @@ async fn not_found() -> TransportError {
 
 async fn method_not_allowed() -> TransportError {
     TransportError::MethodNotAllowed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SqlRequest, ValueEncoding};
+
+    #[test]
+    fn sql_request_defaults_and_explicit_legacy_selection_preserve_raw_parameters() {
+        for (raw, expected_parameter) in [
+            (
+                r#"{"sql":"SELECT ?1","params":[{"z":0,"a":1}]}"#,
+                r#"{"z":0,"a":1}"#,
+            ),
+            (
+                r#"{"sql":"SELECT ?1","params":[ [ 1, 2 ] ],"value_encoding":"legacy-json-v1"}"#,
+                "[ 1, 2 ]",
+            ),
+        ] {
+            let request = serde_json::from_str::<SqlRequest>(raw).unwrap();
+
+            assert_eq!(request.value_encoding, ValueEncoding::LegacyJsonV1);
+            assert_eq!(request.params.len(), 1);
+            assert_eq!(request.params[0].get(), expected_parameter);
+        }
+    }
 }

--- a/tests/embedded_sql_api.rs
+++ b/tests/embedded_sql_api.rs
@@ -22,6 +22,10 @@ async fn request_json(router: axum::Router, uri: &str, body: JsonValue) -> (Stat
     (status, serde_json::from_slice(&bytes).unwrap())
 }
 
+fn tagged(tag: &str, value: &str) -> JsonValue {
+    json!({"$briskdb_type": tag, "value": value})
+}
+
 #[tokio::test]
 async fn embedded_prepared_commands_preserve_order_values_and_handle_lifecycle() {
     let temp = tempfile::tempdir().unwrap();
@@ -156,7 +160,7 @@ async fn embedded_and_http_calls_observe_the_same_engine_outcome() {
         .unwrap();
     let application = briskdb::api::router_with_engine(database.engine().clone());
     let http = request_json(
-        application,
+        application.clone(),
         "/v1/query",
         json!({
             "shard_key": "shared-outcome",
@@ -179,6 +183,25 @@ async fn embedded_and_http_calls_observe_the_same_engine_outcome() {
             Value::Binary(vec![1, 2, 255]),
             Value::Null,
         ]
+    );
+
+    let lossless = request_json(
+        application,
+        "/v1/query",
+        json!({
+            "shard_key": "shared-outcome",
+            "sql": "SELECT id, payload, note FROM records WHERE id = ?1",
+            "params": ["shared-outcome"],
+            "value_encoding": "lossless-json-v1"
+        }),
+    )
+    .await;
+    assert_eq!(lossless.0, StatusCode::OK);
+    assert_eq!(lossless.1["shard"], json!(embedded.shards[0]));
+    assert_eq!(lossless.1["value_encoding"], "lossless-json-v1");
+    assert_eq!(
+        lossless.1["rows"],
+        json!([["shared-outcome", tagged("binary", "AQL/"), null]])
     );
 
     session.close().await.unwrap();

--- a/tests/http_v1.rs
+++ b/tests/http_v1.rs
@@ -9,7 +9,10 @@ use axum::{
 };
 use briskdb::{
     Statement,
-    core::{Database, Engine},
+    core::{
+        Database, Engine, EngineOptions, ResultLimits, ShardKeyMetadata, ShardKeyType,
+        TableDeclaration, Value as CoreValue,
+    },
 };
 use serde_json::{Value, json};
 use tower::ServiceExt;
@@ -20,9 +23,68 @@ fn application() -> (tempfile::TempDir, Engine, Router) {
     database
         .broadcast("CREATE TABLE notes (id INTEGER PRIMARY KEY)")
         .unwrap();
+    database
+        .broadcast(
+            "CREATE TABLE binary_notes (
+                id INTEGER PRIMARY KEY,
+                payload BLOB NOT NULL
+             )",
+        )
+        .unwrap();
     let engine = Engine::from_database(database);
     let router = briskdb::api::router_with_engine(engine.clone());
     (temp, engine, router)
+}
+
+fn scatter_application() -> (tempfile::TempDir, Router, [String; 2]) {
+    let temp = tempfile::tempdir().unwrap();
+    let mut database = Database::open(temp.path(), 2).unwrap();
+    database
+        .broadcast(
+            "CREATE TABLE events (
+                tenant_key TEXT NOT NULL PRIMARY KEY,
+                ordinal INTEGER NOT NULL,
+                payload BLOB NOT NULL
+             )",
+        )
+        .unwrap();
+    let logical_database = database.catalog().default_database().id();
+    database
+        .register_tables(vec![
+            TableDeclaration::sharded(
+                logical_database,
+                "events",
+                ShardKeyMetadata::new("tenant_key", ShardKeyType::Text).unwrap(),
+            )
+            .unwrap(),
+        ])
+        .unwrap();
+    let tenant_keys = [0_u16, 1_u16].map(|expected_shard| {
+        (0_u64..)
+            .map(|candidate| format!("lossless-{expected_shard}-{candidate}"))
+            .find(|candidate| database.shard_for_key(candidate.as_bytes()) == expected_shard)
+            .unwrap()
+    });
+    for (shard, tenant_key, payload) in [
+        (0_u16, tenant_keys[0].as_str(), vec![0_u8]),
+        (1_u16, tenant_keys[1].as_str(), vec![0xff_u8]),
+    ] {
+        let inserted = database
+            .execute_routed(
+                tenant_key,
+                "INSERT INTO events (tenant_key, ordinal, payload) VALUES (?1, ?2, ?3)",
+                &[
+                    CoreValue::from(tenant_key),
+                    CoreValue::from(i64::from(shard)),
+                    CoreValue::from(payload),
+                ],
+            )
+            .unwrap();
+        assert_eq!(inserted.shard, shard);
+        assert_eq!(inserted.value, 1);
+    }
+    let router = briskdb::api::router(Arc::new(database));
+    (temp, router, tenant_keys)
 }
 
 async fn request(
@@ -67,6 +129,10 @@ fn assert_problem(
     body
 }
 
+fn tagged(tag: &str, value: &str) -> Value {
+    json!({"$briskdb_type": tag, "value": value})
+}
+
 #[tokio::test]
 async fn discovery_health_alias_and_head_identify_the_contract() {
     let (_temp, _engine, app) = application();
@@ -79,6 +145,7 @@ async fn discovery_health_alias_and_head_identify_the_contract() {
             json!({
                 "api_version": "1",
                 "value_encoding": "legacy-json-v1",
+                "supported_value_encodings": ["legacy-json-v1", "lossless-json-v1"],
                 "session_scope": "request",
                 "sql_dialect": "sqlite",
                 "max_request_bytes": 2097152
@@ -95,6 +162,262 @@ async fn discovery_health_alias_and_head_identify_the_contract() {
     assert_eq!(versioned.1["briskdb-api-version"], "1");
     assert_eq!(versioned.2, legacy.2);
     assert!(!legacy.1.contains_key("briskdb-api-version"));
+}
+
+#[tokio::test]
+async fn omitted_and_explicit_legacy_encoding_have_the_exact_same_response() {
+    let (_temp, _engine, app) = application();
+    let omitted = request(
+        &app,
+        Method::POST,
+        "/v1/query",
+        Some("application/json"),
+        r#"{"shard_key":"legacy-owner","sql":"SELECT ?1 AS object_text, X'00ff' AS data, 9007199254740993 AS large_integer","params":[{"z":0,"a":1}]}"#,
+    )
+    .await;
+    let explicit = request(
+        &app,
+        Method::POST,
+        "/v1/query",
+        Some("application/json"),
+        r#"{"shard_key":"legacy-owner","sql":"SELECT ?1 AS object_text, X'00ff' AS data, 9007199254740993 AS large_integer","params":[{"z":0,"a":1}],"value_encoding":"legacy-json-v1"}"#,
+    )
+    .await;
+
+    assert_eq!(omitted.0, StatusCode::OK);
+    assert_eq!(explicit.0, StatusCode::OK);
+    assert_eq!(omitted.1["content-type"], "application/json");
+    assert_eq!(omitted.1["briskdb-api-version"], "1");
+    assert_eq!(omitted.2, explicit.2);
+    let mut body = serde_json::from_slice::<Value>(&omitted.2).unwrap();
+    assert!(body["shard"].as_u64().is_some());
+    assert!(body.get("value_encoding").is_none());
+    body.as_object_mut().unwrap().remove("shard");
+    assert_eq!(
+        body,
+        json!({
+            "columns": [
+                {"name": "object_text", "data_type": "unknown"},
+                {"name": "data", "data_type": "unknown"},
+                {"name": "large_integer", "data_type": "unknown"}
+            ],
+            "rows": [["{\"a\":1,\"z\":0}", [0, 255], 9007199254740993_i64]]
+        })
+    );
+
+    let omitted_execute = request(
+        &app,
+        Method::POST,
+        "/v1/execute",
+        Some("application/json"),
+        r#"{"shard_key":"legacy-owner","sql":"INSERT INTO notes VALUES (?1)","params":[100]}"#,
+    )
+    .await;
+    let explicit_execute = request(
+        &app,
+        Method::POST,
+        "/v1/execute",
+        Some("application/json"),
+        r#"{"shard_key":"legacy-owner","sql":"INSERT INTO notes VALUES (?1)","params":[101],"value_encoding":"legacy-json-v1"}"#,
+    )
+    .await;
+    assert_eq!(omitted_execute.0, StatusCode::OK);
+    assert_eq!(explicit_execute.0, StatusCode::OK);
+    assert_eq!(omitted_execute.2, explicit_execute.2);
+}
+
+#[tokio::test]
+async fn lossless_binary_can_be_written_queried_and_reused_without_becoming_text() {
+    let (_temp, _engine, app) = application();
+    let insert = json!({
+        "shard_key": "binary-owner",
+        "sql": "INSERT INTO binary_notes (id, payload) VALUES (?1, ?2)",
+        "params": [tagged("int64", "1"), tagged("binary", "AAEC/w==")],
+        "value_encoding": "lossless-json-v1"
+    });
+    let (status, headers, body) = request(
+        &app,
+        Method::POST,
+        "/v1/execute",
+        Some("application/json"),
+        serde_json::to_vec(&insert).unwrap(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(headers["content-type"], "application/json");
+    assert_eq!(headers["briskdb-api-version"], "1");
+    assert_eq!(
+        serde_json::from_slice::<Value>(&body).unwrap()["rows_affected"],
+        1
+    );
+
+    let query = json!({
+        "shard_key": "binary-owner",
+        "sql": "SELECT id, payload, typeof(payload) AS storage_class, hex(payload) AS payload_hex FROM binary_notes WHERE id = ?1",
+        "params": [tagged("int64", "1")],
+        "value_encoding": "lossless-json-v1"
+    });
+    let (status, _, body) = request(
+        &app,
+        Method::POST,
+        "/v1/query",
+        Some("application/json"),
+        serde_json::to_vec(&query).unwrap(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let first: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(first["value_encoding"], "lossless-json-v1");
+    assert_eq!(
+        first["rows"],
+        json!([[
+            tagged("int64", "1"),
+            tagged("binary", "AAEC/w=="),
+            "blob",
+            "000102FF"
+        ]])
+    );
+
+    let returned_binary = first["rows"][0][1].clone();
+    let reuse = json!({
+        "shard_key": "binary-owner",
+        "sql": "INSERT INTO binary_notes (id, payload) VALUES (?1, ?2)",
+        "params": [tagged("int64", "2"), returned_binary],
+        "value_encoding": "lossless-json-v1"
+    });
+    let (status, _, _) = request(
+        &app,
+        Method::POST,
+        "/v1/execute",
+        Some("application/json"),
+        serde_json::to_vec(&reuse).unwrap(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let verify = json!({
+        "shard_key": "binary-owner",
+        "sql": "SELECT typeof(payload), hex(payload) FROM binary_notes WHERE id = ?1",
+        "params": [tagged("int64", "2")],
+        "value_encoding": "lossless-json-v1"
+    });
+    let (status, _, body) = request(
+        &app,
+        Method::POST,
+        "/v1/query",
+        Some("application/json"),
+        serde_json::to_vec(&verify).unwrap(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&body).unwrap()["rows"],
+        json!([["blob", "000102FF"]])
+    );
+}
+
+#[tokio::test]
+async fn invalid_lossless_tags_and_encoding_selection_fail_before_mutation() {
+    let (_temp, engine, app) = application();
+    let invalid_bodies = [
+        r#"{"shard_key":"invalid-owner","sql":"INSERT INTO binary_notes VALUES (?1,?2)","params":[{"$briskdb_type":"int64","value":"1"},{"$briskdb_type":"private-sentinel","value":"AA=="}],"value_encoding":"lossless-json-v1"}"#,
+        r#"{"shard_key":"invalid-owner","sql":"INSERT INTO binary_notes VALUES (?1,?2)","params":[{"$briskdb_type":"int64","value":"2"},{"$briskdb_type":"binary","value":"private-sentinel"}],"value_encoding":"lossless-json-v1"}"#,
+        r#"{"shard_key":"invalid-owner","sql":"INSERT INTO binary_notes VALUES (?1,?2)","params":[{"$briskdb_type":"int64","value":"3"},{"$briskdb_type":"binary","value":"AA==","private-sentinel":true}],"value_encoding":"lossless-json-v1"}"#,
+        r#"{"shard_key":"invalid-owner","sql":"INSERT INTO binary_notes VALUES (?1,?2)","params":[{"$briskdb_type":"int64","value":"4"},{"$briskdb_type":"binary","value":"AA==","value":"private-sentinel"}],"value_encoding":"lossless-json-v1"}"#,
+        r#"{"shard_key":"invalid-owner","sql":"INSERT INTO binary_notes VALUES (?1,?2)","params":[{"$briskdb_type":"int64","value":"5"},{"$briskdb_type":"binary"}],"value_encoding":"lossless-json-v1"}"#,
+        r#"{"shard_key":"invalid-owner","sql":"INSERT INTO binary_notes VALUES (?1,?2)","params":[{"$briskdb_type":"int64","value":"6"},"private-sentinel"],"value_encoding":"future-json-v9"}"#,
+        r#"{"shard_key":"invalid-owner","sql":"INSERT INTO binary_notes VALUES (?1,?2)","params":[{"$briskdb_type":"int64","value":"7"},"private-sentinel"],"value_encoding":"legacy-json-v1","value_encoding":"lossless-json-v1"}"#,
+    ];
+
+    for body in invalid_bodies {
+        assert_problem(
+            request(
+                &app,
+                Method::POST,
+                "/v1/execute",
+                Some("application/json"),
+                body,
+            )
+            .await,
+            StatusCode::BAD_REQUEST,
+            "invalid_argument",
+        );
+    }
+
+    let session = engine.session();
+    session.set_routing_key("invalid-owner").await.unwrap();
+    let rows = engine
+        .query(
+            &session,
+            Statement::new("SELECT COUNT(*) FROM binary_notes", vec![]),
+        )
+        .await
+        .unwrap();
+    assert_eq!(rows.value.rows()[0].get(0), Some(&CoreValue::from(0_i64)));
+}
+
+#[tokio::test]
+async fn lossless_scatter_keeps_shard_row_and_duplicate_column_order() {
+    let (_temp, app, tenant_keys) = scatter_application();
+    let query = json!({
+        "sql": "SELECT tenant_key AS duplicate, ordinal AS duplicate, payload AS \"\" FROM events",
+        "value_encoding": "lossless-json-v1"
+    });
+    let (status, headers, body) = request(
+        &app,
+        Method::POST,
+        "/v1/query",
+        Some("application/json"),
+        serde_json::to_vec(&query).unwrap(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(headers["briskdb-api-version"], "1");
+    assert_eq!(headers["content-type"], "application/json");
+    assert_eq!(
+        serde_json::from_slice::<Value>(&body).unwrap(),
+        json!({
+            "shards": [0, 1],
+            "value_encoding": "lossless-json-v1",
+            "columns": [
+                {"name": "duplicate", "data_type": "text"},
+                {"name": "duplicate", "data_type": "int64"},
+                {"name": "", "data_type": "binary"}
+            ],
+            "rows": [
+                [tenant_keys[0], tagged("int64", "0"), tagged("binary", "AA==")],
+                [tenant_keys[1], tagged("int64", "1"), tagged("binary", "/w==")]
+            ]
+        })
+    );
+
+    let empty = json!({
+        "sql": "SELECT tenant_key AS duplicate, ordinal AS duplicate, payload AS \"\" FROM events WHERE ordinal = ?1",
+        "params": [tagged("int64", "99")],
+        "value_encoding": "lossless-json-v1"
+    });
+    let (status, _, body) = request(
+        &app,
+        Method::POST,
+        "/v1/query",
+        Some("application/json"),
+        serde_json::to_vec(&empty).unwrap(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&body).unwrap(),
+        json!({
+            "shards": [0, 1],
+            "value_encoding": "lossless-json-v1",
+            "columns": [
+                {"name": "duplicate", "data_type": "text"},
+                {"name": "duplicate", "data_type": "int64"},
+                {"name": "", "data_type": "binary"}
+            ],
+            "rows": []
+        })
+    );
 }
 
 #[tokio::test]
@@ -220,6 +543,89 @@ async fn oversized_json_is_rejected_and_later_requests_still_work() {
     assert_eq!(body["columns"][1]["name"], "duplicate");
     assert!(body.get("shard").is_some());
     assert!(body.get("shards").is_none());
+}
+
+#[tokio::test]
+async fn concurrent_requests_keep_value_encoding_request_local() {
+    let (_temp, _engine, app) = application();
+    let mut requests = tokio::task::JoinSet::new();
+    for value in 0_i64..24 {
+        let app = app.clone();
+        requests.spawn(async move {
+            let lossless = value % 2 == 1;
+            let body = if lossless {
+                json!({
+                    "shard_key": format!("concurrent-{value}"),
+                    "sql": "SELECT ?1 AS value",
+                    "params": [tagged("int64", &value.to_string())],
+                    "value_encoding": "lossless-json-v1"
+                })
+            } else {
+                json!({
+                    "shard_key": format!("concurrent-{value}"),
+                    "sql": "SELECT ?1 AS value",
+                    "params": [value],
+                    "value_encoding": "legacy-json-v1"
+                })
+            };
+            let response = request(
+                &app,
+                Method::POST,
+                "/v1/query",
+                Some("application/json"),
+                serde_json::to_vec(&body).unwrap(),
+            )
+            .await;
+            (value, lossless, response)
+        });
+    }
+
+    let mut completed = 0;
+    while let Some(joined) = requests.join_next().await {
+        let (value, lossless, (status, headers, body)) = joined.unwrap();
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(headers["briskdb-api-version"], "1");
+        let body: Value = serde_json::from_slice(&body).unwrap();
+        if lossless {
+            assert_eq!(body["value_encoding"], "lossless-json-v1");
+            assert_eq!(body["rows"], json!([[tagged("int64", &value.to_string())]]));
+        } else {
+            assert!(body.get("value_encoding").is_none());
+            assert_eq!(body["rows"], json!([[value]]));
+        }
+        completed += 1;
+    }
+    assert_eq!(completed, 24);
+}
+
+#[tokio::test]
+async fn lossless_query_result_limit_returns_only_the_problem_document() {
+    let temp = tempfile::tempdir().unwrap();
+    let database = Arc::new(Database::open(temp.path(), 2).unwrap());
+    let options = EngineOptions::default().with_result_limits(ResultLimits::new(1, 1_024).unwrap());
+    let app = briskdb::api::router_with_engine(
+        Engine::from_database_with_options(database, options).unwrap(),
+    );
+    let body = json!({
+        "shard_key": "limited-lossless",
+        "sql": "SELECT 1 AS value UNION ALL SELECT 2",
+        "value_encoding": "lossless-json-v1"
+    });
+    let problem = assert_problem(
+        request(
+            &app,
+            Method::POST,
+            "/v1/query",
+            Some("application/json"),
+            serde_json::to_vec(&body).unwrap(),
+        )
+        .await,
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "limit_exceeded",
+    );
+    assert!(problem.get("value_encoding").is_none());
+    assert!(problem.get("columns").is_none());
+    assert!(problem.get("rows").is_none());
 }
 
 #[tokio::test]

--- a/tests/http_v1_listener.rs
+++ b/tests/http_v1_listener.rs
@@ -1,0 +1,102 @@
+#![cfg(feature = "listeners")]
+
+use std::net::SocketAddr;
+
+use briskdb::{
+    BriskDb,
+    server::{AttachedServer, ListenerConfig},
+};
+use serde_json::{Value, json};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    time::{Duration, timeout},
+};
+
+async fn post_json(address: SocketAddr, path: &str, body: &Value) -> Vec<u8> {
+    let body = serde_json::to_vec(body).unwrap();
+    let headers = format!(
+        "POST {path} HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    );
+    let mut stream = tokio::net::TcpStream::connect(address).await.unwrap();
+    stream.write_all(headers.as_bytes()).await.unwrap();
+    stream.write_all(&body).await.unwrap();
+
+    let mut response = Vec::new();
+    timeout(Duration::from_secs(10), stream.read_to_end(&mut response))
+        .await
+        .expect("the HTTP listener should complete a small query response")
+        .unwrap();
+    response
+}
+
+fn split_response(response: &[u8]) -> (&str, &[u8]) {
+    let boundary = response
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .expect("HTTP response must contain a header terminator");
+    let headers = std::str::from_utf8(&response[..boundary]).unwrap();
+    (headers, &response[boundary + 4..])
+}
+
+fn tagged(tag: &str, value: &str) -> Value {
+    json!({"$briskdb_type": tag, "value": value})
+}
+
+#[tokio::test]
+async fn attached_listener_serves_the_lossless_query_contract_over_tcp() {
+    let temp = tempfile::tempdir().unwrap();
+    let database = BriskDb::builder(temp.path())
+        .with_shard_count(2)
+        .open()
+        .await
+        .unwrap();
+    let mut server = AttachedServer::start(
+        &database,
+        ListenerConfig {
+            http_listen: "127.0.0.1:0".parse().unwrap(),
+            postgres_listen: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let response = post_json(
+        server.addresses().http(),
+        "/v1/query",
+        &json!({
+            "shard_key": "tcp-lossless",
+            "sql": "SELECT 9007199254740993 AS exact_integer, X'0001ff' AS payload, NULL AS nullable",
+            "value_encoding": "lossless-json-v1"
+        }),
+    )
+    .await;
+    let (headers, body) = split_response(&response);
+    let lower_headers = headers.to_ascii_lowercase();
+    assert!(headers.starts_with("HTTP/1.1 200 OK\r\n"));
+    assert!(lower_headers.contains("\r\ncontent-type: application/json\r\n"));
+    assert!(lower_headers.contains("\r\nbriskdb-api-version: 1\r\n"));
+
+    let mut body: Value = serde_json::from_slice(body).unwrap();
+    assert!(body["shard"].as_u64().is_some());
+    body.as_object_mut().unwrap().remove("shard");
+    assert_eq!(
+        body,
+        json!({
+            "value_encoding": "lossless-json-v1",
+            "columns": [
+                {"name": "exact_integer", "data_type": "unknown"},
+                {"name": "payload", "data_type": "unknown"},
+                {"name": "nullable", "data_type": "unknown"}
+            ],
+            "rows": [[
+                tagged("int64", "9007199254740993"),
+                tagged("binary", "AAH/"),
+                null
+            ]]
+        })
+    );
+
+    server.close().await.unwrap();
+    database.close().await.unwrap();
+}


### PR DESCRIPTION
HTTP v1 currently loses value identity for large integers, binary data, decimal text, invalid UTF-8, signed zero, and non-finite floats. This adds an opt-in `lossless-json-v1` codec to `/v1/query` and `/v1/execute` while keeping omitted and explicit `legacy-json-v1` behavior byte-compatible.

The new codec uses strict two-field tags with canonical decimal, IEEE-754 hex-bit, and padded base64 representations. Discovery advertises both encodings, query responses identify the non-default selection, malformed tags fail before session or Engine admission, and returned BLOB tags can be reused as parameters without becoming text. Ordered columns and positional rows remain unchanged.

Relational timestamps remain application-owned `Text` or `Int64` because the shared value model and SQLite have no timestamp storage type. The protocol-neutral temporal contract is tracked separately in #298.

Validation:

- `cargo test --locked --all-targets --all-features` (1,115 library tests passed; 5 expected benchmarks ignored; all remaining targets green)
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- Rust 1.85 HTTP-only and all-feature checks
- focused HTTP v1, embedded differential, real-listener, release, and documentation tests
- `cargo package --locked --allow-dirty`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #51
