### PR TITLE
Generate and test the HTTP v1 OpenAPI contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
         run: |
           forbidden_dependencies="$(
             cargo tree --locked --no-default-features --features embedded --edges normal --prefix none |
-              awk '$1 ~ /^(anyhow|axum|bson|clap|hyper|hyper-util|num-bigint|num-rational|num-traits|pgwire|time|tokio-util|tower|tracing-subscriber)$/ { print $1 }' |
+              awk '$1 ~ /^(anyhow|axum|bson|clap|hyper|hyper-util|num-bigint|num-rational|num-traits|pgwire|time|tokio-util|tower|tracing-subscriber|utoipa|utoipa-axum|utoipa-gen)$/ { print $1 }' |
               sort -u
           )"
           if [ -n "$forbidden_dependencies" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,6 +142,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          test -s docs/openapi-v1.json
           archive="briskdb-v${VERSION}-${{ matrix.platform }}"
           mkdir -p "dist/$archive"
           cp "target/${{ matrix.target }}/release/briskdb" "dist/$archive/"
@@ -150,6 +151,7 @@ jobs:
           cp -R docs "dist/$archive/docs"
           tar -C dist -czf "dist/$archive.tar.gz" "$archive"
           tar -tzf "dist/$archive.tar.gz" | grep -F "$archive/docs/OFFLINE_BACKUP.md"
+          tar -tzf "dist/$archive.tar.gz" | grep -F "$archive/docs/openapi-v1.json"
 
       - name: Build Debian package
         if: matrix.deb_architecture != 'none'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,6 +11,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -23,6 +24,12 @@ checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -294,6 +301,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "briskdb"
 version = "0.1.0-alpha.6"
 dependencies = [
@@ -310,8 +323,10 @@ dependencies = [
  "getrandom 0.4.3",
  "hyper",
  "hyper-util",
+ "jsonschema",
  "libc",
  "num-bigint",
+ "oas3",
  "pgwire",
  "postgres-protocol",
  "proptest",
@@ -330,6 +345,8 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
+ "utoipa",
+ "utoipa-axum",
 ]
 
 [[package]]
@@ -368,6 +385,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "byteorder"
@@ -543,6 +566,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,6 +645,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,6 +681,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.119",
+ "unicode-xid",
+]
+
+[[package]]
 name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,10 +716,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "either"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "equivalent"
@@ -695,6 +776,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fancy-regex"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "476de73bddf2ef8490aa4ee8f1cf40b430bf1d56c48c22080e5186952cd580e6"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,6 +797,17 @@ name = "find-msvc-tools"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
+
+[[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
 
 [[package]]
 name = "fnv"
@@ -725,6 +828,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e246562084dde8ebbcc943b261c406ce4f68e5032ec28029a251a47d6a295500"
+dependencies = [
+ "num",
+ "num-bigint",
 ]
 
 [[package]]
@@ -889,6 +1002,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "hashlink"
@@ -1034,6 +1152,108 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1041,6 +1261,8 @@ checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1073,6 +1295,91 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7070bf0681439ff992bb94947cb3a361f57c880561c1e9e90ddb5941c7ec2d04"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.3.4",
+ "itoa",
+ "jsonschema-macros",
+ "jsonschema-regex",
+ "jsonschema-value",
+ "num-bigint",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema-macros"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09bf2cff6a323e13ecc331d319d8062dc07992c12e6db20b3d6284730f3efd23"
+dependencies = [
+ "jsonschema-macros-core",
+ "proc-macro2",
+]
+
+[[package]]
+name = "jsonschema-macros-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7d537fa1bbdc3aa5be9343fecad25202c73e501535d9a0f9879d0c2c9c3a328"
+dependencies = [
+ "fancy-regex",
+ "indexmap",
+ "jsonschema-regex",
+ "percent-encoding",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "referencing",
+ "regex",
+ "serde_json",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jsonschema-regex"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6525f2f72c37c1a09f59a6d0d33f60ecf8beabd00be92fe8d49555cae15289c"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "jsonschema-value"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4309c6b52390b1ebdd2053e513e9f23d4bb18d0c3c2df8142eded3eb188a85bf"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "fraction",
+ "getrandom 0.3.4",
+ "num-bigint",
+ "num-cmp",
+ "num-traits",
+ "serde_json",
+ "zmij",
 ]
 
 [[package]]
@@ -1148,6 +1455,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1200,6 +1513,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,12 +1561,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -1267,12 +1615,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "oas3"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ed0821ab10d7703415a06df039c2493f3a7667999d8b4e104731de0c53796f"
+dependencies = [
+ "derive_more",
+ "http",
+ "log",
+ "once_cell",
+ "regex",
+ "semver",
+ "serde",
+ "serde_json",
+ "url",
 ]
 
 [[package]]
@@ -1321,6 +1707,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1342,6 +1734,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem"
@@ -1454,6 +1852,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1466,6 +1873,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -1690,6 +2106,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "referencing"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0304d4734d208eaf24528093715e2cb5260c977b1be1eb81cd487f601e3ff35d"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.17.1",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
 name = "regex"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1768,6 +2221,15 @@ name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -1864,6 +2326,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2072,6 +2540,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "stacker"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2100,6 +2574,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "subtle"
@@ -2134,6 +2629,17 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "tap"
@@ -2218,6 +2724,16 @@ checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -2320,6 +2836,36 @@ dependencies = [
  "libc",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -2431,6 +2977,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2452,16 +3004,83 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "utoipa"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-axum"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c25bae5bccc842449ec0c5ddc5cbb6a3a1eaeac4503895dc105a1138f8234a0"
+dependencies = [
+ "axum",
+ "paste",
+ "tower-layer",
+ "tower-service",
+ "utoipa",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "uuid"
@@ -2473,6 +3092,16 @@ dependencies = [
  "js-sys",
  "serde_core",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
 ]
 
 [[package]]
@@ -2492,6 +3121,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wait-timeout"
@@ -2764,10 +3399,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "writeable"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "wyz"
@@ -2798,6 +3448,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2818,6 +3491,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2835,6 +3529,39 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ http = [
     "dep:serde_json",
     "dep:tower",
     "dep:tracing",
+    "dep:utoipa",
+    "dep:utoipa-axum",
 ]
 postgres = [
     "dep:async-trait",
@@ -130,9 +132,13 @@ tokio-util = { version = "0.7", features = ["codec"], optional = true }
 tower = { version = "0.5", features = ["util"], optional = true }
 tracing = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"], optional = true }
+utoipa = { version = "=5.5.0", default-features = false, features = ["macros"], optional = true }
+utoipa-axum = { version = "=0.2.0", default-features = false, optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.7", default-features = false }
+jsonschema = { version = "=0.54.0", default-features = false, features = ["arbitrary-precision"] }
+oas3 = "=0.21.0"
 postgres-protocol = "=0.6.12"
 proptest = "1.7"
 tempfile = "3.23"
@@ -155,3 +161,8 @@ required-features = ["sqlite-import-cli"]
 [[example]]
 name = "embedded"
 required-features = ["embedded"]
+
+[[example]]
+name = "generate-openapi-v1"
+path = "examples/openapi.rs"
+required-features = ["http"]

--- a/README.md
+++ b/README.md
@@ -214,6 +214,9 @@ The [versioned HTTP contract](docs/HTTP_API.md) defines requests, response
 shapes, value encodings, request IDs, eligible-write idempotency, bounded row
 streaming, limits, and errors. `GET /v1` reports the supported API version and
 configured result ceilings.
+The checked [OpenAPI 3.1 artifact](docs/OPENAPI.md) describes the exact v1
+machine surface from the same route and DTO definitions and is included in
+Cargo, native archive, and Debian distributions.
 The [HTTP listener contract](docs/HTTP_LISTENERS.md) defines the strict route
 split, configuration, and shared startup/shutdown behavior. The data listener
 defaults to `127.0.0.1:7654`; administration defaults to
@@ -358,6 +361,7 @@ more valuable than a star. Start with the
 ## Go deeper
 
 - [Architecture](docs/ARCHITECTURE.md)
+- [OpenAPI v1 artifact](docs/OPENAPI.md)
 - [HTTP listener separation](docs/HTTP_LISTENERS.md)
 - [Global uniqueness and value authority](docs/GLOBAL_INDEX_AUTHORITY.md)
 - [Global-index production gate](docs/GLOBAL_INDEX_RELEASE_GATE.md)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,29 @@
 # Unreleased
 
+BriskDB now ships a deterministic, code-first OpenAPI 3.1 artifact at
+`docs/openapi-v1.json`. It describes exactly the 17 versioned `/v1` paths and
+28 GET, HEAD, and POST operations, including each operation's data- or
+administration-listener ownership, closed request schemas, additive response
+schemas, common headers and errors, readiness 503 response, and bounded NDJSON
+record contract.
+The public `briskdb::api::openapi_v1()` Rust function returns the same document
+when the `http` feature is enabled, and the `generate-openapi-v1` example
+regenerates byte-identical checked JSON. The Cargo crate, every native release
+archive, and each Debian package include the artifact.
+
+The artifact deliberately excludes unversioned probes, Prometheus metrics, and
+the `/admin` browser. It is a shipped file for contract validation and client
+tool input, not a served endpoint or committed generated client. It declares no
+security scheme before HTTP authentication and roles exist. OpenAPI cannot by
+itself express duplicate raw JSON members or headers, the raw 2 MiB body limit,
+conditional idempotency headers, or NDJSON byte-sequence ordering, so the live
+router tests and [HTTP contract](docs/HTTP_API.md) remain authoritative for
+those rules. The change is confined to the HTTP adapter and distribution
+contents; it changes no Engine behavior, SQL/routing semantics, manifest, shard
+format, migration, or listener exposure. Normal OpenAPI generation
+dependencies remain optional and selected only by `http`; the independent
+validators are test-only dependencies. Rust 1.85 remains supported.
+
 BriskDB's HTTP routers now assign every response a `BriskDB-Request-ID`;
 callers may supply one canonical nonzero 128-bit lowercase-hex value and BriskDB
 echoes it for correlation, while malformed or duplicate values fail with a fresh redacted ID.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -336,7 +336,10 @@ protocol-specific golden tests only for encoding and state-machine behavior.
   request-local result limits, and bounded HTTP row streaming with stable
   problem-detail errors (issue #54). Retained pagination and global SQL ordering
   remain in Phase 7 issues #58 and #59.
-- [ ] Generate and test an OpenAPI document from the implementation.
+- [x] Generate and test the deterministic code-first OpenAPI 3.1 document for
+  the exact 17-path, 28-operation HTTP v1 machine surface, including explicit
+  listener ownership and shipped Cargo/native/Debian artifact contracts; see
+  [the OpenAPI contract](docs/OPENAPI.md) (issue #55).
 - [ ] Require authentication and role checks; apply TLS or explicitly document
   trusted reverse-proxy termination.
 

--- a/docs/CRATE_FEATURES.md
+++ b/docs/CRATE_FEATURES.md
@@ -28,7 +28,7 @@ Command, BSON, plan, and result types live under `briskdb::document`.
 | Feature | Adds | Tier |
 | --- | --- | --- |
 | `embedded` | Listener-free `BriskDb` and `BriskSession` SQL APIs | Alpha-supported |
-| `http` | Separate Axum data/admin routers, versioned materialized/streamed data and operational APIs, request correlation, eligible-write replay, active-query cancellation, and admin browser; combined compatibility router retained | Alpha-supported |
+| `http` | Separate Axum data/admin routers, versioned materialized/streamed data and operational APIs, request correlation, eligible-write replay, active-query cancellation, code-first OpenAPI, and admin browser; combined compatibility router retained | Alpha-supported |
 | `postgres` | PostgreSQL wire adapter, including TLS/SCRAM implementation | Alpha-supported, bounded SQL subset |
 | `listeners` | Host-controlled data HTTP, optional admin HTTP, and optional PostgreSQL listeners, selecting `tls`, without signals or engine ownership | Alpha-supported |
 | `server` | Daemon listener assembly, signal handling, and engine ownership | Process integration |
@@ -45,6 +45,11 @@ Command, BSON, plan, and result types live under `briskdb::document`.
 `embedded`, `http`, and `postgres`; `server` adds process signal handling.
 Applications using adapters directly may select `http` or `postgres` without
 listener assembly.
+The public `briskdb::api::openapi_v1()` function and its optional normal
+OpenAPI dependencies are selected only by `http`; they are absent from an
+`embedded`-only normal dependency graph. CI rejects `utoipa`, `utoipa-axum`,
+or `utoipa-gen` on that edge. Independent document/schema validators remain
+test-only dependencies. See the [OpenAPI artifact contract](OPENAPI.md).
 
 ## Public API tiers
 

--- a/docs/DEBIAN_INSTALL.md
+++ b/docs/DEBIAN_INSTALL.md
@@ -28,6 +28,7 @@ prerelease version `0.1.0~alpha.6-1` so it sorts before the final release.
 | Import utility | `/usr/bin/briskdb-import` |
 | Administrator configuration | `/etc/default/briskdb` |
 | Vendor systemd unit | `/lib/systemd/system/briskdb.service` |
+| OpenAPI v1 artifact | `/usr/share/doc/briskdb/docs/openapi-v1.json` |
 | Persistent database state | `/var/lib/briskdb` |
 | Logs | systemd journal for `briskdb.service` |
 

--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -1,6 +1,6 @@
 # HTTP API version 1
 
-Status: implemented for issues #50 through #54. BriskDB remains an alpha
+Status: implemented for issues #50 through #55. BriskDB remains an alpha
 database. Its data and administration HTTP listeners are separate,
 loopback-only, and have no complete authorization boundary. The `/admin`
 browser login authenticates only its browser endpoints.
@@ -51,6 +51,13 @@ follow their separately documented alpha contracts.
 including its losses. `lossless-json-v1` is an explicitly selected, tagged
 encoding for the complete current protocol-neutral value model. Adding that
 choice does not reinterpret an omitted v1 field or change the default response.
+
+The deterministic [OpenAPI 3.1 artifact](OPENAPI.md) is generated from the
+registered v1 handlers and their actual DTOs. It covers the exact versioned
+machine surface, including implicit HEAD operations and listener ownership,
+and is available through `briskdb::api::openapi_v1()`. The artifact is not an
+HTTP endpoint; this document remains the human-readable contract for wire
+rules that OpenAPI cannot fully express.
 
 ## Routes and listeners
 
@@ -455,11 +462,13 @@ contention, or a schema transition. Global-index degradation remains visible in
 admission result.
 
 A non-ready engine returns HTTP 503 with the same `application/json` shape,
-`status:"not_ready"`, and `ready:false`. `engine_state` is `draining` or
-`stopped`; `schema_state` is `migrating`, `pending`, or `degraded`. The ordered
-`reasons` array uses the corresponding finite codes `engine_draining`,
-`engine_stopped`, `schema_migrating`, `schema_recovery_pending`, and
-`schema_degraded`. This probe response is not a Problem Details document.
+`status:"not_ready"`, and `ready:false`. `engine_state` retains the observed
+`running`, `draining`, or `stopped` lifecycle state, and `schema_state` retains
+the observed `ready`, `migrating`, `pending`, or `degraded` gate state. The
+ordered `reasons` array names only the non-ready cause or causes with the finite
+codes `engine_draining`, `engine_stopped`, `schema_migrating`,
+`schema_recovery_pending`, and `schema_degraded`. This probe response is not a
+Problem Details document.
 `schema_generation` is exact decimal text. `active_schema_operations` is a
 snapshot count and can change immediately.
 

--- a/docs/HTTP_LISTENERS.md
+++ b/docs/HTTP_LISTENERS.md
@@ -136,7 +136,9 @@ cancellation, backup-capability, and checkpoint-maintenance endpoints. Issue
 #54 adds plane-wide request IDs, eligible-write idempotency, request-local query
 limits, and bounded HTTP row streaming. It deliberately adds no retained
 pagination cursor or global ordering; those semantics remain in Phase 7 issues
-#58 and #59. Issue #55 owns OpenAPI.
+#58 and #59. The checked [OpenAPI v1 artifact](OPENAPI.md) identifies the owner
+of every versioned operation without describing the excluded unversioned and
+browser routes.
 Issue #56 owns the HTTP authentication and role-check boundary, issue #64 owns
 the durable user/role and credential model, and issue #65 owns listener TLS and
 safe remote activation. Until those land, the separate loopback listeners are

--- a/docs/OPENAPI.md
+++ b/docs/OPENAPI.md
@@ -1,0 +1,182 @@
+# OpenAPI version 1 artifact
+
+BriskDB ships a deterministic OpenAPI 3.1 description of its versioned HTTP
+machine API at [`docs/openapi-v1.json`](openapi-v1.json). The document is a
+build artifact generated from the same annotated handler definitions that
+register the `/v1` routes. Its schemas come from the request and response DTOs
+used by those handlers, followed by explicit finalization for middleware and
+wire behavior that a Rust derive cannot describe.
+
+The artifact is useful for contract review, validation, and tool input. BriskDB
+does not serve it from an HTTP endpoint and does not ship generated client
+source. Applications that embed the HTTP adapter can obtain the same document
+as a `serde_json::Value` from:
+
+```rust
+let document = briskdb::api::openapi_v1();
+```
+
+That function is available with the `http` Cargo feature. Its normal OpenAPI
+generation dependencies are optional and selected only by `http`; the
+independent document and schema validators are test-only dependencies.
+SQL-only `embedded` builds do not include any of them on normal dependency
+edges.
+
+## Regeneration and byte identity
+
+From the repository root, regenerate the checked artifact with:
+
+```bash
+cargo run --locked --no-default-features --features http --example generate-openapi-v1 > docs/openapi-v1.json
+```
+
+The example defines the checked serialization: pretty JSON with deterministic
+object and array order and one trailing newline. To verify a checkout without
+modifying it:
+
+```bash
+generated="$(mktemp)"
+cargo run --locked --no-default-features --features http --example generate-openapi-v1 > "$generated"
+cmp "$generated" docs/openapi-v1.json
+rm "$generated"
+```
+
+Tests require the public function, the example output, and the checked file to
+produce identical bytes. Every internal `$ref` must resolve within the same
+document. The document reports `openapi: 3.1.0` and `info.version: "1"`;
+the HTTP API version is independent of the Cargo package version and storage
+format.
+
+The checked file is included at these locations:
+
+| Distribution | Artifact path |
+| --- | --- |
+| Source checkout and Cargo crate | `docs/openapi-v1.json` |
+| Native release archive | `docs/openapi-v1.json` below the archive root |
+| Debian package | `/usr/share/doc/briskdb/docs/openapi-v1.json` |
+
+Cargo package, native archive, and Debian contract tests fail if the artifact
+is absent. The OpenAPI integration tests also validate representative live
+router discovery, query, Problem Details, and NDJSON records against the
+generated component schemas before comparing generated and checked bytes.
+
+## Exact scope and listener ownership
+
+The document contains exactly 17 paths and 28 operations. GET endpoints have
+their implicit HEAD operation written out because HEAD is part of the live Axum
+contract. Each operation has one `servers` entry identifying the production
+listener that owns it. Operation IDs are stable and unique across the document,
+so a change is an explicit compatibility-artifact diff rather than generator
+order noise.
+
+| Listener | Path | Operations |
+| --- | --- | --- |
+| Data, `http://127.0.0.1:7654` | `/v1` | GET, HEAD |
+| Data, `http://127.0.0.1:7654` | `/v1/` | GET, HEAD |
+| Data, `http://127.0.0.1:7654` | `/v1/execute` | POST |
+| Data, `http://127.0.0.1:7654` | `/v1/query` | POST |
+| Data, `http://127.0.0.1:7654` | `/v1/query/stream` | POST |
+| Administration, `http://127.0.0.1:7655` | `/v1/health` | GET, HEAD |
+| Administration, `http://127.0.0.1:7655` | `/v1/ready` | GET, HEAD |
+| Administration, `http://127.0.0.1:7655` | `/v1/admin/broadcast` | POST |
+| Administration, `http://127.0.0.1:7655` | `/v1/admin/global-indexes` | GET, HEAD |
+| Administration, `http://127.0.0.1:7655` | `/v1/admin/catalog` | GET, HEAD |
+| Administration, `http://127.0.0.1:7655` | `/v1/admin/migrations` | GET, HEAD |
+| Administration, `http://127.0.0.1:7655` | `/v1/admin/migrations/{target_generation}` | GET, HEAD |
+| Administration, `http://127.0.0.1:7655` | `/v1/admin/shards` | GET, HEAD |
+| Administration, `http://127.0.0.1:7655` | `/v1/admin/queries` | GET, HEAD |
+| Administration, `http://127.0.0.1:7655` | `/v1/admin/queries/{operation_id}/cancel` | POST |
+| Administration, `http://127.0.0.1:7655` | `/v1/admin/backup` | GET, HEAD |
+| Administration, `http://127.0.0.1:7655` | `/v1/admin/maintenance/checkpoint` | POST |
+
+The server URLs identify the default loopback addresses and plane ownership;
+they do not override configured addresses. The combined Rust router exposes
+the same operations for host-owned integration, while production data and
+administration routers reject cross-plane paths.
+
+Unversioned `/health` and `/ready`, `/metrics`, every `/admin` browser route,
+and versioned fallbacks are intentionally absent. The document does not add
+authentication or authorization metadata ahead of the identity and role work
+owned by issues #56 and #64, so it has no security scheme or operation security
+requirement.
+
+## What the schemas describe
+
+The document describes the strict execute, query, result-limit, migration, and
+checkpoint request objects; the discovery and successful data and operational
+responses; the exact five-field Problem Details representation; every current
+Engine error status and code mapping; readiness JSON at both HTTP 200 and 503;
+and the request, API-version, idempotency, content-type, and method headers
+applicable to each operation. Query response schemas preserve positional rows,
+duplicate column names, the `shard` versus `shards` alternatives, legacy and
+lossless values, catalog placement alternatives, and optional generated keys.
+The root `x-briskdb-engine-errors` and `x-briskdb-transport-errors` extensions
+inventory each current Engine and transport code with the exact HTTP status,
+problem type, title, and redacted detail used by the adapter. Both catalogs are
+generated from the mappings that build live error responses.
+
+HEAD has the GET operation's status and headers but no response body on the
+wire. The live router retains the GET representation's `Content-Length`, as
+HTTP permits; clients must not try to decode a HEAD body.
+
+The stream response uses `application/x-ndjson; charset=utf-8`. OpenAPI can
+describe each metadata, row, completion, and terminal-error record, while its
+`x-briskdb-ndjson` media-type extension records the framing and sequence rule:
+one metadata record, zero or more rows, then exactly one completion or error
+record, with every compact JSON record terminated by LF. The complete
+behavioral contract, including an indeterminate EOF and errors after HTTP 200,
+remains in
+[HTTP API version 1](HTTP_API.md#streaming-query-response).
+
+## Limits of the OpenAPI representation
+
+The checked document is a faithful machine description of parsed requests and
+responses, but these wire rules still require the live-router contract tests
+and the prose HTTP contract. The root `x-briskdb-wire-contract` extension
+records the raw request-byte ceiling, duplicate-member/header boundary, and
+conditional idempotency-status behavior for tools that understand BriskDB's
+extensions:
+
+- OpenAPI and JSON Schema cannot detect duplicate object member names after a
+  generic JSON parser has collapsed them. BriskDB's decoder rejects duplicates
+  and unknown request members before engine execution.
+- JSON Schema validates the numeric value after parsing and cannot retain the
+  original JSON number token. The request schema accepts mathematical values
+  whose conversion rounds to a finite binary64 value, while result cells stay
+  within the finite values the serializer can emit. BriskDB additionally
+  rejects bare integer tokens outside the `i64`/`u64` range. The
+  `x-briskdb-number-token-limit` extension records this distinction.
+- JSON Schema treats mathematically integral values such as `1.0` and `1e0`
+  as integers. The live `result_limits.max_rows` and
+  `result_limits.max_logical_bytes` decoders require unsigned-integer JSON
+  token spelling, so the extension on `QueryResultLimits` records that extra
+  lexical rule.
+- An OpenAPI header schema cannot express repeated raw header lines or every
+  HTTP field-combination rule. BriskDB rejects duplicate, comma-folded, empty,
+  retained-whitespace, or otherwise noncanonical request IDs and idempotency
+  keys according to [Request identity](HTTP_API.md#request-identity).
+- A schema describes decoded values, not the 2,097,152-byte request ceiling,
+  which includes JSON whitespace and is enforced on the raw body before
+  deserialization. Logical result row and byte budgets are separate Engine
+  limits and are not encoded-body size promises.
+- Operations advertise `application/json` as the portable request media type.
+  The live adapter also accepts valid `application/*+json` content types; that
+  structured-suffix rule remains covered by its transport tests and prose
+  contract.
+- OpenAPI can list conditional headers but cannot require
+  `BriskDB-Idempotency-Status` only after an eligible keyed execute or fully
+  couple `created` and `replayed` to durable receipt state.
+- JSON Schema describes the column and positional-row shapes independently; it
+  cannot require every row width to equal the column count or bind later
+  stream-row values to the encoding selected by the preceding metadata record.
+  The live result-shape and streaming tests enforce both relationships.
+- An NDJSON response is a byte sequence rather than one JSON instance. Record
+  schemas alone cannot enforce LF framing, record order, terminal completion,
+  or the meaning of connection loss; the BriskDB extension and live streaming
+  tests carry that contract.
+
+The artifact changes only the HTTP adapter and distribution contents. It does
+not change routing, SQL behavior, Engine admission or cancellation, manifest
+or shard formats, migrations, authentication, or listener exposure. The full
+human-readable v1 contract remains [HTTP_API.md](HTTP_API.md), and listener
+configuration and ownership remain [HTTP_LISTENERS.md](HTTP_LISTENERS.md).

--- a/docs/PRE_1_COMPATIBILITY.md
+++ b/docs/PRE_1_COMPATIBILITY.md
@@ -10,6 +10,10 @@ The [versioned HTTP transport](HTTP_API.md) has its own compatibility boundary:
 breaking request/response or default value-encoding changes require a new API
 major version and a documented migration. This does not stabilize the alpha
 SQL subset, storage layout, browser API, or public Rust library.
+The checked [OpenAPI v1 artifact](OPENAPI.md) makes that machine-readable
+surface reviewable and is tested against the live router. Its documented
+representation limits do not weaken the duplicate-member, raw-byte, header, or
+NDJSON rules in the HTTP contract.
 
 This policy is narrower than the stable storage-format commitment planned for
 1.0 in issue #77.

--- a/docs/openapi-v1.json
+++ b/docs/openapi-v1.json
@@ -1,0 +1,6426 @@
+{
+  "openapi": "3.1.0",
+  "jsonSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
+  "info": {
+    "title": "BriskDB HTTP API",
+    "version": "1",
+    "description": "Versioned BriskDB data and administration machine API. The API version is independent of the Cargo package and storage-format versions.",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "tags": [
+    {
+      "name": "data",
+      "description": "SQL query and write operations on the data listener."
+    },
+    {
+      "name": "administration",
+      "description": "Operational inspection and maintenance on the administration listener."
+    }
+  ],
+  "paths": {
+    "/v1": {
+      "get": {
+        "tags": [
+          "data"
+        ],
+        "operationId": "getApiVersion",
+        "responses": {
+          "200": {
+            "description": "HTTP API version",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiVersion"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/Problem400"
+          },
+          "501": {
+            "$ref": "#/components/responses/Problem501"
+          }
+        },
+        "summary": "Discover HTTP API version",
+        "servers": [
+          {
+            "url": "http://127.0.0.1:7654",
+            "description": "Data listener (default address)"
+          }
+        ],
+        "x-briskdb-plane": "data",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BriskDBRequestId"
+          }
+        ]
+      },
+      "head": {
+        "tags": [
+          "data"
+        ],
+        "operationId": "headApiVersion",
+        "responses": {
+          "200": {
+            "description": "HTTP API version",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or argument",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Unsupported operation or globally rejected request control",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Inspect headers for discover http api version",
+        "servers": [
+          {
+            "url": "http://127.0.0.1:7654",
+            "description": "Data listener (default address)"
+          }
+        ],
+        "x-briskdb-plane": "data",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BriskDBRequestId"
+          }
+        ],
+        "x-briskdb-implicit-head": true
+      }
+    },
+    "/v1/execute": {
+      "post": {
+        "tags": [
+          "data"
+        ],
+        "operationId": "executeStatement",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExecuteRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Routed write result",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "BriskDB-Idempotency-Status": {
+                "$ref": "#/components/headers/BriskDBIdempotencyStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExecuteResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/Problem400"
+          },
+          "501": {
+            "$ref": "#/components/responses/Problem501"
+          },
+          "413": {
+            "$ref": "#/components/responses/Problem413"
+          },
+          "415": {
+            "$ref": "#/components/responses/Problem415"
+          },
+          "403": {
+            "$ref": "#/components/responses/Problem403"
+          },
+          "409": {
+            "$ref": "#/components/responses/Problem409"
+          },
+          "422": {
+            "$ref": "#/components/responses/Problem422"
+          },
+          "500": {
+            "$ref": "#/components/responses/Problem500"
+          },
+          "503": {
+            "$ref": "#/components/responses/Problem503"
+          },
+          "504": {
+            "$ref": "#/components/responses/Problem504"
+          },
+          "507": {
+            "$ref": "#/components/responses/Problem507"
+          }
+        },
+        "summary": "Execute one routed write",
+        "servers": [
+          {
+            "url": "http://127.0.0.1:7654",
+            "description": "Data listener (default address)"
+          }
+        ],
+        "x-briskdb-plane": "data",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BriskDBRequestId"
+          },
+          {
+            "$ref": "#/components/parameters/BriskDBIdempotencyKey"
+          }
+        ],
+        "x-briskdb-max-request-bytes": 2097152
+      }
+    },
+    "/v1/query": {
+      "post": {
+        "tags": [
+          "data"
+        ],
+        "operationId": "queryRows",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Materialized query result",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/Problem400"
+          },
+          "501": {
+            "$ref": "#/components/responses/Problem501"
+          },
+          "413": {
+            "$ref": "#/components/responses/Problem413"
+          },
+          "415": {
+            "$ref": "#/components/responses/Problem415"
+          },
+          "403": {
+            "$ref": "#/components/responses/Problem403"
+          },
+          "409": {
+            "$ref": "#/components/responses/Problem409"
+          },
+          "422": {
+            "$ref": "#/components/responses/Problem422"
+          },
+          "500": {
+            "$ref": "#/components/responses/Problem500"
+          },
+          "503": {
+            "$ref": "#/components/responses/Problem503"
+          },
+          "504": {
+            "$ref": "#/components/responses/Problem504"
+          },
+          "507": {
+            "$ref": "#/components/responses/Problem507"
+          }
+        },
+        "summary": "Query materialized rows",
+        "servers": [
+          {
+            "url": "http://127.0.0.1:7654",
+            "description": "Data listener (default address)"
+          }
+        ],
+        "x-briskdb-plane": "data",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BriskDBRequestId"
+          }
+        ],
+        "x-briskdb-max-request-bytes": 2097152
+      }
+    },
+    "/v1/query/stream": {
+      "post": {
+        "tags": [
+          "data"
+        ],
+        "operationId": "streamQueryRows",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Bounded NDJSON query stream",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              }
+            },
+            "content": {
+              "application/x-ndjson; charset=utf-8": {
+                "schema": {
+                  "type": "string",
+                  "description": "A byte sequence of compact JSON records, each terminated by LF. It is not one JSON instance. Every row uses the value encoding declared by the preceding metadata record."
+                },
+                "x-briskdb-ndjson": {
+                  "framing": "lf-delimited-json",
+                  "delimiter": "LF",
+                  "compact": true,
+                  "sequence": [
+                    {
+                      "schema": "#/components/schemas/QueryStreamMeta",
+                      "minimum": 1,
+                      "maximum": 1
+                    },
+                    {
+                      "schema": "#/components/schemas/QueryStreamRow",
+                      "minimum": 0,
+                      "maximum": 1000000
+                    },
+                    {
+                      "oneOf": [
+                        "#/components/schemas/QueryStreamComplete",
+                        "#/components/schemas/QueryStreamError"
+                      ],
+                      "minimum": 1,
+                      "maximum": 1
+                    }
+                  ],
+                  "terminalRecordRequired": true,
+                  "eofBeforeTerminal": "indeterminate",
+                  "lateErrorsRetainHttpStatus": 200
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/Problem400"
+          },
+          "501": {
+            "$ref": "#/components/responses/Problem501"
+          },
+          "413": {
+            "$ref": "#/components/responses/Problem413"
+          },
+          "415": {
+            "$ref": "#/components/responses/Problem415"
+          },
+          "403": {
+            "$ref": "#/components/responses/Problem403"
+          },
+          "409": {
+            "$ref": "#/components/responses/Problem409"
+          },
+          "422": {
+            "$ref": "#/components/responses/Problem422"
+          },
+          "500": {
+            "$ref": "#/components/responses/Problem500"
+          },
+          "503": {
+            "$ref": "#/components/responses/Problem503"
+          },
+          "504": {
+            "$ref": "#/components/responses/Problem504"
+          },
+          "507": {
+            "$ref": "#/components/responses/Problem507"
+          }
+        },
+        "summary": "Stream bounded query rows",
+        "servers": [
+          {
+            "url": "http://127.0.0.1:7654",
+            "description": "Data listener (default address)"
+          }
+        ],
+        "x-briskdb-plane": "data",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BriskDBRequestId"
+          }
+        ],
+        "x-briskdb-max-request-bytes": 2097152
+      }
+    },
+    "/v1/health": {
+      "get": {
+        "tags": [
+          "administration"
+        ],
+        "operationId": "getHealth",
+        "responses": {
+          "200": {
+            "description": "Engine and global-index health",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/Problem400"
+          },
+          "501": {
+            "$ref": "#/components/responses/Problem501"
+          },
+          "403": {
+            "$ref": "#/components/responses/Problem403"
+          },
+          "409": {
+            "$ref": "#/components/responses/Problem409"
+          },
+          "422": {
+            "$ref": "#/components/responses/Problem422"
+          },
+          "500": {
+            "$ref": "#/components/responses/Problem500"
+          },
+          "503": {
+            "$ref": "#/components/responses/Problem503"
+          },
+          "504": {
+            "$ref": "#/components/responses/Problem504"
+          },
+          "507": {
+            "$ref": "#/components/responses/Problem507"
+          }
+        },
+        "summary": "Inspect engine and global-index health",
+        "servers": [
+          {
+            "url": "http://127.0.0.1:7655",
+            "description": "Administration listener (default address)"
+          }
+        ],
+        "x-briskdb-plane": "administration",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BriskDBRequestId"
+          }
+        ]
+      },
+      "head": {
+        "tags": [
+          "administration"
+        ],
+        "operationId": "headHealth",
+        "responses": {
+          "200": {
+            "description": "Engine and global-index health",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or argument",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Unsupported operation or globally rejected request control",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied or read-only storage",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "State or constraint conflict",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable value, query, type, or limit",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Cancelled request, corruption, or internal error",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Storage, memory, contention, or shutdown unavailable",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "Request deadline exceeded",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "507": {
+            "description": "Storage full",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Inspect headers for inspect engine and global-index health",
+        "servers": [
+          {
+            "url": "http://127.0.0.1:7655",
+            "description": "Administration listener (default address)"
+          }
+        ],
+        "x-briskdb-plane": "administration",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BriskDBRequestId"
+          }
+        ],
+        "x-briskdb-implicit-head": true
+      }
+    },
+    "/v1/ready": {
+      "get": {
+        "tags": [
+          "administration"
+        ],
+        "operationId": "getReadiness",
+        "responses": {
+          "200": {
+            "description": "Ready for ordinary requests",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadyResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Not ready for ordinary requests",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotReadyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/Problem400"
+          },
+          "501": {
+            "$ref": "#/components/responses/Problem501"
+          }
+        },
+        "summary": "Inspect request-admission readiness",
+        "servers": [
+          {
+            "url": "http://127.0.0.1:7655",
+            "description": "Administration listener (default address)"
+          }
+        ],
+        "x-briskdb-plane": "administration",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BriskDBRequestId"
+          }
+        ]
+      },
+      "head": {
+        "tags": [
+          "administration"
+        ],
+        "operationId": "headReadiness",
+        "responses": {
+          "200": {
+            "description": "Ready for ordinary requests",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/json"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Not ready for ordinary requests",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or argument",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Unsupported operation or globally rejected request control",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Inspect headers for inspect request-admission readiness",
+        "servers": [
+          {
+            "url": "http://127.0.0.1:7655",
+            "description": "Administration listener (default address)"
+          }
+        ],
+        "x-briskdb-plane": "administration",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BriskDBRequestId"
+          }
+        ],
+        "x-briskdb-implicit-head": true
+      }
+    },
+    "/v1/admin/broadcast": {
+      "post": {
+        "tags": [
+          "administration"
+        ],
+        "operationId": "broadcastMigration",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BroadcastRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Completed migration shards",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BroadcastResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/Problem400"
+          },
+          "501": {
+            "$ref": "#/components/responses/Problem501"
+          },
+          "413": {
+            "$ref": "#/components/responses/Problem413"
+          },
+          "415": {
+            "$ref": "#/components/responses/Problem415"
+          },
+          "403": {
+            "$ref": "#/components/responses/Problem403"
+          },
+          "409": {
+            "$ref": "#/components/responses/Problem409"
+          },
+          "422": {
+            "$ref": "#/components/responses/Problem422"
+          },
+          "500": {
+            "$ref": "#/components/responses/Problem500"
+          },
+          "503": {
+            "$ref": "#/components/responses/Problem503"
+          },
+          "504": {
+            "$ref": "#/components/responses/Problem504"
+          },
+          "507": {
+            "$ref": "#/components/responses/Problem507"
+          }
+        },
+        "summary": "Apply a journaled schema migration",
+        "servers": [
+          {
+            "url": "http://127.0.0.1:7655",
+            "description": "Administration listener (default address)"
+          }
+        ],
+        "x-briskdb-plane": "administration",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BriskDBRequestId"
+          }
+        ],
+        "x-briskdb-max-request-bytes": 2097152
+      }
+    },
+    "/v1/admin/global-indexes": {
+      "get": {
+        "tags": [
+          "administration"
+        ],
+        "operationId": "getGlobalIndexes",
+        "responses": {
+          "200": {
+            "description": "Global-index operational report",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GlobalIndexesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/Problem400"
+          },
+          "501": {
+            "$ref": "#/components/responses/Problem501"
+          },
+          "403": {
+            "$ref": "#/components/responses/Problem403"
+          },
+          "409": {
+            "$ref": "#/components/responses/Problem409"
+          },
+          "422": {
+            "$ref": "#/components/responses/Problem422"
+          },
+          "500": {
+            "$ref": "#/components/responses/Problem500"
+          },
+          "503": {
+            "$ref": "#/components/responses/Problem503"
+          },
+          "504": {
+            "$ref": "#/components/responses/Problem504"
+          },
+          "507": {
+            "$ref": "#/components/responses/Problem507"
+          }
+        },
+        "summary": "Inspect global-index operation",
+        "servers": [
+          {
+            "url": "http://127.0.0.1:7655",
+            "description": "Administration listener (default address)"
+          }
+        ],
+        "x-briskdb-plane": "administration",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BriskDBRequestId"
+          }
+        ]
+      },
+      "head": {
+        "tags": [
+          "administration"
+        ],
+        "operationId": "headGlobalIndexes",
+        "responses": {
+          "200": {
+            "description": "Global-index operational report",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or argument",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Unsupported operation or globally rejected request control",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied or read-only storage",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "State or constraint conflict",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable value, query, type, or limit",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Cancelled request, corruption, or internal error",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Storage, memory, contention, or shutdown unavailable",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "Request deadline exceeded",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "507": {
+            "description": "Storage full",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Inspect headers for inspect global-index operation",
+        "servers": [
+          {
+            "url": "http://127.0.0.1:7655",
+            "description": "Administration listener (default address)"
+          }
+        ],
+        "x-briskdb-plane": "administration",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BriskDBRequestId"
+          }
+        ],
+        "x-briskdb-implicit-head": true
+      }
+    },
+    "/v1/admin/catalog": {
+      "get": {
+        "tags": [
+          "administration"
+        ],
+        "operationId": "getCatalog",
+        "responses": {
+          "200": {
+            "description": "Relational catalog",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CatalogResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/Problem400"
+          },
+          "501": {
+            "$ref": "#/components/responses/Problem501"
+          }
+        },
+        "summary": "Inspect the relational catalog",
+        "servers": [
+          {
+            "url": "http://127.0.0.1:7655",
+            "description": "Administration listener (default address)"
+          }
+        ],
+        "x-briskdb-plane": "administration",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BriskDBRequestId"
+          }
+        ]
+      },
+      "head": {
+        "tags": [
+          "administration"
+        ],
+        "operationId": "headCatalog",
+        "responses": {
+          "200": {
+            "description": "Relational catalog",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or argument",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Unsupported operation or globally rejected request control",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Inspect headers for inspect the relational catalog",
+        "servers": [
+          {
+            "url": "http://127.0.0.1:7655",
+            "description": "Administration listener (default address)"
+          }
+        ],
+        "x-briskdb-plane": "administration",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BriskDBRequestId"
+          }
+        ],
+        "x-briskdb-implicit-head": true
+      }
+    },
+    "/v1/admin/migrations": {
+      "get": {
+        "tags": [
+          "administration"
+        ],
+        "operationId": "listMigrations",
+        "responses": {
+          "200": {
+            "description": "Migration summary",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MigrationsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/Problem400"
+          },
+          "501": {
+            "$ref": "#/components/responses/Problem501"
+          },
+          "403": {
+            "$ref": "#/components/responses/Problem403"
+          },
+          "409": {
+            "$ref": "#/components/responses/Problem409"
+          },
+          "422": {
+            "$ref": "#/components/responses/Problem422"
+          },
+          "500": {
+            "$ref": "#/components/responses/Problem500"
+          },
+          "503": {
+            "$ref": "#/components/responses/Problem503"
+          },
+          "504": {
+            "$ref": "#/components/responses/Problem504"
+          },
+          "507": {
+            "$ref": "#/components/responses/Problem507"
+          }
+        },
+        "summary": "Inspect migration summary",
+        "servers": [
+          {
+            "url": "http://127.0.0.1:7655",
+            "description": "Administration listener (default address)"
+          }
+        ],
+        "x-briskdb-plane": "administration",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BriskDBRequestId"
+          }
+        ]
+      },
+      "head": {
+        "tags": [
+          "administration"
+        ],
+        "operationId": "headMigrations",
+        "responses": {
+          "200": {
+            "description": "Migration summary",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or argument",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Unsupported operation or globally rejected request control",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied or read-only storage",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "State or constraint conflict",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable value, query, type, or limit",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Cancelled request, corruption, or internal error",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Storage, memory, contention, or shutdown unavailable",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "Request deadline exceeded",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "507": {
+            "description": "Storage full",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Inspect headers for inspect migration summary",
+        "servers": [
+          {
+            "url": "http://127.0.0.1:7655",
+            "description": "Administration listener (default address)"
+          }
+        ],
+        "x-briskdb-plane": "administration",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BriskDBRequestId"
+          }
+        ],
+        "x-briskdb-implicit-head": true
+      }
+    },
+    "/v1/admin/migrations/{target_generation}": {
+      "get": {
+        "tags": [
+          "administration"
+        ],
+        "operationId": "getMigration",
+        "x-briskdb-plane": "administration",
+        "responses": {
+          "200": {
+            "description": "Migration generation",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MigrationResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/Problem400"
+          },
+          "501": {
+            "$ref": "#/components/responses/Problem501"
+          },
+          "404": {
+            "$ref": "#/components/responses/Problem404"
+          },
+          "403": {
+            "$ref": "#/components/responses/Problem403"
+          },
+          "409": {
+            "$ref": "#/components/responses/Problem409"
+          },
+          "422": {
+            "$ref": "#/components/responses/Problem422"
+          },
+          "500": {
+            "$ref": "#/components/responses/Problem500"
+          },
+          "503": {
+            "$ref": "#/components/responses/Problem503"
+          },
+          "504": {
+            "$ref": "#/components/responses/Problem504"
+          },
+          "507": {
+            "$ref": "#/components/responses/Problem507"
+          }
+        },
+        "summary": "Inspect one migration generation",
+        "servers": [
+          {
+            "url": "http://127.0.0.1:7655",
+            "description": "Administration listener (default address)"
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BriskDBRequestId"
+          },
+          {
+            "name": "target_generation",
+            "in": "path",
+            "description": "Canonical positive decimal schema generation",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^(?:[1-9][0-9]{0,18}|1[0-7][0-9]{18}|18[0-3][0-9]{17}|184[0-3][0-9]{16}|1844[0-5][0-9]{15}|18446[0-6][0-9]{14}|184467[0-3][0-9]{13}|1844674[0-3][0-9]{12}|184467440[0-6][0-9]{10}|1844674407[0-2][0-9]{9}|18446744073[0-6][0-9]{8}|1844674407370[0-8][0-9]{6}|18446744073709[0-4][0-9]{5}|184467440737095[0-4][0-9]{4}|1844674407370955[0][0-9]{3}|18446744073709551[0-5][0-9]{2}|184467440737095516[0][0-9]|1844674407370955161[0-4]|18446744073709551615)$"
+            }
+          }
+        ]
+      },
+      "head": {
+        "tags": [
+          "administration"
+        ],
+        "operationId": "headMigration",
+        "x-briskdb-plane": "administration",
+        "responses": {
+          "200": {
+            "description": "Migration generation",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or argument",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Unsupported operation or globally rejected request control",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied or read-only storage",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "State or constraint conflict",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable value, query, type, or limit",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Cancelled request, corruption, or internal error",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Storage, memory, contention, or shutdown unavailable",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "Request deadline exceeded",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "507": {
+            "description": "Storage full",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Inspect headers for inspect one migration generation",
+        "servers": [
+          {
+            "url": "http://127.0.0.1:7655",
+            "description": "Administration listener (default address)"
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BriskDBRequestId"
+          },
+          {
+            "name": "target_generation",
+            "in": "path",
+            "description": "Canonical positive decimal schema generation",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^(?:[1-9][0-9]{0,18}|1[0-7][0-9]{18}|18[0-3][0-9]{17}|184[0-3][0-9]{16}|1844[0-5][0-9]{15}|18446[0-6][0-9]{14}|184467[0-3][0-9]{13}|1844674[0-3][0-9]{12}|184467440[0-6][0-9]{10}|1844674407[0-2][0-9]{9}|18446744073[0-6][0-9]{8}|1844674407370[0-8][0-9]{6}|18446744073709[0-4][0-9]{5}|184467440737095[0-4][0-9]{4}|1844674407370955[0][0-9]{3}|18446744073709551[0-5][0-9]{2}|184467440737095516[0][0-9]|1844674407370955161[0-4]|18446744073709551615)$"
+            }
+          }
+        ],
+        "x-briskdb-implicit-head": true
+      }
+    },
+    "/v1/admin/shards": {
+      "get": {
+        "tags": [
+          "administration"
+        ],
+        "operationId": "listShards",
+        "responses": {
+          "200": {
+            "description": "Validated physical shards",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShardStatusResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/Problem400"
+          },
+          "501": {
+            "$ref": "#/components/responses/Problem501"
+          },
+          "403": {
+            "$ref": "#/components/responses/Problem403"
+          },
+          "409": {
+            "$ref": "#/components/responses/Problem409"
+          },
+          "422": {
+            "$ref": "#/components/responses/Problem422"
+          },
+          "500": {
+            "$ref": "#/components/responses/Problem500"
+          },
+          "503": {
+            "$ref": "#/components/responses/Problem503"
+          },
+          "504": {
+            "$ref": "#/components/responses/Problem504"
+          },
+          "507": {
+            "$ref": "#/components/responses/Problem507"
+          }
+        },
+        "summary": "Inspect validated physical shards",
+        "servers": [
+          {
+            "url": "http://127.0.0.1:7655",
+            "description": "Administration listener (default address)"
+          }
+        ],
+        "x-briskdb-plane": "administration",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BriskDBRequestId"
+          }
+        ]
+      },
+      "head": {
+        "tags": [
+          "administration"
+        ],
+        "operationId": "headShards",
+        "responses": {
+          "200": {
+            "description": "Validated physical shards",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or argument",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Unsupported operation or globally rejected request control",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied or read-only storage",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "State or constraint conflict",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable value, query, type, or limit",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Cancelled request, corruption, or internal error",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Storage, memory, contention, or shutdown unavailable",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "Request deadline exceeded",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "507": {
+            "description": "Storage full",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Inspect headers for inspect validated physical shards",
+        "servers": [
+          {
+            "url": "http://127.0.0.1:7655",
+            "description": "Administration listener (default address)"
+          }
+        ],
+        "x-briskdb-plane": "administration",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BriskDBRequestId"
+          }
+        ],
+        "x-briskdb-implicit-head": true
+      }
+    },
+    "/v1/admin/queries": {
+      "get": {
+        "tags": [
+          "administration"
+        ],
+        "operationId": "listActiveQueries",
+        "responses": {
+          "200": {
+            "description": "Active HTTP queries",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActiveQueriesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/Problem400"
+          },
+          "501": {
+            "$ref": "#/components/responses/Problem501"
+          }
+        },
+        "summary": "List active HTTP queries",
+        "servers": [
+          {
+            "url": "http://127.0.0.1:7655",
+            "description": "Administration listener (default address)"
+          }
+        ],
+        "x-briskdb-plane": "administration",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BriskDBRequestId"
+          }
+        ]
+      },
+      "head": {
+        "tags": [
+          "administration"
+        ],
+        "operationId": "headActiveQueries",
+        "responses": {
+          "200": {
+            "description": "Active HTTP queries",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or argument",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Unsupported operation or globally rejected request control",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Inspect headers for list active http queries",
+        "servers": [
+          {
+            "url": "http://127.0.0.1:7655",
+            "description": "Administration listener (default address)"
+          }
+        ],
+        "x-briskdb-plane": "administration",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BriskDBRequestId"
+          }
+        ],
+        "x-briskdb-implicit-head": true
+      }
+    },
+    "/v1/admin/queries/{operation_id}/cancel": {
+      "post": {
+        "tags": [
+          "administration"
+        ],
+        "operationId": "cancelQuery",
+        "x-briskdb-plane": "administration",
+        "responses": {
+          "202": {
+            "description": "Cancellation requested",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CancelQueryResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/Problem400"
+          },
+          "501": {
+            "$ref": "#/components/responses/Problem501"
+          },
+          "413": {
+            "$ref": "#/components/responses/Problem413"
+          },
+          "404": {
+            "$ref": "#/components/responses/Problem404"
+          }
+        },
+        "summary": "Cancel one active HTTP query",
+        "servers": [
+          {
+            "url": "http://127.0.0.1:7655",
+            "description": "Administration listener (default address)"
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BriskDBRequestId"
+          },
+          {
+            "name": "operation_id",
+            "in": "path",
+            "description": "Active query operation ID",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/OpaqueId"
+            }
+          }
+        ],
+        "x-briskdb-request-body": {
+          "mode": "exactly-zero-bytes",
+          "maxBytes": 2097152
+        }
+      }
+    },
+    "/v1/admin/backup": {
+      "get": {
+        "tags": [
+          "administration"
+        ],
+        "operationId": "getBackupCapability",
+        "responses": {
+          "200": {
+            "description": "Backup capability",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackupCapabilityResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/Problem400"
+          },
+          "501": {
+            "$ref": "#/components/responses/Problem501"
+          }
+        },
+        "summary": "Inspect backup capability",
+        "servers": [
+          {
+            "url": "http://127.0.0.1:7655",
+            "description": "Administration listener (default address)"
+          }
+        ],
+        "x-briskdb-plane": "administration",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BriskDBRequestId"
+          }
+        ]
+      },
+      "head": {
+        "tags": [
+          "administration"
+        ],
+        "operationId": "headBackupCapability",
+        "responses": {
+          "200": {
+            "description": "Backup capability",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or argument",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Unsupported operation or globally rejected request control",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Inspect headers for inspect backup capability",
+        "servers": [
+          {
+            "url": "http://127.0.0.1:7655",
+            "description": "Administration listener (default address)"
+          }
+        ],
+        "x-briskdb-plane": "administration",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BriskDBRequestId"
+          }
+        ],
+        "x-briskdb-implicit-head": true
+      }
+    },
+    "/v1/admin/maintenance/checkpoint": {
+      "post": {
+        "tags": [
+          "administration"
+        ],
+        "operationId": "checkpointDatabases",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EmptyRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Passive checkpoint report",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CheckpointResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/Problem400"
+          },
+          "501": {
+            "$ref": "#/components/responses/Problem501"
+          },
+          "413": {
+            "$ref": "#/components/responses/Problem413"
+          },
+          "415": {
+            "$ref": "#/components/responses/Problem415"
+          },
+          "403": {
+            "$ref": "#/components/responses/Problem403"
+          },
+          "409": {
+            "$ref": "#/components/responses/Problem409"
+          },
+          "422": {
+            "$ref": "#/components/responses/Problem422"
+          },
+          "500": {
+            "$ref": "#/components/responses/Problem500"
+          },
+          "503": {
+            "$ref": "#/components/responses/Problem503"
+          },
+          "504": {
+            "$ref": "#/components/responses/Problem504"
+          },
+          "507": {
+            "$ref": "#/components/responses/Problem507"
+          }
+        },
+        "summary": "Checkpoint every database",
+        "servers": [
+          {
+            "url": "http://127.0.0.1:7655",
+            "description": "Administration listener (default address)"
+          }
+        ],
+        "x-briskdb-plane": "administration",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BriskDBRequestId"
+          }
+        ],
+        "x-briskdb-max-request-bytes": 2097152
+      }
+    },
+    "/v1/": {
+      "get": {
+        "tags": [
+          "data"
+        ],
+        "operationId": "getApiVersionAlias",
+        "responses": {
+          "200": {
+            "description": "HTTP API version",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiVersion"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/Problem400"
+          },
+          "501": {
+            "$ref": "#/components/responses/Problem501"
+          }
+        },
+        "summary": "Discover HTTP API version through the slash alias",
+        "servers": [
+          {
+            "url": "http://127.0.0.1:7654",
+            "description": "Data listener (default address)"
+          }
+        ],
+        "x-briskdb-plane": "data",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BriskDBRequestId"
+          }
+        ]
+      },
+      "head": {
+        "tags": [
+          "data"
+        ],
+        "operationId": "headApiVersionAlias",
+        "responses": {
+          "200": {
+            "description": "HTTP API version",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or argument",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Unsupported operation or globally rejected request control",
+            "headers": {
+              "BriskDB-API-Version": {
+                "$ref": "#/components/headers/BriskDBApiVersion"
+              },
+              "BriskDB-Request-ID": {
+                "$ref": "#/components/headers/BriskDBRequestId"
+              },
+              "Content-Length": {
+                "$ref": "#/components/headers/ContentLength"
+              },
+              "Content-Type": {
+                "description": "Media type of the corresponding GET representation.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "const": "application/problem+json"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Inspect discovery headers through the slash alias",
+        "servers": [
+          {
+            "url": "http://127.0.0.1:7654",
+            "description": "Data listener (default address)"
+          }
+        ],
+        "x-briskdb-plane": "data",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BriskDBRequestId"
+          }
+        ],
+        "x-briskdb-implicit-head": true
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ActiveQueriesResponse": {
+        "type": "object",
+        "properties": {
+          "queries": {
+            "type": "array",
+            "maxItems": 1024,
+            "items": {
+              "$ref": "#/components/schemas/ActiveQueryResponse"
+            }
+          }
+        },
+        "required": [
+          "queries"
+        ]
+      },
+      "ActiveQueryResponse": {
+        "type": "object",
+        "properties": {
+          "operation_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "elapsed_ms": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 18446744073709551615
+          },
+          "sql_bytes": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 18446744073709551615
+          },
+          "cancellation_requested": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "operation_id",
+          "elapsed_ms",
+          "sql_bytes",
+          "cancellation_requested"
+        ]
+      },
+      "ApiVersion": {
+        "type": "object",
+        "properties": {
+          "api_version": {
+            "type": "string",
+            "const": "1"
+          },
+          "value_encoding": {
+            "type": "string",
+            "const": "legacy-json-v1"
+          },
+          "supported_value_encodings": {
+            "type": "array",
+            "prefixItems": [
+              {
+                "type": "string",
+                "const": "legacy-json-v1"
+              },
+              {
+                "type": "string",
+                "const": "lossless-json-v1"
+              }
+            ],
+            "items": false,
+            "minItems": 2,
+            "maxItems": 2
+          },
+          "session_scope": {
+            "type": "string",
+            "const": "request"
+          },
+          "sql_dialect": {
+            "type": "string",
+            "const": "sqlite"
+          },
+          "max_request_bytes": {
+            "type": "integer",
+            "const": 2097152
+          },
+          "max_result_rows": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 1000000
+          },
+          "max_result_logical_bytes": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 1073741824
+          },
+          "stream_buffer_rows": {
+            "type": "integer",
+            "const": 16
+          },
+          "request_id_header": {
+            "type": "string",
+            "const": "BriskDB-Request-ID"
+          },
+          "idempotency_key_header": {
+            "type": "string",
+            "const": "BriskDB-Idempotency-Key"
+          },
+          "stream_media_type": {
+            "type": "string",
+            "const": "application/x-ndjson; charset=utf-8"
+          }
+        },
+        "required": [
+          "api_version",
+          "value_encoding",
+          "supported_value_encodings",
+          "session_scope",
+          "sql_dialect",
+          "max_request_bytes",
+          "max_result_rows",
+          "max_result_logical_bytes",
+          "stream_buffer_rows",
+          "request_id_header",
+          "idempotency_key_header",
+          "stream_media_type"
+        ]
+      },
+      "BackupCapabilityResponse": {
+        "type": "object",
+        "properties": {
+          "mode": {
+            "type": "string",
+            "const": "stopped_directory_copy"
+          },
+          "online": {
+            "type": "boolean",
+            "const": false
+          },
+          "requires_all_processes_stopped": {
+            "type": "boolean",
+            "const": true
+          },
+          "checkpoint_endpoint": {
+            "type": "string",
+            "const": "/v1/admin/maintenance/checkpoint"
+          },
+          "checkpoint_role": {
+            "type": "string",
+            "const": "preparation_only"
+          },
+          "checkpoint_is_recovery_point": {
+            "type": "boolean",
+            "const": false
+          }
+        },
+        "required": [
+          "mode",
+          "online",
+          "requires_all_processes_stopped",
+          "checkpoint_endpoint",
+          "checkpoint_role",
+          "checkpoint_is_recovery_point"
+        ]
+      },
+      "BroadcastRequest": {
+        "type": "object",
+        "properties": {
+          "sql": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "sql"
+        ]
+      },
+      "BroadcastResponse": {
+        "type": "object",
+        "properties": {
+          "completed_shards": {
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 64,
+            "uniqueItems": true,
+            "items": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 63
+            }
+          }
+        },
+        "required": [
+          "completed_shards"
+        ]
+      },
+      "CancelQueryResponse": {
+        "type": "object",
+        "properties": {
+          "operation_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "newly_requested": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "operation_id",
+          "newly_requested"
+        ]
+      },
+      "CatalogDb": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^(?:[1-9][0-9]{0,18}|1[0-7][0-9]{18}|18[0-3][0-9]{17}|184[0-3][0-9]{16}|1844[0-5][0-9]{15}|18446[0-6][0-9]{14}|184467[0-3][0-9]{13}|1844674[0-3][0-9]{12}|184467440[0-6][0-9]{10}|1844674407[0-2][0-9]{9}|18446744073[0-6][0-9]{8}|1844674407370[0-8][0-9]{6}|18446744073709[0-4][0-9]{5}|184467440737095[0-4][0-9]{4}|1844674407370955[0][0-9]{3}|18446744073709551[0-5][0-9]{2}|184467440737095516[0][0-9]|1844674407370955161[0-4]|18446744073709551615)$"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ]
+      },
+      "CatalogGeneratedId": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/CatalogGeneratedIdDisabled"
+          },
+          {
+            "$ref": "#/components/schemas/CatalogGeneratedIdEnabled"
+          }
+        ]
+      },
+      "CatalogGlobalIndex": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^(?:[1-9][0-9]{0,18}|1[0-7][0-9]{18}|18[0-3][0-9]{17}|184[0-3][0-9]{16}|1844[0-5][0-9]{15}|18446[0-6][0-9]{14}|184467[0-3][0-9]{13}|1844674[0-3][0-9]{12}|184467440[0-6][0-9]{10}|1844674407[0-2][0-9]{9}|18446744073[0-6][0-9]{8}|1844674407370[0-8][0-9]{6}|18446744073709[0-4][0-9]{5}|184467440737095[0-4][0-9]{4}|1844674407370955[0][0-9]{3}|18446744073709551[0-5][0-9]{2}|184467440737095516[0][0-9]|1844674407370955161[0-4]|18446744073709551615)$"
+          },
+          "table_id": {
+            "type": "string",
+            "pattern": "^(?:[1-9][0-9]{0,18}|1[0-7][0-9]{18}|18[0-3][0-9]{17}|184[0-3][0-9]{16}|1844[0-5][0-9]{15}|18446[0-6][0-9]{14}|184467[0-3][0-9]{13}|1844674[0-3][0-9]{12}|184467440[0-6][0-9]{10}|1844674407[0-2][0-9]{9}|18446744073[0-6][0-9]{8}|1844674407370[0-8][0-9]{6}|18446744073709[0-4][0-9]{5}|184467440737095[0-4][0-9]{4}|1844674407370955[0][0-9]{3}|18446744073709551[0-5][0-9]{2}|184467440737095516[0][0-9]|1844674407370955161[0-4]|18446744073709551615)$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "unique": {
+            "type": "boolean"
+          },
+          "lifecycle": {
+            "type": "string",
+            "enum": [
+              "creating",
+              "ready",
+              "invalid",
+              "rebuilding",
+              "dropping"
+            ]
+          },
+          "schema_generation": {
+            "type": "string",
+            "pattern": "^(?:0|[1-9][0-9]{0,8}|1[0-9]{9}|20[0-9]{8}|21[0-3][0-9]{7}|214[0-6][0-9]{6}|2147[0-3][0-9]{5}|21474[0-7][0-9]{4}|214748[0-2][0-9]{3}|2147483[0-5][0-9]{2}|21474836[0-3][0-9]|214748364[0-7])$"
+          },
+          "key_encoding_version": {
+            "type": "integer",
+            "const": 1
+          }
+        },
+        "required": [
+          "id",
+          "table_id",
+          "name",
+          "unique",
+          "lifecycle",
+          "schema_generation",
+          "key_encoding_version"
+        ]
+      },
+      "CatalogPlacement": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/CatalogShardedPlacement"
+          },
+          {
+            "$ref": "#/components/schemas/CatalogUnshardedPlacement"
+          }
+        ]
+      },
+      "CatalogResponse": {
+        "type": "object",
+        "properties": {
+          "identifier_encoding_version": {
+            "type": "integer",
+            "const": 1
+          },
+          "schema_generation": {
+            "type": "string",
+            "pattern": "^(?:0|[1-9][0-9]{0,8}|1[0-9]{9}|20[0-9]{8}|21[0-3][0-9]{7}|214[0-6][0-9]{6}|2147[0-3][0-9]{5}|21474[0-7][0-9]{4}|214748[0-2][0-9]{3}|2147483[0-5][0-9]{2}|21474836[0-3][0-9]|214748364[0-7])$"
+          },
+          "default_database_id": {
+            "type": "string",
+            "const": "1"
+          },
+          "databases": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CatalogDb"
+            },
+            "minItems": 1,
+            "maxItems": 64,
+            "contains": {
+              "type": "object",
+              "required": [
+                "id",
+                "name"
+              ],
+              "properties": {
+                "id": {
+                  "const": "1"
+                },
+                "name": {
+                  "const": "default"
+                }
+              }
+            },
+            "minContains": 1,
+            "maxContains": 1
+          },
+          "tables": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CatalogTable"
+            },
+            "maxItems": 4096
+          },
+          "global_indexes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CatalogGlobalIndex"
+            },
+            "maxItems": 4096
+          }
+        },
+        "required": [
+          "identifier_encoding_version",
+          "schema_generation",
+          "default_database_id",
+          "databases",
+          "tables",
+          "global_indexes"
+        ]
+      },
+      "CatalogShardKey": {
+        "type": "object",
+        "properties": {
+          "column": {
+            "type": "string"
+          },
+          "data_type": {
+            "type": "string",
+            "enum": [
+              "int64",
+              "text",
+              "binary"
+            ]
+          }
+        },
+        "required": [
+          "column",
+          "data_type"
+        ]
+      },
+      "CatalogTable": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^(?:[1-9][0-9]{0,18}|1[0-7][0-9]{18}|18[0-3][0-9]{17}|184[0-3][0-9]{16}|1844[0-5][0-9]{15}|18446[0-6][0-9]{14}|184467[0-3][0-9]{13}|1844674[0-3][0-9]{12}|184467440[0-6][0-9]{10}|1844674407[0-2][0-9]{9}|18446744073[0-6][0-9]{8}|1844674407370[0-8][0-9]{6}|18446744073709[0-4][0-9]{5}|184467440737095[0-4][0-9]{4}|1844674407370955[0][0-9]{3}|18446744073709551[0-5][0-9]{2}|184467440737095516[0][0-9]|1844674407370955161[0-4]|18446744073709551615)$"
+          },
+          "database_id": {
+            "type": "string",
+            "pattern": "^(?:[1-9][0-9]{0,18}|1[0-7][0-9]{18}|18[0-3][0-9]{17}|184[0-3][0-9]{16}|1844[0-5][0-9]{15}|18446[0-6][0-9]{14}|184467[0-3][0-9]{13}|1844674[0-3][0-9]{12}|184467440[0-6][0-9]{10}|1844674407[0-2][0-9]{9}|18446744073[0-6][0-9]{8}|1844674407370[0-8][0-9]{6}|18446744073709[0-4][0-9]{5}|184467440737095[0-4][0-9]{4}|1844674407370955[0][0-9]{3}|18446744073709551[0-5][0-9]{2}|184467440737095516[0][0-9]|1844674407370955161[0-4]|18446744073709551615)$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "placement": {
+            "$ref": "#/components/schemas/CatalogPlacement"
+          },
+          "generated_id": {
+            "$ref": "#/components/schemas/CatalogGeneratedId"
+          }
+        },
+        "required": [
+          "id",
+          "database_id",
+          "name",
+          "placement",
+          "generated_id"
+        ]
+      },
+      "CheckpointDbResponse": {
+        "type": "object",
+        "properties": {
+          "database": {
+            "type": "string",
+            "enum": [
+              "manifest",
+              "global_index"
+            ]
+          },
+          "busy": {
+            "type": "boolean"
+          },
+          "counts_available": {
+            "type": "boolean"
+          },
+          "wal_frames": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 18446744073709551615
+          },
+          "checkpointed_frames": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 18446744073709551615
+          },
+          "complete": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "database",
+          "busy",
+          "counts_available",
+          "wal_frames",
+          "checkpointed_frames",
+          "complete"
+        ]
+      },
+      "CheckpointResponse": {
+        "type": "object",
+        "properties": {
+          "operation": {
+            "type": "string",
+            "const": "passive_checkpoint"
+          },
+          "busy": {
+            "type": "boolean"
+          },
+          "complete": {
+            "type": "boolean"
+          },
+          "recovery_point": {
+            "type": "boolean",
+            "const": false
+          },
+          "shards": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CheckpointShardResponse"
+            },
+            "minItems": 2,
+            "maxItems": 64,
+            "uniqueItems": true
+          },
+          "databases": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CheckpointDbResponse"
+            },
+            "minItems": 1,
+            "maxItems": 2,
+            "uniqueItems": true
+          }
+        },
+        "required": [
+          "operation",
+          "busy",
+          "complete",
+          "recovery_point",
+          "shards",
+          "databases"
+        ]
+      },
+      "CheckpointShardResponse": {
+        "type": "object",
+        "properties": {
+          "shard": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 63
+          },
+          "busy": {
+            "type": "boolean"
+          },
+          "counts_available": {
+            "type": "boolean"
+          },
+          "wal_frames": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 18446744073709551615
+          },
+          "checkpointed_frames": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 18446744073709551615
+          },
+          "complete": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "shard",
+          "busy",
+          "counts_available",
+          "wal_frames",
+          "checkpointed_frames",
+          "complete"
+        ]
+      },
+      "EmptyRequest": {
+        "type": "object",
+        "maxProperties": 0,
+        "additionalProperties": false
+      },
+      "ExecuteGeneratedKey": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "column": {
+                "type": "string"
+              },
+              "data_type": {
+                "type": "string",
+                "const": "int64"
+              },
+              "value": {
+                "$ref": "#/components/schemas/LosslessInt64/properties/value"
+              }
+            },
+            "required": [
+              "column",
+              "data_type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "column": {
+                "type": "string"
+              },
+              "data_type": {
+                "type": "string",
+                "const": "uint64"
+              },
+              "value": {
+                "$ref": "#/components/schemas/LosslessUInt64/properties/value"
+              }
+            },
+            "required": [
+              "column",
+              "data_type",
+              "value"
+            ]
+          }
+        ]
+      },
+      "ExecuteRequest": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/LegacyExecuteRequest"
+          },
+          {
+            "$ref": "#/components/schemas/LosslessExecuteRequest"
+          }
+        ]
+      },
+      "ExecuteResponse": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "shard": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 63
+              },
+              "rows_affected": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 18446744073709551615
+              }
+            },
+            "required": [
+              "shard",
+              "rows_affected"
+            ],
+            "not": {
+              "required": [
+                "generated_key"
+              ]
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "shard": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 63
+              },
+              "rows_affected": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 18446744073709551615
+              },
+              "generated_key": {
+                "$ref": "#/components/schemas/ExecuteGeneratedKey"
+              }
+            },
+            "required": [
+              "shard",
+              "rows_affected",
+              "generated_key"
+            ]
+          }
+        ]
+      },
+      "GlobalIndexStatus": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^(?:[1-9][0-9]{0,18}|1[0-7][0-9]{18}|18[0-3][0-9]{17}|184[0-3][0-9]{16}|1844[0-5][0-9]{15}|18446[0-6][0-9]{14}|184467[0-3][0-9]{13}|1844674[0-3][0-9]{12}|184467440[0-6][0-9]{10}|1844674407[0-2][0-9]{9}|18446744073[0-6][0-9]{8}|1844674407370[0-8][0-9]{6}|18446744073709[0-4][0-9]{5}|184467440737095[0-4][0-9]{4}|1844674407370955[0][0-9]{3}|18446744073709551[0-5][0-9]{2}|184467440737095516[0][0-9]|1844674407370955161[0-4]|18446744073709551615)$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "unique": {
+            "type": "boolean"
+          },
+          "lifecycle": {
+            "type": "string",
+            "enum": [
+              "creating",
+              "ready",
+              "invalid",
+              "rebuilding",
+              "dropping"
+            ]
+          },
+          "health": {
+            "type": "string",
+            "enum": [
+              "healthy",
+              "degraded",
+              "unavailable"
+            ]
+          },
+          "available": {
+            "type": "boolean"
+          },
+          "recovery": {
+            "type": "string",
+            "enum": [
+              "build",
+              "none",
+              "rebuild",
+              "resume_rebuild"
+            ]
+          },
+          "authority_entries": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 18446744073709551615
+          },
+          "unique_keys": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 18446744073709551615
+          },
+          "active_operations": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 18446744073709551615
+          },
+          "active_unique_reservations": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 18446744073709551615
+          },
+          "active_value_leases": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 18446744073709551615
+          },
+          "pending_read_repairs": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 18446744073709551615
+          },
+          "applied_read_repairs": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 18446744073709551615
+          },
+          "async_lag": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 18446744073709551615
+          },
+          "async_failures": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 18446744073709551615
+          },
+          "poisoned_shards": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 64
+          },
+          "leased_shards": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 64
+          },
+          "async_paused": {
+            "type": "boolean"
+          },
+          "rebuild_required": {
+            "type": "boolean"
+          },
+          "summary_ready_shards": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 64
+          },
+          "summary_degraded_shards": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 64
+          },
+          "summary_saturated_shards": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 64
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "unique",
+          "lifecycle",
+          "health",
+          "available",
+          "recovery",
+          "authority_entries",
+          "unique_keys",
+          "active_operations",
+          "active_unique_reservations",
+          "active_value_leases",
+          "pending_read_repairs",
+          "applied_read_repairs",
+          "async_lag",
+          "async_failures",
+          "poisoned_shards",
+          "leased_shards",
+          "async_paused",
+          "rebuild_required",
+          "summary_ready_shards",
+          "summary_degraded_shards",
+          "summary_saturated_shards"
+        ]
+      },
+      "GlobalIndexesResponse": {
+        "type": "object",
+        "properties": {
+          "state": {
+            "type": "string",
+            "enum": [
+              "healthy",
+              "degraded",
+              "unavailable"
+            ]
+          },
+          "retained_outbox_events": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 64000000
+          },
+          "retained_outbox_bytes": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 17179869184
+          },
+          "backpressured_outbox_shards": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 64
+          },
+          "indexes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GlobalIndexStatus"
+            },
+            "maxItems": 4096
+          }
+        },
+        "required": [
+          "state",
+          "retained_outbox_events",
+          "retained_outbox_bytes",
+          "backpressured_outbox_shards",
+          "indexes"
+        ]
+      },
+      "HealthGlobalIndexesResponse": {
+        "type": "object",
+        "properties": {
+          "state": {
+            "type": "string",
+            "enum": [
+              "healthy",
+              "degraded",
+              "unavailable"
+            ]
+          },
+          "total": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4096
+          },
+          "healthy": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4096
+          },
+          "degraded": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4096
+          },
+          "unavailable": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4096
+          },
+          "async_lag": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 18446744073709551615
+          },
+          "retained_outbox_events": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 64000000
+          },
+          "retained_outbox_bytes": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 17179869184
+          },
+          "backpressured_outbox_shards": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 64
+          }
+        },
+        "required": [
+          "state",
+          "total",
+          "healthy",
+          "degraded",
+          "unavailable",
+          "async_lag",
+          "retained_outbox_events",
+          "retained_outbox_bytes",
+          "backpressured_outbox_shards"
+        ]
+      },
+      "HealthResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "ok",
+              "degraded"
+            ]
+          },
+          "shards": {
+            "type": "integer",
+            "minimum": 2,
+            "maximum": 64
+          },
+          "global_indexes": {
+            "$ref": "#/components/schemas/HealthGlobalIndexesResponse"
+          }
+        },
+        "required": [
+          "status",
+          "shards",
+          "global_indexes"
+        ]
+      },
+      "MigrationResponse": {
+        "type": "object",
+        "properties": {
+          "generation": {
+            "type": "string",
+            "pattern": "^(?:0|[1-9][0-9]{0,8}|1[0-9]{9}|20[0-9]{8}|21[0-3][0-9]{7}|214[0-6][0-9]{6}|2147[0-3][0-9]{5}|21474[0-7][0-9]{4}|214748[0-2][0-9]{3}|2147483[0-5][0-9]{2}|21474836[0-3][0-9]|214748364[0-7])$",
+            "not": {
+              "const": "0"
+            }
+          },
+          "source_generation": {
+            "type": "string",
+            "pattern": "^(?:0|[1-9][0-9]{0,8}|1[0-9]{9}|20[0-9]{8}|21[0-3][0-9]{7}|214[0-6][0-9]{6}|2147[0-3][0-9]{5}|21474[0-7][0-9]{4}|214748[0-2][0-9]{3}|2147483[0-5][0-9]{2}|21474836[0-3][0-9]|214748364[0-7])$"
+          },
+          "target_generation": {
+            "type": "string",
+            "pattern": "^(?:0|[1-9][0-9]{0,8}|1[0-9]{9}|20[0-9]{8}|21[0-3][0-9]{7}|214[0-6][0-9]{6}|2147[0-3][0-9]{5}|21474[0-7][0-9]{4}|214748[0-2][0-9]{3}|2147483[0-5][0-9]{2}|21474836[0-3][0-9]|214748364[0-7])$",
+            "not": {
+              "const": "0"
+            }
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "applying",
+              "complete"
+            ]
+          },
+          "shard_count": {
+            "type": "integer",
+            "minimum": 2,
+            "maximum": 64
+          },
+          "next_shard": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 64
+          },
+          "completed_shards": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 64
+          },
+          "sql_bytes": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 65536
+          }
+        },
+        "required": [
+          "generation",
+          "source_generation",
+          "target_generation",
+          "state",
+          "shard_count",
+          "next_shard",
+          "completed_shards",
+          "sql_bytes"
+        ]
+      },
+      "MigrationsResponse": {
+        "type": "object",
+        "properties": {
+          "schema_generation": {
+            "type": "string",
+            "pattern": "^(?:0|[1-9][0-9]{0,8}|1[0-9]{9}|20[0-9]{8}|21[0-3][0-9]{7}|214[0-6][0-9]{6}|2147[0-3][0-9]{5}|21474[0-7][0-9]{4}|214748[0-2][0-9]{3}|2147483[0-5][0-9]{2}|21474836[0-3][0-9]|214748364[0-7])$"
+          },
+          "active": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/MigrationResponse"
+              }
+            ]
+          },
+          "latest_complete": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/MigrationResponse"
+              }
+            ]
+          }
+        },
+        "required": [
+          "schema_generation",
+          "active",
+          "latest_complete"
+        ]
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          },
+          "status": {
+            "type": "integer",
+            "minimum": 100,
+            "maximum": 599
+          },
+          "detail": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "type",
+          "title",
+          "status",
+          "detail",
+          "code"
+        ]
+      },
+      "QueryColumn": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "data_type": {
+            "type": "string",
+            "enum": [
+              "unknown",
+              "null",
+              "boolean",
+              "int64",
+              "uint64",
+              "float64",
+              "decimal",
+              "text",
+              "binary"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "data_type"
+        ]
+      },
+      "QueryRequest": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/LegacyQueryRequest"
+          },
+          {
+            "$ref": "#/components/schemas/LosslessQueryRequest"
+          }
+        ]
+      },
+      "QueryResponse": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/LegacySingleShardQueryResponse"
+          },
+          {
+            "$ref": "#/components/schemas/LegacyMultiShardQueryResponse"
+          },
+          {
+            "$ref": "#/components/schemas/LosslessSingleShardQueryResponse"
+          },
+          {
+            "$ref": "#/components/schemas/LosslessMultiShardQueryResponse"
+          }
+        ]
+      },
+      "QueryResultLimits": {
+        "type": "object",
+        "minProperties": 1,
+        "properties": {
+          "max_rows": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 1000000
+          },
+          "max_logical_bytes": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 1073741824
+          }
+        },
+        "additionalProperties": false,
+        "x-briskdb-number-token-limit": "max_rows and max_logical_bytes require unsigned-integer JSON token spelling; JSON Schema validators may also accept mathematically integral decimal or exponent tokens."
+      },
+      "ReadinessResponse": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ReadyResponse"
+          },
+          {
+            "$ref": "#/components/schemas/NotReadyResponse"
+          }
+        ]
+      },
+      "ShardStatus": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 63
+          },
+          "state": {
+            "type": "string",
+            "const": "ready"
+          }
+        },
+        "required": [
+          "id",
+          "state"
+        ]
+      },
+      "ShardStatusResponse": {
+        "type": "object",
+        "properties": {
+          "schema_generation": {
+            "type": "string",
+            "pattern": "^(?:0|[1-9][0-9]{0,8}|1[0-9]{9}|20[0-9]{8}|21[0-3][0-9]{7}|214[0-6][0-9]{6}|2147[0-3][0-9]{5}|21474[0-7][0-9]{4}|214748[0-2][0-9]{3}|2147483[0-5][0-9]{2}|21474836[0-3][0-9]|214748364[0-7])$"
+          },
+          "shards": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ShardStatus"
+            },
+            "minItems": 2,
+            "maxItems": 64,
+            "uniqueItems": true
+          }
+        },
+        "required": [
+          "schema_generation",
+          "shards"
+        ]
+      },
+      "ValueEncoding": {
+        "type": "string",
+        "enum": [
+          "legacy-json-v1",
+          "lossless-json-v1"
+        ],
+        "default": "legacy-json-v1"
+      },
+      "OpaqueId": {
+        "allOf": [
+          {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          {
+            "not": {
+              "const": "00000000000000000000000000000000"
+            }
+          }
+        ],
+        "examples": [
+          "0123456789abcdef0123456789abcdef"
+        ]
+      },
+      "LegacyJsonValue": {
+        "$ref": "#/components/schemas/LegacyJsonParameter",
+        "description": "The legacy parameter codec accepts recursively nested JSON and binds arrays and objects as compact JSON text."
+      },
+      "LegacyJsonParameter": {
+        "description": "One legacy-json-v1 request parameter. Integer tokens fit i64 or u64; fractional or exponent tokens must convert to finite binary64. JSON Schema validation cannot retain the original number token spelling, so its numeric schema accepts every value whose conversion rounds to a finite binary64 value.",
+        "oneOf": [
+          {
+            "type": "null"
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "$ref": "#/components/schemas/LegacyJsonParameterNumber"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LegacyJsonParameter"
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/LegacyJsonParameter"
+            }
+          }
+        ],
+        "x-briskdb-number-token-limit": "JSON Schema sees numeric value, while the decoder also distinguishes integer tokens from fractional or exponent tokens."
+      },
+      "LegacyJsonParameterNumber": {
+        "description": "A legacy request JSON number whose conversion rounds to a finite binary64 value. The decoder additionally restricts bare integer tokens to i64 or u64.",
+        "type": "number",
+        "exclusiveMinimum": -179769313486231580793728971405303415079934132710037826936173778980444968292764750946649017977587207096330286416692887910946555547851940402630657488671505820681908902000708383676273854845817711531764475730270069855571366959622842914819860834936475292719074168444365510704342711559699508093042880177904174497792,
+        "exclusiveMaximum": 179769313486231580793728971405303415079934132710037826936173778980444968292764750946649017977587207096330286416692887910946555547851940402630657488671505820681908902000708383676273854845817711531764475730270069855571366959622842914819860834936475292719074168444365510704342711559699508093042880177904174497792
+      },
+      "LegacyJsonNumber": {
+        "description": "A legacy result JSON number within the finite binary64 range.",
+        "type": "number",
+        "minimum": -1.7976931348623157e+308,
+        "maximum": 1.7976931348623157e+308
+      },
+      "LegacyJsonCell": {
+        "description": "One legacy-json-v1 result cell. A byte array represents Binary; objects and nested arrays are never emitted.",
+        "oneOf": [
+          {
+            "type": "null"
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "$ref": "#/components/schemas/LegacyJsonNumber"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 255
+            }
+          }
+        ]
+      },
+      "LosslessJsonValue": {
+        "description": "One canonical lossless-json-v1 BriskDB value.",
+        "oneOf": [
+          {
+            "type": "null"
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "$ref": "#/components/schemas/LosslessInt64"
+          },
+          {
+            "$ref": "#/components/schemas/LosslessUInt64"
+          },
+          {
+            "$ref": "#/components/schemas/LosslessFloat64"
+          },
+          {
+            "$ref": "#/components/schemas/LosslessDecimal"
+          },
+          {
+            "$ref": "#/components/schemas/LosslessBinary"
+          },
+          {
+            "$ref": "#/components/schemas/LosslessInvalidText"
+          }
+        ]
+      },
+      "LosslessInt64": {
+        "type": "object",
+        "properties": {
+          "$briskdb_type": {
+            "type": "string",
+            "const": "int64"
+          },
+          "value": {
+            "type": "string",
+            "oneOf": [
+              {
+                "pattern": "^(?:0|[1-9][0-9]{0,17}|[1-8][0-9]{18}|9[0-1][0-9]{17}|92[0-1][0-9]{16}|922[0-2][0-9]{15}|9223[0-2][0-9]{14}|92233[0-6][0-9]{13}|922337[0-1][0-9]{12}|92233720[0-2][0-9]{10}|922337203[0-5][0-9]{9}|9223372036[0-7][0-9]{8}|92233720368[0-4][0-9]{7}|922337203685[0-3][0-9]{6}|9223372036854[0-6][0-9]{5}|92233720368547[0-6][0-9]{4}|922337203685477[0-4][0-9]{3}|9223372036854775[0-7][0-9]{2}|922337203685477580[0-6]|9223372036854775807)$"
+              },
+              {
+                "pattern": "^-(?:[1-9][0-9]{0,17}|[1-8][0-9]{18}|9[0-1][0-9]{17}|92[0-1][0-9]{16}|922[0-2][0-9]{15}|9223[0-2][0-9]{14}|92233[0-6][0-9]{13}|922337[0-1][0-9]{12}|92233720[0-2][0-9]{10}|922337203[0-5][0-9]{9}|9223372036[0-7][0-9]{8}|92233720368[0-4][0-9]{7}|922337203685[0-3][0-9]{6}|9223372036854[0-6][0-9]{5}|92233720368547[0-6][0-9]{4}|922337203685477[0-4][0-9]{3}|9223372036854775[0-7][0-9]{2}|922337203685477580[0-7]|9223372036854775808)$"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "$briskdb_type",
+          "value"
+        ]
+      },
+      "LosslessUInt64": {
+        "type": "object",
+        "properties": {
+          "$briskdb_type": {
+            "type": "string",
+            "const": "uint64"
+          },
+          "value": {
+            "type": "string",
+            "pattern": "^(?:0|[1-9][0-9]{0,18}|1[0-7][0-9]{18}|18[0-3][0-9]{17}|184[0-3][0-9]{16}|1844[0-5][0-9]{15}|18446[0-6][0-9]{14}|184467[0-3][0-9]{13}|1844674[0-3][0-9]{12}|184467440[0-6][0-9]{10}|1844674407[0-2][0-9]{9}|18446744073[0-6][0-9]{8}|1844674407370[0-8][0-9]{6}|18446744073709[0-4][0-9]{5}|184467440737095[0-4][0-9]{4}|18446744073709550[0-9]{3}|18446744073709551[0-5][0-9]{2}|1844674407370955160[0-9]|1844674407370955161[0-4]|18446744073709551615)$"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "$briskdb_type",
+          "value"
+        ]
+      },
+      "LosslessFloat64": {
+        "type": "object",
+        "properties": {
+          "$briskdb_type": {
+            "type": "string",
+            "const": "float64"
+          },
+          "value": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{16}$"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "$briskdb_type",
+          "value"
+        ]
+      },
+      "LosslessDecimal": {
+        "type": "object",
+        "properties": {
+          "$briskdb_type": {
+            "type": "string",
+            "const": "decimal"
+          },
+          "value": {
+            "type": "string",
+            "pattern": "^[+-]?(?:[0-9]+(?:\\.[0-9]*)?|\\.[0-9]+)(?:[eE][+-]?[0-9]+)?$"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "$briskdb_type",
+          "value"
+        ]
+      },
+      "LosslessBinary": {
+        "type": "object",
+        "properties": {
+          "$briskdb_type": {
+            "type": "string",
+            "const": "binary"
+          },
+          "value": {
+            "type": "string",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/][AQgw]==|[A-Za-z0-9+/]{2}[AEIMQUYcgkosw048]=)?$"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "$briskdb_type",
+          "value"
+        ]
+      },
+      "LosslessInvalidText": {
+        "type": "object",
+        "properties": {
+          "$briskdb_type": {
+            "type": "string",
+            "const": "invalid_text"
+          },
+          "value": {
+            "type": "string",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/][AQgw]==|[A-Za-z0-9+/]{2}[AEIMQUYcgkosw048]=)?$"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "$briskdb_type",
+          "value"
+        ]
+      },
+      "LegacyExecuteRequest": {
+        "type": "object",
+        "properties": {
+          "shard_key": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sql": {
+            "type": "string"
+          },
+          "params": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LegacyJsonParameter"
+            },
+            "default": []
+          },
+          "value_encoding": {
+            "type": "string",
+            "const": "legacy-json-v1",
+            "default": "legacy-json-v1"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "sql"
+        ]
+      },
+      "LosslessExecuteRequest": {
+        "type": "object",
+        "properties": {
+          "shard_key": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sql": {
+            "type": "string"
+          },
+          "params": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LosslessJsonValue"
+            },
+            "default": []
+          },
+          "value_encoding": {
+            "type": "string",
+            "const": "lossless-json-v1"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "sql",
+          "value_encoding"
+        ]
+      },
+      "LegacyQueryRequest": {
+        "type": "object",
+        "properties": {
+          "shard_key": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sql": {
+            "type": "string"
+          },
+          "params": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LegacyJsonParameter"
+            },
+            "default": []
+          },
+          "value_encoding": {
+            "type": "string",
+            "const": "legacy-json-v1",
+            "default": "legacy-json-v1"
+          },
+          "result_limits": {
+            "$ref": "#/components/schemas/QueryResultLimits"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "sql"
+        ]
+      },
+      "LosslessQueryRequest": {
+        "type": "object",
+        "properties": {
+          "shard_key": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sql": {
+            "type": "string"
+          },
+          "params": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LosslessJsonValue"
+            },
+            "default": []
+          },
+          "value_encoding": {
+            "type": "string",
+            "const": "lossless-json-v1"
+          },
+          "result_limits": {
+            "$ref": "#/components/schemas/QueryResultLimits"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "sql",
+          "value_encoding"
+        ]
+      },
+      "LegacySingleShardQueryResponse": {
+        "type": "object",
+        "properties": {
+          "columns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QueryColumn"
+            }
+          },
+          "rows": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/LegacyJsonCell"
+              }
+            },
+            "maxItems": 1000000
+          },
+          "shard": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 63
+          }
+        },
+        "required": [
+          "columns",
+          "rows",
+          "shard"
+        ],
+        "not": {
+          "anyOf": [
+            {
+              "required": [
+                "shards"
+              ]
+            },
+            {
+              "required": [
+                "value_encoding"
+              ]
+            }
+          ]
+        }
+      },
+      "LegacyMultiShardQueryResponse": {
+        "type": "object",
+        "properties": {
+          "columns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QueryColumn"
+            }
+          },
+          "rows": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/LegacyJsonCell"
+              }
+            },
+            "maxItems": 1000000
+          },
+          "shards": {
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 64,
+            "uniqueItems": true,
+            "items": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 63
+            }
+          }
+        },
+        "required": [
+          "columns",
+          "rows",
+          "shards"
+        ],
+        "not": {
+          "anyOf": [
+            {
+              "required": [
+                "shard"
+              ]
+            },
+            {
+              "required": [
+                "value_encoding"
+              ]
+            }
+          ]
+        }
+      },
+      "LosslessSingleShardQueryResponse": {
+        "type": "object",
+        "properties": {
+          "columns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QueryColumn"
+            }
+          },
+          "rows": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/LosslessJsonValue"
+              }
+            },
+            "maxItems": 1000000
+          },
+          "shard": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 63
+          },
+          "value_encoding": {
+            "type": "string",
+            "const": "lossless-json-v1"
+          }
+        },
+        "required": [
+          "columns",
+          "rows",
+          "shard",
+          "value_encoding"
+        ],
+        "not": {
+          "required": [
+            "shards"
+          ]
+        }
+      },
+      "LosslessMultiShardQueryResponse": {
+        "type": "object",
+        "properties": {
+          "columns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QueryColumn"
+            }
+          },
+          "rows": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/LosslessJsonValue"
+              }
+            },
+            "maxItems": 1000000
+          },
+          "shards": {
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 64,
+            "uniqueItems": true,
+            "items": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 63
+            }
+          },
+          "value_encoding": {
+            "type": "string",
+            "const": "lossless-json-v1"
+          }
+        },
+        "required": [
+          "columns",
+          "rows",
+          "shards",
+          "value_encoding"
+        ],
+        "not": {
+          "required": [
+            "shard"
+          ]
+        }
+      },
+      "LegacySingleShardStreamMeta": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "const": "meta"
+          },
+          "columns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QueryColumn"
+            }
+          },
+          "shard": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 63
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "kind",
+          "columns",
+          "shard"
+        ]
+      },
+      "LegacyMultiShardStreamMeta": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "const": "meta"
+          },
+          "columns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QueryColumn"
+            }
+          },
+          "shards": {
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 64,
+            "uniqueItems": true,
+            "items": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 63
+            }
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "kind",
+          "columns",
+          "shards"
+        ]
+      },
+      "LosslessSingleShardStreamMeta": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "const": "meta"
+          },
+          "columns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QueryColumn"
+            }
+          },
+          "shard": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 63
+          },
+          "value_encoding": {
+            "type": "string",
+            "const": "lossless-json-v1"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "kind",
+          "columns",
+          "shard",
+          "value_encoding"
+        ]
+      },
+      "LosslessMultiShardStreamMeta": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "const": "meta"
+          },
+          "columns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QueryColumn"
+            }
+          },
+          "shards": {
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 64,
+            "uniqueItems": true,
+            "items": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 63
+            }
+          },
+          "value_encoding": {
+            "type": "string",
+            "const": "lossless-json-v1"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "kind",
+          "columns",
+          "shards",
+          "value_encoding"
+        ]
+      },
+      "ReadyResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "const": "ready"
+          },
+          "ready": {
+            "type": "boolean",
+            "const": true
+          },
+          "reasons": {
+            "type": "array",
+            "prefixItems": [],
+            "items": false,
+            "minItems": 0,
+            "maxItems": 0
+          },
+          "engine_state": {
+            "type": "string",
+            "const": "running"
+          },
+          "schema_state": {
+            "type": "string",
+            "const": "ready"
+          },
+          "schema_generation": {
+            "type": "string",
+            "pattern": "^(?:0|[1-9][0-9]{0,8}|1[0-9]{9}|20[0-9]{8}|21[0-3][0-9]{7}|214[0-6][0-9]{6}|2147[0-3][0-9]{5}|21474[0-7][0-9]{4}|214748[0-2][0-9]{3}|2147483[0-5][0-9]{2}|21474836[0-3][0-9]|214748364[0-7])$"
+          },
+          "active_schema_operations": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 18446744073709551615
+          }
+        },
+        "required": [
+          "status",
+          "ready",
+          "reasons",
+          "engine_state",
+          "schema_state",
+          "schema_generation",
+          "active_schema_operations"
+        ]
+      },
+      "NotReadyResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "const": "not_ready"
+          },
+          "ready": {
+            "type": "boolean",
+            "const": false
+          },
+          "reasons": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 2,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "engine_draining",
+                "engine_stopped",
+                "schema_migrating",
+                "schema_recovery_pending",
+                "schema_degraded"
+              ]
+            }
+          },
+          "engine_state": {
+            "type": "string",
+            "enum": [
+              "running",
+              "draining",
+              "stopped"
+            ]
+          },
+          "schema_state": {
+            "type": "string",
+            "enum": [
+              "ready",
+              "migrating",
+              "pending",
+              "degraded"
+            ]
+          },
+          "schema_generation": {
+            "type": "string",
+            "pattern": "^(?:0|[1-9][0-9]{0,8}|1[0-9]{9}|20[0-9]{8}|21[0-3][0-9]{7}|214[0-6][0-9]{6}|2147[0-3][0-9]{5}|21474[0-7][0-9]{4}|214748[0-2][0-9]{3}|2147483[0-5][0-9]{2}|21474836[0-3][0-9]|214748364[0-7])$"
+          },
+          "active_schema_operations": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 18446744073709551615
+          }
+        },
+        "required": [
+          "status",
+          "ready",
+          "reasons",
+          "engine_state",
+          "schema_state",
+          "schema_generation",
+          "active_schema_operations"
+        ],
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "engine_state",
+              "schema_state",
+              "reasons"
+            ],
+            "properties": {
+              "engine_state": {
+                "type": "string",
+                "const": "running"
+              },
+              "schema_state": {
+                "type": "string",
+                "const": "migrating"
+              },
+              "reasons": {
+                "type": "array",
+                "prefixItems": [
+                  {
+                    "type": "string",
+                    "const": "schema_migrating"
+                  }
+                ],
+                "items": false,
+                "minItems": 1,
+                "maxItems": 1
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "engine_state",
+              "schema_state",
+              "reasons"
+            ],
+            "properties": {
+              "engine_state": {
+                "type": "string",
+                "const": "running"
+              },
+              "schema_state": {
+                "type": "string",
+                "const": "pending"
+              },
+              "reasons": {
+                "type": "array",
+                "prefixItems": [
+                  {
+                    "type": "string",
+                    "const": "schema_recovery_pending"
+                  }
+                ],
+                "items": false,
+                "minItems": 1,
+                "maxItems": 1
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "engine_state",
+              "schema_state",
+              "reasons"
+            ],
+            "properties": {
+              "engine_state": {
+                "type": "string",
+                "const": "running"
+              },
+              "schema_state": {
+                "type": "string",
+                "const": "degraded"
+              },
+              "reasons": {
+                "type": "array",
+                "prefixItems": [
+                  {
+                    "type": "string",
+                    "const": "schema_degraded"
+                  }
+                ],
+                "items": false,
+                "minItems": 1,
+                "maxItems": 1
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "engine_state",
+              "schema_state",
+              "reasons"
+            ],
+            "properties": {
+              "engine_state": {
+                "type": "string",
+                "const": "draining"
+              },
+              "schema_state": {
+                "type": "string",
+                "const": "ready"
+              },
+              "reasons": {
+                "type": "array",
+                "prefixItems": [
+                  {
+                    "type": "string",
+                    "const": "engine_draining"
+                  }
+                ],
+                "items": false,
+                "minItems": 1,
+                "maxItems": 1
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "engine_state",
+              "schema_state",
+              "reasons"
+            ],
+            "properties": {
+              "engine_state": {
+                "type": "string",
+                "const": "draining"
+              },
+              "schema_state": {
+                "type": "string",
+                "const": "migrating"
+              },
+              "reasons": {
+                "type": "array",
+                "prefixItems": [
+                  {
+                    "type": "string",
+                    "const": "engine_draining"
+                  },
+                  {
+                    "type": "string",
+                    "const": "schema_migrating"
+                  }
+                ],
+                "items": false,
+                "minItems": 2,
+                "maxItems": 2
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "engine_state",
+              "schema_state",
+              "reasons"
+            ],
+            "properties": {
+              "engine_state": {
+                "type": "string",
+                "const": "draining"
+              },
+              "schema_state": {
+                "type": "string",
+                "const": "pending"
+              },
+              "reasons": {
+                "type": "array",
+                "prefixItems": [
+                  {
+                    "type": "string",
+                    "const": "engine_draining"
+                  },
+                  {
+                    "type": "string",
+                    "const": "schema_recovery_pending"
+                  }
+                ],
+                "items": false,
+                "minItems": 2,
+                "maxItems": 2
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "engine_state",
+              "schema_state",
+              "reasons"
+            ],
+            "properties": {
+              "engine_state": {
+                "type": "string",
+                "const": "draining"
+              },
+              "schema_state": {
+                "type": "string",
+                "const": "degraded"
+              },
+              "reasons": {
+                "type": "array",
+                "prefixItems": [
+                  {
+                    "type": "string",
+                    "const": "engine_draining"
+                  },
+                  {
+                    "type": "string",
+                    "const": "schema_degraded"
+                  }
+                ],
+                "items": false,
+                "minItems": 2,
+                "maxItems": 2
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "engine_state",
+              "schema_state",
+              "reasons"
+            ],
+            "properties": {
+              "engine_state": {
+                "type": "string",
+                "const": "stopped"
+              },
+              "schema_state": {
+                "type": "string",
+                "const": "ready"
+              },
+              "reasons": {
+                "type": "array",
+                "prefixItems": [
+                  {
+                    "type": "string",
+                    "const": "engine_stopped"
+                  }
+                ],
+                "items": false,
+                "minItems": 1,
+                "maxItems": 1
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "engine_state",
+              "schema_state",
+              "reasons"
+            ],
+            "properties": {
+              "engine_state": {
+                "type": "string",
+                "const": "stopped"
+              },
+              "schema_state": {
+                "type": "string",
+                "const": "migrating"
+              },
+              "reasons": {
+                "type": "array",
+                "prefixItems": [
+                  {
+                    "type": "string",
+                    "const": "engine_stopped"
+                  },
+                  {
+                    "type": "string",
+                    "const": "schema_migrating"
+                  }
+                ],
+                "items": false,
+                "minItems": 2,
+                "maxItems": 2
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "engine_state",
+              "schema_state",
+              "reasons"
+            ],
+            "properties": {
+              "engine_state": {
+                "type": "string",
+                "const": "stopped"
+              },
+              "schema_state": {
+                "type": "string",
+                "const": "pending"
+              },
+              "reasons": {
+                "type": "array",
+                "prefixItems": [
+                  {
+                    "type": "string",
+                    "const": "engine_stopped"
+                  },
+                  {
+                    "type": "string",
+                    "const": "schema_recovery_pending"
+                  }
+                ],
+                "items": false,
+                "minItems": 2,
+                "maxItems": 2
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "engine_state",
+              "schema_state",
+              "reasons"
+            ],
+            "properties": {
+              "engine_state": {
+                "type": "string",
+                "const": "stopped"
+              },
+              "schema_state": {
+                "type": "string",
+                "const": "degraded"
+              },
+              "reasons": {
+                "type": "array",
+                "prefixItems": [
+                  {
+                    "type": "string",
+                    "const": "engine_stopped"
+                  },
+                  {
+                    "type": "string",
+                    "const": "schema_degraded"
+                  }
+                ],
+                "items": false,
+                "minItems": 2,
+                "maxItems": 2
+              }
+            }
+          }
+        ]
+      },
+      "QueryStreamMeta": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/LegacySingleShardStreamMeta"
+          },
+          {
+            "$ref": "#/components/schemas/LegacyMultiShardStreamMeta"
+          },
+          {
+            "$ref": "#/components/schemas/LosslessSingleShardStreamMeta"
+          },
+          {
+            "$ref": "#/components/schemas/LosslessMultiShardStreamMeta"
+          }
+        ]
+      },
+      "QueryStreamRow": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "const": "row"
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/LegacyJsonCell"
+                },
+                {
+                  "$ref": "#/components/schemas/LosslessJsonValue"
+                }
+              ]
+            }
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "kind",
+          "values"
+        ]
+      },
+      "QueryStreamComplete": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "const": "complete"
+          },
+          "rows": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 1000000
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "kind",
+          "rows"
+        ]
+      },
+      "QueryStreamError": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "const": "error"
+          },
+          "type": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          },
+          "status": {
+            "type": "integer",
+            "minimum": 100,
+            "maximum": 599
+          },
+          "detail": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "kind",
+          "type",
+          "title",
+          "status",
+          "detail",
+          "code"
+        ]
+      },
+      "QueryStreamRecord": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/QueryStreamMeta"
+          },
+          {
+            "$ref": "#/components/schemas/QueryStreamRow"
+          },
+          {
+            "$ref": "#/components/schemas/QueryStreamComplete"
+          },
+          {
+            "$ref": "#/components/schemas/QueryStreamError"
+          }
+        ]
+      },
+      "CatalogShardedPlacement": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "const": "sharded"
+          },
+          "shard_key": {
+            "$ref": "#/components/schemas/CatalogShardKey"
+          }
+        },
+        "required": [
+          "kind",
+          "shard_key"
+        ]
+      },
+      "CatalogUnshardedPlacement": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "global",
+              "catalog",
+              "unknown"
+            ]
+          }
+        },
+        "required": [
+          "kind"
+        ],
+        "not": {
+          "required": [
+            "shard_key"
+          ]
+        }
+      },
+      "CatalogGeneratedIdDisabled": {
+        "type": "object",
+        "properties": {
+          "policy": {
+            "type": "string",
+            "enum": [
+              "none",
+              "unknown"
+            ]
+          }
+        },
+        "required": [
+          "policy"
+        ],
+        "not": {
+          "anyOf": [
+            {
+              "required": [
+                "column"
+              ]
+            },
+            {
+              "required": [
+                "encoding_version"
+              ]
+            }
+          ]
+        }
+      },
+      "CatalogGeneratedIdEnabled": {
+        "type": "object",
+        "properties": {
+          "policy": {
+            "type": "string",
+            "enum": [
+              "native_range_v1",
+              "hilo_v1"
+            ]
+          },
+          "column": {
+            "type": "string"
+          },
+          "encoding_version": {
+            "type": "integer",
+            "const": 1
+          }
+        },
+        "required": [
+          "policy",
+          "column",
+          "encoding_version"
+        ]
+      },
+      "ProblemDetails400": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          },
+          "status": {
+            "type": "integer",
+            "const": 400
+          },
+          "detail": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "type",
+          "title",
+          "status",
+          "detail",
+          "code"
+        ]
+      },
+      "ProblemDetails403": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          },
+          "status": {
+            "type": "integer",
+            "const": 403
+          },
+          "detail": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "type",
+          "title",
+          "status",
+          "detail",
+          "code"
+        ]
+      },
+      "ProblemDetails404": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          },
+          "status": {
+            "type": "integer",
+            "const": 404
+          },
+          "detail": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "type",
+          "title",
+          "status",
+          "detail",
+          "code"
+        ]
+      },
+      "ProblemDetails405": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          },
+          "status": {
+            "type": "integer",
+            "const": 405
+          },
+          "detail": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "type",
+          "title",
+          "status",
+          "detail",
+          "code"
+        ]
+      },
+      "ProblemDetails409": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          },
+          "status": {
+            "type": "integer",
+            "const": 409
+          },
+          "detail": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "type",
+          "title",
+          "status",
+          "detail",
+          "code"
+        ]
+      },
+      "ProblemDetails413": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          },
+          "status": {
+            "type": "integer",
+            "const": 413
+          },
+          "detail": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "type",
+          "title",
+          "status",
+          "detail",
+          "code"
+        ]
+      },
+      "ProblemDetails415": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          },
+          "status": {
+            "type": "integer",
+            "const": 415
+          },
+          "detail": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "type",
+          "title",
+          "status",
+          "detail",
+          "code"
+        ]
+      },
+      "ProblemDetails422": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          },
+          "status": {
+            "type": "integer",
+            "const": 422
+          },
+          "detail": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "type",
+          "title",
+          "status",
+          "detail",
+          "code"
+        ]
+      },
+      "ProblemDetails500": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          },
+          "status": {
+            "type": "integer",
+            "const": 500
+          },
+          "detail": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "type",
+          "title",
+          "status",
+          "detail",
+          "code"
+        ]
+      },
+      "ProblemDetails501": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          },
+          "status": {
+            "type": "integer",
+            "const": 501
+          },
+          "detail": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "type",
+          "title",
+          "status",
+          "detail",
+          "code"
+        ]
+      },
+      "ProblemDetails503": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          },
+          "status": {
+            "type": "integer",
+            "const": 503
+          },
+          "detail": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "type",
+          "title",
+          "status",
+          "detail",
+          "code"
+        ]
+      },
+      "ProblemDetails504": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          },
+          "status": {
+            "type": "integer",
+            "const": 504
+          },
+          "detail": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "type",
+          "title",
+          "status",
+          "detail",
+          "code"
+        ]
+      },
+      "ProblemDetails507": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          },
+          "status": {
+            "type": "integer",
+            "const": 507
+          },
+          "detail": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "type",
+          "title",
+          "status",
+          "detail",
+          "code"
+        ]
+      }
+    },
+    "parameters": {
+      "BriskDBRequestId": {
+        "name": "BriskDB-Request-ID",
+        "in": "header",
+        "required": false,
+        "description": "Optional caller-supplied correlation ID. It must occur exactly once and use the canonical nonzero 128-bit lowercase hexadecimal form.",
+        "schema": {
+          "$ref": "#/components/schemas/OpaqueId"
+        }
+      },
+      "BriskDBIdempotencyKey": {
+        "name": "BriskDB-Idempotency-Key",
+        "in": "header",
+        "required": false,
+        "description": "Optional durable idempotency key for an eligible exact-target direct autocommit DML request.",
+        "schema": {
+          "$ref": "#/components/schemas/OpaqueId"
+        }
+      }
+    },
+    "headers": {
+      "BriskDBApiVersion": {
+        "description": "Version of the HTTP representation contract.",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "const": "1"
+        }
+      },
+      "BriskDBRequestId": {
+        "description": "Canonical request correlation ID supplied or generated for this attempt.",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/OpaqueId"
+        }
+      },
+      "BriskDBIdempotencyStatus": {
+        "description": "Present only for a successfully created or replayed durable idempotency receipt.",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "created",
+            "replayed"
+          ]
+        }
+      },
+      "ContentLength": {
+        "description": "The size of the corresponding GET representation; a HEAD response carries no body.",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 18446744073709551615
+        }
+      },
+      "Allow": {
+        "description": "Methods accepted by the matched HTTP v1 route family.",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "GET,HEAD",
+            "POST"
+          ]
+        }
+      }
+    },
+    "responses": {
+      "Problem400": {
+        "description": "Invalid request or argument",
+        "headers": {
+          "BriskDB-API-Version": {
+            "$ref": "#/components/headers/BriskDBApiVersion"
+          },
+          "BriskDB-Request-ID": {
+            "$ref": "#/components/headers/BriskDBRequestId"
+          }
+        },
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/ProblemDetails400"
+            }
+          }
+        }
+      },
+      "Problem403": {
+        "description": "Permission denied or read-only storage",
+        "headers": {
+          "BriskDB-API-Version": {
+            "$ref": "#/components/headers/BriskDBApiVersion"
+          },
+          "BriskDB-Request-ID": {
+            "$ref": "#/components/headers/BriskDBRequestId"
+          }
+        },
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/ProblemDetails403"
+            }
+          }
+        }
+      },
+      "Problem404": {
+        "description": "Resource not found",
+        "headers": {
+          "BriskDB-API-Version": {
+            "$ref": "#/components/headers/BriskDBApiVersion"
+          },
+          "BriskDB-Request-ID": {
+            "$ref": "#/components/headers/BriskDBRequestId"
+          }
+        },
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/ProblemDetails404"
+            }
+          }
+        }
+      },
+      "Problem405": {
+        "description": "Method not allowed",
+        "headers": {
+          "BriskDB-API-Version": {
+            "$ref": "#/components/headers/BriskDBApiVersion"
+          },
+          "BriskDB-Request-ID": {
+            "$ref": "#/components/headers/BriskDBRequestId"
+          },
+          "Allow": {
+            "$ref": "#/components/headers/Allow"
+          }
+        },
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/ProblemDetails405"
+            }
+          }
+        }
+      },
+      "Problem409": {
+        "description": "State or constraint conflict",
+        "headers": {
+          "BriskDB-API-Version": {
+            "$ref": "#/components/headers/BriskDBApiVersion"
+          },
+          "BriskDB-Request-ID": {
+            "$ref": "#/components/headers/BriskDBRequestId"
+          }
+        },
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/ProblemDetails409"
+            }
+          }
+        }
+      },
+      "Problem413": {
+        "description": "Request body too large",
+        "headers": {
+          "BriskDB-API-Version": {
+            "$ref": "#/components/headers/BriskDBApiVersion"
+          },
+          "BriskDB-Request-ID": {
+            "$ref": "#/components/headers/BriskDBRequestId"
+          }
+        },
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/ProblemDetails413"
+            }
+          }
+        }
+      },
+      "Problem415": {
+        "description": "Unsupported request media type",
+        "headers": {
+          "BriskDB-API-Version": {
+            "$ref": "#/components/headers/BriskDBApiVersion"
+          },
+          "BriskDB-Request-ID": {
+            "$ref": "#/components/headers/BriskDBRequestId"
+          }
+        },
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/ProblemDetails415"
+            }
+          }
+        }
+      },
+      "Problem422": {
+        "description": "Unprocessable value, query, type, or limit",
+        "headers": {
+          "BriskDB-API-Version": {
+            "$ref": "#/components/headers/BriskDBApiVersion"
+          },
+          "BriskDB-Request-ID": {
+            "$ref": "#/components/headers/BriskDBRequestId"
+          }
+        },
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/ProblemDetails422"
+            }
+          }
+        }
+      },
+      "Problem500": {
+        "description": "Cancelled request, corruption, or internal error",
+        "headers": {
+          "BriskDB-API-Version": {
+            "$ref": "#/components/headers/BriskDBApiVersion"
+          },
+          "BriskDB-Request-ID": {
+            "$ref": "#/components/headers/BriskDBRequestId"
+          }
+        },
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/ProblemDetails500"
+            }
+          }
+        }
+      },
+      "Problem501": {
+        "description": "Unsupported operation or globally rejected request control",
+        "headers": {
+          "BriskDB-API-Version": {
+            "$ref": "#/components/headers/BriskDBApiVersion"
+          },
+          "BriskDB-Request-ID": {
+            "$ref": "#/components/headers/BriskDBRequestId"
+          }
+        },
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/ProblemDetails501"
+            }
+          }
+        }
+      },
+      "Problem503": {
+        "description": "Storage, memory, contention, or shutdown unavailable",
+        "headers": {
+          "BriskDB-API-Version": {
+            "$ref": "#/components/headers/BriskDBApiVersion"
+          },
+          "BriskDB-Request-ID": {
+            "$ref": "#/components/headers/BriskDBRequestId"
+          }
+        },
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/ProblemDetails503"
+            }
+          }
+        }
+      },
+      "Problem504": {
+        "description": "Request deadline exceeded",
+        "headers": {
+          "BriskDB-API-Version": {
+            "$ref": "#/components/headers/BriskDBApiVersion"
+          },
+          "BriskDB-Request-ID": {
+            "$ref": "#/components/headers/BriskDBRequestId"
+          }
+        },
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/ProblemDetails504"
+            }
+          }
+        }
+      },
+      "Problem507": {
+        "description": "Storage full",
+        "headers": {
+          "BriskDB-API-Version": {
+            "$ref": "#/components/headers/BriskDBApiVersion"
+          },
+          "BriskDB-Request-ID": {
+            "$ref": "#/components/headers/BriskDBRequestId"
+          }
+        },
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/ProblemDetails507"
+            }
+          }
+        }
+      }
+    }
+  },
+  "x-briskdb-engine-errors": [
+    {
+      "code": "invalid_argument",
+      "status": 400,
+      "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#invalid-argument",
+      "title": "Invalid argument",
+      "detail": "The request contains an invalid argument."
+    },
+    {
+      "code": "numeric_out_of_range",
+      "status": 422,
+      "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#numeric-out-of-range",
+      "title": "Numeric value out of range",
+      "detail": "A numeric value is outside the supported range."
+    },
+    {
+      "code": "invalid_text_encoding",
+      "status": 422,
+      "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#invalid-text-encoding",
+      "title": "Invalid text encoding",
+      "detail": "A text value has an unsupported encoding."
+    },
+    {
+      "code": "invalid_query",
+      "status": 422,
+      "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#invalid-query",
+      "title": "Invalid query",
+      "detail": "The query could not be processed."
+    },
+    {
+      "code": "unsupported",
+      "status": 501,
+      "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#unsupported",
+      "title": "Unsupported operation",
+      "detail": "The requested operation is not supported."
+    },
+    {
+      "code": "failed_precondition",
+      "status": 409,
+      "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#failed-precondition",
+      "title": "Failed precondition",
+      "detail": "The operation cannot run in the current state."
+    },
+    {
+      "code": "idempotency_conflict",
+      "status": 409,
+      "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#idempotency-conflict",
+      "title": "Idempotency key conflict",
+      "detail": "The idempotency key was already used for a different operation."
+    },
+    {
+      "code": "transaction_aborted",
+      "status": 409,
+      "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#transaction-aborted",
+      "title": "Transaction aborted",
+      "detail": "The transaction is aborted; roll it back before continuing."
+    },
+    {
+      "code": "type_mismatch",
+      "status": 422,
+      "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#type-mismatch",
+      "title": "Type mismatch",
+      "detail": "A value has an incompatible type."
+    },
+    {
+      "code": "constraint_violation",
+      "status": 409,
+      "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#constraint-violation",
+      "title": "Constraint violation",
+      "detail": "A database constraint was violated."
+    },
+    {
+      "code": "unique_violation",
+      "status": 409,
+      "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#unique-violation",
+      "title": "Unique constraint violation",
+      "detail": "A unique constraint was violated."
+    },
+    {
+      "code": "not_null_violation",
+      "status": 409,
+      "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#not-null-violation",
+      "title": "Not-null constraint violation",
+      "detail": "A not-null constraint was violated."
+    },
+    {
+      "code": "foreign_key_violation",
+      "status": 409,
+      "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#foreign-key-violation",
+      "title": "Foreign-key constraint violation",
+      "detail": "A foreign-key constraint was violated."
+    },
+    {
+      "code": "check_violation",
+      "status": 409,
+      "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#check-violation",
+      "title": "Check constraint violation",
+      "detail": "A check constraint was violated."
+    },
+    {
+      "code": "permission_denied",
+      "status": 403,
+      "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#permission-denied",
+      "title": "Permission denied",
+      "detail": "The operation is not permitted."
+    },
+    {
+      "code": "read_only",
+      "status": 403,
+      "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#read-only",
+      "title": "Read-only storage",
+      "detail": "The storage is read-only."
+    },
+    {
+      "code": "busy",
+      "status": 503,
+      "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#busy",
+      "title": "Database busy",
+      "detail": "The database is busy; retry the operation later."
+    },
+    {
+      "code": "cancelled",
+      "status": 500,
+      "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#cancelled",
+      "title": "Request cancelled",
+      "detail": "The operation was cancelled."
+    },
+    {
+      "code": "deadline_exceeded",
+      "status": 504,
+      "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#deadline-exceeded",
+      "title": "Request deadline exceeded",
+      "detail": "The operation exceeded its request deadline."
+    },
+    {
+      "code": "limit_exceeded",
+      "status": 422,
+      "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#limit-exceeded",
+      "title": "Limit exceeded",
+      "detail": "The request exceeds an engine limit."
+    },
+    {
+      "code": "shutting_down",
+      "status": 503,
+      "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#shutting-down",
+      "title": "Server shutting down",
+      "detail": "The server is shutting down and cannot accept the operation."
+    },
+    {
+      "code": "storage_full",
+      "status": 507,
+      "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#storage-full",
+      "title": "Storage full",
+      "detail": "The storage has no available space."
+    },
+    {
+      "code": "out_of_memory",
+      "status": 503,
+      "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#out-of-memory",
+      "title": "Out of memory",
+      "detail": "The engine does not have enough memory."
+    },
+    {
+      "code": "storage_unavailable",
+      "status": 503,
+      "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#storage-unavailable",
+      "title": "Storage unavailable",
+      "detail": "The storage is unavailable."
+    },
+    {
+      "code": "data_corruption",
+      "status": 500,
+      "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#data-corruption",
+      "title": "Data corruption",
+      "detail": "Stored data failed an integrity check."
+    },
+    {
+      "code": "internal",
+      "status": 500,
+      "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#internal",
+      "title": "Internal error",
+      "detail": "An internal engine error occurred."
+    }
+  ],
+  "x-briskdb-transport-errors": [
+    {
+      "code": "invalid_argument",
+      "status": 400,
+      "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#invalid-argument",
+      "title": "Invalid argument",
+      "detail": "The request contains an invalid argument."
+    },
+    {
+      "code": "request_too_large",
+      "status": 413,
+      "type": "urn:briskdb:http:v1:request-too-large",
+      "title": "Request too large",
+      "detail": "The request body exceeds the HTTP API limit."
+    },
+    {
+      "code": "unsupported_media_type",
+      "status": 415,
+      "type": "urn:briskdb:http:v1:unsupported-media-type",
+      "title": "Unsupported media type",
+      "detail": "The request requires a JSON content type."
+    },
+    {
+      "code": "not_found",
+      "status": 404,
+      "type": "urn:briskdb:http:v1:not-found",
+      "title": "Not found",
+      "detail": "The requested API endpoint does not exist."
+    },
+    {
+      "code": "method_not_allowed",
+      "status": 405,
+      "type": "urn:briskdb:http:v1:method-not-allowed",
+      "title": "Method not allowed",
+      "detail": "The method is not supported by this API endpoint."
+    }
+  ],
+  "x-briskdb-wire-contract": {
+    "maxRequestBytes": 2097152,
+    "requestObjectsRejectUnknownAndDuplicateMembers": true,
+    "requestControlHeadersRequireOneCanonicalValue": true,
+    "openapiCannotValidateDuplicateJsonMembersOrRawHeaderMultiplicity": true,
+    "idempotencyStatusHeaderIsConditional": true
+  }
+}

--- a/examples/openapi.rs
+++ b/examples/openapi.rs
@@ -1,0 +1,5 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let document = briskdb::api::openapi_v1();
+    println!("{}", serde_json::to_string_pretty(&document)?);
+    Ok(())
+}

--- a/packaging/debian/build-deb.sh
+++ b/packaging/debian/build-deb.sh
@@ -46,6 +46,11 @@ for binary in briskdb briskdb-import; do
     fi
 done
 
+if [[ ! -s docs/openapi-v1.json ]]; then
+    echo "missing OpenAPI artifact: docs/openapi-v1.json" >&2
+    exit 1
+fi
+
 debian_version=$(to_debian_version "$cargo_version")
 filename_version=${debian_version//\~/.}
 package_basename="briskdb_${filename_version}_${architecture}"

--- a/packaging/debian/test-deb-service.sh
+++ b/packaging/debian/test-deb-service.sh
@@ -71,6 +71,7 @@ PY
 dpkg-deb --info "$package"
 dpkg-deb --contents "$package" | grep -F ./lib/systemd/system/briskdb.service
 dpkg-deb --contents "$package" | grep -F ./etc/default/briskdb
+dpkg-deb --contents "$package" | grep -F ./usr/share/doc/briskdb/docs/openapi-v1.json
 
 sudo env DEBIAN_FRONTEND=noninteractive dpkg -i "$package"
 sudo systemd-analyze verify /lib/systemd/system/briskdb.service

--- a/src/protocol/http.rs
+++ b/src/protocol/http.rs
@@ -1,6 +1,7 @@
 //! Versioned HTTP adapter over the protocol-neutral engine.
 
 mod admin;
+mod openapi;
 mod v1;
 
 use std::{
@@ -25,6 +26,7 @@ use base64::{Engine as _, engine::general_purpose::STANDARD as STANDARD_BASE64};
 use futures::{StreamExt as _, stream};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value as JsonValue, json};
+use utoipa::ToSchema;
 use v1::{
     BroadcastRequest, EmptyRequest, ExecuteRequest, QueryRequest, QueryResultLimits,
     RawJsonParameter, TransportError, V1EmptyBody, V1Json, V1Path, ValueEncoding,
@@ -44,6 +46,15 @@ use crate::{
 pub(super) const REQUEST_ID_HEADER_NAME: &str = "BriskDB-Request-ID";
 pub(super) const IDEMPOTENCY_KEY_HEADER_NAME: &str = "BriskDB-Idempotency-Key";
 pub(super) const STREAM_MEDIA_TYPE: &str = "application/x-ndjson; charset=utf-8";
+
+/// Return the deterministic OpenAPI 3.1 document for the versioned HTTP API.
+///
+/// The document describes only `/v1` machine endpoints. It does not describe
+/// the unversioned probes, Prometheus metrics, or embedded administration
+/// browser.
+pub fn openapi_v1() -> JsonValue {
+    openapi::document()
+}
 
 const REQUEST_ID_HEADER: &str = "briskdb-request-id";
 const IDEMPOTENCY_KEY_HEADER: &str = "briskdb-idempotency-key";
@@ -299,7 +310,37 @@ impl HttpState {
     }
 }
 
-async fn health(State(state): State<HttpState>) -> Result<Json<JsonValue>, ApiError> {
+#[derive(Debug, Serialize, ToSchema)]
+struct HealthResponse {
+    status: &'static str,
+    shards: u16,
+    global_indexes: HealthGlobalIndexesResponse,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+struct HealthGlobalIndexesResponse {
+    state: &'static str,
+    total: usize,
+    healthy: usize,
+    degraded: usize,
+    unavailable: usize,
+    async_lag: u64,
+    retained_outbox_events: u64,
+    retained_outbox_bytes: u64,
+    backpressured_outbox_shards: u16,
+}
+
+#[utoipa::path(
+    get,
+    path = "/health",
+    operation_id = "getHealth",
+    tag = "administration",
+    responses(
+        (status = 200, description = "Engine and global-index health", body = HealthResponse),
+        (status = 500, description = "Engine error", body = ProblemDetails, content_type = "application/problem+json")
+    )
+)]
+async fn health(State(state): State<HttpState>) -> Result<Json<HealthResponse>, ApiError> {
     let engine = state.engine;
     let session = engine.session();
     let status = engine.status(&session).await?;
@@ -321,24 +362,24 @@ async fn health(State(state): State<HttpState>) -> Result<Json<JsonValue>, ApiEr
         "global-index operational health"
     );
 
-    Ok(Json(json!({
-        "status": service_status,
-        "shards": status.shard_count(),
-        "global_indexes": {
-            "state": indexes.state().code(),
-            "total": indexes.indexes().len(),
-            "healthy": indexes.healthy_indexes(),
-            "degraded": indexes.degraded_indexes(),
-            "unavailable": indexes.unavailable_indexes(),
-            "async_lag": indexes.async_lag(),
-            "retained_outbox_events": indexes.retained_outbox_events(),
-            "retained_outbox_bytes": indexes.retained_outbox_bytes(),
-            "backpressured_outbox_shards": indexes.backpressured_outbox_shards(),
+    Ok(Json(HealthResponse {
+        status: service_status,
+        shards: status.shard_count(),
+        global_indexes: HealthGlobalIndexesResponse {
+            state: indexes.state().code(),
+            total: indexes.indexes().len(),
+            healthy: indexes.healthy_indexes(),
+            degraded: indexes.degraded_indexes(),
+            unavailable: indexes.unavailable_indexes(),
+            async_lag: indexes.async_lag(),
+            retained_outbox_events: indexes.retained_outbox_events(),
+            retained_outbox_bytes: indexes.retained_outbox_bytes(),
+            backpressured_outbox_shards: indexes.backpressured_outbox_shards(),
         },
-    })))
+    }))
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct ReadinessResponse {
     status: &'static str,
     ready: bool,
@@ -349,6 +390,16 @@ struct ReadinessResponse {
     active_schema_operations: usize,
 }
 
+#[utoipa::path(
+    get,
+    path = "/ready",
+    operation_id = "getReadiness",
+    tag = "administration",
+    responses(
+        (status = 200, description = "Ready", body = ReadinessResponse),
+        (status = 503, description = "Not ready", body = ReadinessResponse)
+    )
+)]
 async fn ready(State(state): State<HttpState>) -> Response {
     let readiness = state.engine.readiness();
     let engine_state = readiness.lifecycle_state();
@@ -403,7 +454,7 @@ async fn metrics(State(state): State<HttpState>) -> Result<Response, ApiError> {
     Ok(response)
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct CatalogResponse {
     identifier_encoding_version: u32,
     schema_generation: String,
@@ -413,13 +464,13 @@ struct CatalogResponse {
     global_indexes: Vec<CatalogGlobalIndex>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct CatalogDb {
     id: String,
     name: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct CatalogTable {
     id: String,
     database_id: String,
@@ -428,20 +479,20 @@ struct CatalogTable {
     generated_id: CatalogGeneratedId,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct CatalogPlacement {
     kind: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
     shard_key: Option<CatalogShardKey>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct CatalogShardKey {
     column: String,
     data_type: &'static str,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct CatalogGeneratedId {
     policy: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -450,7 +501,7 @@ struct CatalogGeneratedId {
     encoding_version: Option<u32>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct CatalogGlobalIndex {
     id: String,
     table_id: String,
@@ -461,6 +512,13 @@ struct CatalogGlobalIndex {
     key_encoding_version: u32,
 }
 
+#[utoipa::path(
+    get,
+    path = "/admin/catalog",
+    operation_id = "getCatalog",
+    tag = "administration",
+    responses((status = 200, description = "Relational catalog", body = CatalogResponse))
+)]
 async fn catalog(State(state): State<HttpState>) -> Json<CatalogResponse> {
     let catalog = state.engine.catalog();
     let databases = catalog
@@ -555,14 +613,14 @@ fn catalog_generated_id(policy: &GeneratedIdPolicy) -> CatalogGeneratedId {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct MigrationsResponse {
     schema_generation: String,
     active: Option<MigrationResponse>,
     latest_complete: Option<MigrationResponse>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct MigrationResponse {
     generation: String,
     source_generation: String,
@@ -574,6 +632,16 @@ struct MigrationResponse {
     sql_bytes: usize,
 }
 
+#[utoipa::path(
+    get,
+    path = "/admin/migrations",
+    operation_id = "listMigrations",
+    tag = "administration",
+    responses(
+        (status = 200, description = "Migration summary", body = MigrationsResponse),
+        (status = 500, description = "Engine error", body = ProblemDetails, content_type = "application/problem+json")
+    )
+)]
 async fn migrations(State(state): State<HttpState>) -> Result<Json<MigrationsResponse>, ApiError> {
     let summary = state
         .engine
@@ -586,6 +654,18 @@ async fn migrations(State(state): State<HttpState>) -> Result<Json<MigrationsRes
     }))
 }
 
+#[utoipa::path(
+    get,
+    path = "/admin/migrations/{target_generation}",
+    operation_id = "getMigration",
+    tag = "administration",
+    params(("target_generation" = String, Path, description = "Canonical positive decimal schema generation")),
+    responses(
+        (status = 200, description = "Migration", body = MigrationResponse),
+        (status = 404, description = "Migration not found", body = ProblemDetails, content_type = "application/problem+json"),
+        (status = 500, description = "Engine error", body = ProblemDetails, content_type = "application/problem+json")
+    )
+)]
 async fn migration(
     State(state): State<HttpState>,
     V1Path(raw_generation): V1Path<String>,
@@ -629,18 +709,28 @@ fn parse_canonical_generation(value: &str) -> Option<u64> {
         .filter(|generation| *generation > 0)
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct ShardStatusResponse {
     schema_generation: String,
     shards: Vec<ShardStatus>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct ShardStatus {
     id: u16,
     state: &'static str,
 }
 
+#[utoipa::path(
+    get,
+    path = "/admin/shards",
+    operation_id = "listShards",
+    tag = "administration",
+    responses(
+        (status = 200, description = "Validated physical shards", body = ShardStatusResponse),
+        (status = 500, description = "Engine error", body = ProblemDetails, content_type = "application/problem+json")
+    )
+)]
 async fn shard_status(
     State(state): State<HttpState>,
 ) -> Result<Json<ShardStatusResponse>, ApiError> {
@@ -662,12 +752,12 @@ async fn shard_status(
     }))
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct ActiveQueriesResponse {
     queries: Vec<ActiveQueryResponse>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct ActiveQueryResponse {
     operation_id: String,
     elapsed_ms: u64,
@@ -675,6 +765,13 @@ struct ActiveQueryResponse {
     cancellation_requested: bool,
 }
 
+#[utoipa::path(
+    get,
+    path = "/admin/queries",
+    operation_id = "listActiveQueries",
+    tag = "administration",
+    responses((status = 200, description = "Active HTTP queries", body = ActiveQueriesResponse))
+)]
 async fn active_queries(State(state): State<HttpState>) -> Json<ActiveQueriesResponse> {
     let mut queries = state
         .engine
@@ -691,18 +788,29 @@ async fn active_queries(State(state): State<HttpState>) -> Json<ActiveQueriesRes
     Json(ActiveQueriesResponse { queries })
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct CancelQueryResponse {
     operation_id: String,
     newly_requested: bool,
 }
 
+#[utoipa::path(
+    post,
+    path = "/admin/queries/{operation_id}/cancel",
+    operation_id = "cancelQuery",
+    tag = "administration",
+    params(("operation_id" = String, Path, description = "Active query operation ID")),
+    responses(
+        (status = 202, description = "Cancellation requested", body = CancelQueryResponse),
+        (status = 404, description = "Active query not found", body = ProblemDetails, content_type = "application/problem+json")
+    )
+)]
 async fn cancel_query(
     State(state): State<HttpState>,
-    V1Path(raw_query_id): V1Path<String>,
+    V1Path(raw_operation_id): V1Path<String>,
     _body: V1EmptyBody,
 ) -> Response {
-    let Ok(query_id) = raw_query_id.parse() else {
+    let Ok(query_id) = raw_operation_id.parse() else {
         return TransportError::NotFound.into_response();
     };
     match state.engine.cancel_query(query_id) {
@@ -718,7 +826,7 @@ async fn cancel_query(
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct BackupCapabilityResponse {
     mode: &'static str,
     online: bool,
@@ -728,6 +836,13 @@ struct BackupCapabilityResponse {
     checkpoint_is_recovery_point: bool,
 }
 
+#[utoipa::path(
+    get,
+    path = "/admin/backup",
+    operation_id = "getBackupCapability",
+    tag = "administration",
+    responses((status = 200, description = "Backup capability", body = BackupCapabilityResponse))
+)]
 async fn backup_capability() -> Json<BackupCapabilityResponse> {
     Json(BackupCapabilityResponse {
         mode: "stopped_directory_copy",
@@ -739,7 +854,7 @@ async fn backup_capability() -> Json<BackupCapabilityResponse> {
     })
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct CheckpointResponse {
     operation: &'static str,
     busy: bool,
@@ -749,7 +864,7 @@ struct CheckpointResponse {
     databases: Vec<CheckpointDbResponse>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct CheckpointShardResponse {
     shard: u16,
     busy: bool,
@@ -759,7 +874,7 @@ struct CheckpointShardResponse {
     complete: bool,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct CheckpointDbResponse {
     database: &'static str,
     busy: bool,
@@ -769,6 +884,17 @@ struct CheckpointDbResponse {
     complete: bool,
 }
 
+#[utoipa::path(
+    post,
+    path = "/admin/maintenance/checkpoint",
+    operation_id = concat!("checkpoint", "Data", "bases"),
+    tag = "administration",
+    request_body(content = EmptyRequest, content_type = "application/json"),
+    responses(
+        (status = 200, description = "Passive checkpoint report", body = CheckpointResponse),
+        (status = 500, description = "Engine error", body = ProblemDetails, content_type = "application/problem+json")
+    )
+)]
 async fn checkpoint(
     State(state): State<HttpState>,
     V1Json(_request): V1Json<EmptyRequest>,
@@ -811,7 +937,7 @@ async fn checkpoint(
     }))
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct GlobalIndexesResponse {
     state: &'static str,
     retained_outbox_events: u64,
@@ -820,7 +946,7 @@ struct GlobalIndexesResponse {
     indexes: Vec<GlobalIndexStatus>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct GlobalIndexStatus {
     id: String,
     name: String,
@@ -847,7 +973,7 @@ struct GlobalIndexStatus {
     summary_saturated_shards: u16,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct ExecuteResponse {
     shard: u16,
     rows_affected: usize,
@@ -855,14 +981,14 @@ struct ExecuteResponse {
     generated_key: Option<ExecuteGeneratedKey>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct ExecuteGeneratedKey {
     column: String,
     data_type: &'static str,
     value: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct QueryResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     shard: Option<u16>,
@@ -874,13 +1000,13 @@ struct QueryResponse {
     rows: Vec<Vec<JsonValue>>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct QueryColumn {
     name: String,
     data_type: &'static str,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct QueryStreamMeta {
     kind: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -892,19 +1018,19 @@ struct QueryStreamMeta {
     columns: Vec<QueryColumn>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct QueryStreamRow {
     kind: &'static str,
     values: Vec<JsonValue>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct QueryStreamComplete {
     kind: &'static str,
     rows: u64,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct QueryStreamError {
     kind: &'static str,
     #[serde(rename = "type")]
@@ -922,6 +1048,17 @@ struct QueryStreamState {
     rows: u64,
 }
 
+#[utoipa::path(
+    post,
+    path = "/execute",
+    operation_id = "executeStatement",
+    tag = "data",
+    request_body(content = ExecuteRequest, content_type = "application/json"),
+    responses(
+        (status = 200, description = "Routed write result", body = ExecuteResponse),
+        (status = 500, description = "Engine or transport error", body = ProblemDetails, content_type = "application/problem+json")
+    )
+)]
 async fn execute(
     State(state): State<HttpState>,
     Extension(RequestIdempotency(idempotency)): Extension<RequestIdempotency>,
@@ -996,6 +1133,17 @@ fn execute_generated_key(generated: GeneratedKey) -> Result<ExecuteGeneratedKey,
     })
 }
 
+#[utoipa::path(
+    post,
+    path = "/query",
+    operation_id = "queryRows",
+    tag = "data",
+    request_body(content = QueryRequest, content_type = "application/json"),
+    responses(
+        (status = 200, description = "Materialized query result", body = QueryResponse),
+        (status = 500, description = "Engine or transport error", body = ProblemDetails, content_type = "application/problem+json")
+    )
+)]
 async fn query(
     State(state): State<HttpState>,
     V1Json(request): V1Json<QueryRequest>,
@@ -1029,6 +1177,17 @@ async fn query(
     Ok(Json(response))
 }
 
+#[utoipa::path(
+    post,
+    path = "/query/stream",
+    operation_id = "streamQueryRows",
+    tag = "data",
+    request_body(content = QueryRequest, content_type = "application/json"),
+    responses(
+        (status = 200, description = "Bounded NDJSON query stream", body = String, content_type = "application/x-ndjson"),
+        (status = 500, description = "Pre-stream engine or transport error", body = ProblemDetails, content_type = "application/problem+json")
+    )
+)]
 async fn query_stream(
     State(state): State<HttpState>,
     V1Json(request): V1Json<QueryRequest>,
@@ -1176,16 +1335,44 @@ fn ndjson_line(value: &impl Serialize) -> Bytes {
     Bytes::from(encoded)
 }
 
+#[derive(Debug, Serialize, ToSchema)]
+struct BroadcastResponse {
+    completed_shards: Vec<u16>,
+}
+
+#[utoipa::path(
+    post,
+    path = "/admin/broadcast",
+    operation_id = "broadcastMigration",
+    tag = "administration",
+    request_body(content = BroadcastRequest, content_type = "application/json"),
+    responses(
+        (status = 200, description = "Completed migration shards", body = BroadcastResponse),
+        (status = 500, description = "Engine or transport error", body = ProblemDetails, content_type = "application/problem+json")
+    )
+)]
 async fn broadcast(
     State(state): State<HttpState>,
     V1Json(request): V1Json<BroadcastRequest>,
-) -> Result<Json<JsonValue>, ApiError> {
+) -> Result<Json<BroadcastResponse>, ApiError> {
     let engine = state.engine;
     let session = engine.session();
     let shards = engine.migrate(&session, request.sql).await?;
-    Ok(Json(json!({"completed_shards": shards})))
+    Ok(Json(BroadcastResponse {
+        completed_shards: shards,
+    }))
 }
 
+#[utoipa::path(
+    get,
+    path = "/admin/global-indexes",
+    operation_id = "getGlobalIndexes",
+    tag = "administration",
+    responses(
+        (status = 200, description = "Global-index operational report", body = GlobalIndexesResponse),
+        (status = 500, description = "Engine error", body = ProblemDetails, content_type = "application/problem+json")
+    )
+)]
 async fn global_indexes(
     State(state): State<HttpState>,
 ) -> Result<Json<GlobalIndexesResponse>, ApiError> {
@@ -1656,7 +1843,7 @@ impl From<EngineError> for ApiError {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct ProblemDetails {
     #[serde(rename = "type")]
     problem_type: &'static str,
@@ -3408,7 +3595,12 @@ mod tests {
         let (production_source, _) = include_str!("http.rs")
             .split_once(&test_module_marker)
             .expect("the HTTP unit-test module has a cfg(test) boundary");
-        let production_source = [production_source, include_str!("http/v1.rs")].concat();
+        let production_source = [
+            production_source,
+            include_str!("http/v1.rs"),
+            include_str!("http/openapi.rs"),
+        ]
+        .concat();
 
         assert_eq!(
             production_source.matches("Database").count(),

--- a/src/protocol/http/openapi.rs
+++ b/src/protocol/http/openapi.rs
@@ -1,0 +1,2008 @@
+//! Deterministic OpenAPI 3.1 finalization for the annotated v1 router.
+
+use serde_json::{Map, Value, json};
+
+use crate::{
+    core::{
+        DEFAULT_LOGICAL_DATABASE_ID, DEFAULT_LOGICAL_DATABASE_NAME, DEFAULT_STREAM_BUFFER_ROWS,
+        EngineErrorKind, MAX_ACTIVE_QUERIES, MAX_GLOBAL_INDEX_OUTBOX_BYTES_PER_SHARD,
+        MAX_GLOBAL_INDEX_OUTBOX_EVENTS_PER_SHARD, MAX_GLOBAL_INDEXES, MAX_LOGICAL_DATABASES,
+        MAX_RESULT_BYTES, MAX_RESULT_ROWS, MAX_TABLES,
+    },
+    protocol::error::http_error,
+};
+
+use super::{
+    STREAM_MEDIA_TYPE,
+    v1::{MAX_REQUEST_BYTES, TransportError},
+};
+
+const DATA_SERVER: &str = "http://127.0.0.1:7654";
+const ADMIN_SERVER: &str = "http://127.0.0.1:7655";
+const MIN_PHYSICAL_SHARDS: u64 = 2;
+const MAX_PHYSICAL_SHARDS: u64 = 64;
+const MAX_PHYSICAL_SHARD_ID: u64 = MAX_PHYSICAL_SHARDS - 1;
+const MAX_SCHEMA_MIGRATION_SQL_BYTES: u64 = 65_536;
+const MAX_RETAINED_OUTBOX_EVENTS: u64 =
+    MAX_GLOBAL_INDEX_OUTBOX_EVENTS_PER_SHARD * MAX_PHYSICAL_SHARDS;
+const MAX_RETAINED_OUTBOX_BYTES: u64 =
+    MAX_GLOBAL_INDEX_OUTBOX_BYTES_PER_SHARD * MAX_PHYSICAL_SHARDS;
+const CHECKPOINT_OPERATION_ID: &str = concat!("checkpoint", "Data", "bases");
+const U64_DECIMAL_PATTERN: &str = "^(?:0|[1-9][0-9]{0,18}|1[0-7][0-9]{18}|18[0-3][0-9]{17}|184[0-3][0-9]{16}|1844[0-5][0-9]{15}|18446[0-6][0-9]{14}|184467[0-3][0-9]{13}|1844674[0-3][0-9]{12}|184467440[0-6][0-9]{10}|1844674407[0-2][0-9]{9}|18446744073[0-6][0-9]{8}|1844674407370[0-8][0-9]{6}|18446744073709[0-4][0-9]{5}|184467440737095[0-4][0-9]{4}|18446744073709550[0-9]{3}|18446744073709551[0-5][0-9]{2}|1844674407370955160[0-9]|1844674407370955161[0-4]|18446744073709551615)$";
+const SCHEMA_GENERATION_PATTERN: &str = "^(?:0|[1-9][0-9]{0,8}|1[0-9]{9}|20[0-9]{8}|21[0-3][0-9]{7}|214[0-6][0-9]{6}|2147[0-3][0-9]{5}|21474[0-7][0-9]{4}|214748[0-2][0-9]{3}|2147483[0-5][0-9]{2}|21474836[0-3][0-9]|214748364[0-7])$";
+const CANONICAL_BASE64_PATTERN: &str =
+    r"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/][AQgw]==|[A-Za-z0-9+/]{2}[AEIMQUYcgkosw048]=)?$";
+// The round-to-nearest overflow midpoint `(2^54 - 1) * 2^970`. Decimal or
+// exponent request tokens strictly inside these bounds convert to a finite
+// binary64 value; tokens at either bound convert to infinity.
+const F64_ROUNDING_OVERFLOW_MIDPOINT: &str = "179769313486231580793728971405303415079934132710037826936173778980444968292764750946649017977587207096330286416692887910946555547851940402630657488671505820681908902000708383676273854845817711531764475730270069855571366959622842914819860834936475292719074168444365510704342711559699508093042880177904174497792";
+
+const ROUTES: &[&str] = &[
+    "/",
+    "/execute",
+    "/query",
+    "/query/stream",
+    "/health",
+    "/ready",
+    "/admin/broadcast",
+    "/admin/global-indexes",
+    "/admin/catalog",
+    "/admin/migrations",
+    "/admin/migrations/{target_generation}",
+    "/admin/shards",
+    "/admin/queries",
+    "/admin/queries/{operation_id}/cancel",
+    "/admin/backup",
+    "/admin/maintenance/checkpoint",
+];
+
+const ENGINE_ERROR_STATUSES: &[u16] = &[403, 409, 422, 500, 501, 503, 504, 507];
+
+pub(super) fn document() -> Value {
+    let generated = serde_json::to_value(super::v1::openapi())
+        .expect("the annotated HTTP v1 OpenAPI model is serializable");
+    let mut generated_paths = generated
+        .get("paths")
+        .and_then(Value::as_object)
+        .cloned()
+        .expect("the annotated HTTP v1 router has paths");
+
+    let mut paths = Map::new();
+    for relative_path in ROUTES {
+        let mut item = generated_paths
+            .remove(*relative_path)
+            .unwrap_or_else(|| panic!("annotated HTTP v1 route {relative_path} is missing"));
+        let operations = item
+            .as_object_mut()
+            .expect("an OpenAPI path item is an object");
+        for method in ["get", "post"] {
+            if let Some(operation) = operations.get_mut(method) {
+                finalize_operation(relative_path, operation);
+            }
+        }
+        if let Some(get) = operations.get("get").cloned() {
+            operations.insert("head".to_owned(), head_operation(get));
+        }
+
+        let full_path = if *relative_path == "/" {
+            "/v1".to_owned()
+        } else {
+            format!("/v1{relative_path}")
+        };
+        paths.insert(full_path, item);
+    }
+    assert!(
+        generated_paths.is_empty(),
+        "an annotated HTTP v1 route is missing from the OpenAPI scope: {:?}",
+        generated_paths.keys().collect::<Vec<_>>()
+    );
+
+    let mut discovery_alias = paths
+        .get("/v1")
+        .cloned()
+        .expect("the annotated discovery route exists");
+    let alias = discovery_alias
+        .as_object_mut()
+        .expect("the discovery path item is an object");
+    alias["get"]["operationId"] = json!("getApiVersionAlias");
+    alias["get"]["summary"] = json!("Discover HTTP API version through the slash alias");
+    alias["head"]["operationId"] = json!("headApiVersionAlias");
+    alias["head"]["summary"] = json!("Inspect discovery headers through the slash alias");
+    paths.insert("/v1/".to_owned(), discovery_alias);
+
+    let mut schemas = generated
+        .pointer("/components/schemas")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    finalize_schemas(&mut schemas);
+
+    json!({
+        "openapi": "3.1.0",
+        "jsonSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
+        "info": {
+            "title": "BriskDB HTTP API",
+            "version": "1",
+            "description": "Versioned BriskDB data and administration machine API. The API version is independent of the Cargo package and storage-format versions.",
+            "license": {"name": "MIT"}
+        },
+        "tags": [
+            {"name": "data", "description": "SQL query and write operations on the data listener."},
+            {"name": "administration", "description": "Operational inspection and maintenance on the administration listener."}
+        ],
+        "paths": Value::Object(paths),
+        "components": {
+            "schemas": Value::Object(schemas),
+            "parameters": component_parameters(),
+            "headers": component_headers(),
+            "responses": component_responses()
+        },
+        "x-briskdb-engine-errors": engine_error_mappings(),
+        "x-briskdb-transport-errors": transport_error_mappings(),
+        "x-briskdb-wire-contract": {
+            "maxRequestBytes": MAX_REQUEST_BYTES,
+            "requestObjectsRejectUnknownAndDuplicateMembers": true,
+            "requestControlHeadersRequireOneCanonicalValue": true,
+            "openapiCannotValidateDuplicateJsonMembersOrRawHeaderMultiplicity": true,
+            "idempotencyStatusHeaderIsConditional": true
+        }
+    })
+}
+
+fn finalize_operation(relative_path: &str, operation: &mut Value) {
+    let object = operation
+        .as_object_mut()
+        .expect("an OpenAPI operation is an object");
+    let operation_id = object
+        .get("operationId")
+        .and_then(Value::as_str)
+        .expect("every annotated HTTP v1 operation has a stable ID")
+        .to_owned();
+    let listener = listener(relative_path);
+    let (url, description) = match listener {
+        "data" => (DATA_SERVER, "Data listener (default address)"),
+        "administration" => (ADMIN_SERVER, "Administration listener (default address)"),
+        _ => unreachable!(),
+    };
+    object.insert(
+        "summary".to_owned(),
+        json!(operation_summary(&operation_id)),
+    );
+    object.insert("tags".to_owned(), json!([listener]));
+    object.insert(
+        "servers".to_owned(),
+        json!([{"url": url, "description": description}]),
+    );
+    object.insert("x-briskdb-plane".to_owned(), json!(listener));
+
+    let mut parameters = vec![ref_value("#/components/parameters/BriskDBRequestId")];
+    if let Some(existing) = object
+        .remove("parameters")
+        .and_then(|value| value.as_array().cloned())
+    {
+        parameters.extend(existing);
+    }
+    if operation_id == "executeStatement" {
+        parameters.push(ref_value("#/components/parameters/BriskDBIdempotencyKey"));
+    }
+    for parameter in &mut parameters {
+        let Some(parameter) = parameter.as_object_mut() else {
+            continue;
+        };
+        match parameter.get("name").and_then(Value::as_str) {
+            Some("target_generation") => {
+                parameter.insert("required".to_owned(), json!(true));
+                parameter.insert("schema".to_owned(), canonical_positive_u64_string());
+            }
+            Some("operation_id") => {
+                parameter.insert("required".to_owned(), json!(true));
+                parameter.insert(
+                    "schema".to_owned(),
+                    ref_value("#/components/schemas/OpaqueId"),
+                );
+            }
+            _ => {}
+        }
+    }
+    object.insert("parameters".to_owned(), Value::Array(parameters));
+
+    if matches!(
+        operation_id.as_str(),
+        "executeStatement"
+            | "queryRows"
+            | "streamQueryRows"
+            | "broadcastMigration"
+            | CHECKPOINT_OPERATION_ID
+    ) {
+        let schema = match operation_id.as_str() {
+            "executeStatement" => "ExecuteRequest",
+            "queryRows" | "streamQueryRows" => "QueryRequest",
+            "broadcastMigration" => "BroadcastRequest",
+            CHECKPOINT_OPERATION_ID => "EmptyRequest",
+            _ => unreachable!(),
+        };
+        object.insert(
+            "requestBody".to_owned(),
+            json!({
+                "required": true,
+                "content": {
+                    "application/json": {
+                        "schema": ref_value(&format!("#/components/schemas/{schema}"))
+                    }
+                }
+            }),
+        );
+        object.insert(
+            "x-briskdb-max-request-bytes".to_owned(),
+            json!(MAX_REQUEST_BYTES),
+        );
+    } else if operation_id == "cancelQuery" {
+        object.remove("requestBody");
+        object.insert(
+            "x-briskdb-request-body".to_owned(),
+            json!({"mode": "exactly-zero-bytes", "maxBytes": MAX_REQUEST_BYTES}),
+        );
+    } else {
+        object.remove("requestBody");
+    }
+
+    object.insert("responses".to_owned(), operation_responses(&operation_id));
+}
+
+fn head_operation(mut get: Value) -> Value {
+    let object = get
+        .as_object_mut()
+        .expect("a generated GET operation is an object");
+    let get_id = object["operationId"]
+        .as_str()
+        .expect("a generated GET operation has an ID")
+        .to_owned();
+    object.insert("operationId".to_owned(), json!(head_operation_id(&get_id)));
+    object.insert(
+        "summary".to_owned(),
+        json!(format!(
+            "Inspect headers for {}",
+            operation_summary(&get_id).to_lowercase()
+        )),
+    );
+    object.insert("x-briskdb-implicit-head".to_owned(), json!(true));
+    object.remove("requestBody");
+    if let Some(responses) = object.get_mut("responses").and_then(Value::as_object_mut) {
+        for response in responses.values_mut() {
+            if response.get("$ref").is_some() {
+                let status = referenced_problem_status(response)
+                    .expect("a referenced GET response is a reusable Problem response");
+                *response = problem_response(status);
+            }
+            if let Some(response) = response.as_object_mut() {
+                let content_type =
+                    response
+                        .get("content")
+                        .and_then(Value::as_object)
+                        .map(|content| {
+                            assert_eq!(
+                                content.len(),
+                                1,
+                                "a GET response has exactly one representation media type"
+                            );
+                            content
+                                .keys()
+                                .next()
+                                .expect("a nonempty response content object")
+                                .to_owned()
+                        });
+                response.remove("content");
+                let headers = response
+                    .entry("headers")
+                    .or_insert_with(|| Value::Object(Map::new()))
+                    .as_object_mut()
+                    .expect("response headers are an object");
+                headers.insert(
+                    "Content-Length".to_owned(),
+                    ref_value("#/components/headers/ContentLength"),
+                );
+                if let Some(content_type) = content_type {
+                    headers.insert(
+                        "Content-Type".to_owned(),
+                        json!({
+                            "description": "Media type of the corresponding GET representation.",
+                            "required": true,
+                            "schema": {"type": "string", "const": content_type}
+                        }),
+                    );
+                }
+            }
+        }
+    }
+    get
+}
+
+fn listener(path: &str) -> &'static str {
+    if matches!(path, "/" | "/execute" | "/query" | "/query/stream") {
+        "data"
+    } else {
+        "administration"
+    }
+}
+
+fn operation_summary(operation_id: &str) -> &'static str {
+    match operation_id {
+        "getApiVersion" => "Discover HTTP API version",
+        "executeStatement" => "Execute one routed write",
+        "queryRows" => "Query materialized rows",
+        "streamQueryRows" => "Stream bounded query rows",
+        "getHealth" => "Inspect engine and global-index health",
+        "getReadiness" => "Inspect request-admission readiness",
+        "broadcastMigration" => "Apply a journaled schema migration",
+        "getGlobalIndexes" => "Inspect global-index operation",
+        "getCatalog" => "Inspect the relational catalog",
+        "listMigrations" => "Inspect migration summary",
+        "getMigration" => "Inspect one migration generation",
+        "listShards" => "Inspect validated physical shards",
+        "listActiveQueries" => "List active HTTP queries",
+        "cancelQuery" => "Cancel one active HTTP query",
+        "getBackupCapability" => "Inspect backup capability",
+        CHECKPOINT_OPERATION_ID => "Checkpoint every database",
+        _ => panic!("unknown annotated HTTP v1 operation ID: {operation_id}"),
+    }
+}
+
+fn head_operation_id(get_id: &str) -> &'static str {
+    match get_id {
+        "getApiVersion" => "headApiVersion",
+        "getHealth" => "headHealth",
+        "getReadiness" => "headReadiness",
+        "getGlobalIndexes" => "headGlobalIndexes",
+        "getCatalog" => "headCatalog",
+        "listMigrations" => "headMigrations",
+        "getMigration" => "headMigration",
+        "listShards" => "headShards",
+        "listActiveQueries" => "headActiveQueries",
+        "getBackupCapability" => "headBackupCapability",
+        _ => panic!("POST operation unexpectedly acquired HEAD: {get_id}"),
+    }
+}
+
+fn operation_responses(operation_id: &str) -> Value {
+    let (success_status, success_description, success_schema) = match operation_id {
+        "getApiVersion" => (200, "HTTP API version", "ApiVersion"),
+        "executeStatement" => (200, "Routed write result", "ExecuteResponse"),
+        "queryRows" => (200, "Materialized query result", "QueryResponse"),
+        "getHealth" => (200, "Engine and global-index health", "HealthResponse"),
+        "getReadiness" => (200, "Ready for ordinary requests", "ReadyResponse"),
+        "broadcastMigration" => (200, "Completed migration shards", "BroadcastResponse"),
+        "getGlobalIndexes" => (
+            200,
+            "Global-index operational report",
+            "GlobalIndexesResponse",
+        ),
+        "getCatalog" => (200, "Relational catalog", "CatalogResponse"),
+        "listMigrations" => (200, "Migration summary", "MigrationsResponse"),
+        "getMigration" => (200, "Migration generation", "MigrationResponse"),
+        "listShards" => (200, "Validated physical shards", "ShardStatusResponse"),
+        "listActiveQueries" => (200, "Active HTTP queries", "ActiveQueriesResponse"),
+        "cancelQuery" => (202, "Cancellation requested", "CancelQueryResponse"),
+        "getBackupCapability" => (200, "Backup capability", "BackupCapabilityResponse"),
+        CHECKPOINT_OPERATION_ID => (200, "Passive checkpoint report", "CheckpointResponse"),
+        "streamQueryRows" => {
+            let mut responses = Map::new();
+            responses.insert("200".to_owned(), stream_response());
+            add_operation_errors(operation_id, &mut responses);
+            return Value::Object(responses);
+        }
+        _ => panic!("unknown annotated HTTP v1 operation ID: {operation_id}"),
+    };
+    let mut responses = Map::new();
+    responses.insert(
+        success_status.to_string(),
+        json_response(success_description, success_schema, operation_id),
+    );
+    if operation_id == "getReadiness" {
+        responses.insert(
+            "503".to_owned(),
+            json_response(
+                "Not ready for ordinary requests",
+                "NotReadyResponse",
+                operation_id,
+            ),
+        );
+    }
+    add_operation_errors(operation_id, &mut responses);
+    Value::Object(responses)
+}
+
+fn add_operation_errors(operation_id: &str, responses: &mut Map<String, Value>) {
+    responses
+        .entry("400".to_owned())
+        .or_insert_with(|| problem_response_ref(400));
+    responses
+        .entry("501".to_owned())
+        .or_insert_with(|| problem_response_ref(501));
+
+    if matches!(
+        operation_id,
+        "executeStatement"
+            | "queryRows"
+            | "streamQueryRows"
+            | "broadcastMigration"
+            | CHECKPOINT_OPERATION_ID
+    ) {
+        responses.insert("413".to_owned(), problem_response_ref(413));
+        responses.insert("415".to_owned(), problem_response_ref(415));
+    } else if operation_id == "cancelQuery" {
+        responses.insert("413".to_owned(), problem_response_ref(413));
+    }
+
+    if matches!(operation_id, "getMigration" | "cancelQuery") {
+        responses.insert("404".to_owned(), problem_response_ref(404));
+    }
+
+    if matches!(
+        operation_id,
+        "executeStatement"
+            | "queryRows"
+            | "streamQueryRows"
+            | "getHealth"
+            | "broadcastMigration"
+            | "getGlobalIndexes"
+            | "listMigrations"
+            | "getMigration"
+            | "listShards"
+            | CHECKPOINT_OPERATION_ID
+    ) {
+        for status in ENGINE_ERROR_STATUSES {
+            responses.insert(status.to_string(), problem_response_ref(*status));
+        }
+    }
+}
+
+fn problem_response_ref(status: u16) -> Value {
+    ref_value(&format!("#/components/responses/Problem{status}"))
+}
+
+fn referenced_problem_status(response: &Value) -> Option<u16> {
+    response
+        .get("$ref")
+        .and_then(Value::as_str)
+        .and_then(|reference| reference.strip_prefix("#/components/responses/Problem"))
+        .and_then(|status| status.parse().ok())
+}
+
+fn json_response(description: &str, schema: &str, operation_id: &str) -> Value {
+    let mut headers = common_response_headers();
+    if operation_id == "executeStatement" {
+        headers.insert(
+            "BriskDB-Idempotency-Status".to_owned(),
+            ref_value("#/components/headers/BriskDBIdempotencyStatus"),
+        );
+    }
+    json!({
+        "description": description,
+        "headers": Value::Object(headers),
+        "content": {
+            "application/json": {
+                "schema": ref_value(&format!("#/components/schemas/{schema}"))
+            }
+        }
+    })
+}
+
+fn stream_response() -> Value {
+    let mut content = Map::new();
+    content.insert(
+        STREAM_MEDIA_TYPE.to_owned(),
+        json!({
+            "schema": {
+                "type": "string",
+                "description": "A byte sequence of compact JSON records, each terminated by LF. It is not one JSON instance. Every row uses the value encoding declared by the preceding metadata record."
+            },
+            "x-briskdb-ndjson": {
+                "framing": "lf-delimited-json",
+                "delimiter": "LF",
+                "compact": true,
+                "sequence": [
+                    {
+                        "schema": "#/components/schemas/QueryStreamMeta",
+                        "minimum": 1,
+                        "maximum": 1
+                    },
+                    {
+                        "schema": "#/components/schemas/QueryStreamRow",
+                        "minimum": 0,
+                        "maximum": MAX_RESULT_ROWS
+                    },
+                    {
+                        "oneOf": [
+                            "#/components/schemas/QueryStreamComplete",
+                            "#/components/schemas/QueryStreamError"
+                        ],
+                        "minimum": 1,
+                        "maximum": 1
+                    }
+                ],
+                "terminalRecordRequired": true,
+                "eofBeforeTerminal": "indeterminate",
+                "lateErrorsRetainHttpStatus": 200
+            }
+        }),
+    );
+    json!({
+        "description": "Bounded NDJSON query stream",
+        "headers": Value::Object(common_response_headers()),
+        "content": Value::Object(content)
+    })
+}
+
+fn problem_response(status: u16) -> Value {
+    let mut headers = common_response_headers();
+    if status == 405 {
+        headers.insert("Allow".to_owned(), ref_value("#/components/headers/Allow"));
+    }
+    json!({
+        "description": problem_description(status),
+        "headers": Value::Object(headers),
+        "content": {
+            "application/problem+json": {
+                "schema": ref_value(&format!("#/components/schemas/ProblemDetails{status}"))
+            }
+        }
+    })
+}
+
+fn common_response_headers() -> Map<String, Value> {
+    Map::from_iter([
+        (
+            "BriskDB-API-Version".to_owned(),
+            ref_value("#/components/headers/BriskDBApiVersion"),
+        ),
+        (
+            "BriskDB-Request-ID".to_owned(),
+            ref_value("#/components/headers/BriskDBRequestId"),
+        ),
+    ])
+}
+
+fn problem_description(status: u16) -> &'static str {
+    match status {
+        400 => "Invalid request or argument",
+        403 => "Permission denied or read-only storage",
+        404 => "Resource not found",
+        405 => "Method not allowed",
+        409 => "State or constraint conflict",
+        413 => "Request body too large",
+        415 => "Unsupported request media type",
+        422 => "Unprocessable value, query, type, or limit",
+        500 => "Cancelled request, corruption, or internal error",
+        501 => "Unsupported operation or globally rejected request control",
+        503 => "Storage, memory, contention, or shutdown unavailable",
+        504 => "Request deadline exceeded",
+        507 => "Storage full",
+        _ => panic!("undocumented HTTP problem status: {status}"),
+    }
+}
+
+fn component_parameters() -> Value {
+    json!({
+        "BriskDBRequestId": {
+            "name": "BriskDB-Request-ID",
+            "in": "header",
+            "required": false,
+            "description": "Optional caller-supplied correlation ID. It must occur exactly once and use the canonical nonzero 128-bit lowercase hexadecimal form.",
+            "schema": ref_value("#/components/schemas/OpaqueId")
+        },
+        "BriskDBIdempotencyKey": {
+            "name": "BriskDB-Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Optional durable idempotency key for an eligible exact-target direct autocommit DML request.",
+            "schema": ref_value("#/components/schemas/OpaqueId")
+        }
+    })
+}
+
+fn component_headers() -> Value {
+    json!({
+        "BriskDBApiVersion": {
+            "description": "Version of the HTTP representation contract.",
+            "required": true,
+            "schema": {"type": "string", "const": "1"}
+        },
+        "BriskDBRequestId": {
+            "description": "Canonical request correlation ID supplied or generated for this attempt.",
+            "required": true,
+            "schema": ref_value("#/components/schemas/OpaqueId")
+        },
+        "BriskDBIdempotencyStatus": {
+            "description": "Present only for a successfully created or replayed durable idempotency receipt.",
+            "required": false,
+            "schema": {"type": "string", "enum": ["created", "replayed"]}
+        },
+        "ContentLength": {
+            "description": "The size of the corresponding GET representation; a HEAD response carries no body.",
+            "required": true,
+            "schema": {"type": "integer", "minimum": 0, "maximum": u64::MAX}
+        },
+        "Allow": {
+            "description": "Methods accepted by the matched HTTP v1 route family.",
+            "required": true,
+            "schema": {"type": "string", "enum": ["GET,HEAD", "POST"]}
+        }
+    })
+}
+
+fn component_responses() -> Value {
+    let mut responses = Map::new();
+    for status in [
+        400_u16, 403, 404, 405, 409, 413, 415, 422, 500, 501, 503, 504, 507,
+    ] {
+        responses.insert(format!("Problem{status}"), problem_response(status));
+    }
+    Value::Object(responses)
+}
+
+fn engine_error_mappings() -> Value {
+    Value::Array(
+        EngineErrorKind::ALL
+            .iter()
+            .copied()
+            .map(|kind| {
+                let mapping = http_error(kind);
+                json!({
+                    "code": kind.code(),
+                    "status": mapping.status,
+                    "type": mapping.problem_type,
+                    "title": mapping.title,
+                    "detail": mapping.detail
+                })
+            })
+            .collect(),
+    )
+}
+
+fn transport_error_mappings() -> Value {
+    Value::Array(
+        TransportError::ALL
+            .iter()
+            .copied()
+            .map(|error| {
+                let mapping = error.mapping();
+                json!({
+                    "code": mapping.code,
+                    "status": mapping.status,
+                    "type": mapping.problem_type,
+                    "title": mapping.title,
+                    "detail": mapping.detail
+                })
+            })
+            .collect(),
+    )
+}
+
+fn ref_value(reference: &str) -> Value {
+    json!({"$ref": reference})
+}
+
+fn finalize_schemas(schemas: &mut Map<String, Value>) {
+    schemas.remove("Value");
+    for schema in schemas.values_mut() {
+        if schema.get("type").and_then(Value::as_str) == Some("object") {
+            schema["additionalProperties"] = json!(false);
+        }
+    }
+
+    let additions = [
+        ("OpaqueId", opaque_id_schema()),
+        (
+            "LegacyJsonValue",
+            described_ref(
+                "#/components/schemas/LegacyJsonParameter",
+                "The legacy parameter codec accepts recursively nested JSON and binds arrays and objects as compact JSON text.",
+            ),
+        ),
+        ("LegacyJsonParameter", legacy_json_parameter_schema()),
+        (
+            "LegacyJsonParameterNumber",
+            legacy_json_parameter_number_schema(),
+        ),
+        ("LegacyJsonNumber", legacy_json_number_schema()),
+        ("LegacyJsonCell", legacy_json_cell_schema()),
+        ("LosslessJsonValue", lossless_value_schema()),
+        ("LosslessInt64", lossless_int64_schema()),
+        ("LosslessUInt64", lossless_uint64_schema()),
+        (
+            "LosslessFloat64",
+            tagged_value_schema("float64", "^[0-9a-f]{16}$"),
+        ),
+        (
+            "LosslessDecimal",
+            tagged_value_schema(
+                "decimal",
+                r"^[+-]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?$",
+            ),
+        ),
+        (
+            "LosslessBinary",
+            tagged_value_schema("binary", CANONICAL_BASE64_PATTERN),
+        ),
+        (
+            "LosslessInvalidText",
+            tagged_value_schema("invalid_text", CANONICAL_BASE64_PATTERN),
+        ),
+        ("LegacyExecuteRequest", sql_request_schema(false, false)),
+        ("LosslessExecuteRequest", sql_request_schema(true, false)),
+        ("LegacyQueryRequest", sql_request_schema(false, true)),
+        ("LosslessQueryRequest", sql_request_schema(true, true)),
+        (
+            "LegacySingleShardQueryResponse",
+            query_response_schema(false, true),
+        ),
+        (
+            "LegacyMultiShardQueryResponse",
+            query_response_schema(false, false),
+        ),
+        (
+            "LosslessSingleShardQueryResponse",
+            query_response_schema(true, true),
+        ),
+        (
+            "LosslessMultiShardQueryResponse",
+            query_response_schema(true, false),
+        ),
+        (
+            "LegacySingleShardStreamMeta",
+            stream_meta_schema(false, true),
+        ),
+        (
+            "LegacyMultiShardStreamMeta",
+            stream_meta_schema(false, false),
+        ),
+        (
+            "LosslessSingleShardStreamMeta",
+            stream_meta_schema(true, true),
+        ),
+        (
+            "LosslessMultiShardStreamMeta",
+            stream_meta_schema(true, false),
+        ),
+    ];
+    for (name, schema) in additions {
+        schemas.insert(name.to_owned(), schema);
+    }
+
+    schemas.insert(
+        "ValueEncoding".to_owned(),
+        json!({"type": "string", "enum": ["legacy-json-v1", "lossless-json-v1"], "default": "legacy-json-v1"}),
+    );
+    schemas.insert(
+        "ExecuteRequest".to_owned(),
+        refs_one_of(&["LegacyExecuteRequest", "LosslessExecuteRequest"]),
+    );
+    schemas.insert(
+        "QueryRequest".to_owned(),
+        refs_one_of(&["LegacyQueryRequest", "LosslessQueryRequest"]),
+    );
+    schemas.insert("QueryResultLimits".to_owned(), query_result_limits_schema());
+    schemas.insert(
+        "BroadcastRequest".to_owned(),
+        strict_object(&["sql"], json!({"sql": {"type": "string"}})),
+    );
+    schemas.insert(
+        "EmptyRequest".to_owned(),
+        json!({"type": "object", "maxProperties": 0, "additionalProperties": false}),
+    );
+    schemas.insert("ApiVersion".to_owned(), api_version_schema());
+    schemas.insert("HealthResponse".to_owned(), health_schema());
+    schemas.insert(
+        "HealthGlobalIndexesResponse".to_owned(),
+        health_global_indexes_schema(),
+    );
+    schemas.insert("ReadinessResponse".to_owned(), readiness_schema());
+    schemas.insert("ReadyResponse".to_owned(), ready_schema(true));
+    schemas.insert("NotReadyResponse".to_owned(), ready_schema(false));
+    schemas.insert("QueryColumn".to_owned(), query_column_schema());
+    schemas.insert(
+        "QueryResponse".to_owned(),
+        refs_one_of(&[
+            "LegacySingleShardQueryResponse",
+            "LegacyMultiShardQueryResponse",
+            "LosslessSingleShardQueryResponse",
+            "LosslessMultiShardQueryResponse",
+        ]),
+    );
+    schemas.insert(
+        "QueryStreamMeta".to_owned(),
+        refs_one_of(&[
+            "LegacySingleShardStreamMeta",
+            "LegacyMultiShardStreamMeta",
+            "LosslessSingleShardStreamMeta",
+            "LosslessMultiShardStreamMeta",
+        ]),
+    );
+    schemas.insert("QueryStreamRow".to_owned(), stream_row_schema());
+    schemas.insert("QueryStreamComplete".to_owned(), stream_complete_schema());
+    schemas.insert("QueryStreamError".to_owned(), stream_error_schema());
+    schemas.insert(
+        "QueryStreamRecord".to_owned(),
+        refs_one_of(&[
+            "QueryStreamMeta",
+            "QueryStreamRow",
+            "QueryStreamComplete",
+            "QueryStreamError",
+        ]),
+    );
+
+    finalize_operational_schemas(schemas);
+    finalize_problem_schemas(schemas);
+}
+
+fn opaque_id_schema() -> Value {
+    json!({
+        "allOf": [
+            {"type": "string", "pattern": "^[0-9a-f]{32}$"},
+            {"not": {"const": "00000000000000000000000000000000"}}
+        ],
+        "examples": ["0123456789abcdef0123456789abcdef"]
+    })
+}
+
+fn legacy_json_parameter_schema() -> Value {
+    json!({
+        "description": "One legacy-json-v1 request parameter. Integer tokens fit i64 or u64; fractional or exponent tokens must convert to finite binary64. JSON Schema validation cannot retain the original number token spelling, so its numeric schema accepts every value whose conversion rounds to a finite binary64 value.",
+        "oneOf": [
+            {"type": "null"},
+            {"type": "boolean"},
+            ref_value("#/components/schemas/LegacyJsonParameterNumber"),
+            {"type": "string"},
+            {"type": "array", "items": ref_value("#/components/schemas/LegacyJsonParameter")},
+            {"type": "object", "additionalProperties": ref_value("#/components/schemas/LegacyJsonParameter")}
+        ],
+        "x-briskdb-number-token-limit": "JSON Schema sees numeric value, while the decoder also distinguishes integer tokens from fractional or exponent tokens."
+    })
+}
+
+fn legacy_json_parameter_number_schema() -> Value {
+    let negative_overflow_midpoint = format!("-{F64_ROUNDING_OVERFLOW_MIDPOINT}");
+    json!({
+        "description": "A legacy request JSON number whose conversion rounds to a finite binary64 value. The decoder additionally restricts bare integer tokens to i64 or u64.",
+        "type": "number",
+        "exclusiveMinimum": exact_json_number(&negative_overflow_midpoint),
+        "exclusiveMaximum": exact_json_number(F64_ROUNDING_OVERFLOW_MIDPOINT)
+    })
+}
+
+fn legacy_json_number_schema() -> Value {
+    json!({
+        "description": "A legacy result JSON number within the finite binary64 range.",
+        "type": "number",
+        "minimum": -f64::MAX,
+        "maximum": f64::MAX
+    })
+}
+
+fn exact_json_number(number: &str) -> Value {
+    serde_json::from_str(number).expect("a fixed OpenAPI numeric bound is valid JSON")
+}
+
+fn lossless_value_schema() -> Value {
+    json!({
+        "description": "One canonical lossless-json-v1 BriskDB value.",
+        "oneOf": [
+            {"type": "null"},
+            {"type": "boolean"},
+            {"type": "string"},
+            ref_value("#/components/schemas/LosslessInt64"),
+            ref_value("#/components/schemas/LosslessUInt64"),
+            ref_value("#/components/schemas/LosslessFloat64"),
+            ref_value("#/components/schemas/LosslessDecimal"),
+            ref_value("#/components/schemas/LosslessBinary"),
+            ref_value("#/components/schemas/LosslessInvalidText")
+        ]
+    })
+}
+
+fn tagged_value_schema(kind: &str, pattern: &str) -> Value {
+    strict_object(
+        &["$briskdb_type", "value"],
+        json!({
+            "$briskdb_type": {"type": "string", "const": kind},
+            "value": {"type": "string", "pattern": pattern}
+        }),
+    )
+}
+
+fn lossless_int64_schema() -> Value {
+    strict_object(
+        &["$briskdb_type", "value"],
+        json!({
+            "$briskdb_type": {"type": "string", "const": "int64"},
+            "value": {
+                "type": "string",
+                "oneOf": [
+                    {"pattern": "^(?:0|[1-9][0-9]{0,17}|[1-8][0-9]{18}|9[0-1][0-9]{17}|92[0-1][0-9]{16}|922[0-2][0-9]{15}|9223[0-2][0-9]{14}|92233[0-6][0-9]{13}|922337[0-1][0-9]{12}|92233720[0-2][0-9]{10}|922337203[0-5][0-9]{9}|9223372036[0-7][0-9]{8}|92233720368[0-4][0-9]{7}|922337203685[0-3][0-9]{6}|9223372036854[0-6][0-9]{5}|92233720368547[0-6][0-9]{4}|922337203685477[0-4][0-9]{3}|9223372036854775[0-7][0-9]{2}|922337203685477580[0-6]|9223372036854775807)$"},
+                    {"pattern": "^-(?:[1-9][0-9]{0,17}|[1-8][0-9]{18}|9[0-1][0-9]{17}|92[0-1][0-9]{16}|922[0-2][0-9]{15}|9223[0-2][0-9]{14}|92233[0-6][0-9]{13}|922337[0-1][0-9]{12}|92233720[0-2][0-9]{10}|922337203[0-5][0-9]{9}|9223372036[0-7][0-9]{8}|92233720368[0-4][0-9]{7}|922337203685[0-3][0-9]{6}|9223372036854[0-6][0-9]{5}|92233720368547[0-6][0-9]{4}|922337203685477[0-4][0-9]{3}|9223372036854775[0-7][0-9]{2}|922337203685477580[0-7]|9223372036854775808)$"}
+                ]
+            }
+        }),
+    )
+}
+
+fn lossless_uint64_schema() -> Value {
+    tagged_value_schema("uint64", U64_DECIMAL_PATTERN)
+}
+
+fn sql_request_schema(lossless: bool, query: bool) -> Value {
+    let mut properties = Map::from_iter([
+        ("shard_key".to_owned(), json!({"type": ["string", "null"]})),
+        ("sql".to_owned(), json!({"type": "string"})),
+        (
+            "params".to_owned(),
+            json!({
+                "type": "array",
+                "items": ref_value(if lossless {
+                    "#/components/schemas/LosslessJsonValue"
+                } else {
+                    "#/components/schemas/LegacyJsonParameter"
+                }),
+                "default": []
+            }),
+        ),
+        (
+            "value_encoding".to_owned(),
+            if lossless {
+                json!({"type": "string", "const": "lossless-json-v1"})
+            } else {
+                json!({
+                    "type": "string",
+                    "const": "legacy-json-v1",
+                    "default": "legacy-json-v1"
+                })
+            },
+        ),
+    ]);
+    if query {
+        properties.insert(
+            "result_limits".to_owned(),
+            ref_value("#/components/schemas/QueryResultLimits"),
+        );
+    }
+    let required = if lossless {
+        vec!["sql", "value_encoding"]
+    } else {
+        vec!["sql"]
+    };
+    strict_object(&required, Value::Object(properties))
+}
+
+fn query_result_limits_schema() -> Value {
+    json!({
+        "type": "object",
+        "minProperties": 1,
+        "properties": {
+            "max_rows": {"type": "integer", "minimum": 1, "maximum": MAX_RESULT_ROWS},
+            "max_logical_bytes": {"type": "integer", "minimum": 1, "maximum": MAX_RESULT_BYTES}
+        },
+        "additionalProperties": false,
+        "x-briskdb-number-token-limit": "max_rows and max_logical_bytes require unsigned-integer JSON token spelling; JSON Schema validators may also accept mathematically integral decimal or exponent tokens."
+    })
+}
+
+fn refs_one_of(names: &[&str]) -> Value {
+    json!({
+        "oneOf": names
+            .iter()
+            .map(|name| ref_value(&format!("#/components/schemas/{name}")))
+            .collect::<Vec<_>>()
+    })
+}
+
+fn described_ref(reference: &str, description: &str) -> Value {
+    json!({"$ref": reference, "description": description})
+}
+
+fn strict_object(required: &[&str], properties: Value) -> Value {
+    let mut schema = Map::from_iter([
+        ("type".to_owned(), json!("object")),
+        ("properties".to_owned(), properties),
+        ("additionalProperties".to_owned(), json!(false)),
+    ]);
+    if !required.is_empty() {
+        schema.insert("required".to_owned(), json!(required));
+    }
+    Value::Object(schema)
+}
+
+fn unsigned_integer(maximum: Option<u64>) -> Value {
+    let mut schema = Map::from_iter([
+        ("type".to_owned(), json!("integer")),
+        ("minimum".to_owned(), json!(0)),
+    ]);
+    if let Some(maximum) = maximum {
+        schema.insert("maximum".to_owned(), json!(maximum));
+    }
+    Value::Object(schema)
+}
+
+fn canonical_positive_u64_string() -> Value {
+    json!({
+        "type": "string",
+        "pattern": "^(?:[1-9][0-9]{0,18}|1[0-7][0-9]{18}|18[0-3][0-9]{17}|184[0-3][0-9]{16}|1844[0-5][0-9]{15}|18446[0-6][0-9]{14}|184467[0-3][0-9]{13}|1844674[0-3][0-9]{12}|184467440[0-6][0-9]{10}|1844674407[0-2][0-9]{9}|18446744073[0-6][0-9]{8}|1844674407370[0-8][0-9]{6}|18446744073709[0-4][0-9]{5}|184467440737095[0-4][0-9]{4}|1844674407370955[0][0-9]{3}|18446744073709551[0-5][0-9]{2}|184467440737095516[0][0-9]|1844674407370955161[0-4]|18446744073709551615)$"
+    })
+}
+
+fn schema_generation_string() -> Value {
+    json!({"type": "string", "pattern": SCHEMA_GENERATION_PATTERN})
+}
+
+fn positive_schema_generation_string() -> Value {
+    let mut schema = schema_generation_string();
+    schema["not"] = json!({"const": "0"});
+    schema
+}
+
+fn array_of(reference: &str) -> Value {
+    json!({"type": "array", "items": ref_value(reference)})
+}
+
+fn api_version_schema() -> Value {
+    response_object(
+        &[
+            "api_version",
+            "value_encoding",
+            "supported_value_encodings",
+            "session_scope",
+            "sql_dialect",
+            "max_request_bytes",
+            "max_result_rows",
+            "max_result_logical_bytes",
+            "stream_buffer_rows",
+            "request_id_header",
+            "idempotency_key_header",
+            "stream_media_type",
+        ],
+        json!({
+            "api_version": {"type": "string", "const": "1"},
+            "value_encoding": {"type": "string", "const": "legacy-json-v1"},
+            "supported_value_encodings": {
+                "type": "array",
+                "prefixItems": [
+                    {"type": "string", "const": "legacy-json-v1"},
+                    {"type": "string", "const": "lossless-json-v1"}
+                ],
+                "items": false,
+                "minItems": 2,
+                "maxItems": 2
+            },
+            "session_scope": {"type": "string", "const": "request"},
+            "sql_dialect": {"type": "string", "const": "sqlite"},
+            "max_request_bytes": {"type": "integer", "const": MAX_REQUEST_BYTES},
+            "max_result_rows": {"type": "integer", "minimum": 1, "maximum": MAX_RESULT_ROWS},
+            "max_result_logical_bytes": {"type": "integer", "minimum": 1, "maximum": MAX_RESULT_BYTES},
+            "stream_buffer_rows": {"type": "integer", "const": DEFAULT_STREAM_BUFFER_ROWS},
+            "request_id_header": {"type": "string", "const": "BriskDB-Request-ID"},
+            "idempotency_key_header": {"type": "string", "const": "BriskDB-Idempotency-Key"},
+            "stream_media_type": {"type": "string", "const": STREAM_MEDIA_TYPE}
+        }),
+    )
+}
+
+fn health_schema() -> Value {
+    response_object(
+        &["status", "shards", "global_indexes"],
+        json!({
+            "status": {"type": "string", "enum": ["ok", "degraded"]},
+            "shards": {"type": "integer", "minimum": MIN_PHYSICAL_SHARDS, "maximum": MAX_PHYSICAL_SHARDS},
+            "global_indexes": ref_value("#/components/schemas/HealthGlobalIndexesResponse")
+        }),
+    )
+}
+
+fn health_global_indexes_schema() -> Value {
+    response_object(
+        &[
+            "state",
+            "total",
+            "healthy",
+            "degraded",
+            "unavailable",
+            "async_lag",
+            "retained_outbox_events",
+            "retained_outbox_bytes",
+            "backpressured_outbox_shards",
+        ],
+        json!({
+            "state": {"type": "string", "enum": ["healthy", "degraded", "unavailable"]},
+            "total": unsigned_integer(Some(MAX_GLOBAL_INDEXES as u64)),
+            "healthy": unsigned_integer(Some(MAX_GLOBAL_INDEXES as u64)),
+            "degraded": unsigned_integer(Some(MAX_GLOBAL_INDEXES as u64)),
+            "unavailable": unsigned_integer(Some(MAX_GLOBAL_INDEXES as u64)),
+            "async_lag": unsigned_integer(Some(u64::MAX)),
+            "retained_outbox_events": unsigned_integer(Some(MAX_RETAINED_OUTBOX_EVENTS)),
+            "retained_outbox_bytes": unsigned_integer(Some(MAX_RETAINED_OUTBOX_BYTES)),
+            "backpressured_outbox_shards": unsigned_integer(Some(MAX_PHYSICAL_SHARDS))
+        }),
+    )
+}
+
+fn readiness_schema() -> Value {
+    refs_one_of(&["ReadyResponse", "NotReadyResponse"])
+}
+
+fn ready_schema(ready: bool) -> Value {
+    if ready {
+        return readiness_response_branch("ready", true, "running", "ready", &[]);
+    }
+
+    let cases: [(&str, &str, &[&str]); 11] = [
+        ("running", "migrating", &["schema_migrating"]),
+        ("running", "pending", &["schema_recovery_pending"]),
+        ("running", "degraded", &["schema_degraded"]),
+        ("draining", "ready", &["engine_draining"]),
+        (
+            "draining",
+            "migrating",
+            &["engine_draining", "schema_migrating"],
+        ),
+        (
+            "draining",
+            "pending",
+            &["engine_draining", "schema_recovery_pending"],
+        ),
+        (
+            "draining",
+            "degraded",
+            &["engine_draining", "schema_degraded"],
+        ),
+        ("stopped", "ready", &["engine_stopped"]),
+        (
+            "stopped",
+            "migrating",
+            &["engine_stopped", "schema_migrating"],
+        ),
+        (
+            "stopped",
+            "pending",
+            &["engine_stopped", "schema_recovery_pending"],
+        ),
+        (
+            "stopped",
+            "degraded",
+            &["engine_stopped", "schema_degraded"],
+        ),
+    ];
+    let mut response = response_object(
+        &[
+            "status",
+            "ready",
+            "reasons",
+            "engine_state",
+            "schema_state",
+            "schema_generation",
+            "active_schema_operations",
+        ],
+        json!({
+            "status": {"type": "string", "const": "not_ready"},
+            "ready": {"type": "boolean", "const": false},
+            "reasons": {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 2,
+                "uniqueItems": true,
+                "items": {"type": "string", "enum": [
+                    "engine_draining",
+                    "engine_stopped",
+                    "schema_migrating",
+                    "schema_recovery_pending",
+                    "schema_degraded"
+                ]}
+            },
+            "engine_state": {"type": "string", "enum": ["running", "draining", "stopped"]},
+            "schema_state": {"type": "string", "enum": ["ready", "migrating", "pending", "degraded"]},
+            "schema_generation": schema_generation_string(),
+            "active_schema_operations": unsigned_integer(Some(u64::MAX))
+        }),
+    );
+    response["oneOf"] = Value::Array(
+        cases
+            .into_iter()
+            .map(|(engine_state, schema_state, reasons)| {
+                not_ready_state_case(engine_state, schema_state, reasons)
+            })
+            .collect(),
+    );
+    response
+}
+
+fn not_ready_state_case(engine_state: &str, schema_state: &str, reasons: &[&str]) -> Value {
+    json!({
+        "type": "object",
+        "required": ["engine_state", "schema_state", "reasons"],
+        "properties": {
+            "engine_state": {"type": "string", "const": engine_state},
+            "schema_state": {"type": "string", "const": schema_state},
+            "reasons": exact_readiness_reasons(reasons)
+        }
+    })
+}
+
+fn readiness_response_branch(
+    status: &str,
+    ready: bool,
+    engine_state: &str,
+    schema_state: &str,
+    reasons: &[&str],
+) -> Value {
+    let reasons = exact_readiness_reasons(reasons);
+    response_object(
+        &[
+            "status",
+            "ready",
+            "reasons",
+            "engine_state",
+            "schema_state",
+            "schema_generation",
+            "active_schema_operations",
+        ],
+        json!({
+            "status": {"type": "string", "const": status},
+            "ready": {"type": "boolean", "const": ready},
+            "reasons": reasons,
+            "engine_state": {"type": "string", "const": engine_state},
+            "schema_state": {"type": "string", "const": schema_state},
+            "schema_generation": schema_generation_string(),
+            "active_schema_operations": unsigned_integer(Some(u64::MAX))
+        }),
+    )
+}
+
+fn exact_readiness_reasons(reasons: &[&str]) -> Value {
+    let reason_count = reasons.len();
+    json!({
+        "type": "array",
+        "prefixItems": reasons
+            .iter()
+            .map(|reason| json!({"type": "string", "const": reason}))
+            .collect::<Vec<_>>(),
+        "items": false,
+        "minItems": reason_count,
+        "maxItems": reason_count
+    })
+}
+
+fn query_column_schema() -> Value {
+    response_object(
+        &["name", "data_type"],
+        json!({
+            "name": {"type": "string"},
+            "data_type": {"type": "string", "enum": [
+                "unknown", "null", "boolean", "int64", "uint64", "float64", "decimal", "text", "binary"
+            ]}
+        }),
+    )
+}
+
+fn query_response_schema(lossless: bool, single_shard: bool) -> Value {
+    let value_schema = if lossless {
+        "#/components/schemas/LosslessJsonValue"
+    } else {
+        "#/components/schemas/LegacyJsonCell"
+    };
+    let mut properties = Map::from_iter([
+        (
+            "columns".to_owned(),
+            array_of("#/components/schemas/QueryColumn"),
+        ),
+        (
+            "rows".to_owned(),
+            json!({
+                "type": "array",
+                "items": {"type": "array", "items": ref_value(value_schema)},
+                "maxItems": MAX_RESULT_ROWS
+            }),
+        ),
+    ]);
+    let mut required = vec!["columns", "rows"];
+    if single_shard {
+        properties.insert(
+            "shard".to_owned(),
+            unsigned_integer(Some(MAX_PHYSICAL_SHARD_ID)),
+        );
+        required.push("shard");
+    } else {
+        properties.insert(
+            "shards".to_owned(),
+            json!({
+                "type": "array",
+                "minItems": MIN_PHYSICAL_SHARDS,
+                "maxItems": MAX_PHYSICAL_SHARDS,
+                "uniqueItems": true,
+                "items": unsigned_integer(Some(MAX_PHYSICAL_SHARD_ID))
+            }),
+        );
+        required.push("shards");
+    }
+    if lossless {
+        properties.insert(
+            "value_encoding".to_owned(),
+            json!({"type": "string", "const": "lossless-json-v1"}),
+        );
+        required.push("value_encoding");
+    }
+    let schema = response_object(&required, Value::Object(properties));
+    let mut forbidden = vec![if single_shard { "shards" } else { "shard" }];
+    if !lossless {
+        forbidden.push("value_encoding");
+    }
+    forbid_properties(schema, &forbidden)
+}
+
+fn stream_meta_schema(lossless: bool, single_shard: bool) -> Value {
+    let mut properties = Map::from_iter([
+        (
+            "kind".to_owned(),
+            json!({"type": "string", "const": "meta"}),
+        ),
+        (
+            "columns".to_owned(),
+            array_of("#/components/schemas/QueryColumn"),
+        ),
+    ]);
+    let mut required = vec!["kind", "columns"];
+    if single_shard {
+        properties.insert(
+            "shard".to_owned(),
+            unsigned_integer(Some(MAX_PHYSICAL_SHARD_ID)),
+        );
+        required.push("shard");
+    } else {
+        properties.insert(
+            "shards".to_owned(),
+            json!({
+                "type": "array",
+                "minItems": MIN_PHYSICAL_SHARDS,
+                "maxItems": MAX_PHYSICAL_SHARDS,
+                "uniqueItems": true,
+                "items": unsigned_integer(Some(MAX_PHYSICAL_SHARD_ID))
+            }),
+        );
+        required.push("shards");
+    }
+    if lossless {
+        properties.insert(
+            "value_encoding".to_owned(),
+            json!({"type": "string", "const": "lossless-json-v1"}),
+        );
+        required.push("value_encoding");
+    }
+    strict_object(&required, Value::Object(properties))
+}
+
+fn stream_row_schema() -> Value {
+    strict_object(
+        &["kind", "values"],
+        json!({
+            "kind": {"type": "string", "const": "row"},
+            "values": {
+                "type": "array",
+                "items": {
+                    "anyOf": [
+                        ref_value("#/components/schemas/LegacyJsonCell"),
+                        ref_value("#/components/schemas/LosslessJsonValue")
+                    ]
+                }
+            }
+        }),
+    )
+}
+
+fn legacy_json_cell_schema() -> Value {
+    json!({
+        "description": "One legacy-json-v1 result cell. A byte array represents Binary; objects and nested arrays are never emitted.",
+        "oneOf": [
+            {"type": "null"},
+            {"type": "boolean"},
+            ref_value("#/components/schemas/LegacyJsonNumber"),
+            {"type": "string"},
+            {
+                "type": "array",
+                "items": {"type": "integer", "minimum": 0, "maximum": 255}
+            }
+        ]
+    })
+}
+
+fn stream_complete_schema() -> Value {
+    strict_object(
+        &["kind", "rows"],
+        json!({
+            "kind": {"type": "string", "const": "complete"},
+            "rows": unsigned_integer(Some(MAX_RESULT_ROWS))
+        }),
+    )
+}
+
+fn stream_error_schema() -> Value {
+    strict_object(
+        &["kind", "type", "title", "status", "detail", "code"],
+        json!({
+            "kind": {"type": "string", "const": "error"},
+            "type": {"type": "string", "format": "uri"},
+            "title": {"type": "string"},
+            "status": {"type": "integer", "minimum": 100, "maximum": 599},
+            "detail": {"type": "string"},
+            "code": {"type": "string"}
+        }),
+    )
+}
+
+fn finalize_operational_schemas(schemas: &mut Map<String, Value>) {
+    schemas.insert(
+        "BroadcastResponse".to_owned(),
+        response_object(
+            &["completed_shards"],
+            json!({
+                "completed_shards": {
+                    "type": "array",
+                    "minItems": MIN_PHYSICAL_SHARDS,
+                    "maxItems": MAX_PHYSICAL_SHARDS,
+                    "uniqueItems": true,
+                    "items": unsigned_integer(Some(MAX_PHYSICAL_SHARD_ID))
+                }
+            }),
+        ),
+    );
+    schemas.insert("ExecuteGeneratedKey".to_owned(), generated_key_schema());
+    schemas.insert("ExecuteResponse".to_owned(), execute_response_schema());
+
+    schemas.insert(
+        "CatalogDb".to_owned(),
+        response_object(
+            &["id", "name"],
+            json!({"id": canonical_positive_u64_string(), "name": {"type": "string"}}),
+        ),
+    );
+    schemas.insert(
+        "CatalogShardKey".to_owned(),
+        response_object(
+            &["column", "data_type"],
+            json!({
+                "column": {"type": "string"},
+                "data_type": {"type": "string", "enum": ["int64", "text", "binary"]}
+            }),
+        ),
+    );
+    schemas.insert(
+        "CatalogShardedPlacement".to_owned(),
+        response_object(
+            &["kind", "shard_key"],
+            json!({
+                "kind": {"type": "string", "const": "sharded"},
+                "shard_key": ref_value("#/components/schemas/CatalogShardKey")
+            }),
+        ),
+    );
+    schemas.insert(
+        "CatalogUnshardedPlacement".to_owned(),
+        forbid_properties(
+            response_object(
+                &["kind"],
+                json!({"kind": {"type": "string", "enum": ["global", "catalog", "unknown"]}}),
+            ),
+            &["shard_key"],
+        ),
+    );
+    schemas.insert(
+        "CatalogPlacement".to_owned(),
+        refs_one_of(&["CatalogShardedPlacement", "CatalogUnshardedPlacement"]),
+    );
+    schemas.insert(
+        "CatalogGeneratedIdDisabled".to_owned(),
+        forbid_properties(
+            response_object(
+                &["policy"],
+                json!({"policy": {"type": "string", "enum": ["none", "unknown"]}}),
+            ),
+            &["column", "encoding_version"],
+        ),
+    );
+    schemas.insert(
+        "CatalogGeneratedIdEnabled".to_owned(),
+        response_object(
+            &["policy", "column", "encoding_version"],
+            json!({
+                "policy": {"type": "string", "enum": ["native_range_v1", "hilo_v1"]},
+                "column": {"type": "string"},
+                "encoding_version": {"type": "integer", "const": 1}
+            }),
+        ),
+    );
+    schemas.insert(
+        "CatalogGeneratedId".to_owned(),
+        refs_one_of(&["CatalogGeneratedIdDisabled", "CatalogGeneratedIdEnabled"]),
+    );
+    schemas.insert("CatalogTable".to_owned(), catalog_table_schema());
+    schemas.insert(
+        "CatalogGlobalIndex".to_owned(),
+        catalog_global_index_schema(),
+    );
+    schemas.insert("CatalogResponse".to_owned(), catalog_response_schema());
+
+    schemas.insert("MigrationResponse".to_owned(), migration_schema());
+    schemas.insert("MigrationsResponse".to_owned(), migrations_schema());
+    schemas.insert("ShardStatus".to_owned(), shard_schema());
+    schemas.insert("ShardStatusResponse".to_owned(), shards_schema());
+    schemas.insert("ActiveQueryResponse".to_owned(), active_query_schema());
+    schemas.insert(
+        "ActiveQueriesResponse".to_owned(),
+        response_object(
+            &["queries"],
+            json!({
+                "queries": {
+                    "type": "array",
+                    "maxItems": MAX_ACTIVE_QUERIES,
+                    "items": ref_value("#/components/schemas/ActiveQueryResponse")
+                }
+            }),
+        ),
+    );
+    schemas.insert(
+        "CancelQueryResponse".to_owned(),
+        response_object(
+            &["operation_id", "newly_requested"],
+            json!({
+                "operation_id": ref_value("#/components/schemas/OpaqueId"),
+                "newly_requested": {"type": "boolean"}
+            }),
+        ),
+    );
+    schemas.insert(
+        "BackupCapabilityResponse".to_owned(),
+        backup_capability_schema(),
+    );
+    schemas.insert(
+        "CheckpointShardResponse".to_owned(),
+        checkpoint_shard_schema(),
+    );
+    schemas.insert(
+        "CheckpointDbResponse".to_owned(),
+        checkpoint_database_schema(),
+    );
+    schemas.insert("CheckpointResponse".to_owned(), checkpoint_schema());
+    schemas.insert("GlobalIndexStatus".to_owned(), global_index_status_schema());
+    schemas.insert(
+        "GlobalIndexesResponse".to_owned(),
+        global_indexes_response_schema(),
+    );
+}
+
+fn generated_key_schema() -> Value {
+    json!({
+        "oneOf": [
+            response_object(
+                &["column", "data_type", "value"],
+                json!({
+                    "column": {"type": "string"},
+                    "data_type": {"type": "string", "const": "int64"},
+                    "value": ref_value("#/components/schemas/LosslessInt64/properties/value")
+                }),
+            ),
+            response_object(
+                &["column", "data_type", "value"],
+                json!({
+                    "column": {"type": "string"},
+                    "data_type": {"type": "string", "const": "uint64"},
+                    "value": ref_value("#/components/schemas/LosslessUInt64/properties/value")
+                }),
+            )
+        ]
+    })
+}
+
+fn execute_response_schema() -> Value {
+    let without_key = response_object(
+        &["shard", "rows_affected"],
+        json!({
+            "shard": unsigned_integer(Some(MAX_PHYSICAL_SHARD_ID)),
+            "rows_affected": unsigned_integer(Some(u64::MAX))
+        }),
+    );
+    let with_key = response_object(
+        &["shard", "rows_affected", "generated_key"],
+        json!({
+            "shard": unsigned_integer(Some(MAX_PHYSICAL_SHARD_ID)),
+            "rows_affected": unsigned_integer(Some(u64::MAX)),
+            "generated_key": ref_value("#/components/schemas/ExecuteGeneratedKey")
+        }),
+    );
+    json!({"oneOf": [forbid_properties(without_key, &["generated_key"]), with_key]})
+}
+
+fn catalog_table_schema() -> Value {
+    response_object(
+        &["id", "database_id", "name", "placement", "generated_id"],
+        json!({
+            "id": canonical_positive_u64_string(),
+            "database_id": canonical_positive_u64_string(),
+            "name": {"type": "string"},
+            "placement": ref_value("#/components/schemas/CatalogPlacement"),
+            "generated_id": ref_value("#/components/schemas/CatalogGeneratedId")
+        }),
+    )
+}
+
+fn catalog_global_index_schema() -> Value {
+    response_object(
+        &[
+            "id",
+            "table_id",
+            "name",
+            "unique",
+            "lifecycle",
+            "schema_generation",
+            "key_encoding_version",
+        ],
+        json!({
+            "id": canonical_positive_u64_string(),
+            "table_id": canonical_positive_u64_string(),
+            "name": {"type": "string"},
+            "unique": {"type": "boolean"},
+            "lifecycle": {"type": "string", "enum": ["creating", "ready", "invalid", "rebuilding", "dropping"]},
+            "schema_generation": schema_generation_string(),
+            "key_encoding_version": {"type": "integer", "const": 1}
+        }),
+    )
+}
+
+fn catalog_response_schema() -> Value {
+    response_object(
+        &[
+            "identifier_encoding_version",
+            "schema_generation",
+            "default_database_id",
+            "databases",
+            "tables",
+            "global_indexes",
+        ],
+        json!({
+            "identifier_encoding_version": {"type": "integer", "const": 1},
+            "schema_generation": schema_generation_string(),
+            "default_database_id": {
+                "type": "string",
+                "const": DEFAULT_LOGICAL_DATABASE_ID.to_string()
+            },
+            "databases": {
+                "type": "array",
+                "items": ref_value("#/components/schemas/CatalogDb"),
+                "minItems": 1,
+                "maxItems": MAX_LOGICAL_DATABASES,
+                "contains": {
+                    "type": "object",
+                    "required": ["id", "name"],
+                    "properties": {
+                        "id": {"const": DEFAULT_LOGICAL_DATABASE_ID.to_string()},
+                        "name": {"const": DEFAULT_LOGICAL_DATABASE_NAME}
+                    }
+                },
+                "minContains": 1,
+                "maxContains": 1
+            },
+            "tables": {
+                "type": "array",
+                "items": ref_value("#/components/schemas/CatalogTable"),
+                "maxItems": MAX_TABLES
+            },
+            "global_indexes": {
+                "type": "array",
+                "items": ref_value("#/components/schemas/CatalogGlobalIndex"),
+                "maxItems": MAX_GLOBAL_INDEXES
+            }
+        }),
+    )
+}
+
+fn migration_schema() -> Value {
+    response_object(
+        &[
+            "generation",
+            "source_generation",
+            "target_generation",
+            "state",
+            "shard_count",
+            "next_shard",
+            "completed_shards",
+            "sql_bytes",
+        ],
+        json!({
+            "generation": positive_schema_generation_string(),
+            "source_generation": schema_generation_string(),
+            "target_generation": positive_schema_generation_string(),
+            "state": {"type": "string", "enum": ["applying", "complete"]},
+            "shard_count": {"type": "integer", "minimum": MIN_PHYSICAL_SHARDS, "maximum": MAX_PHYSICAL_SHARDS},
+            "next_shard": unsigned_integer(Some(MAX_PHYSICAL_SHARDS)),
+            "completed_shards": unsigned_integer(Some(MAX_PHYSICAL_SHARDS)),
+            "sql_bytes": {"type": "integer", "minimum": 1, "maximum": MAX_SCHEMA_MIGRATION_SQL_BYTES}
+        }),
+    )
+}
+
+fn migrations_schema() -> Value {
+    response_object(
+        &["schema_generation", "active", "latest_complete"],
+        json!({
+            "schema_generation": schema_generation_string(),
+            "active": {"oneOf": [{"type": "null"}, ref_value("#/components/schemas/MigrationResponse")]},
+            "latest_complete": {"oneOf": [{"type": "null"}, ref_value("#/components/schemas/MigrationResponse")]}
+        }),
+    )
+}
+
+fn shard_schema() -> Value {
+    response_object(
+        &["id", "state"],
+        json!({
+            "id": unsigned_integer(Some(MAX_PHYSICAL_SHARD_ID)),
+            "state": {"type": "string", "const": "ready"}
+        }),
+    )
+}
+
+fn shards_schema() -> Value {
+    response_object(
+        &["schema_generation", "shards"],
+        json!({
+            "schema_generation": schema_generation_string(),
+            "shards": {
+                "type": "array",
+                "items": ref_value("#/components/schemas/ShardStatus"),
+                "minItems": MIN_PHYSICAL_SHARDS,
+                "maxItems": MAX_PHYSICAL_SHARDS,
+                "uniqueItems": true
+            }
+        }),
+    )
+}
+
+fn active_query_schema() -> Value {
+    response_object(
+        &[
+            "operation_id",
+            "elapsed_ms",
+            "sql_bytes",
+            "cancellation_requested",
+        ],
+        json!({
+            "operation_id": ref_value("#/components/schemas/OpaqueId"),
+            "elapsed_ms": unsigned_integer(Some(u64::MAX)),
+            "sql_bytes": unsigned_integer(Some(u64::MAX)),
+            "cancellation_requested": {"type": "boolean"}
+        }),
+    )
+}
+
+fn backup_capability_schema() -> Value {
+    response_object(
+        &[
+            "mode",
+            "online",
+            "requires_all_processes_stopped",
+            "checkpoint_endpoint",
+            "checkpoint_role",
+            "checkpoint_is_recovery_point",
+        ],
+        json!({
+            "mode": {"type": "string", "const": "stopped_directory_copy"},
+            "online": {"type": "boolean", "const": false},
+            "requires_all_processes_stopped": {"type": "boolean", "const": true},
+            "checkpoint_endpoint": {"type": "string", "const": "/v1/admin/maintenance/checkpoint"},
+            "checkpoint_role": {"type": "string", "const": "preparation_only"},
+            "checkpoint_is_recovery_point": {"type": "boolean", "const": false}
+        }),
+    )
+}
+
+fn checkpoint_shard_schema() -> Value {
+    response_object(
+        &[
+            "shard",
+            "busy",
+            "counts_available",
+            "wal_frames",
+            "checkpointed_frames",
+            "complete",
+        ],
+        json!({
+            "shard": unsigned_integer(Some(MAX_PHYSICAL_SHARD_ID)),
+            "busy": {"type": "boolean"},
+            "counts_available": {"type": "boolean"},
+            "wal_frames": unsigned_integer(Some(u64::MAX)),
+            "checkpointed_frames": unsigned_integer(Some(u64::MAX)),
+            "complete": {"type": "boolean"}
+        }),
+    )
+}
+
+fn checkpoint_database_schema() -> Value {
+    response_object(
+        &[
+            "database",
+            "busy",
+            "counts_available",
+            "wal_frames",
+            "checkpointed_frames",
+            "complete",
+        ],
+        json!({
+            "database": {"type": "string", "enum": ["manifest", "global_index"]},
+            "busy": {"type": "boolean"},
+            "counts_available": {"type": "boolean"},
+            "wal_frames": unsigned_integer(Some(u64::MAX)),
+            "checkpointed_frames": unsigned_integer(Some(u64::MAX)),
+            "complete": {"type": "boolean"}
+        }),
+    )
+}
+
+fn checkpoint_schema() -> Value {
+    response_object(
+        &[
+            "operation",
+            "busy",
+            "complete",
+            "recovery_point",
+            "shards",
+            "databases",
+        ],
+        json!({
+            "operation": {"type": "string", "const": "passive_checkpoint"},
+            "busy": {"type": "boolean"},
+            "complete": {"type": "boolean"},
+            "recovery_point": {"type": "boolean", "const": false},
+            "shards": {
+                "type": "array",
+                "items": ref_value("#/components/schemas/CheckpointShardResponse"),
+                "minItems": MIN_PHYSICAL_SHARDS,
+                "maxItems": MAX_PHYSICAL_SHARDS,
+                "uniqueItems": true
+            },
+            "databases": {
+                "type": "array",
+                "items": ref_value("#/components/schemas/CheckpointDbResponse"),
+                "minItems": 1,
+                "maxItems": 2,
+                "uniqueItems": true
+            }
+        }),
+    )
+}
+
+fn global_index_status_schema() -> Value {
+    response_object(
+        &[
+            "id",
+            "name",
+            "unique",
+            "lifecycle",
+            "health",
+            "available",
+            "recovery",
+            "authority_entries",
+            "unique_keys",
+            "active_operations",
+            "active_unique_reservations",
+            "active_value_leases",
+            "pending_read_repairs",
+            "applied_read_repairs",
+            "async_lag",
+            "async_failures",
+            "poisoned_shards",
+            "leased_shards",
+            "async_paused",
+            "rebuild_required",
+            "summary_ready_shards",
+            "summary_degraded_shards",
+            "summary_saturated_shards",
+        ],
+        json!({
+            "id": canonical_positive_u64_string(),
+            "name": {"type": "string"},
+            "unique": {"type": "boolean"},
+            "lifecycle": {"type": "string", "enum": ["creating", "ready", "invalid", "rebuilding", "dropping"]},
+            "health": {"type": "string", "enum": ["healthy", "degraded", "unavailable"]},
+            "available": {"type": "boolean"},
+            "recovery": {"type": "string", "enum": ["build", "none", "rebuild", "resume_rebuild"]},
+            "authority_entries": unsigned_integer(Some(u64::MAX)),
+            "unique_keys": unsigned_integer(Some(u64::MAX)),
+            "active_operations": unsigned_integer(Some(u64::MAX)),
+            "active_unique_reservations": unsigned_integer(Some(u64::MAX)),
+            "active_value_leases": unsigned_integer(Some(u64::MAX)),
+            "pending_read_repairs": unsigned_integer(Some(u64::MAX)),
+            "applied_read_repairs": unsigned_integer(Some(u64::MAX)),
+            "async_lag": unsigned_integer(Some(u64::MAX)),
+            "async_failures": unsigned_integer(Some(u64::MAX)),
+            "poisoned_shards": unsigned_integer(Some(MAX_PHYSICAL_SHARDS)),
+            "leased_shards": unsigned_integer(Some(MAX_PHYSICAL_SHARDS)),
+            "async_paused": {"type": "boolean"},
+            "rebuild_required": {"type": "boolean"},
+            "summary_ready_shards": unsigned_integer(Some(MAX_PHYSICAL_SHARDS)),
+            "summary_degraded_shards": unsigned_integer(Some(MAX_PHYSICAL_SHARDS)),
+            "summary_saturated_shards": unsigned_integer(Some(MAX_PHYSICAL_SHARDS))
+        }),
+    )
+}
+
+fn global_indexes_response_schema() -> Value {
+    response_object(
+        &[
+            "state",
+            "retained_outbox_events",
+            "retained_outbox_bytes",
+            "backpressured_outbox_shards",
+            "indexes",
+        ],
+        json!({
+            "state": {"type": "string", "enum": ["healthy", "degraded", "unavailable"]},
+            "retained_outbox_events": unsigned_integer(Some(MAX_RETAINED_OUTBOX_EVENTS)),
+            "retained_outbox_bytes": unsigned_integer(Some(MAX_RETAINED_OUTBOX_BYTES)),
+            "backpressured_outbox_shards": unsigned_integer(Some(MAX_PHYSICAL_SHARDS)),
+            "indexes": {
+                "type": "array",
+                "items": ref_value("#/components/schemas/GlobalIndexStatus"),
+                "maxItems": MAX_GLOBAL_INDEXES
+            }
+        }),
+    )
+}
+
+fn finalize_problem_schemas(schemas: &mut Map<String, Value>) {
+    schemas.insert("ProblemDetails".to_owned(), problem_schema(None));
+    for status in [
+        400_u16, 403, 404, 405, 409, 413, 415, 422, 500, 501, 503, 504, 507,
+    ] {
+        schemas.insert(
+            format!("ProblemDetails{status}"),
+            problem_schema(Some(status)),
+        );
+    }
+}
+
+fn problem_schema(status: Option<u16>) -> Value {
+    strict_object(
+        &["type", "title", "status", "detail", "code"],
+        json!({
+            "type": {"type": "string", "format": "uri"},
+            "title": {"type": "string"},
+            "status": match status {
+                Some(status) => json!({"type": "integer", "const": status}),
+                None => json!({"type": "integer", "minimum": 100, "maximum": 599}),
+            },
+            "detail": {"type": "string"},
+            "code": {"type": "string"}
+        }),
+    )
+}
+
+fn response_object(required: &[&str], properties: Value) -> Value {
+    let mut schema = Map::from_iter([
+        ("type".to_owned(), json!("object")),
+        ("properties".to_owned(), properties),
+    ]);
+    if !required.is_empty() {
+        schema.insert("required".to_owned(), json!(required));
+    }
+    Value::Object(schema)
+}
+
+fn forbid_properties(mut schema: Value, names: &[&str]) -> Value {
+    let forbidden = names
+        .iter()
+        .map(|name| json!({"required": [name]}))
+        .collect::<Vec<_>>();
+    schema["not"] = if forbidden.len() == 1 {
+        forbidden
+            .into_iter()
+            .next()
+            .expect("one forbidden property")
+    } else {
+        json!({"anyOf": forbidden})
+    };
+    schema
+}

--- a/src/protocol/http/v1.rs
+++ b/src/protocol/http/v1.rs
@@ -9,74 +9,66 @@ use axum::{
     http::{HeaderValue, StatusCode, request::Parts},
     middleware,
     response::{IntoResponse, Response},
-    routing::{any, get, post},
+    routing::{any, get},
 };
 use serde::{
     Deserialize, Serialize,
     de::{DeserializeOwned, IgnoredAny, MapAccess, Visitor},
 };
 use serde_json::value::RawValue;
+use utoipa::ToSchema;
+use utoipa_axum::{router::OpenApiRouter, routes};
 
 use super::{
     HttpState, IDEMPOTENCY_KEY_HEADER_NAME, ProblemDetails, REQUEST_ID_HEADER_NAME,
-    STREAM_MEDIA_TYPE, active_queries, backup_capability, broadcast, cancel_query, catalog,
-    checkpoint, execute, global_indexes, health, migration, migrations, problem_response, query,
-    query_stream, ready, shard_status,
+    STREAM_MEDIA_TYPE, problem_response,
 };
 
-const MAX_REQUEST_BYTES: usize = 2 * 1024 * 1024;
+pub(super) const MAX_REQUEST_BYTES: usize = 2 * 1024 * 1024;
 
 pub(super) fn routes() -> Router<HttpState> {
-    versioned_routes(
-        Router::new()
-            .route("/", get(discovery))
-            .route("/health", get(health))
-            .route("/ready", get(ready))
-            .route("/execute", post(execute))
-            .route("/query", post(query))
-            .route("/query/stream", post(query_stream))
-            .route("/admin/broadcast", post(broadcast))
-            .route("/admin/global-indexes", get(global_indexes))
-            .route("/admin/catalog", get(catalog))
-            .route("/admin/migrations", get(migrations))
-            .route("/admin/migrations/{target_generation}", get(migration))
-            .route("/admin/shards", get(shard_status))
-            .route("/admin/queries", get(active_queries))
-            .route("/admin/queries/{query_id}/cancel", post(cancel_query))
-            .route("/admin/backup", get(backup_capability))
-            .route("/admin/maintenance/checkpoint", post(checkpoint)),
-        true,
-    )
+    let endpoints: Router<HttpState> = annotated_data_routes()
+        .merge(annotated_admin_routes())
+        .into();
+    versioned_routes(endpoints, true)
 }
 
 pub(super) fn data_routes() -> Router<HttpState> {
-    versioned_routes(
-        Router::new()
-            .route("/", get(discovery))
-            .route("/execute", post(execute))
-            .route("/query", post(query))
-            .route("/query/stream", post(query_stream)),
-        true,
-    )
+    versioned_routes(annotated_data_routes().into(), true)
 }
 
 pub(super) fn admin_routes() -> Router<HttpState> {
-    versioned_routes(
-        Router::new()
-            .route("/health", get(health))
-            .route("/ready", get(ready))
-            .route("/admin/broadcast", post(broadcast))
-            .route("/admin/global-indexes", get(global_indexes))
-            .route("/admin/catalog", get(catalog))
-            .route("/admin/migrations", get(migrations))
-            .route("/admin/migrations/{target_generation}", get(migration))
-            .route("/admin/shards", get(shard_status))
-            .route("/admin/queries", get(active_queries))
-            .route("/admin/queries/{query_id}/cancel", post(cancel_query))
-            .route("/admin/backup", get(backup_capability))
-            .route("/admin/maintenance/checkpoint", post(checkpoint)),
-        false,
-    )
+    versioned_routes(annotated_admin_routes().into(), false)
+}
+
+pub(super) fn openapi() -> utoipa::openapi::OpenApi {
+    annotated_data_routes()
+        .merge(annotated_admin_routes())
+        .into_openapi()
+}
+
+fn annotated_data_routes() -> OpenApiRouter<HttpState> {
+    OpenApiRouter::new()
+        .routes(routes!(discovery))
+        .routes(routes!(super::execute))
+        .routes(routes!(super::query))
+        .routes(routes!(super::query_stream))
+}
+
+fn annotated_admin_routes() -> OpenApiRouter<HttpState> {
+    OpenApiRouter::new()
+        .routes(routes!(super::health))
+        .routes(routes!(super::ready))
+        .routes(routes!(super::broadcast))
+        .routes(routes!(super::global_indexes))
+        .routes(routes!(super::catalog))
+        .routes(routes!(super::migrations))
+        .routes(routes!(super::migration))
+        .routes(routes!(super::shard_status))
+        .routes(routes!(super::active_queries))
+        .routes(routes!(super::cancel_query))
+        .routes(routes!(super::backup_capability))
+        .routes(routes!(super::checkpoint))
 }
 
 fn versioned_routes(
@@ -106,8 +98,8 @@ async fn version_header(mut response: Response) -> Response {
     response
 }
 
-#[derive(Serialize)]
-struct ApiVersion {
+#[derive(Serialize, ToSchema)]
+pub(super) struct ApiVersion {
     api_version: &'static str,
     value_encoding: ValueEncoding,
     supported_value_encodings: [ValueEncoding; 2],
@@ -122,7 +114,14 @@ struct ApiVersion {
     stream_media_type: &'static str,
 }
 
-async fn discovery(
+#[utoipa::path(
+    get,
+    path = "/",
+    operation_id = "getApiVersion",
+    tag = "data",
+    responses((status = 200, description = "HTTP API version", body = ApiVersion))
+)]
+pub(super) async fn discovery(
     axum::extract::State(state): axum::extract::State<HttpState>,
 ) -> Json<ApiVersion> {
     let result_limits = state.engine.options().result_limits();
@@ -142,7 +141,7 @@ async fn discovery(
     })
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize, ToSchema)]
 pub(super) enum ValueEncoding {
     #[default]
     #[serde(rename = "legacy-json-v1")]
@@ -172,26 +171,28 @@ impl RawJsonParameter {
 /// Execute envelope; each handler creates a fresh core Session and Statement.
 /// Unknown fields must fail rather than silently ignoring a client's routing,
 /// transaction, dialect, value-encoding, or request-control expectations.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub(super) struct ExecuteRequest {
     #[serde(default)]
     pub(super) shard_key: Option<String>,
     pub(super) sql: String,
     #[serde(default)]
+    #[schema(value_type = Vec<serde_json::Value>)]
     pub(super) params: Vec<RawJsonParameter>,
     #[serde(default)]
     pub(super) value_encoding: ValueEncoding,
 }
 
 /// Query envelope with optional protocol-neutral result-limit narrowing.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub(super) struct QueryRequest {
     #[serde(default)]
     pub(super) shard_key: Option<String>,
     pub(super) sql: String,
     #[serde(default)]
+    #[schema(value_type = Vec<serde_json::Value>)]
     pub(super) params: Vec<RawJsonParameter>,
     #[serde(default)]
     pub(super) value_encoding: ValueEncoding,
@@ -206,7 +207,7 @@ where
     QueryResultLimits::deserialize(deserializer).map(Some)
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub(super) struct QueryResultLimits {
     #[serde(default, deserialize_with = "deserialize_optional_u64")]
@@ -222,13 +223,13 @@ where
     u64::deserialize(deserializer).map(Some)
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub(super) struct BroadcastRequest {
     pub(super) sql: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, ToSchema)]
 pub(super) struct EmptyRequest;
 
 impl<'de> Deserialize<'de> for EmptyRequest {
@@ -328,6 +329,7 @@ where
     }
 }
 
+#[derive(Clone, Copy)]
 pub(super) enum TransportError {
     InvalidRequest,
     BodyTooLarge,
@@ -336,55 +338,79 @@ pub(super) enum TransportError {
     MethodNotAllowed,
 }
 
+#[derive(Clone, Copy)]
+pub(super) struct TransportErrorMapping {
+    pub(super) status: u16,
+    pub(super) code: &'static str,
+    pub(super) problem_type: &'static str,
+    pub(super) title: &'static str,
+    pub(super) detail: &'static str,
+}
+
+impl TransportError {
+    pub(super) const ALL: [Self; 5] = [
+        Self::InvalidRequest,
+        Self::BodyTooLarge,
+        Self::MediaType,
+        Self::NotFound,
+        Self::MethodNotAllowed,
+    ];
+
+    pub(super) const fn mapping(self) -> TransportErrorMapping {
+        match self {
+            Self::InvalidRequest => {
+                let mapping = crate::protocol::error::http_error(
+                    crate::core::EngineErrorKind::InvalidArgument,
+                );
+                TransportErrorMapping {
+                    status: mapping.status,
+                    code: "invalid_argument",
+                    problem_type: mapping.problem_type,
+                    title: mapping.title,
+                    detail: mapping.detail,
+                }
+            }
+            Self::BodyTooLarge => TransportErrorMapping {
+                status: 413,
+                code: "request_too_large",
+                problem_type: "urn:briskdb:http:v1:request-too-large",
+                title: "Request too large",
+                detail: "The request body exceeds the HTTP API limit.",
+            },
+            Self::MediaType => TransportErrorMapping {
+                status: 415,
+                code: "unsupported_media_type",
+                problem_type: "urn:briskdb:http:v1:unsupported-media-type",
+                title: "Unsupported media type",
+                detail: "The request requires a JSON content type.",
+            },
+            Self::NotFound => TransportErrorMapping {
+                status: 404,
+                code: "not_found",
+                problem_type: "urn:briskdb:http:v1:not-found",
+                title: "Not found",
+                detail: "The requested API endpoint does not exist.",
+            },
+            Self::MethodNotAllowed => TransportErrorMapping {
+                status: 405,
+                code: "method_not_allowed",
+                problem_type: "urn:briskdb:http:v1:method-not-allowed",
+                title: "Method not allowed",
+                detail: "The method is not supported by this API endpoint.",
+            },
+        }
+    }
+}
+
 impl IntoResponse for TransportError {
     fn into_response(self) -> Response {
-        let (status, code, title, detail) = match self {
-            Self::InvalidRequest => (
-                400,
-                "invalid_argument",
-                "Invalid argument",
-                "The request contains an invalid argument.",
-            ),
-            Self::BodyTooLarge => (
-                413,
-                "request_too_large",
-                "Request too large",
-                "The request body exceeds the HTTP API limit.",
-            ),
-            Self::MediaType => (
-                415,
-                "unsupported_media_type",
-                "Unsupported media type",
-                "The request requires a JSON content type.",
-            ),
-            Self::NotFound => (
-                404,
-                "not_found",
-                "Not found",
-                "The requested API endpoint does not exist.",
-            ),
-            Self::MethodNotAllowed => (
-                405,
-                "method_not_allowed",
-                "Method not allowed",
-                "The method is not supported by this API endpoint.",
-            ),
-        };
-        let problem_type = match self {
-            Self::InvalidRequest => {
-                super::http_error(crate::core::EngineErrorKind::InvalidArgument).problem_type
-            }
-            Self::BodyTooLarge => "urn:briskdb:http:v1:request-too-large",
-            Self::MediaType => "urn:briskdb:http:v1:unsupported-media-type",
-            Self::NotFound => "urn:briskdb:http:v1:not-found",
-            Self::MethodNotAllowed => "urn:briskdb:http:v1:method-not-allowed",
-        };
+        let mapping = self.mapping();
         problem_response(ProblemDetails {
-            problem_type,
-            title,
-            status,
-            detail,
-            code,
+            problem_type: mapping.problem_type,
+            title: mapping.title,
+            status: mapping.status,
+            detail: mapping.detail,
+            code: mapping.code,
         })
     }
 }

--- a/tests/debian_packaging.rs
+++ b/tests/debian_packaging.rs
@@ -73,6 +73,8 @@ fn debian_package_contract_preserves_configuration_and_database_state() {
         "/usr/bin/briskdb-import",
         "/lib/systemd/system/briskdb.service",
         "/etc/default/briskdb",
+        "missing OpenAPI artifact: docs/openapi-v1.json",
+        "cp -R docs",
         "dpkg-deb --build --root-owner-group",
     ] {
         assert!(
@@ -100,6 +102,7 @@ fn debian_package_contract_preserves_configuration_and_database_state() {
         "wait_for_service",
         "dpkg -r briskdb",
         "package-smoke-state",
+        "./usr/share/doc/briskdb/docs/openapi-v1.json",
     ] {
         assert!(
             smoke.contains(required),

--- a/tests/document_engine.rs
+++ b/tests/document_engine.rs
@@ -894,6 +894,10 @@ fn production_protocol_modules_do_not_bypass_the_engine_for_document_storage() {
             include_str!("../src/protocol/http/admin.rs"),
         ),
         (
+            "protocol/http/openapi.rs",
+            include_str!("../src/protocol/http/openapi.rs"),
+        ),
+        (
             "protocol/postgres.rs",
             include_str!("../src/protocol/postgres.rs"),
         ),

--- a/tests/http_plane_listeners.rs
+++ b/tests/http_plane_listeners.rs
@@ -415,6 +415,10 @@ async fn attached_data_and_admin_planes_are_isolated_over_real_tcp() {
     assert_eq!(discovery_head.status, 200);
     assert_eq!(discovery_head.header("briskdb-api-version"), Some("1"));
     assert_eq!(
+        discovery_head.header("content-type"),
+        Some("application/json")
+    );
+    assert_eq!(
         discovery_head.header("content-length"),
         discovery.header("content-length")
     );
@@ -500,6 +504,7 @@ async fn attached_data_and_admin_planes_are_isolated_over_real_tcp() {
     let health_head = request(admin, "HEAD", "/v1/health", None, &[], &[]).await;
     assert_eq!(health_head.status, 200);
     assert_eq!(health_head.header("briskdb-api-version"), Some("1"));
+    assert_eq!(health_head.header("content-type"), Some("application/json"));
     assert_eq!(
         health_head.header("content-length"),
         versioned_health.header("content-length")

--- a/tests/http_v1.rs
+++ b/tests/http_v1.rs
@@ -240,6 +240,7 @@ async fn discovery_health_alias_and_head_identify_the_contract() {
         let (status, headers, body) = request(&app, Method::HEAD, uri, None, Body::empty()).await;
         assert_eq!(status, StatusCode::OK);
         assert_eq!(headers["briskdb-api-version"], "1");
+        assert_eq!(headers["content-type"], "application/json");
         assert_eq!(headers["content-length"], representation_length);
         request_id(&headers);
         assert!(body.is_empty());
@@ -546,6 +547,7 @@ async fn readiness_has_one_exact_versioned_and_unversioned_probe_shape() {
     let head = request(&app, Method::HEAD, "/v1/ready", None, Body::empty()).await;
     assert_eq!(head.0, StatusCode::OK);
     assert_eq!(head.1["briskdb-api-version"], "1");
+    assert_eq!(head.1["content-type"], "application/json");
     assert!(head.2.is_empty());
 
     assert_eq!(
@@ -568,6 +570,16 @@ async fn readiness_has_one_exact_versioned_and_unversioned_probe_shape() {
             "active_schema_operations": 0
         })
     );
+    let unavailable_representation_length = unavailable.2.len().to_string();
+    let unavailable_head = request(&app, Method::HEAD, "/v1/ready", None, Body::empty()).await;
+    assert_eq!(unavailable_head.0, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(unavailable_head.1["briskdb-api-version"], "1");
+    assert_eq!(unavailable_head.1["content-type"], "application/json");
+    assert_eq!(
+        unavailable_head.1["content-length"],
+        unavailable_representation_length
+    );
+    assert!(unavailable_head.2.is_empty());
     engine.shutdown().await.unwrap();
 }
 
@@ -776,6 +788,7 @@ async fn operational_reports_are_bounded_redacted_and_checkpoint_input_is_strict
         let (status, headers, body) = request(&app, Method::HEAD, uri, None, Body::empty()).await;
         assert_eq!(status, StatusCode::OK, "{uri}");
         assert_eq!(headers["briskdb-api-version"], "1", "{uri}");
+        assert_eq!(headers["content-type"], "application/json", "{uri}");
         assert!(body.is_empty(), "{uri}");
     }
 

--- a/tests/openapi_v1.rs
+++ b/tests/openapi_v1.rs
@@ -1,0 +1,2555 @@
+#![cfg(feature = "http")]
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
+
+use axum::{
+    Router,
+    body::{Body, to_bytes},
+    http::{HeaderMap, Method, Request, StatusCode},
+};
+use briskdb::{
+    core::{Database, Engine, EngineErrorKind},
+    protocol::error::http_error,
+};
+use jsonschema::Validator;
+use serde_json::{Map, Value, json};
+use tower::ServiceExt as _;
+
+const DATA_SERVER: &str = "http://127.0.0.1:7654";
+const ADMIN_SERVER: &str = "http://127.0.0.1:7655";
+const LEGACY_REQUEST_ROUNDING_LIMIT: &str = concat!(
+    "179769313486231580793728971405303415079934132710037826936173778980444968292",
+    "764750946649017977587207096330286416692887910946555547851940402630657488671",
+    "505820681908902000708383676273854845817711531764475730270069855571366959622",
+    "842914819860834936475292719074168444365510704342711559699508093042880177904",
+    "174497792"
+);
+const LEGACY_REQUEST_ROUNDING_LIMIT_MINUS_ONE: &str = concat!(
+    "179769313486231580793728971405303415079934132710037826936173778980444968292",
+    "764750946649017977587207096330286416692887910946555547851940402630657488671",
+    "505820681908902000708383676273854845817711531764475730270069855571366959622",
+    "842914819860834936475292719074168444365510704342711559699508093042880177904",
+    "174497791"
+);
+
+const OPERATION_IDS: &[&str] = &[
+    "broadcastMigration",
+    "cancelQuery",
+    "checkpointDatabases",
+    "executeStatement",
+    "getApiVersion",
+    "getApiVersionAlias",
+    "getBackupCapability",
+    "getCatalog",
+    "getGlobalIndexes",
+    "getHealth",
+    "getMigration",
+    "getReadiness",
+    "headActiveQueries",
+    "headApiVersion",
+    "headApiVersionAlias",
+    "headBackupCapability",
+    "headCatalog",
+    "headGlobalIndexes",
+    "headHealth",
+    "headMigration",
+    "headMigrations",
+    "headReadiness",
+    "headShards",
+    "listActiveQueries",
+    "listMigrations",
+    "listShards",
+    "queryRows",
+    "streamQueryRows",
+];
+
+const ROUTES: &[(&str, &[&str], &str)] = &[
+    ("/v1", &["get", "head"], DATA_SERVER),
+    ("/v1/", &["get", "head"], DATA_SERVER),
+    ("/v1/execute", &["post"], DATA_SERVER),
+    ("/v1/query", &["post"], DATA_SERVER),
+    ("/v1/query/stream", &["post"], DATA_SERVER),
+    ("/v1/health", &["get", "head"], ADMIN_SERVER),
+    ("/v1/ready", &["get", "head"], ADMIN_SERVER),
+    ("/v1/admin/broadcast", &["post"], ADMIN_SERVER),
+    ("/v1/admin/global-indexes", &["get", "head"], ADMIN_SERVER),
+    ("/v1/admin/catalog", &["get", "head"], ADMIN_SERVER),
+    ("/v1/admin/migrations", &["get", "head"], ADMIN_SERVER),
+    (
+        "/v1/admin/migrations/{target_generation}",
+        &["get", "head"],
+        ADMIN_SERVER,
+    ),
+    ("/v1/admin/shards", &["get", "head"], ADMIN_SERVER),
+    ("/v1/admin/queries", &["get", "head"], ADMIN_SERVER),
+    (
+        "/v1/admin/queries/{operation_id}/cancel",
+        &["post"],
+        ADMIN_SERVER,
+    ),
+    ("/v1/admin/backup", &["get", "head"], ADMIN_SERVER),
+    ("/v1/admin/maintenance/checkpoint", &["post"], ADMIN_SERVER),
+];
+
+fn document() -> Value {
+    briskdb::api::openapi_v1()
+}
+
+fn object<'a>(value: &'a Value, context: &str) -> &'a Map<String, Value> {
+    value
+        .as_object()
+        .unwrap_or_else(|| panic!("{context} must be an object, got {value}"))
+}
+
+fn operation<'a>(document: &'a Value, path: &str, method: &str) -> &'a Value {
+    document
+        .pointer(&format!("/paths/{}/{method}", escape_pointer(path)))
+        .unwrap_or_else(|| panic!("missing {method} {path}"))
+}
+
+fn escape_pointer(value: &str) -> String {
+    value.replace('~', "~0").replace('/', "~1")
+}
+
+fn resolve<'a>(document: &'a Value, value: &'a Value) -> &'a Value {
+    let Some(reference) = value.get("$ref").and_then(Value::as_str) else {
+        return value;
+    };
+    let pointer = reference
+        .strip_prefix('#')
+        .unwrap_or_else(|| panic!("external OpenAPI reference is forbidden: {reference}"));
+    document
+        .pointer(pointer)
+        .unwrap_or_else(|| panic!("unresolved OpenAPI reference: {reference}"))
+}
+
+fn response<'a>(document: &'a Value, path: &str, method: &str, status: &str) -> &'a Value {
+    let response = operation(document, path, method)
+        .pointer(&format!("/responses/{status}"))
+        .unwrap_or_else(|| panic!("missing {status} response for {method} {path}"));
+    resolve(document, response)
+}
+
+fn response_schema<'a>(
+    document: &'a Value,
+    path: &str,
+    method: &str,
+    status: &str,
+    media_type: &str,
+) -> &'a Value {
+    response(document, path, method, status)
+        .pointer(&format!("/content/{}/schema", escape_pointer(media_type)))
+        .unwrap_or_else(|| {
+            panic!("missing {media_type} schema for {status} response to {method} {path}")
+        })
+}
+
+fn request_schema<'a>(document: &'a Value, path: &str) -> &'a Value {
+    operation(document, path, "post")
+        .pointer("/requestBody/content/application~1json/schema")
+        .unwrap_or_else(|| panic!("missing JSON request schema for POST {path}"))
+}
+
+fn parameter<'a>(document: &'a Value, path: &str, method: &str, name: &str) -> &'a Value {
+    operation(document, path, method)["parameters"]
+        .as_array()
+        .unwrap_or_else(|| panic!("{method} {path} must declare parameters"))
+        .iter()
+        .map(|parameter| resolve(document, parameter))
+        .find(|parameter| parameter["name"] == name)
+        .unwrap_or_else(|| panic!("{method} {path} omits parameter {name}"))
+}
+
+fn component<'a>(document: &'a Value, name: &str) -> &'a Value {
+    document
+        .pointer(&format!("/components/schemas/{name}"))
+        .unwrap_or_else(|| panic!("missing {name} component schema"))
+}
+
+fn exact_json(source: &str) -> Value {
+    serde_json::from_str(source)
+        .unwrap_or_else(|error| panic!("invalid test JSON {source}: {error}"))
+}
+
+fn validator(document: &Value, schema: &Value) -> Validator {
+    let mut root = document.clone();
+    let root_object = root
+        .as_object_mut()
+        .expect("the OpenAPI document root must be an object");
+    root_object.insert(
+        "$schema".to_owned(),
+        Value::String("https://json-schema.org/draft/2020-12/schema".to_owned()),
+    );
+    root_object.insert("allOf".to_owned(), Value::Array(vec![schema.clone()]));
+    jsonschema::draft202012::new(&root).expect("component must compile as JSON Schema 2020-12")
+}
+
+fn assert_valid(document: &Value, schema: &Value, instance: &Value, context: &str) {
+    let validator = validator(document, schema);
+    if !validator.is_valid(instance) {
+        let errors = validator
+            .iter_errors(instance)
+            .map(|error| error.to_string())
+            .collect::<Vec<_>>()
+            .join("; ");
+        panic!("{context} does not match its OpenAPI schema: {errors}\ninstance: {instance}");
+    }
+}
+
+fn assert_invalid(document: &Value, schema: &Value, instance: &Value, context: &str) {
+    assert!(
+        !validator(document, schema).is_valid(instance),
+        "{context} unexpectedly matches its OpenAPI schema: {instance}"
+    );
+}
+
+fn collect_references<'a>(value: &'a Value, references: &mut Vec<&'a str>) {
+    match value {
+        Value::Array(values) => {
+            for value in values {
+                collect_references(value, references);
+            }
+        }
+        Value::Object(values) => {
+            for (key, value) in values {
+                if key == "$ref" {
+                    references.push(value.as_str().expect("$ref values must be strings"));
+                }
+                collect_references(value, references);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[test]
+fn generated_document_is_the_deterministic_checked_openapi_31_artifact() {
+    let first = document();
+    let second = document();
+    assert_eq!(
+        first, second,
+        "generation must be deterministic in one process"
+    );
+
+    let mut generated = serde_json::to_vec_pretty(&first).unwrap();
+    generated.push(b'\n');
+    assert_eq!(generated, include_bytes!("../docs/openapi-v1.json"));
+
+    let checked = std::str::from_utf8(include_bytes!("../docs/openapi-v1.json")).unwrap();
+    let parsed = oas3::from_json(checked).expect("the artifact must parse as OpenAPI 3.1");
+    assert_eq!(parsed.openapi.to_string(), "3.1.0");
+    assert_eq!(first["openapi"], "3.1.0");
+    assert_eq!(first["info"]["version"], "1");
+    assert!(
+        first.get("servers").is_none(),
+        "listener ownership belongs to each operation"
+    );
+    assert!(first.get("security").is_none());
+    assert!(
+        first
+            .pointer("/components/securitySchemes")
+            .is_none_or(|schemes| object(schemes, "securitySchemes").is_empty())
+    );
+    assert_eq!(
+        first["x-briskdb-wire-contract"],
+        json!({
+            "maxRequestBytes": 2_097_152,
+            "requestObjectsRejectUnknownAndDuplicateMembers": true,
+            "requestControlHeadersRequireOneCanonicalValue": true,
+            "openapiCannotValidateDuplicateJsonMembersOrRawHeaderMultiplicity": true,
+            "idempotencyStatusHeaderIsConditional": true
+        })
+    );
+
+    let mut references = Vec::new();
+    collect_references(&first, &mut references);
+    assert!(
+        references.len() >= 20,
+        "schemas should share component references"
+    );
+    for reference in references {
+        let pointer = reference
+            .strip_prefix('#')
+            .unwrap_or_else(|| panic!("external reference is forbidden: {reference}"));
+        assert!(
+            first.pointer(pointer).is_some(),
+            "unresolved reference: {reference}"
+        );
+    }
+    let schemas = object(&first["components"]["schemas"], "component schemas");
+    for removed in ["Value", "JsonValue"] {
+        assert!(
+            !schemas.contains_key(removed),
+            "unused generated schema {removed} must not leak into the artifact"
+        );
+    }
+    for retained in ["ValueEncoding", "ReadinessResponse", "QueryStreamRecord"] {
+        assert!(
+            schemas.contains_key(retained),
+            "documented abstraction {retained} must remain available"
+        );
+    }
+}
+
+#[test]
+fn path_operation_and_listener_matrix_is_exact() {
+    let document = document();
+    let paths = object(&document["paths"], "paths");
+    let expected_paths = ROUTES
+        .iter()
+        .map(|(path, _, _)| *path)
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        paths.keys().map(String::as_str).collect::<BTreeSet<_>>(),
+        expected_paths
+    );
+
+    let mut operation_ids = BTreeSet::new();
+    let mut actual_operations = 0;
+    for &(path, expected_methods, expected_server) in ROUTES {
+        let path_item = object(&paths[path], path);
+        let actual_methods = path_item
+            .keys()
+            .map(String::as_str)
+            .filter(|key| {
+                matches!(
+                    *key,
+                    "get" | "head" | "post" | "put" | "patch" | "delete" | "options" | "trace"
+                )
+            })
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            actual_methods,
+            expected_methods.iter().copied().collect(),
+            "wrong operations for {path}"
+        );
+
+        for &method in expected_methods {
+            actual_operations += 1;
+            let operation = operation(&document, path, method);
+            let operation_id = operation["operationId"]
+                .as_str()
+                .unwrap_or_else(|| panic!("{method} {path} needs an operationId"));
+            assert!(
+                operation_ids.insert(operation_id),
+                "duplicate operationId {operation_id}"
+            );
+            assert!(
+                operation.get("security").is_none(),
+                "{method} {path} must not anticipate authentication"
+            );
+            assert_eq!(
+                operation.pointer("/servers/0/url").and_then(Value::as_str),
+                Some(expected_server),
+                "wrong listener owner for {method} {path}"
+            );
+            let expected_plane = if expected_server == DATA_SERVER {
+                "data"
+            } else {
+                "administration"
+            };
+            assert_eq!(
+                operation.get("x-briskdb-plane").and_then(Value::as_str),
+                Some(expected_plane),
+                "wrong plane extension for {method} {path}"
+            );
+            assert_eq!(
+                operation["servers"].as_array().map(Vec::len),
+                Some(1),
+                "{method} {path} must identify exactly one listener"
+            );
+        }
+    }
+    assert_eq!(actual_operations, 28);
+    assert_eq!(
+        operation_ids,
+        OPERATION_IDS.iter().copied().collect::<BTreeSet<_>>()
+    );
+
+    let encoded = serde_json::to_string(&document).unwrap();
+    for excluded in [
+        "\"/health\"",
+        "\"/ready\"",
+        "\"/metrics\"",
+        "\"/admin\"",
+        "\"/openapi",
+    ] {
+        assert!(
+            !encoded.contains(excluded),
+            "out-of-scope route leaked into the document: {excluded}"
+        );
+    }
+}
+
+#[test]
+fn request_objects_are_strict_and_match_the_live_envelopes() {
+    let document = document();
+    let execute = request_schema(&document, "/v1/execute");
+    let query = request_schema(&document, "/v1/query");
+    let stream = request_schema(&document, "/v1/query/stream");
+    let broadcast = request_schema(&document, "/v1/admin/broadcast");
+    let checkpoint = request_schema(&document, "/v1/admin/maintenance/checkpoint");
+
+    for component_name in ["LegacyExecuteRequest", "LegacyQueryRequest"] {
+        let schema = component(&document, component_name);
+        assert_eq!(
+            schema["properties"]["params"]["default"],
+            json!([]),
+            "{component_name} must expose the runtime empty-parameter default"
+        );
+        assert_eq!(
+            schema["properties"]["value_encoding"],
+            json!({
+                "type": "string",
+                "const": "legacy-json-v1",
+                "default": "legacy-json-v1"
+            }),
+            "{component_name} must expose the runtime legacy codec default inline"
+        );
+    }
+
+    let result_limits = component(&document, "QueryResultLimits");
+    assert_eq!(
+        result_limits["x-briskdb-number-token-limit"],
+        "max_rows and max_logical_bytes require unsigned-integer JSON token spelling; JSON Schema validators may also accept mathematically integral decimal or exponent tokens.",
+    );
+    for property in ["max_rows", "max_logical_bytes"] {
+        for token in ["1.0", "1e0"] {
+            let mathematically_integral = exact_json(token);
+            assert_valid(
+                &document,
+                &result_limits["properties"][property],
+                &mathematically_integral,
+                &format!("JSON Schema integral {property} token {token}"),
+            );
+            assert_valid(
+                &document,
+                result_limits,
+                &Value::Object(Map::from_iter([(
+                    property.to_owned(),
+                    mathematically_integral,
+                )])),
+                &format!("result limits schema with integral {property} token {token}"),
+            );
+        }
+    }
+
+    for path in [
+        "/v1/execute",
+        "/v1/query",
+        "/v1/query/stream",
+        "/v1/admin/broadcast",
+        "/v1/admin/maintenance/checkpoint",
+    ] {
+        let request_body = resolve(
+            &document,
+            &operation(&document, path, "post")["requestBody"],
+        );
+        assert_eq!(
+            request_body["required"], true,
+            "POST {path} requires a body"
+        );
+        assert_eq!(
+            object(&request_body["content"], "request content")
+                .keys()
+                .map(String::as_str)
+                .collect::<BTreeSet<_>>(),
+            ["application/json"].into_iter().collect(),
+            "POST {path} has the wrong documented request media types"
+        );
+        assert_eq!(
+            operation(&document, path, "post")["x-briskdb-max-request-bytes"],
+            2_097_152,
+            "POST {path} must expose the raw request ceiling"
+        );
+    }
+
+    for (schema, instance, context) in [
+        (execute, json!({"sql": "DELETE FROM notes"}), "execute"),
+        (
+            query,
+            json!({
+                "shard_key": "tenant-a",
+                "sql": "SELECT ?1",
+                "params": [1, {"arbitrary": [true, null]}],
+                "value_encoding": "legacy-json-v1",
+                "result_limits": {"max_rows": 1}
+            }),
+            "query",
+        ),
+        (
+            stream,
+            json!({"sql": "SELECT 1", "result_limits": {"max_logical_bytes": 128}}),
+            "stream query",
+        ),
+        (
+            query,
+            json!({"sql": "SELECT 1", "result_limits": {"max_rows": 1_000_000, "max_logical_bytes": 1_073_741_824}}),
+            "maximum query limits",
+        ),
+        (
+            broadcast,
+            json!({"sql": "CREATE TABLE t (id INTEGER)"}),
+            "broadcast",
+        ),
+        (checkpoint, json!({}), "checkpoint"),
+    ] {
+        assert_valid(&document, schema, &instance, context);
+    }
+
+    for (schema, instance, context) in [
+        (execute, json!({}), "execute missing sql"),
+        (
+            execute,
+            json!({"sql": "DELETE FROM notes", "result_limits": {"max_rows": 1}}),
+            "execute-only field",
+        ),
+        (
+            query,
+            json!({"sql": "SELECT 1", "result_limits": null}),
+            "null result limits",
+        ),
+        (
+            query,
+            json!({"sql": "SELECT 1", "result_limits": {}}),
+            "empty result limits",
+        ),
+        (
+            query,
+            json!({"sql": "SELECT 1", "result_limits": {"max_rows": null}}),
+            "null row limit",
+        ),
+        (
+            query,
+            json!({"sql": "SELECT ?1", "params": [1], "value_encoding": "lossless-json-v1"}),
+            "native number in lossless query",
+        ),
+        (
+            query,
+            json!({"sql": "SELECT 1", "result_limits": {"max_rows": 1_000_001}}),
+            "row limit above the engine maximum",
+        ),
+        (
+            query,
+            json!({"sql": "SELECT 1", "result_limits": {"max_logical_bytes": 1_073_741_825_u64}}),
+            "byte limit above the engine maximum",
+        ),
+        (
+            broadcast,
+            json!({"sql": "CREATE TABLE t (id INTEGER)", "unknown": true}),
+            "unknown broadcast field",
+        ),
+        (checkpoint, json!({"force": true}), "nonempty checkpoint"),
+    ] {
+        assert_invalid(&document, schema, &instance, context);
+    }
+
+    let boundary_request = json!({
+        "sql": "SELECT ?1, ?2, ?3",
+        "params": [{
+            "nested": [
+                exact_json("-9223372036854775808"),
+                exact_json("18446744073709551615"),
+                exact_json("1.7976931348623157e308")
+            ]
+        }]
+    });
+    assert_valid(
+        &document,
+        query,
+        &boundary_request,
+        "nested legacy parameter with supported numeric boundaries",
+    );
+
+    let parameter_number = component(&document, "LegacyJsonParameterNumber");
+    assert_eq!(parameter_number["type"], "number");
+    assert_eq!(
+        parameter_number["exclusiveMinimum"],
+        exact_json(&format!("-{LEGACY_REQUEST_ROUNDING_LIMIT}")),
+    );
+    assert_eq!(
+        parameter_number["exclusiveMaximum"],
+        exact_json(LEGACY_REQUEST_ROUNDING_LIMIT),
+    );
+    assert!(parameter_number.get("minimum").is_none());
+    assert!(parameter_number.get("maximum").is_none());
+
+    let accepted_parameter_tokens = [
+        "1.7976931348623158e308".to_owned(),
+        "-1.7976931348623158e308".to_owned(),
+        format!("{LEGACY_REQUEST_ROUNDING_LIMIT_MINUS_ONE}.0"),
+        format!("-{LEGACY_REQUEST_ROUNDING_LIMIT_MINUS_ONE}.0"),
+    ];
+    for token in accepted_parameter_tokens {
+        let number = exact_json(&token);
+        assert_valid(
+            &document,
+            parameter_number,
+            &number,
+            &format!("legacy request number just inside the binary64 rounding limit: {token}"),
+        );
+        for (schema, request_name) in [(execute, "execute"), (query, "query")] {
+            assert_valid(
+                &document,
+                schema,
+                &json!({"sql": "SELECT ?1", "params": [{"nested": [number.clone()]}]}),
+                &format!("nested {request_name} parameter just inside the rounding limit: {token}"),
+            );
+        }
+    }
+
+    let rejected_parameter_tokens = [
+        "1.7976931348623159e308".to_owned(),
+        "-1.7976931348623159e308".to_owned(),
+        format!("{LEGACY_REQUEST_ROUNDING_LIMIT}.0"),
+        format!("-{LEGACY_REQUEST_ROUNDING_LIMIT}.0"),
+    ];
+    for token in rejected_parameter_tokens {
+        let number = exact_json(&token);
+        assert_invalid(
+            &document,
+            parameter_number,
+            &number,
+            &format!("legacy request number at or beyond the binary64 rounding limit: {token}"),
+        );
+        for (schema, request_name) in [(execute, "execute"), (query, "query")] {
+            assert_invalid(
+                &document,
+                schema,
+                &json!({"sql": "SELECT ?1", "params": [{"nested": [number.clone()]}]}),
+                &format!("nested {request_name} parameter at the rounding limit: {token}"),
+            );
+        }
+    }
+
+    let overflowing_float_request = json!({
+        "sql": "SELECT ?1",
+        "params": [{"nested": [exact_json("1e400")]}]
+    });
+    assert_invalid(
+        &document,
+        query,
+        &overflowing_float_request,
+        "nested legacy float outside the finite f64 range",
+    );
+
+    assert_eq!(
+        resolve(&document, query),
+        resolve(&document, stream),
+        "materialized and streaming queries accept one envelope"
+    );
+    assert!(
+        operation(&document, "/v1/admin/queries/{operation_id}/cancel", "post",)
+            .get("requestBody")
+            .is_none(),
+        "cancel accepts an exact empty byte body, not a JSON envelope"
+    );
+    assert_eq!(
+        operation(&document, "/v1/admin/queries/{operation_id}/cancel", "post",)["x-briskdb-request-body"],
+        json!({"mode": "exactly-zero-bytes", "maxBytes": 2_097_152})
+    );
+}
+
+#[test]
+fn header_and_path_parameter_schemas_capture_the_parsed_grammar() {
+    let document = document();
+    let request_id = parameter(&document, "/v1/query", "post", "BriskDB-Request-ID");
+    assert_eq!(request_id["in"], "header");
+    assert!(!request_id["required"].as_bool().unwrap_or(false));
+    let request_id_schema = &request_id["schema"];
+    assert_valid(
+        &document,
+        request_id_schema,
+        &json!("0123456789abcdef0123456789abcdef"),
+        "request ID",
+    );
+    for invalid in [
+        json!("00000000000000000000000000000000"),
+        json!("0123456789ABCDEF0123456789ABCDEF"),
+        json!("short"),
+        json!(null),
+    ] {
+        assert_invalid(&document, request_id_schema, &invalid, "invalid request ID");
+    }
+
+    let idempotency = parameter(&document, "/v1/execute", "post", "BriskDB-Idempotency-Key");
+    assert_eq!(idempotency["in"], "header");
+    assert!(!idempotency["required"].as_bool().unwrap_or(false));
+    assert_valid(
+        &document,
+        &idempotency["schema"],
+        &json!("fedcba9876543210fedcba9876543210"),
+        "idempotency key",
+    );
+    for invalid in [
+        json!("00000000000000000000000000000000"),
+        json!("FEDCBA9876543210FEDCBA9876543210"),
+        json!("fedcba9876543210fedcba987654321"),
+    ] {
+        assert_invalid(
+            &document,
+            &idempotency["schema"],
+            &invalid,
+            "invalid idempotency key",
+        );
+    }
+    for &(path, methods, _) in ROUTES {
+        for &method in methods {
+            if path == "/v1/execute" && method == "post" {
+                continue;
+            }
+            let names = operation(&document, path, method)["parameters"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|parameter| resolve(&document, parameter)["name"].as_str().unwrap())
+                .collect::<BTreeSet<_>>();
+            assert!(
+                !names.contains("BriskDB-Idempotency-Key"),
+                "{method} {path} must not advertise execute idempotency"
+            );
+        }
+    }
+
+    for (path, name, valid, invalid) in [
+        (
+            "/v1/admin/migrations/{target_generation}",
+            "target_generation",
+            "18446744073709551615",
+            ["", "0", "01", "+1", "18446744073709551616"],
+        ),
+        (
+            "/v1/admin/queries/{operation_id}/cancel",
+            "operation_id",
+            "0123456789abcdef0123456789abcdef",
+            [
+                "",
+                "00000000000000000000000000000000",
+                "0123456789ABCDEF0123456789ABCDEF",
+                "short",
+                "0123456789abcdef0123456789abcdef0",
+            ],
+        ),
+    ] {
+        let parameter = parameter(
+            &document,
+            path,
+            if name == "operation_id" {
+                "post"
+            } else {
+                "get"
+            },
+            name,
+        );
+        assert_eq!(parameter["in"], "path");
+        assert_eq!(parameter["required"], true);
+        assert_valid(
+            &document,
+            &parameter["schema"],
+            &json!(valid),
+            &format!("valid {name}"),
+        );
+        for invalid in invalid {
+            assert_invalid(
+                &document,
+                &parameter["schema"],
+                &json!(invalid),
+                &format!("invalid {name}"),
+            );
+        }
+    }
+
+    let api_version_header = resolve(
+        &document,
+        &response(&document, "/v1/query", "post", "200")["headers"]["BriskDB-API-Version"],
+    );
+    assert_valid(
+        &document,
+        &api_version_header["schema"],
+        &json!("1"),
+        "API version response header",
+    );
+    assert_invalid(
+        &document,
+        &api_version_header["schema"],
+        &json!("2"),
+        "wrong API version response header",
+    );
+
+    let idempotency_status = resolve(
+        &document,
+        &response(&document, "/v1/execute", "post", "200")["headers"]["BriskDB-Idempotency-Status"],
+    );
+    for status in ["created", "replayed"] {
+        assert_valid(
+            &document,
+            &idempotency_status["schema"],
+            &json!(status),
+            "idempotency status response header",
+        );
+    }
+    assert_invalid(
+        &document,
+        &idempotency_status["schema"],
+        &json!("conflicted"),
+        "unknown idempotency status response header",
+    );
+}
+
+#[test]
+fn value_and_conditional_response_schemas_preserve_wire_shapes() {
+    let document = document();
+    assert_valid(
+        &document,
+        component(&document, "QueryColumn"),
+        &json!({"name": "expression", "data_type": "unknown"}),
+        "unknown expression column type",
+    );
+    let query = component(&document, "QueryResponse");
+    let base = json!({
+        "columns": [{"name": "same", "data_type": "binary"}, {"name": "same", "data_type": "int64"}],
+        "rows": [[{"$briskdb_type": "binary", "value": "AP8="}, {"$briskdb_type": "int64", "value": "9007199254740993"}]],
+        "value_encoding": "lossless-json-v1"
+    });
+    let mut single = base.clone();
+    single["shard"] = json!(0);
+    assert_valid(&document, query, &single, "single-shard query response");
+    let mut scatter = base.clone();
+    scatter["shards"] = json!([0, 1]);
+    assert_valid(&document, query, &scatter, "scatter query response");
+    let mut additive_response = single.clone();
+    additive_response["future_top_level"] = json!({"opaque": true});
+    additive_response["columns"][0]["future_column_field"] = json!(17);
+    assert_valid(
+        &document,
+        query,
+        &additive_response,
+        "additive query response fields",
+    );
+    let mut both = base.clone();
+    both["shard"] = json!(0);
+    both["shards"] = json!([0, 1]);
+    assert_invalid(&document, query, &both, "ambiguous query shard shape");
+    assert_invalid(&document, query, &base, "missing query shard shape");
+
+    let legacy_response = json!({
+        "shard": 0,
+        "columns": [{"name": "value", "data_type": "unknown"}],
+        "rows": [[1], [[0, 255]], ["compact object parameter returns as text"]]
+    });
+    assert_valid(
+        &document,
+        query,
+        &legacy_response,
+        "legacy query response with arbitrary JSON values",
+    );
+    let mut named_legacy_response = legacy_response.clone();
+    named_legacy_response["value_encoding"] = json!("legacy-json-v1");
+    assert_invalid(
+        &document,
+        query,
+        &named_legacy_response,
+        "legacy response must omit value_encoding",
+    );
+    let mut missing_lossless_encoding = single.clone();
+    missing_lossless_encoding
+        .as_object_mut()
+        .unwrap()
+        .remove("value_encoding");
+    assert_invalid(
+        &document,
+        query,
+        &missing_lossless_encoding,
+        "lossless response without its encoding marker",
+    );
+    let mut numeric_lossless = single.clone();
+    numeric_lossless["rows"] = json!([[1, 2]]);
+    assert_invalid(
+        &document,
+        query,
+        &numeric_lossless,
+        "native numeric cells in a lossless response",
+    );
+
+    let legacy_result_number = component(&document, "LegacyJsonNumber");
+    assert_eq!(legacy_result_number["type"], "number");
+    assert_eq!(
+        legacy_result_number["minimum"],
+        exact_json("-1.7976931348623157e308"),
+    );
+    assert_eq!(
+        legacy_result_number["maximum"],
+        exact_json("1.7976931348623157e308"),
+    );
+    assert!(legacy_result_number.get("exclusiveMinimum").is_none());
+    assert!(legacy_result_number.get("exclusiveMaximum").is_none());
+    for token in ["1.7976931348623157e308", "-1.7976931348623157e308"] {
+        assert_valid(
+            &document,
+            legacy_result_number,
+            &exact_json(token),
+            "legacy result number at the largest emitted binary64 magnitude",
+        );
+    }
+    for token in ["1.7976931348623158e308", "-1.7976931348623158e308"] {
+        assert_invalid(
+            &document,
+            legacy_result_number,
+            &exact_json(token),
+            "legacy result number beyond the largest emitted binary64 magnitude",
+        );
+    }
+
+    let legacy_cell = component(&document, "LegacyJsonCell");
+    for valid in [
+        Value::Null,
+        json!(true),
+        json!(1),
+        json!(1.5),
+        json!("text"),
+        json!([]),
+        json!([0, 255]),
+    ] {
+        assert_valid(&document, legacy_cell, &valid, "legacy response cell");
+    }
+    for invalid in [
+        json!([256]),
+        json!([-1]),
+        json!([[1]]),
+        json!({"arbitrary": true}),
+    ] {
+        assert_invalid(
+            &document,
+            legacy_cell,
+            &invalid,
+            "invalid legacy response cell",
+        );
+    }
+    for (number, context) in [
+        (
+            exact_json("-9223372036854775808"),
+            "legacy cell at i64::MIN",
+        ),
+        (
+            exact_json("18446744073709551615"),
+            "legacy cell at u64::MAX",
+        ),
+        (
+            exact_json("1.7976931348623157e308"),
+            "legacy cell at maximum finite f64",
+        ),
+        (
+            exact_json("-1.7976931348623157e308"),
+            "legacy cell at minimum finite f64",
+        ),
+    ] {
+        assert_valid(&document, legacy_cell, &number, context);
+    }
+    for token in [
+        "1.7976931348623158e308",
+        "-1.7976931348623158e308",
+        "1e400",
+        "-1e400",
+    ] {
+        assert_invalid(
+            &document,
+            legacy_cell,
+            &exact_json(token),
+            "legacy cell float outside the emitted finite f64 range",
+        );
+    }
+    let stream_row = component(&document, "QueryStreamRow");
+    for valid in [
+        json!({"kind": "row", "values": [null, true, 1, "text", [0, 255]]}),
+        json!({"kind": "row", "values": [{"$briskdb_type": "int64", "value": "1"}]}),
+    ] {
+        assert_valid(&document, stream_row, &valid, "stream row values");
+    }
+    for invalid in [
+        json!({"kind": "row", "values": [{"arbitrary": true}]}),
+        json!({"kind": "row", "values": [[[1]]]}),
+        json!({"kind": "row", "values": [1], "future": true}),
+    ] {
+        assert_invalid(&document, stream_row, &invalid, "invalid stream row value");
+    }
+    let mut nested_legacy_response = legacy_response.clone();
+    nested_legacy_response["rows"] = json!([[{"arbitrary": true}]]);
+    assert_invalid(
+        &document,
+        query,
+        &nested_legacy_response,
+        "object in a legacy query response",
+    );
+
+    let legacy_value = component(&document, "LegacyJsonValue");
+    for valid in [
+        Value::Null,
+        json!(true),
+        json!(17),
+        json!(1.5),
+        json!("text"),
+        json!([1, {"nested": true}]),
+        json!({"arbitrary": [null]}),
+    ] {
+        assert_valid(&document, legacy_value, &valid, "legacy JSON value");
+    }
+    for (number, context) in [
+        (
+            exact_json("-9223372036854775808"),
+            "legacy value at i64::MIN",
+        ),
+        (
+            exact_json("18446744073709551615"),
+            "legacy value at u64::MAX",
+        ),
+        (
+            exact_json("1.7976931348623158e308"),
+            "legacy parameter value that rounds to maximum finite f64",
+        ),
+        (
+            exact_json("-1.7976931348623158e308"),
+            "legacy parameter value that rounds to minimum finite f64",
+        ),
+        (
+            exact_json(&format!("{LEGACY_REQUEST_ROUNDING_LIMIT_MINUS_ONE}.0")),
+            "legacy parameter value just inside the positive rounding limit",
+        ),
+        (
+            exact_json(&format!("-{LEGACY_REQUEST_ROUNDING_LIMIT_MINUS_ONE}.0")),
+            "legacy parameter value just inside the negative rounding limit",
+        ),
+    ] {
+        assert_valid(&document, legacy_value, &number, context);
+    }
+    for token in [
+        "1.7976931348623159e308".to_owned(),
+        "-1.7976931348623159e308".to_owned(),
+        format!("{LEGACY_REQUEST_ROUNDING_LIMIT}.0"),
+        format!("-{LEGACY_REQUEST_ROUNDING_LIMIT}.0"),
+        "1e400".to_owned(),
+        "-1e400".to_owned(),
+    ] {
+        assert_invalid(
+            &document,
+            legacy_value,
+            &exact_json(&token),
+            "legacy parameter value outside the finite binary64 rounding range",
+        );
+    }
+    assert_eq!(
+        component(&document, "LegacyJsonParameter")["x-briskdb-number-token-limit"],
+        "JSON Schema sees numeric value, while the decoder also distinguishes integer tokens from fractional or exponent tokens.",
+        "the schema must document its lexical-number validation limit",
+    );
+
+    let value = component(&document, "LosslessJsonValue");
+    for valid in [
+        Value::Null,
+        json!(true),
+        json!("text"),
+        json!({"$briskdb_type": "uint64", "value": "18446744073709551615"}),
+        json!({"$briskdb_type": "int64", "value": "9223372036854775807"}),
+        json!({"$briskdb_type": "int64", "value": "-9223372036854775808"}),
+        json!({"$briskdb_type": "float64", "value": "7ff8000000000000"}),
+        json!({"$briskdb_type": "decimal", "value": "12.3400"}),
+        json!({"$briskdb_type": "invalid_text", "value": "/w=="}),
+    ] {
+        assert_valid(&document, value, &valid, "BriskDB value");
+    }
+    for invalid in [
+        json!(17),
+        json!([]),
+        json!({}),
+        json!({"$briskdb_type": "binary"}),
+        json!({"$briskdb_type": "unknown", "value": "x"}),
+        json!({"$briskdb_type": "binary", "value": "AA==", "extra": true}),
+        json!({"$briskdb_type": "int64", "value": "01"}),
+        json!({"$briskdb_type": "int64", "value": "-0"}),
+        json!({"$briskdb_type": "int64", "value": "9223372036854775808"}),
+        json!({"$briskdb_type": "uint64", "value": "18446744073709551616"}),
+        json!({"$briskdb_type": "float64", "value": "7FF8000000000000"}),
+        json!({"$briskdb_type": "decimal", "value": "."}),
+        json!({"$briskdb_type": "binary", "value": "not base64"}),
+    ] {
+        assert_invalid(&document, value, &invalid, "invalid BriskDB value");
+    }
+    for kind in ["binary", "invalid_text"] {
+        for encoded in ["AA==", "AAA=", "/w==", "//8="] {
+            assert_valid(
+                &document,
+                value,
+                &json!({"$briskdb_type": kind, "value": encoded}),
+                &format!("canonical {kind} Base64 with valid pad bits"),
+            );
+        }
+        for encoded in ["AB==", "AAB=", "/x==", "//9="] {
+            assert_invalid(
+                &document,
+                value,
+                &json!({"$briskdb_type": kind, "value": encoded}),
+                &format!("noncanonical {kind} Base64 pad bits"),
+            );
+        }
+    }
+
+    let placement = component(&document, "CatalogPlacement");
+    assert_valid(
+        &document,
+        placement,
+        &json!({"kind": "sharded", "shard_key": {"column": "tenant", "data_type": "text"}}),
+        "sharded catalog placement",
+    );
+    assert_valid(
+        &document,
+        placement,
+        &json!({"kind": "global"}),
+        "global catalog placement",
+    );
+    assert_invalid(
+        &document,
+        placement,
+        &json!({"kind": "sharded"}),
+        "sharded placement without key",
+    );
+    assert_invalid(
+        &document,
+        placement,
+        &json!({"kind": "global", "shard_key": {"column": "tenant", "data_type": "text"}}),
+        "global placement with key",
+    );
+
+    for (component_name, property) in [
+        ("CatalogDb", "id"),
+        ("CatalogTable", "id"),
+        ("CatalogTable", "database_id"),
+        ("CatalogGlobalIndex", "id"),
+        ("CatalogGlobalIndex", "table_id"),
+        ("GlobalIndexStatus", "id"),
+    ] {
+        let schema = &component(&document, component_name)["properties"][property];
+        for valid in ["1", "18446744073709551615"] {
+            assert_valid(
+                &document,
+                schema,
+                &json!(valid),
+                &format!("positive {component_name}.{property}"),
+            );
+        }
+        for invalid in ["0", "01", "18446744073709551616"] {
+            assert_invalid(
+                &document,
+                schema,
+                &json!(invalid),
+                &format!("invalid persisted identity {component_name}.{property}"),
+            );
+        }
+    }
+    for (component_name, property) in [
+        ("CatalogResponse", "schema_generation"),
+        ("CatalogGlobalIndex", "schema_generation"),
+        ("MigrationsResponse", "schema_generation"),
+        ("MigrationResponse", "source_generation"),
+        ("ShardStatusResponse", "schema_generation"),
+        ("ReadyResponse", "schema_generation"),
+        ("NotReadyResponse", "schema_generation"),
+    ] {
+        let schema = &component(&document, component_name)["properties"][property];
+        for valid in ["0", "2147483647"] {
+            assert_valid(
+                &document,
+                schema,
+                &json!(valid),
+                &format!("zero-capable {component_name}.{property}"),
+            );
+        }
+        for invalid in ["00", "2147483648"] {
+            assert_invalid(
+                &document,
+                schema,
+                &json!(invalid),
+                &format!("invalid generation {component_name}.{property}"),
+            );
+        }
+    }
+    for property in ["generation", "target_generation"] {
+        let schema = &component(&document, "MigrationResponse")["properties"][property];
+        for valid in ["1", "2147483647"] {
+            assert_valid(
+                &document,
+                schema,
+                &json!(valid),
+                &format!("positive MigrationResponse.{property}"),
+            );
+        }
+        for invalid in ["0", "01", "2147483648"] {
+            assert_invalid(
+                &document,
+                schema,
+                &json!(invalid),
+                &format!("invalid MigrationResponse.{property}"),
+            );
+        }
+    }
+    assert_eq!(
+        component(&document, "CatalogResponse")["properties"]["default_database_id"],
+        json!({"type": "string", "const": "1"}),
+        "the catalog default database identity is fixed by the v1 store contract",
+    );
+
+    let catalog_properties = &component(&document, "CatalogResponse")["properties"];
+    assert_eq!(catalog_properties["databases"]["type"], "array");
+    assert_eq!(catalog_properties["databases"]["minItems"], 1);
+    assert_eq!(catalog_properties["databases"]["maxItems"], 64);
+    assert_valid(
+        &document,
+        &catalog_properties["databases"],
+        &json!([{"id": "1", "name": "default"}]),
+        "catalog database list containing the fixed default database",
+    );
+    assert_invalid(
+        &document,
+        &catalog_properties["databases"],
+        &json!([]),
+        "catalog database list without any database",
+    );
+    assert_invalid(
+        &document,
+        &catalog_properties["databases"],
+        &json!([{"id": "2", "name": "other"}]),
+        "catalog database list without the fixed default database",
+    );
+    for property in ["tables", "global_indexes"] {
+        assert_eq!(catalog_properties[property]["type"], "array");
+        assert_eq!(catalog_properties[property]["maxItems"], 4_096);
+    }
+    assert_eq!(
+        component(&document, "GlobalIndexesResponse")["properties"]["indexes"]["maxItems"],
+        4_096,
+    );
+
+    for property in ["total", "healthy", "degraded", "unavailable"] {
+        let schema = &component(&document, "HealthGlobalIndexesResponse")["properties"][property];
+        assert_eq!(schema["type"], "integer");
+        assert_eq!(schema["minimum"], 0);
+        assert_eq!(schema["maximum"], 4_096);
+        assert_valid(
+            &document,
+            schema,
+            &json!(4_096),
+            &format!("HealthGlobalIndexesResponse.{property} at the catalog index limit"),
+        );
+        assert_invalid(
+            &document,
+            schema,
+            &json!(4_097),
+            &format!("HealthGlobalIndexesResponse.{property} above the catalog index limit"),
+        );
+    }
+
+    let migration_sql_bytes = &component(&document, "MigrationResponse")["properties"]["sql_bytes"];
+    assert_eq!(migration_sql_bytes["type"], "integer");
+    assert_eq!(migration_sql_bytes["minimum"], 1);
+    assert_eq!(migration_sql_bytes["maximum"], 65_536);
+    for valid in [1, 65_536] {
+        assert_valid(
+            &document,
+            migration_sql_bytes,
+            &json!(valid),
+            "migration SQL byte length",
+        );
+    }
+    for invalid in [0, 65_537] {
+        assert_invalid(
+            &document,
+            migration_sql_bytes,
+            &json!(invalid),
+            "invalid migration SQL byte length",
+        );
+    }
+
+    let not_ready_branches = component(&document, "NotReadyResponse")["oneOf"]
+        .as_array()
+        .expect("NotReadyResponse must enumerate its reachable state pairs");
+    assert_eq!(not_ready_branches.len(), 11);
+    assert_eq!(
+        component(&document, "NotReadyResponse")["properties"]["reasons"]["maxItems"],
+        2,
+        "at most one engine and one schema reason can be emitted",
+    );
+
+    for component_name in ["GlobalIndexesResponse", "HealthGlobalIndexesResponse"] {
+        for (property, maximum) in [
+            ("retained_outbox_events", 64_000_000_u64),
+            ("retained_outbox_bytes", 17_179_869_184_u64),
+        ] {
+            let schema = &component(&document, component_name)["properties"][property];
+            assert_eq!(schema["minimum"], 0);
+            assert_eq!(schema["maximum"], maximum);
+            assert_valid(
+                &document,
+                schema,
+                &json!(maximum),
+                &format!("{component_name}.{property} at its retention limit"),
+            );
+            assert_invalid(
+                &document,
+                schema,
+                &json!(maximum + 1),
+                &format!("{component_name}.{property} above its retention limit"),
+            );
+        }
+    }
+    for (component_name, property) in [
+        ("GlobalIndexStatus", "async_lag"),
+        ("HealthGlobalIndexesResponse", "async_lag"),
+    ] {
+        let schema = &component(&document, component_name)["properties"][property];
+        assert_eq!(schema["maximum"], u64::MAX);
+        assert_valid(
+            &document,
+            schema,
+            &json!(u64::MAX),
+            &format!("{component_name}.{property} at the u64 lifetime-watermark limit"),
+        );
+    }
+    for (component_name, pointer) in [
+        ("ActiveQueryResponse", "/properties/sql_bytes"),
+        ("ExecuteResponse", "/oneOf/0/properties/rows_affected"),
+        ("ExecuteResponse", "/oneOf/1/properties/rows_affected"),
+        ("ReadyResponse", "/properties/active_schema_operations"),
+        ("NotReadyResponse", "/properties/active_schema_operations"),
+    ] {
+        let schema = component(&document, component_name)
+            .pointer(pointer)
+            .unwrap_or_else(|| panic!("missing usize schema {component_name}{pointer}"));
+        assert_eq!(schema["type"], "integer");
+        assert_eq!(schema["minimum"], 0);
+        assert_eq!(schema["maximum"], u64::MAX);
+        assert_valid(
+            &document,
+            schema,
+            &json!(u64::MAX),
+            &format!("{component_name}{pointer} at the platform-independent wire maximum"),
+        );
+        assert_invalid(
+            &document,
+            schema,
+            &exact_json("18446744073709551616"),
+            &format!("{component_name}{pointer} above the u64 wire maximum"),
+        );
+    }
+
+    for (component_name, pointer) in [
+        ("ExecuteResponse", "/oneOf/0/properties/shard"),
+        ("ExecuteResponse", "/oneOf/1/properties/shard"),
+        ("LegacySingleShardQueryResponse", "/properties/shard"),
+        ("LosslessSingleShardQueryResponse", "/properties/shard"),
+        ("LegacyMultiShardQueryResponse", "/properties/shards/items"),
+        (
+            "LosslessMultiShardQueryResponse",
+            "/properties/shards/items",
+        ),
+        ("LegacySingleShardStreamMeta", "/properties/shard"),
+        ("LosslessSingleShardStreamMeta", "/properties/shard"),
+        ("LegacyMultiShardStreamMeta", "/properties/shards/items"),
+        ("LosslessMultiShardStreamMeta", "/properties/shards/items"),
+        ("BroadcastResponse", "/properties/completed_shards/items"),
+        ("ShardStatus", "/properties/id"),
+        ("CheckpointShardResponse", "/properties/shard"),
+    ] {
+        let schema = component(&document, component_name)
+            .pointer(pointer)
+            .unwrap_or_else(|| panic!("missing shard ID schema {component_name}{pointer}"));
+        assert_eq!(schema["type"], "integer");
+        assert_eq!(schema["minimum"], 0);
+        assert_eq!(schema["maximum"], 63);
+        assert_valid(
+            &document,
+            schema,
+            &json!(63),
+            &format!("{component_name}{pointer} at the maximum physical shard ID"),
+        );
+        assert_invalid(
+            &document,
+            schema,
+            &json!(64),
+            &format!("{component_name}{pointer} beyond the maximum physical shard ID"),
+        );
+    }
+
+    for (component_name, property) in [
+        ("HealthGlobalIndexesResponse", "backpressured_outbox_shards"),
+        ("GlobalIndexesResponse", "backpressured_outbox_shards"),
+        ("GlobalIndexStatus", "poisoned_shards"),
+        ("GlobalIndexStatus", "leased_shards"),
+        ("GlobalIndexStatus", "summary_ready_shards"),
+        ("GlobalIndexStatus", "summary_degraded_shards"),
+        ("GlobalIndexStatus", "summary_saturated_shards"),
+        ("MigrationResponse", "next_shard"),
+        ("MigrationResponse", "completed_shards"),
+    ] {
+        let schema = &component(&document, component_name)["properties"][property];
+        assert_eq!(schema["type"], "integer");
+        assert_eq!(schema["minimum"], 0);
+        assert_eq!(schema["maximum"], 64);
+        assert_valid(
+            &document,
+            schema,
+            &json!(64),
+            &format!("{component_name}.{property} at the physical shard count limit"),
+        );
+        assert_invalid(
+            &document,
+            schema,
+            &json!(65),
+            &format!("{component_name}.{property} above the physical shard count limit"),
+        );
+    }
+
+    for (component_name, property) in [
+        ("HealthResponse", "shards"),
+        ("MigrationResponse", "shard_count"),
+    ] {
+        let schema = &component(&document, component_name)["properties"][property];
+        assert_eq!(schema["type"], "integer");
+        assert_eq!(schema["minimum"], 2);
+        assert_eq!(schema["maximum"], 64);
+        for valid in [2, 64] {
+            assert_valid(
+                &document,
+                schema,
+                &json!(valid),
+                &format!("valid {component_name}.{property}"),
+            );
+        }
+        for invalid in [1, 65] {
+            assert_invalid(
+                &document,
+                schema,
+                &json!(invalid),
+                &format!("invalid {component_name}.{property}"),
+            );
+        }
+    }
+
+    for (component_name, property) in [
+        ("LegacyMultiShardQueryResponse", "shards"),
+        ("LosslessMultiShardQueryResponse", "shards"),
+        ("LegacyMultiShardStreamMeta", "shards"),
+        ("LosslessMultiShardStreamMeta", "shards"),
+        ("BroadcastResponse", "completed_shards"),
+        ("ShardStatusResponse", "shards"),
+        ("CheckpointResponse", "shards"),
+    ] {
+        let schema = &component(&document, component_name)["properties"][property];
+        assert_eq!(schema["type"], "array");
+        assert_eq!(schema["minItems"], 2);
+        assert_eq!(schema["maxItems"], 64);
+        assert_eq!(schema["uniqueItems"], true);
+    }
+
+    let all_shard_ids = Value::Array((0..64).map(|shard| json!(shard)).collect());
+    for (component_name, property) in [
+        ("LegacyMultiShardQueryResponse", "shards"),
+        ("LosslessMultiShardQueryResponse", "shards"),
+        ("LegacyMultiShardStreamMeta", "shards"),
+        ("LosslessMultiShardStreamMeta", "shards"),
+        ("BroadcastResponse", "completed_shards"),
+    ] {
+        let schema = &component(&document, component_name)["properties"][property];
+        assert_valid(
+            &document,
+            schema,
+            &all_shard_ids,
+            &format!("{component_name}.{property} with all 64 physical shards"),
+        );
+        assert_invalid(
+            &document,
+            schema,
+            &json!([0]),
+            &format!("{component_name}.{property} below its multi-shard minimum"),
+        );
+    }
+
+    for component_name in [
+        "LegacySingleShardQueryResponse",
+        "LegacyMultiShardQueryResponse",
+        "LosslessSingleShardQueryResponse",
+        "LosslessMultiShardQueryResponse",
+    ] {
+        let rows = &component(&document, component_name)["properties"]["rows"];
+        assert_eq!(rows["type"], "array");
+        assert_eq!(rows["maxItems"], 1_000_000);
+    }
+    let completed_rows = &component(&document, "QueryStreamComplete")["properties"]["rows"];
+    assert_eq!(completed_rows["type"], "integer");
+    assert_eq!(completed_rows["minimum"], 0);
+    assert_eq!(completed_rows["maximum"], 1_000_000);
+    assert_valid(
+        &document,
+        completed_rows,
+        &json!(1_000_000),
+        "stream completion at the result row limit",
+    );
+    assert_invalid(
+        &document,
+        completed_rows,
+        &json!(1_000_001),
+        "stream completion above the result row limit",
+    );
+
+    let checkpoint_databases =
+        &component(&document, "CheckpointResponse")["properties"]["databases"];
+    assert_eq!(checkpoint_databases["type"], "array");
+    assert_eq!(checkpoint_databases["minItems"], 1);
+    assert_eq!(checkpoint_databases["maxItems"], 2);
+    assert_eq!(checkpoint_databases["uniqueItems"], true);
+    let shard_statuses = Value::Array(
+        (0..64)
+            .map(|id| json!({"id": id, "state": "ready"}))
+            .collect(),
+    );
+    let shard_statuses_schema =
+        &component(&document, "ShardStatusResponse")["properties"]["shards"];
+    assert_valid(
+        &document,
+        shard_statuses_schema,
+        &shard_statuses,
+        "status response with all 64 physical shards",
+    );
+    assert_invalid(
+        &document,
+        shard_statuses_schema,
+        &json!([{"id": 0, "state": "ready"}]),
+        "status response below the physical shard minimum",
+    );
+
+    let checkpoint_shards = Value::Array(
+        (0..64)
+            .map(|shard| {
+                json!({
+                    "shard": shard,
+                    "busy": false,
+                    "counts_available": true,
+                    "wal_frames": 0,
+                    "checkpointed_frames": 0,
+                    "complete": true
+                })
+            })
+            .collect(),
+    );
+    let checkpoint_shards_schema =
+        &component(&document, "CheckpointResponse")["properties"]["shards"];
+    assert_valid(
+        &document,
+        checkpoint_shards_schema,
+        &checkpoint_shards,
+        "checkpoint response with all 64 physical shards",
+    );
+    assert_invalid(
+        &document,
+        checkpoint_shards_schema,
+        &json!([{
+            "shard": 0,
+            "busy": false,
+            "counts_available": true,
+            "wal_frames": 0,
+            "checkpointed_frames": 0,
+            "complete": true
+        }]),
+        "checkpoint response below the physical shard minimum",
+    );
+    assert_valid(
+        &document,
+        checkpoint_databases,
+        &json!([
+            {
+                "database": "manifest",
+                "busy": false,
+                "counts_available": true,
+                "wal_frames": 0,
+                "checkpointed_frames": 0,
+                "complete": true
+            },
+            {
+                "database": "global_index",
+                "busy": false,
+                "counts_available": true,
+                "wal_frames": 0,
+                "checkpointed_frames": 0,
+                "complete": true
+            }
+        ]),
+        "checkpoint response with both database families",
+    );
+    assert_invalid(
+        &document,
+        checkpoint_databases,
+        &json!([]),
+        "checkpoint response without a database result",
+    );
+    for (component_name, property) in [
+        ("CatalogResponse", "identifier_encoding_version"),
+        ("CatalogGeneratedIdEnabled", "encoding_version"),
+        ("CatalogGlobalIndex", "key_encoding_version"),
+    ] {
+        assert_eq!(
+            component(&document, component_name)["properties"][property],
+            json!({"type": "integer", "const": 1}),
+            "{component_name}.{property} is a frozen v1 encoding"
+        );
+    }
+
+    let checkpoint_database = component(&document, "CheckpointDbResponse");
+    for database in ["manifest", "global_index"] {
+        assert_valid(
+            &document,
+            checkpoint_database,
+            &json!({
+                "database": database,
+                "busy": false,
+                "counts_available": true,
+                "wal_frames": 0,
+                "checkpointed_frames": 0,
+                "complete": true
+            }),
+            "checkpoint database result",
+        );
+    }
+    assert_invalid(
+        &document,
+        checkpoint_database,
+        &json!({
+            "database": "catalog",
+            "busy": false,
+            "counts_available": true,
+            "wal_frames": 0,
+            "checkpointed_frames": 0,
+            "complete": true
+        }),
+        "invented checkpoint database name",
+    );
+
+    let generated_key = component(&document, "ExecuteGeneratedKey");
+    for valid in [
+        json!({"column": "id", "data_type": "int64", "value": "-9223372036854775808"}),
+        json!({"column": "id", "data_type": "uint64", "value": "18446744073709551615"}),
+    ] {
+        assert_valid(&document, generated_key, &valid, "generated key");
+    }
+    for invalid in [
+        json!({"column": "id", "data_type": "uint64", "value": "-1"}),
+        json!({"column": "id", "data_type": "int64", "value": "01"}),
+    ] {
+        assert_invalid(&document, generated_key, &invalid, "invalid generated key");
+    }
+}
+
+#[test]
+fn response_headers_problems_head_and_stream_contract_are_explicit() {
+    let document = document();
+
+    for &(path, methods, _) in ROUTES {
+        for &method in methods {
+            let operation = operation(&document, path, method);
+            let request_headers = operation["parameters"]
+                .as_array()
+                .unwrap_or_else(|| panic!("{method} {path} must declare request headers"))
+                .iter()
+                .map(|parameter| resolve(&document, parameter))
+                .filter(|parameter| parameter["in"] == "header")
+                .filter_map(|parameter| parameter["name"].as_str())
+                .collect::<BTreeSet<_>>();
+            assert!(
+                request_headers.contains("BriskDB-Request-ID"),
+                "{method} {path} omits the request identity header"
+            );
+            assert_eq!(
+                request_headers.contains("BriskDB-Idempotency-Key"),
+                path == "/v1/execute" && method == "post",
+                "only exact POST /v1/execute accepts the idempotency header"
+            );
+            assert!(
+                operation["responses"].get("501").is_some(),
+                "{method} {path} must expose the global idempotency middleware rejection"
+            );
+
+            for (status, response) in object(&operation["responses"], "responses") {
+                if method == "head" {
+                    assert!(
+                        response.get("$ref").is_none(),
+                        "HEAD {path} {status} must materialize its response before removing content"
+                    );
+                } else if !(status.starts_with('2') || path == "/v1/ready" && status == "503") {
+                    assert_eq!(
+                        response["$ref"],
+                        format!("#/components/responses/Problem{status}"),
+                        "{method} {path} {status} must reuse its Problem component"
+                    );
+                }
+                let response = resolve(&document, response);
+                let headers = object(&response["headers"], "response headers");
+                assert!(
+                    headers.contains_key("BriskDB-Request-ID"),
+                    "{method} {path} {status} omits BriskDB-Request-ID"
+                );
+                assert!(
+                    headers.contains_key("BriskDB-API-Version"),
+                    "{method} {path} {status} omits BriskDB-API-Version"
+                );
+            }
+        }
+    }
+
+    let execute_headers = operation(&document, "/v1/execute", "post")["parameters"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|parameter| resolve(&document, parameter))
+        .filter_map(|parameter| parameter["name"].as_str())
+        .collect::<BTreeSet<_>>();
+    assert!(execute_headers.contains("BriskDB-Idempotency-Key"));
+    assert!(
+        response(&document, "/v1/execute", "post", "200")["headers"]
+            .get("BriskDB-Idempotency-Status")
+            .is_some()
+    );
+
+    let content_length_schema = &document["components"]["headers"]["ContentLength"]["schema"];
+    assert_valid(
+        &document,
+        content_length_schema,
+        &json!(u64::MAX),
+        "Content-Length at the platform-independent wire maximum",
+    );
+    assert_invalid(
+        &document,
+        content_length_schema,
+        &exact_json("18446744073709551616"),
+        "Content-Length above the u64 wire maximum",
+    );
+
+    for &(path, methods, _) in ROUTES {
+        if methods == ["get", "head"] {
+            let get_responses = object(
+                &operation(&document, path, "get")["responses"],
+                "GET responses",
+            );
+            let head_responses = object(
+                &operation(&document, path, "head")["responses"],
+                "HEAD responses",
+            );
+            assert_eq!(
+                get_responses.keys().collect::<BTreeSet<_>>(),
+                head_responses.keys().collect()
+            );
+            for (status, response) in head_responses {
+                let get_response = resolve(&document, &get_responses[status]);
+                let response = resolve(&document, response);
+                assert!(
+                    response.get("content").is_none(),
+                    "HEAD {path} must describe no response body"
+                );
+                let headers = object(&response["headers"], "HEAD response headers");
+                assert_eq!(
+                    headers["Content-Length"],
+                    json!({"$ref": "#/components/headers/ContentLength"}),
+                    "HEAD {path} must reference the retained representation length"
+                );
+                assert_eq!(
+                    resolve(&document, &headers["Content-Length"]),
+                    &json!({
+                        "description": "The size of the corresponding GET representation; a HEAD response carries no body.",
+                        "required": true,
+                        "schema": {"type": "integer", "minimum": 0, "maximum": u64::MAX}
+                    }),
+                    "HEAD {path} must require the retained representation length"
+                );
+                let get_content = object(&get_response["content"], "GET response content");
+                assert_eq!(
+                    get_content.len(),
+                    1,
+                    "GET {path} {status} must have one representation media type"
+                );
+                let expected_content_type = get_content.keys().next().unwrap();
+                let content_type = resolve(
+                    &document,
+                    headers.get("Content-Type").unwrap_or_else(|| {
+                        panic!("HEAD {path} {status} omits its representation Content-Type")
+                    }),
+                );
+                assert_eq!(
+                    content_type,
+                    &json!({
+                        "description": "Media type of the corresponding GET representation.",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "const": expected_content_type
+                        }
+                    }),
+                    "HEAD {path} {status} has the wrong representation Content-Type"
+                );
+            }
+        }
+    }
+
+    let problem = resolve(
+        &document,
+        response_schema(
+            &document,
+            "/v1/query",
+            "post",
+            "400",
+            "application/problem+json",
+        ),
+    );
+    assert_eq!(problem["type"], "object");
+    assert_eq!(problem["additionalProperties"], false);
+    assert_eq!(
+        problem["required"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(Value::as_str)
+            .collect::<BTreeSet<_>>(),
+        ["code", "detail", "status", "title", "type"]
+            .into_iter()
+            .collect()
+    );
+    assert_eq!(
+        object(&problem["properties"], "Problem properties")
+            .keys()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>(),
+        ["code", "detail", "status", "title", "type"]
+            .into_iter()
+            .collect()
+    );
+    let problem_code = resolve(&document, &problem["properties"]["code"]);
+    assert_eq!(problem_code["type"], "string");
+    assert!(
+        problem_code.get("enum").is_none(),
+        "Problem.code remains open to additive future error kinds"
+    );
+    let invalid_argument = http_error(EngineErrorKind::InvalidArgument);
+    assert_invalid(
+        &document,
+        problem,
+        &json!({
+            "type": invalid_argument.problem_type,
+            "title": invalid_argument.title,
+            "status": invalid_argument.status,
+            "detail": invalid_argument.detail,
+            "code": EngineErrorKind::InvalidArgument.code(),
+            "future": true
+        }),
+        "Problem with an extra member",
+    );
+    let stream_error_code = resolve(
+        &document,
+        &component(&document, "QueryStreamError")["properties"]["code"],
+    );
+    assert_eq!(stream_error_code["type"], "string");
+    assert!(
+        stream_error_code.get("enum").is_none(),
+        "terminal stream error codes remain additive"
+    );
+    let problem_responses = object(
+        &document["components"]["responses"],
+        "reusable Problem responses",
+    );
+    for status in [
+        400_u16, 403, 404, 405, 409, 413, 415, 422, 500, 501, 503, 504, 507,
+    ] {
+        let name = format!("Problem{status}");
+        let response = resolve(
+            &document,
+            problem_responses
+                .get(&name)
+                .unwrap_or_else(|| panic!("missing reusable {name}")),
+        );
+        let headers = object(&response["headers"], "reusable Problem headers");
+        if status == 405 {
+            assert_eq!(
+                headers["Allow"],
+                json!({"$ref": "#/components/headers/Allow"})
+            );
+            assert_eq!(
+                resolve(&document, &headers["Allow"]),
+                &json!({
+                    "description": "Methods accepted by the matched HTTP v1 route family.",
+                    "required": true,
+                    "schema": {"type": "string", "enum": ["GET,HEAD", "POST"]}
+                })
+            );
+        } else {
+            assert!(
+                !headers.contains_key("Allow"),
+                "{name} must not claim the status-specific Allow header"
+            );
+        }
+    }
+    for (component_name, instance) in [
+        (
+            "QueryStreamMeta",
+            json!({"kind": "meta", "shard": 0, "columns": [], "future": true}),
+        ),
+        (
+            "QueryStreamComplete",
+            json!({"kind": "complete", "rows": 0, "future": true}),
+        ),
+        (
+            "QueryStreamError",
+            json!({
+                "kind": "error",
+                "type": invalid_argument.problem_type,
+                "title": invalid_argument.title,
+                "status": invalid_argument.status,
+                "detail": invalid_argument.detail,
+                "code": EngineErrorKind::InvalidArgument.code(),
+                "future": true
+            }),
+        ),
+    ] {
+        assert_invalid(
+            &document,
+            component(&document, component_name),
+            &instance,
+            &format!("strict {component_name}"),
+        );
+    }
+
+    let ready_schema = response_schema(&document, "/v1/ready", "get", "200", "application/json");
+    let not_ready_schema =
+        response_schema(&document, "/v1/ready", "get", "503", "application/json");
+    assert_eq!(
+        ready_schema,
+        &json!({"$ref": "#/components/schemas/ReadyResponse"})
+    );
+    assert_eq!(
+        not_ready_schema,
+        &json!({"$ref": "#/components/schemas/NotReadyResponse"})
+    );
+    let ready = json!({
+        "status": "ready",
+        "ready": true,
+        "reasons": [],
+        "engine_state": "running",
+        "schema_state": "ready",
+        "schema_generation": "0",
+        "active_schema_operations": 0
+    });
+    let not_ready = json!({
+        "status": "not_ready",
+        "ready": false,
+        "reasons": ["engine_draining"],
+        "engine_state": "draining",
+        "schema_state": "ready",
+        "schema_generation": "0",
+        "active_schema_operations": 0
+    });
+    assert_valid(&document, ready_schema, &ready, "200 readiness response");
+    assert_valid(
+        &document,
+        not_ready_schema,
+        &not_ready,
+        "503 readiness response",
+    );
+    assert_invalid(
+        &document,
+        ready_schema,
+        &not_ready,
+        "503 readiness body under the 200 schema",
+    );
+    assert_invalid(
+        &document,
+        not_ready_schema,
+        &ready,
+        "200 readiness body under the 503 schema",
+    );
+
+    assert_eq!(
+        component(&document, "NotReadyResponse")["oneOf"]
+            .as_array()
+            .expect("NotReadyResponse must enumerate its reachable state pairs")
+            .len(),
+        11,
+    );
+    for (engine_state, engine_reason) in [
+        ("running", None),
+        ("draining", Some("engine_draining")),
+        ("stopped", Some("engine_stopped")),
+    ] {
+        for (schema_state, schema_reason) in [
+            ("ready", None),
+            ("migrating", Some("schema_migrating")),
+            ("pending", Some("schema_recovery_pending")),
+            ("degraded", Some("schema_degraded")),
+        ] {
+            if engine_reason.is_none() && schema_reason.is_none() {
+                continue;
+            }
+            let reasons = engine_reason
+                .into_iter()
+                .chain(schema_reason)
+                .collect::<Vec<_>>();
+            assert_valid(
+                &document,
+                not_ready_schema,
+                &json!({
+                    "status": "not_ready",
+                    "ready": false,
+                    "reasons": reasons,
+                    "engine_state": engine_state,
+                    "schema_state": schema_state,
+                    "schema_generation": "0",
+                    "active_schema_operations": 0
+                }),
+                &format!("reachable not-ready state pair {engine_state}/{schema_state}"),
+            );
+        }
+    }
+    for (instance, context) in [
+        (
+            json!({
+                "status": "not_ready",
+                "ready": false,
+                "reasons": [],
+                "engine_state": "running",
+                "schema_state": "ready",
+                "schema_generation": "0",
+                "active_schema_operations": 0
+            }),
+            "running/ready is the 200 readiness state",
+        ),
+        (
+            json!({
+                "status": "not_ready",
+                "ready": false,
+                "reasons": ["engine_stopped"],
+                "engine_state": "draining",
+                "schema_state": "ready",
+                "schema_generation": "0",
+                "active_schema_operations": 0
+            }),
+            "mismatched engine readiness reason",
+        ),
+        (
+            json!({
+                "status": "not_ready",
+                "ready": false,
+                "reasons": ["schema_degraded", "engine_stopped"],
+                "engine_state": "stopped",
+                "schema_state": "degraded",
+                "schema_generation": "0",
+                "active_schema_operations": 0
+            }),
+            "reversed two-cause readiness reasons",
+        ),
+        (
+            json!({
+                "status": "not_ready",
+                "ready": false,
+                "reasons": ["engine_draining", "engine_stopped"],
+                "engine_state": "draining",
+                "schema_state": "ready",
+                "schema_generation": "0",
+                "active_schema_operations": 0
+            }),
+            "duplicate engine-cause category",
+        ),
+        (
+            json!({
+                "status": "not_ready",
+                "ready": false,
+                "reasons": ["schema_state_unknown"],
+                "engine_state": "running",
+                "schema_state": "migrating",
+                "schema_generation": "0",
+                "active_schema_operations": 0
+            }),
+            "unreachable fallback readiness reason",
+        ),
+    ] {
+        assert_invalid(&document, not_ready_schema, &instance, context);
+    }
+
+    let stream_response = response(&document, "/v1/query/stream", "post", "200");
+    let stream_media = &stream_response["content"]["application/x-ndjson; charset=utf-8"];
+    assert!(stream_media.is_object());
+    assert_eq!(stream_media["schema"]["type"], "string");
+    assert_eq!(
+        stream_media["x-briskdb-ndjson"],
+        json!({
+            "framing": "lf-delimited-json",
+            "delimiter": "LF",
+            "compact": true,
+            "sequence": [
+                {
+                    "schema": "#/components/schemas/QueryStreamMeta",
+                    "minimum": 1,
+                    "maximum": 1
+                },
+                {
+                    "schema": "#/components/schemas/QueryStreamRow",
+                    "minimum": 0,
+                    "maximum": 1_000_000
+                },
+                {
+                    "oneOf": [
+                        "#/components/schemas/QueryStreamComplete",
+                        "#/components/schemas/QueryStreamError"
+                    ],
+                    "minimum": 1,
+                    "maximum": 1
+                }
+            ],
+            "terminalRecordRequired": true,
+            "eofBeforeTerminal": "indeterminate",
+            "lateErrorsRetainHttpStatus": 200
+        })
+    );
+}
+
+#[test]
+fn every_engine_and_transport_error_mapping_is_present_verbatim() {
+    let document = document();
+    let mappings = document["x-briskdb-engine-errors"]
+        .as_array()
+        .expect("the document must expose its stable engine error mapping");
+    assert_eq!(
+        mappings
+            .iter()
+            .map(|mapping| mapping["code"].as_str().expect("mapping code"))
+            .collect::<Vec<_>>(),
+        EngineErrorKind::ALL
+            .iter()
+            .map(|kind| kind.code())
+            .collect::<Vec<_>>()
+    );
+    let actual = mappings
+        .iter()
+        .map(|mapping| {
+            (
+                mapping["code"].as_str().expect("mapping code"),
+                (
+                    mapping["status"].as_u64().expect("mapping status") as u16,
+                    mapping["type"].as_str().expect("mapping problem type"),
+                    mapping["title"].as_str().expect("mapping title"),
+                    mapping["detail"].as_str().expect("mapping detail"),
+                ),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    assert_eq!(actual.len(), EngineErrorKind::ALL.len());
+    for &kind in EngineErrorKind::ALL {
+        let expected = http_error(kind);
+        assert_eq!(
+            actual.get(kind.code()),
+            Some(&(
+                expected.status,
+                expected.problem_type,
+                expected.title,
+                expected.detail,
+            )),
+            "wrong OpenAPI mapping for {}",
+            kind.code()
+        );
+        assert_valid(
+            &document,
+            component(&document, &format!("ProblemDetails{}", expected.status)),
+            &json!({
+                "type": expected.problem_type,
+                "title": expected.title,
+                "status": expected.status,
+                "detail": expected.detail,
+                "code": kind.code()
+            }),
+            &format!("{} Problem mapping", kind.code()),
+        );
+    }
+
+    let transport_mappings = document["x-briskdb-transport-errors"]
+        .as_array()
+        .expect("the document must expose its stable transport error mapping");
+    let expected_transport_mappings = json!([
+        {
+            "code": "invalid_argument",
+            "status": 400,
+            "type": "https://github.com/schapman1974/briskdb/blob/main/docs/ERRORS.md#invalid-argument",
+            "title": "Invalid argument",
+            "detail": "The request contains an invalid argument."
+        },
+        {
+            "code": "request_too_large",
+            "status": 413,
+            "type": "urn:briskdb:http:v1:request-too-large",
+            "title": "Request too large",
+            "detail": "The request body exceeds the HTTP API limit."
+        },
+        {
+            "code": "unsupported_media_type",
+            "status": 415,
+            "type": "urn:briskdb:http:v1:unsupported-media-type",
+            "title": "Unsupported media type",
+            "detail": "The request requires a JSON content type."
+        },
+        {
+            "code": "not_found",
+            "status": 404,
+            "type": "urn:briskdb:http:v1:not-found",
+            "title": "Not found",
+            "detail": "The requested API endpoint does not exist."
+        },
+        {
+            "code": "method_not_allowed",
+            "status": 405,
+            "type": "urn:briskdb:http:v1:method-not-allowed",
+            "title": "Method not allowed",
+            "detail": "The method is not supported by this API endpoint."
+        }
+    ]);
+    assert_eq!(
+        transport_mappings,
+        expected_transport_mappings.as_array().unwrap(),
+        "transport errors must retain their exact runtime order and mapping"
+    );
+
+    let engine_codes = mappings
+        .iter()
+        .map(|mapping| mapping["code"].as_str().unwrap())
+        .collect::<BTreeSet<_>>();
+    let transport_codes = transport_mappings
+        .iter()
+        .map(|mapping| mapping["code"].as_str().unwrap())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        engine_codes
+            .intersection(&transport_codes)
+            .copied()
+            .collect::<BTreeSet<_>>(),
+        ["invalid_argument"].into_iter().collect(),
+        "transport-only errors must not be conflated with EngineErrorKind"
+    );
+    assert_eq!(
+        transport_codes
+            .difference(&engine_codes)
+            .copied()
+            .collect::<BTreeSet<_>>(),
+        [
+            "method_not_allowed",
+            "not_found",
+            "request_too_large",
+            "unsupported_media_type",
+        ]
+        .into_iter()
+        .collect(),
+    );
+    for mapping in transport_mappings {
+        let status = mapping["status"].as_u64().unwrap();
+        assert_valid(
+            &document,
+            component(&document, &format!("ProblemDetails{status}")),
+            mapping,
+            &format!("{} transport Problem mapping", mapping["code"]),
+        );
+    }
+}
+
+fn application() -> (tempfile::TempDir, Engine, Router) {
+    let temp = tempfile::tempdir().unwrap();
+    let database = Arc::new(Database::open(temp.path(), 2).unwrap());
+    database
+        .broadcast("CREATE TABLE notes (id INTEGER PRIMARY KEY, body BLOB NOT NULL)")
+        .unwrap();
+    let engine = Engine::from_database(database);
+    let app = briskdb::api::router_with_engine(engine.clone());
+    (temp, engine, app)
+}
+
+async fn request(
+    app: &Router,
+    method: Method,
+    path: &str,
+    content_type: Option<&str>,
+    body: impl Into<Body>,
+) -> (StatusCode, HeaderMap, Vec<u8>) {
+    let mut request = Request::builder().method(method).uri(path);
+    if let Some(content_type) = content_type {
+        request = request.header("content-type", content_type);
+    }
+    let response = app
+        .clone()
+        .oneshot(request.body(body.into()).unwrap())
+        .await
+        .unwrap();
+    let (parts, body) = response.into_parts();
+    let body = to_bytes(body, 4 * 1024 * 1024).await.unwrap().to_vec();
+    (parts.status, parts.headers, body)
+}
+
+#[tokio::test]
+async fn live_json_problem_and_ndjson_records_match_component_schemas() {
+    let document = document();
+    let (_temp, engine, app) = application();
+
+    for token in [
+        "1.7976931348623158e308".to_owned(),
+        "-1.7976931348623158e308".to_owned(),
+        format!("{LEGACY_REQUEST_ROUNDING_LIMIT_MINUS_ONE}.0"),
+        format!("-{LEGACY_REQUEST_ROUNDING_LIMIT_MINUS_ONE}.0"),
+    ] {
+        let body =
+            format!(r#"{{"shard_key":"tenant-a","sql":"SELECT ?1 AS value","params":[{token}]}}"#);
+        let (status, headers, response_body) = request(
+            &app,
+            Method::POST,
+            "/v1/query",
+            Some("application/json"),
+            body,
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "finite-rounded legacy request token {token} must be accepted: {}",
+            String::from_utf8_lossy(&response_body),
+        );
+        assert_eq!(headers["content-type"], "application/json");
+        let response: Value = serde_json::from_slice(&response_body).unwrap();
+        assert_valid(
+            &document,
+            response_schema(&document, "/v1/query", "post", "200", "application/json"),
+            &response,
+            &format!("live response for finite-rounded legacy request token {token}"),
+        );
+    }
+
+    for token in [
+        "1.7976931348623159e308".to_owned(),
+        "-1.7976931348623159e308".to_owned(),
+        format!("{LEGACY_REQUEST_ROUNDING_LIMIT}.0"),
+        format!("-{LEGACY_REQUEST_ROUNDING_LIMIT}.0"),
+    ] {
+        let body =
+            format!(r#"{{"shard_key":"tenant-a","sql":"SELECT ?1 AS value","params":[{token}]}}"#);
+        let (status, headers, response_body) = request(
+            &app,
+            Method::POST,
+            "/v1/query",
+            Some("application/json"),
+            body,
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "overflowing legacy request token {token} must be rejected",
+        );
+        assert_eq!(headers["content-type"], "application/problem+json");
+        let problem: Value = serde_json::from_slice(&response_body).unwrap();
+        assert_eq!(problem["code"], "invalid_argument");
+        assert_valid(
+            &document,
+            response_schema(
+                &document,
+                "/v1/query",
+                "post",
+                "400",
+                "application/problem+json",
+            ),
+            &problem,
+            &format!("live Problem for overflowing legacy request token {token}"),
+        );
+    }
+
+    for path in ["/v1/query", "/v1/query/stream"] {
+        for property in ["max_rows", "max_logical_bytes"] {
+            for token in ["1.0", "1e0"] {
+                let body = format!(
+                    r#"{{"shard_key":"tenant-a","sql":"SELECT 1","result_limits":{{"{property}":{token}}}}}"#
+                );
+                let (status, headers, response_body) =
+                    request(&app, Method::POST, path, Some("application/json"), body).await;
+                assert_eq!(
+                    status,
+                    StatusCode::BAD_REQUEST,
+                    "{path} must reject non-integer {property} token {token}",
+                );
+                assert_eq!(headers["content-type"], "application/problem+json");
+                let problem: Value = serde_json::from_slice(&response_body).unwrap();
+                assert_eq!(problem["code"], "invalid_argument");
+                assert_valid(
+                    &document,
+                    response_schema(&document, path, "post", "400", "application/problem+json"),
+                    &problem,
+                    &format!("live Problem for {path} {property} token {token}"),
+                );
+            }
+        }
+    }
+
+    let (status, headers, body) = request(
+        &app,
+        Method::POST,
+        "/v1/query",
+        Some("application/json"),
+        serde_json::to_vec(&json!({
+            "shard_key": "tenant-a",
+            "sql": "SELECT ?1 AS payload",
+            "params": [{"$briskdb_type": "binary", "value": "AP8="}],
+            "value_encoding": "lossless-json-v1"
+        }))
+        .unwrap(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(headers["content-type"], "application/json");
+    let query: Value = serde_json::from_slice(&body).unwrap();
+    assert_valid(
+        &document,
+        response_schema(&document, "/v1/query", "post", "200", "application/json"),
+        &query,
+        "live query response",
+    );
+
+    let (status, headers, body) = request(
+        &app,
+        Method::POST,
+        "/v1/query",
+        Some("application/json"),
+        br#"{"sql":"SELECT 1","unknown":true}"#.as_slice(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(headers["content-type"], "application/problem+json");
+    let problem: Value = serde_json::from_slice(&body).unwrap();
+    assert_valid(
+        &document,
+        response_schema(
+            &document,
+            "/v1/query",
+            "post",
+            "400",
+            "application/problem+json",
+        ),
+        &problem,
+        "live Problem response",
+    );
+
+    let (status, headers, body) = request(
+        &app,
+        Method::POST,
+        "/v1/query/stream",
+        Some("application/json"),
+        br#"{"shard_key":"tenant-a","sql":"SELECT 7 AS value"}"#.as_slice(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        headers["content-type"],
+        "application/x-ndjson; charset=utf-8"
+    );
+    assert_eq!(body.last(), Some(&b'\n'));
+    let records = body
+        .split(|byte| *byte == b'\n')
+        .filter(|line| !line.is_empty())
+        .map(|line| serde_json::from_slice::<Value>(line).unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        records
+            .iter()
+            .filter_map(|record| record["kind"].as_str())
+            .collect::<Vec<_>>(),
+        ["meta", "row", "complete"]
+    );
+
+    for record in &records {
+        let kind = record["kind"].as_str().unwrap();
+        let component = match kind {
+            "meta" => "QueryStreamMeta",
+            "row" => "QueryStreamRow",
+            "complete" => "QueryStreamComplete",
+            "error" => "QueryStreamError",
+            other => panic!("unknown stream record kind: {other}"),
+        };
+        let schema = document
+            .pointer(&format!("/components/schemas/{component}"))
+            .unwrap_or_else(|| panic!("missing {component} component"));
+        assert_valid(
+            &document,
+            schema,
+            record,
+            &format!("live {kind} stream record"),
+        );
+    }
+
+    let (status, headers, body) = request(
+        &app,
+        Method::POST,
+        "/v1/query/stream",
+        Some("application/json"),
+        br#"{"shard_key":"tenant-a","sql":"SELECT 1 AS value UNION ALL SELECT 2","result_limits":{"max_rows":1}}"#.as_slice(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        headers["content-type"],
+        "application/x-ndjson; charset=utf-8"
+    );
+    let records = body
+        .split(|byte| *byte == b'\n')
+        .filter(|line| !line.is_empty())
+        .map(|line| serde_json::from_slice::<Value>(line).unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        records
+            .iter()
+            .filter_map(|record| record["kind"].as_str())
+            .collect::<Vec<_>>(),
+        ["meta", "row", "error"]
+    );
+    let error_schema = &document["components"]["schemas"]["QueryStreamError"];
+    assert_valid(
+        &document,
+        error_schema,
+        &records[2],
+        "live terminal stream error",
+    );
+
+    let (status, headers, body) =
+        request(&app, Method::GET, "/v1/ready", None, Body::empty()).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(headers["content-type"], "application/json");
+    let ready: Value = serde_json::from_slice(&body).unwrap();
+    assert_valid(
+        &document,
+        response_schema(&document, "/v1/ready", "get", "200", "application/json"),
+        &ready,
+        "live 200 readiness response",
+    );
+
+    engine.begin_shutdown();
+    let (status, headers, body) =
+        request(&app, Method::GET, "/v1/ready", None, Body::empty()).await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(headers["content-type"], "application/json");
+    let not_ready: Value = serde_json::from_slice(&body).unwrap();
+    assert_valid(
+        &document,
+        response_schema(&document, "/v1/ready", "get", "503", "application/json"),
+        &not_ready,
+        "live 503 readiness response",
+    );
+    assert_invalid(
+        &document,
+        response_schema(&document, "/v1/ready", "get", "200", "application/json"),
+        &not_ready,
+        "live 503 readiness body under the 200 schema",
+    );
+    engine.shutdown().await.unwrap();
+}

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -325,6 +325,7 @@ fn legacy_and_explicit_module_paths_are_both_available() {
     let _description: Option<core::PreparedStatementDescription> = None;
     let _prepared_execution: Option<core::PreparedExecution> = None;
     let _legacy_router: fn(Arc<storage::Database>) -> Router = api::router;
+    let _openapi_document: fn() -> serde_json::Value = api::openapi_v1;
     let _http_router: fn(Arc<core::Database>) -> Router = http::router;
     let _engine_router: fn(core::Engine) -> Router = http::router_with_engine;
     let _data_router: fn(Arc<core::Database>) -> Router = http::data_router;

--- a/tests/release_packaging.rs
+++ b/tests/release_packaging.rs
@@ -27,6 +27,8 @@ fn alpha_release_contract_covers_every_native_archive_and_safety_boundary() {
         "Install and smoke-test Debian service",
         "packaging/debian/build-deb.sh",
         "docs/OFFLINE_BACKUP.md",
+        "test -s docs/openapi-v1.json",
+        "$archive/docs/openapi-v1.json",
         "SHA256SUMS",
         "--prerelease",
     ] {
@@ -69,6 +71,33 @@ fn alpha_release_contract_covers_every_native_archive_and_safety_boundary() {
             "current release notes are missing critical boundary: {required}"
         );
     }
+}
+
+#[test]
+fn openapi_artifact_and_generator_are_part_of_the_cargo_contract() {
+    let manifest = include_str!("../Cargo.toml");
+    for required in [
+        "name = \"generate-openapi-v1\"",
+        "path = \"examples/openapi.rs\"",
+        "required-features = [\"http\"]",
+        "\"dep:utoipa\"",
+        "\"dep:utoipa-axum\"",
+        "utoipa = { version = \"=5.5.0\", default-features = false, features = [\"macros\"], optional = true }",
+        "utoipa-axum = { version = \"=0.2.0\", default-features = false, optional = true }",
+        "jsonschema = { version = \"=0.54.0\", default-features = false, features = [\"arbitrary-precision\"] }",
+        "oas3 = \"=0.21.0\"",
+    ] {
+        assert!(
+            manifest.contains(required),
+            "Cargo OpenAPI contract is missing: {required}"
+        );
+    }
+
+    let continuous_integration = include_str!("../.github/workflows/ci.yml");
+    assert!(continuous_integration.contains("cargo package --locked --allow-dirty"));
+    assert!(continuous_integration.contains("utoipa|utoipa-axum|utoipa-gen"));
+    assert!(!include_bytes!("../docs/openapi-v1.json").is_empty());
+    assert!(!include_bytes!("../examples/openapi.rs").is_empty());
 }
 
 #[test]


### PR DESCRIPTION
BriskDB's HTTP v1 implementation had no machine-readable contract that could be regenerated and checked against the routes clients actually call. This adds a deterministic OpenAPI 3.1 document generated from the same annotated handler definitions used to construct the Axum routers. The checked `docs/openapi-v1.json` artifact covers the exact 17 versioned paths and 28 GET, HEAD, and POST operations, assigns each operation to the data or administration listener, and preserves the existing `/v1/` discovery alias and implicit HEAD behavior. Unversioned probes, metrics, and the administration browser remain outside the document; this change does not serve a new endpoint.

The finalizer records middleware and wire behavior that derives alone cannot express: stable operation IDs, common request and API-version headers, durable execute idempotency headers, strict request objects, legacy and lossless value encodings, conditional query and catalog shapes, status-correlated readiness responses, exact five-field Problem Details, all current Engine and transport error mappings, and the bounded NDJSON record sequence. Ordinary response objects remain open for compatible additive fields. Vendor extensions state the remaining runtime rules for duplicate raw members and headers, byte limits, conditional headers, numeric-token distinctions, and streaming sequence completion.

The public `briskdb::api::openapi_v1()` function returns the document when `http` is enabled, and `cargo run --locked --no-default-features --features http --example generate-openapi-v1` regenerates byte-identical JSON. The artifact ships in the Cargo crate, native archives, and Debian packages. Utoipa remains confined to the optional HTTP dependency graph; independent OpenAPI and JSON Schema validators are test-only. The change adds no Engine, SQL, routing, lifecycle, storage-format, migration, authentication, or listener behavior.

Validation:
- Stable and Rust 1.85 passed the locked all-target/all-feature suites (1,160 library tests passed and 5 ignored on each toolchain, with every integration, example, benchmark, and all 3 doc tests green), all nine feature surfaces, and the embedded dependency boundary.
- OpenAPI contract tests passed 8/8 under stable and Rust 1.85, including independent OAS parsing, complete reference resolution, exact route/operation ownership, schema boundary cases, live JSON/problem/NDJSON fixture validation, and byte identity.
- Existing HTTP v1, raw TCP listener, and split-plane suites passed 21/21, 1/1, and 4/4; public API, storage-boundary, release, and Debian package contract suites passed.
- Cargo package verification passed; generator output matched the checked and packaged artifact at SHA-256 `78e93f3e4b2f783ded0e7ffbd026f298873579fdec9d22d9d78e6761eb95d52e`.
- Focused Clippy with `-D warnings`, rustfmt, diff checks, dependency-boundary checks, and package-content checks passed.
- Python native, wheel, sdist, CPython 3.9/3.14, strict mypy, Node, shell, workflow-YAML, and all 293 Markdown link/fragment checks passed.

Closes #55
