### PR TITLE
Harden lazy connection deadline test under load

### DIFF
--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -10494,13 +10494,13 @@ mod tests {
                     &request_session,
                     Statement::new("SELECT 1", vec![]),
                     RequestContext::new()
-                        .with_timeout(Duration::from_millis(20))
+                        .with_timeout(Duration::from_secs(1))
                         .unwrap(),
                 )
                 .await
         });
         wait_for_blocking_signal(started_rx, "connection setup should become active").await;
-        let error = timeout(Duration::from_secs(1), request)
+        let error = timeout(Duration::from_secs(2), request)
             .await
             .expect("the deadline should interrupt connection setup")
             .unwrap()


### PR DESCRIPTION
The lazy-connection deadline regression used a 20 ms operation deadline even though its setup barrier runs only after opening an unconfigured SQLite handle and arming `OperationControl`. Under full-suite runner load, that deadline could expire before the barrier, dropping its sender and panicking the test with `RecvError` even though the request followed the correct deadline path.

Raise the operation deadline to one second and the outer harness bound to two seconds, matching the established scatter-deadline test pattern. This preserves the post-arm barrier, real deadline timer, `DeadlineExceeded` assertion, capacity/pool cleanup checks, and successful recovery query. Production behavior is unchanged.

Validation:

- exact regression: Rust 1.85 10/10 and stable 10/10
- exact regression under 20 CPU-hog processes: Rust 1.85 5/5 and stable 5/5
- Rust 1.85 full all-feature library suite: 1,160 passed, 5 ignored
- stable all-target/all-feature Clippy with `-D warnings`
- rustfmt and `git diff --check`

Follow-up to the load-sensitive failure in main CI run 34049678727 after #303.
