### PR TITLE
Harden forced shutdown cleanup test under load

### DIFF
--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -6928,7 +6928,7 @@ mod tests {
         .unwrap();
 
         let report = engine
-            .shutdown_with_grace(Duration::from_millis(20))
+            .shutdown_with_grace(Duration::from_secs(1))
             .await
             .unwrap();
         assert!(report.forced());


### PR DESCRIPTION
The forced-shutdown regression used a 20 ms grace period for both phases of `shutdown_with_grace`. Its idle pinned transaction intentionally consumes the first phase so shutdown becomes forced, but the second phase then had only 20 ms to schedule the session watcher, acquire the session lock, run SQLite rollback on a blocking worker, release the lifecycle lease, and wake the drain waiter. Under full-suite runner load, that valid cleanup exceeded the harness assumption and returned `DeadlineExceeded`.

Raise the test grace to one second. The pinned transaction still guarantees the first phase expires and the report remains forced, while the second phase has a realistic scheduling margin. All existing state, lifecycle, session, and durable rollback assertions remain unchanged. Production behavior is unchanged.

Validation:

- exact regression: Rust 1.85 10/10 and stable 10/10
- exact regression under 20 CPU-hog processes: Rust 1.85 5/5 and stable 5/5
- Rust 1.85 full all-feature library suite: 1,160 passed, 5 ignored
- stable all-target/all-feature Clippy with `-D warnings`
- rustfmt and `git diff --check`

Follow-up to the load-sensitive failure in main CI run 34051297091 after #304.
