### PR TITLE
Add operational HTTP endpoints

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,7 @@ jobs:
           trap cleanup EXIT
           for attempt in {1..30}; do
             if curl --fail --silent --show-error http://127.0.0.1:17654/v1 >/dev/null \
+              && curl --fail --silent --show-error http://127.0.0.1:17655/v1/ready >/dev/null \
               && curl --fail --silent --show-error http://127.0.0.1:17655/admin >/dev/null; then
               kill -TERM "$server_pid"
               wait "$server_pid"

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ experimental and opt-in; the exact contract lives in
 | --- | --- |
 | Durable virtual-bucket routing over independent SQLite WAL files | Working |
 | Exact-key routing and bounded scatter/gather reads | Working |
-| HTTP query/write API and admin data browser | Working on separate data/admin listeners, loopback-only |
+| HTTP query/write API, operational API, and admin data browser | Working on separate data/admin listeners, loopback-only; readiness, catalog/migration/shard inspection, active-query cancellation, stopped-copy capability, and passive checkpoint are versioned |
 | PostgreSQL wire protocol | TLS/SCRAM, backpressured row streaming, SQLite-interrupt cancellation, text/binary CRUD, real single-shard transactions, and a live psql/tokio-postgres/psycopg/SQLAlchemy matrix |
 | Offline import from a standard SQLite database | Working |
 | Native-range and hi/lo generated IDs | Experimental, opt-in |
@@ -185,6 +185,8 @@ the separate administration listener:
 
 ```bash
 curl http://127.0.0.1:7655/health
+curl http://127.0.0.1:7655/v1/ready
+curl http://127.0.0.1:7655/v1/admin/catalog
 curl http://127.0.0.1:7655/metrics
 ```
 
@@ -332,8 +334,10 @@ more valuable than a star. Start with the
 - Global ordering/pagination and general aggregate pushdown are still limited.
 - The supported backup today is a stopped-server copy of the complete data
   directory after every server and embedder exits. Passive checkpoints now
-  report shards, manifest, and global-index storage, but are not an online
-  snapshot; online/serverless snapshots are planned.
+  report shards, manifest, and global-index storage through both Rust and the
+  administration API, but are not an online snapshot. The backup capability
+  endpoint reports this limitation rather than copying live files;
+  online/serverless snapshots are planned.
 - Multi-process access is same-host/local-filesystem only. Schema, catalog,
   upgrade, and recovery work requires sole-process ownership.
 - Pre-1.0 storage and public-library compatibility can change between releases.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,26 @@
 # Unreleased
 
+The administration HTTP listener now exposes versioned operational endpoints
+for readiness, relational catalog inspection, migration progress and exact
+generation lookup, validated shard state, bounded active-query inspection and
+cancellation, stopped-server backup capability, and passive checkpoint
+maintenance. The data listener continues to own query and execute; an opaque
+active-query handle created there can be listed and cancelled from the admin
+listener because every Engine clone shares the same bounded registry. Reports
+omit SQL, parameters, query SQL digests, and the durable migration identity;
+handles disappear when their HTTP handlers finish or drop, and cancelling one
+handle cannot target later work. Engine leases remain held independently until
+any interrupted SQLite cleanup finishes.
+
+`GET /v1/ready` returns HTTP 200 only while lifecycle and schema admission are
+ready; release archives and Debian service smoke tests now require that probe
+instead of treating a bound socket as sufficient. `/ready` is its unversioned
+probe alias. The backup endpoint reports the existing stopped-directory-copy
+procedure and performs no copy. Passive checkpoint remains optional preparation
+and is not an online snapshot or cross-file recovery point; coordinated online
+backup remains issue #67. These endpoints add no manifest, shard, or other
+on-disk format change.
+
 HTTP data and administration traffic now use separate routers and listener
 sockets over the same engine. `--listen` and `BRISKDB_LISTEN` remain the data
 plane at `127.0.0.1:7654`, serving `/v1` discovery, query, and execute. The new

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -330,7 +330,7 @@ protocol-specific golden tests only for encoding and state-machine behavior.
   `--listen` for data on `127.0.0.1:7654` and moving operator and browser routes
   to the optional loopback administration listener on `127.0.0.1:7655`
   (issue #52); see [the listener contract](docs/HTTP_LISTENERS.md).
-- [ ] Add endpoints for health, readiness, catalog inspection, migrations,
+- [x] Add endpoints for health, readiness, catalog inspection, migrations,
   shard state, query cancellation, backup, and maintenance.
 - [ ] Add request IDs, idempotency keys for eligible writes, pagination/streaming,
   body/result limits, and stable problem-detail errors.

--- a/docs/ADMIN_BROWSER.md
+++ b/docs/ADMIN_BROWSER.md
@@ -25,9 +25,10 @@ roadmap issues #56, #64, and #65.
 Anyone who can reach the administration listener knows these credentials.
 Server startup therefore restricts the current administration service to an
 IPv4 or IPv6 loopback address. Do not treat this login as a production identity
-boundary. It does not authenticate `/health`, `/metrics`, `/v1/health`, or
-`/v1/admin/*` on the same listener, and no `/v1/query` or `/v1/execute` handler
-exists there. The data listener has no `/admin` handlers.
+boundary. It does not authenticate `/health`, `/ready`, `/metrics`,
+`/v1/health`, `/v1/ready`, or `/v1/admin/*` on the same listener, and no
+`/v1/query` or `/v1/execute` handler exists there. The data listener has no
+`/admin` handlers.
 
 A successful login creates an opaque session from 32 operating-system-random
 bytes and sends its lowercase 64-character hexadecimal token only in the
@@ -176,9 +177,12 @@ continue.
 ## Deliberate non-goals
 
 The browser does not add editing, arbitrary SQL, schema migration, backup,
-maintenance, an atomic cross-file snapshot, stable pagination across concurrent
-writes, general distributed SQL aggregation or ordering, durable users or
-roles, credential configuration, or TLS. Those remain separate roadmap work.
+maintenance, active-query controls, an atomic cross-file snapshot, stable
+pagination across concurrent writes, general distributed SQL aggregation or
+ordering, durable users or roles, credential configuration, or TLS. The
+versioned operator API exposes separate migration inspection, query
+cancellation, stopped-copy capability, and passive-checkpoint routes; none is
+called by the browser or protected by its temporary login.
 Listener topology is specified in [HTTP_LISTENERS.md](HTTP_LISTENERS.md). The
 browser adds no manifest table, file, version, checksum input, migration, or
 recovery step.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -109,13 +109,36 @@ add no routing or SQLite implementation.
 Issue #52 gives the production server two disjoint Axum routers. The data
 router owns `/v1` discovery, query, and execute on `Config::listen`, which keeps
 the `127.0.0.1:7654` process default. The administration router owns
-`/health`, `/metrics`, `/v1/health`, `/v1/admin/*`, and `/admin/*` on
+`/health`, `/ready`, `/metrics`, `/v1/health`, `/v1/ready`, `/v1/admin/*`, and
+`/admin/*` on
 `Config::admin_listen`; the binary defaults it to `127.0.0.1:7655` and maps the
 exact `disabled` CLI/environment sentinel to `None`. Cross-plane paths are
-absent rather than forwarded. Both routers convert into the same `Engine`, and
-the established public `router`/`router_with_engine` constructors remain
+absent rather than forwarded. The server clones one `Engine` into both routers,
+and the established public `router`/`router_with_engine` constructors remain
 combined compatibility helpers for applications that own their serving
 boundary. See [the HTTP listener contract](HTTP_LISTENERS.md).
+
+Issue #53 adds protocol-neutral readiness, relational-catalog, migration,
+physical-shard, active-query, and checkpoint reports. Core and storage validate
+and own their semantics; the HTTP adapter only selects fields, assigns v1 names,
+and serializes them. In particular, it does not open the manifest or shard
+files, count routing buckets, hash migration SQL, or infer lifecycle from an
+error message. The readiness snapshot can observe a non-ready schema gate
+without trying to enter that same gate. Catalog responses expose stable
+identifiers, while migration responses expose generations without revealing
+retained migration SQL or its deterministic durable identity.
+The backup route serializes the supported stopped-directory-copy capability;
+it performs no copy and does not turn a passive checkpoint into a recovery
+point.
+
+Active HTTP query handles live in a finite Engine-owned registry shared by all
+Engine clones, so a request arriving through the administration router can
+cancel work admitted through the data router. The opaque handle maps only to
+that query's existing `CancellationToken`; query execution still enters the
+normal `RequestContext` and `OperationControl` path. Registration and removal
+use the exact opaque ID, completion keeps the established close-race rule, and
+listing returns only bounded redaction-safe metadata. The handles are neither
+general request IDs nor durable records.
 
 The independent `Config::postgres_listen` is also either a numeric socket
 address or disabled with `None`. The process default disables PostgreSQL;
@@ -843,9 +866,9 @@ numeric codes, downgrade policy, recovery cases, and tests are documented in
 Integrity failure marks the canonical-root admission gate sticky `Degraded`;
 ordinary operations, status calls, and migrations then fail with
 `DataCorruption`, and a trusted manifest records that terminal state when
-possible. BriskDB exposes no repair, rebaseline, or detailed integrity status
-API here; richer migration administration and status surfaces remain issue
-#53.
+possible. The issue-53 readiness, migration, and validated-shard reports expose
+the finite operational state without returning stored SQL or fingerprints.
+BriskDB still exposes no repair or rebaseline API.
 
 ## Generated-ID boundary
 

--- a/docs/CRATE_FEATURES.md
+++ b/docs/CRATE_FEATURES.md
@@ -28,7 +28,7 @@ Command, BSON, plan, and result types live under `briskdb::document`.
 | Feature | Adds | Tier |
 | --- | --- | --- |
 | `embedded` | Listener-free `BriskDb` and `BriskSession` SQL APIs | Alpha-supported |
-| `http` | Separate Axum data/admin routers, HTTP API, and admin browser; combined compatibility router retained | Alpha-supported |
+| `http` | Separate Axum data/admin routers, versioned data and operational APIs, active-query cancellation, and admin browser; combined compatibility router retained | Alpha-supported |
 | `postgres` | PostgreSQL wire adapter, including TLS/SCRAM implementation | Alpha-supported, bounded SQL subset |
 | `listeners` | Host-controlled data HTTP, optional admin HTTP, and optional PostgreSQL listeners, selecting `tls`, without signals or engine ownership | Alpha-supported |
 | `server` | Daemon listener assembly, signal handling, and engine ownership | Process integration |

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -18,6 +18,18 @@ addresses. Equal nonzero data/admin socket addresses are rejected as a
 configuration error; port zero may be requested for both because the operating
 system resolves them to distinct sockets. A path sent to the wrong HTTP plane
 is an ordinary 404 and never reaches the hidden handler.
+Within HTTP v1, a malformed or absent exact migration generation and a
+malformed, unknown, completed, or stale active-query operation ID use the same
+fixed `not_found` transport problem. These resource lookups do not add an
+engine error kind. A non-ready probe instead returns its documented readiness
+JSON at HTTP 503 rather than a Problem Details document.
+The active-query cancel route requires a zero-byte body. A nonempty body is a
+fixed v1 `invalid_argument`, or `request_too_large` above the transport limit,
+and is rejected before it can request cancellation.
+An HTTP query that encounters all 1,024 active-query registry entries occupied
+returns the standard `LimitExceeded` mapping at HTTP 422 before Engine
+admission. Handler removal restores registry capacity independently of any
+remaining SQLite cleanup lease.
 
 ## Taxonomy and protocol mappings
 

--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -1,6 +1,6 @@
 # HTTP API version 1
 
-Status: implemented for issues #50, #51, and #52. BriskDB remains an alpha
+Status: implemented for issues #50 through #53. BriskDB remains an alpha
 database. Its data and administration HTTP listeners are separate,
 loopback-only, and have no complete authorization boundary. The `/admin`
 browser login authenticates only its browser endpoints.
@@ -24,8 +24,9 @@ Every response within `/v1`, including engine errors, decoding failures,
 unknown endpoints, and unsupported methods, carries `BriskDB-API-Version: 1`.
 The URL selects the API version; a client header does not select another
 version. Unknown versions have no routes and return HTTP 404. Discovery is
-static contract metadata, not a readiness check; use `/v1/health` on the
-administration listener for the current engine health report.
+static contract metadata, not a readiness check; use `/v1/ready` on the
+administration listener before sending traffic and `/v1/health` for the
+broader engine and global-index health report.
 
 The HTTP API major version is independent of the package version and manifest
 format. Within v1, existing request fields, successful response fields, known
@@ -65,12 +66,25 @@ the entire plane:
 | `GET /health` | Engine and aggregate global-index health report |
 | `GET /metrics` | Prometheus text report |
 | `GET /v1/health` | Versioned alias of `/health` |
+| `GET /ready` | Unversioned readiness probe |
+| `GET /v1/ready` | Versioned readiness probe |
 | `POST /v1/admin/broadcast` | Journaled application-schema migration result |
+| `GET /v1/admin/catalog` | Relational catalog metadata |
+| `GET /v1/admin/migrations` | Current schema generation and migration summary |
+| `GET /v1/admin/migrations/{target_generation}` | One exact migration generation |
+| `GET /v1/admin/shards` | Validated physical-shard state |
+| `GET /v1/admin/queries` | Bounded active-query report |
+| `POST /v1/admin/queries/{operation_id}/cancel` | Cancel one exact active query |
+| `GET /v1/admin/backup` | Supported stopped-server backup capability |
+| `POST /v1/admin/maintenance/checkpoint` | Passive checkpoint of every database |
 | `GET /v1/admin/global-indexes` | [Global-index operational report](GLOBAL_INDEX_RELEASE_GATE.md) |
 | `/admin`, `/admin/`, assets, and `/admin/api/*` | [Admin data browser](ADMIN_BROWSER.md) |
 
 GET routes also accept HEAD, returning headers without a body. Success is HTTP
-200 with `application/json`, except for Prometheus text and browser assets.
+200 with `application/json`, except for Prometheus text, browser assets, and a
+successful cancellation request, which is HTTP 202. A readiness response uses
+HTTP 503 while the engine cannot admit ordinary work but retains the readiness
+JSON representation described below.
 Each production router omits the other plane's handlers, so sending a route to
 the wrong listener returns 404 without executing it. The complete address,
 Rust/Python configuration, startup, and drain contract is in
@@ -128,8 +142,9 @@ not parse SQL, hash keys, open files, or implement transaction or migration
 coordination. See [SQL compatibility](SQL_COMPATIBILITY.md),
 [generated keys](GENERATED_KEYS.md), and [request controls](REQUEST_CONTROLS.md).
 Engine deadlines, cancellation, admission, and result limits still apply.
-This API buffers bounded results; it does not expose an HTTP row stream or a
-multi-request cancellation endpoint.
+This API buffers bounded results and does not expose an HTTP row stream. The
+administration listener can enumerate and cancel a currently active query, as
+described below; the handle does not retain an HTTP transaction or result.
 
 ## Successful responses
 
@@ -273,6 +288,256 @@ On the administration listener, broadcast accepts only
 operation, with preflight and resumable application across every shard. It
 does not create catalog metadata implicitly or accept bound parameters.
 
+## Operational responses
+
+### Readiness
+
+`GET /ready` and `GET /v1/ready` return the same JSON. The versioned form adds
+the v1 response header. A ready engine returns HTTP 200:
+
+```json
+{
+  "status": "ready",
+  "ready": true,
+  "reasons": [],
+  "engine_state": "running",
+  "schema_state": "ready",
+  "schema_generation": "7",
+  "active_schema_operations": 2
+}
+```
+
+Readiness means that the engine lifecycle is `running` and its schema gate is
+`ready`, so a new ordinary operation can attempt admission. It does not reserve
+a pool slot or promise that a later request cannot race with shutdown,
+contention, or a schema transition. Global-index degradation remains visible in
+`/health` and `/v1/admin/global-indexes`; it does not change this narrow
+admission result.
+
+A non-ready engine returns HTTP 503 with the same `application/json` shape,
+`status:"not_ready"`, and `ready:false`. `engine_state` is `draining` or
+`stopped`; `schema_state` is `migrating`, `pending`, or `degraded`. The ordered
+`reasons` array uses the corresponding finite codes `engine_draining`,
+`engine_stopped`, `schema_migrating`, `schema_recovery_pending`, and
+`schema_degraded`. This probe response is not a Problem Details document.
+`schema_generation` is exact decimal text. `active_schema_operations` is a
+snapshot count and can change immediately.
+
+### Relational catalog and physical shards
+
+`GET /v1/admin/catalog` returns the immutable relational catalog view and its
+currently published schema generation:
+
+```json
+{
+  "identifier_encoding_version": 1,
+  "schema_generation": "7",
+  "default_database_id": "1",
+  "databases": [{"id":"1","name":"default"}],
+  "tables": [{
+    "id": "9",
+    "database_id": "1",
+    "name": "events",
+    "placement": {
+      "kind": "sharded",
+      "shard_key": {"column":"tenant_id","data_type":"text"}
+    },
+    "generated_id": {"policy":"none"}
+  }],
+  "global_indexes": [{
+    "id": "3",
+    "table_id": "9",
+    "name": "events_email",
+    "unique": false,
+    "lifecycle": "ready",
+    "schema_generation": "7",
+    "key_encoding_version": 1
+  }]
+}
+```
+
+Database, table, and global-index IDs and schema generations use decimal
+strings so JavaScript does not round a persisted `u64`. Arrays preserve the
+catalog's stable order. A sharded placement includes one shard-key declaration
+whose `data_type` is `int64`, `text`, or `binary`; `global` and `catalog`
+placements contain only `kind`. `generated_id.policy` is `none`,
+`native_range_v1`, or `hilo_v1`; enabled policies also include `column` and
+`encoding_version`. Global-index lifecycle is one of `creating`, `ready`,
+`invalid`, `rebuilding`, or `dropping`. This catalog response deliberately
+omits migration SQL, index expressions and predicates, physical filenames, and
+row contents. Runtime global-index health and recovery instructions remain in
+the dedicated global-index endpoint.
+
+`GET /v1/admin/shards` reopens and validates every configured physical shard
+through the bounded engine path before returning any result:
+
+```json
+{
+  "schema_generation": "7",
+  "shards": [
+    {"id":0,"state":"ready"},
+    {"id":1,"state":"ready"}
+  ]
+}
+```
+
+The array is ordered by numeric shard ID. `ready` currently means that the
+file's identity, layout, metadata, schema generation, and committed schema
+digest all match the validated engine view. Any shard failure rejects the
+whole request through the standard engine error mapping; the endpoint never
+returns a partial healthy subset. It does not claim a heartbeat, replica state,
+WAL-size measurement, load sample, or cross-file transaction snapshot.
+
+### Migration inspection
+
+`GET /v1/admin/migrations` returns a bounded summary rather than unbounded
+history:
+
+```json
+{
+  "schema_generation": "7",
+  "active": null,
+  "latest_complete": {
+    "generation": "7",
+    "source_generation": "6",
+    "target_generation": "7",
+    "state": "complete",
+    "shard_count": 2,
+    "next_shard": 2,
+    "completed_shards": 2,
+    "sql_bytes": 42
+  }
+}
+```
+
+`active` and `latest_complete` are always present and use JSON null when there
+is no matching row. `generation` names the target generation and is repeated as
+`target_generation` to make the source-to-target transition explicit.
+`completed_shards` is a count and equals `next_shard`; it is separate from
+broadcast's array of completed shard IDs. Neither the journal's exact SQL nor
+its deterministic durable identity is returned. `sql_bytes` permits size
+diagnosis without exposing its contents.
+
+`GET /v1/admin/migrations/{target_generation}` returns the same migration
+object for one canonical positive decimal generation. Leading zeroes, signs,
+non-decimal text, zero, overflow, and a generation absent from retained history
+all receive the fixed v1 404 problem. This exact lookup keeps the surface
+bounded while general pagination remains later work.
+
+Broadcast remains the only v1 migration mutation. Its SQL is capped at 65,536
+UTF-8 bytes by the durable migration contract in addition to the HTTP body
+limit. An exact retry resumes or recognizes the same journaled operation; a
+different migration while one is active fails without replacing its durable
+state. Migration inspection participates in engine cancellation, deadlines,
+worker admission, and manifest validation, but may observe the active journal
+without entering the ordinary schema gate that the migration excludes.
+
+### Active query cancellation
+
+`GET /v1/admin/queries` returns at most 1,024 currently registered HTTP query
+operations, sorted by opaque operation ID:
+
+```json
+{
+  "queries": [{
+    "operation_id": "0123456789abcdef0123456789abcdef",
+    "elapsed_ms": 17,
+    "sql_bytes": 128,
+    "cancellation_requested": false
+  }]
+}
+```
+
+The 32-character lowercase hexadecimal ID is random and exists only while that
+query is active. `elapsed_ms` is the whole-millisecond age at snapshot time and
+can increase between calls. The report does not contain SQL, a SQL digest,
+parameters, routing keys, result data, sessions, or paths. Execute, migration,
+checkpoint, browser, and PostgreSQL operations do not enter this HTTP-query
+list. The list is live: an operation can complete after it is returned. When
+all 1,024 registry entries are occupied, another HTTP query fails before Engine
+admission with the standard HTTP 422 `limit_exceeded` problem. Removing a
+tracking guard restores capacity.
+
+`POST /v1/admin/queries/{operation_id}/cancel` selects the operation entirely
+from the path and requires exactly zero request-body bytes; no content type is
+required. A nonempty body within the 2 MiB limit receives the fixed HTTP 400
+`invalid_argument` problem, while a larger body receives HTTP 413
+`request_too_large`. Body rejection occurs before registry cancellation, so it
+cannot cancel the named query. An exact active ID with an empty body receives
+HTTP 202:
+
+```json
+{"operation_id":"0123456789abcdef0123456789abcdef","newly_requested":true}
+```
+
+`newly_requested` is false when cancellation was already sticky but cleanup
+has not removed the operation yet. A malformed, all-zero, unknown, completed,
+or stale ID receives the fixed 404 problem and cannot target another query.
+The data query ultimately reports the existing `cancelled` engine problem,
+currently HTTP 500. Completion known to have succeeded wins a close
+cancellation race. Disconnecting the data client drops the HTTP handler and
+removes its ID. The Engine's separate operation guard requests exact-handle
+interruption and retains lifecycle and pool ownership until SQLite cleanup
+finishes; registry disappearance does not claim that cleanup has already
+finished. Handles are neither preallocated tickets, response headers, general
+request IDs, durable records, nor idempotency keys.
+
+### Backup capability and checkpoint maintenance
+
+`GET /v1/admin/backup` reports the only supported alpha backup procedure:
+
+```json
+{
+  "mode": "stopped_directory_copy",
+  "online": false,
+  "requires_all_processes_stopped": true,
+  "checkpoint_endpoint": "/v1/admin/maintenance/checkpoint",
+  "checkpoint_role": "preparation_only",
+  "checkpoint_is_recovery_point": false
+}
+```
+
+This response performs no copy and accepts no destination. Follow the complete
+[stopped-server backup procedure](OFFLINE_BACKUP.md). Coordinated online backup
+and a manifest-defined recovery point remain issue #67.
+
+`POST /v1/admin/maintenance/checkpoint` accepts the exact JSON object `{}` and
+passively checkpoints every shard, the manifest, and the global-index database
+when present:
+
+```json
+{
+  "operation": "passive_checkpoint",
+  "busy": false,
+  "complete": true,
+  "recovery_point": false,
+  "shards": [{
+    "shard": 0,
+    "busy": false,
+    "counts_available": true,
+    "wal_frames": 0,
+    "checkpointed_frames": 0,
+    "complete": true
+  }],
+  "databases": [{
+    "database": "manifest",
+    "busy": false,
+    "counts_available": true,
+    "wal_frames": 0,
+    "checkpointed_frames": 0,
+    "complete": true
+  }]
+}
+```
+
+Auxiliary `database` names are `manifest` and `global_index`. Every array is
+deterministically ordered. HTTP 200 means the passive attempt ran; SQLite may
+still report `busy:true` or `complete:false`, and unavailable counts are zero
+with `counts_available:false`. Engine failures use Problem Details. Unknown or
+duplicate request fields, a non-object, an empty body, or a missing JSON content
+type fail before maintenance. A complete report can reduce retained WAL but
+still has `recovery_point:false` and does not make a live directory copy safe.
+
 ## Errors
 
 Errors within v1 have `Content-Type: application/problem+json`, the version
@@ -282,8 +547,9 @@ names, query text, filesystem paths, and decoder diagnostics are not echoed.
 
 | Failure | HTTP | Code |
 | --- | ---: | --- |
-| Malformed JSON, invalid request envelope, or invalid value encoding/tag | 400 | `invalid_argument` |
+| Malformed JSON, invalid request envelope, nonempty cancel body, or invalid value encoding/tag | 400 | `invalid_argument` |
 | Unknown v1 endpoint | 404 | `not_found` |
+| Unknown migration generation or malformed/stale query operation ID | 404 | `not_found` |
 | Unsupported method on a known endpoint | 405 | `method_not_allowed` |
 | Body exceeds 2 MiB | 413 | `request_too_large` |
 | Missing or non-JSON content type | 415 | `unsupported_media_type` |
@@ -296,31 +562,44 @@ engine `busy` code advertises retryability. A write may commit before its
 response reaches the client; v1 supplies no idempotency key and makes no
 exactly-once delivery guarantee.
 
+The readiness probe's HTTP 503 JSON is the documented exception to the
+Problem Details shape: it is a successful observation that the engine cannot
+currently admit ordinary work, not an `EngineError` serialization.
+
 ## Migration from the combined listener
 
 Route names, valid request bodies, successful result shapes, and cell encodings
 are unchanged. Data requests and discovery stay on `--listen`. Operator and
-browser clients must change their base address to `--admin-listen` for
-`/health`, `/metrics`, `/v1/health`, `/v1/admin/*`, and `/admin/*`. The daemon
-default moves those routes from `127.0.0.1:7654` to `127.0.0.1:7655`; setting
-the admin listener to `disabled` makes every one of them unavailable.
+browser clients must use `--admin-listen` for `/health`, `/ready`, `/metrics`,
+`/v1/health`, `/v1/ready`, `/v1/admin/*`, and `/admin/*`. The daemon default
+serves those routes at `127.0.0.1:7655`; setting the admin listener to
+`disabled` makes every one of them unavailable.
 
 This authority change is intentional pre-1.0 listener configuration, not an
 API-major representation change. It introduces no storage migration and does
 not alter Rust engine behavior. The established Rust `router` and
 `router_with_engine` helpers remain combined for host-owned integrations; the
-daemon and attached server use the isolated plane routers.
+daemon and attached server use the isolated plane routers with clones of one
+Engine. A host constructing both planes must also pass clones of one Engine to
+`data_router_with_engine` and `admin_router_with_engine` for shared lifecycle
+and cancellation. Calling the two `Arc<Database>` split-router wrappers
+separately creates independent Engines and operational registries.
 
 The earlier experimental-to-v1 migration still applies: unknown envelope
 fields and malformed bodies now return the fixed errors above, and clients may
 adopt lossless cells one request at a time with
 `"value_encoding":"lossless-json-v1"`.
 
-`tests/http_v1.rs` exercises discovery, schema rejection before mutation, body
-limits, routing errors, method headers, version isolation, and session isolation.
-Existing HTTP tests cover catalog routing, generated keys, concurrent requests,
-deadlines, result limits, and exact response shapes. Lossless-codec tests cover
-every tag, canonical validation, binary reuse, and unchanged legacy responses;
-embedded differential tests verify shared-engine outcomes. Listener tests prove
-the route matrix on separate real sockets, disabled administration, partial-bind
-cleanup, address reporting, and common shutdown behavior.
+`tests/http_v1.rs` exercises discovery, readiness and drain state, catalog and
+operational response shapes, migration lookup redaction, checkpoint envelope
+strictness, active-query cancellation and cleanup, schema rejection before
+mutation, body limits, routing errors, method headers, version isolation, and
+session isolation. Existing HTTP tests cover catalog routing, generated keys,
+concurrent requests, deadlines, result limits, and exact response shapes.
+Lossless-codec tests cover every tag, canonical validation, binary reuse, and
+unchanged legacy responses; embedded differential tests verify shared-engine
+outcomes. Listener tests prove the complete admin-only route matrix on separate
+real sockets, selected-query cancellation from the admin plane, stale-handle
+isolation, registry disappearance and later query usability after a client
+disconnect, disabled administration, partial-bind cleanup, address reporting,
+and common shutdown behavior.

--- a/docs/HTTP_LISTENERS.md
+++ b/docs/HTTP_LISTENERS.md
@@ -36,7 +36,14 @@ operator or browser paths at `127.0.0.1:7654` must use
 | `GET /v1`, `GET /v1/` | `GET /health` |
 | `POST /v1/query` | `GET /metrics` |
 | `POST /v1/execute` | `GET /v1/health` |
+|  | `GET /ready`, `GET /v1/ready` |
 |  | `POST /v1/admin/broadcast` |
+|  | `GET /v1/admin/catalog` |
+|  | `GET /v1/admin/migrations`, `GET /v1/admin/migrations/{target_generation}` |
+|  | `GET /v1/admin/shards` |
+|  | `GET /v1/admin/queries`, `POST /v1/admin/queries/{operation_id}/cancel` |
+|  | `GET /v1/admin/backup` |
+|  | `POST /v1/admin/maintenance/checkpoint` |
 |  | `GET /v1/admin/global-indexes` |
 |  | `/admin`, `/admin/`, assets, and `/admin/api/*` |
 
@@ -45,16 +52,21 @@ therefore receives HTTP 404 and cannot execute the hidden operation. Responses
 under an omitted `/v1` path retain the version-1 problem-detail and version
 header behavior; unversioned missing paths use the ordinary HTTP 404 response.
 The embedded browser and its JSON endpoints stay together on the administration
-listener, so its same-origin cookie and asset rules do not change.
+listener, so its same-origin cookie and asset rules do not change. Its temporary
+cookie does not authenticate the operator endpoints above.
 
 The public Rust HTTP module exposes `data_router` and
 `data_router_with_engine`, plus `admin_router` and
 `admin_router_with_engine`. Its established `router` and `router_with_engine`
 functions remain combined-router compatibility helpers for applications that
 deliberately own their HTTP serving boundary. BriskDB's daemon and attached
-server use only the separate routers. A host that serves a router itself owns
-socket validation and exposure; loopback enforcement belongs to `server`, not
-to an Axum `Router` value.
+server clone one Engine into the two Engine-based router constructors. A host
+building both planes must do the same so lifecycle and active-query
+cancellation are shared. Calling the two `Arc<Database>` compatibility wrappers
+separately creates independent Engines and therefore independent operational
+registries. A host that serves a router itself owns socket validation and
+exposure; loopback enforcement belongs to `server`, not to an Axum `Router`
+value.
 
 ## Rust and Python attached servers
 
@@ -83,11 +95,27 @@ and logs readiness only after every configured socket has bound. Any bind or
 accept failure releases all listener sockets and enters the existing cleanup
 path; a partially started daemon never reports readiness.
 
+After binding, service and packaging probes use `GET /v1/ready` on the
+administration listener. HTTP 200 means the shared engine lifecycle is running
+and its schema gate is ready at that snapshot. A non-ready engine returns HTTP
+503 with the same JSON report and finite lifecycle/schema reasons. `/ready` is
+the unversioned alias. Data discovery remains static metadata and is not a
+readiness signal. Disabling the administration listener also removes both
+readiness paths, so a host that chooses that configuration must inspect its
+embedded Engine lifecycle directly.
+
 Both HTTP planes share the existing finite engine admission, deadline, result,
 pool, and shutdown controls. One shutdown signal stops admission, closes every
 listener, signals all tracked HTTP and PostgreSQL connections, and drains them
 against the configured grace period. An attached server performs the same
 listener drain without beginning shutdown of its borrowed database.
+
+Active HTTP query handles are likewise stored in the shared Engine rather than
+one router. A data-plane `/v1/query` can therefore be listed and cancelled from
+the administration listener even though neither plane forwards requests to the
+other. Closing a data socket drops its handler and removes the query handle;
+the engine's operation guard retains its own lifecycle and pool leases until
+SQLite interruption and cleanup finish.
 
 ## Compatibility and deferred work
 
@@ -98,9 +126,10 @@ administration address. `/v1/query`, `/v1/execute`, and version discovery stay
 on the established data address. The move changes no SQL semantics, JSON value
 codec, error mapping, manifest or shard format, migration, or dependency.
 
-Issue #53 owns richer health/readiness, catalog, migration, shard, cancellation,
-backup, and maintenance endpoints. Issue #54 owns request IDs, idempotency,
-pagination/streaming, and further transport limits. Issue #55 owns OpenAPI.
+Issue #53 adds readiness, catalog, migration, shard, active-query cancellation,
+backup-capability, and checkpoint-maintenance endpoints. Issue #54 owns general
+request IDs, idempotency, pagination/streaming, and further transport limits.
+Issue #55 owns OpenAPI.
 Issue #56 owns the HTTP authentication and role-check boundary, issue #64 owns
 the durable user/role and credential model, and issue #65 owns listener TLS and
 safe remote activation. Until those land, the separate loopback listeners are

--- a/docs/OFFLINE_BACKUP.md
+++ b/docs/OFFLINE_BACKUP.md
@@ -10,13 +10,22 @@ This is not an online backup. Do not copy a live data directory, even when no
 application writes are expected. Coordinated online backup remains tracked by
 issue #67.
 
+`GET /v1/admin/backup` reports this stopped-copy capability in machine-readable
+form. It does not start a copy, choose a destination, stop an embedder, or make
+live files consistent. `POST /v1/admin/maintenance/checkpoint` with the exact
+JSON body `{}` performs the same optional passive checkpoint available through
+the embedded engine. Neither endpoint is an online-backup API or a
+manifest-defined cross-file recovery point.
+
 ## Backup
 
-1. Optionally ask the running engine to perform a passive checkpoint and inspect
+1. Optionally ask the running engine to perform a passive checkpoint, directly
+   or through `POST /v1/admin/maintenance/checkpoint` with `{}`, and inspect
    every returned shard plus the `manifest` and optional `global_index`
    database report. Retry a `busy`/incomplete report if reducing retained WAL
    is important. This is preparation only: it does not make a live copy safe
-   or establish a cross-file recovery point.
+   or establish a cross-file recovery point. A successful HTTP response can
+   still report `busy` or `complete: false`.
 2. Record the BriskDB version, configured shard count, and absolute data
    directory path.
 3. Stop every BriskDB server and embedded application cleanly and wait for each
@@ -54,9 +63,10 @@ stopped directory as one recovery point.
 3. Start the same BriskDB release with the recorded shard count and the restored
    directory. Startup must reach `Ready` without a migration, integrity, shard
    identity, WAL-mode, or schema-generation error.
-4. Check `/health` on the administration listener, inspect the expected logical
-   catalog, and read known rows through the data listener from representative
-   shard keys before returning the service to use.
+4. Require HTTP 200 from `/v1/ready` on the administration listener, inspect
+   `/v1/admin/catalog`, check `/health`, and read known rows through the data
+   listener from representative shard keys before returning the service to
+   use.
 5. Keep the prior directory and backup unchanged until validation succeeds.
    If validation fails, stop the process and investigate; do not edit manifest
    state, SQLite headers, or checksums to force startup.

--- a/docs/REQUEST_CONTROLS.md
+++ b/docs/REQUEST_CONTROLS.md
@@ -44,6 +44,45 @@ keys. Closing a PostgreSQL connection unregisters its key and cancels active
 work. A cancelled command returns SQLSTATE `57014`; an explicit transaction
 enters failed state until rollback.
 
+The Engine also keeps a bounded registry for active HTTP queries. A query gets
+an opaque 32-character lowercase hexadecimal handle before it enters engine
+admission. Normal completion removes that handle when the handler finishes.
+Dropping the handler unregisters it immediately while the Engine's independent
+operation drop guard cancels SQLite and retains lifecycle and pool ownership
+until cleanup actually finishes. `GET /v1/admin/queries` returns a bounded,
+redaction-safe snapshot that never includes SQL, SQL digests, parameter values,
+routing keys, sessions, or paths.
+`POST /v1/admin/queries/{operation_id}/cancel` requests cancellation for that
+exact live handle and returns HTTP 202. An unknown,
+malformed, completed, or stale handle returns the fixed versioned 404 problem
+and cannot affect another query. The response's `newly_requested` Boolean
+distinguishes the call that changed the sticky token from a repeated request
+while cleanup is still in progress.
+
+Cancel takes its identity only from the path and requires a zero-byte body. A
+nonempty body receives the fixed versioned HTTP 400 problem, or HTTP 413 when
+it exceeds the 2 MiB limit, before the registry can be changed. An empty body
+does not require a content type.
+
+The registry is shared by every Engine clone, including the clones the server
+passes to its separate data and administration routers. An embedder building
+both planes must likewise clone one Engine into `data_router_with_engine` and
+`admin_router_with_engine`; calling the two `Arc<Database>` compatibility
+wrappers separately constructs independent Engines and registries. The registry
+is process memory, has no manifest or restart state, and contains active
+operations only. Listing and cancellation are inherently live observations: a
+listed query can complete before the cancel request arrives. Completion known
+to have succeeded still wins its close race with cancellation. Closing a data
+connection or dropping its HTTP handler unregisters the HTTP handle, requests
+exact-operation cancellation, and leaves the engine lease in place until the
+leased SQLite work and pool cleanup have really stopped.
+
+The registry holds at most 1,024 queries. When it is full, another HTTP query
+returns the standard HTTP 422 `limit_exceeded` problem before Engine admission.
+When a handler drops its tracking guard, removing the exact entry immediately
+restores one registry slot even when the independently leased SQLite cleanup is
+still finishing.
+
 An operation still waiting for its session, shard connection, or blocking
 worker leaves the queue immediately when cancelled. It never starts SQL. Once
 SQLite is running, BriskDB arms an interrupt handle and progress callback only

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -327,10 +327,12 @@ keys in the same generated-ID routing domain, Sharded-to-Global, or
 Global-to-Global placement, and SQLite must accept the referenced parent key;
 triggers and virtual tables remain prohibited. Row-moving DML, table drops, and
 trigger creation are rejected before this rollback-only check. A violation fails
-preflight before journal publication. Richer
-migration/history APIs remain issue #53. Manifest v8 retains the v7
-generation-bound persistent-schema fingerprint requirement in addition to this
-catalog enforcement.
+preflight before journal publication. HTTP v1 exposes a bounded current/latest
+migration summary and exact target-generation lookup without returning this SQL
+or its durable migration identity; `broadcast` remains its only migration
+submission route. Manifest v8 retains the v7 generation-bound
+persistent-schema fingerprint requirement in addition to this catalog
+enforcement.
 
 The schema gate admits no new routed work after migration begins and waits for
 previously admitted operations to drain. During active preflight or apply,

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -1132,10 +1132,12 @@ The retained journal proves which exact batches BriskDB coordinated; it does
 not authenticate the files or cryptographically cover application rows. Version
 7 separately requires every shard's persistent application-schema fingerprint
 to match the trusted source or target fingerprint for its position in an active
-migration. Richer migration submission, history, and status APIs remain issue
-#53. The general physical-SQL entry point retains the `broadcast` name and
-response shape; the generated-table DDL bridge is a separate initialization-only
-producer of one canonical physical migration.
+migration. HTTP v1 now exposes a bounded current/latest summary and exact
+target-generation lookup without returning retained SQL or the internal
+migration identity described here; it does not add an unbounded history
+listing. The general physical-SQL entry point retains the `broadcast` name and
+response shape; the generated-table DDL bridge is a separate
+initialization-only producer of one canonical physical migration.
 
 ### Integrity metadata and durable database states
 

--- a/docs/SUPPORTED_PLATFORMS.md
+++ b/docs/SUPPORTED_PLATFORMS.md
@@ -32,9 +32,12 @@ contract.
 
 The supported runner tests separate Tokio TCP listeners on numeric IPv4
 secure/non-secure address validation, isolated data/admin HTTP routes,
-concurrent HTTP and PostgreSQL sessions, disabled administration/PostgreSQL
-binding, bind-failure cleanup, TLS/SCRAM exchange, and shutdown of every
-listener.
+concurrent HTTP and PostgreSQL sessions, cross-plane HTTP query cancellation,
+registry disappearance and later query usability after a data-client
+disconnect, disabled administration/PostgreSQL binding, bind-failure cleanup,
+TLS/SCRAM exchange, and shutdown of every listener. HTTP tests also freeze the
+readiness, relational catalog, migration, validated-shard, backup-capability,
+and checkpoint representations over real sockets.
 It also starts a real imported two-shard server and gates releases on
 transaction CRUD, error recovery, close, and reconnect through Ubuntu's
 `psql`, tokio-postgres 0.7.18, psycopg 3.2.13, and SQLAlchemy 2.0.43.
@@ -81,8 +84,9 @@ on these GitHub-hosted runners:
 - macOS Apple Silicon ARM64 (`aarch64-apple-darwin`).
 
 Those release artifacts are previews outside Ubuntu 24.04 x86-64. Their native
-jobs verify the locked release build, CLI version, HTTP startup, admin endpoint,
-and clean termination, but do not run the full storage and integration suite.
+jobs verify the locked release build, CLI version, data discovery, an HTTP 200
+administration readiness probe, the admin endpoint, and clean termination, but
+do not run the full storage and integration suite.
 Windows, the musl target, 32-bit targets, big-endian targets, mobile platforms,
 and WebAssembly are not currently tested or supported.
 

--- a/packaging/debian/test-deb-service.sh
+++ b/packaging/debian/test-deb-service.sh
@@ -14,6 +14,7 @@ wait_for_service() {
     for attempt in {1..30}; do
         if sudo systemctl is-active --quiet briskdb.service \
             && curl --fail --silent --show-error http://127.0.0.1:7654/v1 >/dev/null \
+            && curl --fail --silent --show-error http://127.0.0.1:7655/v1/ready >/dev/null \
             && curl --fail --silent --show-error http://127.0.0.1:7655/admin >/dev/null; then
             return 0
         fi

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -19,18 +19,22 @@ use tokio::{
 
 use super::session::TransactionState;
 use super::{
-    BlockingPool, BoundStatementPlan, CancelOnDrop, CancellationReason, CancellationToken,
-    Database, DescribeTarget, EngineError, EngineErrorKind, EngineOptions, EngineResult,
-    EngineState, Executed, GlobalIndexOperationalReport, Lifecycle, LogicalDatabaseId,
-    OperationControl, OperationLease, PortalId, PrepareRequest, PreparedExecution,
-    PreparedStatementDescription, PreparedStatementId, PreparedStatementLimits, RawDataOperation,
-    RawDataTarget, RequestContext, ResultLimits, ResultSet, Routed, RowProducer, RowStream,
-    Session, SessionInner, ShutdownReport, TablePlacement, TransactionExecution, Value,
-    merge_scatter_results, wait_for_cancellation, wait_pending,
+    ActiveQueryRegistry, ActiveQueryStatus, BlockingPool, BoundStatementPlan, CancelOnDrop,
+    CancellationReason, CancellationToken, Database, DescribeTarget, EngineError, EngineErrorKind,
+    EngineOptions, EngineResult, EngineState, Executed, GlobalIndexOperationalReport, Lifecycle,
+    LogicalDatabaseId, OperationControl, OperationLease, PortalId, PrepareRequest,
+    PreparedExecution, PreparedStatementDescription, PreparedStatementId, PreparedStatementLimits,
+    QueryId, RawDataOperation, RawDataTarget, ReadinessSnapshot, RequestContext, ResultLimits,
+    ResultSet, Routed, RowProducer, RowStream, SchemaMigrationStatus, SchemaMigrationSummary,
+    SchemaState, Session, SessionInner, ShardState, ShardStatus, ShardStatusReport, ShutdownReport,
+    TablePlacement, TrackedQuery, TransactionExecution, Value, merge_scatter_results,
+    wait_for_cancellation, wait_pending,
 };
 use crate::{
     sql,
-    storage::{ConnectionOwner, ConnectionPools, PooledConnection, SchemaOperationGuard},
+    storage::{
+        ConnectionOwner, ConnectionPools, PooledConnection, SchemaGateState, SchemaOperationGuard,
+    },
 };
 
 #[cfg(feature = "experimental-vtab")]
@@ -375,6 +379,7 @@ struct EngineInner {
     workers: BlockingPool,
     connections: ConnectionPools,
     lifecycle: Arc<Lifecycle>,
+    active_queries: Arc<ActiveQueryRegistry>,
     shutdown_cancel: CancellationToken,
     shutdown_gate: Arc<tokio::sync::Mutex<()>>,
     #[cfg(feature = "experimental-vtab")]
@@ -600,6 +605,7 @@ impl Engine {
                 workers,
                 connections,
                 lifecycle: Lifecycle::new(),
+                active_queries: ActiveQueryRegistry::new(),
                 shutdown_cancel: CancellationToken::new(),
                 shutdown_gate: Arc::new(tokio::sync::Mutex::new(())),
                 #[cfg(feature = "experimental-vtab")]
@@ -856,6 +862,54 @@ impl Engine {
         self.inner.lifecycle.state()
     }
 
+    /// Return a narrow readiness snapshot without admitting an operation.
+    ///
+    /// Readiness means the engine lifecycle is running and the application
+    /// schema gate is ready. Global-index degradation is reported by its
+    /// dedicated health surface and does not change this admission result.
+    pub fn readiness(&self) -> ReadinessSnapshot {
+        // Admission occupancy can change continuously under load, so readiness
+        // must never spin waiting for two identical observations. The gate
+        // snapshot is internally coherent; the published generation is a
+        // neighboring live diagnostic and may advance immediately before or
+        // after any returned snapshot.
+        let schema = self.inner.database.storage.schema_gate_snapshot();
+        let schema_generation = self.inner.database.storage.current_schema_generation();
+        ReadinessSnapshot {
+            lifecycle_state: self.state(),
+            schema_state: match schema.state {
+                SchemaGateState::Ready => SchemaState::Ready,
+                SchemaGateState::Migrating => SchemaState::Migrating,
+                SchemaGateState::Pending => SchemaState::Pending,
+                SchemaGateState::Degraded => SchemaState::Degraded,
+            },
+            schema_generation,
+            active_schema_operations: schema.active_operations,
+        }
+    }
+
+    /// Register one frontend query for bounded inspection and cancellation.
+    ///
+    /// The returned guard owns registration. Dropping it requests cancellation
+    /// and removes the query, including after errors or task unwinding.
+    pub fn begin_tracked_query(&self, sql: &str) -> EngineResult<TrackedQuery> {
+        self.inner.active_queries.begin(sql)
+    }
+
+    /// Return a deterministic, redaction-safe snapshot of active queries.
+    pub fn active_queries(&self) -> Vec<ActiveQueryStatus> {
+        self.inner.active_queries.snapshot()
+    }
+
+    /// Request cancellation of one active query.
+    ///
+    /// `None` means the identity is unknown or already stale. `Some(true)`
+    /// records a new cancellation and `Some(false)` means it was already
+    /// requested. Cancellation is performed after releasing registry locks.
+    pub fn cancel_query(&self, id: QueryId) -> Option<bool> {
+        self.inner.active_queries.cancel(id)
+    }
+
     #[cfg(test)]
     pub(crate) fn active_operations_for_test(&self) -> usize {
         self.inner.lifecycle.active()
@@ -1010,6 +1064,155 @@ impl Engine {
         operation.finish(result)
     }
 
+    /// Fully validate every physical shard under one application-schema generation.
+    pub async fn shard_status(&self) -> EngineResult<ShardStatusReport> {
+        self.shard_status_with_context(RequestContext::new()).await
+    }
+
+    /// Fully validate every physical shard with request cancellation controls.
+    ///
+    /// The result is all-or-nothing and ordered by shard ID. Each validation
+    /// replaces any retained pooled handle with a fresh controlled open so a
+    /// successful status never relies only on stale pool metadata.
+    pub async fn shard_status_with_context(
+        &self,
+        context: RequestContext,
+    ) -> EngineResult<ShardStatusReport> {
+        let mut operation = self.operation(context)?;
+        let schema_operation = match self.inner.database.storage.enter_schema_operation() {
+            Ok(guard) => guard,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let schema_generation = self.inner.database.storage.current_schema_generation();
+        let permits = match operation
+            .wait_pending(
+                self.inner
+                    .connections
+                    .acquire_all_for_owner(ConnectionOwner::stateless_catalog_write()),
+            )
+            .await
+        {
+            Ok(permits) => permits,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        let worker = match operation.wait_pending(self.inner.workers.acquire()).await {
+            Ok(worker) => worker,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        if let Err(error) = operation.check_before_start() {
+            return operation.finish(Err(error));
+        }
+
+        let lease = operation.take_lease();
+        let worker_control = Arc::clone(&operation.control);
+        let storage = self.inner.database.storage.clone();
+        let join = worker.spawn(move || {
+            let _lease = lease;
+            let _schema_operation = schema_operation;
+            let result = permits
+                .into_iter()
+                .map(|(shard_id, permit)| {
+                    let mut connection = permit.checkout_controlled(Arc::clone(&worker_control))?;
+                    connection.revalidate_controlled(Arc::clone(&worker_control))?;
+                    if storage.current_schema_generation() != schema_generation {
+                        return Err(EngineError::new(
+                            EngineErrorKind::Internal,
+                            "application-schema generation changed during shard inspection",
+                        ));
+                    }
+                    Ok(ShardStatus {
+                        shard_id,
+                        state: ShardState::Ready,
+                    })
+                })
+                .collect::<EngineResult<Vec<_>>>()
+                .map(|shards| ShardStatusReport {
+                    schema_generation,
+                    shards,
+                });
+            if result
+                .as_ref()
+                .is_err_and(|error| error.kind() == EngineErrorKind::DataCorruption)
+            {
+                storage.record_schema_degraded();
+            }
+            worker_control.complete(result)
+        });
+        let result = operation.wait_started(join).await;
+        operation.finish_started(result)
+    }
+
+    /// Return the active and latest complete schema migrations without SQL text.
+    pub async fn migration_summary(&self) -> EngineResult<SchemaMigrationSummary> {
+        self.migration_summary_with_context(RequestContext::new())
+            .await
+    }
+
+    /// Return the bounded schema-migration summary with request controls.
+    ///
+    /// This deliberately bypasses ordinary schema-operation admission so
+    /// `Migrating` and `Pending` journal state remains observable.
+    pub async fn migration_summary_with_context(
+        &self,
+        context: RequestContext,
+    ) -> EngineResult<SchemaMigrationSummary> {
+        let mut operation = self.operation(context)?;
+        let worker = match operation.wait_pending(self.inner.workers.acquire()).await {
+            Ok(worker) => worker,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        if let Err(error) = operation.check_before_start() {
+            return operation.finish(Err(error));
+        }
+        let lease = operation.take_lease();
+        let worker_control = Arc::clone(&operation.control);
+        let storage = self.inner.database.storage.clone();
+        let join = worker.spawn(move || {
+            let _lease = lease;
+            let result = storage.schema_migration_summary(Arc::clone(&worker_control));
+            worker_control.complete(result)
+        });
+        let result = operation.wait_started(join).await;
+        operation.finish_started(result)
+    }
+
+    /// Look up one schema migration by its indexed target generation.
+    pub async fn migration(
+        &self,
+        target_generation: u64,
+    ) -> EngineResult<Option<SchemaMigrationStatus>> {
+        self.migration_with_context(target_generation, RequestContext::new())
+            .await
+    }
+
+    /// Look up one schema migration generation with request controls.
+    ///
+    /// The returned metadata never includes the migration SQL.
+    pub async fn migration_with_context(
+        &self,
+        target_generation: u64,
+        context: RequestContext,
+    ) -> EngineResult<Option<SchemaMigrationStatus>> {
+        let mut operation = self.operation(context)?;
+        let worker = match operation.wait_pending(self.inner.workers.acquire()).await {
+            Ok(worker) => worker,
+            Err(error) => return operation.finish(Err(error)),
+        };
+        if let Err(error) = operation.check_before_start() {
+            return operation.finish(Err(error));
+        }
+        let lease = operation.take_lease();
+        let worker_control = Arc::clone(&operation.control);
+        let storage = self.inner.database.storage.clone();
+        let join = worker.spawn(move || {
+            let _lease = lease;
+            let result = storage.schema_migration(target_generation, Arc::clone(&worker_control));
+            worker_control.complete(result)
+        });
+        let result = operation.wait_started(join).await;
+        operation.finish_started(result)
+    }
+
     /// Inspect redaction-safe global-index health and operational counters.
     pub async fn global_index_operational_report(
         &self,
@@ -1140,6 +1343,12 @@ impl Engine {
                     let databases = storage.checkpoint_auxiliary_databases()?;
                     Ok(CheckpointReport { shards, databases })
                 });
+            if result
+                .as_ref()
+                .is_err_and(|error| error.kind() == EngineErrorKind::DataCorruption)
+            {
+                storage.record_schema_degraded();
+            }
             worker_control.complete(result)
         });
         let result = operation.wait_started(join).await;
@@ -3198,7 +3407,24 @@ impl Engine {
         operation.finish_started(result)
     }
 
+    /// Apply a parameterless SQL migration through the durable shard journal.
+    pub async fn migrate(&self, session: &Session, sql: String) -> EngineResult<Vec<u16>> {
+        self.broadcast(session, sql).await
+    }
+
+    /// Apply a parameterless SQL migration with explicit request controls.
+    pub async fn migrate_with_context(
+        &self,
+        session: &Session,
+        sql: String,
+        context: RequestContext,
+    ) -> EngineResult<Vec<u16>> {
+        self.broadcast_with_context(session, sql, context).await
+    }
+
     /// Apply a parameterless SQL migration batch through the durable shard journal.
+    ///
+    /// This compatibility name has the same behavior as [`Engine::migrate`].
     pub async fn broadcast(&self, session: &Session, sql: String) -> EngineResult<Vec<u16>> {
         self.broadcast_with_context(session, sql, RequestContext::new())
             .await
@@ -4572,7 +4798,8 @@ mod tests {
     #[cfg(feature = "experimental-vtab")]
     use crate::core::GeneratedIdPolicy;
     use crate::core::{
-        Column, DataType, Row, SessionState, ShardKeyMetadata, ShardKeyType, TableDeclaration,
+        Column, DataType, Row, SchemaMigrationState, SessionState, ShardKeyMetadata, ShardKeyType,
+        TableDeclaration,
     };
 
     #[test]
@@ -4979,6 +5206,202 @@ mod tests {
             PreparedStatementLimits::default()
         );
         assert_eq!(session.state().await, SessionState::Ready);
+    }
+
+    #[tokio::test]
+    async fn operational_query_readiness_shards_and_migrations_share_engine_state() {
+        let (_temp, engine) = engine_with_options(2, 1, 2);
+        let clone = engine.clone();
+
+        let readiness = engine.readiness();
+        assert!(readiness.ready());
+        assert_eq!(readiness.lifecycle_state(), EngineState::Running);
+        assert_eq!(readiness.schema_state(), SchemaState::Ready);
+        assert_eq!(readiness.schema_generation(), 0);
+        assert_eq!(readiness.active_schema_operations(), 0);
+
+        let tracked = engine.begin_tracked_query("SELECT private_value").unwrap();
+        assert_eq!(clone.active_queries().len(), 1);
+        assert_eq!(clone.cancel_query(tracked.id()), Some(true));
+        assert_eq!(clone.cancel_query(tracked.id()), Some(false));
+        assert!(tracked.cancellation_token().is_cancelled());
+        let tracked_id = tracked.id();
+        drop(tracked);
+        assert!(clone.active_queries().is_empty());
+        assert_eq!(clone.cancel_query(tracked_id), None);
+
+        let shards = engine.shard_status().await.unwrap();
+        assert_eq!(shards.schema_generation(), 0);
+        assert_eq!(
+            shards
+                .shards()
+                .iter()
+                .map(|shard| (shard.shard_id(), shard.state()))
+                .collect::<Vec<_>>(),
+            vec![(0, ShardState::Ready), (1, ShardState::Ready)]
+        );
+
+        let initial = engine.migration_summary().await.unwrap();
+        assert_eq!(initial.schema_generation(), 0);
+        assert_eq!(initial.active(), None);
+        assert_eq!(initial.latest_complete(), None);
+
+        let session = engine.session();
+        let sql = "CREATE TABLE operational_marker (id INTEGER PRIMARY KEY)".to_owned();
+        assert_eq!(engine.migrate(&session, sql.clone()).await.unwrap(), [0, 1]);
+        let summary = engine.migration_summary().await.unwrap();
+        assert_eq!(summary.schema_generation(), 1);
+        assert_eq!(summary.active(), None);
+        let completed = summary.latest_complete().unwrap();
+        assert_eq!(completed.generation(), 1);
+        assert_eq!(completed.source_generation(), 0);
+        assert_eq!(completed.target_generation(), 1);
+        assert_eq!(completed.state(), SchemaMigrationState::Complete);
+        assert_eq!(completed.shard_count(), 2);
+        assert_eq!(completed.next_shard(), 2);
+        assert_eq!(completed.completed_shards(), 2);
+        assert_eq!(completed.sql_bytes(), sql.len());
+        assert_eq!(engine.migration(1).await.unwrap(), Some(completed));
+        assert_eq!(engine.migration(0).await.unwrap(), None);
+        assert_eq!(engine.migration(2).await.unwrap(), None);
+    }
+
+    #[test]
+    fn readiness_tracks_schema_occupancy_migration_and_lifecycle() {
+        let (_temp, engine) = engine_with_options(2, 1, 1);
+        let schema_operation = engine
+            .inner
+            .database
+            .storage
+            .enter_schema_operation()
+            .unwrap();
+        let occupied = engine.readiness();
+        assert!(occupied.ready());
+        assert_eq!(occupied.active_schema_operations(), 1);
+        drop(schema_operation);
+
+        let migration = engine
+            .inner
+            .database
+            .storage
+            .begin_schema_migration()
+            .unwrap();
+        let migrating = engine.readiness();
+        assert!(!migrating.ready());
+        assert_eq!(migrating.schema_state(), SchemaState::Migrating);
+        drop(migration);
+        assert!(engine.readiness().ready());
+
+        assert_eq!(engine.begin_shutdown(), EngineState::Draining);
+        let draining = engine.readiness();
+        assert!(!draining.ready());
+        assert_eq!(draining.lifecycle_state(), EngineState::Draining);
+    }
+
+    #[test]
+    fn readiness_remains_bounded_while_schema_admission_churns() {
+        let (_temp, engine) = engine_with_options(2, 1, 1);
+        let engine = Arc::new(engine);
+        let running = Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let churn = (0..4)
+            .map(|_| {
+                let engine = Arc::clone(&engine);
+                let running = Arc::clone(&running);
+                std::thread::spawn(move || {
+                    while running.load(std::sync::atomic::Ordering::Acquire) {
+                        let operation = engine
+                            .inner
+                            .database
+                            .storage
+                            .enter_schema_operation()
+                            .unwrap();
+                        std::thread::yield_now();
+                        drop(operation);
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+        let (complete_tx, complete_rx) = mpsc::channel();
+        let reader_engine = Arc::clone(&engine);
+        let reader = std::thread::spawn(move || {
+            for _ in 0..10_000 {
+                let readiness = reader_engine.readiness();
+                assert!(readiness.ready());
+                assert_eq!(readiness.schema_generation(), 0);
+            }
+            complete_tx.send(()).unwrap();
+        });
+
+        let completed = complete_rx.recv_timeout(Duration::from_secs(5)).is_ok();
+        running.store(false, std::sync::atomic::Ordering::Release);
+        for thread in churn {
+            thread.join().unwrap();
+        }
+        reader.join().unwrap();
+        assert!(
+            completed,
+            "readiness must not wait for admission occupancy to stop changing"
+        );
+    }
+
+    #[tokio::test]
+    async fn shard_status_is_all_or_nothing_and_degrades_on_authoritative_corruption() {
+        let (temp, engine) = engine_with_options(2, 1, 1);
+        let shard = rusqlite::Connection::open(temp.path().join("shards/0001.sqlite")).unwrap();
+        shard
+            .execute(
+                "UPDATE briskdb_shard_metadata SET shard_id = 0 WHERE singleton = 1",
+                [],
+            )
+            .unwrap();
+        drop(shard);
+
+        let error = engine.shard_status().await.unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::DataCorruption);
+        assert_eq!(engine.readiness().schema_state(), SchemaState::Degraded);
+    }
+
+    #[tokio::test]
+    async fn operational_inspection_degrades_when_authoritative_storage_disappears() {
+        let (summary_temp, summary_engine) = engine_with_options(2, 1, 1);
+        std::fs::remove_file(summary_temp.path().join("manifest.sqlite")).unwrap();
+
+        let summary_error = summary_engine.migration_summary().await.unwrap_err();
+        assert_eq!(summary_error.kind(), EngineErrorKind::DataCorruption);
+        assert_eq!(
+            summary_engine.readiness().schema_state(),
+            SchemaState::Degraded
+        );
+
+        let (detail_temp, detail_engine) = engine_with_options(2, 1, 1);
+        std::fs::remove_file(detail_temp.path().join("manifest.sqlite")).unwrap();
+
+        let detail_error = detail_engine.migration(0).await.unwrap_err();
+        assert_eq!(detail_error.kind(), EngineErrorKind::DataCorruption);
+        assert_eq!(
+            detail_engine.readiness().schema_state(),
+            SchemaState::Degraded
+        );
+
+        let (checkpoint_temp, checkpoint_engine) = engine_with_options(2, 1, 1);
+        std::fs::remove_file(checkpoint_temp.path().join("manifest.sqlite")).unwrap();
+
+        let checkpoint_error = checkpoint_engine.checkpoint().await.unwrap_err();
+        assert_eq!(checkpoint_error.kind(), EngineErrorKind::DataCorruption);
+        assert_eq!(
+            checkpoint_engine.readiness().schema_state(),
+            SchemaState::Degraded
+        );
+
+        let (shard_temp, shard_engine) = engine_with_options(2, 1, 1);
+        std::fs::remove_file(shard_temp.path().join("shards/0001.sqlite")).unwrap();
+
+        let shard_error = shard_engine.checkpoint().await.unwrap_err();
+        assert_eq!(shard_error.kind(), EngineErrorKind::DataCorruption);
+        assert_eq!(
+            shard_engine.readiness().schema_state(),
+            SchemaState::Degraded
+        );
     }
 
     #[tokio::test]
@@ -7691,6 +8114,68 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn migration_inspection_spans_finalization_publication_and_pending_recovery() {
+        let (_temp, engine) = engine_with_options(2, 1, 1);
+        let sql = "CREATE TABLE finalization_handoff_marker (id INTEGER)";
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        engine
+            .inner
+            .database
+            .storage
+            .install_schema_migration_test_block(
+                crate::storage::SchemaMigrationCoordinatorPoint::FinalizationCommitted,
+                started_tx,
+                release_rx,
+            )
+            .unwrap();
+
+        let session = Arc::new(engine.session());
+        let migration_engine = engine.clone();
+        let migration_session = Arc::clone(&session);
+        let migration = tokio::spawn(async move {
+            migration_engine
+                .migrate(&migration_session, sql.to_owned())
+                .await
+        });
+        wait_for_blocking_signal(started_rx, "migration finalization should commit").await;
+
+        let readiness = engine.readiness();
+        assert_eq!(readiness.schema_state(), SchemaState::Migrating);
+        assert_eq!(readiness.schema_generation(), 0);
+        let committed = timeout(Duration::from_secs(2), engine.migration_summary())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(committed.schema_generation(), 1);
+        assert_eq!(committed.active(), None);
+        let completed = committed.latest_complete().unwrap();
+        assert_eq!(completed.state(), SchemaMigrationState::Complete);
+        assert_eq!(engine.migration(1).await.unwrap(), Some(completed));
+
+        // Disconnecting this one-shot barrier injects a failure after the
+        // durable finalization commit but before in-memory publication.
+        drop(release_tx);
+        let error = migration.await.unwrap().unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::Internal);
+        let pending_readiness = engine.readiness();
+        assert_eq!(pending_readiness.schema_state(), SchemaState::Pending);
+        assert_eq!(pending_readiness.schema_generation(), 0);
+
+        let pending = engine.migration_summary().await.unwrap();
+        assert_eq!(pending, committed);
+        assert_eq!(engine.migration(1).await.unwrap(), Some(completed));
+
+        let retry = engine.session();
+        assert_eq!(
+            engine.migrate(&retry, sql.to_owned()).await.unwrap(),
+            [0, 1]
+        );
+        assert!(engine.readiness().ready());
+        assert_eq!(engine.readiness().schema_generation(), 1);
+    }
+
+    #[tokio::test]
     async fn cancellation_after_durable_journal_waits_for_cleanup_and_exact_retry_recovers() {
         let (_temp, engine) = engine_with_options(2, 1, 1);
         let sql = "CREATE TABLE durable_cancel_marker (id INTEGER)";
@@ -7723,6 +8208,12 @@ mod tests {
             engine.inner.database.storage.schema_gate_snapshot().state,
             crate::storage::SchemaGateState::Migrating
         );
+        let active = engine.migration_summary().await.unwrap().active().unwrap();
+        assert_eq!(active.state(), SchemaMigrationState::Applying);
+        assert_eq!(active.source_generation(), 0);
+        assert_eq!(active.target_generation(), 1);
+        assert_eq!(active.next_shard(), 0);
+        assert_eq!(active.sql_bytes(), sql.len());
 
         assert!(token.cancel());
         assert!(
@@ -7745,6 +8236,8 @@ mod tests {
             engine.inner.database.storage.schema_gate_snapshot().state,
             crate::storage::SchemaGateState::Pending
         );
+        let pending = engine.migration_summary().await.unwrap().active().unwrap();
+        assert_eq!(pending, active);
 
         let ordinary = engine.session();
         ordinary.set_routing_key("pending-work").await.unwrap();

--- a/src/core/lifecycle.rs
+++ b/src/core/lifecycle.rs
@@ -21,6 +21,17 @@ pub enum EngineState {
     Stopped,
 }
 
+impl EngineState {
+    /// Return the stable machine-readable lifecycle state name.
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::Draining => "draining",
+            Self::Stopped => "stopped",
+        }
+    }
+}
+
 /// Outcome of a completed graceful shutdown.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ShutdownReport {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod generated_id;
 mod global_index;
 mod index_key;
 mod lifecycle;
+mod operations;
 mod options;
 mod planner;
 mod prepared;
@@ -72,6 +73,12 @@ pub use index_key::{
 };
 pub use lifecycle::{EngineState, ShutdownReport};
 pub(crate) use lifecycle::{Lifecycle, OperationLease};
+pub(crate) use operations::ActiveQueryRegistry;
+pub use operations::{
+    ActiveQueryStatus, MAX_ACTIVE_QUERIES, ParseQueryIdError, QueryId, ReadinessSnapshot,
+    SchemaMigrationState, SchemaMigrationStatus, SchemaMigrationSummary, SchemaState, ShardState,
+    ShardStatus, ShardStatusReport, TrackedQuery,
+};
 pub use options::{
     DEFAULT_CONNECTIONS_PER_SHARD, DEFAULT_MAX_PORTALS_PER_SESSION,
     DEFAULT_MAX_PREPARED_STATEMENTS_PER_SESSION, DEFAULT_MAX_RESULT_BYTES, DEFAULT_MAX_RESULT_ROWS,

--- a/src/core/operations.rs
+++ b/src/core/operations.rs
@@ -1,0 +1,555 @@
+//! Protocol-neutral operational inspection and query-cancellation types.
+
+use std::{
+    collections::BTreeMap,
+    error::Error,
+    fmt,
+    str::FromStr,
+    sync::{Arc, Mutex},
+    time::Instant,
+};
+
+use super::{
+    CancellationToken, EngineError, EngineErrorKind, EngineResult, EngineState, RequestContext,
+};
+
+/// Maximum number of cancellable frontend queries retained by one engine.
+pub const MAX_ACTIVE_QUERIES: usize = 1_024;
+
+/// A random, opaque identity for one tracked query.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct QueryId([u8; 16]);
+
+impl QueryId {
+    fn random() -> EngineResult<Self> {
+        loop {
+            let mut bytes = [0_u8; 16];
+            getrandom::fill(&mut bytes).map_err(|error| {
+                EngineError::from_source(
+                    EngineErrorKind::StorageUnavailable,
+                    "could not generate a query identity",
+                    error,
+                )
+            })?;
+            if bytes != [0; 16] {
+                return Ok(Self(bytes));
+            }
+        }
+    }
+
+    /// Return the opaque identity bytes.
+    pub const fn as_bytes(&self) -> &[u8; 16] {
+        &self.0
+    }
+}
+
+impl fmt::Display for QueryId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in self.0 {
+            write!(formatter, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Debug for QueryId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_tuple("QueryId")
+            .field(&self.to_string())
+            .finish()
+    }
+}
+
+/// Failure to parse the canonical lowercase hexadecimal query identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParseQueryIdError;
+
+impl fmt::Display for ParseQueryIdError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("query IDs must be 32 lowercase hexadecimal characters and nonzero")
+    }
+}
+
+impl Error for ParseQueryIdError {}
+
+impl FromStr for QueryId {
+    type Err = ParseQueryIdError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if value.len() != 32
+            || !value
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        {
+            return Err(ParseQueryIdError);
+        }
+        let mut bytes = [0_u8; 16];
+        for (index, pair) in value.as_bytes().chunks_exact(2).enumerate() {
+            bytes[index] = (decode_hex(pair[0]) << 4) | decode_hex(pair[1]);
+        }
+        if bytes == [0; 16] {
+            return Err(ParseQueryIdError);
+        }
+        Ok(Self(bytes))
+    }
+}
+
+const fn decode_hex(byte: u8) -> u8 {
+    match byte {
+        b'0'..=b'9' => byte - b'0',
+        b'a'..=b'f' => byte - b'a' + 10,
+        _ => 0,
+    }
+}
+
+/// Redaction-safe status for one currently tracked query.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ActiveQueryStatus {
+    id: QueryId,
+    elapsed_ms: u64,
+    sql_bytes: usize,
+    cancellation_requested: bool,
+}
+
+impl ActiveQueryStatus {
+    /// Return the opaque query identity.
+    pub const fn id(&self) -> QueryId {
+        self.id
+    }
+
+    /// Return whole milliseconds elapsed when this snapshot was taken.
+    pub const fn elapsed_ms(&self) -> u64 {
+        self.elapsed_ms
+    }
+
+    /// Return the number of exact SQL bytes without exposing the SQL.
+    pub const fn sql_bytes(&self) -> usize {
+        self.sql_bytes
+    }
+
+    /// Return whether cancellation had been requested at snapshot time.
+    pub const fn cancellation_requested(&self) -> bool {
+        self.cancellation_requested
+    }
+}
+
+#[derive(Debug)]
+struct ActiveQueryEntry {
+    started: Instant,
+    sql_bytes: usize,
+    cancellation: CancellationToken,
+}
+
+/// Engine-shared bounded registry for frontend query cancellation.
+#[derive(Debug, Default)]
+pub(crate) struct ActiveQueryRegistry {
+    entries: Mutex<BTreeMap<QueryId, ActiveQueryEntry>>,
+}
+
+impl ActiveQueryRegistry {
+    pub(crate) fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    pub(crate) fn begin(self: &Arc<Self>, sql: &str) -> EngineResult<TrackedQuery> {
+        let cancellation = CancellationToken::new();
+        let entry = ActiveQueryEntry {
+            started: Instant::now(),
+            sql_bytes: sql.len(),
+            cancellation: cancellation.clone(),
+        };
+
+        // Random collisions are retried while the mutex makes capacity and
+        // insertion one atomic decision. No entropy source or cancellation
+        // callback runs while the registry is locked.
+        for _ in 0..16 {
+            let id = QueryId::random()?;
+            let mut entries = self.lock();
+            if entries.len() >= MAX_ACTIVE_QUERIES {
+                return Err(EngineError::new(
+                    EngineErrorKind::LimitExceeded,
+                    format!("active query tracking exceeds the {MAX_ACTIVE_QUERIES}-query limit"),
+                ));
+            }
+            if entries.contains_key(&id) {
+                continue;
+            }
+            entries.insert(
+                id,
+                ActiveQueryEntry {
+                    started: entry.started,
+                    sql_bytes: entry.sql_bytes,
+                    cancellation: cancellation.clone(),
+                },
+            );
+            return Ok(TrackedQuery {
+                registry: Arc::clone(self),
+                id,
+                cancellation,
+            });
+        }
+        Err(EngineError::new(
+            EngineErrorKind::Internal,
+            "could not allocate a unique query identity",
+        ))
+    }
+
+    pub(crate) fn snapshot(&self) -> Vec<ActiveQueryStatus> {
+        let now = Instant::now();
+        self.lock()
+            .iter()
+            .map(|(&id, entry)| ActiveQueryStatus {
+                id,
+                elapsed_ms: u64::try_from(now.saturating_duration_since(entry.started).as_millis())
+                    .unwrap_or(u64::MAX),
+                sql_bytes: entry.sql_bytes,
+                cancellation_requested: entry.cancellation.is_cancelled(),
+            })
+            .collect()
+    }
+
+    pub(crate) fn cancel(&self, id: QueryId) -> Option<bool> {
+        let cancellation = self.lock().get(&id).map(|entry| entry.cancellation.clone());
+        // Cancellation wakes tasks and can invoke further code, so never call
+        // it under the registry mutex.
+        cancellation.map(|cancellation| cancellation.cancel())
+    }
+
+    fn remove(&self, id: QueryId) {
+        self.lock().remove(&id);
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, BTreeMap<QueryId, ActiveQueryEntry>> {
+        self.entries
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+/// RAII registration for one cancellable frontend query.
+#[derive(Debug)]
+#[must_use = "dropping the tracked query cancels it and removes operational inspection"]
+pub struct TrackedQuery {
+    registry: Arc<ActiveQueryRegistry>,
+    id: QueryId,
+    cancellation: CancellationToken,
+}
+
+impl TrackedQuery {
+    /// Return the opaque query identity.
+    pub const fn id(&self) -> QueryId {
+        self.id
+    }
+
+    /// Create an engine request context observing this query's cancellation.
+    pub fn request_context(&self) -> RequestContext {
+        RequestContext::new().with_cancellation_token(self.cancellation.clone())
+    }
+
+    /// Return a clone of this query's cancellation token.
+    pub fn cancellation_token(&self) -> CancellationToken {
+        self.cancellation.clone()
+    }
+}
+
+impl Drop for TrackedQuery {
+    fn drop(&mut self) {
+        self.cancellation.cancel();
+        self.registry.remove(self.id);
+    }
+}
+
+/// Public application-schema admission state for readiness inspection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SchemaState {
+    Ready,
+    Migrating,
+    Pending,
+    Degraded,
+}
+
+impl SchemaState {
+    /// Return the stable machine-readable state name.
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::Ready => "ready",
+            Self::Migrating => "migrating",
+            Self::Pending => "pending",
+            Self::Degraded => "degraded",
+        }
+    }
+}
+
+/// A bounded operational-readiness snapshot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReadinessSnapshot {
+    pub(crate) lifecycle_state: EngineState,
+    pub(crate) schema_state: SchemaState,
+    pub(crate) schema_generation: u64,
+    pub(crate) active_schema_operations: usize,
+}
+
+impl ReadinessSnapshot {
+    /// Return whether ordinary work can currently be admitted.
+    pub const fn ready(self) -> bool {
+        matches!(self.lifecycle_state, EngineState::Running)
+            && matches!(self.schema_state, SchemaState::Ready)
+    }
+
+    /// Return the engine lifecycle state observed by this snapshot.
+    pub const fn lifecycle_state(self) -> EngineState {
+        self.lifecycle_state
+    }
+
+    /// Return the application-schema admission state observed by this snapshot.
+    pub const fn schema_state(self) -> SchemaState {
+        self.schema_state
+    }
+
+    /// Return the neighboring live application-schema generation.
+    pub const fn schema_generation(self) -> u64 {
+        self.schema_generation
+    }
+
+    /// Return the number of admitted schema operations observed by this snapshot.
+    pub const fn active_schema_operations(self) -> usize {
+        self.active_schema_operations
+    }
+}
+
+/// Operational state of one validated physical shard.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ShardState {
+    Ready,
+}
+
+impl ShardState {
+    /// Return the stable machine-readable state name.
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::Ready => "ready",
+        }
+    }
+}
+
+/// Redaction-safe status of one physical shard.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ShardStatus {
+    pub(crate) shard_id: u16,
+    pub(crate) state: ShardState,
+}
+
+impl ShardStatus {
+    /// Return the physical shard identifier.
+    pub const fn shard_id(self) -> u16 {
+        self.shard_id
+    }
+
+    /// Return the validated operational state.
+    pub const fn state(self) -> ShardState {
+        self.state
+    }
+}
+
+/// All-or-nothing result of validating every physical shard.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShardStatusReport {
+    pub(crate) schema_generation: u64,
+    pub(crate) shards: Vec<ShardStatus>,
+}
+
+impl ShardStatusReport {
+    /// Return the application-schema generation used for validation.
+    pub const fn schema_generation(&self) -> u64 {
+        self.schema_generation
+    }
+
+    /// Return validated shard statuses in shard-ID order.
+    pub fn shards(&self) -> &[ShardStatus] {
+        &self.shards
+    }
+}
+
+/// Durable state of one schema migration journal row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SchemaMigrationState {
+    Applying,
+    Complete,
+}
+
+impl SchemaMigrationState {
+    /// Return the stable machine-readable state name.
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::Applying => "applying",
+            Self::Complete => "complete",
+        }
+    }
+}
+
+/// Redaction-safe metadata for one schema migration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SchemaMigrationStatus {
+    pub(crate) generation: u64,
+    pub(crate) source_generation: u64,
+    pub(crate) target_generation: u64,
+    pub(crate) state: SchemaMigrationState,
+    pub(crate) shard_count: u16,
+    pub(crate) next_shard: u16,
+    pub(crate) sql_bytes: usize,
+}
+
+impl SchemaMigrationStatus {
+    /// Return the migration history lookup generation.
+    pub const fn generation(self) -> u64 {
+        self.generation
+    }
+
+    /// Return the schema generation from which the migration began.
+    pub const fn source_generation(self) -> u64 {
+        self.source_generation
+    }
+
+    /// Return the schema generation published by the migration.
+    pub const fn target_generation(self) -> u64 {
+        self.target_generation
+    }
+
+    /// Return the durable migration journal state.
+    pub const fn state(self) -> SchemaMigrationState {
+        self.state
+    }
+
+    /// Return the number of physical shards in the migration.
+    pub const fn shard_count(self) -> u16 {
+        self.shard_count
+    }
+
+    /// Return the next shard that still requires application.
+    pub const fn next_shard(self) -> u16 {
+        self.next_shard
+    }
+
+    /// Return the number of shards durably completed so far.
+    pub const fn completed_shards(self) -> u16 {
+        self.next_shard
+    }
+
+    /// Return the retained migration SQL length without exposing its text.
+    pub const fn sql_bytes(self) -> usize {
+        self.sql_bytes
+    }
+}
+
+/// Bounded schema migration history summary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SchemaMigrationSummary {
+    pub(crate) schema_generation: u64,
+    pub(crate) active: Option<SchemaMigrationStatus>,
+    pub(crate) latest_complete: Option<SchemaMigrationStatus>,
+}
+
+impl SchemaMigrationSummary {
+    /// Return the manifest schema generation observed by this summary.
+    pub const fn schema_generation(self) -> u64 {
+        self.schema_generation
+    }
+
+    /// Return the active resumable migration, if one exists.
+    pub const fn active(self) -> Option<SchemaMigrationStatus> {
+        self.active
+    }
+
+    /// Return the most recently completed migration, if one exists.
+    pub const fn latest_complete(self) -> Option<SchemaMigrationStatus> {
+        self.latest_complete
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn query_ids_have_one_strict_canonical_representation() {
+        let id = "0123456789abcdef0123456789abcdef"
+            .parse::<QueryId>()
+            .unwrap();
+        assert_eq!(id.to_string(), "0123456789abcdef0123456789abcdef");
+        for invalid in [
+            "",
+            "0123456789abcdef0123456789abcde",
+            "0123456789abcdef0123456789abcdef0",
+            "0123456789ABCDEF0123456789ABCDEF",
+            "g123456789abcdef0123456789abcdef",
+            "00000000000000000000000000000000",
+        ] {
+            assert!(invalid.parse::<QueryId>().is_err(), "accepted {invalid:?}");
+        }
+    }
+
+    #[test]
+    fn registry_is_sorted_redacted_cancellable_and_raii_bounded() {
+        let registry = ActiveQueryRegistry::new();
+        let first = registry.begin("SELECT secret FROM records").unwrap();
+        let second = registry.begin("SELECT 2").unwrap();
+        let snapshot = registry.snapshot();
+        assert_eq!(snapshot.len(), 2);
+        assert!(snapshot.windows(2).all(|pair| pair[0].id() < pair[1].id()));
+        assert!(snapshot.iter().all(|status| status.sql_bytes() > 0));
+        let first_status = snapshot
+            .iter()
+            .find(|status| status.id() == first.id())
+            .unwrap();
+        assert_eq!(first_status.sql_bytes(), 26);
+        assert!(!format!("{snapshot:?}").contains("secret"));
+
+        assert_eq!(registry.cancel(first.id()), Some(true));
+        assert_eq!(registry.cancel(first.id()), Some(false));
+        assert!(first.cancellation_token().is_cancelled());
+        assert!(
+            registry
+                .snapshot()
+                .iter()
+                .find(|status| status.id() == first.id())
+                .unwrap()
+                .cancellation_requested()
+        );
+        let first_id = first.id();
+        drop(first);
+        assert_eq!(registry.cancel(first_id), None);
+        assert_eq!(registry.snapshot().len(), 1);
+        drop(second);
+        assert!(registry.snapshot().is_empty());
+
+        let dropped = registry.begin("SELECT 3").unwrap();
+        let dropped_id = dropped.id();
+        let dropped_token = dropped.cancellation_token();
+        assert!(!dropped_token.is_cancelled());
+        drop(dropped);
+        assert!(dropped_token.is_cancelled());
+        assert_eq!(registry.cancel(dropped_id), None);
+    }
+
+    #[test]
+    fn registry_enforces_its_exact_capacity_and_recovers_on_drop() {
+        let registry = ActiveQueryRegistry::new();
+        let mut queries = Vec::with_capacity(MAX_ACTIVE_QUERIES);
+        for _ in 0..MAX_ACTIVE_QUERIES {
+            queries.push(registry.begin("SELECT 1").unwrap());
+        }
+        let error = registry.begin("SELECT 2").unwrap_err();
+        assert_eq!(error.kind(), EngineErrorKind::LimitExceeded);
+
+        queries.pop();
+        let replacement = registry.begin("SELECT 3").unwrap();
+        assert_eq!(registry.snapshot().len(), MAX_ACTIVE_QUERIES);
+        drop(replacement);
+        drop(queries);
+        assert!(registry.snapshot().is_empty());
+    }
+}

--- a/src/protocol/http.rs
+++ b/src/protocol/http.rs
@@ -16,15 +16,16 @@ use base64::{Engine as _, engine::general_purpose::STANDARD as STANDARD_BASE64};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value as JsonValue, json};
 use v1::{
-    BroadcastRequest, RawJsonParameter, SqlRequest as QueryRequest, SqlRequest as RoutedSqlRequest,
-    V1Json, ValueEncoding,
+    BroadcastRequest, EmptyRequest, RawJsonParameter, SqlRequest as QueryRequest,
+    SqlRequest as RoutedSqlRequest, TransportError, V1EmptyBody, V1Json, V1Path, ValueEncoding,
 };
 
 use crate::{
     core::{
-        DataType, Database, Decimal, Engine, EngineError, EngineErrorKind, Executed, GeneratedKey,
-        GlobalIndexHealthState, GlobalIndexLifecycle, GlobalIndexOperationalReport,
-        GlobalIndexOperationalStatus, ResultSet, Routed, Statement, Value,
+        DataType, Database, Decimal, Engine, EngineError, EngineErrorKind, EngineState, Executed,
+        GeneratedIdPolicy, GeneratedKey, GlobalIndexHealthState, GlobalIndexLifecycle,
+        GlobalIndexOperationalReport, GlobalIndexOperationalStatus, RequestContext, ResultSet,
+        Routed, SchemaMigrationStatus, SchemaState, ShardKeyType, Statement, TablePlacement, Value,
     },
     protocol::error::http_error,
 };
@@ -48,6 +49,7 @@ pub fn router_with_engine(engine: Engine) -> Router {
     let state = HttpState::new(engine);
     Router::new()
         .route("/health", get(health))
+        .route("/ready", get(ready))
         .route("/metrics", get(metrics))
         .merge(v1::routes())
         .merge(admin::routes(state.clone()))
@@ -55,6 +57,12 @@ pub fn router_with_engine(engine: Engine) -> Router {
 }
 
 /// Build the data-plane router from the legacy synchronous database handle.
+///
+/// This compatibility wrapper constructs a new [`Engine`] for this router. A
+/// host serving separate data and administration planes must construct one
+/// Engine and pass clones to [`data_router_with_engine`] and
+/// [`admin_router_with_engine`] so lifecycle and active-query cancellation are
+/// shared across both routers.
 pub fn data_router(database: Arc<Database>) -> Router {
     data_router_with_engine(Engine::from_database(database))
 }
@@ -69,6 +77,11 @@ pub fn data_router_with_engine(engine: Engine) -> Router {
 }
 
 /// Build the admin-plane router from the legacy synchronous database handle.
+///
+/// This compatibility wrapper constructs a new [`Engine`] for this router. A
+/// separately constructed [`data_router`] has an independent lifecycle and
+/// active-query registry. Use the two Engine-based constructors with clones of
+/// one Engine when the routers form one service.
 pub fn admin_router(database: Arc<Database>) -> Router {
     admin_router_with_engine(Engine::from_database(database))
 }
@@ -81,6 +94,7 @@ pub fn admin_router_with_engine(engine: Engine) -> Router {
     let state = HttpState::new(engine);
     Router::new()
         .route("/health", get(health))
+        .route("/ready", get(ready))
         .route("/metrics", get(metrics))
         .merge(v1::admin_routes())
         .merge(admin::routes(state.clone()))
@@ -141,6 +155,61 @@ async fn health(State(state): State<HttpState>) -> Result<Json<JsonValue>, ApiEr
     })))
 }
 
+#[derive(Debug, Serialize)]
+struct ReadinessResponse {
+    status: &'static str,
+    ready: bool,
+    reasons: Vec<&'static str>,
+    engine_state: &'static str,
+    schema_state: &'static str,
+    schema_generation: String,
+    active_schema_operations: usize,
+}
+
+async fn ready(State(state): State<HttpState>) -> Response {
+    let readiness = state.engine.readiness();
+    let engine_state = readiness.lifecycle_state();
+    let schema_state = readiness.schema_state();
+    let mut reasons = Vec::new();
+    #[allow(unreachable_patterns)]
+    match engine_state {
+        EngineState::Running => {}
+        EngineState::Draining => reasons.push("engine_draining"),
+        EngineState::Stopped => reasons.push("engine_stopped"),
+        _ => reasons.push("engine_state_unknown"),
+    }
+    #[allow(unreachable_patterns)]
+    match schema_state {
+        SchemaState::Ready => {}
+        SchemaState::Migrating => reasons.push("schema_migrating"),
+        SchemaState::Pending => reasons.push("schema_recovery_pending"),
+        SchemaState::Degraded => reasons.push("schema_degraded"),
+        _ => reasons.push("schema_state_unknown"),
+    }
+    if !readiness.ready() && reasons.is_empty() {
+        reasons.push("readiness_unavailable");
+    }
+    let ready = readiness.ready();
+    let status = if ready {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    (
+        status,
+        Json(ReadinessResponse {
+            status: if ready { "ready" } else { "not_ready" },
+            ready,
+            reasons,
+            engine_state: engine_state.code(),
+            schema_state: schema_state.code(),
+            schema_generation: readiness.schema_generation().to_string(),
+            active_schema_operations: readiness.active_schema_operations(),
+        }),
+    )
+        .into_response()
+}
+
 async fn metrics(State(state): State<HttpState>) -> Result<Response, ApiError> {
     let report = state.engine.global_index_operational_report().await?;
     let mut response = prometheus_metrics(&report).into_response();
@@ -149,6 +218,414 @@ async fn metrics(State(state): State<HttpState>) -> Result<Response, ApiError> {
         HeaderValue::from_static("text/plain; version=0.0.4; charset=utf-8"),
     );
     Ok(response)
+}
+
+#[derive(Debug, Serialize)]
+struct CatalogResponse {
+    identifier_encoding_version: u32,
+    schema_generation: String,
+    default_database_id: String,
+    databases: Vec<CatalogDb>,
+    tables: Vec<CatalogTable>,
+    global_indexes: Vec<CatalogGlobalIndex>,
+}
+
+#[derive(Debug, Serialize)]
+struct CatalogDb {
+    id: String,
+    name: String,
+}
+
+#[derive(Debug, Serialize)]
+struct CatalogTable {
+    id: String,
+    database_id: String,
+    name: String,
+    placement: CatalogPlacement,
+    generated_id: CatalogGeneratedId,
+}
+
+#[derive(Debug, Serialize)]
+struct CatalogPlacement {
+    kind: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    shard_key: Option<CatalogShardKey>,
+}
+
+#[derive(Debug, Serialize)]
+struct CatalogShardKey {
+    column: String,
+    data_type: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct CatalogGeneratedId {
+    policy: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    column: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    encoding_version: Option<u32>,
+}
+
+#[derive(Debug, Serialize)]
+struct CatalogGlobalIndex {
+    id: String,
+    table_id: String,
+    name: String,
+    unique: bool,
+    lifecycle: &'static str,
+    schema_generation: String,
+    key_encoding_version: u32,
+}
+
+async fn catalog(State(state): State<HttpState>) -> Json<CatalogResponse> {
+    let catalog = state.engine.catalog();
+    let databases = catalog
+        .logical_databases()
+        .iter()
+        .map(|database| CatalogDb {
+            id: database.id().to_string(),
+            name: database.name().to_owned(),
+        })
+        .collect();
+    let tables = catalog
+        .tables()
+        .iter()
+        .map(|table| CatalogTable {
+            id: table.id().to_string(),
+            database_id: table.database_id().to_string(),
+            name: table.name().to_owned(),
+            placement: catalog_placement(table.placement()),
+            generated_id: catalog_generated_id(table.generated_id_policy()),
+        })
+        .collect();
+    let global_indexes = catalog
+        .global_indexes()
+        .iter()
+        .map(|index| CatalogGlobalIndex {
+            id: index.id().to_string(),
+            table_id: index.table_id().to_string(),
+            name: index.name().to_owned(),
+            unique: index.is_unique(),
+            lifecycle: lifecycle_status(index.lifecycle()).0,
+            schema_generation: index.schema_generation().to_string(),
+            key_encoding_version: index.key_encoding_version(),
+        })
+        .collect();
+    Json(CatalogResponse {
+        identifier_encoding_version: catalog.identifier_encoding_version(),
+        schema_generation: catalog.schema_generation().to_string(),
+        default_database_id: catalog.default_database().id().to_string(),
+        databases,
+        tables,
+        global_indexes,
+    })
+}
+
+#[allow(unreachable_patterns)]
+fn catalog_placement(placement: &TablePlacement) -> CatalogPlacement {
+    match placement {
+        TablePlacement::Sharded(shard_key) => CatalogPlacement {
+            kind: "sharded",
+            shard_key: Some(CatalogShardKey {
+                column: shard_key.column().to_owned(),
+                data_type: shard_key_type_name(shard_key.key_type()),
+            }),
+        },
+        TablePlacement::Global => CatalogPlacement {
+            kind: "global",
+            shard_key: None,
+        },
+        TablePlacement::Catalog => CatalogPlacement {
+            kind: "catalog",
+            shard_key: None,
+        },
+        _ => CatalogPlacement {
+            kind: "unknown",
+            shard_key: None,
+        },
+    }
+}
+
+#[allow(unreachable_patterns)]
+const fn shard_key_type_name(key_type: ShardKeyType) -> &'static str {
+    match key_type {
+        ShardKeyType::Int64 => "int64",
+        ShardKeyType::Text => "text",
+        ShardKeyType::Binary => "binary",
+        _ => "unknown",
+    }
+}
+
+#[allow(unreachable_patterns)]
+fn catalog_generated_id(policy: &GeneratedIdPolicy) -> CatalogGeneratedId {
+    let policy_name = match policy {
+        GeneratedIdPolicy::None => "none",
+        GeneratedIdPolicy::NativeRangeV1 { .. } => "native_range_v1",
+        GeneratedIdPolicy::HiloV1 { .. } => "hilo_v1",
+        _ => "unknown",
+    };
+    CatalogGeneratedId {
+        policy: policy_name,
+        column: policy.column().map(ToOwned::to_owned),
+        encoding_version: policy.encoding_version(),
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct MigrationsResponse {
+    schema_generation: String,
+    active: Option<MigrationResponse>,
+    latest_complete: Option<MigrationResponse>,
+}
+
+#[derive(Debug, Serialize)]
+struct MigrationResponse {
+    generation: String,
+    source_generation: String,
+    target_generation: String,
+    state: &'static str,
+    shard_count: u16,
+    next_shard: u16,
+    completed_shards: u16,
+    sql_bytes: usize,
+}
+
+async fn migrations(State(state): State<HttpState>) -> Result<Json<MigrationsResponse>, ApiError> {
+    let summary = state
+        .engine
+        .migration_summary_with_context(RequestContext::new())
+        .await?;
+    Ok(Json(MigrationsResponse {
+        schema_generation: summary.schema_generation().to_string(),
+        active: summary.active().map(migration_response),
+        latest_complete: summary.latest_complete().map(migration_response),
+    }))
+}
+
+async fn migration(
+    State(state): State<HttpState>,
+    V1Path(raw_generation): V1Path<String>,
+) -> Result<Response, ApiError> {
+    let Some(generation) = parse_canonical_generation(&raw_generation) else {
+        return Ok(TransportError::NotFound.into_response());
+    };
+    let migration = state
+        .engine
+        .migration_with_context(generation, RequestContext::new())
+        .await?;
+    Ok(match migration {
+        Some(migration) => Json(migration_response(migration)).into_response(),
+        None => TransportError::NotFound.into_response(),
+    })
+}
+
+fn migration_response(migration: SchemaMigrationStatus) -> MigrationResponse {
+    MigrationResponse {
+        generation: migration.generation().to_string(),
+        source_generation: migration.source_generation().to_string(),
+        target_generation: migration.target_generation().to_string(),
+        state: migration.state().code(),
+        shard_count: migration.shard_count(),
+        next_shard: migration.next_shard(),
+        completed_shards: migration.completed_shards(),
+        sql_bytes: migration.sql_bytes(),
+    }
+}
+
+fn parse_canonical_generation(value: &str) -> Option<u64> {
+    if value.is_empty()
+        || (value.len() > 1 && value.starts_with('0'))
+        || !value.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return None;
+    }
+    value
+        .parse::<u64>()
+        .ok()
+        .filter(|generation| *generation > 0)
+}
+
+#[derive(Debug, Serialize)]
+struct ShardStatusResponse {
+    schema_generation: String,
+    shards: Vec<ShardStatus>,
+}
+
+#[derive(Debug, Serialize)]
+struct ShardStatus {
+    id: u16,
+    state: &'static str,
+}
+
+async fn shard_status(
+    State(state): State<HttpState>,
+) -> Result<Json<ShardStatusResponse>, ApiError> {
+    let report = state
+        .engine
+        .shard_status_with_context(RequestContext::new())
+        .await?;
+    let shards = report
+        .shards()
+        .iter()
+        .map(|shard| ShardStatus {
+            id: shard.shard_id(),
+            state: shard.state().code(),
+        })
+        .collect();
+    Ok(Json(ShardStatusResponse {
+        schema_generation: report.schema_generation().to_string(),
+        shards,
+    }))
+}
+
+#[derive(Debug, Serialize)]
+struct ActiveQueriesResponse {
+    queries: Vec<ActiveQueryResponse>,
+}
+
+#[derive(Debug, Serialize)]
+struct ActiveQueryResponse {
+    operation_id: String,
+    elapsed_ms: u64,
+    sql_bytes: usize,
+    cancellation_requested: bool,
+}
+
+async fn active_queries(State(state): State<HttpState>) -> Json<ActiveQueriesResponse> {
+    let mut queries = state
+        .engine
+        .active_queries()
+        .into_iter()
+        .map(|query| ActiveQueryResponse {
+            operation_id: query.id().to_string(),
+            elapsed_ms: query.elapsed_ms(),
+            sql_bytes: query.sql_bytes(),
+            cancellation_requested: query.cancellation_requested(),
+        })
+        .collect::<Vec<_>>();
+    queries.sort_unstable_by(|left, right| left.operation_id.cmp(&right.operation_id));
+    Json(ActiveQueriesResponse { queries })
+}
+
+#[derive(Debug, Serialize)]
+struct CancelQueryResponse {
+    operation_id: String,
+    newly_requested: bool,
+}
+
+async fn cancel_query(
+    State(state): State<HttpState>,
+    V1Path(raw_query_id): V1Path<String>,
+    _body: V1EmptyBody,
+) -> Response {
+    let Ok(query_id) = raw_query_id.parse() else {
+        return TransportError::NotFound.into_response();
+    };
+    match state.engine.cancel_query(query_id) {
+        Some(newly_requested) => (
+            StatusCode::ACCEPTED,
+            Json(CancelQueryResponse {
+                operation_id: query_id.to_string(),
+                newly_requested,
+            }),
+        )
+            .into_response(),
+        None => TransportError::NotFound.into_response(),
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct BackupCapabilityResponse {
+    mode: &'static str,
+    online: bool,
+    requires_all_processes_stopped: bool,
+    checkpoint_endpoint: &'static str,
+    checkpoint_role: &'static str,
+    checkpoint_is_recovery_point: bool,
+}
+
+async fn backup_capability() -> Json<BackupCapabilityResponse> {
+    Json(BackupCapabilityResponse {
+        mode: "stopped_directory_copy",
+        online: false,
+        requires_all_processes_stopped: true,
+        checkpoint_endpoint: "/v1/admin/maintenance/checkpoint",
+        checkpoint_role: "preparation_only",
+        checkpoint_is_recovery_point: false,
+    })
+}
+
+#[derive(Debug, Serialize)]
+struct CheckpointResponse {
+    operation: &'static str,
+    busy: bool,
+    complete: bool,
+    recovery_point: bool,
+    shards: Vec<CheckpointShardResponse>,
+    databases: Vec<CheckpointDbResponse>,
+}
+
+#[derive(Debug, Serialize)]
+struct CheckpointShardResponse {
+    shard: u16,
+    busy: bool,
+    counts_available: bool,
+    wal_frames: u64,
+    checkpointed_frames: u64,
+    complete: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct CheckpointDbResponse {
+    database: &'static str,
+    busy: bool,
+    counts_available: bool,
+    wal_frames: u64,
+    checkpointed_frames: u64,
+    complete: bool,
+}
+
+async fn checkpoint(
+    State(state): State<HttpState>,
+    V1Json(_request): V1Json<EmptyRequest>,
+) -> Result<Json<CheckpointResponse>, ApiError> {
+    let report = state
+        .engine
+        .checkpoint_with_context(RequestContext::new())
+        .await?;
+    let shards = report
+        .shards()
+        .iter()
+        .map(|shard| CheckpointShardResponse {
+            shard: shard.shard(),
+            busy: shard.busy(),
+            counts_available: shard.counts_available(),
+            wal_frames: shard.wal_frames(),
+            checkpointed_frames: shard.checkpointed_frames(),
+            complete: shard.complete(),
+        })
+        .collect();
+    let databases = report
+        .databases()
+        .iter()
+        .map(|database| CheckpointDbResponse {
+            database: database.database().code(),
+            busy: database.busy(),
+            counts_available: database.counts_available(),
+            wal_frames: database.wal_frames(),
+            checkpointed_frames: database.checkpointed_frames(),
+            complete: database.complete(),
+        })
+        .collect();
+    Ok(Json(CheckpointResponse {
+        operation: "passive_checkpoint",
+        busy: report.busy(),
+        complete: report.complete(),
+        recovery_point: false,
+        shards,
+        databases,
+    }))
 }
 
 #[derive(Debug, Serialize)]
@@ -289,12 +766,15 @@ async fn query(
             session.set_routing_key(shard_key).await?;
         }
     }
+    let tracked_query = engine.begin_tracked_query(&request.sql)?;
+    let context = tracked_query.request_context();
     let Executed {
         shards,
         value: result,
     } = engine
-        .query_logical(&session, Statement::new(request.sql, params))
+        .query_logical_with_context(&session, Statement::new(request.sql, params), context)
         .await?;
+    drop(tracked_query);
     let response = result_set_to_query_response(shards, result, value_encoding);
 
     Ok(Json(response))
@@ -306,7 +786,7 @@ async fn broadcast(
 ) -> Result<Json<JsonValue>, ApiError> {
     let engine = state.engine;
     let session = engine.session();
-    let shards = engine.broadcast(&session, request.sql).await?;
+    let shards = engine.migrate(&session, request.sql).await?;
     Ok(Json(json!({"completed_shards": shards})))
 }
 
@@ -1051,6 +1531,32 @@ mod tests {
 
         let engine = Engine::from_database(Arc::new(database));
         let application = router_with_engine(engine.clone());
+        let catalog_index = engine
+            .catalog()
+            .global_indexes()
+            .iter()
+            .find(|index| index.id() == index_id)
+            .unwrap();
+        let (_, catalog) = request_json(&application, Method::GET, "/v1/admin/catalog", None).await;
+        let definition = &catalog["global_indexes"][0];
+        assert_eq!(catalog["global_indexes"].as_array().unwrap().len(), 1);
+        assert_eq!(definition.as_object().unwrap().len(), 7);
+        assert_eq!(
+            definition,
+            &json!({
+                "id": index_id.to_string(),
+                "table_id": table.to_string(),
+                "name": "events_email_lookup",
+                "unique": false,
+                "lifecycle": "ready",
+                "schema_generation": catalog_index.schema_generation().to_string(),
+                "key_encoding_version": catalog_index.key_encoding_version()
+            })
+        );
+        for withheld in ["key_sql", "predicate", "predicate_sql", "sql"] {
+            assert!(definition.get(withheld).is_none());
+        }
+
         assert_eq!(
             request_json(&application, Method::GET, "/v1/admin/global-indexes", None,).await,
             (

--- a/src/protocol/http/v1.rs
+++ b/src/protocol/http/v1.rs
@@ -1,18 +1,26 @@
 //! Version 1 transport contract. Storage and SQL semantics remain in Engine.
 
+use std::fmt;
+
 use axum::{
     Json, Router,
-    extract::{DefaultBodyLimit, FromRequest, Request},
-    http::{HeaderValue, StatusCode},
+    body::Bytes,
+    extract::{DefaultBodyLimit, FromRequest, FromRequestParts, Path, Request},
+    http::{HeaderValue, StatusCode, request::Parts},
     middleware,
     response::{IntoResponse, Response},
     routing::{any, get, post},
 };
-use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use serde::{
+    Deserialize, Serialize,
+    de::{DeserializeOwned, IgnoredAny, MapAccess, Visitor},
+};
 use serde_json::value::RawValue;
 
 use super::{
-    HttpState, ProblemDetails, broadcast, execute, global_indexes, health, problem_response, query,
+    HttpState, ProblemDetails, active_queries, backup_capability, broadcast, cancel_query, catalog,
+    checkpoint, execute, global_indexes, health, migration, migrations, problem_response, query,
+    ready, shard_status,
 };
 
 const MAX_REQUEST_BYTES: usize = 2 * 1024 * 1024;
@@ -22,10 +30,19 @@ pub(super) fn routes() -> Router<HttpState> {
         Router::new()
             .route("/", get(discovery))
             .route("/health", get(health))
+            .route("/ready", get(ready))
             .route("/execute", post(execute))
             .route("/query", post(query))
             .route("/admin/broadcast", post(broadcast))
-            .route("/admin/global-indexes", get(global_indexes)),
+            .route("/admin/global-indexes", get(global_indexes))
+            .route("/admin/catalog", get(catalog))
+            .route("/admin/migrations", get(migrations))
+            .route("/admin/migrations/{target_generation}", get(migration))
+            .route("/admin/shards", get(shard_status))
+            .route("/admin/queries", get(active_queries))
+            .route("/admin/queries/{query_id}/cancel", post(cancel_query))
+            .route("/admin/backup", get(backup_capability))
+            .route("/admin/maintenance/checkpoint", post(checkpoint)),
         true,
     )
 }
@@ -44,8 +61,17 @@ pub(super) fn admin_routes() -> Router<HttpState> {
     versioned_routes(
         Router::new()
             .route("/health", get(health))
+            .route("/ready", get(ready))
             .route("/admin/broadcast", post(broadcast))
-            .route("/admin/global-indexes", get(global_indexes)),
+            .route("/admin/global-indexes", get(global_indexes))
+            .route("/admin/catalog", get(catalog))
+            .route("/admin/migrations", get(migrations))
+            .route("/admin/migrations/{target_generation}", get(migration))
+            .route("/admin/shards", get(shard_status))
+            .route("/admin/queries", get(active_queries))
+            .route("/admin/queries/{query_id}/cancel", post(cancel_query))
+            .route("/admin/backup", get(backup_capability))
+            .route("/admin/maintenance/checkpoint", post(checkpoint)),
         false,
     )
 }
@@ -146,6 +172,40 @@ pub(super) struct BroadcastRequest {
     pub(super) sql: String,
 }
 
+#[derive(Debug)]
+pub(super) struct EmptyRequest;
+
+impl<'de> Deserialize<'de> for EmptyRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct EmptyRequestVisitor;
+
+        impl<'de> Visitor<'de> for EmptyRequestVisitor {
+            type Value = EmptyRequest;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("an empty JSON object")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                if map.next_entry::<IgnoredAny, IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::custom(
+                        "the empty request must not contain fields",
+                    ));
+                }
+                Ok(EmptyRequest)
+            }
+        }
+
+        deserializer.deserialize_map(EmptyRequestVisitor)
+    }
+}
+
 pub(super) struct V1Json<T>(pub(super) T);
 
 impl<T, S> FromRequest<S> for V1Json<T>
@@ -164,6 +224,51 @@ where
                 StatusCode::UNSUPPORTED_MEDIA_TYPE => TransportError::MediaType,
                 _ => TransportError::InvalidRequest,
             })
+    }
+}
+
+/// An exact empty request body under the shared v1 byte limit.
+///
+/// Routes without a JSON envelope still extract the body so Axum applies
+/// [`DefaultBodyLimit`] before the handler can perform an operation.
+pub(super) struct V1EmptyBody;
+
+impl<S> FromRequest<S> for V1EmptyBody
+where
+    S: Send + Sync,
+{
+    type Rejection = TransportError;
+
+    async fn from_request(request: Request, state: &S) -> Result<Self, Self::Rejection> {
+        let body =
+            Bytes::from_request(request, state)
+                .await
+                .map_err(|rejection| match rejection.status() {
+                    StatusCode::PAYLOAD_TOO_LARGE => TransportError::BodyTooLarge,
+                    _ => TransportError::InvalidRequest,
+                })?;
+        if body.is_empty() {
+            Ok(Self)
+        } else {
+            Err(TransportError::InvalidRequest)
+        }
+    }
+}
+
+pub(super) struct V1Path<T>(pub(super) T);
+
+impl<T, S> FromRequestParts<S> for V1Path<T>
+where
+    T: DeserializeOwned + Send,
+    S: Send + Sync,
+{
+    type Rejection = TransportError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        Path::<T>::from_request_parts(parts, state)
+            .await
+            .map(|Path(value)| Self(value))
+            .map_err(|_| TransportError::NotFound)
     }
 }
 

--- a/src/storage/manifest.rs
+++ b/src/storage/manifest.rs
@@ -989,6 +989,28 @@ pub(super) enum SchemaMigrationClassification {
     Complete(SchemaMigration),
 }
 
+/// A bounded, transactionally coherent view of migration history.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct SchemaMigrationSummarySnapshot {
+    schema_generation: u64,
+    active: Option<SchemaMigration>,
+    latest_complete: Option<SchemaMigration>,
+}
+
+impl SchemaMigrationSummarySnapshot {
+    pub(super) const fn schema_generation(&self) -> u64 {
+        self.schema_generation
+    }
+
+    pub(super) fn active(&self) -> Option<&SchemaMigration> {
+        self.active.as_ref()
+    }
+
+    pub(super) fn latest_complete(&self) -> Option<&SchemaMigration> {
+        self.latest_complete.as_ref()
+    }
+}
+
 /// One fully validated, checksummed table-provisioning journal.
 ///
 /// The durable prefix means every shard below `next_shard` has committed the
@@ -4573,6 +4595,135 @@ fn find_schema_migration(
              FROM briskdb_schema_migrations
              WHERE migration_id = ?1",
             [migration_id.as_slice()],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                    row.get(6)?,
+                    row.get(7)?,
+                ))
+            },
+        )
+        .map(Some)
+        .or_else(|error| match error {
+            rusqlite::Error::QueryReturnedNoRows => Ok(None),
+            error => Err(error),
+        })
+        .map_err(|error| manifest_read_error(error, "failed to read schema migration journal"))?
+        .map(|stored| schema_migration_from_stored(stored, expected_shard_count))
+        .transpose()
+}
+
+/// Inspect only the active and latest complete journal rows.
+///
+/// Both rows are addressed through the `target_generation` primary key: a
+/// valid active row can only be the generation after the catalog, and the
+/// latest complete row can only be the catalog generation itself.
+pub(super) fn inspect_schema_migration_summary(
+    connection: &Connection,
+    expected_shard_count: u16,
+) -> EngineResult<SchemaMigrationSummarySnapshot> {
+    let schema_generation =
+        validate_schema_catalog_configuration(connection, SchemaGenerationPolicy::Journaled)?
+            .schema_generation;
+    let latest_complete = if schema_generation == 0 {
+        None
+    } else {
+        let migration = find_schema_migration_by_generation(
+            connection,
+            expected_shard_count,
+            schema_generation,
+        )?
+        .ok_or_else(|| {
+            EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "schema migration journal is missing its latest complete generation",
+            )
+        })?;
+        if !migration.is_complete() {
+            return Err(EngineError::new(
+                EngineErrorKind::DataCorruption,
+                "catalog generation refers to an incomplete schema migration",
+            ));
+        }
+        Some(migration)
+    };
+    let active = match schema_generation.checked_add(1) {
+        Some(target) if target <= MAX_SCHEMA_GENERATION => {
+            find_schema_migration_by_generation(connection, expected_shard_count, target)?
+        }
+        Some(_) | None => None,
+    };
+    if active
+        .as_ref()
+        .is_some_and(|migration| !migration.is_applying())
+    {
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "journal row after the catalog generation is not active",
+        ));
+    }
+    Ok(SchemaMigrationSummarySnapshot {
+        schema_generation,
+        active,
+        latest_complete,
+    })
+}
+
+/// Look up one journal row through its indexed target-generation key.
+pub(super) fn inspect_schema_migration_generation(
+    connection: &Connection,
+    expected_shard_count: u16,
+    target_generation: u64,
+) -> EngineResult<(u64, Option<SchemaMigration>)> {
+    let schema_generation =
+        validate_schema_catalog_configuration(connection, SchemaGenerationPolicy::Journaled)?
+            .schema_generation;
+    if target_generation == 0 || target_generation > MAX_SCHEMA_GENERATION {
+        return Ok((schema_generation, None));
+    }
+    let migration =
+        find_schema_migration_by_generation(connection, expected_shard_count, target_generation)?;
+    if let Some(migration) = migration.as_ref() {
+        if migration.is_complete() && target_generation <= schema_generation {
+            return Ok((schema_generation, Some(migration.clone())));
+        }
+        if migration.is_applying() && schema_generation.checked_add(1) == Some(target_generation) {
+            return Ok((schema_generation, Some(migration.clone())));
+        }
+        return Err(EngineError::new(
+            EngineErrorKind::DataCorruption,
+            "schema migration state is inconsistent with the catalog generation",
+        ));
+    }
+    Ok((schema_generation, None))
+}
+
+fn find_schema_migration_by_generation(
+    connection: &Connection,
+    expected_shard_count: u16,
+    target_generation: u64,
+) -> EngineResult<Option<SchemaMigration>> {
+    debug_assert!((1..=MAX_SCHEMA_GENERATION).contains(&target_generation));
+    let target_generation =
+        i64::try_from(target_generation).expect("validated schema generation fits SQLite");
+    connection
+        .query_row(
+            "SELECT target_generation,
+                    source_generation,
+                    migration_id,
+                    digest_version,
+                    sql_text,
+                    shard_count,
+                    migration_state,
+                    next_shard
+             FROM briskdb_schema_migrations
+             WHERE target_generation = ?1",
+            [target_generation],
             |row| {
                 Ok((
                     row.get(0)?,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -44,7 +44,6 @@ use rusqlite::{
 pub(crate) use migration::SchemaMigrationCoordinatorPoint;
 use schema_gate::SchemaMigrationGuard as LocalSchemaMigrationGuard;
 pub(crate) use schema_gate::SchemaOperationGuard;
-#[cfg(test)]
 pub(crate) use schema_gate::{SchemaGateSnapshot, SchemaGateState};
 
 pub use crate::core::Database;
@@ -62,7 +61,8 @@ use crate::{
         GlobalIndexShardSummaryRebuildReport, GlobalIndexShardSummaryState,
         GlobalIndexShardSummaryStatus, GlobalIndexValidationMode, GlobalIndexValidationOptions,
         GlobalIndexValidationReport, GlobalOperationId, GlobalUniqueMutation,
-        GlobalUniqueReservation, GlobalValueLease, IndexKeyValue, MAX_TABLES, ShardKeyType,
+        GlobalUniqueReservation, GlobalValueLease, IndexKeyValue, MAX_TABLES, OperationControl,
+        SchemaMigrationState, SchemaMigrationStatus, SchemaMigrationSummary, ShardKeyType,
         TableDeclaration, TablePlacement,
         generated_id::{
             NATIVE_RANGE_V1_FORMAT_MARKER, native_range_v1_sequence_ceiling,
@@ -549,6 +549,24 @@ pub(crate) struct GlobalWriteReservationGuard {
     _lease: process_lock::GlobalWriteOperationLease,
 }
 
+fn schema_migration_status(migration: &manifest::SchemaMigration) -> SchemaMigrationStatus {
+    let state = if migration.is_applying() {
+        SchemaMigrationState::Applying
+    } else {
+        debug_assert!(migration.is_complete());
+        SchemaMigrationState::Complete
+    };
+    SchemaMigrationStatus {
+        generation: migration.target_generation(),
+        source_generation: migration.source_generation(),
+        target_generation: migration.target_generation(),
+        state,
+        shard_count: migration.shard_count(),
+        next_shard: migration.next_shard(),
+        sql_bytes: migration.sql_text().len(),
+    }
+}
+
 impl Storage {
     pub(crate) fn open(root: impl AsRef<Path>, requested_shards: u16) -> EngineResult<Self> {
         validate_shard_count(requested_shards)?;
@@ -946,19 +964,22 @@ impl Storage {
     pub(crate) fn checkpoint_auxiliary_databases(
         &self,
     ) -> EngineResult<Vec<CheckpointDatabaseReport>> {
-        let manifest = open_existing_manifest(&self.root.join("manifest.sqlite"))?;
-        configure_manifest_connection(&manifest)?;
-        let mut reports = vec![checkpoint_database(
-            &manifest,
-            CheckpointDatabase::Manifest,
-        )?];
-        if let Some((global_index, _)) = global_index::open_existing(&self.root)? {
-            reports.push(checkpoint_database(
-                &global_index,
-                CheckpointDatabase::GlobalIndex,
-            )?);
-        }
-        Ok(reports)
+        let result = (|| {
+            let manifest = open_existing_manifest(&self.root.join("manifest.sqlite"))?;
+            configure_manifest_connection(&manifest)?;
+            let mut reports = vec![checkpoint_database(
+                &manifest,
+                CheckpointDatabase::Manifest,
+            )?];
+            if let Some((global_index, _)) = global_index::open_existing(&self.root)? {
+                reports.push(checkpoint_database(
+                    &global_index,
+                    CheckpointDatabase::GlobalIndex,
+                )?);
+            }
+            Ok(reports)
+        })();
+        self.fail_closed_on_corruption(result)
     }
 
     pub(crate) fn shard_for_key(&self, key: &[u8]) -> u16 {
@@ -2834,9 +2855,151 @@ impl Storage {
             .publish_schema_generation(expected_generation, target_generation)
     }
 
-    #[cfg(test)]
     pub(crate) fn schema_gate_snapshot(&self) -> SchemaGateSnapshot {
         self.schema_coordination.gate.snapshot()
+    }
+
+    /// Inspect the bounded migration summary without entering ordinary schema
+    /// admission, so an active or pending migration remains observable.
+    pub(crate) fn schema_migration_summary(
+        &self,
+        control: Arc<OperationControl>,
+    ) -> EngineResult<SchemaMigrationSummary> {
+        const MAX_GENERATION_RETRIES: usize = 8;
+        let mut committed_handoff = None;
+        for _ in 0..MAX_GENERATION_RETRIES {
+            let before_generation = self.current_schema_generation();
+            let manifest_path = self.root.join("manifest.sqlite");
+            let snapshot = (|| {
+                let mut connection = open_existing_manifest(&manifest_path)?;
+                pool::run_dedicated_connection_controlled(
+                    &mut connection,
+                    Arc::clone(&control),
+                    |connection| {
+                        configure_manifest_connection_after_busy_setup(connection)?;
+                        let transaction = connection
+                            .transaction_with_behavior(TransactionBehavior::Deferred)
+                            .map_err(sqlite_error::storage)?;
+                        let snapshot = manifest::inspect_schema_migration_summary(
+                            &transaction,
+                            self.shard_count(),
+                        )?;
+                        transaction.commit().map_err(sqlite_error::storage)?;
+                        Ok(snapshot)
+                    },
+                )
+            })();
+            let snapshot = self.fail_closed_on_corruption(snapshot)?;
+            let after_generation = self.current_schema_generation();
+            if before_generation == after_generation
+                && snapshot.schema_generation() == after_generation
+            {
+                return Ok(SchemaMigrationSummary {
+                    schema_generation: after_generation,
+                    active: snapshot.active().map(schema_migration_status),
+                    latest_complete: snapshot.latest_complete().map(schema_migration_status),
+                });
+            }
+            if before_generation == after_generation {
+                let gate_state = self.schema_gate_snapshot().state;
+                if self.current_schema_generation() != after_generation {
+                    continue;
+                }
+                if after_generation.checked_add(1) == Some(snapshot.schema_generation())
+                    && matches!(
+                        gate_state,
+                        SchemaGateState::Migrating | SchemaGateState::Pending
+                    )
+                {
+                    committed_handoff = Some(snapshot);
+                } else {
+                    self.record_schema_degraded();
+                    return Err(EngineError::new(
+                        EngineErrorKind::DataCorruption,
+                        "manifest schema generation is inconsistent with runtime publication",
+                    ));
+                }
+            }
+            std::thread::yield_now();
+        }
+        if let Some(snapshot) = committed_handoff {
+            return Ok(SchemaMigrationSummary {
+                schema_generation: snapshot.schema_generation(),
+                active: snapshot.active().map(schema_migration_status),
+                latest_complete: snapshot.latest_complete().map(schema_migration_status),
+            });
+        }
+        Err(EngineError::new(
+            EngineErrorKind::Busy,
+            "application-schema generation changed during migration inspection",
+        ))
+    }
+
+    /// Inspect one migration by its indexed target generation without exposing SQL.
+    pub(crate) fn schema_migration(
+        &self,
+        target_generation: u64,
+        control: Arc<OperationControl>,
+    ) -> EngineResult<Option<SchemaMigrationStatus>> {
+        const MAX_GENERATION_RETRIES: usize = 8;
+        let mut committed_handoff = None;
+        for _ in 0..MAX_GENERATION_RETRIES {
+            let before_generation = self.current_schema_generation();
+            let manifest_path = self.root.join("manifest.sqlite");
+            let snapshot = (|| {
+                let mut connection = open_existing_manifest(&manifest_path)?;
+                pool::run_dedicated_connection_controlled(
+                    &mut connection,
+                    Arc::clone(&control),
+                    |connection| {
+                        configure_manifest_connection_after_busy_setup(connection)?;
+                        let transaction = connection
+                            .transaction_with_behavior(TransactionBehavior::Deferred)
+                            .map_err(sqlite_error::storage)?;
+                        let snapshot = manifest::inspect_schema_migration_generation(
+                            &transaction,
+                            self.shard_count(),
+                            target_generation,
+                        )?;
+                        transaction.commit().map_err(sqlite_error::storage)?;
+                        Ok(snapshot)
+                    },
+                )
+            })();
+            let (manifest_generation, migration) = self.fail_closed_on_corruption(snapshot)?;
+            let after_generation = self.current_schema_generation();
+            if before_generation == after_generation && manifest_generation == after_generation {
+                return Ok(migration.as_ref().map(schema_migration_status));
+            }
+            if before_generation == after_generation {
+                let gate_state = self.schema_gate_snapshot().state;
+                if self.current_schema_generation() != after_generation {
+                    continue;
+                }
+                if after_generation.checked_add(1) == Some(manifest_generation)
+                    && matches!(
+                        gate_state,
+                        SchemaGateState::Migrating | SchemaGateState::Pending
+                    )
+                {
+                    committed_handoff = Some(migration);
+                } else {
+                    self.record_schema_degraded();
+                    return Err(EngineError::new(
+                        EngineErrorKind::DataCorruption,
+                        "manifest schema generation is inconsistent with runtime publication",
+                    ));
+                }
+            }
+            std::thread::yield_now();
+        }
+        if let Some(migration) = committed_handoff {
+            return Ok(migration.as_ref().map(schema_migration_status));
+        }
+        Err(EngineError::new(
+            EngineErrorKind::Busy,
+            "application-schema generation changed during migration inspection",
+        ))
     }
 
     pub(crate) fn apply_schema_migration(

--- a/src/storage/pool.rs
+++ b/src/storage/pool.rs
@@ -7,7 +7,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-#[cfg(feature = "documents")]
 use std::panic::{AssertUnwindSafe, catch_unwind, resume_unwind};
 
 #[cfg(test)]
@@ -844,6 +843,18 @@ impl PooledConnection {
         self.broken = true;
     }
 
+    /// Replace this lease with a freshly opened, fully validated shard handle.
+    ///
+    /// Operational shard inspection uses this path so a successful report
+    /// revalidates durable identity, generation, metadata, and schema digest
+    /// instead of relying on an earlier pooled checkout.
+    pub(crate) fn revalidate_controlled(
+        &mut self,
+        control: Arc<OperationControl>,
+    ) -> EngineResult<()> {
+        self.replace_with_fresh_controlled(control)
+    }
+
     /// Run work while cancellation is armed against exactly this leased handle.
     ///
     /// The progress hook closes the small race between starting SQLite and an
@@ -1134,7 +1145,6 @@ fn run_connection_validation_controlled<T>(
 /// pool should retire it. One [`OperationControl`] may use this helper
 /// repeatedly for sequential manifest and shard work; each invocation arms
 /// exactly the handle currently executing SQLite.
-#[cfg(feature = "documents")]
 pub(super) fn run_dedicated_connection_controlled<T>(
     connection: &mut Connection,
     control: Arc<OperationControl>,

--- a/src/storage/schema_gate.rs
+++ b/src/storage/schema_gate.rs
@@ -28,7 +28,6 @@ fn degraded_error() -> EngineError {
 }
 
 /// One deterministic view of schema admission and current occupancy.
-#[cfg(test)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct SchemaGateSnapshot {
     pub(crate) state: SchemaGateState,
@@ -93,7 +92,6 @@ impl SchemaGate {
     }
 
     /// Return a coherent snapshot for status and diagnostics.
-    #[cfg(test)]
     pub(crate) fn snapshot(&self) -> SchemaGateSnapshot {
         let data = self.inner.lock();
         SchemaGateSnapshot {

--- a/tests/debian_packaging.rs
+++ b/tests/debian_packaging.rs
@@ -90,6 +90,7 @@ fn debian_package_contract_preserves_configuration_and_database_state() {
         "systemd-analyze verify",
         "BriskDB is ready",
         "http://127.0.0.1:7654/v1",
+        "http://127.0.0.1:7655/v1/ready",
         "http://127.0.0.1:7655/admin",
         "package smoke-test local configuration",
         "wait_for_service",

--- a/tests/http_plane_listeners.rs
+++ b/tests/http_plane_listeners.rs
@@ -112,6 +112,65 @@ fn assert_versioned_not_found(response: &HttpResponse) {
     assert_eq!(response.json()["code"], "not_found");
 }
 
+fn assert_versioned_problem(response: &HttpResponse, expected_status: u16, expected_code: &str) {
+    assert_eq!(response.status, expected_status);
+    assert_eq!(response.header("briskdb-api-version"), Some("1"));
+    assert_eq!(
+        response.header("content-type"),
+        Some("application/problem+json")
+    );
+    let body = response.json();
+    assert_eq!(body["status"], expected_status);
+    assert_eq!(body["code"], expected_code);
+    assert_eq!(body.as_object().unwrap().len(), 5);
+    assert!(body["type"].as_str().unwrap().contains(':'));
+    assert!(!body.to_string().contains("private-sentinel"));
+}
+
+fn assert_cancelled_problem(response: &HttpResponse) {
+    assert_versioned_problem(response, 500, "cancelled");
+}
+
+async fn wait_for_active_query_count(address: SocketAddr, expected: usize) -> Vec<Value> {
+    timeout(Duration::from_secs(5), async {
+        loop {
+            let response = get(address, "/v1/admin/queries").await;
+            assert_eq!(response.status, 200);
+            assert_eq!(response.header("briskdb-api-version"), Some("1"));
+            let body = response.json();
+            let queries = body["queries"].as_array().unwrap();
+            if queries.len() == expected {
+                return queries.clone();
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("active-query registry should reach the expected size")
+}
+
+fn operation_id(query: &Value) -> &str {
+    let id = query["operation_id"].as_str().unwrap();
+    assert_eq!(id.len(), 32);
+    assert!(
+        id.bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    );
+    id
+}
+
+async fn start_unread_query(address: SocketAddr, sql: &str) -> tokio::net::TcpStream {
+    let body = serde_json::to_vec(&json!({"shard_key":"dropped-owner", "sql":sql})).unwrap();
+    let head = format!(
+        "POST /v1/query HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n",
+        body.len()
+    );
+    let mut stream = tokio::net::TcpStream::connect(address).await.unwrap();
+    stream.write_all(head.as_bytes()).await.unwrap();
+    stream.write_all(&body).await.unwrap();
+    stream
+}
+
 #[tokio::test]
 async fn attached_data_and_admin_planes_are_isolated_over_real_tcp() {
     let temp = tempfile::tempdir().unwrap();
@@ -157,7 +216,7 @@ async fn attached_data_and_admin_planes_are_isolated_over_real_tcp() {
     assert_eq!(data_query.status, 200);
     assert_eq!(data_query.json()["rows"], json!([[7]]));
 
-    for path in ["/health", "/metrics", "/admin"] {
+    for path in ["/health", "/ready", "/metrics", "/admin"] {
         let response = get(data, path).await;
         assert_eq!(response.status, 404, "{path}");
         assert!(response.header("briskdb-api-version").is_none(), "{path}");
@@ -172,12 +231,37 @@ async fn attached_data_and_admin_planes_are_isolated_over_real_tcp() {
     assert_eq!(leaked_login.status, 404);
     assert!(leaked_login.header("set-cookie").is_none());
     assert_versioned_not_found(&get(data, "/v1/health").await);
-    assert_versioned_not_found(&get(data, "/v1/admin/global-indexes").await);
+    for path in [
+        "/v1/ready",
+        "/v1/admin/global-indexes",
+        "/v1/admin/catalog",
+        "/v1/admin/migrations",
+        "/v1/admin/migrations/1",
+        "/v1/admin/shards",
+        "/v1/admin/queries",
+        "/v1/admin/backup",
+    ] {
+        assert_versioned_not_found(&get(data, path).await);
+    }
     assert_versioned_not_found(
         &post_json(
             data,
             "/v1/admin/broadcast",
             json!({"sql":"CREATE TABLE leaked_from_data (id INTEGER)"}),
+        )
+        .await,
+    );
+    assert_versioned_not_found(
+        &post_json(data, "/v1/admin/maintenance/checkpoint", json!({})).await,
+    );
+    assert_versioned_not_found(
+        &request(
+            data,
+            "POST",
+            "/v1/admin/queries/0123456789abcdef0123456789abcdef/cancel",
+            None,
+            &[],
+            &[],
         )
         .await,
     );
@@ -193,6 +277,14 @@ async fn attached_data_and_admin_planes_are_isolated_over_real_tcp() {
     assert_eq!(health_head.status, 200);
     assert_eq!(health_head.header("briskdb-api-version"), Some("1"));
     assert!(health_head.body.is_empty());
+    let ready = get(admin, "/ready").await;
+    assert_eq!(ready.status, 200);
+    assert!(ready.header("briskdb-api-version").is_none());
+    assert_eq!(ready.json()["ready"], true);
+    let versioned_ready = get(admin, "/v1/ready").await;
+    assert_eq!(versioned_ready.status, 200);
+    assert_eq!(versioned_ready.header("briskdb-api-version"), Some("1"));
+    assert_eq!(versioned_ready.json(), ready.json());
     let metrics = get(admin, "/metrics").await;
     assert_eq!(metrics.status, 200);
     assert!(metrics.header("briskdb-api-version").is_none());
@@ -264,6 +356,46 @@ async fn attached_data_and_admin_planes_are_isolated_over_real_tcp() {
     assert_eq!(migration.header("briskdb-api-version"), Some("1"));
     assert_eq!(migration.json()["completed_shards"], json!([0, 1]));
     assert_eq!(get(admin, "/v1/admin/global-indexes").await.status, 200);
+    let catalog = get(admin, "/v1/admin/catalog").await;
+    assert_eq!(catalog.status, 200);
+    assert_eq!(catalog.json()["schema_generation"], "1");
+    assert_eq!(catalog.json()["databases"][0]["name"], "default");
+    let migrations = get(admin, "/v1/admin/migrations").await;
+    assert_eq!(migrations.status, 200);
+    let migrations_body = migrations.json();
+    assert_eq!(migrations_body["schema_generation"], "1");
+    assert!(migrations_body["active"].is_null());
+    let latest_complete = &migrations_body["latest_complete"];
+    assert_eq!(latest_complete["generation"], "1");
+    assert_eq!(latest_complete.as_object().unwrap().len(), 8);
+    assert!(latest_complete.get("id").is_none());
+    assert!(latest_complete.get("digest").is_none());
+    assert!(!String::from_utf8_lossy(&migrations.body).contains("CREATE TABLE"));
+    let exact_migration = get(admin, "/v1/admin/migrations/1").await;
+    assert_eq!(exact_migration.status, 200);
+    assert_eq!(exact_migration.json(), latest_complete.clone());
+    let shards = get(admin, "/v1/admin/shards").await;
+    assert_eq!(shards.status, 200);
+    assert_eq!(
+        shards.json(),
+        json!({
+            "schema_generation":"1",
+            "shards":[{"id":0,"state":"ready"},{"id":1,"state":"ready"}]
+        })
+    );
+    assert_eq!(
+        get(admin, "/v1/admin/queries").await.json(),
+        json!({"queries":[]})
+    );
+    let backup = get(admin, "/v1/admin/backup").await;
+    assert_eq!(backup.status, 200);
+    assert_eq!(backup.json()["online"], false);
+    assert_eq!(backup.json()["requires_all_processes_stopped"], true);
+    assert_eq!(backup.json()["checkpoint_is_recovery_point"], false);
+    let checkpoint = post_json(admin, "/v1/admin/maintenance/checkpoint", json!({})).await;
+    assert_eq!(checkpoint.status, 200);
+    assert_eq!(checkpoint.json()["operation"], "passive_checkpoint");
+    assert_eq!(checkpoint.json()["recovery_point"], false);
 
     let write = post_json(
         data,
@@ -305,6 +437,187 @@ async fn attached_data_and_admin_planes_are_isolated_over_real_tcp() {
 }
 
 #[tokio::test]
+async fn admin_cancels_only_the_selected_data_query_and_disconnect_unregisters_its_handle() {
+    let temp = tempfile::tempdir().unwrap();
+    let database = BriskDb::builder(temp.path())
+        .with_shard_count(2)
+        .open()
+        .await
+        .unwrap();
+    let mut server = AttachedServer::start(
+        &database,
+        ListenerConfig {
+            http_listen: "127.0.0.1:0".parse().unwrap(),
+            admin_listen: Some("127.0.0.1:0".parse().unwrap()),
+            postgres_listen: None,
+        },
+    )
+    .await
+    .unwrap();
+    let data = server.addresses().data();
+    let admin = server.addresses().admin().unwrap();
+    let slow_sql = "WITH RECURSIVE numbers(value) AS (VALUES(0) UNION ALL SELECT value + 1 FROM numbers WHERE value < 1000000000) SELECT sum(value) FROM numbers";
+
+    let first = tokio::spawn(async move {
+        post_json(
+            data,
+            "/v1/query",
+            json!({"shard_key":"cancel-one", "sql":slow_sql}),
+        )
+        .await
+    });
+    let first_status = wait_for_active_query_count(admin, 1).await;
+    assert_eq!(first_status[0].as_object().unwrap().len(), 4);
+    assert!(first_status[0].get("sql_digest").is_none());
+    assert!(first_status[0].get("digest").is_none());
+    let first_id = operation_id(&first_status[0]).to_owned();
+    assert_eq!(first_status[0]["sql_bytes"], slow_sql.len());
+    assert_eq!(first_status[0]["cancellation_requested"], false);
+    assert!(
+        !serde_json::to_string(&first_status)
+            .unwrap()
+            .contains(slow_sql)
+    );
+
+    let rejected_nonempty = request(
+        admin,
+        "POST",
+        &format!("/v1/admin/queries/{first_id}/cancel"),
+        None,
+        b"private-sentinel",
+        &[],
+    )
+    .await;
+    assert_versioned_problem(&rejected_nonempty, 400, "invalid_argument");
+    let still_active = wait_for_active_query_count(admin, 1).await;
+    assert_eq!(operation_id(&still_active[0]), first_id);
+    assert_eq!(still_active[0]["cancellation_requested"], false);
+
+    let oversized_cancel_body = vec![b'x'; 2 * 1024 * 1024 + 1];
+    let rejected_oversized = request(
+        admin,
+        "POST",
+        &format!("/v1/admin/queries/{first_id}/cancel"),
+        None,
+        &oversized_cancel_body,
+        &[],
+    )
+    .await;
+    assert_versioned_problem(&rejected_oversized, 413, "request_too_large");
+    let still_active = wait_for_active_query_count(admin, 1).await;
+    assert_eq!(operation_id(&still_active[0]), first_id);
+    assert_eq!(still_active[0]["cancellation_requested"], false);
+
+    let second = tokio::spawn(async move {
+        post_json(
+            data,
+            "/v1/query",
+            json!({"shard_key":"cancel-two", "sql":slow_sql}),
+        )
+        .await
+    });
+    let both = wait_for_active_query_count(admin, 2).await;
+    let second_id = both
+        .iter()
+        .map(operation_id)
+        .find(|id| *id != first_id)
+        .unwrap()
+        .to_owned();
+
+    let cancel_second = request(
+        admin,
+        "POST",
+        &format!("/v1/admin/queries/{second_id}/cancel"),
+        None,
+        &[],
+        &[],
+    )
+    .await;
+    assert_eq!(cancel_second.status, 202);
+    assert_eq!(cancel_second.header("briskdb-api-version"), Some("1"));
+    assert_eq!(
+        cancel_second.json(),
+        json!({"operation_id":second_id, "newly_requested":true})
+    );
+    let second_response = timeout(Duration::from_secs(5), second)
+        .await
+        .expect("selected query should stop promptly")
+        .unwrap();
+    assert_cancelled_problem(&second_response);
+
+    let still_active = wait_for_active_query_count(admin, 1).await;
+    assert_eq!(operation_id(&still_active[0]), first_id);
+    assert_eq!(still_active[0]["cancellation_requested"], false);
+    assert_versioned_not_found(
+        &request(
+            admin,
+            "POST",
+            &format!("/v1/admin/queries/{second_id}/cancel"),
+            None,
+            &[],
+            &[],
+        )
+        .await,
+    );
+
+    let cancel_first = request(
+        admin,
+        "POST",
+        &format!("/v1/admin/queries/{first_id}/cancel"),
+        None,
+        &[],
+        &[],
+    )
+    .await;
+    assert_eq!(cancel_first.status, 202);
+    assert_eq!(cancel_first.json()["newly_requested"], true);
+    let first_response = timeout(Duration::from_secs(5), first)
+        .await
+        .expect("remaining query should stop promptly")
+        .unwrap();
+    assert_cancelled_problem(&first_response);
+    assert!(wait_for_active_query_count(admin, 0).await.is_empty());
+
+    let later = post_json(
+        data,
+        "/v1/query",
+        json!({"shard_key":"cancel-one", "sql":"SELECT 7 AS value"}),
+    )
+    .await;
+    assert_eq!(later.status, 200);
+    assert_eq!(later.json()["rows"], json!([[7]]));
+
+    let unread = start_unread_query(data, slow_sql).await;
+    let dropped = wait_for_active_query_count(admin, 1).await;
+    let dropped_id = operation_id(&dropped[0]).to_owned();
+    drop(unread);
+    assert!(wait_for_active_query_count(admin, 0).await.is_empty());
+    assert_versioned_not_found(
+        &request(
+            admin,
+            "POST",
+            &format!("/v1/admin/queries/{dropped_id}/cancel"),
+            None,
+            &[],
+            &[],
+        )
+        .await,
+    );
+    let after_disconnect = post_json(
+        data,
+        "/v1/query",
+        json!({"shard_key":"dropped-owner", "sql":"SELECT 11 AS value"}),
+    )
+    .await;
+    assert_eq!(after_disconnect.status, 200);
+    assert_eq!(after_disconnect.json()["rows"], json!([[11]]));
+
+    assert!(!server.close().await.unwrap());
+    assert_eq!(database.state(), briskdb::core::EngineState::Running);
+    database.close().await.unwrap();
+}
+
+#[tokio::test]
 async fn attached_server_can_disable_the_admin_plane_and_restart_it() {
     let temp = tempfile::tempdir().unwrap();
     let database = BriskDb::builder(temp.path())
@@ -324,6 +637,7 @@ async fn attached_server_can_disable_the_admin_plane_and_restart_it() {
     .unwrap();
     assert!(data_only.addresses().admin().is_none());
     assert_eq!(get(data_only.addresses().http(), "/v1").await.status, 200);
+    assert_versioned_not_found(&get(data_only.addresses().http(), "/v1/ready").await);
     assert_eq!(
         get(data_only.addresses().http(), "/admin").await.status,
         404

--- a/tests/http_v1.rs
+++ b/tests/http_v1.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "http")]
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use axum::{
     Router,
@@ -36,7 +36,7 @@ fn application() -> (tempfile::TempDir, Engine, Router) {
     (temp, engine, router)
 }
 
-fn scatter_application() -> (tempfile::TempDir, Router, [String; 2]) {
+fn scatter_application() -> (tempfile::TempDir, Engine, Router, [String; 2]) {
     let temp = tempfile::tempdir().unwrap();
     let mut database = Database::open(temp.path(), 2).unwrap();
     database
@@ -83,8 +83,9 @@ fn scatter_application() -> (tempfile::TempDir, Router, [String; 2]) {
         assert_eq!(inserted.shard, shard);
         assert_eq!(inserted.value, 1);
     }
-    let router = briskdb::api::router(Arc::new(database));
-    (temp, router, tenant_keys)
+    let engine = Engine::from_database(Arc::new(database));
+    let router = briskdb::api::router_with_engine(engine.clone());
+    (temp, engine, router, tenant_keys)
 }
 
 async fn request(
@@ -133,6 +134,25 @@ fn tagged(tag: &str, value: &str) -> Value {
     json!({"$briskdb_type": tag, "value": value})
 }
 
+async fn wait_for_active_query_count(app: &Router, expected: usize) -> Vec<Value> {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let (status, headers, body) =
+                request(app, Method::GET, "/v1/admin/queries", None, Body::empty()).await;
+            assert_eq!(status, StatusCode::OK);
+            assert_eq!(headers["briskdb-api-version"], "1");
+            let body = serde_json::from_slice::<Value>(&body).unwrap();
+            let queries = body["queries"].as_array().unwrap();
+            if queries.len() == expected {
+                return queries.clone();
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("active-query registry should reach the expected size")
+}
+
 #[tokio::test]
 async fn discovery_health_alias_and_head_identify_the_contract() {
     let (_temp, _engine, app) = application();
@@ -162,6 +182,425 @@ async fn discovery_health_alias_and_head_identify_the_contract() {
     assert_eq!(versioned.1["briskdb-api-version"], "1");
     assert_eq!(versioned.2, legacy.2);
     assert!(!legacy.1.contains_key("briskdb-api-version"));
+}
+
+#[tokio::test]
+async fn readiness_has_one_exact_versioned_and_unversioned_probe_shape() {
+    let (_temp, engine, app) = application();
+    let expected = json!({
+        "status": "ready",
+        "ready": true,
+        "reasons": [],
+        "engine_state": "running",
+        "schema_state": "ready",
+        "schema_generation": engine.catalog().schema_generation().to_string(),
+        "active_schema_operations": 0
+    });
+
+    let versioned = request(&app, Method::GET, "/v1/ready", None, Body::empty()).await;
+    let unversioned = request(&app, Method::GET, "/ready", None, Body::empty()).await;
+    assert_eq!(versioned.0, StatusCode::OK);
+    assert_eq!(versioned.1["briskdb-api-version"], "1");
+    assert_eq!(versioned.1["content-type"], "application/json");
+    assert_eq!(
+        serde_json::from_slice::<Value>(&versioned.2).unwrap(),
+        expected
+    );
+    assert_eq!(unversioned.0, StatusCode::OK);
+    assert!(!unversioned.1.contains_key("briskdb-api-version"));
+    assert_eq!(unversioned.2, versioned.2);
+
+    let head = request(&app, Method::HEAD, "/v1/ready", None, Body::empty()).await;
+    assert_eq!(head.0, StatusCode::OK);
+    assert_eq!(head.1["briskdb-api-version"], "1");
+    assert!(head.2.is_empty());
+
+    assert_eq!(
+        engine.begin_shutdown(),
+        briskdb::core::EngineState::Draining
+    );
+    let unavailable = request(&app, Method::GET, "/v1/ready", None, Body::empty()).await;
+    assert_eq!(unavailable.0, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(unavailable.1["briskdb-api-version"], "1");
+    assert_eq!(unavailable.1["content-type"], "application/json");
+    assert_eq!(
+        serde_json::from_slice::<Value>(&unavailable.2).unwrap(),
+        json!({
+            "status": "not_ready",
+            "ready": false,
+            "reasons": ["engine_draining"],
+            "engine_state": "draining",
+            "schema_state": "ready",
+            "schema_generation": engine.catalog().schema_generation().to_string(),
+            "active_schema_operations": 0
+        })
+    );
+    engine.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn relational_catalog_preserves_ids_order_and_placement_without_physical_details() {
+    let (_temp, engine, app, _tenant_keys) = scatter_application();
+    let (status, headers, body) =
+        request(&app, Method::GET, "/v1/admin/catalog", None, Body::empty()).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(headers["briskdb-api-version"], "1");
+    assert_eq!(headers["content-type"], "application/json");
+    assert_eq!(
+        serde_json::from_slice::<Value>(&body).unwrap(),
+        json!({
+            "identifier_encoding_version": 1,
+            "schema_generation": engine.catalog().schema_generation().to_string(),
+            "default_database_id": "1",
+            "databases": [{"id":"1", "name":"default"}],
+            "tables": [{
+                "id": "1",
+                "database_id": "1",
+                "name": "events",
+                "placement": {
+                    "kind": "sharded",
+                    "shard_key": {"column":"tenant_key", "data_type":"text"}
+                },
+                "generated_id": {"policy":"none"}
+            }],
+            "global_indexes": []
+        })
+    );
+    let rendered = String::from_utf8(body).unwrap();
+    for forbidden in [
+        "manifest.sqlite",
+        "shard-",
+        "CREATE TABLE",
+        "private-sentinel",
+    ] {
+        assert!(!rendered.contains(forbidden));
+    }
+}
+
+#[tokio::test]
+async fn operational_reports_are_bounded_redacted_and_checkpoint_input_is_strict() {
+    let temp = tempfile::tempdir().unwrap();
+    let database = Arc::new(Database::open(temp.path(), 2).unwrap());
+    let engine = Engine::from_database(database);
+    let app = briskdb::api::router_with_engine(engine.clone());
+
+    let (status, _, body) = request(
+        &app,
+        Method::GET,
+        "/v1/admin/migrations",
+        None,
+        Body::empty(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&body).unwrap(),
+        json!({"schema_generation":"0", "active":null, "latest_complete":null})
+    );
+
+    let migration_sql = "CREATE TABLE private_sentinel_items (id INTEGER PRIMARY KEY)";
+    let (status, _, body) = request(
+        &app,
+        Method::POST,
+        "/v1/admin/broadcast",
+        Some("application/json"),
+        serde_json::to_vec(&json!({"sql":migration_sql})).unwrap(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&body).unwrap(),
+        json!({"completed_shards":[0, 1]})
+    );
+
+    let (status, headers, body) = request(
+        &app,
+        Method::GET,
+        "/v1/admin/migrations",
+        None,
+        Body::empty(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(headers["briskdb-api-version"], "1");
+    let summary = serde_json::from_slice::<Value>(&body).unwrap();
+    assert_eq!(summary["schema_generation"], "1");
+    assert!(summary["active"].is_null());
+    let completed = summary["latest_complete"].clone();
+    assert_eq!(completed["generation"], "1");
+    assert_eq!(completed["source_generation"], "0");
+    assert_eq!(completed["target_generation"], "1");
+    assert_eq!(completed["state"], "complete");
+    assert_eq!(completed["shard_count"], 2);
+    assert_eq!(completed["next_shard"], 2);
+    assert_eq!(completed["completed_shards"], 2);
+    assert_eq!(completed["sql_bytes"], migration_sql.len());
+    assert_eq!(completed.as_object().unwrap().len(), 8);
+    assert!(completed.get("id").is_none());
+    assert!(completed.get("digest").is_none());
+    assert!(!String::from_utf8(body).unwrap().contains(migration_sql));
+
+    let (status, _, body) = request(
+        &app,
+        Method::GET,
+        "/v1/admin/migrations/1",
+        None,
+        Body::empty(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(serde_json::from_slice::<Value>(&body).unwrap(), completed);
+    for generation in [
+        "0",
+        "01",
+        "-1",
+        "2",
+        "18446744073709551616",
+        "private-sentinel",
+    ] {
+        assert_problem(
+            request(
+                &app,
+                Method::GET,
+                &format!("/v1/admin/migrations/{generation}"),
+                None,
+                Body::empty(),
+            )
+            .await,
+            StatusCode::NOT_FOUND,
+            "not_found",
+        );
+    }
+
+    let (status, _, body) =
+        request(&app, Method::GET, "/v1/admin/shards", None, Body::empty()).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&body).unwrap(),
+        json!({
+            "schema_generation": "1",
+            "shards": [{"id":0,"state":"ready"},{"id":1,"state":"ready"}]
+        })
+    );
+
+    let (status, _, body) =
+        request(&app, Method::GET, "/v1/admin/backup", None, Body::empty()).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&body).unwrap(),
+        json!({
+            "mode": "stopped_directory_copy",
+            "online": false,
+            "requires_all_processes_stopped": true,
+            "checkpoint_endpoint": "/v1/admin/maintenance/checkpoint",
+            "checkpoint_role": "preparation_only",
+            "checkpoint_is_recovery_point": false
+        })
+    );
+
+    let (status, headers, body) = request(
+        &app,
+        Method::POST,
+        "/v1/admin/maintenance/checkpoint",
+        Some("application/json"),
+        "{}",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(headers["briskdb-api-version"], "1");
+    let checkpoint = serde_json::from_slice::<Value>(&body).unwrap();
+    assert_eq!(checkpoint["operation"], "passive_checkpoint");
+    assert_eq!(checkpoint["busy"], false);
+    assert_eq!(checkpoint["complete"], true);
+    assert_eq!(checkpoint["recovery_point"], false);
+    assert_eq!(checkpoint["shards"].as_array().unwrap().len(), 2);
+    assert_eq!(checkpoint["shards"][0]["shard"], 0);
+    assert_eq!(checkpoint["shards"][1]["shard"], 1);
+    assert_eq!(checkpoint["databases"].as_array().unwrap().len(), 1);
+    assert_eq!(checkpoint["databases"][0]["database"], "manifest");
+    for row in checkpoint["shards"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .chain(checkpoint["databases"].as_array().unwrap())
+    {
+        assert_eq!(row.as_object().unwrap().len(), 6);
+        assert!(row["busy"].is_boolean());
+        assert!(row["counts_available"].is_boolean());
+        assert!(row["wal_frames"].is_u64());
+        assert!(row["checkpointed_frames"].is_u64());
+        assert!(row["complete"].is_boolean());
+    }
+
+    for uri in [
+        "/v1/admin/catalog",
+        "/v1/admin/migrations",
+        "/v1/admin/migrations/1",
+        "/v1/admin/shards",
+        "/v1/admin/queries",
+        "/v1/admin/backup",
+    ] {
+        let (status, headers, body) = request(&app, Method::HEAD, uri, None, Body::empty()).await;
+        assert_eq!(status, StatusCode::OK, "{uri}");
+        assert_eq!(headers["briskdb-api-version"], "1", "{uri}");
+        assert!(body.is_empty(), "{uri}");
+    }
+
+    for body in ["", "[]", "null", r#"{"private-sentinel":true}"#] {
+        assert_problem(
+            request(
+                &app,
+                Method::POST,
+                "/v1/admin/maintenance/checkpoint",
+                Some("application/json"),
+                body,
+            )
+            .await,
+            StatusCode::BAD_REQUEST,
+            "invalid_argument",
+        );
+    }
+    assert_problem(
+        request(
+            &app,
+            Method::POST,
+            "/v1/admin/maintenance/checkpoint",
+            None,
+            "{}",
+        )
+        .await,
+        StatusCode::UNSUPPORTED_MEDIA_TYPE,
+        "unsupported_media_type",
+    );
+}
+
+#[tokio::test]
+async fn active_query_handles_cancel_exact_work_and_disappear_after_cleanup() {
+    let (_temp, _engine, app) = application();
+    let sql = "WITH RECURSIVE numbers(value) AS (VALUES(0) UNION ALL SELECT value + 1 FROM numbers WHERE value < 1000000000) SELECT sum(value) FROM numbers";
+    let query_app = app.clone();
+    let query_body = serde_json::to_vec(&json!({"shard_key":"cancel-owner", "sql":sql})).unwrap();
+    let query = tokio::spawn(async move {
+        request(
+            &query_app,
+            Method::POST,
+            "/v1/query",
+            Some("application/json"),
+            query_body,
+        )
+        .await
+    });
+
+    let active = wait_for_active_query_count(&app, 1).await;
+    let query_status = active[0].as_object().unwrap();
+    assert_eq!(query_status.len(), 4);
+    let operation_id = query_status["operation_id"].as_str().unwrap().to_owned();
+    assert_eq!(operation_id.len(), 32);
+    assert!(
+        operation_id
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    );
+    assert!(query_status["elapsed_ms"].is_u64());
+    assert_eq!(query_status["sql_bytes"], sql.len());
+    assert_eq!(query_status["cancellation_requested"], false);
+    let rendered = serde_json::to_string(&active).unwrap();
+    assert!(!rendered.contains("WITH RECURSIVE"));
+    assert!(!rendered.contains("sql_digest"));
+
+    assert_problem(
+        request(
+            &app,
+            Method::POST,
+            &format!("/v1/admin/queries/{operation_id}/cancel"),
+            None,
+            "private-sentinel",
+        )
+        .await,
+        StatusCode::BAD_REQUEST,
+        "invalid_argument",
+    );
+    let still_active = wait_for_active_query_count(&app, 1).await;
+    assert_eq!(still_active[0]["operation_id"], operation_id);
+    assert_eq!(still_active[0]["cancellation_requested"], false);
+
+    let oversized_cancel_body = "private-sentinel".repeat(150_000);
+    assert_problem(
+        request(
+            &app,
+            Method::POST,
+            &format!("/v1/admin/queries/{operation_id}/cancel"),
+            None,
+            oversized_cancel_body,
+        )
+        .await,
+        StatusCode::PAYLOAD_TOO_LARGE,
+        "request_too_large",
+    );
+    let still_active = wait_for_active_query_count(&app, 1).await;
+    assert_eq!(still_active[0]["operation_id"], operation_id);
+    assert_eq!(still_active[0]["cancellation_requested"], false);
+
+    let cancellation = request(
+        &app,
+        Method::POST,
+        &format!("/v1/admin/queries/{operation_id}/cancel"),
+        None,
+        Body::empty(),
+    )
+    .await;
+    assert_eq!(cancellation.0, StatusCode::ACCEPTED);
+    assert_eq!(cancellation.1["briskdb-api-version"], "1");
+    assert_eq!(cancellation.1["content-type"], "application/json");
+    assert_eq!(
+        serde_json::from_slice::<Value>(&cancellation.2).unwrap(),
+        json!({"operation_id":operation_id, "newly_requested":true})
+    );
+
+    let query_response = tokio::time::timeout(Duration::from_secs(5), query)
+        .await
+        .expect("the cancelled query should stop promptly")
+        .unwrap();
+    assert_problem(
+        query_response,
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "cancelled",
+    );
+    assert!(wait_for_active_query_count(&app, 0).await.is_empty());
+
+    for stale_or_invalid in [
+        operation_id.as_str(),
+        "00000000000000000000000000000000",
+        "0123456789ABCDEF0123456789ABCDEF",
+        "private-sentinel",
+    ] {
+        assert_problem(
+            request(
+                &app,
+                Method::POST,
+                &format!("/v1/admin/queries/{stale_or_invalid}/cancel"),
+                None,
+                Body::empty(),
+            )
+            .await,
+            StatusCode::NOT_FOUND,
+            "not_found",
+        );
+    }
+
+    let (status, _, body) = request(
+        &app,
+        Method::POST,
+        "/v1/query",
+        Some("application/json"),
+        r#"{"shard_key":"cancel-owner","sql":"SELECT 1 AS value"}"#,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&body).unwrap()["rows"],
+        json!([[1]])
+    );
 }
 
 #[tokio::test]
@@ -358,7 +797,7 @@ async fn invalid_lossless_tags_and_encoding_selection_fail_before_mutation() {
 
 #[tokio::test]
 async fn lossless_scatter_keeps_shard_row_and_duplicate_column_order() {
-    let (_temp, app, tenant_keys) = scatter_application();
+    let (_temp, _engine, app, tenant_keys) = scatter_application();
     let query = json!({
         "sql": "SELECT tenant_key AS duplicate, ordinal AS duplicate, payload AS \"\" FROM events",
         "value_encoding": "lossless-json-v1"
@@ -487,6 +926,19 @@ async fn transport_rejections_have_redacted_versioned_problems_and_allow_headers
         ("/v1/query", Method::GET, "POST"),
         ("/v1/admin/broadcast", Method::PUT, "POST"),
         ("/v1/admin/global-indexes", Method::POST, "GET,HEAD"),
+        ("/v1/ready", Method::POST, "GET,HEAD"),
+        ("/v1/admin/catalog", Method::POST, "GET,HEAD"),
+        ("/v1/admin/migrations", Method::POST, "GET,HEAD"),
+        ("/v1/admin/migrations/1", Method::POST, "GET,HEAD"),
+        ("/v1/admin/shards", Method::POST, "GET,HEAD"),
+        ("/v1/admin/queries", Method::POST, "GET,HEAD"),
+        (
+            "/v1/admin/queries/0123456789abcdef0123456789abcdef/cancel",
+            Method::GET,
+            "POST",
+        ),
+        ("/v1/admin/backup", Method::POST, "GET,HEAD"),
+        ("/v1/admin/maintenance/checkpoint", Method::GET, "POST"),
         ("/v1", Method::POST, "GET,HEAD"),
     ] {
         let response = request(&app, method, uri, None, Body::empty()).await;
@@ -518,7 +970,12 @@ async fn transport_rejections_have_redacted_versioned_problems_and_allow_headers
 async fn oversized_json_is_rejected_and_later_requests_still_work() {
     let (_temp, _engine, app) = application();
     let oversized = json!({"sql": "private-sentinel".repeat(150_000)}).to_string();
-    for uri in ["/v1/query", "/v1/execute", "/v1/admin/broadcast"] {
+    for uri in [
+        "/v1/query",
+        "/v1/execute",
+        "/v1/admin/broadcast",
+        "/v1/admin/maintenance/checkpoint",
+    ] {
         assert_problem(
             request(
                 &app,

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -278,6 +278,19 @@ fn legacy_and_explicit_module_paths_are_both_available() {
     let _request_context: core::RequestContext = core::RequestContext::new();
     let _cancellation_token: core::CancellationToken = core::CancellationToken::new();
     let _running = core::EngineState::Running;
+    let _schema_ready = core::SchemaState::Ready;
+    let _shard_ready = core::ShardState::Ready;
+    let _migration_complete = core::SchemaMigrationState::Complete;
+    let _query_id: Option<core::QueryId> = None;
+    let _query_id_error: Option<core::ParseQueryIdError> = None;
+    let _tracked_query: Option<core::TrackedQuery> = None;
+    let _active_query: Option<core::ActiveQueryStatus> = None;
+    let _readiness: Option<core::ReadinessSnapshot> = None;
+    let _shard_status: Option<core::ShardStatus> = None;
+    let _shard_report: Option<core::ShardStatusReport> = None;
+    let _migration_status: Option<core::SchemaMigrationStatus> = None;
+    let _migration_summary: Option<core::SchemaMigrationSummary> = None;
+    assert_eq!(core::MAX_ACTIVE_QUERIES, 1_024);
     let _shutdown_report: Option<core::ShutdownReport> = None;
     let _session: Option<core::Session> = None;
     let _ready = core::SessionState::Ready;
@@ -351,6 +364,68 @@ fn legacy_and_explicit_module_paths_are_both_available() {
         error::mysql_error(core::EngineErrorKind::UniqueViolation).error_number,
         1062
     );
+}
+
+#[tokio::test]
+async fn operational_engine_api_is_public_shared_bounded_and_redacted() {
+    let temp = tempfile::tempdir().unwrap();
+    let engine = core::Engine::open(temp.path(), 2).await.unwrap();
+
+    let readiness: core::ReadinessSnapshot = engine.readiness();
+    assert!(readiness.ready());
+    assert_eq!(readiness.lifecycle_state().code(), "running");
+    assert_eq!(readiness.schema_state(), core::SchemaState::Ready);
+    assert_eq!(readiness.schema_generation(), 0);
+
+    let tracked: core::TrackedQuery = engine
+        .begin_tracked_query("SELECT private_public_api_sentinel")
+        .unwrap();
+    let query_id: core::QueryId = tracked.id().to_string().parse().unwrap();
+    assert_eq!(query_id, tracked.id());
+    let invalid: core::ParseQueryIdError = "INVALID".parse::<core::QueryId>().unwrap_err();
+    assert!(invalid.to_string().contains("lowercase hexadecimal"));
+    let active: Vec<core::ActiveQueryStatus> = engine.active_queries();
+    assert_eq!(active.len(), 1);
+    assert_eq!(active[0].id(), query_id);
+    assert_eq!(active[0].sql_bytes(), 34);
+    assert!(!format!("{active:?}").contains("private_public_api_sentinel"));
+    assert_eq!(engine.cancel_query(query_id), Some(true));
+    assert!(tracked.cancellation_token().is_cancelled());
+    drop(tracked);
+    assert!(engine.active_queries().is_empty());
+    assert_eq!(engine.cancel_query(query_id), None);
+
+    let shards: core::ShardStatusReport = engine.shard_status().await.unwrap();
+    assert_eq!(shards.schema_generation(), 0);
+    assert_eq!(shards.shards().len(), 2);
+    assert!(
+        shards
+            .shards()
+            .iter()
+            .all(|shard: &core::ShardStatus| shard.state().code() == "ready")
+    );
+
+    let session = engine.session();
+    let sql = "CREATE TABLE public_operational_marker (id INTEGER PRIMARY KEY)";
+    assert_eq!(
+        engine.migrate(&session, sql.to_owned()).await.unwrap(),
+        [0, 1]
+    );
+    let summary: core::SchemaMigrationSummary = engine.migration_summary().await.unwrap();
+    assert_eq!(summary.schema_generation(), 1);
+    assert_eq!(summary.active(), None);
+    let completed: core::SchemaMigrationStatus = summary.latest_complete().unwrap();
+    assert_eq!(completed.generation(), 1);
+    assert_eq!(completed.source_generation(), 0);
+    assert_eq!(completed.target_generation(), 1);
+    assert_eq!(completed.state().code(), "complete");
+    assert_eq!(completed.completed_shards(), 2);
+    assert_eq!(completed.sql_bytes(), sql.len());
+    assert_eq!(engine.migration(1).await.unwrap(), Some(completed));
+    assert_eq!(engine.migration(2).await.unwrap(), None);
+
+    engine.shutdown().await.unwrap();
+    assert_eq!(engine.readiness().lifecycle_state().code(), "stopped");
 }
 
 #[test]

--- a/tests/release_packaging.rs
+++ b/tests/release_packaging.rs
@@ -16,6 +16,7 @@ fn alpha_release_contract_covers_every_native_archive_and_safety_boundary() {
         "Smoke-test native server",
         "--admin-listen 127.0.0.1:17655",
         "http://127.0.0.1:17654/v1",
+        "http://127.0.0.1:17655/v1/ready",
         "http://127.0.0.1:17655/admin",
         "deb_architecture: amd64",
         "deb_architecture: arm64",


### PR DESCRIPTION
The split administration listener lacked a bounded way to determine readiness, inspect catalog/migration/shard state, cancel an active data-plane query, or report the supported backup and checkpoint boundaries.

This adds protocol-neutral Engine reports and a shared, 1,024-entry active-query registry, then exposes the operational surface only on the administration router. For example, a long-running `POST /v1/query` now appears under `GET /v1/admin/queries` with an opaque handle that `POST /v1/admin/queries/{id}/cancel` can target across the two sockets. Reports omit SQL, deterministic SQL digests, parameters, routing keys, sessions, and physical paths. Readiness is a bounded lifecycle/schema snapshot; migration history uses active/latest summary plus exact generation lookup; shard status freshly validates every shard; backup remains a stopped-directory-copy capability; and passive checkpoint remains preparation rather than a recovery point.

Existing data routes and JSON value codecs are unchanged. `/v1/admin/broadcast` remains the migration-submission compatibility route, combined Rust routers remain available, and this adds no storage-format or dependency change. Release and Debian smokes now require `/v1/ready` on the admin listener.

Validation:
- stable and Rust 1.85 all-target/all-feature suites: 1,126 library tests and 39 target binaries per toolchain, zero failures
- stable and Rust 1.85 doc tests: 3/3 per toolchain; all nine feature/dependency surfaces passed
- Clippy with `-D warnings`, formatting, diff, packaging, benchmark, fuzz, Node, shell/YAML, version, and Markdown-link gates: passed
- focused HTTP v1 tests: 15/15
- real TCP listener/cancellation tests: 4/4
- independent API, privacy, concurrency, recovery, and adversarial reviews: GO

Closes #53
